### PR TITLE
[CFX-3938] fix: Use direct system calls in Homebrew postflight for shell completions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datarobot/cli
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datarobot/cli
 
-go 1.26.2
+go 1.26.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -84,12 +84,12 @@ homebrew_casks:
             system_command "/bin/ln", args: ["-sf", "#{HOMEBREW_PREFIX}/bin/dr", "#{HOMEBREW_PREFIX}/bin/datarobot"]
             system_command "xattr", args: ["-dr", "com.apple.quarantine", "#{HOMEBREW_PREFIX}/bin/datarobot"]
             system_command "xattr", args: ["-dr", "com.apple.quarantine", "#{HOMEBREW_PREFIX}/bin/dr"]
-            system_command "#{HOMEBREW_PREFIX}/bin/dr", args: ["self", "completion", "install", "--yes"]
+            system "#{HOMEBREW_PREFIX}/bin/dr", "self", "completion", "install", "--yes"
           end
       pre:
         uninstall: |
           if OS.mac?
-            system_command "#{HOMEBREW_PREFIX}/bin/dr", args: ["self", "completion", "uninstall", "--yes"]
+            system "#{HOMEBREW_PREFIX}/bin/dr", "self", "completion", "uninstall", "--yes" if File.exist?("#{HOMEBREW_PREFIX}/bin/dr")
             symlink = Pathname.new("#{HOMEBREW_PREFIX}/bin/datarobot")
             symlink.delete if symlink.symlink?
           end


### PR DESCRIPTION
The previous implementation used Homebrew's system_command helper with shell invocation, which could fail silently when the newly installed binary wasn't properly available in PATH. This change:

1. Switches to Ruby's direct system() calls instead of system_command()
2. Adds proper error handling in the uninstall hook to check if the binary exists

This ensures shell completions are properly installed when users run 'brew install dr-cli'.

# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. A maintainer must manually trigger the "Fork PR Smoke Tests" workflow from the Actions tab, providing your PR number. Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes Homebrew cask post/pre hooks for installing/removing shell completions, with a guard to avoid running uninstall when `dr` is missing.
> 
> **Overview**
> Updates `goreleaser.yaml` Homebrew cask hooks to invoke `dr self completion install/uninstall` using Ruby `system` instead of `system_command`.
> 
> Adds a `File.exist?` guard in the pre-uninstall hook so completion removal is skipped if the `dr` binary is not present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5be9636a18b3d81132ac3b625cf52a740c8901e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->