### PR TITLE
Enable API consumer tracking

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,6 +90,8 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 		// Store telemetry client in context for use by commands
 		cmd.SetContext(context.WithValue(cmd.Context(), telemetryClientKey{}, client))
 
+		config.SetAPIConsumerTrace(config.CommandPathToTrace(cmd.CommandPath()))
+
 		return nil
 	},
 	PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -211,6 +211,13 @@ func initializeConfig(cmd *cobra.Command) error {
 
 	_ = viper.BindEnv("external-editor", "VISUAL", "EDITOR")
 
+	// API consumer tracking is enabled by default.
+	// Set DATAROBOT_API_CONSUMER_TRACKING_ENABLED=false to opt out,
+	// matching the Python SDK convention.
+	viper.SetDefault(config.APIConsumerTrackingEnabled, true)
+
+	_ = viper.BindEnv(config.APIConsumerTrackingEnabled, "DATAROBOT_API_CONSUMER_TRACKING_ENABLED")
+
 	// If DATAROBOT_CLI_CONFIG is set and no explicit --config flag was provided,
 	// use the environment variable value
 	if configFilePath == "" {

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -139,6 +139,8 @@ export DATAROBOT_CLI_FORCE_INTERACTIVE=true
 # API consumer tracking (default: true)
 # Set to false to disable the X-DataRobot-Api-Consumer-Trace header on API requests.
 # Matches the Python SDK's DATAROBOT_API_CONSUMER_TRACKING_ENABLED behavior.
+# When enabled, the header value identifies the command being run using dot-notation:
+#   datarobot.cli.<command>.<subcommand>  (e.g. datarobot.cli.templates.setup)
 export DATAROBOT_API_CONSUMER_TRACKING_ENABLED=false
 ```
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -135,6 +135,11 @@ export EDITOR=nano
 
 # Force setup wizard to run even if already completed
 export DATAROBOT_CLI_FORCE_INTERACTIVE=true
+
+# API consumer tracking (default: true)
+# Set to false to disable the X-DataRobot-Api-Consumer-Trace header on API requests.
+# Matches the Python SDK's DATAROBOT_API_CONSUMER_TRACKING_ENABLED behavior.
+export DATAROBOT_API_CONSUMER_TRACKING_ENABLED=false
 ```
 
 ### Advanced flags

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -69,6 +69,13 @@ func GetUserAgentHeader() string {
 	return version.GetAppNameVersionText()
 }
 
+// IsAPIConsumerTrackingEnabled returns true if the X-DataRobot-Api-Consumer-Trace
+// header should be sent with API requests. Controlled by the
+// DATAROBOT_API_CONSUMER_TRACKING_ENABLED environment variable (default: true).
+func IsAPIConsumerTrackingEnabled() bool {
+	return viper.GetBool(APIConsumerTrackingEnabled)
+}
+
 func RedactedReqInfo(req *http.Request) string {
 	// Dump the request to a byte slice after cloning and removing Auth header
 	dumpReq := req.Clone(req.Context())

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -69,6 +69,39 @@ func GetUserAgentHeader() string {
 	return version.GetAppNameVersionText()
 }
 
+// apiConsumerTrace holds the dot-notation command path set at startup.
+// Example: "datarobot.cli.templates.setup"
+var apiConsumerTrace string
+
+// SetAPIConsumerTrace stores the dot-notation trace value for the running command.
+// Called once during PersistentPreRunE with the result of CommandPathToTrace.
+func SetAPIConsumerTrace(trace string) {
+	apiConsumerTrace = trace
+}
+
+// GetAPIConsumerTrace returns the dot-notation trace value for the running command.
+// Falls back to "datarobot.cli" if SetAPIConsumerTrace has not been called.
+func GetAPIConsumerTrace() string {
+	if apiConsumerTrace == "" {
+		return "datarobot.cli"
+	}
+
+	return apiConsumerTrace
+}
+
+// CommandPathToTrace converts a cobra command path (e.g. "dr templates setup")
+// to the canonical dot-notation trace format (e.g. "datarobot.cli.templates.setup").
+func CommandPathToTrace(commandPath string) string {
+	parts := strings.Fields(commandPath)
+	if len(parts) == 0 {
+		return "datarobot.cli"
+	}
+
+	parts[0] = "datarobot.cli"
+
+	return strings.Join(parts, ".")
+}
+
 // IsAPIConsumerTrackingEnabled returns true if the X-DataRobot-Api-Consumer-Trace
 // header should be sent with API requests. Controlled by the
 // DATAROBOT_API_CONSUMER_TRACKING_ENABLED environment variable (default: true).

--- a/internal/config/api_test.go
+++ b/internal/config/api_test.go
@@ -107,3 +107,65 @@ func (suite *APITestSuite) TestSetURLToConfigDoesNotWriteFile() {
 	configFile := filepath.Join(suite.tempDir, ".config/datarobot/drconfig.yaml")
 	suite.NoFileExists(configFile, "SetURLToConfig must not write the config file to disk")
 }
+
+func (suite *APITestSuite) TestCommandPathToTrace() {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "datarobot.cli",
+		},
+		{
+			name:     "root command only",
+			input:    "dr",
+			expected: "datarobot.cli",
+		},
+		{
+			name:     "single subcommand",
+			input:    "dr start",
+			expected: "datarobot.cli.start",
+		},
+		{
+			name:     "nested subcommand",
+			input:    "dr templates setup",
+			expected: "datarobot.cli.templates.setup",
+		},
+		{
+			name:     "deeply nested subcommand",
+			input:    "dr self plugin add",
+			expected: "datarobot.cli.self.plugin.add",
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			suite.Equal(tc.expected, CommandPathToTrace(tc.input))
+		})
+	}
+}
+
+func (suite *APITestSuite) TestGetSetAPIConsumerTrace() {
+	SetAPIConsumerTrace("")
+
+	suite.Equal("datarobot.cli", GetAPIConsumerTrace(), "should fall back to datarobot.cli when unset")
+
+	SetAPIConsumerTrace("datarobot.cli.templates.list")
+	suite.Equal("datarobot.cli.templates.list", GetAPIConsumerTrace())
+
+	SetAPIConsumerTrace("datarobot.cli.start")
+	suite.Equal("datarobot.cli.start", GetAPIConsumerTrace())
+}
+
+func (suite *APITestSuite) TestIsAPIConsumerTrackingEnabled() {
+	suite.False(IsAPIConsumerTrackingEnabled(), "should be false when viper has no config set")
+
+	viper.Set(APIConsumerTrackingEnabled, true)
+	suite.True(IsAPIConsumerTrackingEnabled())
+
+	viper.Set(APIConsumerTrackingEnabled, false)
+	suite.False(IsAPIConsumerTrackingEnabled())
+}

