### PR TITLE
[CFX-5727] Adding fully non-interactive 'dr dotenv setup --yes'

### DIFF
--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -130,6 +130,22 @@ This wizard will help you:
 			}
 		}
 
+		showAllPrompts, _ := cmd.Flags().GetBool("all")
+		yes := viper.GetBool("yes")
+
+		// When --yes is set, run fully non-interactive setup without TUI
+		if yes {
+			if err := setupNonInteractive(repositoryRoot, dotenvFile); err != nil {
+				return err
+			}
+
+			// Update state after successful completion
+			_ = state.UpdateAfterDotenvSetup(repositoryRoot)
+
+			return nil
+		}
+
+		// Interactive mode: load variables and launch TUI
 		// TODO: There's an inconsistency between validation and wizard variable loading:
 		// - shouldSkipSetup uses ParseVariablesOnly (reads only .env file)
 		// - ValidateEnvironment also checks OS environment variables (os.LookupEnv)
@@ -144,9 +160,6 @@ This wizard will help you:
 		// or documenting the behavior more clearly in the flag description.
 		dotenvFileLines, _ := readDotenvFile(dotenvFile)
 		variables, contents := envbuilder.VariablesFromLines(dotenvFileLines)
-
-		showAllPrompts, _ := cmd.Flags().GetBool("all")
-		yes := viper.GetBool("yes")
 
 		needsPulumi, pulumiLoggedIn, needsPassphrase := CheckPulumiSetup(repositoryRoot, variables)
 

--- a/cmd/dotenv/helpers.go
+++ b/cmd/dotenv/helpers.go
@@ -160,9 +160,9 @@ func applyDefaultsToPrompts(prompts []envbuilder.UserPrompt) ([]envbuilder.UserP
 		// Otherwise leave as empty string (which is the zero value)
 	}
 
-	// Apply generated values for prompts with generate: true
 	var err error
 
