### PR TITLE
[-] Cleanup smoke test

### DIFF
--- a/smoke_test_scripts/run_smoke_test.sh
+++ b/smoke_test_scripts/run_smoke_test.sh
@@ -91,7 +91,7 @@ expect ./smoke_test_scripts/expect_auth_setURL.exp "$DATAROBOT_CLI_CONFIG"
 # Check if we have the auth URL correctly set
 auth_endpoint_check=$(cat "$DATAROBOT_CLI_CONFIG" | grep endpoint | grep "${testing_url}/api/v2")
 if [[ -n "$auth_endpoint_check" ]]; then
-  echo "✅ Assertion passed: We have expected expected 'endpoint' auth URL value in config."
+  echo "✅ Assertion passed: We have expected 'endpoint' auth URL value in config."
   echo "Value: $auth_endpoint_check"
 else
   echo "❌ Assertion failed: We don't have expected 'endpoint' auth URL value."

--- a/smoke_test_scripts/run_smoke_test.sh
+++ b/smoke_test_scripts/run_smoke_test.sh
@@ -1,17 +1,45 @@
 #!/bin/bash
 
+set -euo pipefail
+
+# Helper functions
+error() {
+  echo "❌ $1"
+  exit 1
+}
+
+success() {
+  echo "✅ $1"
+}
+
+info() {
+  echo "ℹ️ $1"
+}
+
 # Be sure to get DR_API_TOKEN from args
 args=("$@")
 DR_API_TOKEN=${args[0]}
 if [[ -z "$DR_API_TOKEN" ]]; then
-  echo "❌ The variable 'DR_API_TOKEN' must be supplied as arg."
-  exit 1
+  error "The variable 'DR_API_TOKEN' must be supplied as arg."
 fi
 
 export TERM="dumb"
 
 # Used throughout testing
 testing_url="https://app.datarobot.com"
+
+# Using `DATAROBOT_CLI_CONFIG` to be sure we can save/update config file in GitHub Action runners
+testing_dr_cli_config_dir="$(pwd)/.config/datarobot/"
+mkdir -p "$testing_dr_cli_config_dir"
+export DATAROBOT_CLI_CONFIG="${testing_dr_cli_config_dir}drconfig.yaml"
+
+cleanup() {
+  info "Cleaning up..."
+  rm -rf "$testing_dr_cli_config_dir"
+  rm -f completion_bash.sh
+}
+
+trap cleanup EXIT
 
 # Determine if we can access URL
 wget -q --spider "$testing_url"
@@ -21,10 +49,6 @@ else
     url_accessible=0
 fi
 
-# Using `DATAROBOT_CLI_CONFIG` to be sure we can save/update config file in GitHub Action runners
-testing_dr_cli_config_dir="$(pwd)/.config/datarobot/"
-mkdir -p "$testing_dr_cli_config_dir"
-export DATAROBOT_CLI_CONFIG="${testing_dr_cli_config_dir}drconfig.yaml"
 touch "$DATAROBOT_CLI_CONFIG"
 cat "$(pwd)/smoke_test_scripts/assets/example_config.yaml" > "$DATAROBOT_CLI_CONFIG"
 
@@ -35,37 +59,32 @@ yq -i ".token = \"$DR_API_TOKEN\"" "$DATAROBOT_CLI_CONFIG"
 header_copy="Build AI Applications Faster"
 has_header=$(dr help | grep "${header_copy}")
 if [[ -n "$has_header" ]]; then
-    echo "✅ Help command returned expected content."
+    success "Help command returned expected content."
 else
-    echo "❌ Help command did not return expected content - missing header copy: ${header_copy}"
-    exit 1
+    error "Help command did not return expected content - missing header copy: ${header_copy}"
 fi
 
 # Check that JSON output of version command has expected `version` key
 has_version_key=$(dr self version --format=json | yq eval 'has("version")')
 if [[ "$has_version_key" == "true" ]]; then
-    echo "✅ Version command returned expected 'version' key in json output."
+    success "Version command returned expected 'version' key in json output."
 else
