### PR TITLE
[CFX-5557] tweak templates setup timeouts

### DIFF
--- a/smoke_test_scripts/expect_templates_setup.exp
+++ b/smoke_test_scripts/expect_templates_setup.exp
@@ -49,9 +49,6 @@ send -- "\r\n"
 # The Pulumi State Backend Selection screen may appear before the wizard if the
 # template includes PULUMI_CONFIG_PASSPHRASE and Pulumi is installed but not
 # logged in on the runner.
-# Note that git clone can take 60+ seconds or more on slower macOS runners,
-# plus CheckPulumiSetup adds up to 10s more.
-set timeout 180
 expect {
     "Pulumi State Backend Selection" {
         puts "Pulumi setup screen detected - selecting Login locally"

--- a/smoke_test_scripts/expect_templates_setup.exp
+++ b/smoke_test_scripts/expect_templates_setup.exp
@@ -49,7 +49,9 @@ send -- "\r\n"
 # The Pulumi State Backend Selection screen may appear before the wizard if the
 # template includes PULUMI_CONFIG_PASSPHRASE and Pulumi is installed but not
 # logged in on the runner.
-set timeout 60
+# Use a longer timeout: git clone can take 60+ seconds on slower macOS runners,
+# plus CheckPulumiSetup adds up to 10s more.
+set timeout 180
 expect {
     "Pulumi State Backend Selection" {
         puts "Pulumi setup screen detected - selecting Login locally"

--- a/smoke_test_scripts/expect_templates_setup.exp
+++ b/smoke_test_scripts/expect_templates_setup.exp
@@ -49,7 +49,7 @@ send -- "\r\n"
 # The Pulumi State Backend Selection screen may appear before the wizard if the
 # template includes PULUMI_CONFIG_PASSPHRASE and Pulumi is installed but not
 # logged in on the runner.
-set timeout 30
+set timeout 60
 expect {
     "Pulumi State Backend Selection" {
         puts "Pulumi setup screen detected - selecting Login locally"

--- a/smoke_test_scripts/expect_templates_setup.exp
+++ b/smoke_test_scripts/expect_templates_setup.exp
@@ -49,7 +49,7 @@ send -- "\r\n"
 # The Pulumi State Backend Selection screen may appear before the wizard if the
 # template includes PULUMI_CONFIG_PASSPHRASE and Pulumi is installed but not
 # logged in on the runner.
-# Use a longer timeout: git clone can take 60+ seconds on slower macOS runners,
+# Note that git clone can take 60+ seconds or more on slower macOS runners,
 # plus CheckPulumiSetup adds up to 10s more.
 set timeout 180
 expect {


### PR DESCRIPTION
# RATIONALE

Flaky test now: https://github.com/datarobot-oss/cli/actions/runs/24057232285/attempts/1

But it succeeded on the second try:  https://github.com/datarobot-oss/cli/actions/runs/24057232285

I think its because I changed timeouts to 30s for Phase 0, but that's not really necessary. Let's see if the previous value of 360s works here.

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. A maintainer must manually trigger the "Fork PR Smoke Tests" workflow from the Actions tab, providing your PR number. Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes an Expect timeout in smoke-test automation to reduce flakiness; no product/runtime logic is affected.
> 
> **Overview**
> Reduces smoke-test flakiness in `smoke_test_scripts/expect_templates_setup.exp` by removing the shortened Phase 0 timeout, allowing the existing longer timeout to cover the Pulumi pre-wizard flow before the dotenv wizard starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182723734c378d25b401477715fd3de672f187dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->