### PR TITLE
[CFX-5727] Fix a bug in dotenv setup

### DIFF
--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -28,7 +29,6 @@ import (
 	"github.com/datarobot/cli/internal/state"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func Cmd() *cobra.Command {
@@ -146,7 +146,12 @@ This wizard will help you:
 		variables, contents := envbuilder.VariablesFromLines(dotenvFileLines)
 
 		showAllPrompts, _ := cmd.Flags().GetBool("all")
-		yes := viper.GetBool("yes")
+
+		// Check --yes flag from command line or DATAROBOT_CLI_NON_INTERACTIVE env var
+		yes, _ := cmd.Flags().GetBool("yes")
+		if !yes {
+			yes, _ = strconv.ParseBool(os.Getenv("DATAROBOT_CLI_NON_INTERACTIVE"))
+		}
 
 		needsPulumi, pulumiLoggedIn, needsPassphrase := CheckPulumiSetup(repositoryRoot, variables)
 
@@ -192,12 +197,8 @@ This wizard will help you:
 func init() {
 	SetupCmd.Flags().Bool("if-needed", false, "Only run setup if '.env' file doesn't exist or there are missing env vars.")
 	SetupCmd.Flags().BoolP("all", "a", false, "Show all prompts including those with default values already set.")
-	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for automation).")
+	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for automation). Can also be set via DATAROBOT_CLI_NON_INTERACTIVE env var.")
 	SetupCmd.MarkFlagsMutuallyExclusive("yes", "all")
-
-	// Bind flag to viper to enable env var support (DATAROBOT_CLI_NON_INTERACTIVE)
-	_ = viper.BindPFlag("yes", SetupCmd.Flags().Lookup("yes"))
-	_ = viper.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 }
 
 // shouldSkipSetup checks if setup should be skipped when --if-needed flag is set.

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -197,7 +197,7 @@ This wizard will help you:
 func init() {
 	SetupCmd.Flags().Bool("if-needed", false, "Only run setup if '.env' file doesn't exist or there are missing env vars.")
 	SetupCmd.Flags().BoolP("all", "a", false, "Show all prompts including those with default values already set.")
-	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for automation). Can also be set via DATAROBOT_CLI_NON_INTERACTIVE env var.")
+	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for automation).")
 	SetupCmd.MarkFlagsMutuallyExclusive("yes", "all")
 }
 

--- a/cmd/dotenv/model_test.go
+++ b/cmd/dotenv/model_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"testing"
 	"time"
 
@@ -500,31 +501,44 @@ func (suite *DotenvModelTestSuite) TestDotenvModel_Yes() {
 	os.Remove(fm.DotenvFile)
 }
 
-func (suite *DotenvModelTestSuite) TestYes_ViperBinding() {
-	// This test validates that the --yes flag can be controlled
-	// via the DATAROBOT_CLI_NON_INTERACTIVE environment variable through viper binding.
+func (suite *DotenvModelTestSuite) TestYes_EnvVarHandling() {
+	// Test that the --yes flag logic correctly handles DATAROBOT_CLI_NON_INTERACTIVE
+	// This test validates the actual implementation that uses strconv.ParseBool()
+	// instead of viper to avoid treating empty env vars as true.
 
-	// Reset viper and bind the flag to simulate what happens in init()
-	// This mimics the actual command initialization
-	_ = viper.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	testCases := []struct {
+		name     string
+		envValue string
+		envSet   bool
+		expected bool
+	}{
+		{"env var true", "true", true, true},
+		{"env var 1", "1", true, true},
+		{"env var false", "false", true, false},
+		{"env var 0", "0", true, false},
+		{"env var empty", "", true, false},
+		{"env var unset", "", false, false},
+	}
 
-	// Test that env var enables the flag
-	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "true")
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			// Clear the env var first
+			suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "")
 
-	suite.True(viper.GetBool("yes"), "Expected viper to read env var as true")
+			if tc.envSet {
+				suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", tc.envValue)
+			} else {
+				os.Unsetenv("DATAROBOT_CLI_NON_INTERACTIVE")
+			}
 
-	// Test that "1" also works
-	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "1")
+			// Simulate the actual logic from SetupCmd
+			yes := false // Simulating cmd.Flags().GetBool("yes") when flag not set
+			if !yes {
+				yes, _ = strconv.ParseBool(os.Getenv("DATAROBOT_CLI_NON_INTERACTIVE"))
+			}
 
-	suite.True(viper.GetBool("yes"), "Expected viper to read '1' as true")
-
-	// Test that it's false when not set
-	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "")
-
-	suite.False(viper.GetBool("yes"), "Expected viper to read empty as false")
-
-	// Test that "false" works
-	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "false")
-
-	suite.False(viper.GetBool("yes"), "Expected viper to read 'false' as false")
+			suite.Equal(tc.expected, yes,
+				"env=%q (set=%v) should result in yes=%v", tc.envValue, tc.envSet, tc.expected)
+		})
+	}
 }

--- a/cmd/dotenv/model_test.go
+++ b/cmd/dotenv/model_test.go
@@ -505,7 +505,6 @@ func (suite *DotenvModelTestSuite) TestYes_EnvVarHandling() {
 	// Test that the --yes flag logic correctly handles DATAROBOT_CLI_NON_INTERACTIVE
 	// This test validates the actual implementation that uses strconv.ParseBool()
 	// instead of viper to avoid treating empty env vars as true.
-
 	testCases := []struct {
 		name     string
 		envValue string


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

Fix a bug in dotenv setup which was previously introduced in https://github.com/datarobot-oss/cli/pull/447

`dr dotenv setup` was incorrectly entering into non-interactive mode with empty `DATAROBOT_CLI_NON_INTERACTIVE`

Root Cause:
Viper's `BindPFlag()` + `GetBool()` treats any environment variable presence (even empty strings) as true for boolean flags.

Fix:
- Check the `--yes` flag directly via `cmd.Flags().GetBool()`
- Fall back to parsing `DATAROBOT_CLI_NON_INTERACTIVE` with `strconv.ParseBool()`

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested change limited to CLI flag/env parsing for dotenv setup; main risk is subtle behavior differences for existing automation relying on the previous (buggy) empty-env handling.
> 
> **Overview**
> Fixes `dr dotenv setup` non-interactive mode detection so an empty `DATAROBOT_CLI_NON_INTERACTIVE` no longer forces `--yes` behavior. The command now reads `--yes` directly from cobra flags and only falls back to `strconv.ParseBool()` on `DATAROBOT_CLI_NON_INTERACTIVE`, removing the prior viper binding and updating tests to cover true/false/0/1/empty/unset env-var cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 917b8a33aa61722e5cdf06e5d1b0144584131387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->