### PR TITLE
[RAPTOR-16918] workload artifact get command

### DIFF
--- a/DRCODEOWNERS
+++ b/DRCODEOWNERS
@@ -1,1 +1,3 @@
 * @datarobot/applications
+cmd/workload/ @datarobot/genai-systems
+internal/workload/ @datarobot/genai-systems

--- a/cmd/workload/artifact/cmd.go
+++ b/cmd/workload/artifact/cmd.go
@@ -12,28 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package workload
+package artifact
 
 import (
-	"github.com/datarobot/cli/cmd/workload/artifact"
-	"github.com/datarobot/cli/internal/features"
+	"github.com/datarobot/cli/cmd/workload/artifact/get"
 	"github.com/spf13/cobra"
 )
 
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "workload",
-		GroupID: "core",
-		Short:   "🚀 Workload management commands",
-		Long: `Workload management commands for your DataRobot applications.
-
-Manage and monitor workloads in your deployment infrastructure.`,
+		Use:   "artifact",
+		Short: "Manage workload artifacts",
+		Long:  `Manage workload artifacts in your DataRobot deployment infrastructure.`,
 	}
 
-	features.SetGate(cmd, "workload")
-
 	cmd.AddCommand(
-		artifact.Cmd(),
+		get.Cmd(),
 	)
 
 	return cmd

