### PR TITLE
[CFX-5680] ci: completions test not triggering

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,6 +11,8 @@ on:
 
 jobs:
 
+  # This job detects what types of files were changed in the PR and sets outputs
+  # that other jobs can use to conditionally run only when relevant files were changed.
   detect-changes:
     runs-on: ubuntu-latest
     name: Detect Changes
@@ -31,7 +33,7 @@ jobs:
           filters: |
             completion:
               - 'cmd/self/completion/**'
-              - 'goreleaser.yaml'
+              - 'goreleaser.yaml'  # Homebrew post-install hook runs `dr self completion install`
             dotenv:
               - 'cmd/dotenv/**'
             templates:
@@ -172,7 +174,8 @@ jobs:
   build:
     needs: detect-changes
     name: Build Binaries
-    if: needs.detect-changes.outputs.go_code == 'true'
+    # Completion-tests is dependent on Build, so we need to build binaries if either code or completion-related files changed.
+    if: needs.detect-changes.outputs.go_code == 'true' || needs.detect-changes.outputs.completion == 'true'
     uses: ./.github/workflows/.build-matrix.yaml
     with:
       go-version: '1.26.1'

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -30,7 +30,8 @@ jobs:
         with:
           filters: |
             completion:
-              - 'cmd/completion/**'
+              - 'cmd/self/completion/**'
+              - 'goreleaser.yaml'
             dotenv:
               - 'cmd/dotenv/**'
             templates:

--- a/cmd/self/completion/install/cmd_test.go
+++ b/cmd/self/completion/install/cmd_test.go
@@ -15,6 +15,7 @@
 package install
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -353,7 +354,7 @@ func TestResolveShell(t *testing.T) {
 	}
 }
 
