### PR TITLE
[CFX-5822] Use .GlobalIndex() to account for filtered list when selecting option

### DIFF
--- a/cmd/dotenv/promptModel.go
+++ b/cmd/dotenv/promptModel.go
@@ -251,7 +251,7 @@ func (pm promptModel) GetValues() []string {
 	}
 
 	items := pm.list.Items()
-	current := items[pm.list.Index()].(item)
+	current := items[pm.list.GlobalIndex()].(item)
 
 	if pm.prompt.Multiple {
 		values := make([]string, 0, len(items))


### PR DESCRIPTION
# RATIONALE

This is a bugfix for LLM selection not working as expected when filtering list.

Please see Jira for comprehensive breakdown including screenshots

FYI @victorborshak and @taras-pokornyy 

## CHANGES

We want to use `GlobalIndex()` and not `Index()` so that filtering of the list is accounted for.

> GlobalIndex returns the index of the currently selected item as it is stored in the unfiltered list of items. This value can be used with SetItem().

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to how selected values are read from a TUI list, affecting only filtered-list selection behavior.
> 
> **Overview**
> Fixes a selection bug in `cmd/dotenv/promptModel.go` by switching `GetValues()` to use `pm.list.VisibleItems()` instead of `Items()`, so the chosen/checked values correspond to the currently *filtered* list rather than the full underlying dataset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d1a758b9a71d0f3b40c28ff4903231823fa3551. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->