### PR TITLE
[RAPTOR-16919] workload artifact list command

### DIFF
--- a/cmd/workload/artifact/cmd.go
+++ b/cmd/workload/artifact/cmd.go
@@ -16,6 +16,7 @@ package artifact
 
 import (
 	"github.com/datarobot/cli/cmd/workload/artifact/get"
+	"github.com/datarobot/cli/cmd/workload/artifact/list"
 	"github.com/spf13/cobra"
 )
 
@@ -28,6 +29,7 @@ func Cmd() *cobra.Command {
 
 	cmd.AddCommand(
 		get.Cmd(),
+		list.Cmd(),
 	)
 
 	return cmd

--- a/cmd/workload/artifact/get/cmd.go
+++ b/cmd/workload/artifact/get/cmd.go
@@ -17,23 +17,12 @@ package get
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
-
-type ArtifactOutput struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Status    string `json:"status"`
-	Version   string `json:"version"`
-	Catalog   string `json:"catalog"`
-	CreatedAt string `json:"createdAt"`
-	UpdatedAt string `json:"updatedAt"`
-}
 
 func Cmd() *cobra.Command {
 	var outputFormat string
@@ -81,22 +70,7 @@ Example:
 }
 
 func printJSON(artifact workload.Artifact) error {
-	codeRef := workload.ExtractCodeRef(artifact)
-
-	output := ArtifactOutput{
-		ID:        artifact.ID,
-		Name:      artifact.Name,
-		Status:    artifact.Status,
-		CreatedAt: artifact.CreatedAt.Format(time.RFC3339),
-		UpdatedAt: artifact.UpdatedAt.Format(time.RFC3339),
-	}
-
-	if codeRef != nil {
-		output.Version = codeRef.CatalogVersionID
-		output.Catalog = codeRef.CatalogID
-	}
-
-	data, err := json.MarshalIndent(output, "", "  ")
+	data, err := json.MarshalIndent(workload.NewArtifactOutput(artifact), "", "  ")
 	if err != nil {
 		return err
 	}
@@ -109,19 +83,19 @@ func printJSON(artifact workload.Artifact) error {
 func printHuman(artifact workload.Artifact) {
 	codeRef := workload.ExtractCodeRef(artifact)
 
-	version := "\u2014"
-	catalog := "\u2014"
+	catalogID := "\u2014"
+	versionID := "\u2014"
 
 	if codeRef != nil {
-		version = codeRef.CatalogVersionID
-		catalog = codeRef.CatalogID
+		catalogID = codeRef.CatalogID
+		versionID = codeRef.CatalogVersionID
 	}
 
-	fmt.Println(tui.BaseTextStyle.Render("ID:       " + artifact.ID))
-	fmt.Println(tui.BaseTextStyle.Render("Name:     " + artifact.Name))
-	fmt.Println(tui.BaseTextStyle.Render("Status:   " + artifact.Status))
-	fmt.Println(tui.BaseTextStyle.Render("Version:  " + version))
-	fmt.Println(tui.BaseTextStyle.Render("Catalog:  " + catalog))
-	fmt.Println(tui.DimStyle.Render("Created:  " + artifact.CreatedAt.UTC().Format("2006-01-02 15:04 UTC")))
-	fmt.Println(tui.DimStyle.Render("Updated:  " + artifact.UpdatedAt.UTC().Format("2006-01-02 15:04 UTC")))
+	fmt.Println(tui.BaseTextStyle.Render("ID:          " + artifact.ID))
+	fmt.Println(tui.BaseTextStyle.Render("Name:        " + artifact.Name))
+	fmt.Println(tui.BaseTextStyle.Render("Status:      " + artifact.Status))
+	fmt.Println(tui.BaseTextStyle.Render("Catalog ID:  " + catalogID))
+	fmt.Println(tui.BaseTextStyle.Render("Version ID:  " + versionID))
+	fmt.Println(tui.DimStyle.Render("Created:     " + artifact.CreatedAt.UTC().Format("2006-01-02 15:04 UTC")))
+	fmt.Println(tui.DimStyle.Render("Updated:     " + artifact.UpdatedAt.UTC().Format("2006-01-02 15:04 UTC")))
 }

--- a/cmd/workload/artifact/get/cmd_test.go
+++ b/cmd/workload/artifact/get/cmd_test.go
@@ -84,8 +84,8 @@ func TestPrintJSON_WithCodeRef(t *testing.T) {
 	assert.Equal(t, "art-abc-123", parsed["id"])
 	assert.Equal(t, "my-agent", parsed["name"])
 	assert.Equal(t, "DRAFT", parsed["status"])
-	assert.Equal(t, "fedcba09", parsed["version"])
-	assert.Equal(t, "cat-xyz-789", parsed["catalog"])
+	assert.Equal(t, "fedcba09", parsed["versionId"])
+	assert.Equal(t, "cat-xyz-789", parsed["catalogId"])
 	assert.Equal(t, "2026-04-01T08:00:00Z", parsed["createdAt"])
 	assert.Equal(t, "2026-04-10T14:30:00Z", parsed["updatedAt"])
 }
@@ -109,8 +109,8 @@ func TestPrintJSON_WithoutCodeRef(t *testing.T) {
 
 	err := json.Unmarshal([]byte(output), &parsed)
 	require.NoError(t, err)
-	assert.Empty(t, parsed["version"])
-	assert.Empty(t, parsed["catalog"])
+	assert.Empty(t, parsed["versionId"])
+	assert.Empty(t, parsed["catalogId"])
 }
 
 func TestPrintHuman_WithCodeRef(t *testing.T) {
@@ -142,13 +142,13 @@ func TestPrintHuman_WithCodeRef(t *testing.T) {
 		printHuman(artifact)
 	})
 
-	assert.Contains(t, output, "ID:       art-abc-123")
-	assert.Contains(t, output, "Name:     my-agent")
-	assert.Contains(t, output, "Status:   DRAFT")
-	assert.Contains(t, output, "Version:  fedcba09")
-	assert.Contains(t, output, "Catalog:  cat-xyz-789")
-	assert.Contains(t, output, "Created:  2026-04-01 08:00 UTC")
-	assert.Contains(t, output, "Updated:  2026-04-10 14:30 UTC")
+	assert.Contains(t, output, "ID:          art-abc-123")
+	assert.Contains(t, output, "Name:        my-agent")
+	assert.Contains(t, output, "Status:      DRAFT")
+	assert.Contains(t, output, "Catalog ID:  cat-xyz-789")
+	assert.Contains(t, output, "Version ID:  fedcba09")
+	assert.Contains(t, output, "Created:     2026-04-01 08:00 UTC")
+	assert.Contains(t, output, "Updated:     2026-04-10 14:30 UTC")
 }
 
 func TestPrintHuman_WithoutCodeRef(t *testing.T) {
@@ -165,8 +165,8 @@ func TestPrintHuman_WithoutCodeRef(t *testing.T) {
 		printHuman(artifact)
 	})
 
-	assert.Contains(t, output, "Version:  \u2014")
-	assert.Contains(t, output, "Catalog:  \u2014")
+	assert.Contains(t, output, "Catalog ID:  \u2014")
+	assert.Contains(t, output, "Version ID:  \u2014")
 }
 
 func TestCmd_RequiresArg(t *testing.T) {

--- a/cmd/workload/artifact/list/cmd.go
+++ b/cmd/workload/artifact/list/cmd.go
@@ -1,0 +1,140 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat string
+
+	var limit int
+
+	var status string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List workload artifacts.",
+		Long: `List workload artifacts in your DataRobot deployment infrastructure.
+
+This command fetches artifacts and shows:
+  * Name and current status (draft or locked)
+  * Code reference catalog ID and version ID
+  * Last update timestamp
+
+By default, output is a human-readable table. Use --output json for machine-parseable output.
+
+Example:
+  dr workload artifact list
+  dr workload artifact list --limit 10
+  dr workload artifact list --status draft
+  dr workload artifact list --output json`,
+		Args:    cobra.NoArgs,
+		PreRunE: auth.EnsureAuthenticatedE,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if outputFormat != "" && outputFormat != "json" {
+				return fmt.Errorf("invalid output format: %s (supported: json)", outputFormat)
+			}
+
+			if limit <= 0 {
+				return fmt.Errorf("invalid --limit %d: must be positive", limit)
+			}
+
+			status, err := workload.ParseArtifactStatus(status)
+			if err != nil {
+				return err
+			}
+
+			artifacts, err := workload.ListArtifacts(limit, status)
+			if err != nil {
+				return err
+			}
+
+			if outputFormat == "json" {
+				return printJSON(artifacts)
+			}
+
+			printTable(artifacts)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&outputFormat, "output", "", "Output format (json)")
+	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of artifacts to return")
+	cmd.Flags().StringVar(&status, "status", "", "Filter by status (draft, locked)")
+
+	return cmd
+}
+
+func printJSON(artifacts []workload.Artifact) error {
+	outputs := make([]workload.ArtifactOutput, 0, len(artifacts))
+
+	for _, a := range artifacts {
+		outputs = append(outputs, workload.NewArtifactOutput(a))
+	}
+
+	data, err := json.MarshalIndent(outputs, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+
+	return nil
+}
+
+func printTable(artifacts []workload.Artifact) {
+	if len(artifacts) == 0 {
+		fmt.Println("No artifacts found.")
+
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "ARTIFACT ID\tNAME\tSTATUS\tCATALOG ID\tVERSION ID\tUPDATED\n")
+
+	for _, a := range artifacts {
+		var catalogID, versionID string
+
+		if codeRef := workload.ExtractCodeRef(a); codeRef != nil {
+			catalogID = codeRef.CatalogID
+			versionID = codeRef.CatalogVersionID
+		}
+
+		updated := a.UpdatedAt.UTC().Format("2006-01-02 15:04 UTC")
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", a.ID, a.Name, a.Status, orDash(catalogID), orDash(versionID), updated)
+	}
+
+	w.Flush()
+}
+
+func orDash(v string) string {
+	if v == "" {
+		return "\u2014"
+	}
+
+	return v
+}

--- a/cmd/workload/artifact/list/cmd_test.go
+++ b/cmd/workload/artifact/list/cmd_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+
+	os.Stdout = old
+
+	var buf bytes.Buffer
+
+	_, _ = io.Copy(&buf, r)
+
+	return buf.String()
+}
+
+func makeArtifact(id, name, status, catalogID, catalogVersionID string) workload.Artifact {
+	a := workload.Artifact{
+		ID:        id,
+		Name:      name,
+		Status:    status,
+		CreatedAt: time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 4, 10, 14, 30, 0, 0, time.UTC),
+	}
+
+	if catalogID != "" {
+		a.Spec = workload.Spec{
+			ContainerGroups: []workload.ContainerGroup{
+				{
+					Containers: []workload.Container{
+						{
+							CodeRef: &workload.CodeRef{
+								Datarobot: &workload.DatarobotCodeRef{
+									CatalogID:        catalogID,
+									CatalogVersionID: catalogVersionID,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return a
+}
+
+func TestPrintTable_WithCodeRef(t *testing.T) {
+	artifacts := []workload.Artifact{
+		makeArtifact("art-abc-123", "my-agent", "DRAFT", "0123456789abcdef01234567", "fedcba0987654321fedcba09"),
+	}
+
+	output := captureStdout(t, func() {
+		printTable(artifacts)
+	})
+
+	assert.Contains(t, output, "ARTIFACT ID")
+	assert.Contains(t, output, "CATALOG ID")
+	assert.Contains(t, output, "VERSION ID")
+	assert.Contains(t, output, "art-abc-123")
+	assert.Contains(t, output, "my-agent")
+	assert.Contains(t, output, "DRAFT")
+	assert.Contains(t, output, "0123456789abcdef01234567")
+	assert.Contains(t, output, "fedcba0987654321fedcba09")
+	assert.Contains(t, output, "2026-04-10 14:30 UTC")
+}
+
+func TestPrintTable_WithoutCodeRef(t *testing.T) {
+	artifacts := []workload.Artifact{
+		makeArtifact("art-abc-123", "my-agent", "DRAFT", "", ""),
+	}
+
+	output := captureStdout(t, func() {
+		printTable(artifacts)
+	})
+
+	assert.Contains(t, output, "\u2014")
+}
+
+func TestPrintTable_Empty(t *testing.T) {
+	output := captureStdout(t, func() {
+		printTable([]workload.Artifact{})
+	})
+
+	assert.Equal(t, "No artifacts found.\n", output)
+}
+
+func TestPrintJSON_Array(t *testing.T) {
+	artifacts := []workload.Artifact{
+		makeArtifact("art-001", "agent-one", "DRAFT", "cat-001", "ver-001"),
+		makeArtifact("art-002", "agent-two", "LOCKED", "", ""),
+	}
+
+	output := captureStdout(t, func() {
+		err := printJSON(artifacts)
+		require.NoError(t, err)
+	})
+
+	var parsed []map[string]interface{}
+
+	err := json.Unmarshal([]byte(output), &parsed)
+	require.NoError(t, err)
+	assert.Len(t, parsed, 2)
+	assert.Equal(t, "art-001", parsed[0]["id"])
+	assert.Equal(t, "ver-001", parsed[0]["versionId"])
+	assert.Equal(t, "art-002", parsed[1]["id"])
+	assert.Empty(t, parsed[1]["versionId"])
+}
+
+func TestPrintJSON_EmptyArray(t *testing.T) {
+	output := captureStdout(t, func() {
+		err := printJSON([]workload.Artifact{})
+		require.NoError(t, err)
+	})
+
+	var parsed []interface{}
+
+	err := json.Unmarshal([]byte(output), &parsed)
+	require.NoError(t, err)
+	assert.Empty(t, parsed)
+}
+
+func TestPrintJSON_FullVersion(t *testing.T) {
+	artifacts := []workload.Artifact{
+		makeArtifact("art-abc-123", "my-agent", "DRAFT", "cat-xyz-789", "fedcba0987654321fedcba09"),
+	}
+
+	output := captureStdout(t, func() {
+		err := printJSON(artifacts)
+		require.NoError(t, err)
+	})
+
+	var parsed []map[string]interface{}
+
+	err := json.Unmarshal([]byte(output), &parsed)
+	require.NoError(t, err)
+	assert.Equal(t, "fedcba0987654321fedcba09", parsed[0]["versionId"])
+}
+
+func TestCmd_InvalidOutputFormat(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--output", "xml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format: xml")
+}
+
+func TestCmd_InvalidStatus(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--status", "UNKNOWN"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid status")
+}
+
+func TestCmd_InvalidLimit(t *testing.T) {
+	for _, v := range []string{"-1", "0"} {
+		cmd := Cmd()
+		cmd.PreRunE = nil
+		cmd.SetArgs([]string{"--limit", v})
+
+		err := cmd.Execute()
+		require.Error(t, err, "limit %s", v)
+		assert.Contains(t, err.Error(), "must be positive")
+	}
+}

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -15,11 +15,33 @@
 package workload
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/drapi"
 )
+
+const (
+	ArtifactStatusDraft  = "draft"
+	ArtifactStatusLocked = "locked"
+)
+
+func ParseArtifactStatus(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+
+	lower := strings.ToLower(s)
+
+	if lower != ArtifactStatusDraft && lower != ArtifactStatusLocked {
+		return "", fmt.Errorf("invalid status %q: use %s or %s", s, ArtifactStatusDraft, ArtifactStatusLocked)
+	}
+
+	return lower, nil
+}
 
 type Artifact struct {
 	ID        string    `json:"id"`
@@ -49,6 +71,33 @@ type CodeRef struct {
 type DatarobotCodeRef struct {
 	CatalogID        string `json:"catalogId"`
 	CatalogVersionID string `json:"catalogVersionId"`
+}
+
+type ArtifactOutput struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	CatalogID string `json:"catalogId"`
+	VersionID string `json:"versionId"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+func NewArtifactOutput(a Artifact) ArtifactOutput {
+	out := ArtifactOutput{
+		ID:        a.ID,
+		Name:      a.Name,
+		Status:    a.Status,
+		CreatedAt: a.CreatedAt.Format(time.RFC3339),
+		UpdatedAt: a.UpdatedAt.Format(time.RFC3339),
+	}
+
+	if codeRef := ExtractCodeRef(a); codeRef != nil {
+		out.CatalogID = codeRef.CatalogID
+		out.VersionID = codeRef.CatalogVersionID
+	}
+
+	return out
 }
 
 func ExtractCodeRef(artifact Artifact) *DatarobotCodeRef {
@@ -82,4 +131,45 @@ func GetArtifact(artifactID string) (*Artifact, error) {
 	}
 
 	return &artifact, nil
+}
+
+type ArtifactList struct {
+	Data       []Artifact `json:"data"`
+	Count      int        `json:"count"`
+	TotalCount int        `json:"totalCount"`
+	Next       string     `json:"next"`
+	Previous   string     `json:"previous"`
+}
+
+func ListArtifacts(limit int, status string) ([]Artifact, error) {
+	endpoint := "/api/v2/artifacts/?limit=" + strconv.Itoa(limit)
+
+	if status != "" {
+		endpoint += "&status=" + status
+	}
+
+	pageURL, err := config.GetEndpointURL(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	var all []Artifact
+
+	for pageURL != "" {
+		var list ArtifactList
+
+		if err := drapi.GetJSON(pageURL, "artifacts", &list); err != nil {
+			return nil, err
+		}
+
+		all = append(all, list.Data...)
+
+		if len(all) >= limit {
+			return all[:limit], nil
+		}
+
+		pageURL = list.Next
+	}
+
+	return all, nil
 }

--- a/internal/workload/artifact_test.go
+++ b/internal/workload/artifact_test.go
@@ -124,3 +124,29 @@ func TestExtractCodeRef_NotInResponse(t *testing.T) {
 
 	assert.Nil(t, ExtractCodeRef(artifact))
 }
+
+func TestParseArtifactStatus(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"draft", "draft"},
+		{"DRAFT", "draft"},
+		{"Locked", "locked"},
+		{"locked", "locked"},
+	}
+
+	for _, c := range cases {
+		got, err := ParseArtifactStatus(c.in)
+		require.NoError(t, err, "input %q", c.in)
+		assert.Equal(t, c.want, got, "input %q", c.in)
+	}
+}
+
+func TestParseArtifactStatus_Invalid(t *testing.T) {
+	_, err := ParseArtifactStatus("bogus")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid status")
+	assert.Contains(t, err.Error(), "bogus")
+}


### PR DESCRIPTION
# RATIONALE
Adds `dr workload artifact list` to enumerate DataRobot Workload API artifacts.

## CHANGES

- **`internal/workload/artifact.go`** — `ArtifactList` + `ListArtifacts(limit, status)` paginating via `.Next`; `ArtifactStatusDraft`/`Locked` constants. Extracted `ArtifactOutput` + `NewArtifactOutput(Artifact)` so `get` and `list` share one flat output shape.
- **`cmd/workload/artifact/list/cmd.go`** — Cobra command with `--output`, `--limit`, `--status` flags; `tabwriter` table, JSON array, `"No artifacts found."` on empty. Status validated case-insensitively.
- **`cmd/workload/artifact/list/cmd_test.go`** — Covers table/JSON paths and invalid-flag errors.
- **`cmd/workload/artifact/cmd.go`** — Wires `list.Cmd()` alongside `get.Cmd()`.
- **`cmd/workload/artifact/get/cmd.go`** — Drops the local `ArtifactOutput` in favor of shared `workload.NewArtifactOutput`. Renamed output fields/labels to `catalogId`/`versionId` and `Catalog ID:`/`Version ID:` to match upstream API naming.
- **`cmd/workload/artifact/get/cmd_test.go`** — Updated for renamed fields.

## NOTES

- Status constants are lowercase (`"draft"`/`"locked"`): the API returns `HTTP 422: Input should be 'draft' or 'locked'` on uppercase. `--status DRAFT` still works — input is lowercased before sending.
- Verified end-to-end against `staging.datarobot.com` (list, filter, lock via `PATCH status: locked`, artifacts with and without codeRef).

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new paginated `ListArtifacts` API call and CLI surface area, and changes `artifact get --output json` field names (`catalogId`/`versionId`), which could impact downstream scripts expecting the old keys.
> 
> **Overview**
> Adds `dr workload artifact list` to enumerate workload artifacts, supporting `--limit`, case-insensitive `--status` filtering (`draft`/`locked`), and either table or JSON array output.
> 
> Refactors artifact serialization into shared `workload.ArtifactOutput`/`NewArtifactOutput` and updates `artifact get` to use it, renaming JSON fields and human labels to **Catalog/Version ID**. The workload client gains `ParseArtifactStatus` plus a paginated `ListArtifacts` implementation following `.Next`, with new unit tests covering list output and status parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2372de3e3c4052c1b309754671848f177e551c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->