-func testEnsureFpathInZshrcHelper(t *testing.T, name, content, shouldContain string) {
+func testEnsureFpathInZshrcHelper(t *testing.T, content, shouldContain string) {
 	t.Helper()
 
 	tmpDir, err := os.MkdirTemp("", "test-zshrc-*")
@@ -383,9 +384,15 @@ func testEnsureFpathInZshrcHelper(t *testing.T, name, content, shouldContain str
 }
 
 func TestEnsureFpathInZshrc(t *testing.T) {
-	testEnsureFpathInZshrcHelper(t, "add fpath to empty zshrc", "", "fpath=")
-	testEnsureFpathInZshrcHelper(t, "add fpath to existing content", "export PATH=/usr/local/bin:$PATH\n", "fpath=")
-	testEnsureFpathInZshrcHelper(t, "already contains fpath", "fpath=(/custom/path $fpath)\n", "/custom/path")
+	t.Run("add fpath to empty zshrc", func(t *testing.T) {
+		testEnsureFpathInZshrcHelper(t, "", "fpath=")
+	})
+	t.Run("add fpath to existing content", func(t *testing.T) {
+		testEnsureFpathInZshrcHelper(t, "export PATH=/usr/local/bin:$PATH\n", "fpath=")
+	})
+	t.Run("already contains fpath", func(t *testing.T) {
+		testEnsureFpathInZshrcHelper(t, "fpath=(/custom/path $fpath)\n", "/custom/path")
+	})
 }
 
 func TestEnsureFpathInZshrcNotFound(t *testing.T) {
@@ -400,7 +407,7 @@ func TestEnsureFpathInZshrcNotFound(t *testing.T) {
 
 	err = ensureFpathInZshrc(nonexistentPath, compDir)
 	if err == nil {
-		t.Error("expected error for nonexistent file, got nil")
+		t.Fatal("expected error for nonexistent file, got nil")
 	}
 
 	if !strings.Contains(err.Error(), "~/.zshrc not found") {
@@ -408,7 +415,7 @@ func TestEnsureFpathInZshrcNotFound(t *testing.T) {
 	}
 }
 
-func testEnsureSourceInBashrcHelper(t *testing.T, content, completionFile, shouldContain string) {
+func testEnsureSourceInBashrcHelper(t *testing.T, compFileInTmpDir, expectedInFile string, expectIdempotent bool) {
 	t.Helper()
 
 	tmpDir, err := os.MkdirTemp("", "test-bashrc-*")
@@ -418,11 +425,18 @@ func testEnsureSourceInBashrcHelper(t *testing.T, content, completionFile, shoul
 	defer os.RemoveAll(tmpDir)
 
 	bashrcPath := filepath.Join(tmpDir, ".bashrc")
-	if err := os.WriteFile(bashrcPath, []byte(content), 0o644); err != nil {
+	compFile := filepath.Join(tmpDir, compFileInTmpDir)
+
+	// For idempotent test, pre-populate bashrc with the expected source line
+	var initialContent string
+	if expectIdempotent {
+		initialContent = fmt.Sprintf("[ -f %s ] && source %s\n", compFile, compFile)
+	}
+
+	if err := os.WriteFile(bashrcPath, []byte(initialContent), 0o644); err != nil {
 		t.Fatalf("failed to write bashrc: %v", err)
 	}
 
-	compFile := filepath.Join(tmpDir, completionFile)
 	if err := ensureSourceInBashrc(bashrcPath, compFile); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -432,15 +446,30 @@ func testEnsureSourceInBashrcHelper(t *testing.T, content, completionFile, shoul
 		t.Fatalf("failed to read bashrc: %v", err)
 	}
 
-	if !strings.Contains(string(fileContent), shouldContain) {
-		t.Errorf("expected content to contain %q, got: %s", shouldContain, string(fileContent))
+	contentStr := string(fileContent)
+	if !strings.Contains(contentStr, expectedInFile) {
+		t.Errorf("expected content to contain %q, got: %s", expectedInFile, contentStr)
+	}
+
+	// For idempotent test, verify it only appears once
+	if expectIdempotent {
+		sourceCount := strings.Count(contentStr, fmt.Sprintf("[ -f %s ]", compFile))
+		if sourceCount != 1 {
+			t.Errorf("expected source line to appear exactly once, got %d", sourceCount)
+		}
 	}
 }
 
 func TestEnsureSourceInBashrc(t *testing.T) {
-	testEnsureSourceInBashrcHelper(t, "", ".bash_completions/dr", "source")
-	testEnsureSourceInBashrcHelper(t, "export PATH=/usr/local/bin:$PATH\n", ".bash_completions/dr", "source")
-	testEnsureSourceInBashrcHelper(t, "[ -f /existing/completion ] && source /existing/completion\n", "/existing/completion", "/existing/completion")
+	t.Run("add source to empty bashrc", func(t *testing.T) {
+		testEnsureSourceInBashrcHelper(t, ".bash_completions/dr", "source", false)
+	})
+	t.Run("add source to bashrc with existing content", func(t *testing.T) {
+		testEnsureSourceInBashrcHelper(t, ".bash_completions/dr", "source", false)
+	})
+	t.Run("already contains source line", func(t *testing.T) {
+		testEnsureSourceInBashrcHelper(t, ".bash_completions/dr", "source", true)
+	})
 }
 
 func TestEnsureSourceInBashrcNotFound(t *testing.T) {
@@ -455,7 +484,7 @@ func TestEnsureSourceInBashrcNotFound(t *testing.T) {
 
 	err = ensureSourceInBashrc(nonexistentPath, completionFile)
 	if err == nil {
-		t.Error("expected error for nonexistent file, got nil")
+		t.Fatal("expected error for nonexistent file, got nil")
 	}
 
 	if !strings.Contains(err.Error(), "~/.bashrc not found") {

--- a/cmd/self/completion/install/cmd_test.go
+++ b/cmd/self/completion/install/cmd_test.go
@@ -415,7 +415,7 @@ func TestEnsureFpathInZshrcNotFound(t *testing.T) {
 	}
 }
 
-func testEnsureSourceInBashrcHelper(t *testing.T, compFileInTmpDir, expectedInFile string, expectIdempotent bool) {
+func testEnsureSourceInBashrcHelper(t *testing.T, compFileInTmpDir, initialContent, expectedInFile string, expectIdempotent bool) {
 	t.Helper()
 
 	tmpDir, err := os.MkdirTemp("", "test-bashrc-*")
@@ -427,9 +427,9 @@ func testEnsureSourceInBashrcHelper(t *testing.T, compFileInTmpDir, expectedInFi
 	bashrcPath := filepath.Join(tmpDir, ".bashrc")
 	compFile := filepath.Join(tmpDir, compFileInTmpDir)
 
-	// For idempotent test, pre-populate bashrc with the expected source line
-	var initialContent string
+	// Pre-populate bashrc with initial content if provided
 	if expectIdempotent {
+		// For idempotent test, include the source line that should already exist
 		initialContent = fmt.Sprintf("[ -f %s ] && source %s\n", compFile, compFile)
 	}
 
@@ -462,13 +462,13 @@ func testEnsureSourceInBashrcHelper(t *testing.T, compFileInTmpDir, expectedInFi
 
 func TestEnsureSourceInBashrc(t *testing.T) {
 	t.Run("add source to empty bashrc", func(t *testing.T) {
-		testEnsureSourceInBashrcHelper(t, ".bash_completions/dr", "source", false)
+		testEnsureSourceInBashrcHelper(t, ".bash_completions/dr", "", "source", false)
 	})
 	t.Run("add source to bashrc with existing content", func(t *testing.T) {
-		testEnsureSourceInBashrcHelper(t, ".bash_completions/dr", "source", false)
+		testEnsureSourceInBashrcHelper(t, ".bash_completions/dr", "export PATH=/usr/local/bin:$PATH\n", "source", false)
 	})
 	t.Run("already contains source line", func(t *testing.T) {
-		testEnsureSourceInBashrcHelper(t, ".bash_completions/dr", "source", true)
+		testEnsureSourceInBashrcHelper(t, ".bash_completions/dr", "", "source", true)
 	})
 }
 

--- a/cmd/self/completion/install/cmd_test.go
+++ b/cmd/self/completion/install/cmd_test.go
@@ -16,6 +16,7 @@ package install
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -349,6 +350,116 @@ func TestResolveShell(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expected, shell)
 			}
 		})
+	}
+}
+
+func testEnsureFpathInZshrcHelper(t *testing.T, name, content, shouldContain string) {
+	t.Helper()
+
+	tmpDir, err := os.MkdirTemp("", "test-zshrc-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	zshrcPath := filepath.Join(tmpDir, ".zshrc")
+	if err := os.WriteFile(zshrcPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write zshrc: %v", err)
+	}
+
+	compDir := filepath.Join(tmpDir, ".zsh", "completions")
+	if err := ensureFpathInZshrc(zshrcPath, compDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fileContent, err := os.ReadFile(zshrcPath)
+	if err != nil {
+		t.Fatalf("failed to read zshrc: %v", err)
+	}
+
+	if !strings.Contains(string(fileContent), shouldContain) {
+		t.Errorf("expected content to contain %q, got: %s", shouldContain, string(fileContent))
+	}
+}
+
+func TestEnsureFpathInZshrc(t *testing.T) {
+	testEnsureFpathInZshrcHelper(t, "add fpath to empty zshrc", "", "fpath=")
+	testEnsureFpathInZshrcHelper(t, "add fpath to existing content", "export PATH=/usr/local/bin:$PATH\n", "fpath=")
+	testEnsureFpathInZshrcHelper(t, "already contains fpath", "fpath=(/custom/path $fpath)\n", "/custom/path")
+}
+
+func TestEnsureFpathInZshrcNotFound(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-zshrc-notfound-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	nonexistentPath := filepath.Join(tmpDir, "nonexistent", ".zshrc")
+	compDir := filepath.Join(tmpDir, ".zsh", "completions")
+
+	err = ensureFpathInZshrc(nonexistentPath, compDir)
+	if err == nil {
+		t.Error("expected error for nonexistent file, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "~/.zshrc not found") {
+		t.Errorf("expected error to mention ~/.zshrc not found, got: %v", err)
+	}
+}
+
+func testEnsureSourceInBashrcHelper(t *testing.T, content, completionFile, shouldContain string) {
+	t.Helper()
+
+	tmpDir, err := os.MkdirTemp("", "test-bashrc-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	bashrcPath := filepath.Join(tmpDir, ".bashrc")
+	if err := os.WriteFile(bashrcPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write bashrc: %v", err)
+	}
+
+	compFile := filepath.Join(tmpDir, completionFile)
+	if err := ensureSourceInBashrc(bashrcPath, compFile); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fileContent, err := os.ReadFile(bashrcPath)
+	if err != nil {
+		t.Fatalf("failed to read bashrc: %v", err)
+	}
+
+	if !strings.Contains(string(fileContent), shouldContain) {
+		t.Errorf("expected content to contain %q, got: %s", shouldContain, string(fileContent))
+	}
+}
+
+func TestEnsureSourceInBashrc(t *testing.T) {
+	testEnsureSourceInBashrcHelper(t, "", ".bash_completions/dr", "source")
+	testEnsureSourceInBashrcHelper(t, "export PATH=/usr/local/bin:$PATH\n", ".bash_completions/dr", "source")
+	testEnsureSourceInBashrcHelper(t, "[ -f /existing/completion ] && source /existing/completion\n", "/existing/completion", "/existing/completion")
+}
+
+func TestEnsureSourceInBashrcNotFound(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test-bashrc-notfound-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	nonexistentPath := filepath.Join(tmpDir, "nonexistent", ".bashrc")
+	completionFile := filepath.Join(tmpDir, ".bash_completions", "dr")
+
+	err = ensureSourceInBashrc(nonexistentPath, completionFile)
+	if err == nil {
+		t.Error("expected error for nonexistent file, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "~/.bashrc not found") {
+		t.Errorf("expected error to mention ~/.bashrc not found, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
# RATIONALE

The completions test has been broken for about five months.

```
   Timeline:
   •  Dec 17, 2025 (commit 15c48b3): Completion moved to cmd/self/completion/ but workflow not updated ❌
   •  Apr 14, 2026 (commit 59a754f): The broken path was finally fixed ✅
```

Broken by me in https://github.com/datarobot-oss/cli/pull/292

## CHANGES

Update Harness CI to check self/completion as well as goreleaser.yaml
Update build step to trigger when completions have changed
Vibe test the self/completion module a bit to do a productive self-test :)

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. A maintainer must manually trigger the "Fork PR Smoke Tests" workflow from the Actions tab, providing your PR number. Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GitHub Actions change-detection and build gating, so misconfigured filters/conditions could cause CI jobs to skip or run unexpectedly. Code changes are limited to additional unit tests around shell completion installer config updates.
> 
> **Overview**
> Fixes PR CI change detection for shell completions by updating the `paths-filter` to watch `cmd/self/completion/**` (and `goreleaser.yaml`) and by making the `build` job run when either Go code *or* completion files change, ensuring `completion-tests` can execute.
> 
> Adds unit tests for the completion installer’s rc-file mutation helpers (`ensureFpathInZshrc` and `ensureSourceInBashrc`), covering empty/existing content, idempotency, and missing-file error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb98cd42416bf24c517b792c9fb3fa27275c115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->