### PR TITLE
[APP-3939] Prompt the user for a DataRobot URL in new `setURL` command and in the `auth login` command 

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -63,10 +63,12 @@ func clearAuthFile() error {
 func waitForAPIKeyCallback() string {
 	addr := "localhost:51164"
 	apiKeyChan := make(chan string, 1) // If we don't have a buffer of 1, this may hang.
+
 	datarobotHost, err := GetURL(false)
 	if err != nil {
 		panic(err)
 	}
+
 	mux := http.NewServeMux()
 	server := &http.Server{
 		Addr:    addr,
@@ -77,8 +79,10 @@ func waitForAPIKeyCallback() string {
 		apiKey := r.URL.Query().Get("key")
 
 		fmt.Fprint(w, "Successfully processed API key, you may close this window.")
+
 		apiKeyChan <- apiKey // send the key to the main goroutine
 	})
+
 	listen, err := net.Listen("tcp", addr)
 	if err != nil {
 		panic(err)
@@ -87,6 +91,7 @@ func waitForAPIKeyCallback() string {
 	// Start the server in a goroutine
 	go func() {
 		fmt.Printf("Via this link : %s/account/developer-tools?cliRedirect=true\n\n", datarobotHost)
+
 		err := server.Serve(listen)
 		if err != http.ErrServerClosed {
 			fmt.Printf("Server error: %v\n", err)
@@ -95,7 +100,8 @@ func waitForAPIKeyCallback() string {
 
 	// Wait for the key from the handler
 	apiKey := <-apiKeyChan
-	fmt.Println("Sucessfully consumed API Key from API Request")
+
+	fmt.Println("Successfully consumed API Key from API Request")
 	// Now shut down the server after key is received
 	if err := server.Shutdown(context.Background()); err != nil {
 		fmt.Printf("Error during shutdown: %v\n", err)
@@ -144,6 +150,7 @@ func LoginAction() error {
 	if _, err := file.WriteString(strings.Replace(key, "\n", "", -1)); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -201,6 +208,6 @@ func init() {
 	AuthCmd.AddCommand(
 		loginCmd,
 		logoutCmd,
-		setUrlCmd,
+		setURLCmd,
 	)
 }


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

This PR adds a check so that users can enter their URL either via the newly added `dr auth setURL` command, or hooked into the `dr auth login` command. 
see super grainy demo here:

https://drive.google.com/file/d/1AXoGACf45RPksac39LzA-Tyeim6WLMnT/view?usp=sharing

NEXT STEP is to add a check that the API Key is valid when you run `dr auth login` to make sure that the expired API keys get rotated properly. 

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
