### PR TITLE
[CFX-3582] Switch Check for LLM Gateway Access

### DIFF
--- a/internal/drapi/llmGateway.go
+++ b/internal/drapi/llmGateway.go
@@ -36,7 +36,7 @@ func IsLLMGatewayEnabled() (bool, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 200 {
+	if resp.StatusCode == http.StatusOK {
 		return true, nil
 	}
 


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

Our previous check depended on a 422 error being detected with a GET request, which wasn't working as intended. After speaking with the owning team, making a simple GET call to `/genai/llms/` should return a 200 if the user has access.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- Update LLMGateway check to make a request to `GET /api/v2/genai/llms` and check for a 200 response

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
