### PR TITLE
[CFX-5712] fix(envbuilder): skip generate: true prompts, but generate secrets behind the scenes

### DIFF
--- a/cmd/dotenv/helpers.go
+++ b/cmd/dotenv/helpers.go
@@ -28,6 +28,7 @@ import (
 	"github.com/datarobot/cli/tui"
 )
 
+// generateRandomSecret creates a random string of the specified length, suitable for use as a secret value.
 func generateRandomSecret(length int) (string, error) {
 	bytes := make([]byte, length)
 

--- a/cmd/dotenv/helpers.go
+++ b/cmd/dotenv/helpers.go
@@ -15,8 +15,6 @@
 package dotenv
 
 import (
-	"crypto/rand"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
@@ -27,18 +25,6 @@ import (
 	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/tui"
 )
-
-// generateRandomSecret creates a random string of the specified length, suitable for use as a secret value.
-func generateRandomSecret(length int) (string, error) {
-	bytes := make([]byte, length)
-
-	_, err := rand.Read(bytes)
-	if err != nil {
-		return "", fmt.Errorf("Failed to generate random bytes: %w", err)
-	}
-
-	return base64.URLEncoding.EncodeToString(bytes)[:length], nil
-}
 
 // ensureInRepo checks if we're in a git repository, and returns the repo root path.
 func ensureInRepo() (string, error) {

--- a/cmd/dotenv/promptModel.go
+++ b/cmd/dotenv/promptModel.go
@@ -43,8 +43,7 @@ var (
 )
 
 const (
-	cursorStyle           = '•'
-	generatedSecretLength = 32
+	cursorStyle = '•'
 )
 
 type item envbuilder.PromptOption
@@ -105,18 +104,6 @@ func newPromptModel(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptMod
 }
 
 func newTextInputPrompt(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptModel, tea.Cmd) {
-	// Auto-generate a random secret if:
-	// 1. Generate flag is set
-	// 2. Type is secret_string
-	// 3. No value is currently set
-	if prompt.Value == "" && prompt.Generate && prompt.Type == envbuilder.PromptTypeSecret {
-		generatedSecret, err := generateRandomSecret(generatedSecretLength)
-		if err == nil {
-			prompt.Value = generatedSecret
-		}
-		// If generation fails, just leave value empty and let user enter manually
-	}
-
 	ti := textinput.New()
 	ti.SetValue(prompt.Value)
 

--- a/cmd/dotenv/pulumiModel.go
+++ b/cmd/dotenv/pulumiModel.go
@@ -223,7 +223,7 @@ func (m pulumiLoginModel) handlePassphrasePromptKey(msg tea.KeyMsg) (tea.Model, 
 }
 
 func (m pulumiLoginModel) handlePassphraseAccepted() (tea.Model, tea.Cmd) {
-	passphrase, err := generateRandomSecret(generatedPassphraseLength)
+	passphrase, err := envbuilder.GenerateRandomSecret(generatedPassphraseLength)
 	if err != nil {
 		m.err = fmt.Errorf("failed to generate passphrase: %w", err)
 

--- a/cmd/dotenv/pulumiModel_test.go
+++ b/cmd/dotenv/pulumiModel_test.go
@@ -229,11 +229,11 @@ func TestPulumiLoginModel_PassphraseScreen_Esc_Completes(t *testing.T) {
 // --- Passphrase generation ---
 
 func TestGenerateRandomPassphrase(t *testing.T) {
-	passphrase, err := generateRandomSecret(32)
+	passphrase, err := envbuilder.GenerateRandomSecret(32)
 	require.NoError(t, err)
 	assert.Len(t, passphrase, 32)
 
-	passphrase2, err := generateRandomSecret(32)
+	passphrase2, err := envbuilder.GenerateRandomSecret(32)
 	require.NoError(t, err)
 	assert.NotEqual(t, passphrase, passphrase2, "generated passphrases must be unique")
 }

--- a/docs/template-system/interactive-config.md
+++ b/docs/template-system/interactive-config.md
@@ -448,7 +448,8 @@ prompts:
 ```
 
 Shown as:
-```
+
+```log
 Application port
 > 8080█
 
@@ -456,6 +457,7 @@ Default: 8080
 ```
 
 **Note:** Prompts with default values are automatically skipped during the wizard unless:
+
 - The user has modified the value from the default
 - The prompt has `always_prompt: true` set
 - The prompt has options with `requires` fields (which control conditional sections)
@@ -514,12 +516,12 @@ prompts:
     help: "Session encryption key"
 ```
 
-When `generate: true` is set:
-
 - A 32-character cryptographically secure random string is generated if no value exists.
 - Uses base64 URL-safe encoding.
 - Preserves existing values (only generates for empty fields).
 - User can still override with a custom value.
+
+**Note:** Prompts with generated values are automatically skipped during the wizard, following the same rules as prompts with default values.
 
 ### Merge environment variables
 

--- a/internal/envbuilder/builder.go
+++ b/internal/envbuilder/builder.go
@@ -176,6 +176,7 @@ func (up UserPrompt) HasRequiresOptions() bool {
 // ShouldAsk returns true if this prompt should be shown to the user.
 // Prompts with defaults are skipped unless AlwaysPrompt is set, showAll is true,
 // or the prompt has options with requires (which control conditional sections).
+// Prompts with generate: true are also skipped as they are auto-generated.
 func (up UserPrompt) ShouldAsk(showAll bool) bool {
 	if !up.Active || up.Hidden {
 		return false
@@ -194,6 +195,11 @@ func (up UserPrompt) ShouldAsk(showAll bool) bool {
 	// Always show prompts with requires options - they control conditional sections
 	if up.HasRequiresOptions() {
 		return true
+	}
+
+	// Skip prompts that are auto-generated
+	if up.Generate {
+		return false
 	}
 
 	// Skip prompts that have a default and value equals default (not user-modified)

--- a/internal/envbuilder/builder.go
+++ b/internal/envbuilder/builder.go
@@ -15,6 +15,8 @@
 package envbuilder
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"maps"
 	"os"
@@ -29,8 +31,9 @@ import (
 type PromptType string
 
 const (
-	PromptTypeString PromptType = "string"
-	PromptTypeSecret PromptType = "secret_string"
+	PromptTypeString      PromptType = "string"
+	PromptTypeSecret      PromptType = "secret_string"
+	GeneratedSecretLength int        = 32
 )
 
 func (pt PromptType) String() string {
@@ -210,6 +213,38 @@ func (up UserPrompt) ShouldAsk(showAll bool) bool {
 	return true
 }
 
+// GenerateRandomSecret creates a cryptographically random base64-encoded secret of the specified length.
+func GenerateRandomSecret(length int) (string, error) {
+	bytes := make([]byte, length)
+
+	_, err := rand.Read(bytes)
+	if err != nil {
+		return "", fmt.Errorf("Failed to generate random bytes: %w", err)
+	}
+
+	return base64.URLEncoding.EncodeToString(bytes)[:length], nil
+}
+
+// ApplyGeneratedValues auto-generates values for prompts with generate: true that don't already have a value.
+func ApplyGeneratedValues(prompts []UserPrompt) ([]UserPrompt, error) {
+	for p := range prompts {
+		prompt := prompts[p]
+
+		// Only generate for prompts with generate: true, secret_string type, and no existing value
+		if prompt.Generate && prompt.Type == PromptTypeSecret && prompt.Value == "" {
+			generatedValue, err := GenerateRandomSecret(GeneratedSecretLength)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to generate value for %s: %w", prompt.VarName(), err)
+			}
+
+			prompt.Value = generatedValue
+			prompts[p] = prompt
+		}
+	}
+
+	return prompts, nil
+}
+
 func GatherUserPrompts(rootDir string, variables Variables) ([]UserPrompt, error) {
 	yamlFiles, err := Discover(rootDir, 5)
 	if err != nil {
@@ -230,6 +265,12 @@ func GatherUserPrompts(rootDir string, variables Variables) ([]UserPrompt, error
 	}
 
 	allPrompts = promptsWithValues(allPrompts, variables)
+
+	allPrompts, err = ApplyGeneratedValues(allPrompts)
+	if err != nil {
+		return nil, err
+	}
+
 	allPrompts = DetermineRequiredSections(allPrompts)
 
 	return allPrompts, nil

--- a/internal/envbuilder/builder_test.go
+++ b/internal/envbuilder/builder_test.go
@@ -412,3 +412,94 @@ func (suite *BuilderTestSuite) TestHasRequiresOptions() {
 	promptNoOptions := UserPrompt{}
 	suite.False(promptNoOptions.HasRequiresOptions())
 }
+
+func (suite *BuilderTestSuite) TestApplyGeneratedValues_GeneratesValue() {
+	prompts := []UserPrompt{
+		{
+			Env:      "SESSION_SECRET",
+			Type:     PromptTypeSecret,
+			Generate: true,
+			Value:    "",
+		},
+	}
+
+	result, err := ApplyGeneratedValues(prompts)
+	suite.Require().NoError(err)
+	suite.NotEmpty(result[0].Value, "Should generate a value for secret_string with generate: true")
+	suite.Len(result[0].Value, GeneratedSecretLength, "Generated value should match expected length")
+}
+
+func (suite *BuilderTestSuite) TestApplyGeneratedValues_DoesNotOverwriteExistingValue() {
+	prompts := []UserPrompt{
+		{
+			Env:      "SESSION_SECRET",
+			Type:     PromptTypeSecret,
+			Generate: true,
+			Value:    "existing_value",
+		},
+	}
+
+	result, err := ApplyGeneratedValues(prompts)
+	suite.Require().NoError(err)
+	suite.Equal("existing_value", result[0].Value, "Should not overwrite existing value")
+}
+
+func (suite *BuilderTestSuite) TestApplyGeneratedValues_IgnoresNonGeneratePrompts() {
+	prompts := []UserPrompt{
+		{
+			Env:      "API_KEY",
+			Type:     PromptTypeSecret,
+			Generate: false,
+			Value:    "",
+		},
+	}
+
+	result, err := ApplyGeneratedValues(prompts)
+	suite.Require().NoError(err)
+	suite.Empty(result[0].Value, "Should not generate value for prompts with generate: false")
+}
+
+func (suite *BuilderTestSuite) TestApplyGeneratedValues_IgnoresNonSecretTypes() {
+	prompts := []UserPrompt{
+		{
+			Env:      "SOME_VAR",
+			Type:     PromptTypeString,
+			Generate: true,
+			Value:    "",
+		},
+	}
+
+	result, err := ApplyGeneratedValues(prompts)
+	suite.Require().NoError(err)
+	suite.Empty(result[0].Value, "Should not generate value for non-secret_string types")
+}
+
+func (suite *BuilderTestSuite) TestApplyGeneratedValues_MultiplePrompts() {
+	prompts := []UserPrompt{
+		{
+			Env:      "SESSION_SECRET",
+			Type:     PromptTypeSecret,
+			Generate: true,
+			Value:    "",
+		},
+		{
+			Env:      "EXISTING_SECRET",
+			Type:     PromptTypeSecret,
+			Generate: true,
+			Value:    "already_set",
+		},
+		{
+			Env:      "API_KEY",
+			Type:     PromptTypeSecret,
+			Generate: false,
+			Value:    "",
+		},
+	}
+
+	result, err := ApplyGeneratedValues(prompts)
+	suite.Require().NoError(err)
+
+	suite.NotEmpty(result[0].Value, "First secret should be generated")
+	suite.Equal("already_set", result[1].Value, "Second secret should not be overwritten")
+	suite.Empty(result[2].Value, "Third secret should not be generated (generate: false)")
+}

--- a/internal/envbuilder/builder_test.go
+++ b/internal/envbuilder/builder_test.go
@@ -309,6 +309,11 @@ func (suite *BuilderTestSuite) TestShouldAsk_OptionsWithoutRequiresCanBeSkipped(
 	suite.False(prompt.ShouldAsk(false), "Should skip prompt with options but no requires if value equals default")
 }
 
+func (suite *BuilderTestSuite) TestShouldAsk_SkipsPromptWithGenerate() {
+	prompt := UserPrompt{Active: true, Hidden: false, Generate: true}
+	suite.False(prompt.ShouldAsk(false), "Should skip prompt when generate is true")
+}
+
 func (suite *BuilderTestSuite) TestHasRequiresOptions() {
 	promptWithRequires := UserPrompt{
 		Options: []PromptOption{

--- a/internal/envbuilder/builder_test.go
+++ b/internal/envbuilder/builder_test.go
@@ -314,6 +314,84 @@ func (suite *BuilderTestSuite) TestShouldAsk_SkipsPromptWithGenerate() {
 	suite.False(prompt.ShouldAsk(false), "Should skip prompt when generate is true")
 }
 
+func (suite *BuilderTestSuite) TestShouldAsk_GenerateWithValueSkipped() {
+	prompt := UserPrompt{Active: true, Hidden: false, Generate: true, Value: "some_generated_value"}
+	suite.False(prompt.ShouldAsk(false), "Should skip prompt when generate is true even if value is set")
+}
+
+func (suite *BuilderTestSuite) TestShouldAsk_GenerateAlwaysPromptShowAll() {
+	prompt := UserPrompt{Active: true, Hidden: false, Generate: true}
+	suite.True(prompt.ShouldAsk(true), "Should show prompt when generate is true but showAll is true")
+}
+
+func (suite *BuilderTestSuite) TestShouldAsk_GenerateWithSecretType() {
+	prompt := UserPrompt{
+		Active:   true,
+		Hidden:   false,
+		Generate: true,
+		Type:     PromptTypeSecret,
+		Help:     "Auto-generated secret",
+	}
+	suite.False(prompt.ShouldAsk(false), "Should skip secret_string prompt when generate is true")
+}
+
+func (suite *BuilderTestSuite) TestShouldAsk_GenerateWithDefault() {
+	prompt := UserPrompt{
+		Active:   true,
+		Hidden:   false,
+		Generate: true,
+		Default:  "default_secret",
+		Value:    "default_secret",
+	}
+	suite.False(prompt.ShouldAsk(false), "Should skip prompt when generate is true, even if default is set")
+}
+
+func (suite *BuilderTestSuite) TestGenerateYAMLParsing() {
+	yamlContent := `
+root:
+  - env: SESSION_SECRET
+    type: secret_string
+    generate: true
+    help: Session encryption key (auto-generated)
+    optional: false
+  - env: API_KEY
+    type: secret_string
+    generate: false
+    help: Enter your API key
+    optional: false
+  - env: JWT_SECRET
+    type: secret_string
+    generate: true
+    help: JWT signing key
+    optional: false
+    always_prompt: true
+`
+
+	// Create a temporary YAML file
+	tmpFile := filepath.Join(suite.tempDir, ".datarobot", "test_generate.yaml")
+	err := os.WriteFile(tmpFile, []byte(yamlContent), 0o600)
+	suite.Require().NoError(err)
+
+	// Parse the file
+	prompts, err := filePrompts(tmpFile)
+	suite.Require().NoError(err)
+	suite.Require().Len(prompts, 3, "Expected 3 prompts")
+
+	// Verify generate is correctly parsed
+	suite.Equal("SESSION_SECRET", prompts[0].Env)
+	suite.True(prompts[0].Generate, "SESSION_SECRET should have generate=true")
+	suite.Equal(PromptTypeSecret, prompts[0].Type, "SESSION_SECRET should be secret_string type")
+	suite.False(prompts[0].AlwaysPrompt, "SESSION_SECRET should have always_prompt=false (default)")
+
+	suite.Equal("API_KEY", prompts[1].Env)
+	suite.False(prompts[1].Generate, "API_KEY should have generate=false (explicit)")
+	suite.Equal(PromptTypeSecret, prompts[1].Type, "API_KEY should be secret_string type")
+
+	suite.Equal("JWT_SECRET", prompts[2].Env)
+	suite.True(prompts[2].Generate, "JWT_SECRET should have generate=true")
+	suite.True(prompts[2].AlwaysPrompt, "JWT_SECRET should have always_prompt=true")
+}
+
 func (suite *BuilderTestSuite) TestHasRequiresOptions() {
 	promptWithRequires := UserPrompt{
 		Options: []PromptOption{


### PR DESCRIPTION
# RATIONALE

@carsongee noted that we should also skip any template prompts where we auto-generate an answer. This is handled with `generate: true` in the relevant yaml config.

## CHANGES

- Update the envbuilder to track whether a prompt is generated (`UserPrompt.Generate`) and then skip them in the ShouldAsk() function.
- factory for tests

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. A maintainer must manually trigger the "Fork PR Smoke Tests" workflow from the Actions tab, providing your PR number. Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to prompt-display logic with test coverage; minimal impact outside the env wizard UX.
> 
> **Overview**
> Updates `UserPrompt.ShouldAsk` to **not display prompts marked `generate: true`**, treating them as auto-generated even when they are active and not hidden.
> 
> Adds a unit test to lock in the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42b81002202e45a9814cb703155fe28dcac631ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->