### PR TITLE
[CFX-6271] Logo animation on a first run 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"os"
+
 	"github.com/datarobot/cli/cmd/allcommands"
 	"github.com/datarobot/cli/cmd/artifact"
 	"github.com/datarobot/cli/cmd/auth"
@@ -41,6 +43,7 @@ import (
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/outputformat"
 	internalPlugin "github.com/datarobot/cli/internal/plugin"
+	"github.com/datarobot/cli/internal/state"
 	"github.com/datarobot/cli/internal/telemetry"
 	internalVersion "github.com/datarobot/cli/internal/version"
 	"github.com/datarobot/cli/tui"
@@ -155,6 +158,8 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 
 			config.SetAPIConsumerTrace(config.CommandPathToTrace(cmd.CommandPath()))
 
+			showFirstRunAnimation()
+
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
@@ -167,6 +172,9 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 
 			return nil
 		},
+	},
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
 	},
 }
 
@@ -371,3 +379,24 @@ func initializeConfig(_ *cobra.Command) error {
 
 	return nil
 }
+
+// showFirstRunAnimation displays the animated DataRobot logo on the very first CLI invocation.
+// It checks global state to avoid showing it more than once, and only runs in interactive terminals.
+func showFirstRunAnimation() {
+	if !state.IsFirstRun() {
+		return
+	}
+
+	// Only show animation when stdout is a terminal (not piped or redirected)
+	fi, err := os.Stdout.Stat()
+	if err != nil || (fi.Mode()&os.ModeCharDevice) == 0 {
+		return
+	}
+
+	m := tui.NewLogoAnimationModel()
+
+	_, _ = tui.Run(m)
+
+	state.MarkAnimationShown()
+}
+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,11 +17,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
-	"os"
-
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/cmd/allcommands"
 	"github.com/datarobot/cli/cmd/auth"
 	"github.com/datarobot/cli/cmd/component"
@@ -113,9 +113,9 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 
 			return nil
 		},
-	},
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		return cmd.Help()
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
 	},
 }
 
@@ -273,8 +273,7 @@ func showFirstRunAnimation() {
 
 	m := tui.NewLogoAnimationModel()
 
-	_, _ = tui.Run(m)
+	_, _ = tui.Run(m, tea.WithAltScreen())
 
 	state.MarkAnimationShown()
 }
-

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"os"
+
 	"github.com/datarobot/cli/cmd/allcommands"
 	"github.com/datarobot/cli/cmd/auth"
 	"github.com/datarobot/cli/cmd/component"
@@ -36,6 +38,7 @@ import (
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/log"
 	internalPlugin "github.com/datarobot/cli/internal/plugin"
+	"github.com/datarobot/cli/internal/state"
 	"github.com/datarobot/cli/internal/telemetry"
 	internalVersion "github.com/datarobot/cli/internal/version"
 	"github.com/datarobot/cli/tui"
@@ -96,6 +99,8 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 
 			config.SetAPIConsumerTrace(config.CommandPathToTrace(cmd.CommandPath()))
 
+			showFirstRunAnimation()
+
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
@@ -108,6 +113,9 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 
 			return nil
 		},
+	},
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
 	},
 }
 
@@ -249,3 +257,24 @@ func initializeConfig(cmd *cobra.Command) error {
 
 	return nil
 }
+
+// showFirstRunAnimation displays the animated DataRobot logo on the very first CLI invocation.
+// It checks global state to avoid showing it more than once, and only runs in interactive terminals.
+func showFirstRunAnimation() {
+	if !state.IsFirstRun() {
+		return
+	}
+
+	// Only show animation when stdout is a terminal (not piped or redirected)
+	fi, err := os.Stdout.Stat()
+	if err != nil || (fi.Mode()&os.ModeCharDevice) == 0 {
+		return
+	}
+
+	m := tui.NewLogoAnimationModel()
+
+	_, _ = tui.Run(m)
+
+	state.MarkAnimationShown()
+}
+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,6 +172,17 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 
 			return nil
 		},
+		// RootCmd needs its own RunE (to show help on a bare "dr" invocation, after
+		// the first-run animation), which disqualifies it from setUnknownArgGuards'
+		// generic walk (that skips any command with a pre-existing RunE). So it gets
+		// the same "unknown command" Args validator explicitly here.
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return nil
+			}
+
+			return fmt.Errorf("unknown command: %s", args[0])
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Help()
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/cmd/allcommands"
 	"github.com/datarobot/cli/cmd/artifact"
 	"github.com/datarobot/cli/cmd/auth"
@@ -41,6 +40,7 @@ import (
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/outputformat"
 	internalPlugin "github.com/datarobot/cli/internal/plugin"
 	"github.com/datarobot/cli/internal/state"
@@ -380,9 +380,19 @@ func initializeConfig(_ *cobra.Command) error {
 	return nil
 }
 
-// showFirstRunAnimation displays the animated DataRobot logo on the very first CLI invocation.
-// It checks global state to avoid showing it more than once, and only runs in interactive terminals.
+// showFirstRunAnimation displays the animated DataRobot logo inline (no alt-screen)
+// on the very first CLI invocation, so the final settled frame remains in normal
+// terminal scrollback and whatever runs next (help text, or dr start's own inline
+// wizard) continues directly below it instead of hard-cutting from a full-screen
+// takeover. It checks global state to avoid showing it more than once, only runs
+// in interactive terminals, and is skipped entirely under automation (e.g. tools
+// like expect that attach a real pty and would otherwise see animation frames
+// mixed into output they're pattern-matching).
 func showFirstRunAnimation() {
+	if reader.IsNonInteractive() {
+		return
+	}
+
 	if !state.IsFirstRun() {
 		return
 	}
@@ -395,7 +405,7 @@ func showFirstRunAnimation() {
 
 	m := tui.NewLogoAnimationModel()
 
-	_, _ = tui.Run(m, tea.WithAltScreen())
+	_, _ = tui.Run(m)
 
 	state.MarkAnimationShown()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,11 +17,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
-	"os"
-
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/cmd/allcommands"
 	"github.com/datarobot/cli/cmd/artifact"
 	"github.com/datarobot/cli/cmd/auth"
@@ -172,9 +172,9 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 
 			return nil
 		},
-	},
-	RunE: func(cmd *cobra.Command, _ []string) error {
-		return cmd.Help()
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
 	},
 }
 
@@ -395,8 +395,7 @@ func showFirstRunAnimation() {
 
 	m := tui.NewLogoAnimationModel()
 
-	_, _ = tui.Run(m)
+	_, _ = tui.Run(m, tea.WithAltScreen())
 
 	state.MarkAnimationShown()
 }
-

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/tools"
 	"github.com/spf13/cobra"
@@ -412,4 +413,17 @@ func TestUniversalFlagsParsedOnCoreSubcommand(t *testing.T) {
 
 	assert.True(t, parsedDebug,
 		"--debug must be parsed by core when it appears after a core subcommand and its own flags")
+}
+
+// TestShowFirstRunAnimationSkipsWhenNonInteractive guards against tools like
+// `expect` (used by the smoke test suite) attaching a real pty to dr's
+// stdout: that would satisfy the TTY check and trigger the animation right
+// in the middle of output another tool is pattern-matching. The
+// non-interactive check must short-circuit before any state-file or TTY
+// check runs, so this must return promptly regardless of terminal or
+// first-run state.
+func TestShowFirstRunAnimationSkipsWhenNonInteractive(t *testing.T) {
+	t.Setenv(reader.NonInteractiveEnv, "1")
+
+	assert.NotPanics(t, showFirstRunAnimation)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
+	github.com/charmbracelet/harmonica v0.2.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/log v1.0.0
 	github.com/charmbracelet/x/exp/teatest v0.0.0-20250818131617-61d774aefe53

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
 github.com/charmbracelet/glamour v1.0.0 h1:AWMLOVFHTsysl4WV8T8QgkQ0s/ZNZo7CiE4WKhk8l08=
 github.com/charmbracelet/glamour v1.0.0/go.mod h1:DSdohgOBkMr2ZQNhw4LZxSGpx3SvpeujNoXrQyH2hxo=
+github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
+github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
 github.com/charmbracelet/log v1.0.0 h1:HVVVMmfOorfj3BA9i8X8UL69Hoz9lI0PYwXfJvOdRc4=

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/charmbracelet/colorprofile v0.4.1 h1:a1lO03qTrSIRaK8c3JRxJDZOvhvIeSco
 github.com/charmbracelet/colorprofile v0.4.1/go.mod h1:U1d9Dljmdf9DLegaJ0nGZNJvoXAhayhmidOdcBwAvKk=
 github.com/charmbracelet/glamour v1.0.0 h1:AWMLOVFHTsysl4WV8T8QgkQ0s/ZNZo7CiE4WKhk8l08=
 github.com/charmbracelet/glamour v1.0.0/go.mod h1:DSdohgOBkMr2ZQNhw4LZxSGpx3SvpeujNoXrQyH2hxo=
+github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
+github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 h1:ZR7e0ro+SZZiIZD7msJyA+NjkCNNavuiPBLgerbOziE=
 github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834/go.mod h1:aKC/t2arECF6rNOnaKaVU6y4t4ZeHQzqfxedE/VkVhA=
 github.com/charmbracelet/log v1.0.0 h1:HVVVMmfOorfj3BA9i8X8UL69Hoz9lI0PYwXfJvOdRc4=

--- a/internal/state/global.go
+++ b/internal/state/global.go
@@ -31,8 +31,8 @@ type globalState struct {
 	fullPath string
 	// PluginUpdateChecks maps plugin name → last check timestamp (UTC).
 	PluginUpdateChecks map[string]time.Time `yaml:"plugin_update_checks,omitempty"`
-	// FirstAnimationShown tracks whether the welcome animation has been displayed.
-	FirstAnimationShown bool `yaml:"first_animation_shown,omitempty"`
+	// WelcomeAnimationShown tracks whether the welcome animation has been displayed.
+	WelcomeAnimationShown bool `yaml:"welcome_animation_shown,omitempty"`
 }
 
 // globalStatePath returns the path to the global state file.
@@ -98,7 +98,7 @@ func IsFirstRun() bool {
 		return false
 	}
 
-	return !gs.FirstAnimationShown
+	return !gs.WelcomeAnimationShown
 }
 
 // MarkAnimationShown records that the welcome animation has been displayed.
