### PR TITLE
[CFX-4730] Add CLI version constraints to plugin manifest

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,7 +104,7 @@ func init() {
 	RootCmd.PersistentFlags().Bool("all-commands", false, "display all available commands and their flags in tree format")
 	RootCmd.PersistentFlags().Bool("skip-auth", false, "skip authentication checks (for advanced users)")
 	RootCmd.PersistentFlags().Bool("force-interactive", false, "force setup wizards to run even if already completed")
-	RootCmd.PersistentFlags().Duration("plugin-discovery-timeout", 2*time.Second, "timeout for plugin discovery (0s disables)")
+	RootCmd.PersistentFlags().Duration("plugin-discovery-timeout", 3*time.Second, "timeout for plugin discovery (0s disables)")
 
 	// Make some of these flags available via Viper
 	_ = viper.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config"))

--- a/docs/development/plugins.md
+++ b/docs/development/plugins.md
@@ -30,7 +30,7 @@ Plugins are deduplicated by `manifest.name` (not by filename). If multiple binar
 
 ### Timeouts
 
-- Overall discovery is bounded by the global flag `--plugin-discovery-timeout` (default `2s`).
+- Overall discovery is bounded by the global flag `--plugin-discovery-timeout` (default `3s`).
   - Set to `0s` to disable plugin discovery entirely.
 - Manifest retrieval is bounded by `plugin.manifest_timeout_ms` (default `500ms`).
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -115,7 +115,7 @@ dr templates list --verbose
 dr templates list --debug
 
 # Timeout for plugin discovery (0s disables discovery)
-dr --plugin-discovery-timeout 2s --help
+dr --plugin-discovery-timeout 3s --help
 ```
 
 > [!WARNING]

--- a/internal/plugin/cli_version_test.go
+++ b/internal/plugin/cli_version_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompatibleCLIVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		cliVersion string
+		constraint string
+		compatible bool
+		expectErr  bool
+	}{
+		// No constraint - always compatible
+		{
+			name:       "empty constraint is always compatible",
+			cliVersion: "1.0.0",
+			constraint: "",
+			compatible: true,
+		},
+		// Dev version - always compatible
+		{
+			name:       "dev CLI version is always compatible",
+			cliVersion: "dev",
+			constraint: ">=1.0.0",
+			compatible: true,
+		},
+		// Latest CLI + plugin with no CLI constraints
+		{
+			name:       "latest CLI with no constraints",
+			cliVersion: "2.0.0",
+			constraint: "",
+			compatible: true,
+		},
+		// Latest CLI + plugin with CLI min version (using >= constraint)
+		{
+			name:       "latest CLI satisfies min version constraint",
+			cliVersion: "2.0.0",
+			constraint: ">=1.0.0",
+			compatible: true,
+		},
+		// Latest CLI + plugin with CLI max version (using < constraint)
+		{
+			name:       "latest CLI within max version constraint",
+			cliVersion: "1.5.0",
+			constraint: "< 2.0.0",
+			compatible: true,
+		},
+		{
+			name:       "latest CLI exceeds max version constraint",
+			cliVersion: "2.0.0",
+			constraint: "< 2.0.0",
+			compatible: false,
+		},
+		// Old CLI + plugin with no CLI constraints
+		{
+			name:       "old CLI with no constraints",
+			cliVersion: "0.1.0",
+			constraint: "",
+			compatible: true,
+		},
+		// Old CLI + plugin with CLI min version → incompatible
+		{
+			name:       "old CLI below min version constraint",
+			cliVersion: "0.1.0",
+			constraint: ">=1.0.0",
+			compatible: false,
+		},
+		// Old CLI + plugin with CLI max version
+		{
+			name:       "old CLI within max version constraint",
+			cliVersion: "0.1.0",
+			constraint: "< 2.0.0",
+			compatible: true,
+		},
+		// Semver constraint patterns
+		{
+			name:       "caret constraint compatible",
+			cliVersion: "1.5.0",
+			constraint: "^1.0.0",
+			compatible: true,
+		},
+		{
+			name:       "caret constraint incompatible major bump",
+			cliVersion: "2.0.0",
+			constraint: "^1.0.0",
+			compatible: false,
+		},
+		{
+			name:       "tilde constraint compatible",
+			cliVersion: "1.0.5",
+			constraint: "~1.0.0",
+			compatible: true,
+		},
+		{
+			name:       "tilde constraint incompatible minor bump",
+			cliVersion: "1.1.0",
+			constraint: "~1.0.0",
+			compatible: false,
+		},
+		{
+			name:       "exact version match",
+			cliVersion: "1.2.3",
+			constraint: "1.2.3",
+			compatible: true,
+		},
+		{
+			name:       "exact version mismatch",
+			cliVersion: "1.2.4",
+			constraint: "1.2.3",
+			compatible: false,
+		},
+		{
+			name:       "range constraint compatible",
+			cliVersion: "1.5.0",
+			constraint: ">= 1.0.0, < 2.0.0",
+			compatible: true,
+		},
+		{
+			name:       "range constraint incompatible",
+			cliVersion: "2.0.0",
+			constraint: ">= 1.0.0, < 2.0.0",
+			compatible: false,
+		},
+		// Error cases
+		{
+			name:       "invalid constraint syntax",
+			cliVersion: "1.0.0",
+			constraint: "@invalid",
+			compatible: false,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid CLI version",
+			cliVersion: "not-semver",
+			constraint: ">=1.0.0",
+			compatible: false,
+			expectErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := compatibleCLIVersion(tt.cliVersion, tt.constraint)
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.compatible, result)
+		})
+	}
+}

--- a/internal/plugin/discover.go
+++ b/internal/plugin/discover.go
@@ -162,6 +162,21 @@ func loadManagedPlugin(dir, name string, seen map[string]bool) (*DiscoveredPlugi
 		return nil, nil
 	}
 
+	compatible, err := compatibleCLIVersion(version.Version, manifest.CLIVersion)
+	if err != nil {
+		log.Warn("Cannot parse cli version constraint for plugin",
+			"name", manifest.Name,
+			"installed", version.Version,
+			"constraint", manifest.CLIVersion)
+	} else if !compatible {
+		log.Warn("Plugin is incompatible with DataRobot CLI version",
+			"name", manifest.Name,
+			"installed", version.Version,
+			"constraint", manifest.CLIVersion)
+
+		return nil, nil
+	}
+
 	executable, err := resolvePlatformExecutable(pluginDir, &manifest)
 	if err != nil {
 		return nil, err

--- a/internal/plugin/discover_test.go
+++ b/internal/plugin/discover_test.go
@@ -15,256 +15,159 @@
 package plugin
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 
-	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
-// Test manifests
-var (
-	validManifest   = `{"name":"test-plugin","version":"1.0.0","description":"Test plugin"}`
-	invalidManifest = `{invalid json`
-)
-
-// createMockPlugin creates a shell script that responds to --dr-plugin-manifest
-func createMockPlugin(t *testing.T, dir, name, manifestJSON string) string {
-	t.Helper()
-
-	script := fmt.Sprintf(`#!/bin/sh
-if [ "$1" = "--dr-plugin-manifest" ]; then
-  echo '%s'
-else
-  exit 0
-fi
-`, manifestJSON)
-
-	path := filepath.Join(dir, name)
-	err := os.WriteFile(path, []byte(script), 0o755)
-	require.NoError(t, err)
-
-	return path
-}
-
-// DiscoverTestSuite tests discovery functions with filesystem fixtures
-type DiscoverTestSuite struct {
-	suite.Suite
-	tempDir string
-}
-
-func TestDiscoverTestSuite(t *testing.T) {
-	suite.Run(t, new(DiscoverTestSuite))
-}
-
-func (s *DiscoverTestSuite) SetupTest() {
-	var err error
-
-	s.tempDir, err = os.MkdirTemp("", "plugin-discover-test")
-	s.Require().NoError(err)
-}
-
-func (s *DiscoverTestSuite) TearDownTest() {
-	if s.tempDir != "" {
-		_ = os.RemoveAll(s.tempDir)
-	}
-}
-
-func (s *DiscoverTestSuite) TestDiscoverInDirEmptyDirectory() {
-	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(s.tempDir, seen)
-
-	s.Empty(plugins)
-	s.Empty(errs)
-}
-
-func (s *DiscoverTestSuite) TestDiscoverInDirNonExistent() {
-	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(filepath.Join(s.tempDir, "nonexistent"), seen)
-
-	s.Nil(plugins)
-	s.Nil(errs)
-}
-
-func (s *DiscoverTestSuite) TestDiscoverInDirValidPlugin() {
-	createMockPlugin(s.T(), s.tempDir, "dr-testplugin", validManifest)
-
-	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(s.tempDir, seen)
-
-	s.Require().Len(plugins, 1, "Expected exactly one plugin")
-	s.Empty(errs)
-	s.Equal("test-plugin", plugins[0].Manifest.Name)
-	s.Equal("1.0.0", plugins[0].Manifest.Version)
-	s.Equal("Test plugin", plugins[0].Manifest.Description)
-	s.True(seen["test-plugin"]) // seen map now uses manifest.Name
-}
-
-func (s *DiscoverTestSuite) TestDiscoverInDirSkipsNonDrFiles() {
-	// Create a valid plugin
-	createMockPlugin(s.T(), s.tempDir, "dr-valid", validManifest)
-
-	// Create non-dr files
-	s.Require().NoError(os.WriteFile(filepath.Join(s.tempDir, "other-binary"), []byte("#!/bin/sh\nexit 0"), 0o755))
-	s.Require().NoError(os.WriteFile(filepath.Join(s.tempDir, "random.txt"), []byte("text"), 0o644))
-
-	seen := make(map[string]bool)
-	plugins, _ := discoverInDir(s.tempDir, seen)
-
-	s.Require().Len(plugins, 1, "Expected exactly one plugin (non-dr files should be skipped)")
-	s.Equal("test-plugin", plugins[0].Manifest.Name)
-}
-
-func (s *DiscoverTestSuite) TestDiscoverInDirSkipsNonExecutable() {
-	// Create a dr-prefixed file that is not executable
-	path := filepath.Join(s.tempDir, "dr-notexec")
-	s.Require().NoError(os.WriteFile(path, []byte("not executable"), 0o644))
-
-	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(s.tempDir, seen)
-
-	s.Empty(plugins)
-	s.Empty(errs)
-}
-
-func (s *DiscoverTestSuite) TestDiscoverInDirHandlesDuplicates() {
-	createMockPlugin(s.T(), s.tempDir, "dr-duplicate", validManifest)
-
-	// Pre-populate seen map with manifest name (not filename)
-	seen := map[string]bool{
-		"test-plugin": true, // validManifest has name: "test-plugin"
-	}
-
-	plugins, _ := discoverInDir(s.tempDir, seen)
-
-	// Should be skipped due to duplicate manifest name
-	s.Empty(plugins)
-}
-
-func (s *DiscoverTestSuite) TestDiscoverInDirDeduplicatesByManifestName() {
-	// Two different binary names, same manifest name
-	manifest := `{"name":"shared-name","version":"1.0.0","description":"Test"}`
-	createMockPlugin(s.T(), s.tempDir, "dr-first", manifest)
-	createMockPlugin(s.T(), s.tempDir, "dr-second", manifest)
-
-	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(s.tempDir, seen)
-
-	// Only one should be registered (first one wins based on directory order)
-	s.Require().Len(plugins, 1, "Expected exactly one plugin when two share the same manifest name")
-	s.Empty(errs)
-	s.Equal("shared-name", plugins[0].Manifest.Name)
-}
-
-func (s *DiscoverTestSuite) TestDiscoverInDirInvalidManifest() {
-	createMockPlugin(s.T(), s.tempDir, "dr-invalid", invalidManifest)
-
-	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(s.tempDir, seen)
-
-	s.Empty(plugins)
-	s.Len(errs, 1) // JSON parse error logged
-}
-
-func (s *DiscoverTestSuite) TestDiscoverInDirMultipleValidPlugins() {
-	manifest1 := `{"name":"plugin-one","version":"1.0.0","description":"First plugin"}`
-	manifest2 := `{"name":"plugin-two","version":"2.0.0","description":"Second plugin"}`
-
-	createMockPlugin(s.T(), s.tempDir, "dr-one", manifest1)
-	createMockPlugin(s.T(), s.tempDir, "dr-two", manifest2)
-
-	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(s.tempDir, seen)
-
-	s.Len(plugins, 2)
-	s.Empty(errs)
-
-	// Verify both plugins discovered
-	names := make(map[string]bool)
-	for _, p := range plugins {
-		names[p.Manifest.Name] = true
+func TestCompatibleCLIVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		cliVersion string
+		constraint string
+		compatible bool
+		expectErr  bool
+	}{
+		// No constraint - always compatible
+		{
+			name:       "empty constraint is always compatible",
+			cliVersion: "1.0.0",
+			constraint: "",
+			compatible: true,
+		},
+		// Dev version - always compatible
+		{
+			name:       "dev CLI version is always compatible",
+			cliVersion: "dev",
+			constraint: ">=1.0.0",
+			compatible: true,
+		},
+		// Latest CLI + plugin with no CLI constraints
+		{
+			name:       "latest CLI with no constraints",
+			cliVersion: "2.0.0",
+			constraint: "",
+			compatible: true,
+		},
+		// Latest CLI + plugin with CLI min version (using >= constraint)
+		{
+			name:       "latest CLI satisfies min version constraint",
+			cliVersion: "2.0.0",
+			constraint: ">=1.0.0",
+			compatible: true,
+		},
+		// Latest CLI + plugin with CLI max version (using < constraint)
+		{
+			name:       "latest CLI within max version constraint",
+			cliVersion: "1.5.0",
+			constraint: "< 2.0.0",
+			compatible: true,
+		},
+		{
+			name:       "latest CLI exceeds max version constraint",
+			cliVersion: "2.0.0",
+			constraint: "< 2.0.0",
+			compatible: false,
+		},
+		// Old CLI + plugin with no CLI constraints
+		{
+			name:       "old CLI with no constraints",
+			cliVersion: "0.1.0",
+			constraint: "",
+			compatible: true,
+		},
+		// Old CLI + plugin with CLI min version → incompatible
+		{
+			name:       "old CLI below min version constraint",
+			cliVersion: "0.1.0",
+			constraint: ">=1.0.0",
+			compatible: false,
+		},
+		// Old CLI + plugin with CLI max version
+		{
+			name:       "old CLI within max version constraint",
+			cliVersion: "0.1.0",
+			constraint: "< 2.0.0",
+			compatible: true,
+		},
+		// Semver constraint patterns
+		{
+			name:       "caret constraint compatible",
+			cliVersion: "1.5.0",
+			constraint: "^1.0.0",
+			compatible: true,
+		},
+		{
+			name:       "caret constraint incompatible major bump",
+			cliVersion: "2.0.0",
+			constraint: "^1.0.0",
+			compatible: false,
+		},
+		{
+			name:       "tilde constraint compatible",
+			cliVersion: "1.0.5",
+			constraint: "~1.0.0",
+			compatible: true,
+		},
+		{
+			name:       "tilde constraint incompatible minor bump",
+			cliVersion: "1.1.0",
+			constraint: "~1.0.0",
+			compatible: false,
+		},
+		{
+			name:       "exact version match",
+			cliVersion: "1.2.3",
+			constraint: "1.2.3",
+			compatible: true,
+		},
+		{
+			name:       "exact version mismatch",
+			cliVersion: "1.2.4",
+			constraint: "1.2.3",
+			compatible: false,
+		},
+		{
+			name:       "range constraint compatible",
+			cliVersion: "1.5.0",
+			constraint: ">= 1.0.0, < 2.0.0",
+			compatible: true,
+		},
+		{
+			name:       "range constraint incompatible",
+			cliVersion: "2.0.0",
+			constraint: ">= 1.0.0, < 2.0.0",
+			compatible: false,
+		},
+		// Error cases
+		{
+			name:       "invalid constraint syntax",
+			cliVersion: "1.0.0",
+			constraint: "@invalid",
+			compatible: false,
+			expectErr:  true,
+		},
+		{
+			name:       "invalid CLI version",
+			cliVersion: "not-semver",
+			constraint: ">=1.0.0",
+			compatible: false,
+			expectErr:  true,
+		},
 	}
 
-	s.True(names["plugin-one"])
-	s.True(names["plugin-two"])
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := compatibleCLIVersion(tt.cliVersion, tt.constraint)
 
-// TestGetManifest tests manifest retrieval
-type ManifestTestSuite struct {
-	suite.Suite
-	tempDir string
-}
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 
-func TestManifestTestSuite(t *testing.T) {
-	suite.Run(t, new(ManifestTestSuite))
-}
-
-func (s *ManifestTestSuite) SetupTest() {
-	var err error
-
-	s.tempDir, err = os.MkdirTemp("", "plugin-manifest-test")
-	s.Require().NoError(err)
-
-	// Reset viper state for each test
-	viper.Reset()
-}
-
-func (s *ManifestTestSuite) TearDownTest() {
-	if s.tempDir != "" {
-		_ = os.RemoveAll(s.tempDir)
+			assert.Equal(t, tt.compatible, result)
+		})
 	}
-
-	viper.Reset()
-}
-
-func (s *ManifestTestSuite) TestGetManifestValid() {
-	path := createMockPlugin(s.T(), s.tempDir, "dr-test", validManifest)
-
-	manifest, err := getManifest(path)
-	s.Require().NoError(err)
-	s.NotNil(manifest)
-	s.Equal("test-plugin", manifest.Name)
-	s.Equal("1.0.0", manifest.Version)
-	s.Equal("Test plugin", manifest.Description)
-}
-
-func (s *ManifestTestSuite) TestGetManifestInvalidJSON() {
-	path := createMockPlugin(s.T(), s.tempDir, "dr-invalid", invalidManifest)
-
-	manifest, err := getManifest(path)
-	s.Require().Error(err)
-	s.Nil(manifest)
-}
-
-func (s *ManifestTestSuite) TestGetManifestNonExistent() {
-	manifest, err := getManifest(filepath.Join(s.tempDir, "nonexistent"))
-	s.Require().Error(err)
-	s.Nil(manifest)
-}
-
-func (s *ManifestTestSuite) TestGetManifestWithConfiguredTimeout() {
-	// Set a custom timeout via viper
-	viper.Set("plugin.manifest_timeout_ms", 1000)
-
-	path := createMockPlugin(s.T(), s.tempDir, "dr-test", validManifest)
-
-	manifest, err := getManifest(path)
-	s.Require().NoError(err)
-	s.NotNil(manifest)
-}
-
-func (s *ManifestTestSuite) TestGetManifestCommandFailure() {
-	// Create a script that exits with error
-	script := `#!/bin/sh
-exit 1
-`
-	path := filepath.Join(s.tempDir, "dr-failing")
-	s.Require().NoError(os.WriteFile(path, []byte(script), 0o755))
-
-	manifest, err := getManifest(path)
-	s.Require().Error(err)
-	s.Nil(manifest)
 }

--- a/internal/plugin/discover_test.go
+++ b/internal/plugin/discover_test.go
@@ -15,159 +15,256 @@
 package plugin
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestCompatibleCLIVersion(t *testing.T) {
-	tests := []struct {
-		name       string
-		cliVersion string
-		constraint string
-		compatible bool
-		expectErr  bool
-	}{
-		// No constraint - always compatible
-		{
-			name:       "empty constraint is always compatible",
-			cliVersion: "1.0.0",
-			constraint: "",
-			compatible: true,
-		},
-		// Dev version - always compatible
-		{
-			name:       "dev CLI version is always compatible",
-			cliVersion: "dev",
-			constraint: ">=1.0.0",
-			compatible: true,
-		},
-		// Latest CLI + plugin with no CLI constraints
-		{
-			name:       "latest CLI with no constraints",
-			cliVersion: "2.0.0",
-			constraint: "",
-			compatible: true,
-		},
-		// Latest CLI + plugin with CLI min version (using >= constraint)
-		{
-			name:       "latest CLI satisfies min version constraint",
-			cliVersion: "2.0.0",
-			constraint: ">=1.0.0",
-			compatible: true,
-		},
-		// Latest CLI + plugin with CLI max version (using < constraint)
-		{
-			name:       "latest CLI within max version constraint",
-			cliVersion: "1.5.0",
-			constraint: "< 2.0.0",
-			compatible: true,
-		},
-		{
-			name:       "latest CLI exceeds max version constraint",
-			cliVersion: "2.0.0",
-			constraint: "< 2.0.0",
-			compatible: false,
-		},
-		// Old CLI + plugin with no CLI constraints
-		{
-			name:       "old CLI with no constraints",
-			cliVersion: "0.1.0",
-			constraint: "",
-			compatible: true,
-		},
-		// Old CLI + plugin with CLI min version → incompatible
-		{
-			name:       "old CLI below min version constraint",
-			cliVersion: "0.1.0",
-			constraint: ">=1.0.0",
-			compatible: false,
-		},
-		// Old CLI + plugin with CLI max version
-		{
-			name:       "old CLI within max version constraint",
-			cliVersion: "0.1.0",
-			constraint: "< 2.0.0",
-			compatible: true,
-		},
-		// Semver constraint patterns
-		{
-			name:       "caret constraint compatible",
-			cliVersion: "1.5.0",
-			constraint: "^1.0.0",
-			compatible: true,
-		},
-		{
-			name:       "caret constraint incompatible major bump",
-			cliVersion: "2.0.0",
-			constraint: "^1.0.0",
-			compatible: false,
-		},
-		{
-			name:       "tilde constraint compatible",
-			cliVersion: "1.0.5",
-			constraint: "~1.0.0",
-			compatible: true,
-		},
-		{
-			name:       "tilde constraint incompatible minor bump",
-			cliVersion: "1.1.0",
-			constraint: "~1.0.0",
-			compatible: false,
-		},
-		{
-			name:       "exact version match",
-			cliVersion: "1.2.3",
-			constraint: "1.2.3",
-			compatible: true,
-		},
-		{
-			name:       "exact version mismatch",
-			cliVersion: "1.2.4",
-			constraint: "1.2.3",
-			compatible: false,
-		},
-		{
-			name:       "range constraint compatible",
-			cliVersion: "1.5.0",
-			constraint: ">= 1.0.0, < 2.0.0",
-			compatible: true,
-		},
-		{
-			name:       "range constraint incompatible",
-			cliVersion: "2.0.0",
-			constraint: ">= 1.0.0, < 2.0.0",
-			compatible: false,
-		},
-		// Error cases
-		{
-			name:       "invalid constraint syntax",
-			cliVersion: "1.0.0",
-			constraint: "@invalid",
-			compatible: false,
-			expectErr:  true,
-		},
-		{
-			name:       "invalid CLI version",
-			cliVersion: "not-semver",
-			constraint: ">=1.0.0",
-			compatible: false,
-			expectErr:  true,
-		},
+// Test manifests
+var (
+	validManifest   = `{"name":"test-plugin","version":"1.0.0","description":"Test plugin"}`
+	invalidManifest = `{invalid json`
+)
+
+// createMockPlugin creates a shell script that responds to --dr-plugin-manifest
+func createMockPlugin(t *testing.T, dir, name, manifestJSON string) string {
+	t.Helper()
+
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--dr-plugin-manifest" ]; then
+  echo '%s'
+else
+  exit 0
+fi
+`, manifestJSON)
+
+	path := filepath.Join(dir, name)
+	err := os.WriteFile(path, []byte(script), 0o755)
+	require.NoError(t, err)
+
+	return path
+}
+
+// DiscoverTestSuite tests discovery functions with filesystem fixtures
+type DiscoverTestSuite struct {
+	suite.Suite
+	tempDir string
+}
+
+func TestDiscoverTestSuite(t *testing.T) {
+	suite.Run(t, new(DiscoverTestSuite))
+}
+
+func (s *DiscoverTestSuite) SetupTest() {
+	var err error
+
+	s.tempDir, err = os.MkdirTemp("", "plugin-discover-test")
+	s.Require().NoError(err)
+}
+
+func (s *DiscoverTestSuite) TearDownTest() {
+	if s.tempDir != "" {
+		_ = os.RemoveAll(s.tempDir)
+	}
+}
+
+func (s *DiscoverTestSuite) TestDiscoverInDirEmptyDirectory() {
+	seen := make(map[string]bool)
+	plugins, errs := discoverInDir(s.tempDir, seen)
+
+	s.Empty(plugins)
+	s.Empty(errs)
+}
+
+func (s *DiscoverTestSuite) TestDiscoverInDirNonExistent() {
+	seen := make(map[string]bool)
+	plugins, errs := discoverInDir(filepath.Join(s.tempDir, "nonexistent"), seen)
+
+	s.Nil(plugins)
+	s.Nil(errs)
+}
+
+func (s *DiscoverTestSuite) TestDiscoverInDirValidPlugin() {
+	createMockPlugin(s.T(), s.tempDir, "dr-testplugin", validManifest)
+
+	seen := make(map[string]bool)
+	plugins, errs := discoverInDir(s.tempDir, seen)
+
+	s.Require().Len(plugins, 1, "Expected exactly one plugin")
+	s.Empty(errs)
+	s.Equal("test-plugin", plugins[0].Manifest.Name)
+	s.Equal("1.0.0", plugins[0].Manifest.Version)
+	s.Equal("Test plugin", plugins[0].Manifest.Description)
+	s.True(seen["test-plugin"]) // seen map now uses manifest.Name
+}
+
+func (s *DiscoverTestSuite) TestDiscoverInDirSkipsNonDrFiles() {
+	// Create a valid plugin
+	createMockPlugin(s.T(), s.tempDir, "dr-valid", validManifest)
+
+	// Create non-dr files
+	s.Require().NoError(os.WriteFile(filepath.Join(s.tempDir, "other-binary"), []byte("#!/bin/sh\nexit 0"), 0o755))
+	s.Require().NoError(os.WriteFile(filepath.Join(s.tempDir, "random.txt"), []byte("text"), 0o644))
+
+	seen := make(map[string]bool)
+	plugins, _ := discoverInDir(s.tempDir, seen)
+
+	s.Require().Len(plugins, 1, "Expected exactly one plugin (non-dr files should be skipped)")
+	s.Equal("test-plugin", plugins[0].Manifest.Name)
+}
+
+func (s *DiscoverTestSuite) TestDiscoverInDirSkipsNonExecutable() {
+	// Create a dr-prefixed file that is not executable
+	path := filepath.Join(s.tempDir, "dr-notexec")
+	s.Require().NoError(os.WriteFile(path, []byte("not executable"), 0o644))
+
+	seen := make(map[string]bool)
+	plugins, errs := discoverInDir(s.tempDir, seen)
+
+	s.Empty(plugins)
+	s.Empty(errs)
+}
+
+func (s *DiscoverTestSuite) TestDiscoverInDirHandlesDuplicates() {
+	createMockPlugin(s.T(), s.tempDir, "dr-duplicate", validManifest)
+
+	// Pre-populate seen map with manifest name (not filename)
+	seen := map[string]bool{
+		"test-plugin": true, // validManifest has name: "test-plugin"
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := compatibleCLIVersion(tt.cliVersion, tt.constraint)
+	plugins, _ := discoverInDir(s.tempDir, seen)
 
-			if tt.expectErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+	// Should be skipped due to duplicate manifest name
+	s.Empty(plugins)
+}
 
-			assert.Equal(t, tt.compatible, result)
-		})
+func (s *DiscoverTestSuite) TestDiscoverInDirDeduplicatesByManifestName() {
+	// Two different binary names, same manifest name
+	manifest := `{"name":"shared-name","version":"1.0.0","description":"Test"}`
+	createMockPlugin(s.T(), s.tempDir, "dr-first", manifest)
+	createMockPlugin(s.T(), s.tempDir, "dr-second", manifest)
+
+	seen := make(map[string]bool)
+	plugins, errs := discoverInDir(s.tempDir, seen)
+
+	// Only one should be registered (first one wins based on directory order)
+	s.Require().Len(plugins, 1, "Expected exactly one plugin when two share the same manifest name")
+	s.Empty(errs)
+	s.Equal("shared-name", plugins[0].Manifest.Name)
+}
+
+func (s *DiscoverTestSuite) TestDiscoverInDirInvalidManifest() {
+	createMockPlugin(s.T(), s.tempDir, "dr-invalid", invalidManifest)
+
+	seen := make(map[string]bool)
+	plugins, errs := discoverInDir(s.tempDir, seen)
+
+	s.Empty(plugins)
+	s.Len(errs, 1) // JSON parse error logged
+}
+
+func (s *DiscoverTestSuite) TestDiscoverInDirMultipleValidPlugins() {
+	manifest1 := `{"name":"plugin-one","version":"1.0.0","description":"First plugin"}`
+	manifest2 := `{"name":"plugin-two","version":"2.0.0","description":"Second plugin"}`
+
+	createMockPlugin(s.T(), s.tempDir, "dr-one", manifest1)
+	createMockPlugin(s.T(), s.tempDir, "dr-two", manifest2)
+
+	seen := make(map[string]bool)
+	plugins, errs := discoverInDir(s.tempDir, seen)
+
+	s.Len(plugins, 2)
+	s.Empty(errs)
+
+	// Verify both plugins discovered
+	names := make(map[string]bool)
+	for _, p := range plugins {
+		names[p.Manifest.Name] = true
 	}
+
+	s.True(names["plugin-one"])
+	s.True(names["plugin-two"])
+}
+
+// TestGetManifest tests manifest retrieval
+type ManifestTestSuite struct {
+	suite.Suite
+	tempDir string
+}
+
+func TestManifestTestSuite(t *testing.T) {
+	suite.Run(t, new(ManifestTestSuite))
+}
+
+func (s *ManifestTestSuite) SetupTest() {
+	var err error
+
+	s.tempDir, err = os.MkdirTemp("", "plugin-manifest-test")
+	s.Require().NoError(err)
+
+	// Reset viper state for each test
+	viper.Reset()
+}
+
+func (s *ManifestTestSuite) TearDownTest() {
+	if s.tempDir != "" {
+		_ = os.RemoveAll(s.tempDir)
+	}
+
+	viper.Reset()
+}
+
+func (s *ManifestTestSuite) TestGetManifestValid() {
+	path := createMockPlugin(s.T(), s.tempDir, "dr-test", validManifest)
+
+	manifest, err := getManifest(path)
+	s.Require().NoError(err)
+	s.NotNil(manifest)
+	s.Equal("test-plugin", manifest.Name)
+	s.Equal("1.0.0", manifest.Version)
+	s.Equal("Test plugin", manifest.Description)
+}
+
+func (s *ManifestTestSuite) TestGetManifestInvalidJSON() {
+	path := createMockPlugin(s.T(), s.tempDir, "dr-invalid", invalidManifest)
+
+	manifest, err := getManifest(path)
+	s.Require().Error(err)
+	s.Nil(manifest)
+}
+
+func (s *ManifestTestSuite) TestGetManifestNonExistent() {
+	manifest, err := getManifest(filepath.Join(s.tempDir, "nonexistent"))
+	s.Require().Error(err)
+	s.Nil(manifest)
+}
+
+func (s *ManifestTestSuite) TestGetManifestWithConfiguredTimeout() {
+	// Set a custom timeout via viper
+	viper.Set("plugin.manifest_timeout_ms", 1000)
+
+	path := createMockPlugin(s.T(), s.tempDir, "dr-test", validManifest)
+
+	manifest, err := getManifest(path)
+	s.Require().NoError(err)
+	s.NotNil(manifest)
+}
+
+func (s *ManifestTestSuite) TestGetManifestCommandFailure() {
+	// Create a script that exits with error
+	script := `#!/bin/sh
+exit 1
+`
+	path := filepath.Join(s.tempDir, "dr-failing")
+	s.Require().NoError(os.WriteFile(path, []byte(script), 0o755))
+
+	manifest, err := getManifest(path)
+	s.Require().Error(err)
+	s.Nil(manifest)
 }