+	// Apply generated values for prompts with generate: true
 	prompts, err = envbuilder.ApplyGeneratedValues(prompts)
 	if err != nil {
 		return nil, err

--- a/cmd/dotenv/helpers.go
+++ b/cmd/dotenv/helpers.go
@@ -135,3 +135,79 @@ func ValidateAndEditIfNeeded() error {
 
 	return nil
 }
+
+// applyDefaultsToPrompts auto-populates prompts with their default values,
+// applies generated values, and determines required sections. This is the
+// core logic shared between interactive and non-interactive setup flows.
+// Modifies the prompts slice in place and returns it (or error if generation fails).
+func applyDefaultsToPrompts(prompts []envbuilder.UserPrompt) ([]envbuilder.UserPrompt, error) {
+	// Auto-populate all prompts with their default values (or empty strings)
+	for i := range prompts {
+		prompt := &prompts[i]
+
+		// Ensure variables are uncommented (consistent with interactive wizard)
+		prompt.Commented = false
+
+		// Skip if already has a value (e.g., from environment or existing .env)
+		if prompt.Value != "" {
+			continue
+		}
+
+		// Use default if available
+		if prompt.Default != "" {
+			prompt.Value = prompt.Default
+		}
+		// Otherwise leave as empty string (which is the zero value)
+	}
+
+	// Apply generated values for prompts with generate: true
+	var err error
+
+	prompts, err = envbuilder.ApplyGeneratedValues(prompts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine required sections based on selected options
+	prompts = envbuilder.DetermineRequiredSections(prompts)
+
+	return prompts, nil
+}
+
+// setupNonInteractive performs non-interactive dotenv setup without launching the TUI.
+// It auto-populates all prompts with their default values (or empty strings) and saves
+// the .env file. This is used when --yes flag is set or DATAROBOT_CLI_NON_INTERACTIVE=true.
+func setupNonInteractive(repositoryRoot, dotenvFile string) error {
+	// Read existing .env file or use default template
+	dotenvFileLines, contents := readDotenvFile(dotenvFile)
+	variables, _ := envbuilder.VariablesFromLines(dotenvFileLines)
+
+	// Check if Pulumi passphrase setup is needed and handle it before gathering prompts
+	// (this will save the passphrase to drconfig.yaml if needed)
+	if err := handlePulumiPassphraseNonInteractive(repositoryRoot, variables); err != nil {
+		return fmt.Errorf("failed to setup Pulumi passphrase: %w", err)
+	}
+
+	// Gather user prompts from template configuration
+	// (if passphrase was just saved, it will be picked up from drconfig.yaml via viper)
+	prompts, err := envbuilder.GatherUserPrompts(repositoryRoot, variables)
+	if err != nil {
+		return fmt.Errorf("failed to gather prompts: %w", err)
+	}
+
+	// Apply defaults and process prompts (shared logic with TUI)
+	prompts, err = applyDefaultsToPrompts(prompts)
+	if err != nil {
+		return fmt.Errorf("failed to process prompts: %w", err)
+	}
+
+	// Generate .env content from prompts merged with existing contents
+	newContents := envbuilder.DotenvFromPromptsMerged(prompts, contents)
+
+	// Save the file
+	if err := writeContents(newContents, dotenvFile); err != nil {
+		return fmt.Errorf("failed to write .env file: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/dotenv/helpers.go
+++ b/cmd/dotenv/helpers.go
@@ -162,7 +162,7 @@ func applyDefaultsToPrompts(prompts []envbuilder.UserPrompt) ([]envbuilder.UserP
 
 	var err error
 
-	// Apply generated values for prompts with generate: true
+	// Apply generated values for prompts with field: `generate: true`
 	prompts, err = envbuilder.ApplyGeneratedValues(prompts)
 	if err != nil {
 		return nil, err

--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -249,38 +249,14 @@ func (m Model) moveToPreviousPrompt() (tea.Model, tea.Cmd) {
 // autoPopulateAndSave auto-populates all prompts with their default values (or empty strings)
 // and saves the .env file without showing the wizard. This is used when --yes is set.
 func (m Model) autoPopulateAndSave() (tea.Model, tea.Cmd) {
-	// Auto-populate all prompts with their defaults or empty values
-	for p := range m.prompts {
-		prompt := &m.prompts[p]
-
-		// Ensure variables are uncommented (consistent with interactive wizard)
-		prompt.Commented = false
-
-		// Skip if already has a value (e.g., from environment or existing .env)
-		if prompt.Value != "" {
-			continue
-		}
-
-		// Use default if available
-		if prompt.Default != "" {
-			prompt.Value = prompt.Default
-		} else {
-			// Otherwise leave as empty string (which is the zero value)
-			prompt.Value = ""
-		}
-	}
-
-	// Apply generated values for prompts with generate: true
+	// Apply defaults and process prompts (shared logic with non-interactive setup)
 	var err error
 
-	m.prompts, err = envbuilder.ApplyGeneratedValues(m.prompts)
+	m.prompts, err = applyDefaultsToPrompts(m.prompts)
 	if err != nil {
 		m.err = err
 		return m, nil
 	}
-
-	// Determine required sections based on selected options
-	m.prompts = envbuilder.DetermineRequiredSections(m.prompts)
 
 	// Generate .env content from prompts
 	m.contents = envbuilder.DotenvFromPromptsMerged(m.prompts, m.contents)

--- a/cmd/dotenv/model_test.go
+++ b/cmd/dotenv/model_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/envbuilder"
+	"github.com/datarobot/cli/tui"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -162,6 +163,11 @@ func (suite *DotenvModelTestSuite) FinalModel(tm *teatest.TestModel) Model {
 	}
 
 	finalModel := tm.FinalModel(suite.T())
+
+	// The model is wrapped in InterruptibleModel, so we need to unwrap it
+	if wrappedModel, ok := finalModel.(tui.InterruptibleModel); ok {
+		finalModel = wrappedModel.Model
+	}
 
 	fm, ok := finalModel.(Model)
 	if !ok {

--- a/cmd/dotenv/pulumiModel.go
+++ b/cmd/dotenv/pulumiModel.go
@@ -29,7 +29,6 @@ import (
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/envbuilder"
 	"github.com/datarobot/cli/tui"
-	"github.com/spf13/viper"
 )
 
 const (
@@ -403,7 +402,7 @@ func CheckPulumiSetup(dir string, variables []envbuilder.Variable) (needsSetup, 
 // This is called during 'dr dotenv setup --yes' to ensure passphrase is configured.
 func handlePulumiPassphraseNonInteractive(repositoryRoot string, variables []envbuilder.Variable) error {
 	loggedIn := isPulumiLoggedIn()
-	passphraseSet := viper.GetString(pulumiConfigPassphraseKey) != ""
+	passphraseSet := viperx.GetString(pulumiConfigPassphraseKey) != ""
 
 	// Gather prompts to check if template requires Pulumi
 	prompts, err := envbuilder.GatherUserPrompts(repositoryRoot, variables)

--- a/cmd/dotenv/pulumiModel.go
+++ b/cmd/dotenv/pulumiModel.go
@@ -240,11 +240,16 @@ func (m pulumiLoginModel) handlePassphraseAccepted() (tea.Model, tea.Cmd) {
 }
 
 func (m pulumiLoginModel) savePassphraseToConfig() error {
+	return savePulumiPassphraseToConfig(m.generatedPassphrase)
+}
+
+// savePulumiPassphraseToConfig saves the given passphrase to drconfig.yaml.
+func savePulumiPassphraseToConfig(passphrase string) error {
 	if err := config.CreateConfigFileDirIfNotExists(); err != nil {
 		return fmt.Errorf("failed to create config: %w", err)
 	}
 
-	viper.Set(pulumiConfigPassphraseKey, m.generatedPassphrase)
+	viper.Set(pulumiConfigPassphraseKey, passphrase)
 
 	if err := viper.WriteConfig(); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
@@ -390,4 +395,31 @@ func CheckPulumiSetup(dir string, variables []envbuilder.Variable) (needsSetup, 
 	passphraseSet := viper.GetString(pulumiConfigPassphraseKey) != ""
 
 	return needsPulumiSetup(prompts, loggedIn, passphraseSet), loggedIn, !passphraseSet
+}
+
+// handlePulumiPassphraseNonInteractive checks if Pulumi passphrase needs to be
+// generated in non-interactive mode and saves it to drconfig.yaml if needed.
+// This is called during 'dr dotenv setup --yes' to ensure passphrase is configured.
+func handlePulumiPassphraseNonInteractive(repositoryRoot string, variables []envbuilder.Variable) error {
+	loggedIn := isPulumiLoggedIn()
+	passphraseSet := viper.GetString(pulumiConfigPassphraseKey) != ""
+
+	// Gather prompts to check if template requires Pulumi
+	prompts, err := envbuilder.GatherUserPrompts(repositoryRoot, variables)
+	if err != nil {
+		return fmt.Errorf("failed to gather prompts: %w", err)
+	}
+
+	// Use same logic as interactive mode to check if setup is needed
+	if !needsPulumiSetup(prompts, loggedIn, passphraseSet) || passphraseSet {
+		return nil
+	}
+
+	// Generate and save passphrase
+	passphrase, err := envbuilder.GenerateRandomSecret(generatedPassphraseLength)
+	if err != nil {
+		return fmt.Errorf("failed to generate passphrase: %w", err)
+	}
+
+	return savePulumiPassphraseToConfig(passphrase)
 }


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

Adding fully non-interactive 'dr dotenv setup --yes'. Useful when 'dr dotenv setup --yes' is used by coding agents.
- no TUI used at all when `--yes`
- no TUI used at all when `DATAROBOT_CLI_NON_INTERACTIVE` var is set.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `dotenv setup` execution path to bypass the TUI and auto-write `.env` (and possibly `drconfig.yaml`) when `--yes`/`DATAROBOT_CLI_NON_INTERACTIVE` is set, which could impact automated setups and Pulumi secret handling if defaults/templates are wrong.
> 
> **Overview**
> Adds a **fully non-interactive** `dr dotenv setup --yes` mode that skips launching the TUI and instead gathers prompts, auto-fills defaults/generated values, merges them into the existing template contents, and writes the `.env` file.
> 
> Extracts shared prompt-processing logic into `applyDefaultsToPrompts`, and extends the non-interactive flow to **auto-generate and persist** `PULUMI_CONFIG_PASSPHRASE` to `drconfig.yaml` when required by the template, reusing a new `savePulumiPassphraseToConfig` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94c2bc7aff6c9035a21e7a24d6bd0a5dabd708c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->