@@ -108,7 +108,7 @@ func MarkAnimationShown() {
 		return
 	}
 
-	gs.FirstAnimationShown = true
+	gs.WelcomeAnimationShown = true
 
 	_ = gs.save()
 }

--- a/internal/state/global.go
+++ b/internal/state/global.go
@@ -31,6 +31,8 @@ type globalState struct {
 	fullPath string
 	// PluginUpdateChecks maps plugin name → last check timestamp (UTC).
 	PluginUpdateChecks map[string]time.Time `yaml:"plugin_update_checks,omitempty"`
+	// FirstAnimationShown tracks whether the welcome animation has been displayed.
+	FirstAnimationShown bool `yaml:"first_animation_shown,omitempty"`
 }
 
 // globalStatePath returns the path to the global state file.
@@ -87,6 +89,28 @@ func (gs globalState) save() error {
 	}
 
 	return os.WriteFile(gs.fullPath, data, 0o644)
+}
+
+// IsFirstRun returns true if the CLI has never shown the welcome animation.
+func IsFirstRun() bool {
+	gs, err := loadGlobalState()
+	if err != nil {
+		return false
+	}
+
+	return !gs.FirstAnimationShown
+}
+
+// MarkAnimationShown records that the welcome animation has been displayed.
+func MarkAnimationShown() {
+	gs, err := loadGlobalState()
+	if err != nil {
+		return
+	}
+
+	gs.FirstAnimationShown = true
+
+	_ = gs.save()
 }
 
 // GetLastPluginCheck returns the last time an update check was performed for the given plugin.

--- a/smoke_test_scripts/run_plugin_update_smoke_test.sh
+++ b/smoke_test_scripts/run_plugin_update_smoke_test.sh
@@ -34,6 +34,14 @@ DR_CONFIG_DIR="$SANDBOX_DIR/datarobot"
 STATE_FILE="$DR_CONFIG_DIR/state.yaml"
 INSTALLED_META="$DR_CONFIG_DIR/plugins/$PLUGIN_NAME/.installed.json"
 
