### PR TITLE
[CFX-5377] Add error handling for newLLMListPrompt

### DIFF
--- a/cmd/dotenv/promptModel.go
+++ b/cmd/dotenv/promptModel.go
@@ -49,6 +49,7 @@ var (
 const (
 	cursorStyle = '•'
 
+	typeError			 = "error"
 	errMsgPrefix         = "😞 Unable to retrieve the list of available LLMs.\n\n"
 	errMsgAuthFailed     = "🔐 Authentication failed. Please check your credentials and try again."
 	errMsgNotFound       = "🔍 Requested resource not found. Please contact support for assistance."
@@ -197,7 +198,7 @@ func newLLMListPrompt(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptM
 		var (
 			netErr     net.Error
 			httpErr    *drapi.HTTPError
-			StatusCode int
+			statusCode int
 		)
 
 		helpMsg := errMsgPrefix
@@ -205,12 +206,12 @@ func newLLMListPrompt(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptM
 		// Check if the error is a network timeout or an HTTP error to provide more specific feedback
 		// Treat net.Error.Timeout() as an HTTP 408 Request Timeout for user-friendly messaging
 		if errors.As(err, &netErr) && netErr.Timeout() {
-			StatusCode = http.StatusRequestTimeout
+			statusCode = http.StatusRequestTimeout
 		} else if errors.As(err, &httpErr) {
-			StatusCode = httpErr.StatusCode
+			statusCode = httpErr.StatusCode
 		}
 
-		switch StatusCode {
+		switch statusCode {
 		case http.StatusUnauthorized, http.StatusForbidden:
 			helpMsg += errMsgAuthFailed
 		case http.StatusNotFound:
@@ -222,7 +223,7 @@ func newLLMListPrompt(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptM
 		}
 
 		errPrompt := prompt
-		errPrompt.Type = "error"
+		errPrompt.Type = typeError
 
 		errPrompt.Help = helpMsg
 
@@ -233,7 +234,7 @@ func newLLMListPrompt(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptM
 		log.Warn("No active LLMs found in the catalog")
 
 		errPrompt := prompt
-		errPrompt.Type = "error"
+		errPrompt.Type = typeError
 		errPrompt.Help = errMsgNoLLMs
 
 		return promptModel{prompt: errPrompt, successCmd: successCmd}, nil
@@ -377,7 +378,7 @@ func (pm promptModel) View() string {
 		if pm.prompt.Multiple {
 			sb.WriteString(tui.DimStyle.Render("space to toggle • enter to answer • "))
 		}
-	} else if pm.prompt.Type.String() == "error" {
+	} else if pm.prompt.Type.String() == typeError {
 		sb.WriteString("\n\n")
 	} else {
 		sb.WriteString(pm.input.View())

--- a/cmd/dotenv/promptModel.go
+++ b/cmd/dotenv/promptModel.go
@@ -15,8 +15,11 @@
 package dotenv
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"slices"
 	"strings"
 
@@ -45,6 +48,13 @@ var (
 
 const (
 	cursorStyle = '•'
+
+	errMsgPrefix         = "😞 Unable to retrieve the list of available LLMs.\n\n"
+	errMsgAuthFailed     = "🔐 Authentication failed. Please check your credentials and try again."
+	errMsgNotFound       = "🔍 Requested resource not found. Please contact support for assistance."
+	errMsgTimeout        = "⏳ Request timed out. Please check your network connection and try again."
+	errMsgNoLLMs         = "🤷 No available LLMs found. Please contact support for assistance."
+	errMsgContactSupport = "👥 Please try again or contact support if the issue persists."
 )
 
 type item envbuilder.PromptOption
@@ -184,19 +194,35 @@ func newLLMListPrompt(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptM
 	if err != nil {
 		log.Errorf("Error retrieving LLMs: %s", err.Error())
 
-		errPrompt := prompt
-		errPrompt.Type = "llmgw_error"
-		helpMsg := "😞 Unable to retrieve the list of available LLMs.\n\n"
+		var (
+			netErr     net.Error
+			httpErr    *drapi.HTTPError
+			StatusCode int
+		)
 
-		if strings.Contains(err.Error(), "Unauthorized") {
-			helpMsg += "🔐 Authentication failed. Please check your credentials and try again."
-		} else if strings.Contains(err.Error(), "Not Found") {
-			helpMsg += "🔍 Requested resource not found. Please contact support for assistance."
-		} else if strings.Contains(err.Error(), "Timeout") {
-			helpMsg += "⏳ Request timed out. Please check your network connection and try again."
-		} else {
-			helpMsg += fmt.Sprintf("%s\n\n👥 Please try again or contact support if the issue persists.", err.Error())
+		helpMsg := errMsgPrefix
+
+		// Check if the error is a network timeout or an HTTP error to provide more specific feedback
+		// Treat net.Error.Timeout() as an HTTP 408 Request Timeout for user-friendly messaging
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			StatusCode = http.StatusRequestTimeout
+		} else if errors.As(err, &httpErr) {
+			StatusCode = httpErr.StatusCode
 		}
+
+		switch StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			helpMsg += errMsgAuthFailed
+		case http.StatusNotFound:
+			helpMsg += errMsgNotFound
+		case http.StatusRequestTimeout, http.StatusGatewayTimeout:
+			helpMsg += errMsgTimeout
+		default:
+			helpMsg += err.Error() + "\n\n" + errMsgContactSupport
+		}
+
+		errPrompt := prompt
+		errPrompt.Type = "error"
 
 		errPrompt.Help = helpMsg
 
@@ -207,8 +233,8 @@ func newLLMListPrompt(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptM
 		log.Warn("No active LLMs found in the catalog")
 
 		errPrompt := prompt
-		errPrompt.Type = "llmgw_error"
-		errPrompt.Help = "😞 No available LLMs found. Please contact support for assistance."
+		errPrompt.Type = "error"
+		errPrompt.Help = errMsgNoLLMs
 
 		return promptModel{prompt: errPrompt, successCmd: successCmd}, nil
 	}
@@ -331,7 +357,8 @@ func (pm promptModel) View() string {
 	sb.Write([]byte(tui.SubTitleStyle.Render(fmt.Sprintf("Variable: %v", pm.prompt.Env))))
 	sb.WriteString("\n\n")
 
-	if strings.Contains(pm.prompt.Type.String(), "error") {
+	// if strings.Contains(pm.prompt.Type.String(), "error") {
+	if pm.prompt.Type.String() == "error" {
 		sb.WriteString(tui.ErrorStyle.Render(pm.prompt.Help))
 	} else {
 		sb.WriteString(tui.BaseTextStyle.Render(pm.prompt.Help))
@@ -351,7 +378,7 @@ func (pm promptModel) View() string {
 		if pm.prompt.Multiple {
 			sb.WriteString(tui.DimStyle.Render("space to toggle • enter to answer • "))
 		}
-	} else if strings.Contains(pm.prompt.Type.String(), "error") {
+	} else if pm.prompt.Type.String() == "error" {
 		sb.WriteString("\n\n")
 	} else {
 		sb.WriteString(pm.input.View())

--- a/cmd/dotenv/promptModel.go
+++ b/cmd/dotenv/promptModel.go
@@ -26,6 +26,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/envbuilder"
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/tui"
 )
 
@@ -181,7 +182,33 @@ func llmsToPromptOptions(llms []drapi.LLM) []envbuilder.PromptOption {
 func newLLMListPrompt(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptModel, tea.Cmd) {
 	llms, err := drapi.GetLLMs()
 	if err != nil {
-		return promptModel{}, nil
+		log.Errorf("Error retrieving LLMs: %s", err.Error())
+
+		errPrompt := prompt
+		errPrompt.Type = "llmgw_error"
+		helpMsg := "😞 Unable to retrieve the list of available LLMs.\n\n"
+
+		if strings.Contains(err.Error(), "Unauthorized") {
+			helpMsg += "🔐 Authentication failed. Please check your credentials and try again."
+		} else if strings.Contains(err.Error(), "Not Found") {
+			helpMsg += "🔍 Requested resource not found. Please contact support for assistance."
+		} else if strings.Contains(err.Error(), "Timeout") {
+			helpMsg += "⏳ Request timed out. Please check your network connection and try again."
+		}
+
+		errPrompt.Help = helpMsg
+
+		return promptModel{prompt: errPrompt, successCmd: successCmd}, nil
+	}
+
+	if len(llms.LLMs) == 0 {
+		log.Warn("No active LLMs found in the catalog")
+
+		errPrompt := prompt
+		errPrompt.Type = "llmgw_error"
+		errPrompt.Help = "😞 No available LLMs found. Please contact support for assistance."
+
+		return promptModel{prompt: errPrompt, successCmd: successCmd}, nil
 	}
 
 	prompt.Options = append(prompt.Options, llmsToPromptOptions(llms.LLMs)...)
@@ -301,7 +328,13 @@ func (pm promptModel) View() string {
 
 	sb.Write([]byte(tui.SubTitleStyle.Render(fmt.Sprintf("Variable: %v", pm.prompt.Env))))
 	sb.WriteString("\n\n")
-	sb.WriteString(tui.BaseTextStyle.Render(pm.prompt.Help))
+
+	if strings.Contains(pm.prompt.Type.String(), "error") {
+		sb.WriteString(tui.ErrorStyle.Render(pm.prompt.Help))
+	} else {
+		sb.WriteString(tui.BaseTextStyle.Render(pm.prompt.Help))
+	}
+
 	sb.WriteString("\n")
 
 	if pm.prompt.Default != "" {
@@ -316,6 +349,8 @@ func (pm promptModel) View() string {
 		if pm.prompt.Multiple {
 			sb.WriteString(tui.DimStyle.Render("space to toggle • enter to answer • "))
 		}
+	} else if strings.Contains(pm.prompt.Type.String(), "error") {
+		sb.WriteString("\n\n")
 	} else {
 		sb.WriteString(pm.input.View())
 		sb.WriteString("\n\n")

--- a/cmd/dotenv/promptModel.go
+++ b/cmd/dotenv/promptModel.go
@@ -194,6 +194,8 @@ func newLLMListPrompt(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptM
 			helpMsg += "🔍 Requested resource not found. Please contact support for assistance."
 		} else if strings.Contains(err.Error(), "Timeout") {
 			helpMsg += "⏳ Request timed out. Please check your network connection and try again."
+		} else {
+			helpMsg += fmt.Sprintf("%s\n\n👥 Please try again or contact support if the issue persists.", err.Error())
 		}
 
 		errPrompt.Help = helpMsg

--- a/cmd/dotenv/promptModel.go
+++ b/cmd/dotenv/promptModel.go
@@ -49,7 +49,7 @@ var (
 const (
 	cursorStyle = '•'
 
-	typeError			 = "error"
+	typeError            = "error"
 	errMsgPrefix         = "😞 Unable to retrieve the list of available LLMs.\n\n"
 	errMsgAuthFailed     = "🔐 Authentication failed. Please check your credentials and try again."
 	errMsgNotFound       = "🔍 Requested resource not found. Please contact support for assistance."
@@ -358,7 +358,7 @@ func (pm promptModel) View() string {
 	sb.Write([]byte(tui.SubTitleStyle.Render(fmt.Sprintf("Variable: %v", pm.prompt.Env))))
 	sb.WriteString("\n\n")
 
-	if pm.prompt.Type.String() == "error" {
+	if pm.prompt.Type.String() == typeError {
 		sb.WriteString(tui.ErrorStyle.Render(pm.prompt.Help))
 	} else {
 		sb.WriteString(tui.BaseTextStyle.Render(pm.prompt.Help))

--- a/cmd/dotenv/promptModel.go
+++ b/cmd/dotenv/promptModel.go
@@ -357,7 +357,6 @@ func (pm promptModel) View() string {
 	sb.Write([]byte(tui.SubTitleStyle.Render(fmt.Sprintf("Variable: %v", pm.prompt.Env))))
 	sb.WriteString("\n\n")
 
-	// if strings.Contains(pm.prompt.Type.String(), "error") {
 	if pm.prompt.Type.String() == "error" {
 		sb.WriteString(tui.ErrorStyle.Render(pm.prompt.Help))
 	} else {

--- a/cmd/dotenv/promptModel_test.go
+++ b/cmd/dotenv/promptModel_test.go
@@ -176,7 +176,7 @@ func TestNewLLMListPrompt_Success(t *testing.T) {
 func TestPromptModelView_ErrorType(t *testing.T) {
 	pm := promptModel{
 		prompt: envbuilder.UserPrompt{
-			Type: "llmgw_error",
+			Type: "error",
 			Env:  "MY_VAR",
 			Help: "Unable to retrieve LLMs.",
 		},

--- a/cmd/dotenv/promptModel_test.go
+++ b/cmd/dotenv/promptModel_test.go
@@ -15,12 +15,49 @@
 package dotenv
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/envbuilder"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// setupLLMTestServer starts an httptest.Server that handles token verification
+// and the LLM catalog endpoint, responding with catalogStatus and optional JSON body.
+func setupLLMTestServer(t *testing.T, catalogStatus int, catalogBody any) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/api/v2/version/":
+			w.WriteHeader(http.StatusOK)
+
+		case strings.HasPrefix(r.URL.Path, "/api/v2/genai/llmgw/catalog"):
+			w.WriteHeader(catalogStatus)
+
+			if catalogBody != nil {
+				_ = json.NewEncoder(w).Encode(catalogBody)
+			}
+		}
+	}))
+
+	viper.Set(config.DataRobotURL, srv.URL+"/api/v2")
+	viper.Set(config.DataRobotAPIKey, "test-token")
+
+	t.Cleanup(func() {
+		srv.Close()
+		viper.Reset()
+	})
+}
 
 func TestLLMsToPromptOptions(t *testing.T) {
 	llms := []drapi.LLM{
@@ -53,4 +90,167 @@ func TestLLMsToPromptOptions_Empty(t *testing.T) {
 	options := llmsToPromptOptions([]drapi.LLM{})
 
 	assert.Empty(t, options)
+}
+
+// TestNewLLMListPrompt_Unauthorized verifies that when the API returns 401,
+// the model is set to an error state with an authentication failure message.
+func TestNewLLMListPrompt_Unauthorized(t *testing.T) {
+	setupLLMTestServer(t, http.StatusUnauthorized, nil)
+
+	prompt := envbuilder.UserPrompt{Type: "llmgw_catalog", Env: "LLM_VAR"}
+
+	pm, cmd := newLLMListPrompt(prompt, nil)
+
+	assert.Nil(t, cmd)
+	assert.True(t, strings.Contains(pm.prompt.Type.String(), "error"))
+	assert.Contains(t, pm.prompt.Help, "Authentication failed")
+}
+
+// TestNewLLMListPrompt_NotFound verifies that when the API returns 404,
+// the model is set to an error state with a resource not found message.
+func TestNewLLMListPrompt_NotFound(t *testing.T) {
+	setupLLMTestServer(t, http.StatusNotFound, nil)
+
+	prompt := envbuilder.UserPrompt{Type: "llmgw_catalog", Env: "LLM_VAR"}
+
+	pm, cmd := newLLMListPrompt(prompt, nil)
+
+	assert.Nil(t, cmd)
+	assert.True(t, strings.Contains(pm.prompt.Type.String(), "error"))
+	assert.Contains(t, pm.prompt.Help, "Requested resource not found")
+}
+
+// TestNewLLMListPrompt_Timeout verifies that when the API returns 408,
+// the model is set to an error state with a timeout message.
+// Note: 408 Request Timeout triggers the "Timeout" string check in newLLMListPrompt
+// without requiring a 30-second real client timeout.
+func TestNewLLMListPrompt_Timeout(t *testing.T) {
+	setupLLMTestServer(t, http.StatusRequestTimeout, nil)
+
+	prompt := envbuilder.UserPrompt{Type: "llmgw_catalog", Env: "LLM_VAR"}
+
+	pm, cmd := newLLMListPrompt(prompt, nil)
+
+	assert.Nil(t, cmd)
+	assert.True(t, strings.Contains(pm.prompt.Type.String(), "error"))
+	assert.Contains(t, pm.prompt.Help, "Request timed out")
+}
+
+// TestNewLLMListPrompt_EmptyLLMs verifies that when the API returns a 200 response
+// with an empty LLM list, the model is set to an error state indicating no LLMs are available.
+func TestNewLLMListPrompt_EmptyLLMs(t *testing.T) {
+	setupLLMTestServer(t, http.StatusOK, drapi.LLMList{
+		LLMs: []drapi.LLM{}, Count: 0, TotalCount: 0,
+	})
+
+	prompt := envbuilder.UserPrompt{Type: "llmgw_catalog", Env: "LLM_VAR"}
+
+	pm, cmd := newLLMListPrompt(prompt, nil)
+
+	assert.Nil(t, cmd)
+	assert.True(t, strings.Contains(pm.prompt.Type.String(), "error"))
+	assert.Contains(t, pm.prompt.Help, "No available LLMs")
+}
+
+// TestNewLLMListPrompt_Success verifies that when the API returns a valid LLM list,
+// the model is a list prompt with all returned LLMs as selectable options.
+func TestNewLLMListPrompt_Success(t *testing.T) {
+	setupLLMTestServer(t, http.StatusOK, drapi.LLMList{
+		LLMs: []drapi.LLM{
+			{LlmID: "1", Name: "GPT-4o", Provider: "azure", Model: "gpt-4o", IsActive: true},
+			{LlmID: "2", Name: "Claude 3", Provider: "anthropic", Model: "claude-3-sonnet", IsActive: true},
+		},
+		Count: 2, TotalCount: 2,
+	})
+
+	prompt := envbuilder.UserPrompt{Type: "llmgw_catalog", Env: "LLM_VAR"}
+
+	pm, _ := newLLMListPrompt(prompt, nil)
+
+	require.False(t, strings.Contains(pm.prompt.Type.String(), "error"))
+	assert.Len(t, pm.list.Items(), 2)
+}
+
+// TestPromptModelView_ErrorType verifies that when the prompt type contains "error",
+// View renders the variable name, error help message, and back navigation hint.
+func TestPromptModelView_ErrorType(t *testing.T) {
+	pm := promptModel{
+		prompt: envbuilder.UserPrompt{
+			Type: "llmgw_error",
+			Env:  "MY_VAR",
+			Help: "Unable to retrieve LLMs.",
+		},
+	}
+
+	view := pm.View()
+
+	assert.Contains(t, view, "MY_VAR")
+	assert.Contains(t, view, "Unable to retrieve LLMs.")
+	assert.Contains(t, view, "ctrl-p back to previous")
+}
+
+// TestPromptModelView_Success verifies that when the prompt type is a non-error type,
+// View renders the variable name, help text, text input, and back navigation hint.
+func TestPromptModelView_Success(t *testing.T) {
+	pm, _ := newTextInputPrompt(envbuilder.UserPrompt{
+		Type: envbuilder.PromptTypeString,
+		Env:  "MY_VAR",
+		Help: "Enter a value",
+	}, nil)
+
+	view := pm.View()
+
+	assert.Contains(t, view, "MY_VAR")
+	assert.Contains(t, view, "Enter a value")
+	assert.Contains(t, view, "ctrl-p back to previous")
+}
+
+// TestPromptModelView_WithDefault verifies that when prompt.Default is set,
+// View renders the default value in the output.
+func TestPromptModelView_WithDefault(t *testing.T) {
+	pm, _ := newTextInputPrompt(envbuilder.UserPrompt{
+		Type:    envbuilder.PromptTypeString,
+		Env:     "MY_VAR",
+		Default: "my-default",
+	}, nil)
+
+	view := pm.View()
+
+	assert.Contains(t, view, "Default: my-default")
+}
+
+// TestPromptModelView_WithOptions verifies that when prompt.Options is non-empty,
+// View renders the variable name and the selectable option names.
+func TestPromptModelView_WithOptions(t *testing.T) {
+	pm, _ := newListPrompt(envbuilder.UserPrompt{
+		Type: envbuilder.PromptTypeString,
+		Env:  "MY_VAR",
+		Options: []envbuilder.PromptOption{
+			{Name: "Option A", Value: "a"},
+			{Name: "Option B", Value: "b"},
+		},
+	}, nil)
+
+	view := pm.View()
+
+	assert.Contains(t, view, "MY_VAR")
+	assert.Contains(t, view, "Option A")
+}
+
+// TestPromptModelView_MultipleChoice verifies that when prompt.Multiple is true,
+// View renders the multi-select keyboard hint alongside the options list.
+func TestPromptModelView_MultipleChoice(t *testing.T) {
+	pm, _ := newListPrompt(envbuilder.UserPrompt{
+		Type:     envbuilder.PromptTypeString,
+		Env:      "MY_VAR",
+		Multiple: true,
+		Options: []envbuilder.PromptOption{
+			{Name: "Option A", Value: "a"},
+			{Name: "Option B", Value: "b"},
+		},
+	}, nil)
+
+	view := pm.View()
+
+	assert.Contains(t, view, "space to toggle")
 }

--- a/cmd/dotenv/promptModel_test.go
+++ b/cmd/dotenv/promptModel_test.go
@@ -102,7 +102,7 @@ func TestNewLLMListPrompt_Unauthorized(t *testing.T) {
 	pm, cmd := newLLMListPrompt(prompt, nil)
 
 	assert.Nil(t, cmd)
-	assert.True(t, strings.Contains(pm.prompt.Type.String(), "error"))
+	assert.Contains(t, pm.prompt.Type.String(), "error")
 	assert.Contains(t, pm.prompt.Help, "Authentication failed")
 }
 
@@ -116,7 +116,7 @@ func TestNewLLMListPrompt_NotFound(t *testing.T) {
 	pm, cmd := newLLMListPrompt(prompt, nil)
 
 	assert.Nil(t, cmd)
-	assert.True(t, strings.Contains(pm.prompt.Type.String(), "error"))
+	assert.Contains(t, pm.prompt.Type.String(), "error")
 	assert.Contains(t, pm.prompt.Help, "Requested resource not found")
 }
 
@@ -132,7 +132,7 @@ func TestNewLLMListPrompt_Timeout(t *testing.T) {
 	pm, cmd := newLLMListPrompt(prompt, nil)
 
 	assert.Nil(t, cmd)
-	assert.True(t, strings.Contains(pm.prompt.Type.String(), "error"))
+	assert.Contains(t, pm.prompt.Type.String(), "error")
 	assert.Contains(t, pm.prompt.Help, "Request timed out")
 }
 
@@ -148,7 +148,7 @@ func TestNewLLMListPrompt_EmptyLLMs(t *testing.T) {
 	pm, cmd := newLLMListPrompt(prompt, nil)
 
 	assert.Nil(t, cmd)
-	assert.True(t, strings.Contains(pm.prompt.Type.String(), "error"))
+	assert.Contains(t, pm.prompt.Type.String(), "error")
 	assert.Contains(t, pm.prompt.Help, "No available LLMs")
 }
 
@@ -167,7 +167,7 @@ func TestNewLLMListPrompt_Success(t *testing.T) {
 
 	pm, _ := newLLMListPrompt(prompt, nil)
 
-	require.False(t, strings.Contains(pm.prompt.Type.String(), "error"))
+	require.NotContains(t, pm.prompt.Type.String(), "error")
 	assert.Len(t, pm.list.Items(), 2)
 }
 

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -29,10 +29,12 @@ import (
 // Callers can extract the status code with errors.As to make decisions without string matching.
 type HTTPError struct {
 	StatusCode int
+	URL        string
 }
 
+// Error implements the error interface for HTTPError.
 func (e *HTTPError) Error() string {
-	return fmt.Sprintf("HTTP error: %d %s", e.StatusCode, http.StatusText(e.StatusCode))
+	return fmt.Sprintf("HTTP error: %d %s (url: %s)", e.StatusCode, http.StatusText(e.StatusCode), e.URL)
 }
 
 var token string

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -80,7 +80,7 @@ func Get(url, info string) (*http.Response, error) {
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
 
-		return nil, &HTTPError{StatusCode: resp.StatusCode}
+		return nil, &HTTPError{StatusCode: resp.StatusCode, URL: url}
 	}
 
 	return resp, err

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -17,13 +17,23 @@ package drapi
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/log"
 )
+
+// HTTPError is returned by Get when the server responds with a non-200 status code.
+// Callers can extract the status code with errors.As to make decisions without string matching.
+type HTTPError struct {
+	StatusCode int
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("HTTP error: %d %s", e.StatusCode, http.StatusText(e.StatusCode))
+}
 
 var token string
 
@@ -67,7 +77,8 @@ func Get(url, info string) (*http.Response, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		resp.Body.Close()
-		return nil, errors.New("Response status code is " + resp.Status + ".")
+
+		return nil, &HTTPError{StatusCode: resp.StatusCode}
 	}
 
 	return resp, err


### PR DESCRIPTION
# RATIONALE
As a user running the dr dotenv setup wizard to configure a template that uses the DataRobot LLM Gateway, I want to see a clear error message when the CLI is unable to retrieve the list of available LLMs, so that I can quickly understand and resolve the root cause (e.g., auth misconfiguration, missing credentials, or a network issue) instead of staring at an empty, unresponsive wizard screen.


<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Added error handling for newLLMListPrompt:

<img width="546" height="225" alt="401 Unauthorized" src="https://github.com/user-attachments/assets/62dd2277-2a91-4dc7-be63-318d486ac728" />
- Once GetLLMs returns err 401 Unauthorized 👆 
<hr>

<img width="551" height="218" alt="404 Not Found" src="https://github.com/user-attachments/assets/26ec5bed-ea74-45c1-b7ba-5a1a6b2bfd68" />
- Once GetLLMs returns err  404 Not Found 👆 
<hr>

<img width="564" height="222" alt="Client Timeout" src="https://github.com/user-attachments/assets/94e056de-bba1-44d2-ac09-ecdd04e80e41" />
- Once GetLLMs returns err  Request timeout (Client.Timeout) 👆 
<hr>

<img width="516" height="192" alt="No active LLMs found in the catalog" src="https://github.com/user-attachments/assets/ac7fddb8-2a7e-4687-bf36-4e70faea27b0" />
- Once GetLLMs returns empty list llms.LLMs 👆 
<hr>

<img width="512" height="263" alt="Misc Errors" src="https://github.com/user-attachments/assets/25994738-a6a6-44d4-904d-77bff92a65b2" />
- In case of other errors
<hr> 

Also added tests for changes that were made


## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error propagation from `drapi.Get` to return a typed `HTTPError` and updates the dotenv wizard to branch UI behavior on HTTP/network failures, which could affect any callers that relied on previous error strings or handling.

**No risk**
`drapi.Get` is used only in one place 😈 
> 
> **Overview**
> Improves the `dr dotenv` setup wizard’s LLM Gateway catalog prompt to **fail gracefully**: `newLLMListPrompt` now converts LLM catalog fetch failures (401/403, 404, timeouts, and other errors) and empty catalogs into an *error prompt* with user-facing guidance, while logging the underlying error.
> 
> Adds `drapi.HTTPError` from `drapi.Get` for non-200 responses so callers can inspect status codes via `errors.As`, and updates `promptModel.View()` to render error prompts with `tui.ErrorStyle` and suppress the text input when in an error state. Includes new tests covering the new error cases and view rendering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e521c71a475ddc528d13489f5cdf984789bbb933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->