### PR TITLE
Add assist plugin v0.1.20

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.20",
+          "url": "assist/assist-0.1.20.tar.xz",
+          "sha256": "36311fbea982ae7482ed36c63542066b305075125772cd3a5c2c3fa1acc4e024",
+          "releaseDate": "2026-04-27"
+        },
+        {
           "version": "0.1.19",
           "url": "assist/assist-0.1.19.tar.xz",
           "sha256": "8bbb0ded53db02e422cf166456903c808edba74fef99f66dc8dda69aa1720a26",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.20 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.20
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.20
- **SHA256:** `36311fbea982ae7482ed36c63542066b305075125772cd3a5c2c3fa1acc4e024`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that adds a new `assist` release entry; primary risk is an incorrect URL or checksum breaking installs.
> 
> **Overview**
> Updates the CLI plugin index (`docs/plugins/index.json`) to publish **`assist` v0.1.20**, including its download URL, SHA256 checksum, and release date, ahead of the existing v0.1.19 entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f06d6386c5a31d291de2a026f179c9c048fab939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->