### PR TITLE
[RAPTOR-16920] workload artifact create command

### DIFF
--- a/cmd/workload/artifact/cmd.go
+++ b/cmd/workload/artifact/cmd.go
@@ -15,6 +15,7 @@
 package artifact
 
 import (
+	"github.com/datarobot/cli/cmd/workload/artifact/create"
 	"github.com/datarobot/cli/cmd/workload/artifact/get"
 	"github.com/datarobot/cli/cmd/workload/artifact/list"
 	"github.com/spf13/cobra"
@@ -28,6 +29,7 @@ func Cmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
+		create.Cmd(),
 		get.Cmd(),
 		list.Cmd(),
 	)

--- a/cmd/workload/artifact/create/cmd.go
+++ b/cmd/workload/artifact/create/cmd.go
@@ -1,0 +1,156 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package create
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat string
+
+	var specFile string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a workload artifact.",
+		Long: `Create a workload artifact in your DataRobot deployment infrastructure.
+
+This command reads a JSON spec from a file and POSTs it to the Workload API.
+The created artifact is returned and shown.
+
+By default, output is human-readable. Use --output json for machine-parseable output.
+
+Spec file format (minimal valid example):
+
+  {
+    "name": "my-agent",
+    "spec": {
+      "containerGroups": [{
+        "containers": [{
+          "imageUri": "nginx:latest",
+          "port": 8080,
+          "resourceRequest": {"cpu": 1, "memory": 536870912}
+        }]
+      }]
+    }
+  }
+
+Required fields: name, spec.containerGroups (>=1), and at least one container
+per group. Optional top-level field: description. Optional container fields:
+imageUri, port, resourceRequest{cpu, memory}, codeRef. Unknown fields are
+rejected before the request is sent.
+
+Example:
+  dr workload artifact create --spec-file spec.json
+  dr workload artifact create --spec-file spec.json --output json`,
+		Args:    cobra.NoArgs,
+		PreRunE: auth.EnsureAuthenticatedE,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if outputFormat != "" && outputFormat != "json" {
+				return fmt.Errorf("invalid output format: %s (supported: json)", outputFormat)
+			}
+
+			if specFile == "" {
+				return errors.New("--spec-file is required")
+			}
+
+			payload, err := readSpecFile(specFile)
+			if err != nil {
+				return err
+			}
+
+			if err := workload.ValidateCreateRequest(payload); err != nil {
+				return err
+			}
+
+			artifact, err := workload.CreateArtifact(payload)
+			if err != nil {
+				return err
+			}
+
+			if outputFormat == "json" {
+				return printJSON(*artifact)
+			}
+
+			printHuman(*artifact)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&outputFormat, "output", "", "Output format (json)")
+	cmd.Flags().StringVar(&specFile, "spec-file", "", "Path to JSON spec file (required)")
+
+	return cmd
+}
+
+func readSpecFile(path string) (json.RawMessage, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("file not found: %s", path)
+		}
+
+		return nil, err
+	}
+
+	var probe map[string]any
+
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	return json.RawMessage(data), nil
+}
+
+func printJSON(artifact workload.Artifact) error {
+	data, err := json.MarshalIndent(workload.NewArtifactOutput(artifact), "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+
+	return nil
+}
+
+func printHuman(artifact workload.Artifact) {
+	codeRef := workload.ExtractCodeRef(artifact)
+
+	catalogID := "\u2014"
+	versionID := "\u2014"
+
+	if codeRef != nil {
+		catalogID = codeRef.CatalogID
+		versionID = codeRef.CatalogVersionID
+	}
+
+	fmt.Println(tui.BaseTextStyle.Render("ID:          " + artifact.ID))
+	fmt.Println(tui.BaseTextStyle.Render("Name:        " + artifact.Name))
+	fmt.Println(tui.BaseTextStyle.Render("Status:      " + artifact.Status))
+	fmt.Println(tui.BaseTextStyle.Render("Catalog ID:  " + catalogID))
+	fmt.Println(tui.BaseTextStyle.Render("Version ID:  " + versionID))
+	fmt.Println(tui.DimStyle.Render("Created:     " + artifact.CreatedAt.UTC().Format("2006-01-02 15:04 UTC")))
+	fmt.Println(tui.DimStyle.Render("Updated:     " + artifact.UpdatedAt.UTC().Format("2006-01-02 15:04 UTC")))
+}

--- a/cmd/workload/artifact/create/cmd.go
+++ b/cmd/workload/artifact/create/cmd.go
@@ -22,12 +22,11 @@ import (
 
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/workload"
-	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
 func Cmd() *cobra.Command {
-	var outputFormat string
+	var outputFormat workload.OutputFormat
 
 	var specFile string
 
@@ -39,7 +38,7 @@ func Cmd() *cobra.Command {
 This command reads a JSON spec from a file and POSTs it to the Workload API.
 The created artifact is returned and shown.
 
-By default, output is human-readable. Use --output json for machine-parseable output.
+By default, output is human-readable. Use --output-format json for machine-parseable output.
 
 Spec file format (minimal valid example):
 
@@ -63,18 +62,10 @@ rejected before the request is sent.
 
 Example:
   dr workload artifact create --spec-file spec.json
-  dr workload artifact create --spec-file spec.json --output json`,
+  dr workload artifact create --spec-file spec.json --output-format json`,
 		Args:    cobra.NoArgs,
 		PreRunE: auth.EnsureAuthenticatedE,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if outputFormat != "" && outputFormat != "json" {
-				return fmt.Errorf("invalid output format: %s (supported: json)", outputFormat)
-			}
-
-			if specFile == "" {
-				return errors.New("--spec-file is required")
-			}
-
 			payload, err := readSpecFile(specFile)
 			if err != nil {
 				return err
@@ -89,18 +80,13 @@ Example:
 				return err
 			}
 
-			if outputFormat == "json" {
-				return printJSON(*artifact)
-			}
-
-			printHuman(*artifact)
-
-			return nil
+			return workload.RenderArtifact(outputFormat, *artifact)
 		},
 	}
 
-	cmd.Flags().StringVar(&outputFormat, "output", "", "Output format (json)")
+	workload.AddOutputFlag(cmd, &outputFormat)
 	cmd.Flags().StringVar(&specFile, "spec-file", "", "Path to JSON spec file (required)")
+	_ = cmd.MarkFlagRequired("spec-file")
 
 	return cmd
 }
@@ -115,42 +101,5 @@ func readSpecFile(path string) (json.RawMessage, error) {
 		return nil, err
 	}
 
-	var probe map[string]any
-
-	if err := json.Unmarshal(data, &probe); err != nil {
-		return nil, fmt.Errorf("invalid JSON: %w", err)
-	}
-
 	return json.RawMessage(data), nil
-}
-
-func printJSON(artifact workload.Artifact) error {
-	data, err := json.MarshalIndent(workload.NewArtifactOutput(artifact), "", "  ")
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(string(data))
-
-	return nil
-}
-
-func printHuman(artifact workload.Artifact) {
-	codeRef := workload.ExtractCodeRef(artifact)
-
-	catalogID := "\u2014"
-	versionID := "\u2014"
-
-	if codeRef != nil {
-		catalogID = codeRef.CatalogID
-		versionID = codeRef.CatalogVersionID
-	}
-
-	fmt.Println(tui.BaseTextStyle.Render("ID:          " + artifact.ID))
-	fmt.Println(tui.BaseTextStyle.Render("Name:        " + artifact.Name))
-	fmt.Println(tui.BaseTextStyle.Render("Status:      " + artifact.Status))
-	fmt.Println(tui.BaseTextStyle.Render("Catalog ID:  " + catalogID))
-	fmt.Println(tui.BaseTextStyle.Render("Version ID:  " + versionID))
-	fmt.Println(tui.DimStyle.Render("Created:     " + artifact.CreatedAt.UTC().Format("2006-01-02 15:04 UTC")))
-	fmt.Println(tui.DimStyle.Render("Updated:     " + artifact.UpdatedAt.UTC().Format("2006-01-02 15:04 UTC")))
 }