-    echo "❌ Version command did not return expected 'version' key in json output."
-    exit 1
+    error "Version command did not return expected 'version' key in json output."
 fi
 
 dr self completion bash > completion_bash.sh
 # Check if we have the file with expected __start_dr() function
 function_check=$(cat completion_bash.sh | grep __start_dr\()
 if [[ -n "$function_check" ]]; then
-  echo "✅ Assertion passed: We have expected completion_bash.sh file."
-  # Remove created bash file - especially helpful when running smoke tests locally
-  rm completion_bash.sh
+  success "Assertion passed: We have expected completion_bash.sh file."
 else
-  echo "❌ Assertion failed: We don't have expected completion_bash.sh file w/ expected function: __start_dr()."
   # Print completion_bash.sh (if it exists) to aid in debugging if needed
   cat completion_bash.sh
-  exit 1
+  error "Assertion failed: We don't have expected completion_bash.sh file w/ expected function: __start_dr()."
 fi
 
 # Test completion install/uninstall interactively
-echo "Testing completion install/uninstall..."
+info "Testing completion install/uninstall..."
 expect ./smoke_test_scripts/expect_completion.exp
 
 # Check we have expected usage message output
@@ -74,14 +93,14 @@ if [ -f ".env" ]; then
 else
     usage_message="You don't seem to be in a DataRobot Template directory."
 fi
-echo "Testing dr run command..."
+
+info "Testing dr run command..."
 # Use 2>&1 to stderr to stdout
 has_message=$(dr run 2>&1 | grep "${usage_message}")
 if [[ -n "$has_message" ]]; then
-    echo "✅ Run command returned expected content."
+    success "Run command returned expected content."
 else
-    echo "❌ Run command did not return expected content - missing informative message: ${usage_message}"
-    exit 1
+    error "Run command did not return expected content - missing informative message: ${usage_message}"
 fi
 
 # Use expect to run commands as user and we expect to update auth URL config value using `dr auth setURL`
@@ -91,49 +110,46 @@ expect ./smoke_test_scripts/expect_auth_setURL.exp "$DATAROBOT_CLI_CONFIG"
 # Check if we have the auth URL correctly set
 auth_endpoint_check=$(cat "$DATAROBOT_CLI_CONFIG" | grep endpoint | grep "${testing_url}/api/v2")
 if [[ -n "$auth_endpoint_check" ]]; then
-  echo "✅ Assertion passed: We have expected 'endpoint' auth URL value in config."
-  echo "Value: $auth_endpoint_check"
+  success "Assertion passed: We have expected 'endpoint' auth URL value in config."
+  info "Value: $auth_endpoint_check"
 else
-  echo "❌ Assertion failed: We don't have expected 'endpoint' auth URL value."
   # Print ~/.config/datarobot/drconfig.yaml (if it exists) to aid in debugging if needed
-  echo "${DATAROBOT_CLI_CONFIG} contents:"
+  info "${DATAROBOT_CLI_CONFIG} contents:"
   cat "$DATAROBOT_CLI_CONFIG"
-  exit 1
+  error "Assertion failed: We don't have expected 'endpoint' auth URL value."
 fi
 
 # Test `dr auth login` and we should have the value shown in output:
 # `https://app.datarobot.com/account/developer-tools?cliRedirect=true`
-echo "Testing dr auth login..."
+info "Testing dr auth login..."
 expect ./smoke_test_scripts/expect_auth_login.exp
 
 # Test templates - Confirm expect script has cloned TTMDocs and that .env has expected value
 if [ "$url_accessible" -eq 0 ]; then
-  echo "ℹ️ URL (${testing_url}) is not accessible so skipping 'dr templates setup' test."
+  info "URL (${testing_url}) is not accessible so skipping 'dr templates setup' test."
 else
-  echo "Testing dr templates setup..."
+  info "Testing dr templates setup..."
   expect ./smoke_test_scripts/expect_templates_setup.exp
   testing_session_secret_key="TESTING_SESSION_SECRET_KEY"
   DIRECTORY="./talk-to-my-docs-agents"
   if [ -d "$DIRECTORY" ]; then
-    echo "✅ Directory ($DIRECTORY) exists."
+    success "Directory ($DIRECTORY) exists."
   else
-    echo "❌ Directory ($DIRECTORY) does not exist."
-    exit 1
+    error "Directory ($DIRECTORY) does not exist."
   fi
   cd "$DIRECTORY"
 
   # Validate the SESSION_SECRET_KEY set during templates setup
   session_secret_key_check=$(cat .env | grep "SESSION_SECRET_KEY=\"${testing_session_secret_key}\"")
   if [[ -n "$session_secret_key_check" ]]; then
-    echo "✅ Assertion passed: We have expected SESSION_SECRET_KEY in created .env file."
+    success "Assertion passed: We have expected SESSION_SECRET_KEY in created .env file."
   else
-    echo "❌ Assertion failed: We don't have expected SESSION_SECRET_KEY value in created .env file."
     cat .env
-    exit 1
+    error "Assertion failed: We don't have expected SESSION_SECRET_KEY value in created .env file."
   fi
 
   # Now test dr dotenv setup within the template directory
-  echo "Testing dr dotenv setup within template directory..."
+  info "Testing dr dotenv setup within template directory..."
 
   # Run dotenv setup - it should prompt for existing variables including DATAROBOT_ENDPOINT
   # The expect script will accept defaults for all variables
@@ -143,14 +159,13 @@ else
   # Validate DATAROBOT_ENDPOINT exists in .env (it should already be there from template)
   endpoint_check=$(cat .env | grep "DATAROBOT_ENDPOINT")
   if [[ -n "$endpoint_check" ]]; then
-    echo "✅ Assertion passed: dr dotenv setup preserved DATAROBOT_ENDPOINT in template .env file."
-    echo "Value: $endpoint_check"
+    success "Assertion passed: dr dotenv setup preserved DATAROBOT_ENDPOINT in template .env file."
+    info "Value: $endpoint_check"
   else
-    echo "❌ Assertion failed: DATAROBOT_ENDPOINT not found in .env file."
     cat .env
     cd ..
     rm -rf "$DIRECTORY"
-    exit 1
+    error "Assertion failed: DATAROBOT_ENDPOINT not found in .env file."
   fi
 
   # Now delete directory to clean up

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -51,120 +51,154 @@ function Test-URLAccessible {
     }
 }
 
