### PR TITLE
feat: propagate locale setting to plugins via DR_LOCALE

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,6 +106,7 @@ func init() {
 	RootCmd.PersistentFlags().Duration("plugin-discovery-timeout", 2*time.Second, "timeout for plugin discovery (0s disables)")
 	RootCmd.PersistentFlags().Duration("plugin-update-check-interval", internalPlugin.DefaultUpdateCheckInterval, "cooldown between plugin update checks (0s disables)")
 	RootCmd.PersistentFlags().Bool("skip-plugin-update-check", false, "skip plugin update checks before running plugins")
+	RootCmd.PersistentFlags().String("locale", "", "locale for plugins (e.g., en, ja)")
 
 	// Make some of these flags available via Viper
 	_ = viper.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config"))
@@ -116,6 +117,7 @@ func init() {
 	_ = viper.BindPFlag("plugin-discovery-timeout", RootCmd.PersistentFlags().Lookup("plugin-discovery-timeout"))
 	_ = viper.BindPFlag("plugin-update-check-interval", RootCmd.PersistentFlags().Lookup("plugin-update-check-interval"))
 	_ = viper.BindPFlag("skip-plugin-update-check", RootCmd.PersistentFlags().Lookup("skip-plugin-update-check"))
+	_ = viper.BindPFlag("locale", RootCmd.PersistentFlags().Lookup("locale"))
 
 	// Add command groups (plugin group added conditionally by registerPluginCommands)
 	RootCmd.AddGroup(
@@ -204,5 +206,3 @@ func initializeConfig(cmd *cobra.Command) error {
 
 	return nil
 }
-
-

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -16,6 +16,7 @@ These flags are available for all commands:
       --skip-auth                Skip authentication checks (for advanced users)
       --force-interactive        Force the setup wizard to run even if already completed
       --all-commands             Display all available commands and their flags in tree format
+      --locale string            Locale for plugins (e.g., en, ja)
       --plugin-discovery-timeout duration   Timeout for plugin discovery (e.g. 2s, 500ms; default: 2s; 0s disables)
   -h, --help                     Show help information
 ```
@@ -260,6 +261,7 @@ Global environment variables that affect all commands:
 DATAROBOT_ENDPOINT                  # DataRobot URL
 DATAROBOT_API_TOKEN                 # API token (not recommended)
 DATAROBOT_CLI_CONFIG                # Path to config file
+DATAROBOT_CLI_LOCALE                    # Locale for plugins (e.g., en, ja)
 DATAROBOT_CLI_PLUGIN_DISCOVERY_TIMEOUT  # Timeout for plugin discovery (e.g. 2s; 0s disables)
 VISUAL                              # External editor for file editing
 EDITOR                              # External editor for file editing (fallback)

--- a/docs/development/plugins.md
+++ b/docs/development/plugins.md
@@ -117,6 +117,10 @@ When `authentication` is enabled:
 - Authentication can be bypassed with the global `--skip-auth` flag (for advanced users).
 - Your plugin will receive a clean environment with authentication already validated
 
+### Locale
+
+When the user configures a locale via `drconfig.yaml`, the `--locale` flag, or the `DATAROBOT_CLI_LOCALE` environment variable, the CLI passes it to plugins as the `DR_LOCALE` environment variable. Plugins can use this as the highest-priority locale source, falling back to their own detection logic when `DR_LOCALE` is not set.
+
 ## Developing a plugin
 
 Minimum requirements:

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -30,12 +30,16 @@ The main configuration file (`drconfig.yaml`) stores your DataRobot connection s
 # DataRobot Connection
 endpoint: DATA_ROBOT_ENDPOINT_URL # e.g. https://app.datarobot.com
 token: API_KEY_HERE
+
+# Optional: locale for plugins (e.g., en, ja)
+# locale: ja
 ```
 
 **Configuration fields:**
 
 - `endpoint`: Your DataRobot instance URL (e.g., `https://app.datarobot.com`)
 - `token`: Your API authentication token (automatically stored after `dr auth login`)
+- `locale`: Locale for plugins (e.g., `en`, `ja`). When set, passed to plugins as `DR_LOCALE` environment variable.
 
 > [!NOTE]
 > You typically don't need to edit this file manually. The CLI manages it automatically when you use `dr auth set-url` and `dr auth login`.

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/ulikunitz/xz v0.5.15
+	golang.org/x/term v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -75,7 +76,6 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
-	golang.org/x/term v0.36.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
 )

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -17,4 +17,5 @@ package config
 const (
 	DataRobotURL    = "endpoint"
 	DataRobotAPIKey = "token"
+	DataRobotLocale = "locale"
 )

--- a/internal/drapi/llms.go
+++ b/internal/drapi/llms.go
@@ -24,7 +24,7 @@ type LLM struct {
 	Provider string `json:"provider"`
 	IsActive bool   `json:"isActive"`
 	Model    string `json:"model"`
-	
+
 	//Version              string   `json:"version"`
 	//Description          string   `json:"description"`
 	//Creator              string   `json:"creator"`

--- a/internal/plugin/exec.go
+++ b/internal/plugin/exec.go
@@ -126,6 +126,11 @@ func buildPluginEnv(pluginPath string, requireAuth bool) []string {
 		env = append(env, "DATAROBOT_CONFIG="+configPath)
 	}
 
+	// Propagate locale setting to plugins when explicitly configured
+	if locale := viper.GetString(config.DataRobotLocale); locale != "" {
+		env = append(env, "DR_LOCALE="+locale)
+	}
+
 	if !requireAuth {
 		return env
 	}

--- a/internal/plugin/exec_test.go
+++ b/internal/plugin/exec_test.go
@@ -187,3 +187,74 @@ func TestExecutePluginCustomUserAgent(t *testing.T) {
 
 	assert.Equal(t, "DataRobot CLI plugin: test-plugin (version 1.2.3)", capturedUserAgent)
 }
+
+func TestBuildPluginEnvLocale(t *testing.T) {
+	tests := []struct {
+		name        string
+		locale      string
+		expectEnv   bool
+		expectedVal string
+	}{
+		{"locale set to ja", "ja", true, "ja"},
+		{"locale set to en", "en", true, "en"},
+		{"locale set to ja_JP", "ja_JP", true, "ja_JP"},
+		{"locale not set", "", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+
+			if tt.locale != "" {
+				viper.Set(config.DataRobotLocale, tt.locale)
+			}
+
+			env := buildPluginEnv("/path/to/plugin", false)
+
+			found := false
+
+			for _, e := range env {
+				if len(e) > 10 && e[:10] == "DR_LOCALE=" {
+					found = true
+
+					assert.Equal(t, "DR_LOCALE="+tt.expectedVal, e)
+				}
+			}
+
+			assert.Equal(t, tt.expectEnv, found,
+				"DR_LOCALE presence mismatch: expected=%v, found=%v", tt.expectEnv, found)
+		})
+	}
+}
+
+func TestBuildPluginEnvAlwaysSetsPluginMode(t *testing.T) {
+	viper.Reset()
+
+	env := buildPluginEnv("/path/to/plugin", false)
+
+	found := false
+
+	for _, e := range env {
+		if e == "DR_PLUGIN_MODE=1" {
+			found = true
+		}
+	}
+
+	assert.True(t, found, "DR_PLUGIN_MODE=1 should always be set")
+}
+
+func TestBuildPluginEnvSetsPluginPath(t *testing.T) {
+	viper.Reset()
+
+	env := buildPluginEnv("/path/to/my-plugin", false)
+
+	found := false
+
+	for _, e := range env {
+		if e == "DR_PLUGIN_PATH=/path/to/my-plugin" {
+			found = true
+		}
+	}
+
+	assert.True(t, found, "DR_PLUGIN_PATH should be set to the plugin path")
+}


### PR DESCRIPTION
## Summary
- Add `--locale` persistent flag and `locale` config key to the CLI
- Propagate `DR_LOCALE` environment variable to all plugins when explicitly configured
- Only set when user explicitly specifies locale (via `drconfig.yaml`, `--locale` flag, or `DATAROBOT_CLI_LOCALE` env var), preserving each plugin's existing fallback behavior

## Motivation
Currently, the `assist` plugin implements its own locale detection independently. This makes it difficult for users to set a unified locale across plugins. By propagating `DR_LOCALE` from the CLI config, users can configure locale once and have it apply to all plugins.

### How plugins can adopt this
Plugins should check `DR_LOCALE` as the highest-priority locale source:

**agent-assist (Python):** `DR_LOCALE` > `AGENT_ASSIST_LANG` > `config.yaml` > `"en"`

### Configuration methods
```yaml
# ~/.config/datarobot/drconfig.yaml
locale: ja
```
```bash
dr --locale ja assist    # CLI flag
DATAROBOT_CLI_LOCALE=ja dr assist  # env var
```

## Test plan
- [x] `TestBuildPluginEnvLocale` - verifies DR_LOCALE is set/unset correctly (4 patterns)
- [x] `TestBuildPluginEnvAlwaysSetsPluginMode` - verifies DR_PLUGIN_MODE always present
- [x] `TestBuildPluginEnvSetsPluginPath` - verifies DR_PLUGIN_PATH set correctly
- [x] `task lint` passes
- [x] `go test ./internal/plugin/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `--locale`/`locale` config value and forwards it as `DR_LOCALE` to plugin subprocesses, with docs/tests updates and minimal impact when unset.
> 
> **Overview**
> Adds a new global `--locale` flag (and `locale` config key / `DATAROBOT_CLI_LOCALE` env override via Viper) and propagates it to all plugin executions as `DR_LOCALE` when explicitly set.
> 
> Updates plugin execution tests to cover locale env propagation (and a couple of baseline env invariants), and refreshes user/developer docs to document the new flag/config/env behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 358636a55248ac2c2ecb186b1241896fc05a606e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->