### PR TITLE
[CFX-5727] Add pulumi passphrase generation logic to non interactive mode in 'dr dotenv setup'

### DIFF
--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -378,9 +378,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		}
 
 		// Check if Pulumi login/passphrase setup is needed before the wizard
+		// Only enter Pulumi flow if template actually uses Pulumi (NeedsPulumiLogin validates this)
 		// Interactive: show Pulumi screen when login or passphrase is needed
 		// --yes mode: only enter when passphrase needs auto-generation (can't do interactive login)
-		if (m.NeedsPulumiLogin && !m.Yes) || (m.Yes && m.NeedsPulumiPassphrase) {
+		if m.NeedsPulumiLogin && (!m.Yes || m.NeedsPulumiPassphrase) {
 			// Use pulumiLoginModel for both interactive and non-interactive modes
 			plm := newPulumiLoginModel(m.PulumiAlreadyLoggedIn, m.NeedsPulumiPassphrase, m.Yes)
 			m.pulumiModel = &plm

--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -308,6 +308,7 @@ func (m Model) handlePulumiUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// is picked up before the wizard starts.
 		m.pulumiModel = nil
 		m.NeedsPulumiLogin = false
+		m.NeedsPulumiPassphrase = false
 
 		return m, m.loadPrompts()
 	}
@@ -377,9 +378,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		}
 
 		// Check if Pulumi login/passphrase setup is needed before the wizard
