### PR TITLE
[CFX-5727] Add --yes to dotenv setup and global non-interactive env variable for non interactive mode

### DIFF
--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -193,6 +193,7 @@ func init() {
 	SetupCmd.Flags().Bool("if-needed", false, "Only run setup if '.env' file doesn't exist or there are missing env vars.")
 	SetupCmd.Flags().BoolP("all", "a", false, "Show all prompts including those with default values already set.")
 	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for automation).")
+	SetupCmd.MarkFlagsMutuallyExclusive("yes", "all")
 
 	// Bind flag to viper to enable env var support (DATAROBOT_CLI_NON_INTERACTIVE)
 	_ = viper.BindPFlag("yes", SetupCmd.Flags().Lookup("yes"))

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -192,7 +192,7 @@ This wizard will help you:
 func init() {
 	SetupCmd.Flags().Bool("if-needed", false, "Only run setup if '.env' file doesn't exist or there are missing env vars.")
 	SetupCmd.Flags().BoolP("all", "a", false, "Show all prompts including those with default values already set.")
-	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for CI/CD).")
+	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for automation).")
 
 	// Bind flag to viper to enable env var support (DATAROBOT_CLI_NON_INTERACTIVE)
 	_ = viper.BindPFlag("yes", SetupCmd.Flags().Lookup("yes"))

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -28,6 +28,7 @@ import (
 	"github.com/datarobot/cli/internal/state"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func Cmd() *cobra.Command {
@@ -145,6 +146,7 @@ This wizard will help you:
 		variables, contents := envbuilder.VariablesFromLines(dotenvFileLines)
 
 		showAllPrompts, _ := cmd.Flags().GetBool("all")
+		nonInteractive := viper.GetBool("non-interactive")
 
 		needsPulumi, pulumiLoggedIn, needsPassphrase := CheckPulumiSetup(repositoryRoot, variables)
 
@@ -155,6 +157,7 @@ This wizard will help you:
 			contents:              contents,
 			SuccessCmd:            tea.Quit,
 			ShowAllPrompts:        showAllPrompts,
+			NonInteractive:        nonInteractive,
 			NeedsPulumiLogin:      needsPulumi,
 			PulumiAlreadyLoggedIn: pulumiLoggedIn,
 			NeedsPulumiPassphrase: needsPassphrase,
@@ -189,6 +192,10 @@ This wizard will help you:
 func init() {
 	SetupCmd.Flags().Bool("if-needed", false, "Only run setup if '.env' file doesn't exist or there are missing env vars.")
 	SetupCmd.Flags().BoolP("all", "a", false, "Show all prompts including those with default values already set.")
+	SetupCmd.Flags().Bool("non-interactive", false, "Skip interactive prompts and use defaults (useful for CI/CD).")
+
+	// Bind flag to viper to enable env var support (DATAROBOT_CLI_NON_INTERACTIVE)
+	_ = viper.BindPFlag("non-interactive", SetupCmd.Flags().Lookup("non-interactive"))
 }
 
 // shouldSkipSetup checks if setup should be skipped when --if-needed flag is set.

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -146,7 +146,7 @@ This wizard will help you:
 		variables, contents := envbuilder.VariablesFromLines(dotenvFileLines)
 
 		showAllPrompts, _ := cmd.Flags().GetBool("all")
-		nonInteractive := viper.GetBool("non-interactive")
+		yes := viper.GetBool("yes")
 
 		needsPulumi, pulumiLoggedIn, needsPassphrase := CheckPulumiSetup(repositoryRoot, variables)
 
@@ -157,7 +157,7 @@ This wizard will help you:
 			contents:              contents,
 			SuccessCmd:            tea.Quit,
 			ShowAllPrompts:        showAllPrompts,
-			NonInteractive:        nonInteractive,
+			Yes:                   yes,
 			NeedsPulumiLogin:      needsPulumi,
 			PulumiAlreadyLoggedIn: pulumiLoggedIn,
 			NeedsPulumiPassphrase: needsPassphrase,
@@ -192,10 +192,11 @@ This wizard will help you:
 func init() {
 	SetupCmd.Flags().Bool("if-needed", false, "Only run setup if '.env' file doesn't exist or there are missing env vars.")
 	SetupCmd.Flags().BoolP("all", "a", false, "Show all prompts including those with default values already set.")
-	SetupCmd.Flags().Bool("non-interactive", false, "Skip interactive prompts and use defaults (useful for CI/CD).")
+	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for CI/CD).")
 
 	// Bind flag to viper to enable env var support (DATAROBOT_CLI_NON_INTERACTIVE)
-	_ = viper.BindPFlag("non-interactive", SetupCmd.Flags().Lookup("non-interactive"))
+	_ = viper.BindPFlag("yes", SetupCmd.Flags().Lookup("yes"))
+	_ = viper.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 }
 
 // shouldSkipSetup checks if setup should be skipped when --if-needed flag is set.

--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -64,6 +64,7 @@ type Model struct {
 	currentPrompt         promptModel
 	hasPrompts            *bool             // Cache whether prompts are available
 	ShowAllPrompts        bool              // When true, show all prompts regardless of defaults
+	NonInteractive        bool              // When true, auto-populate all prompts with defaults (or empty) without showing wizard
 	skippedPrompts        int               // Count of prompts skipped due to having defaults
 	pulumiModel           *pulumiLoginModel // Sub-model for Pulumi login flow, shown before wizard if needed
 	NeedsPulumiLogin      bool              // Set by callers before Init(); true when login or passphrase setup is needed
@@ -245,6 +246,46 @@ func (m Model) moveToPreviousPrompt() (tea.Model, tea.Cmd) {
 	return m.updateCurrentPrompt()
 }
 
+// autoPopulateAndSave auto-populates all prompts with their default values (or empty strings)
+// and saves the .env file without showing the wizard. This is used when --non-interactive is set.
+func (m Model) autoPopulateAndSave() (tea.Model, tea.Cmd) {
+	// Auto-populate all prompts with their defaults or empty values
+	for p := range m.prompts {
+		prompt := &m.prompts[p]
+
+		// Skip if already has a value (e.g., from environment or existing .env)
+		if prompt.Value != "" {
+			continue
+		}
+
+		// Use default if available
+		if prompt.Default != "" {
+			prompt.Value = prompt.Default
+		} else {
+			// Otherwise leave as empty string (which is the zero value)
+			prompt.Value = ""
+		}
+	}
+
+	// Apply generated values for prompts with generate: true
+	var err error
+
+	m.prompts, err = envbuilder.ApplyGeneratedValues(m.prompts)
+	if err != nil {
+		m.err = err
+		return m, nil
+	}
+
+	// Determine required sections based on selected options
+	m.prompts = envbuilder.DetermineRequiredSections(m.prompts)
+
+	// Generate .env content from prompts
+	m.contents = envbuilder.DotenvFromPromptsMerged(m.prompts, m.contents)
+
+	// Save the file
+	return m, m.saveEditedFile()
+}
+
 func (m Model) Init() tea.Cmd {
 	if m.initialScreen == editorScreen {
 		return tea.Batch(openEditorCmd, tea.WindowSize())
@@ -305,6 +346,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 			return m, m.loadPrompts()
 		}
 
+		// If NonInteractive is true, auto-quit without waiting for user confirmation
+		if m.NonInteractive {
+			return m, m.SuccessCmd
+		}
+
 		return m, nil
 	case promptsLoadedMsg:
 		// Start in the wizard screen
@@ -329,6 +375,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 			m.screen = pulumiScreen
 
 			return m, plm.Init()
+		}
+
+		// If NonInteractive is true, auto-populate all values and save without showing wizard
+		if m.NonInteractive {
+			return m.autoPopulateAndSave()
 		}
 
 		return m.moveToNextPrompt()

--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -253,6 +253,9 @@ func (m Model) autoPopulateAndSave() (tea.Model, tea.Cmd) {
 	for p := range m.prompts {
 		prompt := &m.prompts[p]
 
+		// Ensure variables are uncommented (consistent with interactive wizard)
+		prompt.Commented = false
+
 		// Skip if already has a value (e.g., from environment or existing .env)
 		if prompt.Value != "" {
 			continue
@@ -363,13 +366,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		m.hasPrompts = &hasPrompts
 
 		if len(m.prompts) == 0 {
+			// In --yes mode, save immediately and exit even if no prompts exist
+			if m.Yes {
+				return m.autoPopulateAndSave()
+			}
+
 			m.screen = listScreen
 
 			return m, nil
 		}
 
 		// Check if Pulumi login/passphrase setup is needed before the wizard
-		if m.NeedsPulumiLogin {
+		// Skip interactive Pulumi screen in --yes mode (passphrase will be auto-generated if needed)
+		if m.NeedsPulumiLogin && !m.Yes {
 			plm := newPulumiLoginModel(m.PulumiAlreadyLoggedIn, m.NeedsPulumiPassphrase)
 			m.pulumiModel = &plm
 			m.screen = pulumiScreen

--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -64,7 +64,7 @@ type Model struct {
 	currentPrompt         promptModel
 	hasPrompts            *bool             // Cache whether prompts are available
 	ShowAllPrompts        bool              // When true, show all prompts regardless of defaults
-	NonInteractive        bool              // When true, auto-populate all prompts with defaults (or empty) without showing wizard
+	Yes                   bool              // When true, auto-populate all prompts with defaults (or empty) without showing wizard
 	skippedPrompts        int               // Count of prompts skipped due to having defaults
 	pulumiModel           *pulumiLoginModel // Sub-model for Pulumi login flow, shown before wizard if needed
 	NeedsPulumiLogin      bool              // Set by callers before Init(); true when login or passphrase setup is needed
@@ -247,7 +247,7 @@ func (m Model) moveToPreviousPrompt() (tea.Model, tea.Cmd) {
 }
 
 // autoPopulateAndSave auto-populates all prompts with their default values (or empty strings)
-// and saves the .env file without showing the wizard. This is used when --non-interactive is set.
+// and saves the .env file without showing the wizard. This is used when --yes is set.
 func (m Model) autoPopulateAndSave() (tea.Model, tea.Cmd) {
 	// Auto-populate all prompts with their defaults or empty values
 	for p := range m.prompts {
@@ -346,8 +346,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 			return m, m.loadPrompts()
 		}
 
-		// If NonInteractive is true, auto-quit without waiting for user confirmation
-		if m.NonInteractive {
+		// If Yes is true, auto-quit without waiting for user confirmation
+		if m.Yes {
 			return m, m.SuccessCmd
 		}
 
@@ -377,8 +377,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 			return m, plm.Init()
 		}
 
-		// If NonInteractive is true, auto-populate all values and save without showing wizard
-		if m.NonInteractive {
+		// If Yes is true, auto-populate all values and save without showing wizard
+		if m.Yes {
 			return m.autoPopulateAndSave()
 		}
 

--- a/cmd/dotenv/model_test.go
+++ b/cmd/dotenv/model_test.go
@@ -464,17 +464,17 @@ func (suite *DotenvModelTestSuite) TestDotenvModel_SkipsPromptsWithDefaults() {
 	os.Remove(fm.DotenvFile)
 }
 
-func (suite *DotenvModelTestSuite) TestDotenvModel_NonInteractive() {
-	// This test validates that when NonInteractive is true:
+func (suite *DotenvModelTestSuite) TestDotenvModel_Yes() {
+	// This test validates that when Yes is true:
 	// 1. The wizard is not shown
 	// 2. All prompts are auto-populated with defaults (or empty strings)
 	// 3. The file is saved automatically
 	// 4. The model exits immediately without waiting for user confirmation
 	tm := suite.NewTestModel(Model{
-		screen:         wizardScreen,
-		initialScreen:  wizardScreen,
-		DotenvFile:     filepath.Join(suite.tempDir, ".env"),
-		NonInteractive: true,
+		screen:        wizardScreen,
+		initialScreen: wizardScreen,
+		DotenvFile:    filepath.Join(suite.tempDir, ".env"),
+		Yes:           true,
 	})
 
 	// Wait a moment for the async save operation to complete before quitting
@@ -500,31 +500,31 @@ func (suite *DotenvModelTestSuite) TestDotenvModel_NonInteractive() {
 	os.Remove(fm.DotenvFile)
 }
 
-func (suite *DotenvModelTestSuite) TestNonInteractive_ViperBinding() {
-	// This test validates that the --non-interactive flag can be controlled
+func (suite *DotenvModelTestSuite) TestYes_ViperBinding() {
+	// This test validates that the --yes flag can be controlled
 	// via the DATAROBOT_CLI_NON_INTERACTIVE environment variable through viper binding.
 
 	// Reset viper and bind the flag to simulate what happens in init()
 	// This mimics the actual command initialization
-	_ = viper.BindEnv("non-interactive", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viper.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	// Test that env var enables the flag
 	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "true")
 
-	suite.True(viper.GetBool("non-interactive"), "Expected viper to read env var as true")
+	suite.True(viper.GetBool("yes"), "Expected viper to read env var as true")
 
 	// Test that "1" also works
 	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "1")
 
-	suite.True(viper.GetBool("non-interactive"), "Expected viper to read '1' as true")
+	suite.True(viper.GetBool("yes"), "Expected viper to read '1' as true")
 
 	// Test that it's false when not set
 	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "")
 
-	suite.False(viper.GetBool("non-interactive"), "Expected viper to read empty as false")
+	suite.False(viper.GetBool("yes"), "Expected viper to read empty as false")
 
 	// Test that "false" works
 	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "false")
 
-	suite.False(viper.GetBool("non-interactive"), "Expected viper to read 'false' as false")
+	suite.False(viper.GetBool("yes"), "Expected viper to read 'false' as false")
 }

--- a/cmd/dotenv/model_test.go
+++ b/cmd/dotenv/model_test.go
@@ -463,3 +463,68 @@ func (suite *DotenvModelTestSuite) TestDotenvModel_SkipsPromptsWithDefaults() {
 
 	os.Remove(fm.DotenvFile)
 }
+
+func (suite *DotenvModelTestSuite) TestDotenvModel_NonInteractive() {
+	// This test validates that when NonInteractive is true:
+	// 1. The wizard is not shown
+	// 2. All prompts are auto-populated with defaults (or empty strings)
+	// 3. The file is saved automatically
+	// 4. The model exits immediately without waiting for user confirmation
+	tm := suite.NewTestModel(Model{
+		screen:         wizardScreen,
+		initialScreen:  wizardScreen,
+		DotenvFile:     filepath.Join(suite.tempDir, ".env"),
+		NonInteractive: true,
+	})
+
+	// Wait a moment for the async save operation to complete before quitting
+	// Since there's no visible screen to wait for, we sleep briefly
+	time.Sleep(100 * time.Millisecond)
+
+	fm := suite.FinalModel(tm)
+
+	actualContents, err := os.ReadFile(fm.DotenvFile)
+	suite.Require().NoError(err, "Expected to read .env file")
+
+	actualContentsStr := string(actualContents)
+
+	// Verify that prompts with defaults got their default values
+	suite.Contains(actualContentsStr, "PULUMI_CONFIG_PASSPHRASE=\"123\"\n", "Expected env file to contain the default passphrase")
+
+	// Verify that prompts without defaults got empty strings
+	suite.Contains(actualContentsStr, "DATAROBOT_DEFAULT_USE_CASE=\"\"\n", "Expected env file to contain empty use case")
+
+	// Verify that the file was created successfully
+	suite.FileExists(fm.DotenvFile, "Expected .env file to be created")
+
+	os.Remove(fm.DotenvFile)
+}
+
+func (suite *DotenvModelTestSuite) TestNonInteractive_ViperBinding() {
+	// This test validates that the --non-interactive flag can be controlled
+	// via the DATAROBOT_CLI_NON_INTERACTIVE environment variable through viper binding.
+
+	// Reset viper and bind the flag to simulate what happens in init()
+	// This mimics the actual command initialization
+	_ = viper.BindEnv("non-interactive", "DATAROBOT_CLI_NON_INTERACTIVE")
+
+	// Test that env var enables the flag
+	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "true")
+
+	suite.True(viper.GetBool("non-interactive"), "Expected viper to read env var as true")
+
+	// Test that "1" also works
+	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "1")
+
+	suite.True(viper.GetBool("non-interactive"), "Expected viper to read '1' as true")
+
+	// Test that it's false when not set
+	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "")
+
+	suite.False(viper.GetBool("non-interactive"), "Expected viper to read empty as false")
+
+	// Test that "false" works
+	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "false")
+
+	suite.False(viper.GetBool("non-interactive"), "Expected viper to read 'false' as false")
+}

--- a/docs/commands/dotenv.md
+++ b/docs/commands/dotenv.md
@@ -55,7 +55,7 @@ dr dotenv setup [--if-needed]
 **Flags:**
 
 - `--if-needed`&mdash;Only run setup if `.env` file doesn't exist or validation fails. This flag is useful for automation scripts and CI/CD pipelines where you want to ensure configuration exists without prompting if it's already valid.
-- `--non-interactive`&mdash;Skip interactive prompts and auto-populate all environment variables with their default values (or empty strings if no default is provided). This is useful for CI/CD pipelines, automated testing, or quick development setup where you want to use all defaults. Variables with `generate: true` will still have random values auto-generated. Can also be enabled via `DATAROBOT_CLI_NON_INTERACTIVE=true` environment variable.
+- `-y, --yes`&mdash;Skip interactive prompts and auto-populate all environment variables with their default values (or empty strings if no default is provided). This is useful for CI/CD pipelines, automated testing, or quick development setup where you want to use all defaults. Variables with `generate: true` will still have random values auto-generated. Can also be enabled via `DATAROBOT_CLI_NON_INTERACTIVE=true` environment variable.
 - `-a, --all`&mdash;Show all prompts in the wizard, including those with default values already set. By default, prompts with defaults are skipped.
 
 **State tracking:**
@@ -91,7 +91,7 @@ dr dotenv setup --if-needed
 Auto-populate with defaults (no interaction):
 ```bash
 cd my-template
-dr dotenv setup --non-interactive
+dr dotenv setup --yes
 # Creates .env file with all defaults (or empty values), skips wizard entirely
 ```
 
@@ -124,16 +124,16 @@ This makes `--if-needed` ideal for:
 - **Onboarding workflows** that intelligently skip already-completed steps.
 - **Idempotent operations** that can be safely run multiple times.
 
-**How `--non-interactive` works:**
+**How `--yes` works:**
 
-When the `--non-interactive` flag is set, the command skips the interactive wizard entirely and auto-populates all environment variables:
+When the `--yes` flag is set, the command skips the interactive wizard entirely and auto-populates all environment variables:
 
 - ✅ **Uses default values** for all prompts that have a `default:` specified in the YAML configuration.
 - ✅ **Sets empty strings** for prompts without defaults (unless they already have values from environment or existing `.env`).
 - ✅ **Auto-generates secrets** for prompts with `generate: true` (e.g., session secrets, encryption keys).
 - ✅ **Preserves existing values** from environment variables or the existing `.env` file.
 
-This makes `--non-interactive` ideal for:
+This makes `--yes` ideal for:
 - **CI/CD pipelines** that need predictable, non-interactive setup.
 - **Development environments** where defaults are sufficient for local testing.
 - **Automated testing** where you want a quick scaffold of all variables.

--- a/docs/commands/dotenv.md
+++ b/docs/commands/dotenv.md
@@ -55,6 +55,8 @@ dr dotenv setup [--if-needed]
 **Flags:**
 
 - `--if-needed`&mdash;Only run setup if `.env` file doesn't exist or validation fails. This flag is useful for automation scripts and CI/CD pipelines where you want to ensure configuration exists without prompting if it's already valid.
+- `--non-interactive`&mdash;Skip interactive prompts and auto-populate all environment variables with their default values (or empty strings if no default is provided). This is useful for CI/CD pipelines, automated testing, or quick development setup where you want to use all defaults. Variables with `generate: true` will still have random values auto-generated. Can also be enabled via `DATAROBOT_CLI_NON_INTERACTIVE=true` environment variable.
+- `-a, --all`&mdash;Show all prompts in the wizard, including those with default values already set. By default, prompts with defaults are skipped.
 
 **State tracking:**
 
@@ -86,6 +88,19 @@ dr dotenv setup --if-needed
 # Or: launches wizard (if missing or invalid)
 ```
 
+Auto-populate with defaults (no interaction):
+```bash
+cd my-template
+dr dotenv setup --non-interactive
+# Creates .env file with all defaults (or empty values), skips wizard entirely
+```
+
+Or using environment variable:
+```bash
+cd my-template
+DATAROBOT_CLI_NON_INTERACTIVE=true dr dotenv setup
+```
+
 The wizard guides you through:
 
 1. DataRobot credentials (auto-populated if authenticated).
@@ -108,6 +123,21 @@ This makes `--if-needed` ideal for:
 - **CI/CD pipelines** that should only prompt when necessary.
 - **Onboarding workflows** that intelligently skip already-completed steps.
 - **Idempotent operations** that can be safely run multiple times.
+
+**How `--non-interactive` works:**
+
+When the `--non-interactive` flag is set, the command skips the interactive wizard entirely and auto-populates all environment variables:
+
+- ✅ **Uses default values** for all prompts that have a `default:` specified in the YAML configuration.
+- ✅ **Sets empty strings** for prompts without defaults (unless they already have values from environment or existing `.env`).
+- ✅ **Auto-generates secrets** for prompts with `generate: true` (e.g., session secrets, encryption keys).
+- ✅ **Preserves existing values** from environment variables or the existing `.env` file.
+
+This makes `--non-interactive` ideal for:
+- **CI/CD pipelines** that need predictable, non-interactive setup.
+- **Development environments** where defaults are sufficient for local testing.
+- **Automated testing** where you want a quick scaffold of all variables.
+- **Template initialization** in contexts where manual configuration comes later.
 
 ### dr dotenv edit
 


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

This PR extends the non-interactive support in CLI:
- introduce `dr dotenv setup --yes` (runs setup without prompting user and by applying default or empty values)
- add support of a global `DATAROBOT_CLI_NON_INTERACTIVE` env variable, which makes CLI work in non-interactive mode globally

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the dotenv setup flow to support automated, non-interactive writes to `.env`, which could affect CI/dev setups if defaults/empty values are unexpected. Logic is scoped to `dotenv setup` and covered by new tests.
> 
> **Overview**
> Adds a non-interactive path for `dr dotenv setup` via `--yes` (and `DATAROBOT_CLI_NON_INTERACTIVE`) to auto-populate prompts with defaults or empty strings, apply any `generate: true` values, write the `.env` file, and exit without showing the wizard or confirmation.
> 
> Wires the flag through `viper`, makes `--yes` mutually exclusive with `--all`, skips the interactive Pulumi login screen in `--yes` mode, and updates tests + `docs/commands/dotenv.md` to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19aec79f497269046d505ff6edc22ef979c0134d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->