### PR TITLE
[APP-3939] Add API key retrieval flow

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -35,6 +35,7 @@ func createAuthFileDirIfNotExists() error {
 		// File exists, do nothing
 		return nil
 	}
+
 	if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("error checking auth file: %w", err)
 	}
@@ -78,6 +79,7 @@ func waitForAPIKeyCallback() string {
 	// Start the server in a goroutine
 	go func() {
 		fmt.Println("Via this link : https://staging.datarobot.com/account/developer-tools?cliRedirect=true")
+
 		err := server.ListenAndServe()
 		if err != http.ErrServerClosed {
 			fmt.Printf("Server error: %v\n", err)


### PR DESCRIPTION
# RATIONALE

Currently: Just hard-coding staging as the URL:

https://github.com/user-attachments/assets/b13d5ed3-ce93-49b9-9f13-a31462036f3a


<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
This has the following changes:
1. [FIX] Fix the CLI crashing when the key was already set in the tempfile
2. [Improvement] Add mini server which captures an API key from the web browser, at the hard-coded port with the query specified in this PR: https://github.com/datarobot/DataRobot/pull/144491
3. 
<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