--- a/cmd/workload/artifact/get/cmd.go
+++ b/cmd/workload/artifact/get/cmd.go
@@ -20,10 +20,9 @@ import (
 	"time"
 
 	"github.com/datarobot/cli/internal/auth"
-	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 type ArtifactOutput struct {
@@ -41,7 +40,7 @@ func Cmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "get <artifact-id>",
-		Short: "Display details of a workload artifact",
+		Short: "Display details of a workload artifact.",
 		Long: `Display details of a single workload artifact.
 
 This command fetches an artifact by ID and shows:
@@ -61,10 +60,7 @@ Example:
 				return fmt.Errorf("invalid output format: %s (supported: json)", outputFormat)
 			}
 
-			token := viper.GetString(config.DataRobotAPIKey)
-			baseURL := config.GetBaseURL()
-
-			artifact, err := workload.GetArtifact(cmd.Context(), baseURL, token, args[0])
+			artifact, err := workload.GetArtifact(args[0])
 			if err != nil {
 				return err
 			}
@@ -121,11 +117,11 @@ func printHuman(artifact workload.Artifact) {
 		catalog = codeRef.CatalogID
 	}
 
-	fmt.Printf("ID:       %s\n", artifact.ID)
-	fmt.Printf("Name:     %s\n", artifact.Name)
-	fmt.Printf("Status:   %s\n", artifact.Status)
-	fmt.Printf("Version:  %s\n", version)
-	fmt.Printf("Catalog:  %s\n", catalog)
-	fmt.Printf("Created:  %s\n", artifact.CreatedAt.UTC().Format("2006-01-02 15:04 UTC"))
-	fmt.Printf("Updated:  %s\n", artifact.UpdatedAt.UTC().Format("2006-01-02 15:04 UTC"))
+	fmt.Println(tui.BaseTextStyle.Render("ID:       " + artifact.ID))
+	fmt.Println(tui.BaseTextStyle.Render("Name:     " + artifact.Name))
+	fmt.Println(tui.BaseTextStyle.Render("Status:   " + artifact.Status))
+	fmt.Println(tui.BaseTextStyle.Render("Version:  " + version))
+	fmt.Println(tui.BaseTextStyle.Render("Catalog:  " + catalog))
+	fmt.Println(tui.DimStyle.Render("Created:  " + artifact.CreatedAt.UTC().Format("2006-01-02 15:04 UTC")))
+	fmt.Println(tui.DimStyle.Render("Updated:  " + artifact.UpdatedAt.UTC().Format("2006-01-02 15:04 UTC")))
 }

--- a/cmd/workload/artifact/get/cmd.go
+++ b/cmd/workload/artifact/get/cmd.go
@@ -1,0 +1,131 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type ArtifactOutput struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Version   string `json:"version"`
+	Catalog   string `json:"catalog"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+func Cmd() *cobra.Command {
+	var outputFormat string
+
+	cmd := &cobra.Command{
+		Use:   "get <artifact-id>",
+		Short: "Display details of a workload artifact",
+		Long: `Display details of a single workload artifact.
+
+This command fetches an artifact by ID and shows:
+  • Name and current status
+  • Code reference (catalog ID and version)
+  • Creation and last update timestamps
+
+By default, output is human-readable. Use --output json for machine-parseable output.
+
+Example:
+  dr workload artifact get art-abc-123
+  dr workload artifact get art-abc-123 --output json`,
+		Args:    cobra.ExactArgs(1),
+		PreRunE: auth.EnsureAuthenticatedE,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if outputFormat != "" && outputFormat != "json" {
+				return fmt.Errorf("invalid output format: %s (supported: json)", outputFormat)
+			}
+
+			token := viper.GetString(config.DataRobotAPIKey)
+			baseURL := config.GetBaseURL()
+
+			artifact, err := workload.GetArtifact(cmd.Context(), baseURL, token, args[0])
+			if err != nil {
+				return err
+			}
+
+			if outputFormat == "json" {
+				return printJSON(*artifact)
+			}
+
+			printHuman(*artifact)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&outputFormat, "output", "", "Output format (json)")
+
+	return cmd
+}
+
+func printJSON(artifact workload.Artifact) error {
+	codeRef := workload.ExtractCodeRef(artifact)
+
+	output := ArtifactOutput{
+		ID:        artifact.ID,
+		Name:      artifact.Name,
+		Status:    artifact.Status,
+		CreatedAt: artifact.CreatedAt.Format(time.RFC3339),
+		UpdatedAt: artifact.UpdatedAt.Format(time.RFC3339),
+	}
+
+	if codeRef != nil {
+		output.Version = codeRef.CatalogVersionID
+		output.Catalog = codeRef.CatalogID
+	}
+
+	data, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+
+	return nil
+}
+
+func printHuman(artifact workload.Artifact) {
+	codeRef := workload.ExtractCodeRef(artifact)
+
+	version := "\u2014"
+	catalog := "\u2014"
+
+	if codeRef != nil {
+		version = codeRef.CatalogVersionID
+		catalog = codeRef.CatalogID
+	}
+
+	fmt.Printf("ID:       %s\n", artifact.ID)
+	fmt.Printf("Name:     %s\n", artifact.Name)
+	fmt.Printf("Status:   %s\n", artifact.Status)
+	fmt.Printf("Version:  %s\n", version)
+	fmt.Printf("Catalog:  %s\n", catalog)
+	fmt.Printf("Created:  %s\n", artifact.CreatedAt.UTC().Format("2006-01-02 15:04 UTC"))
+	fmt.Printf("Updated:  %s\n", artifact.UpdatedAt.UTC().Format("2006-01-02 15:04 UTC"))
+}

--- a/cmd/workload/artifact/get/cmd_test.go
+++ b/cmd/workload/artifact/get/cmd_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+
+	os.Stdout = old
+
+	var buf bytes.Buffer
+
+	_, _ = io.Copy(&buf, r)
+
+	return buf.String()
+}
+
+func TestPrintJSON_WithCodeRef(t *testing.T) {
+	artifact := workload.Artifact{
+		ID:     "art-abc-123",
+		Name:   "my-agent",
+		Status: "DRAFT",
+		Spec: workload.Spec{
+			ContainerGroups: []workload.ContainerGroup{
+				{
+					Containers: []workload.Container{
+						{
+							CodeRef: &workload.CodeRef{
+								Datarobot: &workload.DatarobotCodeRef{
+									CatalogID:        "cat-xyz-789",
+									CatalogVersionID: "fedcba09",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		CreatedAt: time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 4, 10, 14, 30, 0, 0, time.UTC),
+	}
+
+	output := captureStdout(t, func() {
+		err := printJSON(artifact)
+		require.NoError(t, err)
+	})
+
+	var parsed map[string]interface{}
+
+	err := json.Unmarshal([]byte(output), &parsed)
+	require.NoError(t, err)
+	assert.Equal(t, "art-abc-123", parsed["id"])
+	assert.Equal(t, "my-agent", parsed["name"])
+	assert.Equal(t, "DRAFT", parsed["status"])
+	assert.Equal(t, "fedcba09", parsed["version"])
+	assert.Equal(t, "cat-xyz-789", parsed["catalog"])
+	assert.Equal(t, "2026-04-01T08:00:00Z", parsed["createdAt"])
+	assert.Equal(t, "2026-04-10T14:30:00Z", parsed["updatedAt"])
+}
+
+func TestPrintJSON_WithoutCodeRef(t *testing.T) {
+	artifact := workload.Artifact{
+		ID:        "art-abc-123",
+		Name:      "my-agent",
+		Status:    "DRAFT",
+		Spec:      workload.Spec{},
+		CreatedAt: time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 4, 10, 14, 30, 0, 0, time.UTC),
+	}
+
+	output := captureStdout(t, func() {
+		err := printJSON(artifact)
+		require.NoError(t, err)
+	})
+
+	var parsed map[string]interface{}
+
+	err := json.Unmarshal([]byte(output), &parsed)
+	require.NoError(t, err)
+	assert.Empty(t, parsed["version"])
+	assert.Empty(t, parsed["catalog"])
+}
+
+func TestPrintHuman_WithCodeRef(t *testing.T) {
+	artifact := workload.Artifact{
+		ID:     "art-abc-123",
+		Name:   "my-agent",
+		Status: "DRAFT",
+		Spec: workload.Spec{
+			ContainerGroups: []workload.ContainerGroup{
+				{
+					Containers: []workload.Container{
+						{
+							CodeRef: &workload.CodeRef{
+								Datarobot: &workload.DatarobotCodeRef{
+									CatalogID:        "cat-xyz-789",
+									CatalogVersionID: "fedcba09",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		CreatedAt: time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 4, 10, 14, 30, 0, 0, time.UTC),
+	}
+
+	output := captureStdout(t, func() {
+		printHuman(artifact)
+	})
+
+	assert.Contains(t, output, "ID:       art-abc-123")
+	assert.Contains(t, output, "Name:     my-agent")
+	assert.Contains(t, output, "Status:   DRAFT")
+	assert.Contains(t, output, "Version:  fedcba09")
+	assert.Contains(t, output, "Catalog:  cat-xyz-789")
+	assert.Contains(t, output, "Created:  2026-04-01 08:00 UTC")
+	assert.Contains(t, output, "Updated:  2026-04-10 14:30 UTC")
+}
+
+func TestPrintHuman_WithoutCodeRef(t *testing.T) {
+	artifact := workload.Artifact{
+		ID:        "art-abc-123",
+		Name:      "my-agent",
+		Status:    "DRAFT",
+		Spec:      workload.Spec{},
+		CreatedAt: time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 4, 10, 14, 30, 0, 0, time.UTC),
+	}
+
+	output := captureStdout(t, func() {
+		printHuman(artifact)
+	})
+
+	assert.Contains(t, output, "Version:  \u2014")
+	assert.Contains(t, output, "Catalog:  \u2014")
+}
+
+func TestCmd_RequiresArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -15,14 +15,10 @@
 package workload
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
 )
 
 type Artifact struct {
@@ -72,43 +68,17 @@ func ExtractCodeRef(artifact Artifact) *DatarobotCodeRef {
 	return codeRef.Datarobot
 }
 
-func GetArtifact(ctx context.Context, baseURL, token, artifactID string) (*Artifact, error) {
-	url := baseURL + "/api/v2/artifacts/" + artifactID + "/"
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+func GetArtifact(artifactID string) (*Artifact, error) {
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + artifactID + "/")
 	if err != nil {
-		return nil, fmt.Errorf("failed to reach DataRobot: %w", err)
-	}
-
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("User-Agent", config.GetUserAgentHeader())
-
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to reach DataRobot: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("artifact %s not found", artifactID)
-	}
-
-	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return nil, errors.New("Authentication failed. Check DATAROBOT_ENDPOINT and DATAROBOT_API_TOKEN.")
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected response: %d", resp.StatusCode)
+		return nil, err
 	}
 
 	var artifact Artifact
 
-	if err := json.NewDecoder(resp.Body).Decode(&artifact); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
+	err = drapi.GetJSON(url, "artifact", &artifact)
+	if err != nil {
+		return nil, err
 	}
 
 	return &artifact, nil

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -1,0 +1,115 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/datarobot/cli/internal/config"
+)
+
+type Artifact struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Status    string    `json:"status"`
+	Spec      Spec      `json:"spec"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+type Spec struct {
+	ContainerGroups []ContainerGroup `json:"containerGroups"`
+}
+
+type ContainerGroup struct {
+	Containers []Container `json:"containers"`
+}
+
+type Container struct {
+	CodeRef *CodeRef `json:"codeRef"`
+}
+
+type CodeRef struct {
+	Datarobot *DatarobotCodeRef `json:"datarobot"`
+}
+
+type DatarobotCodeRef struct {
+	CatalogID        string `json:"catalogId"`
+	CatalogVersionID string `json:"catalogVersionId"`
+}
+
+func ExtractCodeRef(artifact Artifact) *DatarobotCodeRef {
+	if len(artifact.Spec.ContainerGroups) == 0 {
+		return nil
+	}
+
+	if len(artifact.Spec.ContainerGroups[0].Containers) == 0 {
+		return nil
+	}
+
+	codeRef := artifact.Spec.ContainerGroups[0].Containers[0].CodeRef
+	if codeRef == nil {
+		return nil
+	}
+
+	return codeRef.Datarobot
+}
+
+func GetArtifact(ctx context.Context, baseURL, token, artifactID string) (*Artifact, error) {
+	url := baseURL + "/api/v2/artifacts/" + artifactID + "/"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reach DataRobot: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("User-Agent", config.GetUserAgentHeader())
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reach DataRobot: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("artifact %s not found", artifactID)
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, errors.New("Authentication failed. Check DATAROBOT_ENDPOINT and DATAROBOT_API_TOKEN.")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response: %d", resp.StatusCode)
+	}
+
+	var artifact Artifact
+
+	if err := json.NewDecoder(resp.Body).Decode(&artifact); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &artifact, nil
+}

--- a/internal/workload/artifact_test.go
+++ b/internal/workload/artifact_test.go
@@ -1,0 +1,214 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testArtifactJSON = `{
+	"id": "art-abc-123",
+	"name": "my-agent",
+	"status": "DRAFT",
+	"spec": {
+		"containerGroups": [
+			{
+				"containers": [
+					{
+						"codeRef": {
+							"datarobot": {
+								"catalogId": "cat-xyz-789",
+								"catalogVersionId": "fedcba0987654321fedcba09"
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	"createdAt": "2026-04-01T08:00:00Z",
+	"updatedAt": "2026-04-10T14:30:00Z"
+}`
+
+const testArtifactNoCodeRefJSON = `{
+	"id": "art-abc-123",
+	"name": "my-agent",
+	"status": "DRAFT",
+	"spec": {
+		"containerGroups": [
+			{
+				"containers": [
+					{}
+				]
+			}
+		]
+	},
+	"createdAt": "2026-04-01T08:00:00Z",
+	"updatedAt": "2026-04-10T14:30:00Z"
+}`
+
+func TestGetArtifact_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/artifacts/art-abc-123/", r.URL.Path)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		assert.NotEmpty(t, r.Header.Get("User-Agent"))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(testArtifactJSON))
+	}))
+	defer server.Close()
+
+	artifact, err := GetArtifact(t.Context(), server.URL, "test-token", "art-abc-123")
+	require.NoError(t, err)
+	assert.Equal(t, "art-abc-123", artifact.ID)
+	assert.Equal(t, "my-agent", artifact.Name)
+	assert.Equal(t, "DRAFT", artifact.Status)
+}
+
+func TestGetArtifact_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	artifact, err := GetArtifact(t.Context(), server.URL, "test-token", "art-abc-123")
+	assert.Nil(t, artifact)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "artifact art-abc-123 not found")
+}
+
+func TestGetArtifact_Unauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	artifact, err := GetArtifact(t.Context(), server.URL, "test-token", "art-abc-123")
+	assert.Nil(t, artifact)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Authentication failed.")
+}
+
+func TestGetArtifact_Forbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	artifact, err := GetArtifact(t.Context(), server.URL, "test-token", "art-abc-123")
+	assert.Nil(t, artifact)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Authentication failed.")
+}
+
+func TestGetArtifact_NetworkError(t *testing.T) {
+	artifact, err := GetArtifact(t.Context(), "http://127.0.0.1:1", "test-token", "art-abc-123")
+	assert.Nil(t, artifact)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to reach DataRobot:")
+}
+
+func TestGetArtifact_UnexpectedStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	artifact, err := GetArtifact(t.Context(), server.URL, "test-token", "art-abc-123")
+	assert.Nil(t, artifact)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected response: 500")
+}
+
+func TestGetArtifact_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{invalid json`))
+	}))
+	defer server.Close()
+
+	artifact, err := GetArtifact(t.Context(), server.URL, "test-token", "art-abc-123")
+	assert.Nil(t, artifact)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse response:")
+}
+
+func TestExtractCodeRef_Found(t *testing.T) {
+	var artifact Artifact
+
+	err := json.Unmarshal([]byte(testArtifactJSON), &artifact)
+	require.NoError(t, err)
+
+	codeRef := ExtractCodeRef(artifact)
+	require.NotNil(t, codeRef)
+	assert.Equal(t, "cat-xyz-789", codeRef.CatalogID)
+	assert.Equal(t, "fedcba0987654321fedcba09", codeRef.CatalogVersionID)
+}
+
+func TestExtractCodeRef_NoContainerGroups(t *testing.T) {
+	artifact := Artifact{Spec: Spec{ContainerGroups: nil}}
+	assert.Nil(t, ExtractCodeRef(artifact))
+}
+
+func TestExtractCodeRef_EmptyContainers(t *testing.T) {
+	artifact := Artifact{
+		Spec: Spec{
+			ContainerGroups: []ContainerGroup{
+				{Containers: []Container{}},
+			},
+		},
+	}
+
+	assert.Nil(t, ExtractCodeRef(artifact))
+}
+
+func TestExtractCodeRef_NilCodeRef(t *testing.T) {
+	artifact := Artifact{
+		Spec: Spec{
+			ContainerGroups: []ContainerGroup{
+				{Containers: []Container{{CodeRef: nil}}},
+			},
+		},
+	}
+
+	assert.Nil(t, ExtractCodeRef(artifact))
+}
+
+func TestExtractCodeRef_NilDatarobot(t *testing.T) {
+	artifact := Artifact{
+		Spec: Spec{
+			ContainerGroups: []ContainerGroup{
+				{Containers: []Container{{CodeRef: &CodeRef{Datarobot: nil}}}},
+			},
+		},
+	}
+
+	assert.Nil(t, ExtractCodeRef(artifact))
+}
+
+func TestExtractCodeRef_NotInResponse(t *testing.T) {
+	var artifact Artifact
+
+	err := json.Unmarshal([]byte(testArtifactNoCodeRefJSON), &artifact)
+	require.NoError(t, err)
+
+	assert.Nil(t, ExtractCodeRef(artifact))
+}

--- a/internal/workload/artifact_test.go
+++ b/internal/workload/artifact_test.go
@@ -16,8 +16,6 @@ package workload
 
 import (
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,92 +62,6 @@ const testArtifactNoCodeRefJSON = `{
 	"createdAt": "2026-04-01T08:00:00Z",
 	"updatedAt": "2026-04-10T14:30:00Z"
 }`
-
-func TestGetArtifact_Success(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v2/artifacts/art-abc-123/", r.URL.Path)
-		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
-		assert.NotEmpty(t, r.Header.Get("User-Agent"))
-
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(testArtifactJSON))
-	}))
-	defer server.Close()
-
-	artifact, err := GetArtifact(t.Context(), server.URL, "test-token", "art-abc-123")
-	require.NoError(t, err)
-	assert.Equal(t, "art-abc-123", artifact.ID)
-	assert.Equal(t, "my-agent", artifact.Name)
-	assert.Equal(t, "DRAFT", artifact.Status)
-}
-
-func TestGetArtifact_NotFound(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer server.Close()
-
-	artifact, err := GetArtifact(t.Context(), server.URL, "test-token", "art-abc-123")
-	assert.Nil(t, artifact)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "artifact art-abc-123 not found")
-}
-
-func TestGetArtifact_Unauthorized(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer server.Close()
-
-	artifact, err := GetArtifact(t.Context(), server.URL, "test-token", "art-abc-123")
-	assert.Nil(t, artifact)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Authentication failed.")
-}
-
-func TestGetArtifact_Forbidden(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-	}))
-	defer server.Close()
-
-	artifact, err := GetArtifact(t.Context(), server.URL, "test-token", "art-abc-123")
-	assert.Nil(t, artifact)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "Authentication failed.")
-}
-
-func TestGetArtifact_NetworkError(t *testing.T) {
-	artifact, err := GetArtifact(t.Context(), "http://127.0.0.1:1", "test-token", "art-abc-123")
-	assert.Nil(t, artifact)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to reach DataRobot:")
-}
-
-func TestGetArtifact_UnexpectedStatus(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer server.Close()
-
-	artifact, err := GetArtifact(t.Context(), server.URL, "test-token", "art-abc-123")
-	assert.Nil(t, artifact)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unexpected response: 500")
-}
-
-func TestGetArtifact_InvalidJSON(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{invalid json`))
-	}))
-	defer server.Close()
-
-	artifact, err := GetArtifact(t.Context(), server.URL, "test-token", "art-abc-123")
-	assert.Nil(t, artifact)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to parse response:")
-}
 
 func TestExtractCodeRef_Found(t *testing.T) {
 	var artifact Artifact


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->
Adds `dr workload artifact get <artifact-id>` to fetch and display a single DataRobot Workload API artifact's details. 


## CHANGES
- **`internal/workload/artifact.go`** — Artifact types and `GetArtifact()` using `drapi.GetJSON()`, plus `ExtractCodeRef()` helper for navigating nested spec.
- **`internal/workload/artifact_test.go`** — Tests for `ExtractCodeRef` covering all nil paths and JSON unmarshalling.
- **`cmd/workload/artifact/cmd.go`** — `artifact` subgroup registration.
- **`cmd/workload/artifact/get/cmd.go`** — Cobra command with `--output json` flag, human-readable default with `tui/styles`, `PreRunE` auth guard.
- **`cmd/workload/artifact/get/cmd_test.go`** — Tests for both output formats and arg validation.
- **`cmd/workload/cmd.go`** — Wires `artifact.Cmd()` into the `workload` group.
- **`DRCODEOWNERS`** — Assigns `cmd/workload/` and `internal/workload/` to `@datarobot/genai-systems`.


## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated CLI command that makes real API calls and parses nested artifact JSON; risk is mainly around endpoint/response-shape mismatches and output expectations, but impact is scoped to the new command path.
> 
> **Overview**
> Adds a new `dr workload artifact get <artifact-id>` CLI flow to fetch a single workload artifact from `/api/v2/artifacts/<id>/` and display its details in either human-readable output or `--output json`.
> 
> Introduces `internal/workload` types for artifact JSON unmarshalling, a small `ExtractCodeRef` helper to surface catalog/version info when present, wires the new `artifact` subcommand into `workload`, and updates `DRCODEOWNERS` ownership for `cmd/workload/` and `internal/workload/`. Tests cover the output formatting and `ExtractCodeRef` nil-path behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3b4897407d77744b8721774b99de504d2cd404c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->