### PR TITLE
[CFX-4964] Create/Edit drconfig.yaml only after valid API key received

### DIFF
--- a/cmd/auth/cmd.go
+++ b/cmd/auth/cmd.go
@@ -1,4 +1,4 @@
-// Copyright 2025 DataRobot, Inc. and its affiliates.
+// Copyright 2026 DataRobot, Inc. and its affiliates.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/auth/login/cmd.go
+++ b/cmd/auth/login/cmd.go
@@ -1,4 +1,4 @@
-// Copyright 2025 DataRobot, Inc. and its affiliates.
+// Copyright 2026 DataRobot, Inc. and its affiliates.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/auth/login/cmd.go
+++ b/cmd/auth/login/cmd.go
@@ -44,7 +44,7 @@ func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop
 	}
 
 	if url != "" {
-		err := config.SaveURLToConfig(url)
+		err := config.SetURLToConfig(url)
 		if err != nil {
 			log.Error(err.Error())
 		}

--- a/cmd/auth/seturl/cmd.go
+++ b/cmd/auth/seturl/cmd.go
@@ -40,7 +40,7 @@ This command helps you choose the correct DataRobot environment:
 			}
 
 			if url != "" {
-				err := config.SaveURLToConfig(url)
+				err := config.SetURLToConfig(url)
 				if err == nil {
 					_ = auth.EnsureAuthenticatedE(cmd, args)
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,4 +1,4 @@
-// Copyright 2025 DataRobot, Inc. and its affiliates.
+// Copyright 2026 DataRobot, Inc. and its affiliates.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -262,6 +262,7 @@ func WriteConfigFileSilent() error {
 	}
 
 	err := viper.WriteConfig()
+
 	if err != nil {
 		log.Error(err)
 		return err

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -262,7 +262,6 @@ func WriteConfigFileSilent() error {
 	}
 
 	err := viper.WriteConfig()
-
 	if err != nil {
 		log.Error(err)
 		return err

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -256,6 +256,10 @@ func WaitForAPIKeyCallback(ctx context.Context, datarobotHost string) (string, e
 }
 
 func WriteConfigFileSilent() error {
+	// Ensure the config directory and file exist before writing the config file
+	if err := config.CreateConfigFileDirIfNotExists(); err != nil {
+		return err
+	}
 	err := viper.WriteConfig()
 	if err != nil {
 		log.Error(err)
@@ -320,7 +324,7 @@ func SetURLAction() bool {
 				break
 			}
 
-			err = config.SaveURLToConfig(url)
+			err = config.SetURLToConfig(url)
 			if err != nil {
 				if errors.Is(err, config.ErrInvalidURL) {
 					fmt.Print("\nInvalid URL provided. Verify your URL and try again.\n\n")
@@ -331,7 +335,9 @@ func SetURLAction() bool {
 
 				break
 			}
-
+			// TODO: I believe we want to change this message to "Thank you for providing the URL. Please wait while we validate it and retrieve your API key."
+			// Or just delete it since this action does not mean that URL is written to file or configured until API key is valid.
+			// And we don't want to confuse users .
 			fmt.Println("Environment URL configured successfully!")
 
 			return true

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -260,6 +260,7 @@ func WriteConfigFileSilent() error {
 	if err := config.CreateConfigFileDirIfNotExists(); err != nil {
 		return err
 	}
+
 	err := viper.WriteConfig()
 	if err != nil {
 		log.Error(err)
@@ -335,10 +336,8 @@ func SetURLAction() bool {
 
 				break
 			}
-			// TODO: I believe we want to change this message to "Thank you for providing the URL. Please wait while we validate it and retrieve your API key."
-			// Or just delete it since this action does not mean that URL is written to file or configured until API key is valid.
-			// And we don't want to confuse users .
-			fmt.Println("Environment URL configured successfully!")
+
+			fmt.Println("Thank you for providing the URL. Validating it and retrieving your API key...")
 
 			return true
 		}

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -1,4 +1,4 @@
-// Copyright 2025 DataRobot, Inc. and its affiliates.
+// Copyright 2026 DataRobot, Inc. and its affiliates.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -82,6 +82,8 @@ func RedactedReqInfo(req *http.Request) string {
 	return string(requestDump)
 }
 
+// TODO: I believe we want to delete this function as there is SetURLToConfig function
+// But it is used in cmd/templates/setup/model.go
 func SaveURLToConfig(newURL string) error {
 	newURL, err := SchemeHostOnly(urlFromShortcut(newURL))
 	if err != nil {
@@ -104,6 +106,20 @@ func SaveURLToConfig(newURL string) error {
 	viper.Set(DataRobotURL, newURL+"/api/v2")
 
 	return viper.WriteConfig()
+}
+
+// SetURLToConfig is a helper function that sets the DataRobot URL with the "/api/v2" suffix in the config object.
+// It is used by both cmd/auth/set-url and cmd/auth/login to ensure consistent URL formatting.
+// It does NOT write to the config file, in order not to break drconfig.yaml file once URL is not valid or some issues with API key.
+func SetURLToConfig(newURL string) error {
+	newURL, err := SchemeHostOnly(urlFromShortcut(newURL))
+	if err != nil {
+		return err
+	}
+
+	viper.Set(DataRobotURL, newURL+"/api/v2")
+
+	return nil
 }
 
 func urlFromShortcut(selectedOption string) string {

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -25,6 +25,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+const DRAPIURLSuffix = "/api/v2"
+
 var ErrInvalidURL = errors.New("Invalid URL.")
 
 // SchemeHostOnly takes a URL like: https://app.datarobot.com/api/v2 and just
@@ -103,12 +105,12 @@ func SaveURLToConfig(newURL string) error {
 		return viper.WriteConfig()
 	}
 
-	viper.Set(DataRobotURL, newURL+"/api/v2")
+	viper.Set(DataRobotURL, newURL+DRAPIURLSuffix)
 
 	return viper.WriteConfig()
 }
 
-// SetURLToConfig is a helper function that sets the DataRobot URL with the "/api/v2" suffix in the config object.
+// SetURLToConfig is a helper function that sets the DataRobot URL with the DRAPIURLSuffix in the config object.
 // It is used by both cmd/auth/set-url and cmd/auth/login to ensure consistent URL formatting.
 // It does NOT write to the config file, in order not to break drconfig.yaml file once URL is not valid or some issues with API key.
 func SetURLToConfig(newURL string) error {
@@ -117,7 +119,7 @@ func SetURLToConfig(newURL string) error {
 		return err
 	}
 
-	viper.Set(DataRobotURL, newURL+"/api/v2")
+	viper.Set(DataRobotURL, newURL+DRAPIURLSuffix)
 
 	return nil
 }

--- a/internal/config/api_test.go
+++ b/internal/config/api_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 DataRobot, Inc. and its affiliates.
+// Copyright 2026 DataRobot, Inc. and its affiliates.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/config/api_test.go
+++ b/internal/config/api_test.go
@@ -1,0 +1,109 @@
+// Copyright 2025 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestAPITestSuite(t *testing.T) {
+	suite.Run(t, new(APITestSuite))
+}
+
+type APITestSuite struct {
+	suite.Suite
+	tempDir string
+}
+
+func (suite *APITestSuite) SetupTest() {
+	dir, _ := os.MkdirTemp("", "datarobot-api-test")
+	suite.tempDir = dir
+	suite.T().Setenv("HOME", suite.tempDir)
+	suite.T().Setenv("XDG_CONFIG_HOME", "")
+	viper.Reset()
+}
+
+func (suite *APITestSuite) TestSetURLToConfig() {
+	tests := []struct {
+		name        string
+		input       string
+		expectedURL string
+		expectError bool
+	}{
+		{
+			name:        "full URL with API suffix",
+			input:       "https://app.datarobot.com/api/v2",
+			expectedURL: "https://app.datarobot.com/api/v2",
+		},
+		{
+			name:        "base URL without suffix",
+			input:       "https://app.datarobot.com",
+			expectedURL: "https://app.datarobot.com/api/v2",
+		},
+		{
+			name:        "shortcut 1 resolves to app.datarobot.com",
+			input:       "1",
+			expectedURL: "https://app.datarobot.com/api/v2",
+		},
+		{
+			name:        "shortcut 2 resolves to app.eu.datarobot.com",
+			input:       "2",
+			expectedURL: "https://app.eu.datarobot.com/api/v2",
+		},
+		{
+			name:        "shortcut 3 resolves to app.jp.datarobot.com",
+			input:       "3",
+			expectedURL: "https://app.jp.datarobot.com/api/v2",
+		},
+		{
+			name:        "URL with trailing path gets trimmed to host",
+			input:       "https://custom.example.com/some/path",
+			expectedURL: "https://custom.example.com/api/v2",
+		},
+		{
+			name:        "invalid URL without host returns error",
+			input:       "not-a-url",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			viper.Reset()
+
+			err := SetURLToConfig(tc.input)
+
+			if tc.expectError {
+				suite.Require().Error(err)
+			} else {
+				suite.Require().NoError(err)
+				suite.Equal(tc.expectedURL, viper.GetString(DataRobotURL))
+			}
+		})
+	}
+}
+
+func (suite *APITestSuite) TestSetURLToConfigDoesNotWriteFile() {
+	err := SetURLToConfig("https://app.datarobot.com")
+	suite.Require().NoError(err)
+
+	configFile := filepath.Join(suite.tempDir, ".config/datarobot/drconfig.yaml")
+	suite.NoFileExists(configFile, "SetURLToConfig must not write the config file to disk")
+}


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->
Don't touch ~/.config/datarobot/drconfig.yaml until both valid endpoint AND token are ready when running dr auth login. So unfinished auth flow won't break anything.



Actual:

When running dr auth login, the CLI will write to ~/.config/datarobot/drconfig.yaml a set of credentials before the auth flow is complete.

Expected:

When running dr auth login, the CLI will write to ~/.config/datarobot/drconfig.yaml the set of credentials ONLY once auth flow is complete and successful.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
- Created `SetURLToConfig` function in `internal/config/api.go`
- Updated following files to use new `SetURLToConfig` function instead of `SaveURLToConfig`:
-- `cmd/auth/login/cmd.go`
-- `cmd/auth/seturl/cmd.go`
-- `internal/auth/auth.go`

## IMPORTANT
`SaveURLToConfig` function still exists as it is used in `cmd/templates/setup/model.go`

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. A maintainer must manually trigger the "Fork PR Smoke Tests" workflow from the Actions tab, providing your PR number. Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the CLI mutates and writes `drconfig.yaml` during authentication, which can affect users’ ability to log in and persist credentials if there are edge-case failures. The scope is contained to URL-setting and config-write helpers, with added tests to reduce regression risk.
> 
> **Overview**
> **Defers config-file writes during auth URL setup.** `dr auth login` and `dr auth set-url` now call the new `config.SetURLToConfig` helper, which updates the in-memory Viper config with a normalized endpoint (`/api/v2`) **without writing** `drconfig.yaml` until the auth flow completes successfully.
> 
> `auth.WriteConfigFileSilent` now ensures the config directory/file exists before writing, and the interactive URL prompt messaging is updated to reflect that validation/API-key retrieval happens next. Adds a new `internal/config/api_test.go` suite covering URL normalization (including shortcuts) and asserting `SetURLToConfig` does not write to disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69035964918543aa3bb8ccd47c0f285580c2bdfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->