### PR TITLE
refactor(auth): return EnvCredentials by value in VerifyEnvCredentials

### DIFF
--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -113,8 +113,15 @@ You can still manually run `dr auth login` to refresh credentials or change acco
 
 ## Internal APIs
 
-The auth package writes configuration through Viper.
+The auth package provides the following functions for authentication management:
+
+### Configuration management
 
 - `WriteConfigFileSilent()`&mdash;writes the config file and returns an error.
 - `WriteConfigFile()`&mdash;writes the config file, prints a success message, and returns an error.
 - `SetURLAction()`&mdash;prompts for a DataRobot URL, optionally overwrites an existing value, and returns a boolean indicating whether the URL changed.
+
+### Credential verification
+
+- `GetEnvCredentials() EnvCredentials`&mdash;reads `DATAROBOT_ENDPOINT` (or `DATAROBOT_API_ENDPOINT` fallback) and `DATAROBOT_API_TOKEN` from environment variables. Returns an `EnvCredentials` struct by value containing the endpoint and token (may be empty strings if not set).
+- `VerifyEnvCredentials() (EnvCredentials, error)`&mdash;checks if environment variable credentials are valid by calling `GetEnvCredentials()` and verifying the token with the DataRobot API. Returns the credentials by value and an error. Returns `ErrEnvCredentialsNotSet` if either endpoint or token is empty.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -62,15 +62,15 @@ func GetEnvCredentials() EnvCredentials {
 
 // VerifyEnvCredentials checks if environment variable credentials are valid.
 // Returns credentials and nil error if valid, credentials and error otherwise.
-func VerifyEnvCredentials() (*EnvCredentials, error) {
+func VerifyEnvCredentials() (EnvCredentials, error) {
 	creds := GetEnvCredentials()
 	if creds.Endpoint == "" || creds.Token == "" {
-		return &creds, ErrEnvCredentialsNotSet
+		return creds, ErrEnvCredentialsNotSet
 	}
 
 	err := config.VerifyToken(creds.Endpoint, creds.Token)
 
-	return &creds, err
+	return creds, err
 }
 
 // EnsureAuthenticatedE checks if valid authentication exists, and if not,

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -303,7 +303,8 @@ func TestVerifyEnvCredentials(t *testing.T) {
 
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrEnvCredentialsNotSet)
-		assert.NotNil(t, creds)
+		assert.Empty(t, creds.Endpoint)
+		assert.Empty(t, creds.Token)
 	})
 
 	t.Run("returns error when only endpoint set", func(t *testing.T) {
@@ -315,6 +316,7 @@ func TestVerifyEnvCredentials(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrEnvCredentialsNotSet)
 		assert.Equal(t, "https://example.com", creds.Endpoint)
+		assert.Empty(t, creds.Token)
 	})
 
 	t.Run("returns error when only token set", func(t *testing.T) {
@@ -326,6 +328,7 @@ func TestVerifyEnvCredentials(t *testing.T) {
 
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrEnvCredentialsNotSet)
+		assert.Empty(t, creds.Endpoint)
 		assert.Equal(t, "some-token", creds.Token)
 	})
 


### PR DESCRIPTION
# RATIONALE

Was reviewing the code in #354 again and saw a couple of things to fix.

## CHANGES

- VerifyEnvCredentials() does not need to return EnvCredentials struct as a pointer. Let's just return it by value.
- Update auth dev docs a bit.

This makes the return type consistent with GetEnvCredentials, which already returns by value. EnvCredentials is a small struct (two strings) anyway.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. Only maintainers can trigger smoke tests on forked PRs by applying the `approved-for-smoke-tests` label after security review. Please comment requesting maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
