### PR TITLE
[CFX-3682] Support Updating Homebrew Tap

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install PowerShell
+        uses: PSModule/install-powershell@v1
+        with:
+          Version: 7.5.0
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -32,3 +37,22 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
+          AZURE_CERTIFICATE_PROFILE_NAME: ${{ secrets.AZURE_CERTIFICATE_PROFILE_NAME }}
+          # The base64 of the contents of your '.p12' key.
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+
+          # The password to open the '.p12' key.
+          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+
+          # The base64 of the contents of your '.p8' key.
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+
+          # The ID of the '.p8' key.
+          # You can find it in the filename, as well as the Apple Developer Portal
+          # website.
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+
+          # The issuer UUID.
+          # You can find it in the Apple Developer Portal website.
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,11 +19,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install PowerShell
-        uses: PSModule/install-powershell@v1
-        with:
-          Version: 7.5.0
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -37,22 +32,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
-          AZURE_CERTIFICATE_PROFILE_NAME: ${{ secrets.AZURE_CERTIFICATE_PROFILE_NAME }}
-          # The base64 of the contents of your '.p12' key.
-          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
-
-          # The password to open the '.p12' key.
-          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
-
-          # The base64 of the contents of your '.p8' key.
-          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
-
-          # The ID of the '.p8' key.
-          # You can find it in the filename, as well as the Apple Developer Portal
-          # website.
-          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
-
-          # The issuer UUID.
-          # You can find it in the Apple Developer Portal website.
-          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -129,9 +129,7 @@ brews:
         enabled: true
         draft: false
       git:
-        url: 'git@github.com:datarobot-oss/homebrew-taps.git'
-        private_key: '{{ .Env.SSH_KEY_PATH }}'
-        ssh_command: 'ssh -i {{ .Env.SSH_KEY_PATH }} -o SomeOption=yes'
+        url: 'https://{{ .Env.GITHUB_TOKEN }}@github.com:datarobot-oss/homebrew-taps.git'
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -118,9 +118,10 @@ brews:
     dependencies:
       - name: go
         type: build
-    test: system bin/"dr" version
+    test: |
+      system bin/"dr", "version"
     install: |
-      system go build -o bin/"dr"
+      system "go", "build", "-ldflags", "-X github.com/datarobot/cli/internal/version.Version={{ .Tag }} -X github.com/datarobot/cli/internal/version.GitCommit={{ .ShortCommit }} -X github.com/datarobot/cli/internal/version.BuildDate={{ .CommitDate }}", "-o", bin/"dr"
     repository:
       owner: datarobot-oss
       name: homebrew-taps

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -41,18 +41,18 @@ builds:
         - '7'
         - '6'
     id: linux
-    goos: linux
+    goos: [linux]
 
   - <<: *build_defaults
     id: darwin
-    goos: darwin
+    goos: [darwin]
     ignore:
       - goos: darwin
         goarch: '386'
 
   - <<: *build_defaults
     id: freebsd
-    goos: freebsd
+    goos: [freebsd]
     ignore:
       - goos: freebsd
         goarch: arm
@@ -61,7 +61,7 @@ builds:
 
   - <<: *build_defaults
     id: openbsd
-    goos: openbsd
+    goos: [openbsd]
     ignore:
       - goos: openbsd
         goarch: arm
@@ -70,11 +70,10 @@ builds:
 
   - <<: *build_defaults
     id: windows
-    goos: windows
+    goos: [windows]
     ignore:
       - goos: windows
         goarch: arm
-
 
 archives:
   - formats: [tar.gz]
@@ -104,35 +103,35 @@ release:
   footer: |
     **Full Changelog**: https://github.com/datarobot-oss/cli/compare/{{ .PreviousTag }}...{{ .Tag }}
 
-#binary_signs:
-#  - id: trusted-signing-binary
-#    cmd: pwsh
-#    args:
-#      - -c
-#      - |
-#        Install-Module -Name Microsoft.TrustedSigning -Force
-#        Invoke-TrustedSigning -File "${artifact}" `
-#          -TrustedSigningAccountName "{{ .Env.AZURE_ACCOUNT_NAME }}" `
-#          -CertificateProfileName "{{ .Env.AZURE_CERTIFICATE_PROFILE_NAME }}" `
-#          -Verbose
-#    # Define the signature output file (optional but good practice)
-#    signature: "${artifact}.sig"
-#    ids: [windows]
-
-notarize:
-  macos:
-    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
-      ids: [darwin]
-      sign:
-        certificate: "{{ .Env.MACOS_SIGN_P12 }}"
-        password: "{{ .Env.MACOS_SIGN_PASSWORD }}"
-      notarize:
-        issuer_id: "{{.Env.MACOS_NOTARY_ISSUER_ID}}"
-        key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
-        key: "{{.Env.MACOS_NOTARY_KEY}}"
-
-        # Whether to wait for the notarization to finish.
-        # Not recommended, as it could take a really long time.
-        wait: true
-
-        timeout: 20m
+brews:
+  - name: dr
+    url_template: "https://github.com/datarobot-oss/cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    download_strategy: GitDownloadStrategy
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    directory: Formula
+    homepage: "https://github.com/datarobot-oss/cli"
+    description: "DataRobot command-line interface."
+    license: "Apache-2.0"
+    skip_upload: true
+    custom_block: |
+      head "https://github.com/datarobot-oss/cli.git", branch: "main"
+    dependencies:
+      - name: go
+        type: build
+    test: system bin/"dr" version
+    install: |
+      system go build -o bin/"dr"
+    repository:
+      owner: datarobot-oss
+      name: homebrew-taps
+      branch: main
+      pull_request:
+        enabled: true
+        draft: false
+      git:
+        url: 'git@github.com:datarobot-oss/homebrew-taps.git'
+        private_key: '{{ .Env.SSH_KEY_PATH }}'
+        ssh_command: 'ssh -i {{ .Env.SSH_KEY_PATH }} -o SomeOption=yes'
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -15,51 +15,66 @@ before:
     - go generate ./...
 
 builds:
-  - env:
-      - CGO_ENABLED=0
+  - <<: &build_defaults
+      env:
+        - CGO_ENABLED=0
 
-    binary: "dr"
-    mod_timestamp: "{{ .CommitTimestamp }}"
+      binary: "dr"
+      mod_timestamp: "{{ .CommitTimestamp }}"
 
-    goos:
-      - linux
-      - darwin
-      - freebsd
-      - openbsd
-      - windows
+      ldflags:
+        - >
+          -s -w
+          -X "github.com/datarobot/cli/internal/version.Version={{ .Tag }}"
+          -X "github.com/datarobot/cli/internal/version.GitCommit={{ .ShortCommit }}"
+          -X "github.com/datarobot/cli/internal/version.BuildDate={{ .CommitDate }}"
 
-    goarch:
-      - amd64
-      - arm
-      - arm64
-      - ppc64le
-      - s390x
-      - riscv64
+      goarch:
+        - amd64
+        - arm
+        - arm64
+        - ppc64le
+        - s390x
+        - riscv64
 
-    goarm:
-      - '7'
-      - '6'
+      goarm:
+        - '7'
+        - '6'
+    id: linux
+    goos: linux
 
+  - <<: *build_defaults
+    id: darwin
+    goos: darwin
     ignore:
       - goos: darwin
         goarch: '386'
-      - goos: openbsd
-        goarch: arm
-      - goos: openbsd
-        goarch: arm64
+
+  - <<: *build_defaults
+    id: freebsd
+    goos: freebsd
+    ignore:
       - goos: freebsd
         goarch: arm
       - goos: freebsd
         goarch: arm64
+
+  - <<: *build_defaults
+    id: openbsd
+    goos: openbsd
+    ignore:
+      - goos: openbsd
+        goarch: arm
+      - goos: openbsd
+        goarch: arm64
+
+  - <<: *build_defaults
+    id: windows
+    goos: windows
+    ignore:
       - goos: windows
         goarch: arm
 
-    ldflags:
-      - >
-        -s -w
-        -X "github.com/datarobot/cli/internal/version.Version={{ .Tag }}"
-        -X "github.com/datarobot/cli/internal/version.GitCommit={{ .ShortCommit }}"
-        -X "github.com/datarobot/cli/internal/version.BuildDate={{ .CommitDate }}"
 
 archives:
   - formats: [tar.gz]
@@ -87,4 +102,37 @@ changelog:
 
 release:
   footer: |
-    **Full Changelog**: https://github.com/datarobot/cli/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: https://github.com/datarobot-oss/cli/compare/{{ .PreviousTag }}...{{ .Tag }}
+
+#binary_signs:
+#  - id: trusted-signing-binary
+#    cmd: pwsh
+#    args:
+#      - -c
+#      - |
+#        Install-Module -Name Microsoft.TrustedSigning -Force
+#        Invoke-TrustedSigning -File "${artifact}" `
+#          -TrustedSigningAccountName "{{ .Env.AZURE_ACCOUNT_NAME }}" `
+#          -CertificateProfileName "{{ .Env.AZURE_CERTIFICATE_PROFILE_NAME }}" `
+#          -Verbose
+#    # Define the signature output file (optional but good practice)
+#    signature: "${artifact}.sig"
+#    ids: [windows]
+
+notarize:
+  macos:
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      ids: [darwin]
+      sign:
+        certificate: "{{ .Env.MACOS_SIGN_P12 }}"
+        password: "{{ .Env.MACOS_SIGN_PASSWORD }}"
+      notarize:
+        issuer_id: "{{.Env.MACOS_NOTARY_ISSUER_ID}}"
+        key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
+        key: "{{.Env.MACOS_NOTARY_KEY}}"
+
+        # Whether to wait for the notarization to finish.
+        # Not recommended, as it could take a really long time.
+        wait: true
+
+        timeout: 20m


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->
Since we're using a Homebrew Tap to host our CLI now, we should be sure that goreleaser updates the formula automatically for each version
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- Add `brews` section to `goreleaser.yaml`
<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