-# Main execution
-Write-Host 'Running smoke tests for Windows...'
+try {
+    # Main execution
+    Write-Host 'Running smoke tests for Windows...'
 
-# Validate DR_API_TOKEN is provided
-if ([string]::IsNullOrEmpty($DR_API_TOKEN)) {
-    Write-ErrorMsg "The variable 'DR_API_TOKEN' must be supplied as an argument."
-}
-
-# Used throughout testing
-$testing_url = "https://app.datarobot.com"
-
-# Determine if we can access URL
-Write-InfoMsg "Checking URL accessibility: $testing_url"
-$url_accessible = Test-URLAccessible -Url $testing_url
-
-# Setup config directory and file
-$testing_dr_cli_config_dir = Join-Path (Join-Path (Get-Location) ".config") "datarobot"
-$null = New-Item -ItemType Directory -Force -Path $testing_dr_cli_config_dir
-$env:DATAROBOT_CLI_CONFIG = Join-Path $testing_dr_cli_config_dir "drconfig.yaml"
-
-# Copy example config
-$example_config = Join-Path (Join-Path (Join-Path (Get-Location) "smoke_test_scripts") "assets") "example_config.yaml"
-Copy-Item -Path $example_config -Destination $env:DATAROBOT_CLI_CONFIG -Force
-
-# Set API token in config file
-Write-InfoMsg "Setting API token in config file: $env:DATAROBOT_CLI_CONFIG"
-$config_content = Get-Content $env:DATAROBOT_CLI_CONFIG -Raw
-$config_content = $config_content -replace 'token: ""', "token: `"$DR_API_TOKEN`""
-Set-Content -Path $env:DATAROBOT_CLI_CONFIG -Value $config_content
-
-# Test basic commands
-Write-Delimiter "Execute dr help"
-dr help
-if ($LASTEXITCODE -ne 0) {
-    Write-ErrorMsg "dr help command failed"
-}
-Write-End
-
-Write-Delimiter "Execute dr help run"
-dr help run
-if ($LASTEXITCODE -ne 0) {
-    Write-ErrorMsg "dr help run command failed"
-}
-Write-End
-
-Write-Delimiter "Execute dr self version"
-dr self version
-if ($LASTEXITCODE -ne 0) {
-    Write-ErrorMsg "dr self version command failed"
-}
-Write-End
-
-# Test completion generation
-Write-Delimiter "Testing completion generation"
-$completion_file = "completion_powershell.ps1"
-dr self completion powershell > $completion_file
-if ($LASTEXITCODE -ne 0) {
-    Write-ErrorMsg "dr self completion powershell command failed"
-}
-
-# Check if completion file contains expected content
-if (Test-Path $completion_file) {
-    $completion_content = Get-Content $completion_file -Raw
-    if ($completion_content -match "Register-ArgumentCompleter") {
-        Write-SuccessMsg "Assertion passed: We have expected $completion_file file with Register-ArgumentCompleter."
-        Remove-Item $completion_file -Force
-    } else {
-        Write-ErrorMsg "Assertion failed: We don't have expected $completion_file file with expected function."
+    # Validate DR_API_TOKEN is provided
+    if ([string]::IsNullOrEmpty($DR_API_TOKEN)) {
+        Write-ErrorMsg "The variable 'DR_API_TOKEN' must be supplied as an argument."
     }
-} else {
-    Write-ErrorMsg "Completion file was not created."
-}
-Write-End
 
-# Test dr run command
-Write-Delimiter "Testing dr run command"
-dr run
-Write-End
+    # Used throughout testing
+    $testing_url = "https://app.datarobot.com"
 
-# Test auth setURL
-Write-Delimiter "Testing dr auth setURL"
-Write-InfoMsg "Setting auth URL to: $testing_url"
-# Simulate setting the URL (in bash version this uses expect)
-# For Windows, we'll set it directly via config
-$config_content = Get-Content $env:DATAROBOT_CLI_CONFIG -Raw
-$config_content = $config_content -replace 'endpoint: ""', "endpoint: `"${testing_url}/api/v2`""
-Set-Content -Path $env:DATAROBOT_CLI_CONFIG -Value $config_content
+    # Determine if we can access URL
+    Write-InfoMsg "Checking URL accessibility: $testing_url"
+    $url_accessible = Test-URLAccessible -Url $testing_url
 
-# Verify the endpoint was set
-$config_content = Get-Content $env:DATAROBOT_CLI_CONFIG -Raw
-if ($config_content -match "endpoint: `"${testing_url}/api/v2`"") {
-    Write-SuccessMsg "Assertion passed: We have expected 'endpoint' auth URL value in config."
-    Write-Host "Value: endpoint: `"${testing_url}/api/v2`""
-} else {
-    Write-ErrorMsg "Assertion failed: We don't have expected 'endpoint' auth URL value."
-}
-Write-End
+    # Setup config directory and file
+    $testing_dr_cli_config_dir = Join-Path (Join-Path (Get-Location) ".config") "datarobot"
+    $null = New-Item -ItemType Directory -Force -Path $testing_dr_cli_config_dir
+    $env:DATAROBOT_CLI_CONFIG = Join-Path $testing_dr_cli_config_dir "drconfig.yaml"
 
-# Test auth login
-Write-Delimiter "Testing dr auth login"
-Write-InfoMsg "Testing dr auth login command (non-interactive)..."
-# Note: Full interactive testing would require a Windows expect equivalent
-dr auth check
-Write-End
+    # Copy example config
+    $example_config = Join-Path (Join-Path (Join-Path (Get-Location) "smoke_test_scripts") "assets") "example_config.yaml"
+    Copy-Item -Path $example_config -Destination $env:DATAROBOT_CLI_CONFIG -Force
 
-# Test templates (if URL is accessible)
-if (-not $url_accessible) {
-    Write-InfoMsg "URL (${testing_url}) is not accessible so skipping 'dr templates setup' test."
-} else {
-    Write-Delimiter "Testing dr templates setup"
-    Write-InfoMsg "Testing template setup would require interactive input..."
-    Write-InfoMsg "Skipping template clone test on Windows (requires interactive expect-like tool)"
+    # Set API token in config file
+    Write-InfoMsg "Setting API token in config file: $env:DATAROBOT_CLI_CONFIG"
+    $config_content = Get-Content $env:DATAROBOT_CLI_CONFIG -Raw
+    $config_content = $config_content -replace 'token: ""', "token: `"$DR_API_TOKEN`""
+    Set-Content -Path $env:DATAROBOT_CLI_CONFIG -Value $config_content
+
+    # Test basic commands
+    Write-Delimiter "Execute dr help"
+    $help_output = dr help
+    if ($LASTEXITCODE -ne 0) {
+        Write-ErrorMsg "dr help command failed"
+    }
+
+    $header_copy = "Build AI Applications Faster"
+    if ($help_output -match $header_copy) {
+        Write-SuccessMsg "Help command returned expected content."
+    } else {
+        Write-ErrorMsg "Help command did not return expected content - missing header copy: $header_copy"
+    }
     Write-End
+
+    Write-Delimiter "Execute dr self version"
+    $version_json = dr self version --format=json
+    if ($LASTEXITCODE -ne 0) {
+        Write-ErrorMsg "dr self version command failed"
+    }
+
+    # Simplified version key check for PowerShell
+    if ($version_json -match '"version":') {
+        Write-SuccessMsg "Version command returned expected 'version' key in json output."
+    } else {
+        Write-ErrorMsg "Version command did not return expected 'version' key in json output."
+    }
+    Write-End
+
+    # Test completion generation
+    Write-Delimiter "Testing completion generation"
+    $completion_file = "completion_powershell.ps1"
+    dr self completion powershell > $completion_file
+    if ($LASTEXITCODE -ne 0) {
+        Write-ErrorMsg "dr self completion powershell command failed"
+    }
+
+    # Check if completion file contains expected content
+    if (Test-Path $completion_file) {
+        $completion_content = Get-Content $completion_file -Raw
+        if ($completion_content -match "Register-ArgumentCompleter") {
+            Write-SuccessMsg "Assertion passed: We have expected $completion_file file with Register-ArgumentCompleter."
+            Remove-Item $completion_file -Force
+        } else {
+            Write-ErrorMsg "Assertion failed: We don't have expected $completion_file file with expected function."
+        }
+    } else {
+        Write-ErrorMsg "Completion file was not created."
+    }
+    Write-End
+
+    # Test dr run command
+    Write-Delimiter "Testing dr run command"
+    $run_output = dr run 2>&1
+    
+    if (Test-Path ".env") {
+        $usage_message = "No Taskfiles found in child directories."
+    } else {
+        $usage_message = "You don't seem to be in a DataRobot Template directory."
+    }
+
+    if ($run_output -match $usage_message) {
+        Write-SuccessMsg "Run command returned expected content."
+    } else {
+        Write-ErrorMsg "Run command did not return expected content - missing informative message: $usage_message"
+    }
+    Write-End
+
+    # Test auth setURL
+    Write-Delimiter "Testing dr auth setURL"
+    Write-InfoMsg "Setting auth URL to: $testing_url"
+    # Simulate setting the URL (in bash version this uses expect)
+    # For Windows, we'll set it directly via config
+    $config_content = Get-Content $env:DATAROBOT_CLI_CONFIG -Raw
+    $config_content = $config_content -replace 'endpoint: ""', "endpoint: `"${testing_url}/api/v2`""
+    Set-Content -Path $env:DATAROBOT_CLI_CONFIG -Value $config_content
+
+    # Verify the endpoint was set
+    $config_content = Get-Content $env:DATAROBOT_CLI_CONFIG -Raw
+    if ($config_content -match "endpoint: `"${testing_url}/api/v2`"") {
+        Write-SuccessMsg "Assertion passed: We have expected 'endpoint' auth URL value in config."
+        Write-Host "Value: endpoint: `"${testing_url}/api/v2`""
+    } else {
+        Write-ErrorMsg "Assertion failed: We don't have expected 'endpoint' auth URL value."
+    }
+    Write-End
+
+    # Test auth login
+    Write-Delimiter "Testing dr auth login"
+    Write-InfoMsg "Testing dr auth login command (non-interactive)..."
+    # Note: Full interactive testing would require a Windows expect equivalent
+    dr auth check
+    if ($LASTEXITCODE -ne 0) {
+        Write-InfoMsg "dr auth check failed as expected (no real credentials)"
+    }
+    Write-End
+
+    # Test templates (if URL is accessible)
+    if (-not $url_accessible) {
+        Write-InfoMsg "URL (${testing_url}) is not accessible so skipping 'dr templates setup' test."
+    } else {
+        Write-Delimiter "Testing dr templates setup"
+        Write-InfoMsg "Testing template setup would require interactive input..."
+        Write-InfoMsg "Skipping template clone test on Windows (requires interactive expect-like tool)"
+        Write-End
+    }
+
+    Write-SuccessMsg "Smoke tests for Windows completed successfully."
+    exit 0
+
+} finally {
+    Write-InfoMsg "Cleaning up..."
+    if (Test-Path $testing_dr_cli_config_dir) {
+        Remove-Item -Recurse -Force $testing_dr_cli_config_dir
+    }
+    if (Test-Path "completion_powershell.ps1") {
+        Remove-Item -Force "completion_powershell.ps1"
+    }
 }
 
-Write-SuccessMsg "Smoke tests for Windows completed successfully."
-exit 0


### PR DESCRIPTION
# RATIONALE

Just doing some minor tweaks to the CLI smoke tests since I'm in this part of the repo anyway.

## CHANGES

## TODO
Cleanup changes were not necessary!

On the Ubuntu and MacOS side

- Add convenience logging functions info/success/error. error will exit automatically.
- typo ("expected expected")
- cleanup the temporary drconfig.yaml file and completion file

Windows side

- try-finally to cleanup the temporary drconfig.yaml file and completion file
- actually validate some output from `dr help`, rather than check the exit code
- actually validate output from `dr self version`
- reorganized tests a bit

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. Only maintainers can trigger smoke tests on forked PRs by applying the `approved-for-smoke-tests` label after security review. Please comment requesting maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