--- a/cmd/workload/artifact/create/cmd_test.go
+++ b/cmd/workload/artifact/create/cmd_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+
+	os.Stdout = old
+
+	var buf bytes.Buffer
+
+	_, _ = io.Copy(&buf, r)
+
+	return buf.String()
+}
+
+func makeArtifact(catalogID, catalogVersionID string) workload.Artifact {
+	a := workload.Artifact{
+		ID:        "art-abc-123",
+		Name:      "my-agent",
+		Status:    "draft",
+		CreatedAt: time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 4, 10, 14, 30, 0, 0, time.UTC),
+	}
+
+	if catalogID != "" {
+		a.Spec = workload.Spec{
+			ContainerGroups: []workload.ContainerGroup{
+				{
+					Containers: []workload.Container{
+						{
+							CodeRef: &workload.CodeRef{
+								Datarobot: &workload.DatarobotCodeRef{
+									CatalogID:        catalogID,
+									CatalogVersionID: catalogVersionID,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return a
+}
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "spec.json")
+
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+func TestReadSpecFile_NotFound(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.json")
+
+	_, err := readSpecFile(path)
+	require.Error(t, err)
+	assert.Equal(t, "file not found: "+path, err.Error())
+}
+
+func TestReadSpecFile_InvalidJSON(t *testing.T) {
+	path := writeTempFile(t, "not json")
+
+	_, err := readSpecFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid JSON:")
+}
+
+func TestReadSpecFile_Valid(t *testing.T) {
+	content := `{"name":"x","spec":{"containerGroups":[{"containers":[{}]}]}}`
+	path := writeTempFile(t, content)
+
+	got, err := readSpecFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(got))
+}
+
+func TestPrintHuman_WithCodeRef(t *testing.T) {
+	artifact := makeArtifact("cat-xyz-789", "fedcba09")
+
+	output := captureStdout(t, func() {
+		printHuman(artifact)
+	})
+
+	assert.Contains(t, output, "ID:          art-abc-123")
+	assert.Contains(t, output, "Name:        my-agent")
+	assert.Contains(t, output, "Status:      draft")
+	assert.Contains(t, output, "Catalog ID:  cat-xyz-789")
+	assert.Contains(t, output, "Version ID:  fedcba09")
+	assert.Contains(t, output, "Created:     2026-04-01 08:00 UTC")
+	assert.Contains(t, output, "Updated:     2026-04-10 14:30 UTC")
+}
+
+func TestPrintHuman_WithoutCodeRef(t *testing.T) {
+	artifact := makeArtifact("", "")
+
+	output := captureStdout(t, func() {
+		printHuman(artifact)
+	})
+
+	assert.Contains(t, output, "Catalog ID:  \u2014")
+	assert.Contains(t, output, "Version ID:  \u2014")
+}
+
+func TestPrintJSON(t *testing.T) {
+	artifact := makeArtifact("cat-xyz-789", "fedcba09")
+
+	output := captureStdout(t, func() {
+		require.NoError(t, printJSON(artifact))
+	})
+
+	var parsed map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	assert.Equal(t, "art-abc-123", parsed["id"])
+	assert.Equal(t, "my-agent", parsed["name"])
+	assert.Equal(t, "draft", parsed["status"])
+	assert.Equal(t, "cat-xyz-789", parsed["catalogId"])
+	assert.Equal(t, "fedcba09", parsed["versionId"])
+	assert.Equal(t, "2026-04-01T08:00:00Z", parsed["createdAt"])
+	assert.Equal(t, "2026-04-10T14:30:00Z", parsed["updatedAt"])
+}
+
+func TestCmd_RejectsArgs(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"unexpected-arg"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_MissingSpecFile(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--spec-file is required")
+}
+
+func TestCmd_InvalidOutputFormat(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--output", "yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format: yaml")
+}

--- a/cmd/workload/artifact/create/cmd_test.go
+++ b/cmd/workload/artifact/create/cmd_test.go
@@ -15,69 +15,13 @@
 package create
 
 import (
-	"bytes"
-	"encoding/json"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/datarobot/cli/internal/workload"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	fn()
-
-	w.Close()
-
-	os.Stdout = old
-
-	var buf bytes.Buffer
-
-	_, _ = io.Copy(&buf, r)
-
-	return buf.String()
-}
-
-func makeArtifact(catalogID, catalogVersionID string) workload.Artifact {
-	a := workload.Artifact{
-		ID:        "art-abc-123",
-		Name:      "my-agent",
-		Status:    "draft",
-		CreatedAt: time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC),
-		UpdatedAt: time.Date(2026, 4, 10, 14, 30, 0, 0, time.UTC),
-	}
-
-	if catalogID != "" {
-		a.Spec = workload.Spec{
-			ContainerGroups: []workload.ContainerGroup{
-				{
-					Containers: []workload.Container{
-						{
-							CodeRef: &workload.CodeRef{
-								Datarobot: &workload.DatarobotCodeRef{
-									CatalogID:        catalogID,
-									CatalogVersionID: catalogVersionID,
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-	}
-
-	return a
-}
 
 func writeTempFile(t *testing.T, content string) string {
 	t.Helper()
@@ -97,14 +41,6 @@ func TestReadSpecFile_NotFound(t *testing.T) {
 	assert.Equal(t, "file not found: "+path, err.Error())
 }
 
-func TestReadSpecFile_InvalidJSON(t *testing.T) {
-	path := writeTempFile(t, "not json")
-
-	_, err := readSpecFile(path)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid JSON:")
-}
-
 func TestReadSpecFile_Valid(t *testing.T) {
 	content := `{"name":"x","spec":{"containerGroups":[{"containers":[{}]}]}}`
 	path := writeTempFile(t, content)
@@ -114,56 +50,10 @@ func TestReadSpecFile_Valid(t *testing.T) {
 	assert.Equal(t, content, string(got))
 }
 
-func TestPrintHuman_WithCodeRef(t *testing.T) {
-	artifact := makeArtifact("cat-xyz-789", "fedcba09")
-
-	output := captureStdout(t, func() {
-		printHuman(artifact)
-	})
-
-	assert.Contains(t, output, "ID:          art-abc-123")
-	assert.Contains(t, output, "Name:        my-agent")
-	assert.Contains(t, output, "Status:      draft")
-	assert.Contains(t, output, "Catalog ID:  cat-xyz-789")
-	assert.Contains(t, output, "Version ID:  fedcba09")
-	assert.Contains(t, output, "Created:     2026-04-01 08:00 UTC")
-	assert.Contains(t, output, "Updated:     2026-04-10 14:30 UTC")
-}
-
-func TestPrintHuman_WithoutCodeRef(t *testing.T) {
-	artifact := makeArtifact("", "")
-
-	output := captureStdout(t, func() {
-		printHuman(artifact)
-	})
-
-	assert.Contains(t, output, "Catalog ID:  \u2014")
-	assert.Contains(t, output, "Version ID:  \u2014")
-}
-
-func TestPrintJSON(t *testing.T) {
-	artifact := makeArtifact("cat-xyz-789", "fedcba09")
-
-	output := captureStdout(t, func() {
-		require.NoError(t, printJSON(artifact))
-	})
-
-	var parsed map[string]any
-
-	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
-	assert.Equal(t, "art-abc-123", parsed["id"])
-	assert.Equal(t, "my-agent", parsed["name"])
-	assert.Equal(t, "draft", parsed["status"])
-	assert.Equal(t, "cat-xyz-789", parsed["catalogId"])
-	assert.Equal(t, "fedcba09", parsed["versionId"])
-	assert.Equal(t, "2026-04-01T08:00:00Z", parsed["createdAt"])
-	assert.Equal(t, "2026-04-10T14:30:00Z", parsed["updatedAt"])
-}
-
 func TestCmd_RejectsArgs(t *testing.T) {
 	cmd := Cmd()
 	cmd.PreRunE = nil
-	cmd.SetArgs([]string{"unexpected-arg"})
+	cmd.SetArgs([]string{"--spec-file", "x.json", "unexpected-arg"})
 
 	require.Error(t, cmd.Execute())
 }
@@ -175,15 +65,15 @@ func TestCmd_MissingSpecFile(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--spec-file is required")
+	assert.Contains(t, err.Error(), `required flag(s) "spec-file" not set`)
 }
 
 func TestCmd_InvalidOutputFormat(t *testing.T) {
 	cmd := Cmd()
 	cmd.PreRunE = nil
-	cmd.SetArgs([]string{"--output", "yaml"})
+	cmd.SetArgs([]string{"--spec-file", "x.json", "--output-format", "yaml"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid output format: yaml")
+	assert.Contains(t, err.Error(), `invalid output format "yaml"`)
 }

--- a/cmd/workload/artifact/get/cmd.go
+++ b/cmd/workload/artifact/get/cmd.go
@@ -15,17 +15,13 @@
 package get
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/workload"
-	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
 func Cmd() *cobra.Command {
-	var outputFormat string
+	var outputFormat workload.OutputFormat
 
 	cmd := &cobra.Command{
 		Use:   "get <artifact-id>",
@@ -37,65 +33,24 @@ This command fetches an artifact by ID and shows:
   • Code reference (catalog ID and version)
   • Creation and last update timestamps
 
-By default, output is human-readable. Use --output json for machine-parseable output.
+By default, output is human-readable. Use --output-format json for machine-parseable output.
 
 Example:
   dr workload artifact get art-abc-123
-  dr workload artifact get art-abc-123 --output json`,
+  dr workload artifact get art-abc-123 --output-format json`,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: auth.EnsureAuthenticatedE,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if outputFormat != "" && outputFormat != "json" {
-				return fmt.Errorf("invalid output format: %s (supported: json)", outputFormat)
-			}
-
+		RunE: func(_ *cobra.Command, args []string) error {
 			artifact, err := workload.GetArtifact(args[0])
 			if err != nil {
 				return err
 			}
 
-			if outputFormat == "json" {
-				return printJSON(*artifact)
-			}
-
-			printHuman(*artifact)
-
-			return nil
+			return workload.RenderArtifact(outputFormat, *artifact)
 		},
 	}
 
-	cmd.Flags().StringVar(&outputFormat, "output", "", "Output format (json)")
+	workload.AddOutputFlag(cmd, &outputFormat)
 
 	return cmd
-}
-
-func printJSON(artifact workload.Artifact) error {
-	data, err := json.MarshalIndent(workload.NewArtifactOutput(artifact), "", "  ")
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(string(data))
-
-	return nil
-}
-
-func printHuman(artifact workload.Artifact) {
-	codeRef := workload.ExtractCodeRef(artifact)
-
-	catalogID := "\u2014"
-	versionID := "\u2014"
-
-	if codeRef != nil {
-		catalogID = codeRef.CatalogID
-		versionID = codeRef.CatalogVersionID
-	}
-
-	fmt.Println(tui.BaseTextStyle.Render("ID:          " + artifact.ID))
-	fmt.Println(tui.BaseTextStyle.Render("Name:        " + artifact.Name))
-	fmt.Println(tui.BaseTextStyle.Render("Status:      " + artifact.Status))
-	fmt.Println(tui.BaseTextStyle.Render("Catalog ID:  " + catalogID))
-	fmt.Println(tui.BaseTextStyle.Render("Version ID:  " + versionID))
-	fmt.Println(tui.DimStyle.Render("Created:     " + artifact.CreatedAt.UTC().Format("2006-01-02 15:04 UTC")))
-	fmt.Println(tui.DimStyle.Render("Updated:     " + artifact.UpdatedAt.UTC().Format("2006-01-02 15:04 UTC")))
 }

--- a/cmd/workload/artifact/get/cmd_test.go
+++ b/cmd/workload/artifact/get/cmd_test.go
@@ -15,159 +15,11 @@
 package get
 
 import (
-	"bytes"
-	"encoding/json"
-	"io"
-	"os"
 	"testing"
-	"time"
 
-	"github.com/datarobot/cli/internal/workload"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	fn()
-
-	w.Close()
-
-	os.Stdout = old
-
-	var buf bytes.Buffer
-
-	_, _ = io.Copy(&buf, r)
-
-	return buf.String()
-}
-
-func TestPrintJSON_WithCodeRef(t *testing.T) {
-	artifact := workload.Artifact{
-		ID:     "art-abc-123",
-		Name:   "my-agent",
-		Status: "DRAFT",
-		Spec: workload.Spec{
-			ContainerGroups: []workload.ContainerGroup{
-				{
-					Containers: []workload.Container{
-						{
-							CodeRef: &workload.CodeRef{
-								Datarobot: &workload.DatarobotCodeRef{
-									CatalogID:        "cat-xyz-789",
-									CatalogVersionID: "fedcba09",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		CreatedAt: time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC),
-		UpdatedAt: time.Date(2026, 4, 10, 14, 30, 0, 0, time.UTC),
-	}
-
-	output := captureStdout(t, func() {
-		err := printJSON(artifact)
-		require.NoError(t, err)
-	})
-
-	var parsed map[string]interface{}
-
-	err := json.Unmarshal([]byte(output), &parsed)
-	require.NoError(t, err)
-	assert.Equal(t, "art-abc-123", parsed["id"])
-	assert.Equal(t, "my-agent", parsed["name"])
-	assert.Equal(t, "DRAFT", parsed["status"])
-	assert.Equal(t, "fedcba09", parsed["versionId"])
-	assert.Equal(t, "cat-xyz-789", parsed["catalogId"])
-	assert.Equal(t, "2026-04-01T08:00:00Z", parsed["createdAt"])
-	assert.Equal(t, "2026-04-10T14:30:00Z", parsed["updatedAt"])
-}
-
-func TestPrintJSON_WithoutCodeRef(t *testing.T) {
-	artifact := workload.Artifact{
-		ID:        "art-abc-123",
-		Name:      "my-agent",
-		Status:    "DRAFT",
-		Spec:      workload.Spec{},
-		CreatedAt: time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC),
-		UpdatedAt: time.Date(2026, 4, 10, 14, 30, 0, 0, time.UTC),
-	}
-
-	output := captureStdout(t, func() {
-		err := printJSON(artifact)
-		require.NoError(t, err)
-	})
-
-	var parsed map[string]interface{}
-
-	err := json.Unmarshal([]byte(output), &parsed)
-	require.NoError(t, err)
-	assert.Empty(t, parsed["versionId"])
-	assert.Empty(t, parsed["catalogId"])
-}
-
-func TestPrintHuman_WithCodeRef(t *testing.T) {
-	artifact := workload.Artifact{
-		ID:     "art-abc-123",
-		Name:   "my-agent",
-		Status: "DRAFT",
-		Spec: workload.Spec{
-			ContainerGroups: []workload.ContainerGroup{
-				{
-					Containers: []workload.Container{
-						{
-							CodeRef: &workload.CodeRef{
-								Datarobot: &workload.DatarobotCodeRef{
-									CatalogID:        "cat-xyz-789",
-									CatalogVersionID: "fedcba09",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		CreatedAt: time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC),
-		UpdatedAt: time.Date(2026, 4, 10, 14, 30, 0, 0, time.UTC),
-	}
-
-	output := captureStdout(t, func() {
-		printHuman(artifact)
-	})
-
-	assert.Contains(t, output, "ID:          art-abc-123")
-	assert.Contains(t, output, "Name:        my-agent")
-	assert.Contains(t, output, "Status:      DRAFT")
-	assert.Contains(t, output, "Catalog ID:  cat-xyz-789")
-	assert.Contains(t, output, "Version ID:  fedcba09")
-	assert.Contains(t, output, "Created:     2026-04-01 08:00 UTC")
-	assert.Contains(t, output, "Updated:     2026-04-10 14:30 UTC")
-}
-
-func TestPrintHuman_WithoutCodeRef(t *testing.T) {
-	artifact := workload.Artifact{
-		ID:        "art-abc-123",
-		Name:      "my-agent",
-		Status:    "DRAFT",
-		Spec:      workload.Spec{},
-		CreatedAt: time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC),
-		UpdatedAt: time.Date(2026, 4, 10, 14, 30, 0, 0, time.UTC),
-	}
-
-	output := captureStdout(t, func() {
-		printHuman(artifact)
-	})
-
-	assert.Contains(t, output, "Catalog ID:  \u2014")
-	assert.Contains(t, output, "Version ID:  \u2014")
-}
 
 func TestCmd_RequiresArg(t *testing.T) {
 	cmd := Cmd()
@@ -175,4 +27,14 @@ func TestCmd_RequiresArg(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
+}
+
+func TestCmd_InvalidOutputFormat(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"art-abc-123", "--output-format", "yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid output format "yaml"`)
 }

--- a/cmd/workload/artifact/list/cmd.go
+++ b/cmd/workload/artifact/list/cmd.go
@@ -15,10 +15,7 @@
 package list
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"text/tabwriter"
 
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/workload"
@@ -26,11 +23,11 @@ import (
 )
 
 func Cmd() *cobra.Command {
-	var outputFormat string
-
-	var limit int
-
-	var status string
+	var (
+		outputFormat workload.OutputFormat
+		status       workload.Status
+		limit        int
+	)
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -42,27 +39,18 @@ This command fetches artifacts and shows:
   * Code reference catalog ID and version ID
   * Last update timestamp
 
-By default, output is a human-readable table. Use --output json for machine-parseable output.
+By default, output is a human-readable table. Use --output-format json for machine-parseable output.
 
 Example:
   dr workload artifact list
   dr workload artifact list --limit 10
   dr workload artifact list --status draft
-  dr workload artifact list --output json`,
+  dr workload artifact list --output-format json`,
 		Args:    cobra.NoArgs,
 		PreRunE: auth.EnsureAuthenticatedE,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if outputFormat != "" && outputFormat != "json" {
-				return fmt.Errorf("invalid output format: %s (supported: json)", outputFormat)
-			}
-
 			if limit <= 0 {
 				return fmt.Errorf("invalid --limit %d: must be positive", limit)
-			}
-
-			status, err := workload.ParseArtifactStatus(status)
-			if err != nil {
-				return err
 			}
 
 			artifacts, err := workload.ListArtifacts(limit, status)
@@ -70,71 +58,13 @@ Example:
 				return err
 			}
 
-			if outputFormat == "json" {
-				return printJSON(artifacts)
-			}
-
-			printTable(artifacts)
-
-			return nil
+			return workload.RenderArtifacts(outputFormat, artifacts)
 		},
 	}
 
-	cmd.Flags().StringVar(&outputFormat, "output", "", "Output format (json)")
+	workload.AddOutputFlag(cmd, &outputFormat)
+	workload.AddStatusFlag(cmd, &status)
 	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of artifacts to return")
-	cmd.Flags().StringVar(&status, "status", "", "Filter by status (draft, locked)")
 
 	return cmd
-}
-
-func printJSON(artifacts []workload.Artifact) error {
-	outputs := make([]workload.ArtifactOutput, 0, len(artifacts))
-
-	for _, a := range artifacts {
-		outputs = append(outputs, workload.NewArtifactOutput(a))
-	}
-
-	data, err := json.MarshalIndent(outputs, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(string(data))
-
-	return nil
-}
-
-func printTable(artifacts []workload.Artifact) {
-	if len(artifacts) == 0 {
-		fmt.Println("No artifacts found.")
-
-		return
-	}
-
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-
-	fmt.Fprintf(w, "ARTIFACT ID\tNAME\tSTATUS\tCATALOG ID\tVERSION ID\tUPDATED\n")
-
-	for _, a := range artifacts {
-		var catalogID, versionID string
-
-		if codeRef := workload.ExtractCodeRef(a); codeRef != nil {
-			catalogID = codeRef.CatalogID
-			versionID = codeRef.CatalogVersionID
-		}
-
-		updated := a.UpdatedAt.UTC().Format("2006-01-02 15:04 UTC")
-
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", a.ID, a.Name, a.Status, orDash(catalogID), orDash(versionID), updated)
-	}
-
-	w.Flush()
-}
-
-func orDash(v string) string {
-	if v == "" {
-		return "\u2014"
-	}
-
-	return v
 }

--- a/cmd/workload/artifact/list/cmd_test.go
+++ b/cmd/workload/artifact/list/cmd_test.go
@@ -15,169 +15,20 @@
 package list
 
 import (
-	"bytes"
-	"encoding/json"
-	"io"
-	"os"
 	"testing"
-	"time"
 
-	"github.com/datarobot/cli/internal/workload"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-
-	old := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	fn()
-
-	w.Close()
-
-	os.Stdout = old
-
-	var buf bytes.Buffer
-
-	_, _ = io.Copy(&buf, r)
-
-	return buf.String()
-}
-
-func makeArtifact(id, name, status, catalogID, catalogVersionID string) workload.Artifact {
-	a := workload.Artifact{
-		ID:        id,
-		Name:      name,
-		Status:    status,
-		CreatedAt: time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC),
-		UpdatedAt: time.Date(2026, 4, 10, 14, 30, 0, 0, time.UTC),
-	}
-
-	if catalogID != "" {
-		a.Spec = workload.Spec{
-			ContainerGroups: []workload.ContainerGroup{
-				{
-					Containers: []workload.Container{
-						{
-							CodeRef: &workload.CodeRef{
-								Datarobot: &workload.DatarobotCodeRef{
-									CatalogID:        catalogID,
-									CatalogVersionID: catalogVersionID,
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-	}
-
-	return a
-}
-
-func TestPrintTable_WithCodeRef(t *testing.T) {
-	artifacts := []workload.Artifact{
-		makeArtifact("art-abc-123", "my-agent", "DRAFT", "0123456789abcdef01234567", "fedcba0987654321fedcba09"),
-	}
-
-	output := captureStdout(t, func() {
-		printTable(artifacts)
-	})
-
-	assert.Contains(t, output, "ARTIFACT ID")
-	assert.Contains(t, output, "CATALOG ID")
-	assert.Contains(t, output, "VERSION ID")
-	assert.Contains(t, output, "art-abc-123")
-	assert.Contains(t, output, "my-agent")
-	assert.Contains(t, output, "DRAFT")
-	assert.Contains(t, output, "0123456789abcdef01234567")
-	assert.Contains(t, output, "fedcba0987654321fedcba09")
-	assert.Contains(t, output, "2026-04-10 14:30 UTC")
-}
-
-func TestPrintTable_WithoutCodeRef(t *testing.T) {
-	artifacts := []workload.Artifact{
-		makeArtifact("art-abc-123", "my-agent", "DRAFT", "", ""),
-	}
-
-	output := captureStdout(t, func() {
-		printTable(artifacts)
-	})
-
-	assert.Contains(t, output, "\u2014")
-}
-
-func TestPrintTable_Empty(t *testing.T) {
-	output := captureStdout(t, func() {
-		printTable([]workload.Artifact{})
-	})
-
-	assert.Equal(t, "No artifacts found.\n", output)
-}
-
-func TestPrintJSON_Array(t *testing.T) {
-	artifacts := []workload.Artifact{
-		makeArtifact("art-001", "agent-one", "DRAFT", "cat-001", "ver-001"),
-		makeArtifact("art-002", "agent-two", "LOCKED", "", ""),
-	}
-
-	output := captureStdout(t, func() {
-		err := printJSON(artifacts)
-		require.NoError(t, err)
-	})
-
-	var parsed []map[string]interface{}
-
-	err := json.Unmarshal([]byte(output), &parsed)
-	require.NoError(t, err)
-	assert.Len(t, parsed, 2)
-	assert.Equal(t, "art-001", parsed[0]["id"])
-	assert.Equal(t, "ver-001", parsed[0]["versionId"])
-	assert.Equal(t, "art-002", parsed[1]["id"])
-	assert.Empty(t, parsed[1]["versionId"])
-}
-
-func TestPrintJSON_EmptyArray(t *testing.T) {
-	output := captureStdout(t, func() {
-		err := printJSON([]workload.Artifact{})
-		require.NoError(t, err)
-	})
-
-	var parsed []interface{}
-
-	err := json.Unmarshal([]byte(output), &parsed)
-	require.NoError(t, err)
-	assert.Empty(t, parsed)
-}
-
-func TestPrintJSON_FullVersion(t *testing.T) {
-	artifacts := []workload.Artifact{
-		makeArtifact("art-abc-123", "my-agent", "DRAFT", "cat-xyz-789", "fedcba0987654321fedcba09"),
-	}
-
-	output := captureStdout(t, func() {
-		err := printJSON(artifacts)
-		require.NoError(t, err)
-	})
-
-	var parsed []map[string]interface{}
-
-	err := json.Unmarshal([]byte(output), &parsed)
-	require.NoError(t, err)
-	assert.Equal(t, "fedcba0987654321fedcba09", parsed[0]["versionId"])
-}
-
 func TestCmd_InvalidOutputFormat(t *testing.T) {
 	cmd := Cmd()
 	cmd.PreRunE = nil
-	cmd.SetArgs([]string{"--output", "xml"})
+	cmd.SetArgs([]string{"--output-format", "xml"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid output format: xml")
+	assert.Contains(t, err.Error(), `invalid output format "xml"`)
 }
 
 func TestCmd_InvalidStatus(t *testing.T) {

--- a/internal/drapi/post.go
+++ b/internal/drapi/post.go
@@ -15,9 +15,9 @@
 package drapi
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -25,25 +25,9 @@ import (
 	"github.com/datarobot/cli/internal/log"
 )
 
-// HTTPError is returned by Get and Post when the server responds with a
-// non-success status code. Callers can extract the status code with errors.As
-// to make decisions without string matching.
-type HTTPError struct {
-	StatusCode int
-	URL        string
-}
-
-// Error implements the error interface for HTTPError.
-func (e *HTTPError) Error() string {
-	return fmt.Sprintf("HTTP error: %d %s (url: %s)", e.StatusCode, http.StatusText(e.StatusCode), e.URL)
-}
-
-var token string
-
-func Get(url, info string) (*http.Response, error) {
+func Post(url, info string, body any) (*http.Response, error) {
 	var err error
 
-	// memoize token to avoid extra VerifyToken() calls
 	if token == "" {
 		token, err = config.GetAPIKey(context.Background())
 		if err != nil {
@@ -51,23 +35,33 @@ func Get(url, info string) (*http.Response, error) {
 		}
 	}
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Add("Authorization", "Bearer "+token)
 	req.Header.Add("User-Agent", config.GetUserAgentHeader())
+	req.Header.Add("Content-Type", "application/json")
 
 	if config.IsAPIConsumerTrackingEnabled() {
 		req.Header.Add("X-DataRobot-Api-Consumer-Trace", config.GetAPIConsumerTrace())
 	}
 
 	if info != "" {
-		log.Infof("Fetching %s from: %s", info, url)
+		log.Infof("Creating %s at: %s", info, url)
 	}
 
 	log.Debug("Request Info: \n" + config.RedactedReqInfo(req))
+
+	if err := restoreRequestBody(req); err != nil {
+		return nil, err
+	}
 
 	client := &http.Client{
 		Timeout: 30 * time.Second,
@@ -78,7 +72,7 @@ func Get(url, info string) (*http.Response, error) {
 		return nil, err
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if !isCreateSuccess(resp.StatusCode) {
 		resp.Body.Close()
 
 		return nil, &HTTPError{StatusCode: resp.StatusCode, URL: url}
@@ -87,25 +81,36 @@ func Get(url, info string) (*http.Response, error) {
 	return resp, err
 }
 
-// GetUserID returns a dummy user ID for telemetry.
-// TODO: Discuss with the team whether /api/v2/userinfo/ is a valid endpoint
-// and the appropriate way to fetch the user ID for telemetry.
-func GetUserID(ctx context.Context) (string, error) {
-	return "unknown", nil
+func isCreateSuccess(code int) bool {
+	return code == http.StatusOK || code == http.StatusCreated
 }
 
-func GetJSON(url, info string, v any) error {
-	resp, err := Get(url, info)
+// restoreRequestBody re-arms req.Body after RedactedReqInfo (which dumps and
+// consumes it). For *bytes.Reader payloads, http.NewRequest sets req.GetBody
+// automatically; for other body kinds we leave Body alone and rely on the
+// transport reading whatever is left.
+func restoreRequestBody(req *http.Request) error {
+	if req.GetBody == nil {
+		return nil
+	}
+
+	body, err := req.GetBody()
 	if err != nil {
 		return err
 	}
 
-	err = json.NewDecoder(resp.Body).Decode(&v)
-	if err != nil {
-		return err
-	}
-
-	resp.Body.Close()
+	req.Body = body
 
 	return nil
+}
+
+func PostJSON(url, info string, body, v any) error {
+	resp, err := Post(url, info, body)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	return json.NewDecoder(resp.Body).Decode(&v)
 }

--- a/internal/drapi/post.go
+++ b/internal/drapi/post.go
@@ -59,6 +59,8 @@ func Post(url, info string, body any) (*http.Response, error) {
 
 	log.Debug("Request Info: \n" + config.RedactedReqInfo(req))
 
+	// RedactedReqInfo above drains req.Body for logging, so re-arm it before client.Do
+	// or the server receives an empty payload.
 	if err := restoreRequestBody(req); err != nil {
 		return nil, err
 	}

--- a/internal/drapi/post_test.go
+++ b/internal/drapi/post_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drapi
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetTokenForTest seeds the package-level token so Post() does not call
+// config.GetAPIKey() (which would require a configured environment).
+// Returns a cleanup function the test should defer.
+func resetTokenForTest(t *testing.T, value string) func() {
+	t.Helper()
+
+	previous := token
+	token = value
+
+	return func() { token = previous }
+}
+
+func TestPost_Created(t *testing.T) {
+	defer resetTokenForTest(t, "test-token")()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"x"}`))
+	}))
+	defer server.Close()
+
+	resp, err := Post(server.URL, "", map[string]string{"name": "v"})
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+}
+
+func TestPost_OK(t *testing.T) {
+	defer resetTokenForTest(t, "test-token")()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	resp, err := Post(server.URL, "", map[string]string{})
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestPost_NonSuccess(t *testing.T) {
+	defer resetTokenForTest(t, "test-token")()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+	}))
+	defer server.Close()
+
+	resp, err := Post(server.URL, "", map[string]string{}) //nolint:bodyclose // resp is nil on error; Post closes it before returning
+	require.Error(t, err)
+	assert.Nil(t, resp)
+
+	var httpErr *HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusUnprocessableEntity, httpErr.StatusCode)
+}
+
+func TestPost_Unauthorized(t *testing.T) {
+	defer resetTokenForTest(t, "test-token")()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	resp, err := Post(server.URL, "", map[string]string{}) //nolint:bodyclose // resp is nil on error; Post closes it before returning
+	require.Error(t, err)
+	assert.Nil(t, resp)
+
+	var httpErr *HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusUnauthorized, httpErr.StatusCode)
+}
+
+func TestPost_NetworkError(t *testing.T) {
+	defer resetTokenForTest(t, "test-token")()
+
+	_, err := Post("http://127.0.0.1:1/does-not-exist", "", map[string]string{}) //nolint:bodyclose // network error path returns nil resp
+	require.Error(t, err)
+}
+
+func TestPost_SetsHeaders(t *testing.T) {
+	defer resetTokenForTest(t, "test-token")()
+
+	var (
+		gotAuth        string
+		gotContentType string
+		gotUserAgent   string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		gotUserAgent = r.Header.Get("User-Agent")
+
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	resp, err := Post(server.URL, "", map[string]string{})
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, "Bearer test-token", gotAuth)
+	assert.Equal(t, "application/json", gotContentType)
+	assert.NotEmpty(t, gotUserAgent)
+}
+
+func TestPost_SendsBody(t *testing.T) {
+	defer resetTokenForTest(t, "test-token")()
+
+	var gotBody []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+
+		gotBody, err = io.ReadAll(r.Body)
+		assert.NoError(t, err)
+
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	body := map[string]any{"name": "my-agent", "count": 3}
+
+	resp, err := Post(server.URL, "", body)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	expected, err := json.Marshal(body)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(expected), string(gotBody))
+}
+
+func TestPostJSON_Decode(t *testing.T) {
+	defer resetTokenForTest(t, "test-token")()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"abc","name":"my-agent"}`))
+	}))
+	defer server.Close()
+
+	var out struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	}
+
+	err := PostJSON(server.URL, "", map[string]string{}, &out)
+	require.NoError(t, err)
+	assert.Equal(t, "abc", out.ID)
+	assert.Equal(t, "my-agent", out.Name)
+}
+
+func TestPostJSON_DecodeError(t *testing.T) {
+	defer resetTokenForTest(t, "test-token")()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer server.Close()
+
+	var out struct{}
+
+	err := PostJSON(server.URL, "", map[string]string{}, &out)
+	require.Error(t, err)
+}

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -15,6 +15,9 @@
 package workload
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -139,6 +142,81 @@ type ArtifactList struct {
 	TotalCount int        `json:"totalCount"`
 	Next       string     `json:"next"`
 	Previous   string     `json:"previous"`
+}
+
+type ArtifactCreateRequest struct {
+	Name        string             `json:"name"`
+	Description string             `json:"description,omitempty"`
+	Spec        ArtifactCreateSpec `json:"spec"`
+}
+
+type ArtifactCreateSpec struct {
+	ContainerGroups []ArtifactCreateContainerGroup `json:"containerGroups"`
+}
+
+type ArtifactCreateContainerGroup struct {
+	Containers []ArtifactCreateContainer `json:"containers"`
+}
+
+type ArtifactCreateContainer struct {
+	ImageURI        string                         `json:"imageUri,omitempty"`
+	Port            int                            `json:"port,omitempty"`
+	ResourceRequest *ArtifactCreateResourceRequest `json:"resourceRequest,omitempty"`
+	CodeRef         *CodeRef                       `json:"codeRef,omitempty"`
+}
+
+type ArtifactCreateResourceRequest struct {
+	CPU    int   `json:"cpu"`
+	Memory int64 `json:"memory"`
+}
+
+// ValidateCreateRequest decodes a user-supplied spec file with DisallowUnknownFields
+// against ArtifactCreateRequest and enforces required-field invariants. The original
+// bytes are still sent verbatim by the caller; the strict struct never reaches the wire.
+func ValidateCreateRequest(data []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+
+	var req ArtifactCreateRequest
+
+	if err := dec.Decode(&req); err != nil {
+		return fmt.Errorf("invalid spec: %w", err)
+	}
+
+	if req.Name == "" {
+		return errors.New("invalid spec: required field 'name' is missing or empty")
+	}
+
+	if len(req.Spec.ContainerGroups) == 0 {
+		return errors.New("invalid spec: 'spec.containerGroups' must contain at least one entry")
+	}
+
+	for i, group := range req.Spec.ContainerGroups {
+		if len(group.Containers) == 0 {
+			return fmt.Errorf("invalid spec: 'spec.containerGroups[%d].containers' must contain at least one entry", i)
+		}
+	}
+
+	return nil
+}
+
+// CreateArtifact POSTs payload to /api/v2/artifacts/ and returns the parsed artifact.
+// payload is typically a json.RawMessage from the spec file, sent verbatim after
+// ValidateCreateRequest passed.
+func CreateArtifact(payload any) (*Artifact, error) {
+	url, err := config.GetEndpointURL("/api/v2/artifacts/")
+	if err != nil {
+		return nil, err
+	}
+
+	var artifact Artifact
+
+	err = drapi.PostJSON(url, "artifact", payload, &artifact)
+	if err != nil {
+		return nil, err
+	}
+
+	return &artifact, nil
 }
 
 func ListArtifacts(limit int, status string) ([]Artifact, error) {

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -219,11 +219,11 @@ func CreateArtifact(payload any) (*Artifact, error) {
 	return &artifact, nil
 }
 
-func ListArtifacts(limit int, status string) ([]Artifact, error) {
+func ListArtifacts(limit int, status Status) ([]Artifact, error) {
 	endpoint := "/api/v2/artifacts/?limit=" + strconv.Itoa(limit)
 
 	if status != "" {
-		endpoint += "&status=" + status
+		endpoint += "&status=" + string(status)
 	}
 
 	pageURL, err := config.GetEndpointURL(endpoint)

--- a/internal/workload/artifact_test.go
+++ b/internal/workload/artifact_test.go
@@ -150,3 +150,101 @@ func TestParseArtifactStatus_Invalid(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid status")
 	assert.Contains(t, err.Error(), "bogus")
 }
+
+const validMinimalSpec = `{
+	"name": "my-agent",
+	"spec": {
+		"containerGroups": [{
+			"containers": [{
+				"imageUri": "nginx:latest",
+				"port": 8080,
+				"resourceRequest": {"cpu": 1, "memory": 536870912}
+			}]
+		}]
+	}
+}`
+
+func TestValidateCreateRequest_MinimalValid(t *testing.T) {
+	require.NoError(t, ValidateCreateRequest([]byte(validMinimalSpec)))
+}
+
+func TestValidateCreateRequest_FullValid(t *testing.T) {
+	spec := `{
+		"name": "my-agent",
+		"description": "demo",
+		"spec": {
+			"containerGroups": [{
+				"containers": [{
+					"imageUri": "nginx:latest",
+					"port": 8080,
+					"resourceRequest": {"cpu": 1, "memory": 536870912},
+					"codeRef": {"datarobot": {"catalogId": "c", "catalogVersionId": "v"}}
+				}]
+			}]
+		}
+	}`
+
+	require.NoError(t, ValidateCreateRequest([]byte(spec)))
+}
+
+func TestValidateCreateRequest_Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    string
+		wantSub string
+	}{
+		{
+			"missing name",
+			`{"spec":{"containerGroups":[{"containers":[{}]}]}}`,
+			"'name' is missing",
+		},
+		{
+			"empty name",
+			`{"name":"","spec":{"containerGroups":[{"containers":[{}]}]}}`,
+			"'name' is missing",
+		},
+		{
+			"missing spec",
+			`{"name":"x"}`,
+			"'spec.containerGroups'",
+		},
+		{
+			"empty container groups",
+			`{"name":"x","spec":{"containerGroups":[]}}`,
+			"'spec.containerGroups'",
+		},
+		{
+			"empty containers in group",
+			`{"name":"x","spec":{"containerGroups":[{"containers":[]}]}}`,
+			"[0].containers",
+		},
+		{
+			"unknown top-level field",
+			`{"nme":"x","spec":{"containerGroups":[{"containers":[{}]}]}}`,
+			`unknown field "nme"`,
+		},
+		{
+			"unknown nested field",
+			`{"name":"x","spec":{"containerGroups":[{"containers":[{"imageUrl":"x"}]}]}}`,
+			`unknown field "imageUrl"`,
+		},
+		{
+			"wrong type cpu",
+			`{"name":"x","spec":{"containerGroups":[{"containers":[{"resourceRequest":{"cpu":"1","memory":1}}]}]}}`,
+			"invalid spec",
+		},
+		{
+			"not json",
+			`not json`,
+			"invalid spec",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateCreateRequest([]byte(c.spec))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), c.wantSub)
+		})
+	}
+}

--- a/internal/workload/flags.go
+++ b/internal/workload/flags.go
@@ -1,0 +1,94 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type OutputFormat string
+
+const (
+	OutputFormatText OutputFormat = "text"
+	OutputFormatJSON OutputFormat = "json"
+)
+
+var _ pflag.Value = (*OutputFormat)(nil)
+
+func (f *OutputFormat) String() string {
+	if f == nil {
+		return ""
+	}
+
+	return string(*f)
+}
+
+func (f *OutputFormat) Set(s string) error {
+	switch s {
+	case string(OutputFormatText), string(OutputFormatJSON):
+		*f = OutputFormat(s)
+
+		return nil
+	}
+
+	return fmt.Errorf("invalid output format %q: use %s or %s", s, OutputFormatText, OutputFormatJSON)
+}
+
+func (f *OutputFormat) Type() string {
+	return "format"
+}
+
+// AddOutputFlag registers --output-format on cmd, defaulting to OutputFormatText.
+// The default is written to *dest before registration so cobra renders it as
+// the default value in --help.
+func AddOutputFlag(cmd *cobra.Command, dest *OutputFormat) {
+	*dest = OutputFormatText
+
+	cmd.Flags().Var(dest, "output-format", fmt.Sprintf("Output format (%s, %s)", OutputFormatText, OutputFormatJSON))
+}
+
+type Status string
+
+var _ pflag.Value = (*Status)(nil)
+
+func (s *Status) String() string {
+	if s == nil {
+		return ""
+	}
+
+	return string(*s)
+}
+
+func (s *Status) Set(v string) error {
+	parsed, err := ParseArtifactStatus(v)
+	if err != nil {
+		return err
+	}
+
+	*s = Status(parsed)
+
+	return nil
+}
+
+func (s *Status) Type() string {
+	return "status"
+}
+
+func AddStatusFlag(cmd *cobra.Command, dest *Status) {
+	cmd.Flags().Var(dest, "status", fmt.Sprintf("Filter by status (%s, %s)", ArtifactStatusDraft, ArtifactStatusLocked))
+}

--- a/internal/workload/flags_test.go
+++ b/internal/workload/flags_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutputFormat_Set(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    OutputFormat
+		wantErr bool
+	}{
+		{"text", OutputFormatText, false},
+		{"json", OutputFormatJSON, false},
+		{"yaml", "", true},
+		{"", "", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			var f OutputFormat
+
+			err := f.Set(c.in)
+			if c.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid output format")
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, c.want, f)
+		})
+	}
+}
+
+func TestStatus_Set(t *testing.T) {
+	var s Status
+
+	require.NoError(t, s.Set("DRAFT"))
+	assert.Equal(t, Status(ArtifactStatusDraft), s)
+
+	require.NoError(t, s.Set("locked"))
+	assert.Equal(t, Status(ArtifactStatusLocked), s)
+
+	err := s.Set("bogus")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid status")
+}

--- a/internal/workload/output.go
+++ b/internal/workload/output.go
@@ -1,0 +1,123 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+)
+
+const (
+	timestampFormat       = "2006-01-02 15:04 UTC"
+	emptyValuePlaceholder = "—"
+)
+
+func RenderArtifact(format OutputFormat, artifact Artifact) error {
+	if format == OutputFormatJSON {
+		return printArtifactJSON(artifact)
+	}
+
+	printArtifactDetails(artifact)
+
+	return nil
+}
+
+func RenderArtifacts(format OutputFormat, artifacts []Artifact) error {
+	if format == OutputFormatJSON {
+		return printArtifactsJSON(artifacts)
+	}
+
+	printArtifactsTable(artifacts)
+
+	return nil
+}
+
+func printArtifactJSON(artifact Artifact) error {
+	data, err := json.MarshalIndent(NewArtifactOutput(artifact), "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+
+	return nil
+}
+
+func printArtifactsJSON(artifacts []Artifact) error {
+	outputs := make([]ArtifactOutput, 0, len(artifacts))
+
+	for _, a := range artifacts {
+		outputs = append(outputs, NewArtifactOutput(a))
+	}
+
+	data, err := json.MarshalIndent(outputs, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+
+	return nil
+}
+
+func printArtifactDetails(artifact Artifact) {
+	catalogID, versionID := emptyValuePlaceholder, emptyValuePlaceholder
+
+	if codeRef := ExtractCodeRef(artifact); codeRef != nil {
+		catalogID = codeRef.CatalogID
+		versionID = codeRef.CatalogVersionID
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "ID:\t%s\n", artifact.ID)
+	fmt.Fprintf(w, "Name:\t%s\n", artifact.Name)
+	fmt.Fprintf(w, "Status:\t%s\n", artifact.Status)
+	fmt.Fprintf(w, "Catalog ID:\t%s\n", catalogID)
+	fmt.Fprintf(w, "Version ID:\t%s\n", versionID)
+	fmt.Fprintf(w, "Created:\t%s\n", artifact.CreatedAt.UTC().Format(timestampFormat))
+	fmt.Fprintf(w, "Updated:\t%s\n", artifact.UpdatedAt.UTC().Format(timestampFormat))
+
+	w.Flush()
+}
+
+func printArtifactsTable(artifacts []Artifact) {
+	if len(artifacts) == 0 {
+		fmt.Println("No artifacts found.")
+
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintln(w, "ARTIFACT ID\tNAME\tSTATUS\tCATALOG ID\tVERSION ID\tUPDATED")
+
+	for _, a := range artifacts {
+		catalogID, versionID := emptyValuePlaceholder, emptyValuePlaceholder
+
+		if codeRef := ExtractCodeRef(a); codeRef != nil {
+			catalogID = codeRef.CatalogID
+			versionID = codeRef.CatalogVersionID
+		}
+
+		updated := a.UpdatedAt.UTC().Format(timestampFormat)
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", a.ID, a.Name, a.Status, catalogID, versionID, updated)
+	}
+
+	w.Flush()
+}

--- a/internal/workload/output_test.go
+++ b/internal/workload/output_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+
+	os.Stdout = old
+
+	var buf bytes.Buffer
+
+	_, _ = io.Copy(&buf, r)
+
+	return buf.String()
+}
+
+func makeTestArtifact(id, name, status, catalogID, versionID string) Artifact {
+	a := Artifact{
+		ID:        id,
+		Name:      name,
+		Status:    status,
+		CreatedAt: time.Date(2026, 4, 1, 8, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 4, 10, 14, 30, 0, 0, time.UTC),
+	}
+
+	if catalogID != "" {
+		a.Spec = Spec{
+			ContainerGroups: []ContainerGroup{
+				{
+					Containers: []Container{
+						{
+							CodeRef: &CodeRef{
+								Datarobot: &DatarobotCodeRef{
+									CatalogID:        catalogID,
+									CatalogVersionID: versionID,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return a
+}
+
+func TestPrintArtifactJSON_WithCodeRef(t *testing.T) {
+	artifact := makeTestArtifact("art-abc-123", "my-agent", "DRAFT", "cat-xyz-789", "fedcba09")
+
+	output := captureStdout(t, func() {
+		require.NoError(t, printArtifactJSON(artifact))
+	})
+
+	var parsed map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	assert.Equal(t, "art-abc-123", parsed["id"])
+	assert.Equal(t, "my-agent", parsed["name"])
+	assert.Equal(t, "DRAFT", parsed["status"])
+	assert.Equal(t, "cat-xyz-789", parsed["catalogId"])
+	assert.Equal(t, "fedcba09", parsed["versionId"])
+	assert.Equal(t, "2026-04-01T08:00:00Z", parsed["createdAt"])
+	assert.Equal(t, "2026-04-10T14:30:00Z", parsed["updatedAt"])
+}
+
+func TestPrintArtifactJSON_WithoutCodeRef(t *testing.T) {
+	artifact := makeTestArtifact("art-abc-123", "my-agent", "DRAFT", "", "")
+
+	output := captureStdout(t, func() {
+		require.NoError(t, printArtifactJSON(artifact))
+	})
+
+	var parsed map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	assert.Empty(t, parsed["catalogId"])
+	assert.Empty(t, parsed["versionId"])
+}
+
+func TestPrintArtifactsJSON(t *testing.T) {
+	artifacts := []Artifact{
+		makeTestArtifact("art-001", "agent-one", "DRAFT", "cat-001", "ver-001"),
+		makeTestArtifact("art-002", "agent-two", "LOCKED", "", ""),
+	}
+
+	output := captureStdout(t, func() {
+		require.NoError(t, printArtifactsJSON(artifacts))
+	})
+
+	var parsed []map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	assert.Len(t, parsed, 2)
+	assert.Equal(t, "art-001", parsed[0]["id"])
+	assert.Equal(t, "ver-001", parsed[0]["versionId"])
+	assert.Equal(t, "art-002", parsed[1]["id"])
+	assert.Empty(t, parsed[1]["versionId"])
+}
+
+func TestPrintArtifactsJSON_Empty(t *testing.T) {
+	output := captureStdout(t, func() {
+		require.NoError(t, printArtifactsJSON([]Artifact{}))
+	})
+
+	var parsed []any
+
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	assert.Empty(t, parsed)
+}
+
+func TestPrintArtifactDetails_WithCodeRef(t *testing.T) {
+	artifact := makeTestArtifact("art-abc-123", "my-agent", "DRAFT", "cat-xyz-789", "fedcba09")
+
+	output := captureStdout(t, func() {
+		printArtifactDetails(artifact)
+	})
+
+	assert.Contains(t, output, "art-abc-123")
+	assert.Contains(t, output, "my-agent")
+	assert.Contains(t, output, "DRAFT")
+	assert.Contains(t, output, "cat-xyz-789")
+	assert.Contains(t, output, "fedcba09")
+	assert.Contains(t, output, "2026-04-01 08:00 UTC")
+	assert.Contains(t, output, "2026-04-10 14:30 UTC")
+	assert.Contains(t, output, "ID:")
+	assert.Contains(t, output, "Catalog ID:")
+	assert.Contains(t, output, "Version ID:")
+}
+
+func TestPrintArtifactDetails_WithoutCodeRef(t *testing.T) {
+	artifact := makeTestArtifact("art-abc-123", "my-agent", "DRAFT", "", "")
+
+	output := captureStdout(t, func() {
+		printArtifactDetails(artifact)
+	})
+
+	assert.Contains(t, output, "Catalog ID:  —")
+	assert.Contains(t, output, "Version ID:  —")
+}
+
+func TestPrintArtifactsTable_WithCodeRef(t *testing.T) {
+	artifacts := []Artifact{
+		makeTestArtifact("art-abc-123", "my-agent", "DRAFT", "cat-001", "ver-001"),
+	}
+
+	output := captureStdout(t, func() {
+		printArtifactsTable(artifacts)
+	})
+
+	assert.Contains(t, output, "ARTIFACT ID")
+	assert.Contains(t, output, "CATALOG ID")
+	assert.Contains(t, output, "VERSION ID")
+	assert.Contains(t, output, "art-abc-123")
+	assert.Contains(t, output, "my-agent")
+	assert.Contains(t, output, "DRAFT")
+	assert.Contains(t, output, "cat-001")
+	assert.Contains(t, output, "ver-001")
+	assert.Contains(t, output, "2026-04-10 14:30 UTC")
+}
+
+func TestPrintArtifactsTable_WithoutCodeRef(t *testing.T) {
+	artifacts := []Artifact{
+		makeTestArtifact("art-abc-123", "my-agent", "DRAFT", "", ""),
+	}
+
+	output := captureStdout(t, func() {
+		printArtifactsTable(artifacts)
+	})
+
+	assert.Equal(t, 2, strings.Count(output, "—"))
+}
+
+func TestPrintArtifactsTable_Empty(t *testing.T) {
+	output := captureStdout(t, func() {
+		printArtifactsTable([]Artifact{})
+	})
+
+	assert.Equal(t, "No artifacts found.\n", output)
+}


### PR DESCRIPTION
# RATIONALE

Continues the RAPTOR-16918/-16919 series (workload artifact `get` and `list`) by adding the write path: `dr workload artifact create`. Users can POST a JSON spec file to the Workload API and see the created artifact back in either human-readable or machine-parseable form, without hand-crafting a cURL against `/api/v2/artifacts/`.

## CHANGES

- New `dr workload artifact create --spec-file <path> [--output json]` subcommand under the `workload` feature gate.
- Strict client-side spec validation (`DisallowUnknownFields` + required-field checks for `name`, `spec.containerGroups`, and ≥1 container per group) so malformed specs fail fast before hitting the server. Raw spec bytes are forwarded verbatim to preserve fields the typed struct doesn't yet model.
- New `drapi.Post` / `drapi.PostJSON` helpers mirroring the existing `Get` / `GetJSON` shape (200/201 success, `HTTPError` on non-success, memoized token, standard headers, request-body restoration after `RedactedReqInfo`).
- `internal/workload` additions: `ArtifactCreateRequest` types, `ValidateCreateRequest`, `CreateArtifact`.
- Unit tests for spec validation, file reading, output formatting, and `Post` / `PostJSON` success + error paths.

## NOTES
- Built on top of #451 (list command). Rebase on `main` once #451 merges.


## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:

- `/trigger-smoke-test` or `/trigger-test-smoke` — Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` — Run installation tests

**Labels:** Apply labels to trigger workflows:

- `run-smoke-tests` or `go` — Run smoke tests on demand (only works for non-forked PRs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new write-path API call and new HTTP POST helper; failures could affect artifact creation or request logging/body handling, though changes are scoped and well-tested.
> 
> **Overview**
> Adds a new `dr workload artifact create --spec-file <file>` command that reads a JSON spec, performs strict client-side validation (unknown-field rejection + required invariants), POSTs to `/api/v2/artifacts/`, and renders the created artifact in `text` or `json`.
> 
> Refactors existing `artifact get`/`list` to use new shared `--output-format` parsing and centralized rendering (`RenderArtifact(s)`), and introduces typed status/output flags. Introduces `drapi.Post`/`PostJSON` (with shared `HTTPError` semantics) to support create calls, along with unit tests for POST behavior, spec validation, flag parsing, and output formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17c708273f11d6442fc6d153e1d87197e287990a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->