-		// Skip interactive Pulumi screen in --yes mode (passphrase will be auto-generated if needed)
-		if m.NeedsPulumiLogin && !m.Yes {
-			plm := newPulumiLoginModel(m.PulumiAlreadyLoggedIn, m.NeedsPulumiPassphrase)
+		if m.NeedsPulumiLogin || (m.Yes && m.NeedsPulumiPassphrase) {
+			// Use pulumiLoginModel for both interactive and non-interactive modes
+			plm := newPulumiLoginModel(m.PulumiAlreadyLoggedIn, m.NeedsPulumiPassphrase, m.Yes)
 			m.pulumiModel = &plm
 			m.screen = pulumiScreen
 

--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -378,7 +378,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		}
 
 		// Check if Pulumi login/passphrase setup is needed before the wizard
-		if m.NeedsPulumiLogin || (m.Yes && m.NeedsPulumiPassphrase) {
+		// Interactive: show Pulumi screen when login or passphrase is needed
+		// --yes mode: only enter when passphrase needs auto-generation (can't do interactive login)
+		if (m.NeedsPulumiLogin && !m.Yes) || (m.Yes && m.NeedsPulumiPassphrase) {
 			// Use pulumiLoginModel for both interactive and non-interactive modes
 			plm := newPulumiLoginModel(m.PulumiAlreadyLoggedIn, m.NeedsPulumiPassphrase, m.Yes)
 			m.pulumiModel = &plm

--- a/cmd/dotenv/pulumiModel.go
+++ b/cmd/dotenv/pulumiModel.go
@@ -53,16 +53,16 @@ const (
 // Login (backend selection → pulumi login) and passphrase setup are independent:
 // login runs first (if needed), then the passphrase prompt appears (if needed).
 type pulumiLoginModel struct {
-	currentScreen       pulumiLoginScreen
-	selectedOption      int
-	options             []string
-	diyInput            textinput.Model
-	diyURL              string
-	generatedPassphrase string
-	err                 error
-	loginOutput         string
-	alreadyLoggedIn     bool // when true, skip backend selection and go straight to passphrase
-	needsPassphrase     bool // when true, show passphrase prompt after login (or immediately if already logged in)
+	currentScreen   pulumiLoginScreen
+	selectedOption  int
+	options         []string
+	diyInput        textinput.Model
+	diyURL          string
+	err             error
+	loginOutput     string
+	alreadyLoggedIn bool // when true, skip backend selection and go straight to passphrase
+	needsPassphrase bool // when true, show passphrase prompt after login (or immediately if already logged in)
+	nonInteractive  bool // when true, auto-generate passphrase without showing prompts (--yes mode)
 }
 
 type (
@@ -71,7 +71,7 @@ type (
 	pulumiLoginSuccessMsg  struct{ output string }
 )
 
-func newPulumiLoginModel(alreadyLoggedIn, needsPassphrase bool) pulumiLoginModel {
+func newPulumiLoginModel(alreadyLoggedIn, needsPassphrase, nonInteractive bool) pulumiLoginModel {
 	ti := textinput.New()
 	ti.Placeholder = "s3://my-pulumi-bucket or azblob://..."
 	ti.Focus()
@@ -90,10 +90,22 @@ func newPulumiLoginModel(alreadyLoggedIn, needsPassphrase bool) pulumiLoginModel
 		diyInput:        ti,
 		alreadyLoggedIn: alreadyLoggedIn,
 		needsPassphrase: needsPassphrase,
+		nonInteractive:  nonInteractive,
 	}
 }
 
 func (m pulumiLoginModel) Init() tea.Cmd {
+	// Non-interactive mode: auto-generate passphrase and complete immediately
+	if m.nonInteractive && m.needsPassphrase {
+		return func() tea.Msg {
+			if err := generateAndSavePulumiPassphrase(); err != nil {
+				return pulumiLoginErrorMsg{err}
+			}
+
+			return pulumiLoginCompleteMsg{}
+		}
+	}
+
 	return textinput.Blink
 }
 
@@ -223,28 +235,28 @@ func (m pulumiLoginModel) handlePassphrasePromptKey(msg tea.KeyMsg) (tea.Model, 
 }
 
 func (m pulumiLoginModel) handlePassphraseAccepted() (tea.Model, tea.Cmd) {
-	passphrase, err := envbuilder.GenerateRandomSecret(generatedPassphraseLength)
-	if err != nil {
-		m.err = fmt.Errorf("failed to generate passphrase: %w", err)
-
-		return m, nil
-	}
-
-	m.generatedPassphrase = passphrase
-
-	if err := m.savePassphraseToConfig(); err != nil {
+	if err := generateAndSavePulumiPassphrase(); err != nil {
 		return m, func() tea.Msg { return pulumiLoginErrorMsg{err} }
 	}
 
 	return m, func() tea.Msg { return pulumiLoginCompleteMsg{} }
 }
 
-func (m pulumiLoginModel) savePassphraseToConfig() error {
+func generateAndSavePulumiPassphrase() error {
+	passphrase, err := envbuilder.GenerateRandomSecret(generatedPassphraseLength)
+	if err != nil {
+		return fmt.Errorf("failed to generate Pulumi passphrase: %w", err)
+	}
+
+	return savePulumiPassphraseToConfig(passphrase)
+}
+
+func savePulumiPassphraseToConfig(passphrase string) error {
 	if err := config.CreateConfigFileDirIfNotExists(); err != nil {
 		return fmt.Errorf("failed to create config: %w", err)
 	}
 
-	viper.Set(pulumiConfigPassphraseKey, m.generatedPassphrase)
+	viper.Set(pulumiConfigPassphraseKey, passphrase)
 
 	if err := viper.WriteConfig(); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
@@ -282,6 +294,11 @@ func (m pulumiLoginModel) performLogin(loginType, url string) tea.Cmd {
 
 func (m pulumiLoginModel) View() string {
 	var sb strings.Builder
+
+	// Non-interactive mode: don't render anything (passphrase generation happens in Init)
+	if m.nonInteractive {
+		return ""
+	}
 
 	if m.err != nil {
 		sb.WriteString(tui.ErrorStyle.Render("Pulumi Login Failed"))

--- a/cmd/dotenv/pulumiModel.go
+++ b/cmd/dotenv/pulumiModel.go
@@ -295,7 +295,7 @@ func (m pulumiLoginModel) performLogin(loginType, url string) tea.Cmd {
 func (m pulumiLoginModel) View() string {
 	var sb strings.Builder
 
-	// Non-interactive mode: don't render anything (passphrase generation happens in Init)
+	// Non-interactive mode: don't render anything
 	if m.nonInteractive {
 		return ""
 	}

--- a/cmd/dotenv/pulumiModel_test.go
+++ b/cmd/dotenv/pulumiModel_test.go
@@ -244,7 +244,7 @@ func TestPulumiLoginModel_NonInteractive_ViewReturnsEmpty(t *testing.T) {
 	model := newPulumiLoginModel(true, true, true)
 
 	view := model.View()
-	assert.Equal(t, "", view, "non-interactive mode should not render anything")
+	assert.Empty(t, view, "non-interactive mode should not render anything")
 }
 
 func TestPulumiLoginModel_NonInteractive_ViewReturnsEmptyEvenWithError(t *testing.T) {
@@ -252,5 +252,5 @@ func TestPulumiLoginModel_NonInteractive_ViewReturnsEmptyEvenWithError(t *testin
 	model.err = assert.AnError
 
 	view := model.View()
-	assert.Equal(t, "", view, "non-interactive mode should not render anything, even with error")
+	assert.Empty(t, view, "non-interactive mode should not render anything, even with error")
 }

--- a/cmd/dotenv/pulumiModel_test.go
+++ b/cmd/dotenv/pulumiModel_test.go
@@ -79,7 +79,7 @@ func TestNeedsPulumiSetup_LoggedIn_PassphraseSet(t *testing.T) {
 // --- Model initial screen ---
 
 func TestPulumiLoginModel_NotLoggedIn_StartsAtBackendSelection(t *testing.T) {
-	model := newPulumiLoginModel(false, false)
+	model := newPulumiLoginModel(false, false, false)
 
 	assert.Equal(t, pulumiLoginScreenBackendSelection, model.currentScreen)
 	assert.Equal(t, 0, model.selectedOption)
@@ -87,7 +87,7 @@ func TestPulumiLoginModel_NotLoggedIn_StartsAtBackendSelection(t *testing.T) {
 }
 
 func TestPulumiLoginModel_AlreadyLoggedIn_StartsAtPassphraseScreen(t *testing.T) {
-	model := newPulumiLoginModel(true, true)
+	model := newPulumiLoginModel(true, true, false)
 
 	assert.Equal(t, pulumiLoginScreenPassphrasePrompt, model.currentScreen)
 }
@@ -97,7 +97,7 @@ func TestPulumiLoginModel_AlreadyLoggedIn_StartsAtPassphraseScreen(t *testing.T)
 // The passphrase screen must NOT appear before the login command runs.
 
 func TestPulumiLoginModel_NotLoggedIn_NeedsPassphrase_LoginBeforePassphrase(t *testing.T) {
-	model := newPulumiLoginModel(false, true)
+	model := newPulumiLoginModel(false, true, false)
 
 	assert.Equal(t, pulumiLoginScreenBackendSelection, model.currentScreen, "must start at backend selection, not passphrase")
 
@@ -118,7 +118,7 @@ func TestPulumiLoginModel_NotLoggedIn_NeedsPassphrase_LoginBeforePassphrase(t *t
 }
 
 func TestPulumiLoginModel_NotLoggedIn_NoPassphrase_LoginThenComplete(t *testing.T) {
-	model := newPulumiLoginModel(false, false)
+	model := newPulumiLoginModel(false, false, false)
 
 	// Press enter on local
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -139,7 +139,7 @@ func TestPulumiLoginModel_NotLoggedIn_NoPassphrase_LoginThenComplete(t *testing.
 // --- Backend selection key handling ---
 
 func TestPulumiLoginModel_BackendSelection_NavigateUpDown(t *testing.T) {
-	model := newPulumiLoginModel(false, false)
+	model := newPulumiLoginModel(false, false, false)
 
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
 	plm := updated.(pulumiLoginModel)
@@ -156,7 +156,7 @@ func TestPulumiLoginModel_BackendSelection_NavigateUpDown(t *testing.T) {
 }
 
 func TestPulumiLoginModel_BackendSelection_DIY_GoesToDIYURLScreen(t *testing.T) {
-	model := newPulumiLoginModel(false, false)
+	model := newPulumiLoginModel(false, false, false)
 
 	// Navigate to DIY (option 2)
 	model.selectedOption = 2
@@ -168,7 +168,7 @@ func TestPulumiLoginModel_BackendSelection_DIY_GoesToDIYURLScreen(t *testing.T) 
 }
 
 func TestPulumiLoginModel_DIYURLScreen_Esc_ReturnsToBackendSelection(t *testing.T) {
-	model := newPulumiLoginModel(false, false)
+	model := newPulumiLoginModel(false, false, false)
 	model.currentScreen = pulumiLoginScreenDIYURL
 
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
@@ -178,7 +178,7 @@ func TestPulumiLoginModel_DIYURLScreen_Esc_ReturnsToBackendSelection(t *testing.
 }
 
 func TestPulumiLoginModel_DIYURLScreen_EmptyURL_DoesNotProceed(t *testing.T) {
-	model := newPulumiLoginModel(false, false)
+	model := newPulumiLoginModel(false, false, false)
 	model.currentScreen = pulumiLoginScreenDIYURL
 	model.diyInput = textinput.New()
 
@@ -194,7 +194,7 @@ func TestPulumiLoginModel_DIYURLScreen_EmptyURL_DoesNotProceed(t *testing.T) {
 // will leave the user stuck on the passphrase screen.
 
 func TestPulumiLoginModel_PassphraseScreen_N_Completes(t *testing.T) {
-	model := newPulumiLoginModel(true, true)
+	model := newPulumiLoginModel(true, true, false)
 
 	_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
 	require.NotNil(t, cmd)
@@ -205,7 +205,7 @@ func TestPulumiLoginModel_PassphraseScreen_N_Completes(t *testing.T) {
 }
 
 func TestPulumiLoginModel_PassphraseScreen_UpperN_Completes(t *testing.T) {
-	model := newPulumiLoginModel(true, true)
+	model := newPulumiLoginModel(true, true, false)
 
 	_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("N")})
 	require.NotNil(t, cmd)
@@ -216,7 +216,7 @@ func TestPulumiLoginModel_PassphraseScreen_UpperN_Completes(t *testing.T) {
 }
 
 func TestPulumiLoginModel_PassphraseScreen_Esc_Completes(t *testing.T) {
-	model := newPulumiLoginModel(true, true)
+	model := newPulumiLoginModel(true, true, false)
 
 	_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	require.NotNil(t, cmd)
@@ -236,4 +236,21 @@ func TestGenerateRandomPassphrase(t *testing.T) {
 	passphrase2, err := envbuilder.GenerateRandomSecret(32)
 	require.NoError(t, err)
 	assert.NotEqual(t, passphrase, passphrase2, "generated passphrases must be unique")
+}
+
+// --- Non-interactive mode tests ---
+
+func TestPulumiLoginModel_NonInteractive_ViewReturnsEmpty(t *testing.T) {
+	model := newPulumiLoginModel(true, true, true)
+
+	view := model.View()
+	assert.Equal(t, "", view, "non-interactive mode should not render anything")
+}
+
+func TestPulumiLoginModel_NonInteractive_ViewReturnsEmptyEvenWithError(t *testing.T) {
+	model := newPulumiLoginModel(true, true, true)
+	model.err = assert.AnError
+
+	view := model.View()
+	assert.Equal(t, "", view, "non-interactive mode should not render anything, even with error")
 }


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

This PR adds pulumi passphrase generation logic to non interactive mode of `dr dotenv setup --yes`. 
The logic is:
- if the value is not found in the config file, it's getting generated and saved.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `dr dotenv setup --yes` flow to write `PULUMI_CONFIG_PASSPHRASE` to the user config without showing UI, which could affect unattended runs and config state if logic misfires. Scope is limited to Pulumi setup gating and passphrase generation/save behavior.
> 
> **Overview**
> Ensures `dr dotenv setup --yes` can complete Pulumi prerequisites by **auto-generating and persisting a `PULUMI_CONFIG_PASSPHRASE`** when required, instead of relying on the interactive Pulumi TUI.
> 
> The Pulumi sub-flow now supports a non-interactive mode: it short-circuits rendering, runs passphrase generation/save during `Init()`, and the main dotenv model only enters the Pulumi path in `--yes` when passphrase generation is needed (while also clearing `NeedsPulumiPassphrase` on completion). Tests are updated to cover the new constructor signature and verify non-interactive view behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36a5061a37136c8a6a11baea2b3f728593c1383a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->