### PR TITLE
[CFX-3556] Handle Cleaning Filepaths

### DIFF
--- a/cmd/templates/clone/cmd.go
+++ b/cmd/templates/clone/cmd.go
@@ -44,7 +44,9 @@ func Run(args []string) error {
 
 	fmt.Printf("\nCloning into %s directory...\n", dirStyled)
 
-	out, err := gitClone(repoURL, dir)
+	updatedDir := CleanDirPath(dir)
+
+	out, err := gitClone(repoURL, updatedDir)
 	if err != nil {
 		return err
 	}
@@ -87,7 +89,7 @@ func gitClone(repoURL, dir string) (string, error) {
 	return string(stdout), nil
 }
 
-func gitOrigin(dir string) string {
+func GitOrigin(dir string, isAbsolute bool) string {
 	cmd := exec.Command("git", "remote", "get-url", "origin")
 
 	path, err := os.Getwd()
@@ -95,7 +97,11 @@ func gitOrigin(dir string) string {
 		return ""
 	}
 
-	cmd.Dir = filepath.Join(path, dir)
+	if isAbsolute {
+		cmd.Dir = dir
+	} else {
+		cmd.Dir = filepath.Join(path, dir)
+	}
 
 	stdout, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/templates/clone/model_test.go
+++ b/cmd/templates/clone/model_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 DataRobot, Inc. and its affiliates.
+// All rights reserved.
+// DataRobot, Inc. Confidential.
+// This is unpublished proprietary source code of DataRobot, Inc.
+// and its affiliates.
+// The copyright notice above does not evidence any actual or intended
+// publication of such source code.
+
+package clone
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestModelTestSuite(t *testing.T) {
+	suite.Run(t, new(ModelTestSuite))
+}
+
+type ModelTestSuite struct {
+	suite.Suite
+	tempDir string
+}
+
+func (suite *ModelTestSuite) SetupTest() {
+	dir, _ := os.MkdirTemp("", "datarobot-config-test")
+	suite.tempDir = dir
+	suite.T().Setenv("HOME", suite.tempDir)
+	suite.T().Setenv("PARAKEET", suite.tempDir)
+}
+
+func (suite *ModelTestSuite) TestLeaveSingleDirNameUnmodified() {
+	testFileName := "squak"
+	createdMsg := DirStatus(testFileName)
+
+	suite.Equal(testFileName, createdMsg.dir, "Expected directory status message to match")
+
+	testFileName = "squak/squak"
+	createdMsg = DirStatus(testFileName)
+
+	suite.Equal(testFileName, createdMsg.dir, "Expected directory status message to match")
+}
+
+func (suite *ModelTestSuite) TestCreateRelativeFilepathExistingFile() {
+	testFileName := "squak/squak"
+	createdMsg := DirStatus(testFileName)
+
+	suite.Equal(testFileName, createdMsg.dir, "Expected directory status message to match")
+}
+
+func (suite *ModelTestSuite) TestCreateAbsoluteFilepathNonExistingFile() {
+	testFileName := filepath.Join(suite.tempDir, "squak/squak")
+	createdMsg := DirStatus(testFileName)
+
+	suite.Equal(testFileName, createdMsg.dir, "Expected directory status message to match")
+}
+
+func (suite *ModelTestSuite) TestCreateAbsoluteFilepathHomeShortcutExistingFile() {
+	// In this case, ~ is the shortcut for the actual home directory of the user running the test
+	testFileName := "~/squak/squak"
+	createdMsg := DirStatus(testFileName)
+
+	testUser, err := user.Current()
+	suite.NoError(err, "Expected no error retrieving current user") //nolint: testifylint
+
+	expectedDir := filepath.Join(testUser.HomeDir, "squak/squak")
+
+	suite.Equal(expectedDir, createdMsg.dir, "Expected directory status message to match")
+}
+
+func (suite *ModelTestSuite) TestCreateAbsoluteFilepathEnvVarExistingFile() {
+	// In this case, $HOME has been set to suite.tempDir in SetupTest
+	testFileName := "$HOME/squak/squak"
+	createdMsg := DirStatus(testFileName)
+
+	expectedDir := filepath.Join(suite.tempDir, "squak/squak")
+
+	suite.Equal(expectedDir, createdMsg.dir, "Expected directory status message to match")
+}
+
+func (suite *ModelTestSuite) TestAbsolutePathDetectedCorrectly() {
+	suite.True(DirIsAbsolute("/squak/squak"), "Expected /squak/squak absolute path to be detected correctly")
+	suite.False(DirIsAbsolute("squak/squak"), "Expected squak/squak relative path to be detected correctly")
+}


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

When cloning a repo previously, we could _only_ clone into the current directory, meaning if you use the `~` shortcut for the home directory in UNIX systems, it would instead create a `~` directory in the current working directory. Additionally, we weren't able to handle path environment variables.

This PR updates our repo pull command, as well as the environment variable editor to ensure they handle these paths correctly.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

- Manually replace `~` with the current user's home directory
- Use `os.ExpandEnv` to populate strings with the correct environment variables
- Export some functions to make them testable

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
