### PR TITLE
[CFX-4389] Enhance smoke tests handling for forked PRs and add status gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,11 @@ the review may happen while you are asleep / otherwise not able to respond quick
 - `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)
 
 > [!IMPORTANT]
-> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. A maintainer must manually trigger the "Fork PR Smoke Tests" workflow from the Actions tab, providing your PR number. Please comment requesting a maintainer review if you need smoke tests to run.
+> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
+> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
+> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
+>
+> Please comment requesting a maintainer review if you need smoke tests to run.
 
 
 <!-- Recommended Additional Sections:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -147,6 +147,11 @@ Triggered by PR labels (`run-smoke-tests` or `go`):
 - Auto-removes `run-smoke-tests` label after completion
 - **Note:** Does NOT run installation tests (those run only on main/schedule to avoid testing unreleased code)
 
+### `smoke-tests-gate.yaml`
+Runs on all PRs targeting `main` to set the required **Smoke Tests** commit status:
+- **Non-fork PRs**: auto-sets status to `success` (smoke tests are optional, run via labels/commands)
+- **Fork PRs**: skips status creation (read-only token). The missing required check blocks merge until a maintainer runs (`/approve-smoke-tests`) or skips (`/skip-smoke-tests`) the tests
+
 ### `fork-smoke-tests.yaml`
 Triggered manually via `workflow_dispatch` by a maintainer (from the Actions tab):
 - Accepts a PR number and optional commit SHA as inputs
@@ -154,6 +159,7 @@ Triggered manually via `workflow_dispatch` by a maintainer (from the Actions tab
 - Builds Windows binary from fork PR code
 - Runs smoke tests on Linux and Windows
 - Posts results as PR comments
+- Updates the **Smoke Tests** commit status to `success` or `failure`
 
 ### `release.yaml`
 Triggered by version tags (`v*.*.*`):
@@ -188,10 +194,10 @@ This repository supports automation for PRs using comment-commands (slash comman
 
 Trigger workflows by commenting on a PR:
 
-- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests on this PR
-- `/trigger-install-test` or `/trigger-test-install` - Run installation tests on this PR
-
-These commands work on regular PRs from the main repository.
+- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests on this PR (non-fork PRs only)
+- `/trigger-install-test` or `/trigger-test-install` - Run installation tests on this PR (non-fork PRs only)
+- `/approve-smoke-tests` or `/approve-fork-tests` - Run smoke tests for a fork PR (maintainers only)
+- `/skip-smoke-tests` - Mark the **Smoke Tests** required check as passed without running tests (maintainers only)
 
 ### Labels for Regular PRs
 
@@ -204,18 +210,19 @@ Apply labels to PRs to trigger workflows:
   - Auto-removes label after completion
   - **Note:** This only works for PRs from the main repository, not forked PRs
 
-### Forked PRs (Manual Dispatch)
+### Forked PRs
 
-Forked PRs require maintainer approval due to security considerations. The `fork-smoke-tests.yaml` workflow uses `workflow_dispatch` (not `pull_request_target`) to avoid secrets leakage:
+Forked PRs block merge via a required **Smoke Tests** commit status that is never auto-set. The `fork-smoke-tests.yaml` workflow uses `workflow_dispatch` (not `pull_request_target`) to avoid secrets leakage:
 
 **Process for Forked PRs:**
 1. External contributor opens a PR from their fork
-2. Maintainer reviews the code changes for security concerns
-3. Maintainer goes to **Actions → Fork PR Smoke Tests → Run workflow**, enters the PR number (and optionally a commit SHA)
-4. Workflow runs security scans and smoke tests
-5. Results are posted as PR comments
+2. The **Smoke Tests** required check appears as "Expected — Waiting for status to be reported", blocking merge
+3. Maintainer reviews the code changes for security concerns, then either:
+   - Comments `/approve-smoke-tests` to trigger security scans + smoke tests (results auto-update the check)
+   - Comments `/skip-smoke-tests` to bypass the check without running tests
+4. Results are posted as PR comments and the commit status is updated
 
-**Important:** If you're an external contributor, the `run-smoke-tests` label won't work on fork PRs. Please comment on the PR requesting a maintainer review if you need smoke tests to run.
+**For external contributors:** the `run-smoke-tests` label and `/trigger-smoke-test` command won't work on fork PRs. Please comment requesting a maintainer review.
 
 ## Benefits of Reusable Workflows
 

--- a/.github/workflows/comment-commands.yaml
+++ b/.github/workflows/comment-commands.yaml
@@ -14,6 +14,7 @@ jobs:
       actions: write
       pull-requests: write
       issues: write
+      statuses: write
     steps:
       - name: Check if PR is from fork and commenter permissions
         id: check-fork
@@ -115,6 +116,28 @@ jobs:
               }
             });
 
+            // Check if any changed files are under .github/
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const githubDirChanged = files.some(f => f.filename.startsWith('.github/'));
+
+            let warning = '';
+            if (githubDirChanged) {
+              const changedWorkflows = files
+                .filter(f => f.filename.startsWith('.github/'))
+                .map(f => `  - \`${f.filename}\``)
+                .join('\n');
+              warning = '\n\n> [!WARNING]\n' +
+                        '> **This PR modifies files under `.github/`**, which may alter CI workflows, ' +
+                        'branch protection rules, or secrets handling. Review these changes carefully ' +
+                        'before proceeding — malicious workflow changes could exfiltrate secrets.\n>\n' +
+                        '> Changed files:\n' +
+                        changedWorkflows.split('\n').map(l => '> ' + l).join('\n');
+            }
+
             // Add comment explaining what happens next
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -126,7 +149,64 @@ jobs:
                     '1. Security scans will run automatically (Trivy, gosec)\n' +
                     '2. If security scans pass, smoke tests will run\n' +
                     '3. Results will be posted as PR comments\n\n' +
