### PR TITLE
[CFX3938] Brew installs dr completions automatically after dr-cli is installed

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -82,9 +82,14 @@ homebrew_casks:
         install: |
           if OS.mac?
             system_command "/bin/ln", args: ["-sf", "#{HOMEBREW_PREFIX}/bin/dr", "#{HOMEBREW_PREFIX}/bin/datarobot"]
+            system_command "xattr", args: ["-dr", "com.apple.quarantine", "#{HOMEBREW_PREFIX}/bin/datarobot"]
+            system_command "xattr", args: ["-dr", "com.apple.quarantine", "#{HOMEBREW_PREFIX}/bin/dr"]
+            system_command "#{HOMEBREW_PREFIX}/bin/dr", args: ["self", "completion", "install", "--yes"]
           end
+      pre:
         uninstall: |
           if OS.mac?
+            system_command "#{HOMEBREW_PREFIX}/bin/dr", args: ["self", "completion", "uninstall", "--yes"]
             symlink = Pathname.new("#{HOMEBREW_PREFIX}/bin/datarobot")
             symlink.delete if symlink.symlink?
           end


### PR DESCRIPTION
# RATIONALE
Homebrew `brew install dr-cli` executes `dr self completions install --yes` right after `dr-cli` installation

<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Added system command in `goreleaser.yaml`  fiel:
- Delete quarantine attribute for `dr` and `datarobot` binaries for cases when Apple is not able to verify the binaries. This command doesn't throw error, once there isn't any quarantine attribute for this binary
- Execute `dr self completions instal --yes` after dr-cli is installed
- Execute `dr self completions uninstal --yes` before dr-cli removed via brew


## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. A maintainer must manually trigger the "Fork PR Smoke Tests" workflow from the Actions tab, providing your PR number. Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Homebrew cask install/uninstall hooks to run extra macOS commands; main impact is potential install/uninstall hook failures or behavior differences on user machines.
> 
> **Overview**
> Updates the `dr-cli` Homebrew cask hooks to perform additional macOS setup/cleanup steps.
> 
> On install, it now clears the `com.apple.quarantine` attribute from the `dr`/`datarobot` binaries and runs `dr self completion install --yes` after creating the `datarobot` symlink. On uninstall, it runs `dr self completion uninstall --yes` before removing the `datarobot` symlink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d995865358476c3288fe7eeddf5ddf31f3ae8188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->