### PR TITLE
[-] Add timing logs for dotenv wizard and env prompt discovery

### DIFF
--- a/internal/envbuilder/builder.go
+++ b/internal/envbuilder/builder.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/datarobot/cli/internal/log"
 	"gopkg.in/yaml.v3"
@@ -143,6 +144,8 @@ func (up UserPrompt) ShouldAsk() bool {
 }
 
 func GatherUserPrompts(rootDir string, variables Variables) ([]UserPrompt, error) {
+	start := time.Now()
+
 	yamlFiles, err := Discover(rootDir, 5)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to discover task yaml files: %w", err)
@@ -167,6 +170,14 @@ func GatherUserPrompts(rootDir string, variables Variables) ([]UserPrompt, error
 
 	allPrompts = promptsWithValues(allPrompts, variables)
 	allPrompts = DetermineRequiredSections(allPrompts)
+
+	timingf(
+		"GatherUserPrompts root=%s files=%d prompts=%d duration=%s",
+		rootDir,
+		len(yamlFiles),
+		len(allPrompts),
+		time.Since(start),
+	)
 
 	return allPrompts, nil
 }

--- a/internal/envbuilder/timing.go
+++ b/internal/envbuilder/timing.go
@@ -1,0 +1,34 @@
+// Copyright 2025 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envbuilder
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func timingEnabled() bool {
+	return os.Getenv("GITHUB_ACTIONS") != "" || os.Getenv("DR_TIMING") != ""
+}
+
+func timingf(format string, args ...any) {
+	if !timingEnabled() {
+		return
+	}
+
+	tp := time.Now().UTC().Format(time.RFC3339)
+	fmt.Fprintf(os.Stderr, "[%s] TIMING envbuilder: %s\n", tp, fmt.Sprintf(format, args...))
+}


### PR DESCRIPTION
# RATIONALE

I wanted to see timings for dotenv wizard and prompt discovery during smoke tests. This should not be merged.

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. Only maintainers can trigger smoke tests on forked PRs by applying the `approved-for-smoke-tests` label after security review. Please comment requesting maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
