### PR TITLE
[CFX-5695] Fix completion installation 

### DIFF
--- a/.github/workflows/.self-update-tests-matrix.yaml
+++ b/.github/workflows/.self-update-tests-matrix.yaml
@@ -2,6 +2,11 @@ name: Self-Update Smoke Tests Matrix
 
 on:
   workflow_call:
+    inputs:
+      debug_brew:
+        description: 'Enable verbose brew debug step on macOS'
+        type: boolean
+        default: false
 
 jobs:
   self-update-tests:
@@ -22,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Debug brew environment (macOS only)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && inputs.debug_brew
         run: |
           echo "=== Homebrew version ==="
           brew --version

--- a/.github/workflows/.self-update-tests-matrix.yaml
+++ b/.github/workflows/.self-update-tests-matrix.yaml
@@ -21,6 +21,36 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Debug brew environment (macOS only)
+        if: runner.os == 'macOS'
+        run: |
+          echo "=== Homebrew version ==="
+          brew --version
+          echo "=== Homebrew prefix ==="
+          brew --prefix
+          echo "=== brew tap list ==="
+          brew tap list
+          echo "=== brew list (casks) ==="
+          brew list --cask 2>/dev/null || true
+          echo "=== PATH ==="
+          echo "$PATH"
+          echo "=== Shell ==="
+          echo "$SHELL"
+          echo "=== uname ==="
+          uname -a
+          echo ""
+          echo "=== Attempting brew tap + install dr-cli (verbose) ==="
+          brew tap datarobot-oss/taps || true
+          brew install --cask dr-cli --verbose 2>&1 || true
+          echo ""
+          echo "=== Checking binary locations after install ==="
+          ls -la "$(brew --prefix)/bin/dr" 2>/dev/null || echo "$(brew --prefix)/bin/dr not found"
+          ls -la "$(brew --prefix)/bin/datarobot" 2>/dev/null || echo "$(brew --prefix)/bin/datarobot not found"
+          which dr 2>/dev/null || echo "dr not on PATH"
+          echo ""
+          echo "=== brew info dr-cli ==="
+          brew info --cask dr-cli 2>&1 || true
+
       - name: Run self-update smoke tests
         run: |
           ./smoke_test_scripts/run_self_update_smoke_test.sh

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -11,6 +11,11 @@ on:
   schedule:
     - cron: '0 */4 * * 1-5'
   workflow_dispatch: # Allow manual trigger
+    inputs:
+      debug_brew:
+        description: 'Enable verbose brew debug step on macOS (self-update tests)'
+        type: boolean
+        default: false
 
 jobs:
   build-windows:
@@ -40,6 +45,8 @@ jobs:
 
   self-update-smoke-test:
     uses: ./.github/workflows/.self-update-tests-matrix.yaml
+    with:
+      debug_brew: ${{ inputs.debug_brew || false }}
 
   notify-failure:
     needs: [build-windows, smoke-test, windows-smoke-test, installs-smoke-test, self-update-smoke-test]