--- a/internal/plugin/integration_test.go
+++ b/internal/plugin/integration_test.go
@@ -88,9 +88,9 @@ func TestLivePluginManifests(t *testing.T) {
 			// Validate version format
 			assert.Regexp(t, `^v?\d+\.\d+\.\d+`, manifest.Version, "Manifest %s version must be semver", manifestPath)
 
-			// Validate minCLIVersion format if present
-			if manifest.MinCLIVersion != "" {
-				assert.Regexp(t, `^v?\d+\.\d+\.\d+`, manifest.MinCLIVersion, "Manifest %s minCLIVersion must be semver", manifestPath)
+			// Validate CLIVersion format if present
+			if manifest.CLIVersion != "" {
+				assert.Regexp(t, `^v?\d+\.\d+\.\d+`, manifest.CLIVersion, "Manifest %s CLIVersion must be semver", manifestPath)
 			}
 		})
 	}

--- a/internal/plugin/remote.go
+++ b/internal/plugin/remote.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-
 	"github.com/codeclysm/extract/v4"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/log"

--- a/internal/plugin/remote_test.go
+++ b/internal/plugin/remote_test.go
@@ -109,7 +109,7 @@ func TestPluginManifestSchema(t *testing.T) {
 				"name":"test",
 				"version":"1.0.0",
 				"description":"Test plugin",
-				"minCLIVersion":"0.2.0",
+				"cliVersion":"0.2.0",
 				"authentication":true,
 				"scripts":{
 					"posix":"scripts/test.sh",
@@ -120,7 +120,7 @@ func TestPluginManifestSchema(t *testing.T) {
 				assert.Equal(t, "test", m.Name)
 				assert.Equal(t, "1.0.0", m.Version)
 				assert.Equal(t, "Test plugin", m.Description)
-				assert.Equal(t, "0.2.0", m.MinCLIVersion)
+				assert.Equal(t, "0.2.0", m.CLIVersion)
 				assert.True(t, m.Authentication)
 				require.NotNil(t, m.Scripts)
 				assert.Equal(t, "scripts/test.sh", m.Scripts.Posix)

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -40,8 +40,8 @@ type BasicPluginManifest struct {
 // Embeds BasicPluginManifest and adds additional fields for managed plugins.
 type PluginManifest struct {
 	BasicPluginManifest
-	Scripts       *PluginScripts `json:"scripts,omitempty"`       // Platform-specific script paths
-	MinCLIVersion string         `json:"minCLIVersion,omitempty"` // Minimum CLI version required
+	Scripts    *PluginScripts `json:"scripts,omitempty"`    // Platform-specific script paths
+	CLIVersion string         `json:"cliVersion,omitempty"` // Minimum CLI version required
 }
 
 // RegistryVersion represents a specific version in the plugin registry

--- a/internal/plugin/validation.go
+++ b/internal/plugin/validation.go
@@ -29,7 +29,7 @@ import (
 )
 
 // ValidatePluginScript validates that a plugin script outputs a manifest matching the expected manifest.
-// All fields must match exactly, including Scripts and MinCLIVersion for managed plugins.
+// All fields must match exactly, including Scripts and CLIVersion for managed plugins.
 func ValidatePluginScript(pluginDir string, expectedManifest PluginManifest) error {
 	if err := ValidateLicense(pluginDir); err != nil {
 		return err
@@ -70,9 +70,9 @@ func ValidateLicense(pluginDir string) error {
 // validateManifests compares two manifests and returns an error if they differ.
 func validateManifests(expected, actual PluginManifest) error {
 	opts := cmp.Options{
-		// Ignore Scripts and MinCLIVersion - they're optional managed plugin fields
+		// Ignore Scripts and CLIVersion - they're optional managed plugin fields
 		cmp.FilterPath(func(p cmp.Path) bool {
-			return p.String() == "Scripts" || p.String() == "MinCLIVersion"
+			return p.String() == "Scripts" || p.String() == "CLIVersion"
 		}, cmp.Ignore()),
 	}
 

--- a/internal/plugin/validation_test.go
+++ b/internal/plugin/validation_test.go
@@ -33,7 +33,7 @@ func TestValidateManifests_Matching(t *testing.T) {
 			Description:    "Test plugin",
 			Authentication: true,
 		},
-		MinCLIVersion: "1.0.0",
+		CLIVersion: "1.0.0",
 	}
 
 	err := validateManifests(manifest, manifest)
@@ -49,7 +49,7 @@ func TestValidateManifests_Mismatch(t *testing.T) {
 			Description:    "Test plugin",
 			Authentication: true,
 		},
-		MinCLIVersion: "1.0.0",
+		CLIVersion: "1.0.0",
 	}
 
 	actual := PluginManifest{
@@ -59,7 +59,7 @@ func TestValidateManifests_Mismatch(t *testing.T) {
 			Description:    "Different description",
 			Authentication: false,
 		},
-		MinCLIVersion: "1.0.0",
+		CLIVersion: "1.0.0",
 	}
 
 	err := validateManifests(expected, actual)
@@ -83,7 +83,7 @@ func TestValidateManifests_ManagedPlugin(t *testing.T) {
 			Posix:   "dr-apps.sh",
 			Windows: "dr-apps.ps1",
 		},
-		MinCLIVersion: "0.2.0",
+		CLIVersion: "0.2.0",
 	}
 
 	err := validateManifests(manifest, manifest)
@@ -92,7 +92,7 @@ func TestValidateManifests_ManagedPlugin(t *testing.T) {
 }
 
 func TestValidateManifests_MissingScripts(t *testing.T) {
-	// Scripts and MinCLIVersion are now ignored in validation
+	// Scripts and CLIVersion are now ignored in validation
 	// This allows managed plugins to work as PATH plugins
 	expected := PluginManifest{
 		BasicPluginManifest: BasicPluginManifest{
@@ -105,7 +105,7 @@ func TestValidateManifests_MissingScripts(t *testing.T) {
 			Posix:   "dr-apps.sh",
 			Windows: "dr-apps.ps1",
 		},
-		MinCLIVersion: "0.2.0",
+		CLIVersion: "0.2.0",
 	}
 
 	actual := PluginManifest{
@@ -115,13 +115,13 @@ func TestValidateManifests_MissingScripts(t *testing.T) {
 			Description:    "Host custom applications in DataRobot",
 			Authentication: true,
 		},
-		Scripts:       nil, // Different but ignored
-		MinCLIVersion: "",  // Different but ignored
+		Scripts:    nil, // Different but ignored
+		CLIVersion: "",  // Different but ignored
 	}
 
 	err := validateManifests(expected, actual)
 
-	assert.NoError(t, err, "Scripts and MinCLIVersion differences should be ignored")
+	assert.NoError(t, err, "Scripts and CLIVersion differences should be ignored")
 }
 
 func TestValidateManifests_AllowExtraFields(t *testing.T) {
@@ -147,7 +147,7 @@ func TestValidateManifests_AllowExtraFields(t *testing.T) {
 			Posix:   "dr-apps.sh",
 			Windows: "dr-apps.ps1",
 		},
-		MinCLIVersion: "0.2.0",
+		CLIVersion: "0.2.0",
 	}
 
 	// Should pass - actual can have more fields than expected
@@ -246,7 +246,7 @@ func TestExecPluginManifest(t *testing.T) {
 			Description:    "Test plugin",
 			Authentication: true,
 		},
-		MinCLIVersion: "1.0.0",
+		CLIVersion: "1.0.0",
 	}
 
 	scriptPath := createTestScript(t, tempDir, expected)


### PR DESCRIPTION
# RATIONALE
Plugins can declare a cliVersion constraint in their manifest (using semver syntax like >=1.0.0, ^1.2.0, < 2.0.0). This PR enforces that constraint during plugin discovery so incompatible plugins are silently skipped with a warning log, giving users clear feedback when a version mismatch occurs.

## CHANGES
   •  Renamed minCLIVersion to cliVersion in PluginManifest to reflect that it supports arbitrary semver constraints, not just minimum versions
   •  Added compatibleCLIVersion() using the Masterminds semver library to evaluate constraints
   •  Enforced CLI version check in both discovery paths: PATH-based plugins (discoverInDir) and
      managed plugins (loadManagedPlugin)
   •  dev CLI version always passes; empty constraint always passes
   •  Bumped default --plugin-discovery-timeout from 2s to 3s
   •  Added 20 unit tests covering all constraint patterns (caret, tilde, range, exact, >=, <), dev bypass, and error cases

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. Only maintainers can trigger smoke tests on forked PRs by applying the `approved-for-smoke-tests` label after security review. Please comment requesting maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes plugin discovery behavior by silently skipping plugins based on version constraints, which could cause plugins to disappear if manifests are misconfigured or constraints are invalid.
> 
> **Overview**
> Plugin manifests now expose `cliVersion` (replacing `minCLIVersion`) and plugin discovery enforces this semver constraint for both managed and PATH-based plugins, logging a warning and skipping incompatible plugins (with `dev` and empty constraints always allowed).
> 
> The default `--plugin-discovery-timeout` is increased from `2s` to `3s`, docs are updated accordingly, and new unit tests cover constraint parsing/matching and schema updates around `cliVersion`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b84279da8ec2b26d634fe9c2446d83f62a1f07f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->