-                    '⚠️ **Important**: Review the PR code carefully before approving!'
+                    '⚠️ **Important**: Review the PR code carefully before approving!' +
+                    warning
+            });
+
+      - name: Handle skip smoke tests command (maintainers only)
+        if: |
+          contains(github.event.comment.body, '/skip-smoke-tests') &&
+          steps.check-fork.outputs.is_maintainer == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Add reaction
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1'
+            });
+
+            // Resolve PR head SHA
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            // Set commit status to success
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: pr.data.head.sha,
+              state: 'success',
+              context: 'Smoke Tests',
+              description: 'Skipped by @' + context.actor,
+            });
+
+      - name: Handle unauthorized skip smoke tests attempt
+        if: |
+          contains(github.event.comment.body, '/skip-smoke-tests') &&
+          steps.check-fork.outputs.is_maintainer == 'false'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Add reaction
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'confused'
+            });
+
+            // Add comment explaining permissions
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '❌ **Insufficient permissions**\n\n' +
+                    'Only maintainers with write or admin access can skip smoke tests.'
             });
 
       - name: Handle unauthorized fork smoke test attempt

--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -97,13 +97,35 @@ jobs:
     needs: [resolve-pr, security-scan]
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      pull-requests: read
       issues: write
     steps:
       - name: Notify smoke tests started
         uses: actions/github-script@v7
         with:
           script: |
+            // Check if any changed files are under .github/
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ inputs.pr_number }},
+            });
+            const githubDirChanged = files.some(f => f.filename.startsWith('.github/'));
+
+            let warning = '';
+            if (githubDirChanged) {
+              const changedWorkflows = files
+                .filter(f => f.filename.startsWith('.github/'))
+                .map(f => `  - \`${f.filename}\``)
+                .join('\n');
+              warning = '\n\n> [!WARNING]\n' +
+                        '> **This PR modifies files under `.github/`**, which may alter CI workflows, ' +
+                        'branch protection rules, or secrets handling. Review these changes carefully ' +
+                        'before proceeding — malicious workflow changes could exfiltrate secrets.\n>\n' +
+                        '> Changed files:\n' +
+                        changedWorkflows.split('\n').map(l => '> ' + l).join('\n');
+            }
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -111,7 +133,8 @@ jobs:
               body: '🔐 **Fork smoke tests started by maintainer**\n\n' +
                     '⏳ Security scans passed. Running smoke tests...\n\n' +
                     `Commit: \`${{ needs.resolve-pr.outputs.sha }}\`\n` +