--- a/cmd/auth/seturl/cmd.go
+++ b/cmd/auth/seturl/cmd.go
@@ -42,6 +42,7 @@ This command helps you choose the correct DataRobot environment:
 			if url != "" {
 				err := config.SetURLToConfig(url)
 				if err == nil {
+					_ = auth.WriteConfigFileSilent()
 					_ = auth.EnsureAuthenticatedE(cmd, args)
 
 					return
@@ -51,6 +52,7 @@ This command helps you choose the correct DataRobot environment:
 			urlChanged := auth.SetURLAction()
 
 			if urlChanged {
+				_ = auth.WriteConfigFileSilent()
 				_ = auth.EnsureAuthenticatedE(cmd, args)
 			}
 		},

--- a/cmd/self/completion/install/cmd.go
+++ b/cmd/self/completion/install/cmd.go
@@ -311,33 +311,37 @@ func installBash(_ *cobra.Command, _ bool) (string, func(*cobra.Command) error) 
 		// Check if bash-completion is available
 		if !isBashCompletionAvailable() {
 			fmt.Println()
-			fmt.Printf("%s Bash completion framework not detected.\n", warnStyle.Render("⚠"))
+			fmt.Printf("%s Shell completions were not installed.\n", warnStyle.Render("⚠  Skipped:"))
 			fmt.Println()
-			fmt.Println("Bash completions require the bash-completion package.")
-			fmt.Println()
-			fmt.Println("To install:")
+			fmt.Println("Bash completions require the " + infoStyle.Render("bash-completion") + " package, which was not detected.")
 			fmt.Println()
 
 			if runtime.GOOS == "darwin" {
-				fmt.Println(infoStyle.Render("  # macOS (Homebrew)"))
+				fmt.Println("Install it with Homebrew:")
+				fmt.Println()
 				fmt.Println(infoStyle.Render("  brew install bash-completion@2"))
 				fmt.Println()
-				fmt.Println(infoStyle.Render("  # Then add to ~/.bash_profile:"))
+				fmt.Println("Then add the following to your " + infoStyle.Render("~/.bash_profile") + " or " + infoStyle.Render("~/.bashrc") + ":")
+				fmt.Println()
 				fmt.Println(infoStyle.Render(`  export BASH_COMPLETION_COMPAT_DIR="/opt/homebrew/etc/bash_completion.d"`))
 				fmt.Println(infoStyle.Render(`  [[ -r "/opt/homebrew/etc/profile.d/bash_completion.sh" ]] && . "/opt/homebrew/etc/profile.d/bash_completion.sh"`))
 			} else {
+				fmt.Println("Install it with your package manager:")
+				fmt.Println()
 				fmt.Println(infoStyle.Render("  # Ubuntu/Debian"))
 				fmt.Println(infoStyle.Render("  sudo apt-get install bash-completion"))
 				fmt.Println()
-				fmt.Println(infoStyle.Render("  # RHEL/CentOS"))
+				fmt.Println(infoStyle.Render("  # RHEL/CentOS/Fedora"))
 				fmt.Println(infoStyle.Render("  sudo yum install bash-completion"))
 			}
 
 			fmt.Println()
-			fmt.Println("After installing bash-completion, run this command again.")
+			fmt.Printf("Once installed, run %s to set up completions.\n", infoStyle.Render(version.CliName+" self completion install --yes"))
 			fmt.Println()
 
-			return errors.New("Bash-completion not available.")
+			// Not an error — prerequisites just aren't met yet. Exit cleanly so
+			// package managers (e.g. Homebrew cask hooks) don't roll back the install.
+			return nil
 		}
 
 		// Create directory

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -84,12 +84,12 @@ homebrew_casks:
             system_command "/bin/ln", args: ["-sf", "#{HOMEBREW_PREFIX}/bin/dr", "#{HOMEBREW_PREFIX}/bin/datarobot"]
             system_command "xattr", args: ["-dr", "com.apple.quarantine", "#{HOMEBREW_PREFIX}/bin/datarobot"]
             system_command "xattr", args: ["-dr", "com.apple.quarantine", "#{HOMEBREW_PREFIX}/bin/dr"]
-            system_command "#{HOMEBREW_PREFIX}/bin/dr", args: ["self", "completion", "install", "--yes"]
+            system_command "#{HOMEBREW_PREFIX}/bin/dr", args: ["self", "completion", "install", "--yes"], must_succeed: false
           end
       pre:
         uninstall: |
           if OS.mac?
-            system_command "#{HOMEBREW_PREFIX}/bin/dr", args: ["self", "completion", "uninstall", "--yes"]
+            system_command "#{HOMEBREW_PREFIX}/bin/dr", args: ["self", "completion", "uninstall", "--yes"], must_succeed: false
             symlink = Pathname.new("#{HOMEBREW_PREFIX}/bin/datarobot")
             symlink.delete if symlink.symlink?
           end

--- a/smoke_test_scripts/run_self_update_smoke_test.sh
+++ b/smoke_test_scripts/run_self_update_smoke_test.sh
@@ -185,7 +185,13 @@ test_brew_self_update() {
 
     echo "Installing dr-cli via brew..."
     brew tap datarobot-oss/taps 2>/dev/null || true
-    brew install --cask dr-cli 2>/dev/null || brew reinstall --cask dr-cli 2>/dev/null || true
+    # Uninstall any existing installation first to avoid same-version no-op behavior
+    brew uninstall --cask dr-cli 2>/dev/null || true
+    # Use --no-quarantine to avoid Gatekeeper issues in CI environments
+    if ! brew install --cask dr-cli --no-quarantine; then
+        echo "⏭️  TEST 3 SKIPPED: brew install dr-cli failed (incompatible CI environment)."
+        return 0
+    fi
 
     # Find the brew-installed binary (cask installs to a predictable location)
     brew_dr=$(brew --prefix 2>/dev/null)/bin/dr
@@ -195,8 +201,8 @@ test_brew_self_update() {
     fi
 
     if [[ -z "$brew_dr" || ! -x "$brew_dr" ]]; then
-        echo "❌ TEST 3 FAILED: dr not found after brew install."
-        exit 1
+        echo "⏭️  TEST 3 SKIPPED: dr not found after brew install (binary not linked in this environment)."
+        return 0
     fi
 
     # Verify this is actually the DataRobot CLI (not some other 'dr' binary)

--- a/smoke_test_scripts/run_self_update_smoke_test.sh
+++ b/smoke_test_scripts/run_self_update_smoke_test.sh
@@ -187,8 +187,7 @@ test_brew_self_update() {
     brew tap datarobot-oss/taps 2>/dev/null || true
     # Uninstall any existing installation first to avoid same-version no-op behavior
     brew uninstall --cask dr-cli 2>/dev/null || true
-    # Use --no-quarantine to avoid Gatekeeper issues in CI environments
-    if ! brew install --cask dr-cli --no-quarantine; then
+    if ! brew install --cask dr-cli; then
         echo "⏭️  TEST 3 SKIPPED: brew install dr-cli failed (incompatible CI environment)."
         return 0
     fi

--- a/smoke_test_scripts/run_self_update_smoke_test.sh
+++ b/smoke_test_scripts/run_self_update_smoke_test.sh
@@ -185,7 +185,7 @@ test_brew_self_update() {
 
     echo "Installing dr-cli via brew..."
     brew tap datarobot-oss/taps 2>/dev/null || true
-    brew install --cask dr-cli 2>/dev/null || brew upgrade --cask dr-cli 2>/dev/null || true
+    brew install --cask dr-cli 2>/dev/null || brew reinstall --cask dr-cli 2>/dev/null || true
 
     # Find the brew-installed binary (cask installs to a predictable location)
     brew_dr=$(brew --prefix 2>/dev/null)/bin/dr

--- a/smoke_test_scripts/run_self_update_smoke_test.sh
+++ b/smoke_test_scripts/run_self_update_smoke_test.sh
@@ -185,12 +185,7 @@ test_brew_self_update() {
 
     echo "Installing dr-cli via brew..."
     brew tap datarobot-oss/taps 2>/dev/null || true
-    # Uninstall any existing installation first to avoid same-version no-op behavior
-    brew uninstall --cask dr-cli 2>/dev/null || true
-    if ! brew install --cask dr-cli; then
-        echo "⏭️  TEST 3 SKIPPED: brew install dr-cli failed (incompatible CI environment)."
-        return 0
-    fi
+    brew install --cask dr-cli 2>/dev/null || brew upgrade --cask dr-cli 2>/dev/null || true
 
     # Find the brew-installed binary (cask installs to a predictable location)
     brew_dr=$(brew --prefix 2>/dev/null)/bin/dr
@@ -200,8 +195,8 @@ test_brew_self_update() {
     fi
 
     if [[ -z "$brew_dr" || ! -x "$brew_dr" ]]; then
-        echo "⏭️  TEST 3 SKIPPED: dr not found after brew install (binary not linked in this environment)."
-        return 0
+        echo "❌ TEST 3 FAILED: dr not found after brew install."
+        exit 1
     fi
 
     # Verify this is actually the DataRobot CLI (not some other 'dr' binary)


### PR DESCRIPTION
This pull request introduces improvements to the installation and configuration experience, especially for Homebrew and shell completions, and enhances the reliability of configuration file updates. The most important changes are grouped below:

**Homebrew and Shell Completion Installation Improvements:**

* Updated the Bash completion installation logic in `cmd/self/completion/install/cmd.go` to provide clearer instructions when prerequisites are missing, avoid returning errors if `bash-completion` is not installed, and ensure package managers like Homebrew do not roll back installations unnecessarily. The output now includes more user-friendly guidance for both macOS and Linux users.
* Modified the Homebrew cask installation and uninstallation steps in `goreleaser.yaml` to not fail the overall process if the shell completion installation or uninstallation commands do not succeed, improving robustness for edge cases where prerequisites are not met.
* Added a debug step to the GitHub Actions workflow in `.github/workflows/.self-update-tests-matrix.yaml` to collect detailed Homebrew environment information and attempt to install the `dr-cli` cask with verbose output, aiding in diagnosing CI issues related to Homebrew.

**Configuration File Reliability:**

* Ensured that after setting a new URL in the authentication command (`cmd/auth/seturl/cmd.go`), the configuration file is always written silently before attempting authentication, both when a URL is provided directly and when changed interactively. This increases reliability and prevents configuration inconsistencies. [[1]](diffhunk://#diff-d5415c83f5d4996bc70b4a55891ac205367017ac9d149882d35584d1c963ca78R45) [[2]](diffhunk://#diff-d5415c83f5d4996bc70b4a55891ac205367017ac9d149882d35584d1c963ca78R55)

# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. A maintainer must manually trigger the "Fork PR Smoke Tests" workflow from the Actions tab, providing your PR number. Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes install-time behavior (Homebrew cask hooks and completion installer) and modifies the `set-url` auth flow, which could affect first-run setup and CI reliability.
> 
> **Overview**
> Improves install/setup robustness by making Bash completion installation **skip cleanly** (with clearer guidance) when `bash-completion` isn’t present, instead of failing and potentially causing package-manager rollbacks.
> 
> Updates Homebrew cask hooks in `goreleaser.yaml` to treat `dr self completion install/uninstall --yes` as **best-effort** (`must_succeed: false`).
> 
> Enhances self-update smoke-test workflows by adding an optional `debug_brew` input that, on macOS, runs a verbose Homebrew diagnostics/install step before executing the self-update tests, and wires this input through `smoke-tests.yaml`.
> 
> Ensures `dr auth set-url` persists URL changes by calling `auth.WriteConfigFileSilent()` before attempting `auth.EnsureAuthenticatedE()` for both argument-based and interactive URL updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d02ab507b06099452df71d121955c00978f930b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->