### PR TITLE
[APP-4239] Link the datarobot CLI with the datarobot python package via `drconfig.yaml`

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -36,9 +36,7 @@ type PartialConfig struct {
 	Endpoint string `yaml:"endpoint"`
 }
 
-var (
-	DATAROBOT_API_KEY = "token"
-)
+var DataRobotAPIKey = "token"
 
 func createConfigFileDirIfNotExists() error {
 	_, err := os.Stat(configFilePath)
@@ -91,7 +89,7 @@ func setValueInConfigFile(key string, value string) error {
 		return err
 	}
 
-	err = os.WriteFile(configFilePath, updatedYAML, 0644)
+	err = os.WriteFile(configFilePath, updatedYAML, 0o644)
 	if err != nil {
 		return err
 	}
@@ -115,8 +113,8 @@ func readValueFromConfigFile(key string) (string, error) {
 	if !exists {
 		return "", nil
 	}
-	return value.(string), nil
 
+	return value.(string), nil
 }
 
 func waitForAPIKeyCallback(datarobotHost string) string {
@@ -213,6 +211,7 @@ func LoginAction() error { //nolint: cyclop
 
 		if isValidKeyPair {
 			fmt.Println("An API key is already present, do you want to overwrite? (y/N): ")
+
 			selectedOption, err := reader.ReadString('\n')
 			if err != nil {
 				panic(err)
@@ -220,7 +219,7 @@ func LoginAction() error { //nolint: cyclop
 
 			if strings.ToLower(strings.Replace(selectedOption, "\n", "", -1)) == "y" {
 				// Set the DataRobot API key to be an empty string
-				if err := setValueInConfigFile(DATAROBOT_API_KEY, ""); err != nil {
+				if err := setValueInConfigFile(DataRobotAPIKey, ""); err != nil {
 					panic(err)
 				}
 			} else {
@@ -233,7 +232,7 @@ func LoginAction() error { //nolint: cyclop
 	}
 
 	key := waitForAPIKeyCallback(datarobotHost)
-	if err := setValueInConfigFile(DATAROBOT_API_KEY, strings.Replace(key, "\n", "", -1)); err != nil {
+	if err := setValueInConfigFile(DataRobotAPIKey, strings.Replace(key, "\n", "", -1)); err != nil {
 		return err
 	}
 
@@ -245,7 +244,7 @@ func LogoutAction() error {
 		panic(err)
 	}
 
-	if err := setValueInConfigFile(DATAROBOT_API_KEY, ""); err != nil {
+	if err := setValueInConfigFile(DataRobotAPIKey, ""); err != nil {
 		panic(err)
 	}
 
@@ -258,7 +257,7 @@ func GetAPIKey() (string, error) {
 		return "", err
 	}
 
-	key, err := readValueFromConfigFile(DATAROBOT_API_KEY)
+	key, err := readValueFromConfigFile(DataRobotAPIKey)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/auth/setURL.go
+++ b/cmd/auth/setURL.go
@@ -18,15 +18,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	DATAROBOT_URL = "endpoint"
-)
+var DataRobotURL = "endpoint"
 
 func getBaseURL() (string, error) {
-	urlContent, err := readValueFromConfigFile(DATAROBOT_URL)
+	urlContent, err := readValueFromConfigFile(DataRobotURL)
 	if err != nil {
 		return "", err
 	}
+
 	if urlContent == "" {
 		return "", nil
 	}
@@ -52,11 +51,11 @@ func loadBaseURLFromURL(longURL string) (string, error) {
 	return base, nil
 }
 
-func saveUrlToConfig(newURL string) error {
+func saveURLToConfig(newURL string) error {
 	// Saves the URL to the config file with the path prefix
 	// Or as an empty string, if that's needed
 	if newURL == "" {
-		err := setValueInConfigFile(DATAROBOT_API_KEY, "")
+		err := setValueInConfigFile(DataRobotAPIKey, "")
 		if err != nil {
 			return err
 		}
@@ -67,10 +66,11 @@ func saveUrlToConfig(newURL string) error {
 		return err
 	}
 
-	err = setValueInConfigFile(DATAROBOT_URL, baseURL+"/api/v2")
+	err = setValueInConfigFile(DataRobotURL, baseURL+"/api/v2")
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -91,6 +91,7 @@ func GetURL(promptIfFound bool) (string, error) { //nolint: cyclop
 	if err != nil {
 		return "", err
 	}
+
 	emptyURLContent := len(urlContent) > 0
 
 	if emptyURLContent && !promptIfFound {
@@ -98,7 +99,6 @@ func GetURL(promptIfFound bool) (string, error) { //nolint: cyclop
 	}
 
 	if emptyURLContent && promptIfFound { //nolint: nestif
-
 		fmt.Printf("A DataRobot URL of %s is already present, do you want to overwrite? (y/N): ", urlContent)
 
 		selectedOption, err := reader.ReadString('\n')
@@ -107,7 +107,7 @@ func GetURL(promptIfFound bool) (string, error) { //nolint: cyclop
 		}
 
 		if strings.ToLower(strings.Replace(selectedOption, "\n", "", -1)) == "y" {
-			if err := setValueInConfigFile(DATAROBOT_URL, ""); err != nil {
+			if err := setValueInConfigFile(DataRobotURL, ""); err != nil {
 				return "", err
 			}
 		} else {
@@ -143,7 +143,7 @@ func GetURL(promptIfFound bool) (string, error) { //nolint: cyclop
 		}
 	}
 
-	errors := saveUrlToConfig(url)
+	errors := saveURLToConfig(url)
 	if errors != nil {
 		return url, errors
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -29,5 +30,4 @@ require (
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,7 @@ github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNE
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
@@ -52,6 +53,7 @@ golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
 golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=


### PR DESCRIPTION
# RATIONALE
see demo (Note: you may want to go to ⚙️ **settings** -> 🎛️ **quality** -> 1020) : https://drive.google.com/file/d/1u6OofP_feS2muSXyRYtml8xj4dKYKrTd/view?usp=sharing


and the discourse in foundational-apps-pod slack channel: https://datarobot.slack.com/archives/C08H1JF68MN/p1748538980910219 


This PR aims to move the configuration from individual files with values in them (eg a file named `datarobot-key` ) to our supported YAML file. That way things will work "out of the box" for the public API. 

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