-                    `[View run](${context.payload.repository.html_url}/actions/runs/${context.runId})`
+                    `[View run](${context.payload.repository.html_url}/actions/runs/${context.runId})` +
+                    warning
             });
 
   linux-smoke-tests:
@@ -137,6 +160,7 @@ jobs:
     permissions:
       pull-requests: write
       issues: write
+      statuses: write
     steps:
       - name: Comment on PR with results
         uses: actions/github-script@v7
@@ -169,4 +193,22 @@ jobs:
                     `${windowsEmoji} Windows: ${windowsStatus}\n\n` +
                     `[View run details](${context.payload.repository.html_url}/actions/runs/${context.runId})` +
                     failureNote
+            });
+
+      - name: Update Smoke Tests commit status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const securityStatus = '${{ needs.security-scan.result }}';
+            const linuxStatus = '${{ needs.linux-smoke-tests.result }}';
+            const windowsStatus = '${{ needs.windows-smoke-tests.result }}';
+            const allPassed = securityStatus === 'success' && linuxStatus === 'success' && windowsStatus === 'success';
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.resolve-pr.outputs.sha }}',
+              state: allPassed ? 'success' : 'failure',
+              context: 'Smoke Tests',
+              description: allPassed ? 'All smoke tests passed' : 'Smoke tests failed',
             });

--- a/.github/workflows/smoke-tests-gate.yaml
+++ b/.github/workflows/smoke-tests-gate.yaml
@@ -1,0 +1,40 @@
+name: Smoke Tests Gate
+
+# Sets the required "Smoke Tests" commit status for all PRs targeting main.
+# - Non-fork PRs: auto-succeed (smoke tests can be run optionally via labels/commands).
+# - Fork PRs: no status is set here (read-only token). The missing required check blocks
+#   merge. A maintainer must run (/approve-smoke-tests) or skip (/skip-smoke-tests) tests.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Set Smoke Tests status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isFork = context.payload.pull_request.head.repo.full_name !== context.payload.pull_request.base.repo.full_name;
+            const sha = context.payload.pull_request.head.sha;
+
+            if (isFork) {
+              console.log('Fork PR detected — skipping status creation (read-only token).');
+              console.log('The missing required "Smoke Tests" check will block merge.');
+              console.log('Maintainers: use /approve-smoke-tests to run tests, or /skip-smoke-tests to bypass.');
+            } else {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: 'success',
+                context: 'Smoke Tests',
+                description: 'Non-fork PR — use /trigger-smoke-test or labels to run smoke tests',
+              });
+              console.log(`Set Smoke Tests → success for ${sha}`);
+            }


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->
This pull request introduces significant improvements to how smoke tests are handled for both forked and non-forked pull requests (PRs), focusing on workflow security, automation, and clearer documentation. The main changes include a new required "Smoke Tests" commit status gate, new maintainer-only commands to approve or skip smoke tests on fork PRs, and enhanced warnings for workflow file changes. These updates help prevent unauthorized code from bypassing CI checks and make the process more transparent for contributors and maintainers.

**Workflow and CI automation improvements:**

