### PR TITLE
[CFX-3680] Handle Existing Env Variables

### DIFF
--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -10,6 +10,7 @@ package dotenv
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -206,13 +207,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 
 		if m.envResponses == nil {
 			m.envResponses = make(map[string]string)
-
+			// Capture existing env var values
+			for _, prompt := range m.prompts {
+				existingEnvValue, ok := os.LookupEnv(prompt.Env)
+				if ok {
+					m.envResponses[prompt.Env] = existingEnvValue
+				}
+			}
 			for _, v := range m.variables {
 				if v.name != "" {
 					if v.commented {
 						m.envResponses["# "+v.name] = v.value
 					} else {
-						m.envResponses[v.name] = v.value
+						existingEnvValue, ok := os.LookupEnv(v.name)
+						if ok {
+							m.envResponses[v.name] = existingEnvValue
+						} else {
+							m.envResponses[v.name] = v.value
+						}
 					}
 				}
 			}

--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -207,25 +207,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 
 		if m.envResponses == nil {
 			m.envResponses = make(map[string]string)
-			// Capture existing env var values
-			for _, prompt := range m.prompts {
-				existingEnvValue, ok := os.LookupEnv(prompt.Env)
-				if ok {
-					m.envResponses[prompt.Env] = existingEnvValue
-				}
+		}
+
+		// Capture existing env var values
+		for _, prompt := range m.prompts {
+			existingEnvValue, ok := os.LookupEnv(prompt.Env)
+			if ok {
+				m.envResponses[prompt.Env] = existingEnvValue
 			}
-			for _, v := range m.variables {
-				if v.name != "" {
-					if v.commented {
-						m.envResponses["# "+v.name] = v.value
-					} else {
-						existingEnvValue, ok := os.LookupEnv(v.name)
-						if ok {
-							m.envResponses[v.name] = existingEnvValue
-						} else {
-							m.envResponses[v.name] = v.value
-						}
-					}
+		}
+
+		for _, v := range m.variables {
+			if v.name == "" {
+				continue
+			}
+
+			if v.commented {
+				m.envResponses["# "+v.name] = v.value
+			} else {
+				existingEnvValue, ok := os.LookupEnv(v.name)
+				if ok {
+					m.envResponses[v.name] = existingEnvValue
+				} else {
+					m.envResponses[v.name] = v.value
 				}
 			}
 		}


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

When we create and populate `m.envResponses`, we should check if that value already exists in the environment and store it ourselves.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- Update `case promptsLoadedMsg` after loading our prompts from `.datarobot/cli`

<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