--- a/internal/config/api_test.go
+++ b/internal/config/api_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
 )
@@ -168,4 +169,52 @@ func (suite *APITestSuite) TestIsAPIConsumerTrackingEnabled() {
 
 	viper.Set(APIConsumerTrackingEnabled, false)
 	suite.False(IsAPIConsumerTrackingEnabled())
+}
+
+// TestCommandPathToTraceWithAliases verifies that cobra always resolves
+// command aliases to their canonical Use name before CommandPath() is called.
+// This means CommandPathToTrace never receives an alias string — cobra
+// normalises it first — so the trace always uses the canonical command name.
+func (suite *APITestSuite) TestCommandPathToTraceWithAliases() {
+	// Build a small cobra command tree that mirrors real CLI aliases:
+	//   root (Use: "dr")
+	//   └─ run (Use: "run", Aliases: ["r"])      → like dr run / dr r
+	//   └─ start (Use: "start", Aliases: ["quickstart"]) → like dr start / dr quickstart
+	//   └─ templates (Use: "templates", Aliases: ["template"])
+	//      └─ list (Use: "list")
+	root := &cobra.Command{Use: "dr"}
+
+	run := &cobra.Command{Use: "run [tasks]", Aliases: []string{"r"}}
+	start := &cobra.Command{Use: "start", Aliases: []string{"quickstart"}}
+	templates := &cobra.Command{Use: "templates", Aliases: []string{"template"}}
+	list := &cobra.Command{Use: "list"}
+
+	templates.AddCommand(list)
+	root.AddCommand(run, start, templates)
+
+	tests := []struct {
+		name          string
+		args          []string
+		expectedTrace string
+	}{
+		// Canonical invocations
+		{"canonical: dr run", []string{"run"}, "datarobot.cli.run"},
+		{"canonical: dr start", []string{"start"}, "datarobot.cli.start"},
+		{"canonical: dr templates list", []string{"templates", "list"}, "datarobot.cli.templates.list"},
+		// Cobra command aliases — CommandPath() must return the canonical name
+		{"alias: dr r → dr run", []string{"r"}, "datarobot.cli.run"},
+		{"alias: dr quickstart → dr start", []string{"quickstart"}, "datarobot.cli.start"},
+		{"alias: dr template list → dr templates list", []string{"template", "list"}, "datarobot.cli.templates.list"},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			cmd, _, err := root.Find(tc.args)
+			suite.Require().NoError(err)
+			suite.Require().NotNil(cmd)
+
+			trace := CommandPathToTrace(cmd.CommandPath())
+			suite.Equal(tc.expectedTrace, trace)
+		})
+	}
 }

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -62,6 +62,10 @@ func VerifyToken(ctx context.Context, datarobotEndpoint, token string) error {
 	req.Header.Add("Authorization", bearer)
 	req.Header.Add("User-Agent", getUserAgent(ctx))
 
+	if IsAPIConsumerTrackingEnabled() {
+		req.Header.Add("X-DataRobot-Api-Consumer-Trace", getUserAgent(ctx))
+	}
+
 	log.Debug("Request Info: \n" + RedactedReqInfo(req))
 
 	client := &http.Client{

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -63,7 +63,7 @@ func VerifyToken(ctx context.Context, datarobotEndpoint, token string) error {
 	req.Header.Add("User-Agent", getUserAgent(ctx))
 
 	if IsAPIConsumerTrackingEnabled() {
-		req.Header.Add("X-DataRobot-Api-Consumer-Trace", getUserAgent(ctx))
+		req.Header.Add("X-DataRobot-Api-Consumer-Trace", "datarobot.cli.auth.verify")
 	}
 
 	log.Debug("Request Info: \n" + RedactedReqInfo(req))

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -17,4 +17,6 @@ package config
 const (
 	DataRobotURL    = "endpoint"
 	DataRobotAPIKey = "token"
+
+	APIConsumerTrackingEnabled = "api-consumer-tracking-enabled"
 )

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -21,8 +21,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/charmbracelet/log"
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/log"
 )
 
 var token string

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -47,7 +47,7 @@ func Get(url, info string) (*http.Response, error) {
 	req.Header.Add("User-Agent", config.GetUserAgentHeader())
 
 	if config.IsAPIConsumerTrackingEnabled() {
-		req.Header.Add("X-DataRobot-Api-Consumer-Trace", config.GetUserAgentHeader())
+		req.Header.Add("X-DataRobot-Api-Consumer-Trace", config.GetAPIConsumerTrace())
 	}
 
 	if info != "" {

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -46,6 +46,10 @@ func Get(url, info string) (*http.Response, error) {
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("User-Agent", config.GetUserAgentHeader())
 
+	if config.IsAPIConsumerTrackingEnabled() {
+		req.Header.Add("X-DataRobot-Api-Consumer-Trace", config.GetUserAgentHeader())
+	}
+
 	if info != "" {
 		log.Infof("Fetching %s from: %s", info, url)
 	}


### PR DESCRIPTION
This pull request introduces API consumer tracking to the CLI, enabling the inclusion of a `X-DataRobot-Api-Consumer-Trace` header in API requests. This header identifies the running command in dot-notation format (e.g., `datarobot.cli.templates.setup`), aligning with the Python SDK's behavior. The feature is enabled by default and can be disabled via an environment variable. The implementation includes configuration changes, header injection in API requests, utility functions, and comprehensive tests.

**API Consumer Tracking Feature:**

* Added support for the `X-DataRobot-Api-Consumer-Trace` header in API requests, using a dot-notation command path to identify the CLI command being executed (e.g., `datarobot.cli.templates.setup`). This is controlled by the `DATAROBOT_API_CONSUMER_TRACKING_ENABLED` environment variable, which is enabled by default to match the Python SDK convention. (`cmd/root.go` [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL72-R78) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR190-R196); `internal/config/constants.go` [[3]](diffhunk://#diff-f7f2997c34707c2697a82f1ed81234fb746dc27cf32a25bd79eddb2e7409fc47R20-R21); `docs/user-guide/configuration.md` [[4]](diffhunk://#diff-546d5ce955be10a583e1890e3a17ae921c5e5166f30a67bf3635f8d697b0eda5R138-R144)

* Implemented utility functions in `internal/config/api.go` for managing the trace value: `SetAPIConsumerTrace`, `GetAPIConsumerTrace`, `CommandPathToTrace`, and `IsAPIConsumerTrackingEnabled`. These handle storing, formatting, and retrieving the trace value and checking if tracking is enabled. (`internal/config/api.go` [internal/config/api.goR72-R111](diffhunk://#diff-a851a5c144f593e9087f2ec08d4732eff8a9715d1c5c1fd0d7afb5ce5c1b6238R72-R111))

**Integration with API Requests:**

* Injected the `X-DataRobot-Api-Consumer-Trace` header into outgoing API requests in both the authentication (`internal/config/auth.go`) and general API (`internal/drapi/get.go`) code paths, using the appropriate trace value. (`internal/config/auth.go` [[1]](diffhunk://#diff-2b566a23119478a07731fceb68804514e96be17798356217f5c52917bb5dc184R65-R68); `internal/drapi/get.go` [[2]](diffhunk://#diff-6a3ac17cde85860cadf73cb10c3feaaef607c6269b098b61ad5db8f0254c9581R49-R52)

**Testing:**

* Added comprehensive unit tests for the new utility functions to verify correct trace formatting, storage, and environment variable behavior. (`internal/config/api_test.go` [internal/config/api_test.goR110-R171](diffhunk://#diff-dc2e6cb67ac6817a083d2228648baf6e5c61d4283671a962e9f48e83616a94d2R110-R171))


<img width="665" height="155" alt="image" src="https://github.com/user-attachments/assets/8d9a70ca-0549-487d-bd16-ec95808d854f" />

<img width="665" height="155" alt="image" src="https://github.com/user-attachments/assets/f479ac5b-92ca-4ff6-9629-f7d0e0de796d" />

# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. A maintainer must manually trigger the "Fork PR Smoke Tests" workflow from the Actions tab, providing your PR number. Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default HTTP request behavior by adding a new `X-DataRobot-Api-Consumer-Trace` header on API calls, which could affect downstream logging/analytics and any integrations sensitive to headers. Includes new global trace state derived from cobra command paths and an opt-out env var.
> 
> **Overview**
> Adds API consumer tracking to the CLI by computing a dot-notation trace from the running cobra command (set during `PersistentPreRunE`) and attaching it as `X-DataRobot-Api-Consumer-Trace` on outgoing API requests.
> 
> Tracking is **enabled by default** via new config key `api-consumer-tracking-enabled` and env var `DATAROBOT_API_CONSUMER_TRACKING_ENABLED`, documented in the user guide; requests in both the auth verification path and generic `drapi.Get` now conditionally include the header. Unit tests cover trace formatting, trace storage, enable/disable behavior, and cobra alias normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a4afa819fb9d66ce76b54fc8f11ac5916764652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->