* Added a new `.github/workflows/smoke-tests-gate.yaml` workflow that sets a required **Smoke Tests** commit status for all PRs targeting `main`. Non-fork PRs are auto-marked as passed, while fork PRs require maintainer action to approve or skip smoke tests, blocking merge until resolved.
* Updated `comment-commands.yaml` and `fork-smoke-tests.yaml` workflows to support new maintainer-only slash commands: `/approve-smoke-tests` to run and update smoke tests status, and `/skip-smoke-tests` to mark the check as passed without running tests. Unauthorized attempts to skip are rejected with a clear message. [[1]](diffhunk://#diff-b54d73c9c6de760797c403cb26ddc8c21f21e87d828384fc4855ee40f6284255R17) [[2]](diffhunk://#diff-b54d73c9c6de760797c403cb26ddc8c21f21e87d828384fc4855ee40f6284255L129-R209) [[3]](diffhunk://#diff-65460b9a219b5249ee7e5720e38fa2fcabc5a9d992ea0058780250ed73084e3cR163) [[4]](diffhunk://#diff-65460b9a219b5249ee7e5720e38fa2fcabc5a9d992ea0058780250ed73084e3cR197-R214)
* Both workflows now check for changes under `.github/` and post a prominent warning comment if workflow or CI-related files are modified, alerting reviewers to potential security risks. [[1]](diffhunk://#diff-b54d73c9c6de760797c403cb26ddc8c21f21e87d828384fc4855ee40f6284255R119-R140) [[2]](diffhunk://#diff-65460b9a219b5249ee7e5720e38fa2fcabc5a9d992ea0058780250ed73084e3cL100-R137)

**Documentation updates:**

* The PR template (`.github/PULL_REQUEST_TEMPLATE.md`) and workflow documentation (`.github/workflows/README.md`) are updated to explain the new "Smoke Tests" gate, the required status check, and the new maintainer commands for forked PRs. This clarifies the process for external contributors and maintainers. [[1]](diffhunk://#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35L22-R26) [[2]](diffhunk://#diff-636942e0afa55e1aea027fb857aa2c6046858fb317c0b9a4f12ff3ca17e64ffbR150-R162) [[3]](diffhunk://#diff-636942e0afa55e1aea027fb857aa2c6046858fb317c0b9a4f12ff3ca17e64ffbL191-R200) [[4]](diffhunk://#diff-636942e0afa55e1aea027fb857aa2c6046858fb317c0b9a4f12ff3ca17e64ffbL207-R225)

**Permissions and security:**

* Workflow permissions are tightened: unnecessary write permissions are removed where possible, and `statuses: write` is added where commit statuses are set. [[1]](diffhunk://#diff-65460b9a219b5249ee7e5720e38fa2fcabc5a9d992ea0058780250ed73084e3cL100-R137) [[2]](diffhunk://#diff-65460b9a219b5249ee7e5720e38fa2fcabc5a9d992ea0058780250ed73084e3cR163) [[3]](diffhunk://#diff-b54d73c9c6de760797c403cb26ddc8c21f21e87d828384fc4855ee40f6284255R17)

These changes collectively ensure that smoke tests cannot be bypassed on forked PRs, improve auditability and transparency, and reduce the risk of malicious workflow modifications.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** If you're an external contributor, the `run-smoke-tests` label won't work. A maintainer must manually trigger the "Fork PR Smoke Tests" workflow from the Actions tab, providing your PR number. Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions and required commit statuses, which can block merges or accidentally weaken/strengthen CI enforcement if misconfigured. Also adds maintainer-only paths that run with secrets, so correctness of permission checks and status updates matters.
> 
> **Overview**
> Introduces a required **Smoke Tests** commit-status gate for PRs to `main` via new `smoke-tests-gate.yaml`: non-fork PRs are auto-marked `success`, while fork PRs remain blocked until a maintainer intervenes.
> 
> Extends PR comment automation to support maintainer-only `/approve-smoke-tests` (dispatch fork smoke tests) and new `/skip-smoke-tests` (set `Smoke Tests` status to `success`), including handling for unauthorized skip attempts, and updates `fork-smoke-tests.yaml` to publish the `Smoke Tests` status as `success`/`failure` after runs.
> 
> Adds prominent warnings in maintainer-triggered comments when a PR changes files under `.github/`, and updates the PR template and workflow docs to reflect the new fork-PR flow and commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0cc02000c75b944395bb25d0c92a7b76a81aa76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->