### PR TITLE
Add assist plugin v0.1.19

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.19",
+          "url": "assist/assist-0.1.19.tar.xz",
+          "sha256": "8bbb0ded53db02e422cf166456903c808edba74fef99f66dc8dda69aa1720a26",
+          "releaseDate": "2026-04-13"
+        },
+        {
           "version": "0.1.18",
           "url": "assist/assist-0.1.18.tar.xz",
           "sha256": "48fb7d2926c58789a47b73ef6634c11d972f70acf4ee548574feb36529c1b754",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.19 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.19
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.19
- **SHA256:** `8bbb0ded53db02e422cf166456903c808edba74fef99f66dc8dda69aa1720a26`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a documentation/index update that adds a new plugin version entry (URL/SHA/date) without changing runtime code paths.
> 
> **Overview**
> Updates `docs/plugins/index.json` to publish `assist` v`0.1.19`, including its download URL, SHA256 checksum, and release date, making it available for CLI plugin installation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d73584715393e57b0a5dc042b34a3c26837184b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->