### PR TITLE
[CFX-5560] chore: new task delint to fix lints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,15 +66,19 @@ func example() {
 
 ## Quality Tools
 
-All code must pass these tools without errors:
+The `task lint` command runs the following tools in order:
 
+**Fixing phase:**
 - `go mod tidy` - dependency management
 - `go fmt` - basic formatting
+- `gofumpt` - aggressive Go formatting
+- `golangci-lint --fix` - comprehensive linting with automatic fixes (includes wsl, revive, staticcheck)
+
+**Checking phase:**
 - `go vet` - suspicious constructs
-- `golangci-lint` - comprehensive linting (includes wsl, revive, staticcheck)
 - `goreleaser check` - release configuration validation
 
-**Before submitting code, mentally verify it follows wsl (whitespace) rules.**
+All code must pass these tools without errors. **Before submitting code, mentally verify it follows wsl (whitespace) rules.**
 
 ### Updating golangci-lint
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,19 +66,21 @@ func example() {
 
 ## Quality Tools
 
-The `task lint` command runs the following tools in order:
+The `task lint` command runs the following tools:
 
 **Fixing phase:**
+
 - `go mod tidy` - dependency management
 - `go fmt` - basic formatting
 - `gofumpt` - aggressive Go formatting
 - `golangci-lint --fix` - comprehensive linting with automatic fixes (includes wsl, revive, staticcheck)
 
 **Checking phase:**
+
 - `go vet` - suspicious constructs
 - `goreleaser check` - release configuration validation
 
-All code must pass these tools without errors. **Before submitting code, mentally verify it follows wsl (whitespace) rules.**
+All code must pass these tools without errors.
 
 ### Updating golangci-lint
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Use Taskfile tasks rather than raw Go commands:
 | Command         | Description                                 |
 | --------------- | ------------------------------------------- |
 | `task build`    | Build the CLI binary (outputs to ./dist/dr) |
-| `task lint`     | Lint and format all code                    |
+| `task lint`     | Check for lint issues (read-only)           |
+| `task delint`   | Fix lint and formatting issues              |
 | `task test`     | Run tests with race detection and coverage  |
 | `task dev-init` | Initialize development environment          |
 | `task run`      | Run CLI directly via `go run`               |
@@ -66,21 +67,20 @@ func example() {
 
 ## Quality Tools
 
-The `task lint` command runs the following tools:
+**`task lint`** (check-only, non-modifying):
+- `go mod tidy -diff` - checks if go.mod/go.sum need updates
+- `gofumpt -l -d` - lists formatting issues and shows diffs
+- `go vet` - checks for suspicious constructs
+- `golangci-lint run` - comprehensive linting checks (includes wsl, revive, staticcheck)
+- `goreleaser check` - validates release configuration
 
-**Fixing phase:**
+**`task delint`** (auto-fixes):
+- `go mod tidy` - fixes go.mod/go.sum
+- `go fmt` - fixes basic formatting
+- `gofumpt -l -w` - fixes aggressive Go formatting
+- `golangci-lint run --fix` - fixes linting issues where possible
 
-- `go mod tidy` - dependency management
-- `go fmt` - basic formatting
-- `gofumpt` - aggressive Go formatting
-- `golangci-lint --fix` - comprehensive linting with automatic fixes (includes wsl, revive, staticcheck)
-
-**Checking phase:**
-
-- `go vet` - suspicious constructs
-- `goreleaser check` - release configuration validation
-
-All code must pass these tools without errors.
+All code must pass `task lint` before submitting.
 
 ### Updating golangci-lint
 
@@ -89,7 +89,7 @@ When upgrading the Go version in `go.mod`, you may need to update golangci-lint 
 1. Check the [golangci-lint releases](https://github.com/golangci/golangci-lint/releases) for a version that supports your target Go version
 2. Update the `GOLANGCI_LINT_VERSION` variable in `Taskfile.yaml`
 3. Run `task install-tools` to download the pre-built binary
-4. Run `task lint` to verify compatibility
+4. Run `task delint` to auto-fix any issues, then `task lint` to verify compatibility
 
 The `GOLANGCI_LINT_VERSION` is pinned to ensure reproducible builds across all development environments. The binary is installed as a standalone pre-built artifact, not via `go install`, so version mismatches between your project's Go version and golangci-lint's internal Go version are handled automatically.
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -52,7 +52,7 @@ tasks:
   dev-init:
     silent: true
     desc: "Initialize development environment"
-    deps: [lint]
+    deps: [delint]
     cmds:
       - |
         export GOBIN={{.BIN_DIR}}
@@ -64,7 +64,23 @@ tasks:
 
   lint:
     silent: true
-    desc: "Lint the source code"
+    desc: "Check for lint issues (does not modify files)"
+    deps: [install-tools]
+    cmds:
+      - echo "🧹 Checking go.mod…"
+      - go mod tidy -diff
+      - echo "🧹 Checking formatting…"
+      - "{{.BIN_DIR}}/gofumpt -l -d ."
+      - echo "🧹 Vetting…"
+      - go vet ./...
+      - echo "🧹 Linting…"
+      - "{{.BIN_DIR}}/golangci-lint run ./..."
+      - echo "🧹 Checking GoReleaser config…"
+      - "{{.BIN_DIR}}/goreleaser check"
+
+  delint:
+    silent: true
+    desc: "Fix lint and formatting issues"
     deps: [install-tools]
     cmds:
       - echo "🧹 Cleaning go.mod…"
@@ -72,12 +88,8 @@ tasks:
       - echo "🧹 Formatting files…"
       - go fmt ./...
       - "{{.BIN_DIR}}/gofumpt -l -w ."
-      - echo "🧹 Linting…"
+      - echo "🧹 Fixing lint issues…"
       - "{{.BIN_DIR}}/golangci-lint run --fix ./..."
-      - echo "🧹 Vetting go.mod…"
-      - go vet ./...
-      - echo "🧹 Checking GoReleaser config…"
-      - "{{.BIN_DIR}}/goreleaser check"
 
   run:
     silent: true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -72,10 +72,10 @@ tasks:
       - echo "🧹 Formatting files…"
       - go fmt ./...
       - "{{.BIN_DIR}}/gofumpt -l -w ."
-      - echo "🧹 Vetting go.mod…"
-      - go vet ./...
       - echo "🧹 Linting…"
       - "{{.BIN_DIR}}/golangci-lint run --fix ./..."
+      - echo "🧹 Vetting go.mod…"
+      - go vet ./...
       - echo "🧹 Checking GoReleaser config…"
       - "{{.BIN_DIR}}/goreleaser check"
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -74,9 +74,9 @@ tasks:
       - "{{.BIN_DIR}}/gofumpt -l -w ."
       - echo "🧹 Vetting go.mod…"
       - go vet ./...
-      - echo "🧹 GoCI Lint…"
-      - "{{.BIN_DIR}}/golangci-lint run ./..."
-      - echo "🧹 Check GoReleaser…"
+      - echo "🧹 Linting…"
+      - "{{.BIN_DIR}}/golangci-lint run --fix ./..."
+      - echo "🧹 Checking GoReleaser config…"
       - "{{.BIN_DIR}}/goreleaser check"
 
   run:


### PR DESCRIPTION
# RATIONALE

I want a way to fix as many lint issues as possible. `lint` does some already, but I know golangci-lint can fix issues, so let's do that too.

Let's actually do that in a new `delint` task, and leave `lint` as is.

## CHANGES

task delint
golangci-lint run --fix
simplify AGENTS.md
update dev docs

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. A maintainer must manually trigger the "Fork PR Smoke Tests" workflow from the Actions tab, providing your PR number. Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling/docs and do not affect runtime CLI behavior. Main impact is local/CI workflows now using `task lint` for non-modifying checks and `task delint` for auto-fixes.
> 
> **Overview**
> Splits linting into **check-only** `task lint` and **auto-fixing** `task delint`, making `lint` non-modifying (uses `go mod tidy -diff`, `gofumpt -d`, `golangci-lint run`, and `goreleaser check`) while `delint` runs formatting/dependency cleanup and `golangci-lint run --fix`.
> 
> Updates `dev-init` to depend on `delint` and refreshes `AGENTS.md` to document the new task semantics and recommended workflow (run `delint` to fix, then `lint` to verify).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d28716daa39682b3518dc5e23571fa380ccfc72e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->