+# `expect` always allocates a real pty for the spawned `dr` process, which
+# satisfies dr's TTY check and, against this always-fresh sandbox, would
+# trigger the first-run welcome animation and corrupt the output expect is
+# pattern-matching. Pre-mark it as already shown; re-seeded again after the
+# state-file reset below (step 4), which would otherwise clear this too.
+mkdir -p "$DR_CONFIG_DIR"
+printf 'first_animation_shown: true\n' > "$STATE_FILE"
+
 cleanup() {
   # Remove only after unsetting so DR_CONFIG_DIR is no longer live
   unset XDG_CONFIG_HOME
@@ -97,11 +105,14 @@ assert_eq "Version after decline" "$(read_version "$INSTALLED_META")" "$PINNED_V
 echo ""
 
 # ── Step 3: Verify cooldown was recorded ──────────────────────────────────────
+# Checks for the plugin_update_checks key specifically, not mere file
+# existence — state.yaml already exists from the first_animation_shown seed
+# above regardless of whether the cooldown was actually recorded.
 echo "── Step 3: Verify state file (cooldown) ──"
-if [[ -f "$STATE_FILE" ]]; then
-  echo "✅ State file written at $STATE_FILE"
+if grep -q "plugin_update_checks" "$STATE_FILE" 2>/dev/null; then
+  echo "✅ Cooldown recorded in $STATE_FILE"
 else
-  echo "❌ State file not found — cooldown was not recorded"
+  echo "❌ Cooldown not recorded in $STATE_FILE"
   exit 1
 fi
 echo ""
@@ -109,6 +120,9 @@ echo ""
 # ── Step 4: Reset cooldown by deleting state file ─────────────────────────────
 echo "── Step 4: Clear state file to reset cooldown ──"
 rm "$STATE_FILE"
+# Re-seed first_animation_shown (cleared by the rm above) so the next `dr
+# assist` invocation in step 5 doesn't retrigger the first-run animation.
+printf 'first_animation_shown: true\n' > "$STATE_FILE"
 echo "✅ Cooldown reset"
 echo ""
 

--- a/smoke_test_scripts/run_plugin_update_smoke_test.sh
+++ b/smoke_test_scripts/run_plugin_update_smoke_test.sh
@@ -40,7 +40,7 @@ INSTALLED_META="$DR_CONFIG_DIR/plugins/$PLUGIN_NAME/.installed.json"
 # pattern-matching. Pre-mark it as already shown; re-seeded again after the
 # state-file reset below (step 4), which would otherwise clear this too.
 mkdir -p "$DR_CONFIG_DIR"
-printf 'first_animation_shown: true\n' > "$STATE_FILE"
+printf 'welcome_animation_shown: true\n' > "$STATE_FILE"
 
 cleanup() {
   # Remove only after unsetting so DR_CONFIG_DIR is no longer live
@@ -106,7 +106,7 @@ echo ""
 
 # ── Step 3: Verify cooldown was recorded ──────────────────────────────────────
 # Checks for the plugin_update_checks key specifically, not mere file
-# existence — state.yaml already exists from the first_animation_shown seed
+# existence — state.yaml already exists from the welcome_animation_shown seed
 # above regardless of whether the cooldown was actually recorded.
 echo "── Step 3: Verify state file (cooldown) ──"
 if grep -q "plugin_update_checks" "$STATE_FILE" 2>/dev/null; then
@@ -120,9 +120,9 @@ echo ""
 # ── Step 4: Reset cooldown by deleting state file ─────────────────────────────
 echo "── Step 4: Clear state file to reset cooldown ──"
 rm "$STATE_FILE"
-# Re-seed first_animation_shown (cleared by the rm above) so the next `dr
+# Re-seed welcome_animation_shown (cleared by the rm above) so the next `dr
 # assist` invocation in step 5 doesn't retrigger the first-run animation.
-printf 'first_animation_shown: true\n' > "$STATE_FILE"
+printf 'welcome_animation_shown: true\n' > "$STATE_FILE"
 echo "✅ Cooldown reset"
 echo ""
 

--- a/smoke_test_scripts/run_pre_release_smoke_test.sh
+++ b/smoke_test_scripts/run_pre_release_smoke_test.sh
@@ -49,7 +49,7 @@ export NO_COLOR=1
 dr_state_dir="${XDG_CONFIG_HOME:-$HOME/.config}/datarobot"
 mkdir -p "$dr_state_dir"
 touch "$dr_state_dir/state.yaml"
-yq -i '.first_animation_shown = true' "$dr_state_dir/state.yaml"
+yq -i '.welcome_animation_shown = true' "$dr_state_dir/state.yaml"
 
 # Timing helpers
 SCRIPT_START=$(date +%s)

--- a/smoke_test_scripts/run_pre_release_smoke_test.sh
+++ b/smoke_test_scripts/run_pre_release_smoke_test.sh
@@ -39,6 +39,17 @@ export TERM="dumb"
 # NO_COLOR overrides that forced colorization so the detection's plain
 # substring match against "start" keeps working.
 export NO_COLOR=1
+# `expect` always allocates a real pty for the spawned `dr` process, which
+# satisfies dr's TTY check and, on a fresh CI $HOME, would trigger the
+# first-run welcome animation and corrupt the output expect is
+# pattern-matching. Pre-mark it as already shown (rather than forcing
+# DATAROBOT_CLI_NON_INTERACTIVE, which is also the fallback for `dr start`'s
+# --yes-gated prompt this suite exercises for real) so only the animation is
+# affected.
+dr_state_dir="${XDG_CONFIG_HOME:-$HOME/.config}/datarobot"
+mkdir -p "$dr_state_dir"
+touch "$dr_state_dir/state.yaml"
+yq -i '.first_animation_shown = true' "$dr_state_dir/state.yaml"
 
 # Timing helpers
 SCRIPT_START=$(date +%s)

--- a/smoke_test_scripts/run_smoke_test.sh
+++ b/smoke_test_scripts/run_smoke_test.sh
@@ -10,6 +10,18 @@ fi
 
 export TERM="dumb"
 
+# Several steps below spawn `dr` under `expect`, which always allocates a real
+# pty for the child — satisfying dr's TTY check and, on a fresh CI $HOME,
+# triggering the first-run welcome animation right in the middle of output an
+# expect script is pattern-matching against. Pre-mark it as already shown
+# (rather than forcing DATAROBOT_CLI_NON_INTERACTIVE, which is also the
+# fallback for several --yes-gated prompts this suite exercises for real,
+# e.g. `dr dotenv setup`) so only the animation is affected.
+dr_state_dir="${XDG_CONFIG_HOME:-$HOME/.config}/datarobot"
+mkdir -p "$dr_state_dir"
+touch "$dr_state_dir/state.yaml"
+yq -i '.first_animation_shown = true' "$dr_state_dir/state.yaml"
+
 # Timing helpers
 SCRIPT_START=$(date +%s)
 TEST_TIMINGS=""

--- a/smoke_test_scripts/run_smoke_test.sh
+++ b/smoke_test_scripts/run_smoke_test.sh
@@ -20,7 +20,7 @@ export TERM="dumb"
 dr_state_dir="${XDG_CONFIG_HOME:-$HOME/.config}/datarobot"
 mkdir -p "$dr_state_dir"
 touch "$dr_state_dir/state.yaml"
-yq -i '.first_animation_shown = true' "$dr_state_dir/state.yaml"
+yq -i '.welcome_animation_shown = true' "$dr_state_dir/state.yaml"
 
 # Timing helpers
 SCRIPT_START=$(date +%s)

--- a/tui/logo_animation.go
+++ b/tui/logo_animation.go
@@ -1,3 +1,17 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tui
 
 import (

--- a/tui/logo_animation.go
+++ b/tui/logo_animation.go
@@ -28,14 +28,52 @@ import (
 
 type logoTickMsg struct{}
 
+// animPhase models the animation as a single continuous "intro" driven by one
+// shared spring, followed by a brief settle grace period, then done.
+type animPhase int
+
+const (
+	phaseIntro   animPhase = iota // bars cascading, text fading, and welcome line overlapping in — all concurrent
+	phaseSettled                  // everything at rest; graceFrames countdown running before quit
+	phaseDone                     // Done=true, quitting
+)
+
 const (
 	animFPS        = 60
 	animFrameDelay = time.Second / animFPS
-	springFreq     = 5.5
-	springDamping  = 0.35
-	staggerFrames  = 4
-	slideDistance  = 30.0
-	settledThresh  = 0.3
+
+	springFreq    = 5.5
+	springDamping = 0.35
+
+	staggerFrames = 4
+	slideDistance = 30.0
+
+	welcomeStartOffset = 3.0
+
+	// Settle thresholds are scaled per quantity: bars/welcome move in column
+	// units (~1-30), opacity lives in 0..1 — a single shared threshold would
+	// either never trigger for opacity or trigger too early for position.
+	barsSettledThresh    = 0.3
+	welcomeSettledThresh = 0.05
+	opacitySettledThresh = 0.02
+
+	// barsOverlapProgress releases the welcome line once the bar cascade is
+	// mostly (not fully) settled, so the two motions overlap instead of the
+	// welcome line waiting for a hard "100% done" gate.
+	barsOverlapProgress = 0.55
+
+	// graceFrames is a short hold (~200ms at 60fps) after everything settles,
+	// so the final frame doesn't feel clipped the instant physics crosses
+	// its threshold.
+	graceFrames = 12
+)
+
+// fadeStartDark/fadeStartLight approximate the muted gray used elsewhere for
+// dim text (DrGray/DrGrayDark, ANSI 256 indices "252"/"240") but in hex form,
+// since lerpColor interpolates hex RGB rather than ANSI palette indices.
+const (
+	fadeStartDark  = lipgloss.Color("#5a5a5a")
+	fadeStartLight = lipgloss.Color("#c8c8c8")
 )
 
 // Pictogram — the 9 bars matching the DataRobot brand icon.
@@ -60,21 +98,24 @@ type pictoBar struct {
 }
 
 // LogoAnimationModel animates a compact DataRobot logo using spring physics.
+// A single shared spring drives every animated quantity (bar offsets, text
+// opacity, welcome-line offset) so all motion shares one physical feel.
 type LogoAnimationModel struct {
 	bars   []pictoBar
 	spring harmonica.Spring
 
-	width  int
-	height int
+	frame         int
+	phase         animPhase
+	settledFrames int
 
-	frame        int
-	phase        int     // 0=bars-slide+text-fade, 2=welcome, 3=slide-out, 4=done
-	textOpacity  float64 // 0..1 for "DataRobot" text
-	welcomePos   float64
-	welcomeVel   float64
-	slideOutVPos float64 // 0.5=centre→0.0=top, animated during phase 3
-	slideOutStep float64 // per-frame step, increases each frame (acceleration)
-	Done         bool
+	textOpacityPos float64
+	textOpacityVel float64
+
+	welcomeStarted bool
+	welcomePos     float64
+	welcomeVel     float64
+
+	Done bool
 }
 
 // NewLogoAnimationModel creates a new compact logo animation model.
@@ -86,13 +127,9 @@ func NewLogoAnimationModel() LogoAnimationModel {
 	}
 
 	return LogoAnimationModel{
-		bars:         bars,
-		spring:       harmonica.NewSpring(harmonica.FPS(animFPS), springFreq, springDamping),
-		width:        80,
-		height:       24,
-		welcomePos:   3.0,
-		slideOutVPos: 0.5,
-		slideOutStep: 0.008,
+		bars:       bars,
+		spring:     harmonica.NewSpring(harmonica.FPS(animFPS), springFreq, springDamping),
+		welcomePos: welcomeStartOffset,
 	}
 }
 
@@ -104,12 +141,6 @@ func (m LogoAnimationModel) Init() tea.Cmd {
 
 func (m LogoAnimationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
-	case tea.WindowSizeMsg:
-		m.width = msg.Width
-		m.height = msg.Height
-
-		return m, nil
-
 	case tea.KeyMsg:
 		_ = msg
 
@@ -126,7 +157,7 @@ func (m LogoAnimationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *LogoAnimationModel) skipToEnd() {
 	m.Done = true
-	m.phase = 4
+	m.phase = phaseDone
 
 	for i := range m.bars {
 		m.bars[i].started = true
@@ -134,8 +165,12 @@ func (m *LogoAnimationModel) skipToEnd() {
 		m.bars[i].vel = 0
 	}
 
-	m.textOpacity = 1.0
+	m.textOpacityPos = 1.0
+	m.textOpacityVel = 0
+
+	m.welcomeStarted = true
 	m.welcomePos = 0
+	m.welcomeVel = 0
 }
 
 func (m LogoAnimationModel) handleTick() (tea.Model, tea.Cmd) {
@@ -146,18 +181,21 @@ func (m LogoAnimationModel) handleTick() (tea.Model, tea.Cmd) {
 	})
 
 	switch m.phase {
-	case 0:
-		m.updateBarsSlide()
+	case phaseIntro:
+		m.updateIntro()
 
 		return m, nextTick
 
-	case 2:
-		return m.updateWelcome(nextTick)
+	case phaseSettled:
+		m.settledFrames++
 
-	case 3:
-		return m.updateSlideOut(nextTick)
+		if m.settledFrames >= graceFrames {
+			m.phase = phaseDone
+		}
 
-	case 4:
+		return m, nextTick
+
+	case phaseDone:
 		m.Done = true
 
 		return m, tea.Quit
@@ -166,14 +204,29 @@ func (m LogoAnimationModel) handleTick() (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m *LogoAnimationModel) updateBarsSlide() {
-	allSettled := true
+// updateIntro advances the bar cascade, text opacity, and welcome line for
+// one tick. All three share m.spring so they decelerate/settle with the same
+// physical feel; the welcome line is released early (see barsOverlapProgress)
+// so it overlaps the tail of the bar cascade instead of waiting for it.
+func (m *LogoAnimationModel) updateIntro() {
+	barsSettled := m.updateBars()
+	opacitySettled := m.updateOpacity()
+	welcomeSettled := m.updateWelcome()
+
+	if barsSettled && opacitySettled && welcomeSettled {
+		m.phase = phaseSettled
+		m.settledFrames = 0
+	}
+}
+
+func (m *LogoAnimationModel) updateBars() bool {
+	settled := true
 
 	for i := range m.bars {
 		startFrame := i * staggerFrames
 
 		if m.frame < startFrame {
-			allSettled = false
+			settled = false
 
 			continue
 		}
@@ -181,81 +234,103 @@ func (m *LogoAnimationModel) updateBarsSlide() {
 		m.bars[i].started = true
 		m.bars[i].pos, m.bars[i].vel = m.spring.Update(m.bars[i].pos, m.bars[i].vel, 0)
 
-		if math.Abs(m.bars[i].pos) > settledThresh || math.Abs(m.bars[i].vel) > settledThresh {
-			allSettled = false
+		if math.Abs(m.bars[i].pos) > barsSettledThresh || math.Abs(m.bars[i].vel) > barsSettledThresh {
+			settled = false
 		}
 	}
 
-	// Fade text in simultaneously with bars sliding in.
-	m.textOpacity = clamp01(m.textOpacity + 0.04)
-
-	if allSettled && m.textOpacity >= 1.0 {
-		for i := range m.bars {
-			m.bars[i].pos = 0
-			m.bars[i].vel = 0
-		}
-
-		m.phase = 2
-	}
+	return settled
 }
 
-func (m LogoAnimationModel) updateSlideOut(nextTick tea.Cmd) (tea.Model, tea.Cmd) {
-	m.slideOutStep += 0.002
-	m.slideOutVPos -= m.slideOutStep
+func (m *LogoAnimationModel) updateOpacity() bool {
+	m.textOpacityPos, m.textOpacityVel = m.spring.Update(m.textOpacityPos, m.textOpacityVel, 1.0)
 
-	if m.slideOutVPos <= 0 {
-		m.slideOutVPos = 0
-		m.phase = 4
-
-		return m, tea.Tick(100*time.Millisecond, func(time.Time) tea.Msg {
-			return logoTickMsg{}
-		})
-	}
-
-	return m, nextTick
+	return math.Abs(m.textOpacityPos-1.0) < opacitySettledThresh &&
+		math.Abs(m.textOpacityVel) < opacitySettledThresh
 }
 
-func (m LogoAnimationModel) updateWelcome(nextTick tea.Cmd) (tea.Model, tea.Cmd) {
+// updateWelcome releases the welcome line once the bar cascade crosses
+// barsOverlapProgress, then springs it toward 0 like any other track.
+func (m *LogoAnimationModel) updateWelcome() bool {
+	if !m.welcomeStarted && m.barsSettleProgress() >= barsOverlapProgress {
+		m.welcomeStarted = true
+	}
+
+	if !m.welcomeStarted {
+		return false
+	}
+
 	m.welcomePos, m.welcomeVel = m.spring.Update(m.welcomePos, m.welcomeVel, 0)
 
-	if math.Abs(m.welcomePos) < 0.05 {
-		m.phase = 3
+	return math.Abs(m.welcomePos) < welcomeSettledThresh && math.Abs(m.welcomeVel) < welcomeSettledThresh
+}
 
-		return m, tea.Tick(1200*time.Millisecond, func(time.Time) tea.Msg {
-			return logoTickMsg{}
-		})
+// barsSettleProgress reports how far along (0..1) the bar cascade is,
+// averaged across all bars. A not-yet-started bar contributes 0. This gates
+// when the welcome line overlaps in (see barsOverlapProgress) instead of
+// requiring every bar to be 100% settled first.
+func (m LogoAnimationModel) barsSettleProgress() float64 {
+	if len(m.bars) == 0 {
+		return 1
 	}
 
-	return m, nextTick
+	var sum float64
+
+	for _, b := range m.bars {
+		if !b.started {
+			continue
+		}
+
+		sum += clamp01(1 - math.Abs(b.pos)/slideDistance)
+	}
+
+	return sum / float64(len(m.bars))
 }
+
+// textOpacity returns the "DataRobot" text's current fade-in progress, 0..1.
+func (m LogoAnimationModel) textOpacity() float64 {
+	return clamp01(m.textOpacityPos)
+}
+
+// leftMargin is the indent applied to the whole animation block, matching
+// the 2-space indent other inline screens (e.g. dr start's step list) use
+// for their content instead of centering it in the terminal.
+const leftMargin = "  "
 
 func (m LogoAnimationModel) View() string {
 	var sb strings.Builder
 
 	sb.WriteString("\n")
 	m.renderLogo(&sb)
-	m.renderWelcome(&sb)
 
-	if m.phase < 3 {
-		sb.WriteString("\n")
-		sb.WriteString(DimStyle.Render("  Press any key to skip"))
+	// The hint line's space is always reserved (blank when not shown) so the
+	// rendered block's height never changes mid-animation — inline bubbletea
+	// redraws in place based on the previous frame's line count, and a
+	// height change there is what causes a visible jump.
+	sb.WriteString("\n")
+
+	if m.phase == phaseIntro {
+		sb.WriteString(DimStyle.Render("Press any key to skip"))
 	}
 
 	sb.WriteString("\n")
 
-	content := sb.String()
+	return indentBlock(sb.String(), leftMargin)
+}
 
-	if m.width > 0 && m.height > 0 {
-		return lipgloss.Place(
-			m.width,
-			m.height,
-			lipgloss.Center,
-			lipgloss.Position(m.slideOutVPos),
-			content,
-		)
+// indentBlock prefixes every line of content with margin.
+func indentBlock(content, margin string) string {
+	lines := strings.Split(content, "\n")
+
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+
+		lines[i] = margin + line
 	}
 
-	return content
+	return strings.Join(lines, "\n")
 }
 
 func (m LogoAnimationModel) renderLogo(sb *strings.Builder) {
@@ -271,13 +346,16 @@ func (m LogoAnimationModel) buildPictogramBlock() string {
 	total := len(pictogramLines)
 	lines := make([]string, 0, total)
 
+	from := GetAdaptiveColor(DrPurple, DrPurpleDark)
+	to := GetAdaptiveColor(DrGreen, DrGreenDark)
+
 	for i, bar := range m.bars {
 		progress := 0.0
 		if total > 1 {
 			progress = float64(i) / float64(total-1)
 		}
 
-		color := lerpColor(DrPurple, DrGreen, progress)
+		color := lerpColor(from, to, progress)
 		style := lipgloss.NewStyle().Foreground(color)
 
 		if !bar.started {
@@ -309,36 +387,40 @@ func (m LogoAnimationModel) buildTextBlock() string {
 	height := len(pictogramLines)
 	lines := make([]string, height)
 
-	// Fade effect for "DataRobot"
-	fadedColor := lerpColor(lipgloss.Color("#1a1a2e"), DrPurple, m.textOpacity)
-	nameStyle := lipgloss.NewStyle().Bold(true).Foreground(fadedColor)
+	// Fade "DataRobot" from the existing dim-gray token to the same purple
+	// BaseTextStyle/WelcomeStyle resolve to, so full opacity matches the
+	// welcome line's color exactly.
+	fadeFrom := GetAdaptiveColor(fadeStartDark, fadeStartLight)
+	fadeTo := GetAdaptiveColor(DrPurple, DrPurpleDark)
+	nameStyle := lipgloss.NewStyle().Bold(true).Foreground(lerpColor(fadeFrom, fadeTo, m.textOpacity()))
 
 	// Layout: place text lines in the vertical center of the pictogram
 	// Line arrangement (for 9 lines, mid=4):
 	//   mid-1 = "DataRobot"
 	//   mid   = (empty spacer)
-	//   mid+1 = welcome (phase 2+)
-	//   mid+2 = subtitle (phase 2+)
+	//   mid+1 = welcome (once welcomeStarted)
+	//   mid+2 = subtitle (once welcomeStarted)
 	mid := height / 2
 
 	lines[mid-1] = nameStyle.Render("DataRobot")
 
-	if m.phase >= 2 {
-		welcomeStyle := lipgloss.NewStyle().Bold(true).Foreground(DrPurple)
+	if m.welcomeStarted {
+		offset := max(int(math.Round(m.welcomePos)), 0)
 
-		welcomeOffset := max(int(math.Round(m.welcomePos)), 0)
+		welcomeLine := "✨ Welcome to DataRobot CLI"
+		subtitleLine := "Build AI Applications Faster"
 
-		if welcomeOffset == 0 {
-			lines[mid+1] = welcomeStyle.Render("✨ Welcome to DataRobot CLI")
-			lines[mid+2] = DimStyle.Render("Build AI Applications Faster")
+		if offset > 0 {
+			welcomeLine = strings.Repeat(" ", offset) + welcomeLine
+			subtitleLine = strings.Repeat(" ", offset) + subtitleLine
 		}
+
+		lines[mid+1] = WelcomeStyle.Render(welcomeLine)
+		lines[mid+2] = DimStyle.Render(subtitleLine)
 	}
 
 	return strings.Join(lines, "\n")
 }
-
-// renderWelcome is a no-op — welcome text is now inside buildTextBlock.
-func (m LogoAnimationModel) renderWelcome(_ *strings.Builder) {}
 
 // clamp01 clamps a value between 0 and 1.
 func clamp01(v float64) float64 {

--- a/tui/logo_animation.go
+++ b/tui/logo_animation.go
@@ -19,8 +19,8 @@ const (
 	animFrameDelay = time.Second / animFPS
 	springFreq     = 5.5
 	springDamping  = 0.35
-	staggerFrames  = 5
-	slideDistance   = 30.0
+	staggerFrames  = 4
+	slideDistance  = 30.0
 	settledThresh  = 0.3
 )
 
@@ -40,9 +40,9 @@ var pictogramLines = []string{
 
 // pictoBar tracks per-line spring animation state.
 type pictoBar struct {
-	fromRight bool
-	pos       float64
-	vel       float64
+	started bool
+	pos     float64
+	vel     float64
 }
 
 // LogoAnimationModel animates a compact DataRobot logo using spring physics.
@@ -50,12 +50,17 @@ type LogoAnimationModel struct {
 	bars   []pictoBar
 	spring harmonica.Spring
 
-	frame       int
-	phase       int     // 0=bars-slide, 1=text-fade, 2=welcome, 3=done
-	textOpacity float64 // 0..1 for "DataRobot" text
-	welcomePos  float64
-	welcomeVel  float64
-	Done        bool
+	width  int
+	height int
+
+	frame        int
+	phase        int     // 0=bars-slide+text-fade, 2=welcome, 3=slide-out, 4=done
+	textOpacity  float64 // 0..1 for "DataRobot" text
+	welcomePos   float64
+	welcomeVel   float64
+	slideOutVPos float64 // 0.5=centre→0.0=top, animated during phase 3
+	slideOutStep float64 // per-frame step, increases each frame (acceleration)
+	Done         bool
 }
 
 // NewLogoAnimationModel creates a new compact logo animation model.
@@ -63,17 +68,17 @@ func NewLogoAnimationModel() LogoAnimationModel {
 	bars := make([]pictoBar, len(pictogramLines))
 
 	for i := range bars {
-		if i%2 == 0 {
-			bars[i] = pictoBar{fromRight: false, pos: -slideDistance}
-		} else {
-			bars[i] = pictoBar{fromRight: true, pos: slideDistance}
-		}
+		bars[i] = pictoBar{started: false, pos: slideDistance}
 	}
 
 	return LogoAnimationModel{
-		bars:       bars,
-		spring:     harmonica.NewSpring(harmonica.FPS(animFPS), springFreq, springDamping),
-		welcomePos: 3.0,
+		bars:         bars,
+		spring:       harmonica.NewSpring(harmonica.FPS(animFPS), springFreq, springDamping),
+		width:        80,
+		height:       24,
+		welcomePos:   3.0,
+		slideOutVPos: 0.5,
+		slideOutStep: 0.008,
 	}
 }
 
@@ -84,8 +89,16 @@ func (m LogoAnimationModel) Init() tea.Cmd {
 }
 
 func (m LogoAnimationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg.(type) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+
+		return m, nil
+
 	case tea.KeyMsg:
+		_ = msg
+
 		m.skipToEnd()
 
 		return m, tea.Quit
@@ -99,9 +112,10 @@ func (m LogoAnimationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *LogoAnimationModel) skipToEnd() {
 	m.Done = true
-	m.phase = 3
+	m.phase = 4
 
 	for i := range m.bars {
+		m.bars[i].started = true
 		m.bars[i].pos = 0
 		m.bars[i].vel = 0
 	}
@@ -123,13 +137,13 @@ func (m LogoAnimationModel) handleTick() (tea.Model, tea.Cmd) {
 
 		return m, nextTick
 
-	case 1:
-		return m.updateTextFade(nextTick)
-
 	case 2:
 		return m.updateWelcome(nextTick)
 
 	case 3:
+		return m.updateSlideOut(nextTick)
+
+	case 4:
 		m.Done = true
 
 		return m, tea.Quit
@@ -143,12 +157,14 @@ func (m *LogoAnimationModel) updateBarsSlide() {
 
 	for i := range m.bars {
 		startFrame := i * staggerFrames
+
 		if m.frame < startFrame {
 			allSettled = false
 
 			continue
 		}
 
+		m.bars[i].started = true
 		m.bars[i].pos, m.bars[i].vel = m.spring.Update(m.bars[i].pos, m.bars[i].vel, 0)
 
 		if math.Abs(m.bars[i].pos) > settledThresh || math.Abs(m.bars[i].vel) > settledThresh {
@@ -156,22 +172,30 @@ func (m *LogoAnimationModel) updateBarsSlide() {
 		}
 	}
 
-	if allSettled {
+	// Fade text in simultaneously with bars sliding in.
+	m.textOpacity = clamp01(m.textOpacity + 0.04)
+
+	if allSettled && m.textOpacity >= 1.0 {
 		for i := range m.bars {
 			m.bars[i].pos = 0
 			m.bars[i].vel = 0
 		}
 
-		m.phase = 1
+		m.phase = 2
 	}
 }
 
-func (m LogoAnimationModel) updateTextFade(nextTick tea.Cmd) (tea.Model, tea.Cmd) {
-	m.textOpacity += 0.06
+func (m LogoAnimationModel) updateSlideOut(nextTick tea.Cmd) (tea.Model, tea.Cmd) {
+	m.slideOutStep += 0.002
+	m.slideOutVPos -= m.slideOutStep
 
-	if m.textOpacity >= 1.0 {
-		m.textOpacity = 1.0
-		m.phase = 2
+	if m.slideOutVPos <= 0 {
+		m.slideOutVPos = 0
+		m.phase = 4
+
+		return m, tea.Tick(100*time.Millisecond, func(time.Time) tea.Msg {
+			return logoTickMsg{}
+		})
 	}
 
 	return m, nextTick
@@ -183,7 +207,7 @@ func (m LogoAnimationModel) updateWelcome(nextTick tea.Cmd) (tea.Model, tea.Cmd)
 	if math.Abs(m.welcomePos) < 0.05 {
 		m.phase = 3
 
-		return m, tea.Tick(700*time.Millisecond, func(time.Time) tea.Msg {
+		return m, tea.Tick(1200*time.Millisecond, func(time.Time) tea.Msg {
 			return logoTickMsg{}
 		})
 	}
@@ -205,21 +229,27 @@ func (m LogoAnimationModel) View() string {
 
 	sb.WriteString("\n")
 
-	return sb.String()
+	content := sb.String()
+
+	if m.width > 0 && m.height > 0 {
+		return lipgloss.Place(
+			m.width,
+			m.height,
+			lipgloss.Center,
+			lipgloss.Position(m.slideOutVPos),
+			content,
+		)
+	}
+
+	return content
 }
 
 func (m LogoAnimationModel) renderLogo(sb *strings.Builder) {
 	pictoBlock := m.buildPictogramBlock()
+	textBlock := m.buildTextBlock()
+	joined := lipgloss.JoinHorizontal(lipgloss.Center, pictoBlock, "   ", textBlock)
 
-	if m.phase >= 1 {
-		textBlock := m.buildTextBlock()
-		joined := lipgloss.JoinHorizontal(lipgloss.Center, pictoBlock, "   ", textBlock)
-
-		sb.WriteString(joined)
-	} else {
-		sb.WriteString(pictoBlock)
-	}
-
+	sb.WriteString(joined)
 	sb.WriteString("\n")
 }
 
@@ -235,6 +265,12 @@ func (m LogoAnimationModel) buildPictogramBlock() string {
 
 		color := lerpColor(DrPurple, DrGreen, progress)
 		style := lipgloss.NewStyle().Foreground(color)
+
+		if !bar.started {
+			lines = append(lines, "")
+
+			continue
+		}
 
 		offset := int(math.Round(bar.pos))
 

--- a/tui/logo_animation.go
+++ b/tui/logo_animation.go
@@ -1,0 +1,327 @@
+package tui
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/harmonica"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type logoTickMsg struct{}
+
+const (
+	animFPS        = 60
+	animFrameDelay = time.Second / animFPS
+	springFreq     = 5.5
+	springDamping  = 0.35
+	staggerFrames  = 5
+	slideDistance   = 30.0
+	settledThresh  = 0.3
+)
+
+// Pictogram — the 9 bars matching the DataRobot brand icon.
+// Pattern: symmetric, alternating left/indented bars.
+var pictogramLines = []string{
+	"█████████",
+	"         █████",
+	"█████████",
+	"              █████",
+	"██████████████",
+	"              █████",
+	"█████████",
+	"         █████",
+	"█████████",
+}
+
+// pictoBar tracks per-line spring animation state.
+type pictoBar struct {
+	fromRight bool
+	pos       float64
+	vel       float64
+}
+
+// LogoAnimationModel animates a compact DataRobot logo using spring physics.
+type LogoAnimationModel struct {
+	bars   []pictoBar
+	spring harmonica.Spring
+
+	frame       int
+	phase       int     // 0=bars-slide, 1=text-fade, 2=welcome, 3=done
+	textOpacity float64 // 0..1 for "DataRobot" text
+	welcomePos  float64
+	welcomeVel  float64
+	Done        bool
+}
+
+// NewLogoAnimationModel creates a new compact logo animation model.
+func NewLogoAnimationModel() LogoAnimationModel {
+	bars := make([]pictoBar, len(pictogramLines))
+
+	for i := range bars {
+		if i%2 == 0 {
+			bars[i] = pictoBar{fromRight: false, pos: -slideDistance}
+		} else {
+			bars[i] = pictoBar{fromRight: true, pos: slideDistance}
+		}
+	}
+
+	return LogoAnimationModel{
+		bars:       bars,
+		spring:     harmonica.NewSpring(harmonica.FPS(animFPS), springFreq, springDamping),
+		welcomePos: 3.0,
+	}
+}
+
+func (m LogoAnimationModel) Init() tea.Cmd {
+	return tea.Tick(animFrameDelay, func(time.Time) tea.Msg {
+		return logoTickMsg{}
+	})
+}
+
+func (m LogoAnimationModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg.(type) {
+	case tea.KeyMsg:
+		m.skipToEnd()
+
+		return m, tea.Quit
+
+	case logoTickMsg:
+		return m.handleTick()
+	}
+
+	return m, nil
+}
+
+func (m *LogoAnimationModel) skipToEnd() {
+	m.Done = true
+	m.phase = 3
+
+	for i := range m.bars {
+		m.bars[i].pos = 0
+		m.bars[i].vel = 0
+	}
+
+	m.textOpacity = 1.0
+	m.welcomePos = 0
+}
+
+func (m LogoAnimationModel) handleTick() (tea.Model, tea.Cmd) {
+	m.frame++
+
+	nextTick := tea.Tick(animFrameDelay, func(time.Time) tea.Msg {
+		return logoTickMsg{}
+	})
+
+	switch m.phase {
+	case 0:
+		m.updateBarsSlide()
+
+		return m, nextTick
+
+	case 1:
+		return m.updateTextFade(nextTick)
+
+	case 2:
+		return m.updateWelcome(nextTick)
+
+	case 3:
+		m.Done = true
+
+		return m, tea.Quit
+	}
+
+	return m, nil
+}
+
+func (m *LogoAnimationModel) updateBarsSlide() {
+	allSettled := true
+
+	for i := range m.bars {
+		startFrame := i * staggerFrames
+		if m.frame < startFrame {
+			allSettled = false
+
+			continue
+		}
+
+		m.bars[i].pos, m.bars[i].vel = m.spring.Update(m.bars[i].pos, m.bars[i].vel, 0)
+
+		if math.Abs(m.bars[i].pos) > settledThresh || math.Abs(m.bars[i].vel) > settledThresh {
+			allSettled = false
+		}
+	}
+
+	if allSettled {
+		for i := range m.bars {
+			m.bars[i].pos = 0
+			m.bars[i].vel = 0
+		}
+
+		m.phase = 1
+	}
+}
+
+func (m LogoAnimationModel) updateTextFade(nextTick tea.Cmd) (tea.Model, tea.Cmd) {
+	m.textOpacity += 0.06
+
+	if m.textOpacity >= 1.0 {
+		m.textOpacity = 1.0
+		m.phase = 2
+	}
+
+	return m, nextTick
+}
+
+func (m LogoAnimationModel) updateWelcome(nextTick tea.Cmd) (tea.Model, tea.Cmd) {
+	m.welcomePos, m.welcomeVel = m.spring.Update(m.welcomePos, m.welcomeVel, 0)
+
+	if math.Abs(m.welcomePos) < 0.05 {
+		m.phase = 3
+
+		return m, tea.Tick(700*time.Millisecond, func(time.Time) tea.Msg {
+			return logoTickMsg{}
+		})
+	}
+
+	return m, nextTick
+}
+
+func (m LogoAnimationModel) View() string {
+	var sb strings.Builder
+
+	sb.WriteString("\n")
+	m.renderLogo(&sb)
+	m.renderWelcome(&sb)
+
+	if m.phase < 3 {
+		sb.WriteString("\n")
+		sb.WriteString(DimStyle.Render("  Press any key to skip"))
+	}
+
+	sb.WriteString("\n")
+
+	return sb.String()
+}
+
+func (m LogoAnimationModel) renderLogo(sb *strings.Builder) {
+	pictoBlock := m.buildPictogramBlock()
+
+	if m.phase >= 1 {
+		textBlock := m.buildTextBlock()
+		joined := lipgloss.JoinHorizontal(lipgloss.Center, pictoBlock, "   ", textBlock)
+
+		sb.WriteString(joined)
+	} else {
+		sb.WriteString(pictoBlock)
+	}
+
+	sb.WriteString("\n")
+}
+
+func (m LogoAnimationModel) buildPictogramBlock() string {
+	total := len(pictogramLines)
+	lines := make([]string, 0, total)
+
+	for i, bar := range m.bars {
+		progress := 0.0
+		if total > 1 {
+			progress = float64(i) / float64(total-1)
+		}
+
+		color := lerpColor(DrPurple, DrGreen, progress)
+		style := lipgloss.NewStyle().Foreground(color)
+
+		offset := int(math.Round(bar.pos))
+
+		line := pictogramLines[i]
+
+		if offset > 0 {
+			line = strings.Repeat(" ", offset) + line
+		} else if offset < 0 {
+			runes := []rune(line)
+			trim := min(-offset, len(runes))
+
+			line = string(runes[trim:])
+		}
+
+		lines = append(lines, style.Render(line))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (m LogoAnimationModel) buildTextBlock() string {
+	height := len(pictogramLines)
+	lines := make([]string, height)
+
+	// Fade effect for "DataRobot"
+	fadedColor := lerpColor(lipgloss.Color("#1a1a2e"), DrPurple, m.textOpacity)
+	nameStyle := lipgloss.NewStyle().Bold(true).Foreground(fadedColor)
+
+	// Layout: place text lines in the vertical center of the pictogram
+	// Line arrangement (for 9 lines, mid=4):
+	//   mid-1 = "DataRobot"
+	//   mid   = (empty spacer)
+	//   mid+1 = welcome (phase 2+)
+	//   mid+2 = subtitle (phase 2+)
+	mid := height / 2
+
+	lines[mid-1] = nameStyle.Render("DataRobot")
+
+	if m.phase >= 2 {
+		welcomeStyle := lipgloss.NewStyle().Bold(true).Foreground(DrPurple)
+
+		welcomeOffset := max(int(math.Round(m.welcomePos)), 0)
+
+		if welcomeOffset == 0 {
+			lines[mid+1] = welcomeStyle.Render("✨ Welcome to DataRobot CLI")
+			lines[mid+2] = DimStyle.Render("Build AI Applications Faster")
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderWelcome is a no-op — welcome text is now inside buildTextBlock.
+func (m LogoAnimationModel) renderWelcome(_ *strings.Builder) {}
+
+// clamp01 clamps a value between 0 and 1.
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+
+	if v > 1 {
+		return 1
+	}
+
+	return v
+}
+
+// lerpColor linearly interpolates between two hex lipgloss colors.
+func lerpColor(from, to lipgloss.Color, t float64) lipgloss.Color {
+	fr, fg, fb := parseHex(string(from))
+	tr, tg, tb := parseHex(string(to))
+
+	r := uint8(math.Round(float64(fr) + float64(int(tr)-int(fr))*t))
+	g := uint8(math.Round(float64(fg) + float64(int(tg)-int(fg))*t))
+	b := uint8(math.Round(float64(fb) + float64(int(tb)-int(fb))*t))
+
+	return lipgloss.Color(fmt.Sprintf("#%02x%02x%02x", r, g, b))
+}
+
+// parseHex extracts RGB values from a hex color string like "#AABBCC".
+func parseHex(hex string) (uint8, uint8, uint8) {
+	hex = strings.TrimPrefix(hex, "#")
+
+	r, _ := strconv.ParseUint(hex[0:2], 16, 8)
+	g, _ := strconv.ParseUint(hex[2:4], 16, 8)
+	b, _ := strconv.ParseUint(hex[4:6], 16, 8)
+
+	return uint8(r), uint8(g), uint8(b)
+}

--- a/tui/logo_animation_test.go
+++ b/tui/logo_animation_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tui
 
 import (

--- a/tui/logo_animation_test.go
+++ b/tui/logo_animation_test.go
@@ -15,20 +15,26 @@
 package tui
 
 import (
+	"io"
+	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewLogoAnimationModel(t *testing.T) {
 	m := NewLogoAnimationModel()
 
 	assert.Len(t, m.bars, len(pictogramLines), "one spring per pictogram line")
-	assert.Equal(t, 0, m.phase)
+	assert.Equal(t, phaseIntro, m.phase)
 	assert.False(t, m.Done)
 	assert.False(t, m.bars[0].started)
-	assert.False(t, m.bars[1].started)
+	assert.False(t, m.welcomeStarted)
+	assert.InDelta(t, 0.0, m.textOpacity(), 0.001)
 }
 
 func TestLogoAnimationSkipOnKeyPress(t *testing.T) {
@@ -39,63 +45,141 @@ func TestLogoAnimationSkipOnKeyPress(t *testing.T) {
 	result := updated.(LogoAnimationModel)
 
 	assert.True(t, result.Done)
-	assert.Equal(t, 4, result.phase)
-	assert.NotNil(t, cmd)
+	assert.Equal(t, phaseDone, result.phase)
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	_, isQuit := msg.(tea.QuitMsg)
+	assert.True(t, isQuit, "skip should issue a real tea.Quit command")
 
 	for _, bar := range result.bars {
 		assert.InDelta(t, 0.0, bar.pos, 0.001)
 		assert.InDelta(t, 0.0, bar.vel, 0.001)
 	}
 
-	assert.InDelta(t, 1.0, result.textOpacity, 0.001)
-	assert.InDelta(t, 0.0, result.welcomePos, 0.001)
+	assert.InDelta(t, 1.0, result.textOpacity(), 0.001)
+
+	view := result.View()
+	assert.NotContains(t, view, "Press any key to skip")
+	assert.Contains(t, view, "DataRobot")
+	assert.Contains(t, view, "Welcome to DataRobot CLI")
+	assert.Contains(t, view, "Build AI Applications Faster")
 }
 
-func TestLogoAnimationBarsConverge(t *testing.T) {
+func TestLogoAnimationBarsCascadeAndSettle(t *testing.T) {
 	m := NewLogoAnimationModel()
 
-	for i := 0; i < 500; i++ {
-		updated, _ := m.Update(logoTickMsg{})
+	terminated := false
 
+	for i := 0; i < 300; i++ {
+		updated, _ := m.Update(logoTickMsg{})
 		m = updated.(LogoAnimationModel)
 
-		if m.phase > 0 {
+		if m.phase != phaseIntro {
+			terminated = true
+
 			break
 		}
 	}
 
-	assert.GreaterOrEqual(t, m.phase, 1)
+	require.True(t, terminated, "bar cascade should settle within a bounded number of ticks")
 
 	for _, bar := range m.bars {
-		assert.InDelta(t, 0.0, bar.pos, 0.001)
+		assert.InDelta(t, 0.0, bar.pos, barsSettledThresh)
 	}
 }
 
-func TestLogoAnimationTextFadesWithBars(t *testing.T) {
+func TestLogoAnimationWelcomeOverlapsBars(t *testing.T) {
 	m := NewLogoAnimationModel()
 
-	assert.Zero(t, m.textOpacity)
+	var progressAtStart float64
 
-	// Text opacity increases during phase 0 alongside bar animation.
+	triggered := false
+
+	for i := 0; i < 300; i++ {
+		wasStarted := m.welcomeStarted
+
+		updated, _ := m.Update(logoTickMsg{})
+		m = updated.(LogoAnimationModel)
+
+		if !wasStarted && m.welcomeStarted {
+			progressAtStart = m.barsSettleProgress()
+			triggered = true
+
+			break
+		}
+
+		if m.phase != phaseIntro {
+			break
+		}
+	}
+
+	require.True(t, triggered, "welcome line should start during the intro phase")
+	assert.GreaterOrEqual(t, progressAtStart, barsOverlapProgress)
+	assert.Less(t, progressAtStart, 1.0, "welcome line should overlap the bar cascade, not wait for it to finish")
+}
+
+func TestLogoAnimationTextOpacitySpringDriven(t *testing.T) {
+	m := NewLogoAnimationModel()
+
+	assert.InDelta(t, 0.0, m.textOpacity(), 0.001)
+
 	for i := 0; i < 10; i++ {
 		updated, _ := m.Update(logoTickMsg{})
 		m = updated.(LogoAnimationModel)
 	}
 
-	assert.Greater(t, m.textOpacity, 0.0)
-	assert.Equal(t, 0, m.phase, "still in phase 0 during early ticks")
+	assert.Greater(t, m.textOpacity(), 0.0, "opacity should be moving early in the intro")
+
+	for i := 0; i < 300 && m.phase == phaseIntro; i++ {
+		updated, _ := m.Update(logoTickMsg{})
+		m = updated.(LogoAnimationModel)
+	}
+
+	assert.GreaterOrEqual(t, m.textOpacity(), 1.0-opacitySettledThresh, "opacity should have settled near 1 by the time the intro ends")
 }
 
-func TestLogoAnimationDonePhase(t *testing.T) {
+func TestLogoAnimationSettleGraceThenDone(t *testing.T) {
 	m := NewLogoAnimationModel()
-	m.phase = 4
+	m.phase = phaseSettled
 
-	updated, cmd := m.Update(logoTickMsg{})
+	ticks := 0
+	done := false
 
-	result := updated.(LogoAnimationModel)
+	for i := 0; i < graceFrames+5; i++ {
+		updated, _ := m.Update(logoTickMsg{})
+		m = updated.(LogoAnimationModel)
+		ticks++
 
-	assert.True(t, result.Done)
-	assert.NotNil(t, cmd)
+		if m.Done {
+			done = true
+
+			break
+		}
+	}
+
+	require.True(t, done)
+	assert.Equal(t, graceFrames+1, ticks, "should take graceFrames ticks to settle plus one to process phaseDone")
+}
+
+func TestLogoAnimationFullRunTerminates(t *testing.T) {
+	m := NewLogoAnimationModel()
+
+	done := false
+
+	for i := 0; i < 400; i++ {
+		updated, _ := m.Update(logoTickMsg{})
+		m = updated.(LogoAnimationModel)
+
+		if m.Done {
+			done = true
+
+			break
+		}
+	}
+
+	require.True(t, done, "animation should reach Done within a bounded number of ticks")
+	assert.NotContains(t, m.View(), "Press any key to skip")
 }
 
 func TestLogoAnimationViewShowsPictogram(t *testing.T) {
@@ -113,32 +197,40 @@ func TestLogoAnimationViewShowsPictogram(t *testing.T) {
 	assert.Contains(t, view, "Press any key to skip")
 }
 
-func TestLogoAnimationViewShowsTextAndWelcome(t *testing.T) {
+func TestLogoAnimationViewIsLeftAligned(t *testing.T) {
 	m := NewLogoAnimationModel()
 
 	for i := range m.bars {
+		m.bars[i].started = true
 		m.bars[i].pos = 0
 		m.bars[i].vel = 0
 	}
 
-	m.phase = 2
-	m.textOpacity = 1.0
-	m.welcomePos = 0
+	for _, line := range strings.Split(m.View(), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
 
-	view := m.View()
-
-	assert.Contains(t, view, "DataRobot")
-	assert.Contains(t, view, "Welcome to DataRobot CLI")
-	assert.Contains(t, view, "Build AI Applications Faster")
+		assert.True(t, strings.HasPrefix(line, leftMargin), "line should start with the shared left margin: %q", line)
+	}
 }
 
-func TestLogoAnimationViewNoSkipWhenDone(t *testing.T) {
-	m := NewLogoAnimationModel()
-	m.phase = 4
+func TestLogoAnimationIntegrationSkipViaKeypress(t *testing.T) {
+	tm := teatest.NewTestModel(t, NewLogoAnimationModel(), teatest.WithInitialTermSize(80, 24))
 
-	view := m.View()
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 
-	assert.NotContains(t, view, "Press any key to skip")
+	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+
+	fm := tm.FinalModel(t)
+	result, ok := fm.(LogoAnimationModel)
+	require.True(t, ok, "final model is not LogoAnimationModel")
+	assert.True(t, result.Done)
+
+	out, err := io.ReadAll(tm.FinalOutput(t))
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "DataRobot")
+	assert.NotContains(t, string(out), "Press any key to skip")
 }
 
 func TestLerpColor(t *testing.T) {

--- a/tui/logo_animation_test.go
+++ b/tui/logo_animation_test.go
@@ -13,8 +13,8 @@ func TestNewLogoAnimationModel(t *testing.T) {
 	assert.Len(t, m.bars, len(pictogramLines), "one spring per pictogram line")
 	assert.Equal(t, 0, m.phase)
 	assert.False(t, m.Done)
-	assert.False(t, m.bars[0].fromRight)
-	assert.True(t, m.bars[1].fromRight)
+	assert.False(t, m.bars[0].started)
+	assert.False(t, m.bars[1].started)
 }
 
 func TestLogoAnimationSkipOnKeyPress(t *testing.T) {
@@ -25,7 +25,7 @@ func TestLogoAnimationSkipOnKeyPress(t *testing.T) {
 	result := updated.(LogoAnimationModel)
 
 	assert.True(t, result.Done)
-	assert.Equal(t, 3, result.phase)
+	assert.Equal(t, 4, result.phase)
 	assert.NotNil(t, cmd)
 
 	for _, bar := range result.bars {
@@ -57,33 +57,24 @@ func TestLogoAnimationBarsConverge(t *testing.T) {
 	}
 }
 
-func TestLogoAnimationTextFadePhase(t *testing.T) {
+func TestLogoAnimationTextFadesWithBars(t *testing.T) {
 	m := NewLogoAnimationModel()
-	m.phase = 1
-	m.frame = 200
 
-	for i := range m.bars {
-		m.bars[i].pos = 0
-		m.bars[i].vel = 0
-	}
+	assert.Zero(t, m.textOpacity)
 
-	for i := 0; i < 30; i++ {
+	// Text opacity increases during phase 0 alongside bar animation.
+	for i := 0; i < 10; i++ {
 		updated, _ := m.Update(logoTickMsg{})
-
 		m = updated.(LogoAnimationModel)
-
-		if m.phase >= 2 {
-			break
-		}
 	}
 
-	assert.Equal(t, 2, m.phase)
-	assert.InDelta(t, 1.0, m.textOpacity, 0.001)
+	assert.Greater(t, m.textOpacity, 0.0)
+	assert.Equal(t, 0, m.phase, "still in phase 0 during early ticks")
 }
 
 func TestLogoAnimationDonePhase(t *testing.T) {
 	m := NewLogoAnimationModel()
-	m.phase = 3
+	m.phase = 4
 
 	updated, cmd := m.Update(logoTickMsg{})
 
@@ -97,6 +88,7 @@ func TestLogoAnimationViewShowsPictogram(t *testing.T) {
 	m := NewLogoAnimationModel()
 
 	for i := range m.bars {
+		m.bars[i].started = true
 		m.bars[i].pos = 0
 		m.bars[i].vel = 0
 	}
@@ -128,7 +120,7 @@ func TestLogoAnimationViewShowsTextAndWelcome(t *testing.T) {
 
 func TestLogoAnimationViewNoSkipWhenDone(t *testing.T) {
 	m := NewLogoAnimationModel()
-	m.phase = 3
+	m.phase = 4
 
 	view := m.View()
 

--- a/tui/logo_animation_test.go
+++ b/tui/logo_animation_test.go
@@ -1,0 +1,161 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLogoAnimationModel(t *testing.T) {
+	m := NewLogoAnimationModel()
+
+	assert.Len(t, m.bars, len(pictogramLines), "one spring per pictogram line")
+	assert.Equal(t, 0, m.phase)
+	assert.False(t, m.Done)
+	assert.False(t, m.bars[0].fromRight)
+	assert.True(t, m.bars[1].fromRight)
+}
+
+func TestLogoAnimationSkipOnKeyPress(t *testing.T) {
+	m := NewLogoAnimationModel()
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+
+	result := updated.(LogoAnimationModel)
+
+	assert.True(t, result.Done)
+	assert.Equal(t, 3, result.phase)
+	assert.NotNil(t, cmd)
+
+	for _, bar := range result.bars {
+		assert.InDelta(t, 0.0, bar.pos, 0.001)
+		assert.InDelta(t, 0.0, bar.vel, 0.001)
+	}
+
+	assert.InDelta(t, 1.0, result.textOpacity, 0.001)
+	assert.InDelta(t, 0.0, result.welcomePos, 0.001)
+}
+
+func TestLogoAnimationBarsConverge(t *testing.T) {
+	m := NewLogoAnimationModel()
+
+	for i := 0; i < 500; i++ {
+		updated, _ := m.Update(logoTickMsg{})
+
+		m = updated.(LogoAnimationModel)
+
+		if m.phase > 0 {
+			break
+		}
+	}
+
+	assert.GreaterOrEqual(t, m.phase, 1)
+
+	for _, bar := range m.bars {
+		assert.InDelta(t, 0.0, bar.pos, 0.001)
+	}
+}
+
+func TestLogoAnimationTextFadePhase(t *testing.T) {
+	m := NewLogoAnimationModel()
+	m.phase = 1
+	m.frame = 200
+
+	for i := range m.bars {
+		m.bars[i].pos = 0
+		m.bars[i].vel = 0
+	}
+
+	for i := 0; i < 30; i++ {
+		updated, _ := m.Update(logoTickMsg{})
+
+		m = updated.(LogoAnimationModel)
+
+		if m.phase >= 2 {
+			break
+		}
+	}
+
+	assert.Equal(t, 2, m.phase)
+	assert.InDelta(t, 1.0, m.textOpacity, 0.001)
+}
+
+func TestLogoAnimationDonePhase(t *testing.T) {
+	m := NewLogoAnimationModel()
+	m.phase = 3
+
+	updated, cmd := m.Update(logoTickMsg{})
+
+	result := updated.(LogoAnimationModel)
+
+	assert.True(t, result.Done)
+	assert.NotNil(t, cmd)
+}
+
+func TestLogoAnimationViewShowsPictogram(t *testing.T) {
+	m := NewLogoAnimationModel()
+
+	for i := range m.bars {
+		m.bars[i].pos = 0
+		m.bars[i].vel = 0
+	}
+
+	view := m.View()
+
+	assert.Contains(t, view, "██████")
+	assert.Contains(t, view, "Press any key to skip")
+}
+
+func TestLogoAnimationViewShowsTextAndWelcome(t *testing.T) {
+	m := NewLogoAnimationModel()
+
+	for i := range m.bars {
+		m.bars[i].pos = 0
+		m.bars[i].vel = 0
+	}
+
+	m.phase = 2
+	m.textOpacity = 1.0
+	m.welcomePos = 0
+
+	view := m.View()
+
+	assert.Contains(t, view, "DataRobot")
+	assert.Contains(t, view, "Welcome to DataRobot CLI")
+	assert.Contains(t, view, "Build AI Applications Faster")
+}
+
+func TestLogoAnimationViewNoSkipWhenDone(t *testing.T) {
+	m := NewLogoAnimationModel()
+	m.phase = 3
+
+	view := m.View()
+
+	assert.NotContains(t, view, "Press any key to skip")
+}
+
+func TestLerpColor(t *testing.T) {
+	result := lerpColor("#ff0000", "#00ff00", 0.0)
+	assert.Equal(t, "#ff0000", string(result))
+
+	result = lerpColor("#ff0000", "#00ff00", 1.0)
+	assert.Equal(t, "#00ff00", string(result))
+
+	result = lerpColor("#ff0000", "#00ff00", 0.5)
+	assert.Equal(t, "#808000", string(result))
+}
+
+func TestParseHex(t *testing.T) {
+	r, g, b := parseHex("#7770F9")
+
+	assert.Equal(t, uint8(0x77), r)
+	assert.Equal(t, uint8(0x70), g)
+	assert.Equal(t, uint8(0xF9), b)
+}
+
+func TestClamp01(t *testing.T) {
+	assert.InDelta(t, 0.0, clamp01(-0.5), 0.001)
+	assert.InDelta(t, 0.5, clamp01(0.5), 0.001)
+	assert.InDelta(t, 1.0, clamp01(1.5), 0.001)
+}


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->
Refactored first run logo with an animation 

<img width="749" height="314" alt="image" src="https://github.com/user-attachments/assets/e3632bd7-d6d6-4436-b40f-8022da1b8c3e" />


https://github.com/user-attachments/assets/33de7280-3279-410b-8673-57d103ce89c7



<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784217289.456839 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runs new TUI code on the hot path for every command’s first execution and writes new global state, which could affect terminal behavior or scripted usage if detection/state persistence misbehaves.
> 
> **Overview**
> Adds a *first-run* welcome experience by running a Bubble Tea animated DataRobot logo before executing any command (via `PersistentPreRunE` in `cmd/root.go`), but only when stdout is an interactive terminal.
> 
> Persists a new global state flag (`first_animation_shown` in `~/.config/datarobot/state.yaml`) to ensure the animation only shows once, and introduces a new `tui` spring-based animation model (plus tests) backed by the new `github.com/charmbracelet/harmonica` dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3678ca8177a55df53f878b9bd17b79c379bddca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->