### PR TITLE
fix: only persistent flags in viper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,48 @@ When upgrading the Go version in `go.mod`, you may need to update golangci-lint 
 
 The `GOLANGCI_LINT_VERSION` is pinned to ensure reproducible builds across all development environments. The binary is installed as a standalone pre-built artifact, not via `go install`, so version mismatches between your project's Go version and golangci-lint's internal Go version are handled automatically.
 
+## Configuration & Flag Binding
+
+The CLI persists user configuration to `drconfig.yaml` via viper. To prevent
+transient command flags from leaking into the config file, follow these rules.
+For full details, see [docs/development/configuration.md](docs/development/configuration.md).
+
+**Quick reference:**
+
+- **Never call `viper.WriteConfig()` directly.** Use `config.UpdateConfigFile(keys ...string)`,
+  which only writes keys listed in `config.PersistableKeys` (`internal/config/write.go`).
+- **Never call `viper.BindPFlags(cmd.Flags())`.** It bulk-binds every subcommand flag
+  (e.g. `--yes`, `--all`) into `viper.AllSettings()`. Bind only specific persistent
+  flags explicitly in `cmd/root.go::init()`.
+- **Read transient flags directly from cobra**: `cmd.Flags().GetBool("yes")`. Do
+  not bind them with `viper.BindPFlag`.
+- **Env-var override for a transient flag:** register only the env var via
+  `viper.BindEnv(key, "DATAROBOT_CLI_…")` and OR the two sources at the call site:
+  `yesFlag, _ := cmd.Flags().GetBool("yes"); yes := yesFlag || viper.GetBool("yes")`.
+- **To make a key persistable**, add it to `config.PersistableKeys` and have the
+  write site call `config.UpdateConfigFile("my-key")`.
+
+## Configuration & Flag Binding
+
+The CLI persists user configuration to `drconfig.yaml` via viper. To prevent
+transient command flags from leaking into the config file, follow these rules.
+For full details, see [docs/development/configuration.md](docs/development/configuration.md).
+
+**Quick reference:**
+
+- **Never call `viper.WriteConfig()` directly.** Use `config.UpdateConfigFile(keys ...string)`,
+  which only writes keys listed in `config.PersistableKeys` (`internal/config/write.go`).
+- **Never call `viper.BindPFlags(cmd.Flags())`.** It bulk-binds every subcommand flag
+  (e.g. `--yes`, `--all`) into `viper.AllSettings()`. Bind only specific persistent
+  flags explicitly in `cmd/root.go::init()`.
+- **Read transient flags directly from cobra**: `cmd.Flags().GetBool("yes")`. Do
+  not bind them with `viper.BindPFlag`.
+- **Env-var override for a transient flag:** register only the env var via
+  `viper.BindEnv(key, "DATAROBOT_CLI_…")` and OR the two sources at the call site:
+  `yesFlag, _ := cmd.Flags().GetBool("yes"); yes := yesFlag || viper.GetBool("yes")`.
+- **To make a key persistable**, add it to `config.PersistableKeys` and have the
+  write site call `config.UpdateConfigFile("my-key")`.
+
 ## Feature Gates
 
 Feature gates allow commands to be hidden until ready for release. For comprehensive documentation including implementation details, see [docs/development/feature-gates.md](docs/development/feature-gates.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,27 +120,6 @@ For full details, see [docs/development/configuration.md](docs/development/confi
 - **To make a key persistable**, add it to `config.PersistableKeys` and have the
   write site call `config.UpdateConfigFile("my-key")`.
 
-## Configuration & Flag Binding
-
-The CLI persists user configuration to `drconfig.yaml` via viper. To prevent
-transient command flags from leaking into the config file, follow these rules.
-For full details, see [docs/development/configuration.md](docs/development/configuration.md).
-
-**Quick reference:**
-
-- **Never call `viper.WriteConfig()` directly.** Use `config.UpdateConfigFile(keys ...string)`,
-  which only writes keys listed in `config.PersistableKeys` (`internal/config/write.go`).
-- **Never call `viper.BindPFlags(cmd.Flags())`.** It bulk-binds every subcommand flag
-  (e.g. `--yes`, `--all`) into `viper.AllSettings()`. Bind only specific persistent
-  flags explicitly in `cmd/root.go::init()`.
-- **Read transient flags directly from cobra**: `cmd.Flags().GetBool("yes")`. Do
-  not bind them with `viper.BindPFlag`.
-- **Env-var override for a transient flag:** register only the env var via
-  `viper.BindEnv(key, "DATAROBOT_CLI_…")` and OR the two sources at the call site:
-  `yesFlag, _ := cmd.Flags().GetBool("yes"); yes := yesFlag || viper.GetBool("yes")`.
-- **To make a key persistable**, add it to `config.PersistableKeys` and have the
-  write site call `config.UpdateConfigFile("my-key")`.
-
 ## Feature Gates
 
 Feature gates allow commands to be hidden until ready for release. For comprehensive documentation including implementation details, see [docs/development/feature-gates.md](docs/development/feature-gates.md).

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -146,7 +146,12 @@ This wizard will help you:
 		variables, contents := envbuilder.VariablesFromLines(dotenvFileLines)
 
 		showAllPrompts, _ := cmd.Flags().GetBool("all")
-		yes := viper.GetBool("yes")
+		// Read --yes directly from flags rather than viper to avoid the
+		// flag value leaking into viper.AllSettings() (and from there into
+		// drconfig.yaml on writes). The DATAROBOT_CLI_NON_INTERACTIVE
+		// environment variable still flows through viper via BindEnv below.
+		yesFlag, _ := cmd.Flags().GetBool("yes")
+		yes := yesFlag || viper.GetBool("yes")
 
 		needsPulumi, pulumiLoggedIn, needsPassphrase := CheckPulumiSetup(repositoryRoot, variables)
 
@@ -195,8 +200,10 @@ func init() {
 	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for automation).")
 	SetupCmd.MarkFlagsMutuallyExclusive("yes", "all")
 
-	// Bind flag to viper to enable env var support (DATAROBOT_CLI_NON_INTERACTIVE)
-	_ = viper.BindPFlag("yes", SetupCmd.Flags().Lookup("yes"))
+	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper.
+	// The --yes flag itself is read directly from cmd.Flags() in RunE so
+	// that an explicit --yes does not leak into viper.AllSettings() and
+	// get persisted to drconfig.yaml on subsequent config writes.
 	_ = viper.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -204,7 +204,7 @@ func init() {
 
 // initializeConfig initializes the configuration by reading from
 // various sources such as environment variables and config files.
-func initializeConfig(cmd *cobra.Command) error {
+func initializeConfig(_ *cobra.Command) error {
 	var err error
 
 	// Set up Viper to process environment variables
@@ -241,11 +241,12 @@ func initializeConfig(cmd *cobra.Command) error {
 		return fmt.Errorf("Failed to read config file: %w", err)
 	}
 
-	// Bind Cobra flags to Viper
-	err = viper.BindPFlags(cmd.Flags())
-	if err != nil {
-		return err
-	}
+	// NOTE: We deliberately do NOT call viper.BindPFlags(cmd.Flags()) here.
+	// Doing so would slurp every subcommand flag (e.g. --yes, --all,
+	// --if-needed) into viper.AllSettings(), causing transient flags to
+	// leak into drconfig.yaml whenever a write occurs. Persistent flags
+	// that need viper integration are bound explicitly above; subcommand
+	// flags should be read directly via cmd.Flags().GetX(...).
 
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -204,6 +204,8 @@ func init() {
 
 // initializeConfig initializes the configuration by reading from
 // various sources such as environment variables and config files.
+// NOTE: Do not call viper.BindPFlags() here as that will slurp all
+// flags from all subcommands into viper.
 func initializeConfig(_ *cobra.Command) error {
 	var err error
 
@@ -241,12 +243,15 @@ func initializeConfig(_ *cobra.Command) error {
 		return fmt.Errorf("Failed to read config file: %w", err)
 	}
 
-	// NOTE: We deliberately do NOT call viper.BindPFlags(cmd.Flags()) here.
-	// Doing so would slurp every subcommand flag (e.g. --yes, --all,
-	// --if-needed) into viper.AllSettings(), causing transient flags to
-	// leak into drconfig.yaml whenever a write occurs. Persistent flags
-	// that need viper integration are bound explicitly above; subcommand
-	// flags should be read directly via cmd.Flags().GetX(...).
+	// NOTE: We used to call viper.BindPFlags(cmd.Flags()) here.
+	// This caused a problem where ALL flags from ALL subcommands would be
+	// included in viper.AllSettings(), which is used when writing back to
+	// the config file. This meant that transient flags like --yes, --all,
+	// and --if-needed would end up being saved to drconfig.yaml whenever
+	// any command was run that had those flags, which is not desirable.
+	// By not calling BindPFlags here, we ensure that only explicitly bound
+	// persistent flags are included in viper's settings, and subcommand
+	// flags are read directly from cmd.Flags() when needed.
 
 	return nil
 }

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -17,6 +17,7 @@ If you're new to developing the CLI, start here:
 - **[Project structure](structure.md)**&mdash;understand the codebase organization, command structure, internal packages, and key design patterns.
 - **[Building](building.md)**&mdash;detailed guide on building the CLI, available tasks, and build configuration.
 - **[Authentication](authentication.md)**&mdash;learn about the OAuth authentication implementation, token management, and API integration.
+- **[Configuration](configuration.md)**&mdash;how viper, `drconfig.yaml`, flags, and env vars compose; rules for adding new flags or persisted keys.
 
 ### Advanced topics
 

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -113,8 +113,17 @@ You can still manually run `dr auth login` to refresh credentials or change acco
 
 ## Internal APIs
 
-The auth package writes configuration through Viper.
+The auth package writes configuration through the allowlisted writer in
+`internal/config` (`config.UpdateConfigFile`). It does **not** call
+`viper.WriteConfig()` directly, because that would serialize every key in
+`viper.AllSettings()`&mdash;including transient flags such as `--yes`&mdash;
+into `drconfig.yaml`. See [Configuration](configuration.md) for the full
+contract.
 
-- `WriteConfigFileSilent()`&mdash;writes the config file and returns an error.
-- `WriteConfigFile()`&mdash;writes the config file, prints a success message, and returns an error.
-- `SetURLAction()`&mdash;prompts for a DataRobot URL, optionally overwrites an existing value, and returns a boolean indicating whether the URL changed.
+- `WriteConfigFileSilent()`&mdash;writes only allowlisted keys
+  (`config.PersistableKeys`) back to `drconfig.yaml` and returns an error.
+- `WriteConfigFile()`&mdash;writes the config file, prints a success
+  message, and returns an error.
+- `SetURLAction()`&mdash;prompts for a DataRobot URL, optionally
+  overwrites an existing value, and returns a boolean indicating whether
+  the URL changed.

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -1,0 +1,155 @@
+# Configuration & viper integration
+
+This guide covers how the CLI loads, reads, and writes its persistent
+configuration (`drconfig.yaml`), and the rules contributors must follow when
+adding new flags or persisted config keys.
+
+## Table of contents
+
+- [Where config lives](#where-config-lives)
+- [How values reach viper](#how-values-reach-viper)
+- [Writing back to drconfig.yaml](#writing-back-to-drconfigyaml)
+- [Rules for new flags](#rules-for-new-flags)
+- [Rules for new env vars](#rules-for-new-env-vars)
+- [Rules for new persisted keys](#rules-for-new-persisted-keys)
+- [Common pitfalls](#common-pitfalls)
+
+## Where config lives
+
+The CLI stores user configuration in a single YAML file:
+
+- Default location: `$XDG_CONFIG_HOME/datarobot/drconfig.yaml`
+  (falls back to `~/.config/datarobot/drconfig.yaml`)
+- Override with `--config <path>` or `DATAROBOT_CLI_CONFIG=<path>`
+
+Today this file holds connection credentials and a small set of sticky CLI
+preferences. It is **not** a dumping ground for transient flag state.
+
+## How values reach viper
+
+Viper resolves a key from these sources in priority order:
+
+1. Explicit `viper.Set(key, value)` call (e.g. after a successful login)
+2. Flag bound via `viper.BindPFlag(key, flag)` (only persistent root flags
+   today &mdash; see below)
+3. Environment variable bound via `viper.BindEnv(key, "DATAROBOT_…")`
+   or auto-mapped via `viper.SetEnvPrefix("DATAROBOT_CLI")`
+4. Value loaded from `drconfig.yaml`
+5. Default registered via `viper.SetDefault`
+
+### Persistent root flags bound to viper
+
+Only the persistent root flags listed in `cmd/root.go::init()` are bound
+explicitly to viper. We **do not** call `viper.BindPFlags(cmd.Flags())`
+because that would slurp every subcommand flag (such as `--yes`,
+`--if-needed`) into `viper.AllSettings()` and risk leaking transient flag
+state into `drconfig.yaml`.
+
+### Subcommand flags
+
+Read subcommand flag values directly from cobra:
+
+```go
+yesFlag, _ := cmd.Flags().GetBool("yes")
+```
+
+If a subcommand flag also needs an environment variable override, register
+the env var only with `viper.BindEnv(...)` and merge the two sources
+explicitly in your handler:
+
+```go
+// cmd/dotenv/cmd.go
+_ = viper.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+
+// In RunE:
+yesFlag, _ := cmd.Flags().GetBool("yes")
+yes := yesFlag || viper.GetBool("yes")
+```
+
+This keeps the explicit `--yes` flag value out of `viper.AllSettings()`
+while preserving env-var support.
+
+## Writing back to drconfig.yaml
+
+Never call `viper.WriteConfig()` directly. Use the allowlisted writer in
+`internal/config`:
+
+```go
+// Write all allowlisted keys that are currently set in viper:
+config.UpdateConfigFile()
+
+// Or write only specific keys (recommended when the call site knows
+// exactly what changed):
+config.UpdateConfigFile(config.DataRobotURL)
+config.UpdateConfigFile(config.DataRobotAPIKey, config.DataRobotURL)
+```
+
+`UpdateConfigFile` reads the existing YAML, overlays only the allowlisted
+keys (`config.PersistableKeys`), and writes the result back. Any other
+viper state &mdash; including transient flags such as `--yes`, `--verbose`,
+`--debug` &mdash; is intentionally dropped.
+
+The wrappers in the auth package (`auth.WriteConfigFileSilent`,
+`auth.WriteConfigFile`) call this writer under the hood.
+
+## Rules for new flags
+
+When adding a new flag, decide which category it falls into:
+
+| Category | Bind to viper? | Persist to drconfig.yaml? |
+| --- | --- | --- |
+| Transient (per-invocation, e.g. `--yes`, `--all`) | No | No |
+| Sticky preference (e.g. `--external-editor`) | Yes (root only) | Yes &mdash; add to `PersistableKeys` |
+| Connection credential (e.g. `--token`) | Yes | Yes |
+
+For transient flags:
+
+- Define with `cmd.Flags().Bool(...)`
+- Read with `cmd.Flags().GetBool(...)`
+- Do **not** call `viper.BindPFlag(...)`
+
+## Rules for new env vars
+
+`viper.AutomaticEnv()` with prefix `DATAROBOT_CLI` is enabled in
+`initializeConfig`, so any key you `viper.Get` will already check
+`DATAROBOT_CLI_<KEY>` (with `-` replaced by `_`).
+
+For env vars that should map to a different name (e.g.
+`DATAROBOT_CLI_NON_INTERACTIVE` → key `yes`), use `viper.BindEnv` and read
+the merged value as shown in [Subcommand flags](#subcommand-flags).
+
+## Rules for new persisted keys
+
+To make a key writable to `drconfig.yaml`:
+
+1. Add the key to `PersistableKeys` in `internal/config/write.go`
+2. Update its production write call sites to pass the key explicitly:
+   `config.UpdateConfigFile("my-new-key")`
+3. Add a regression test under `internal/auth/writeConfig_test.go` (or a
+   dedicated test file) verifying the key round-trips correctly and that
+   transient flags still do not leak.
+
+Use viper dotted-path notation if the value is nested, e.g.
+`"pulumi.config.passphrase"`. The writer handles nested map creation.
+
+## Common pitfalls
+
+- **Don't call `viper.WriteConfig()`** &mdash; it serializes
+  `viper.AllSettings()`, which includes any flag that has ever been bound.
+  Use `config.UpdateConfigFile(...)` instead.
+- **Don't add `viper.BindPFlags(cmd.Flags())` anywhere.** It bulk-binds
+  every flag including transient ones. Bind only the specific persistent
+  flags you mean to expose via viper.
+- **Don't read transient flags through viper.** `viper.GetBool("yes")`
+  hides whether the value came from a flag, an env var, or a stale
+  drconfig entry. Read flags directly from cobra and merge in env vars
+  explicitly.
+- **Don't write to `drconfig.yaml` from tests** without `viper.Reset()`
+  and a temp `XDG_CONFIG_HOME`. See `internal/auth/writeConfig_test.go`
+  for the recommended test pattern.
+
+## See also
+
+- [Flag development guide](flags.md)
+- [Authentication flow](authentication.md)
+- [User configuration guide](../user-guide/configuration.md)

--- a/docs/development/flags.md
+++ b/docs/development/flags.md
@@ -212,7 +212,36 @@ cmd.MarkFlagsMutuallyExclusive("from-file", "release-date")
    dr mycommand --flag1
    ```
 
+## Viper binding rules
+
+The CLI deliberately limits which flags are bound to viper. Subcommand
+flags (such as `--yes`, `--all`, `--if-needed`) **must not** be bound via
+`viper.BindPFlag`, and `cmd/root.go` does not call
+`viper.BindPFlags(cmd.Flags())` for the same reason: doing so would slurp
+those flag values into `viper.AllSettings()` and risk persisting them to
+`drconfig.yaml` on the next config write.
+
+Quick rules for new flags:
+
+- **Transient flags** (per-invocation): read directly via
+  `cmd.Flags().GetBool(...)`. Do not bind to viper.
+- **Env-var override needed?** Register only the env var with
+  `viper.BindEnv(key, "DATAROBOT_CLI_…")` and OR the two sources in your
+  handler:
+
+  ```go
+  yesFlag, _ := cmd.Flags().GetBool("yes")
+  yes := yesFlag || viper.GetBool("yes")
+  ```
+
+- **Sticky CLI preferences** (rare): bind to viper *and* add the key to
+  `config.PersistableKeys` in `internal/config/write.go`.
+
+For full details and test patterns, see the
+[Configuration guide](configuration.md).
+
 ## See also
 
 - [Cobra documentation](https://cobra.dev/)
 - [Building guide](building.md) — General development setup and standards
+- [Configuration guide](configuration.md) — viper, drconfig.yaml, and persisted keys


### PR DESCRIPTION
# RATIONALE

@victorborshak raised the alarm on the fact that Viper writes out all configuration properties to `drconfig.yaml` anytime `viper.WriteConfig()` is invoked. This is the documented behavior for the function, but not what we actually want. We are seeing things like `--yes` get written into drconfig.yaml.

When it comes down to it, we only want a few flags to be persisted.

## CHANGES

- in the root cmd, remove `BindPFlags()`. This is what was binding every single flag to viper. I *think* we added this in just to make it easy to configure everything, but I haven't seen proper use cases for this yet. We already explicitly bind PersistentFlags (as defined in `RootCmd.PersistentFlags`), which are the ones we really care about anyway.

- initializeConfig() now only wires up DATAROBOT_CLI_ env vars, as well as explicit, legacy env vars, as well as the config file. We do NOT call viper.BindPFlags anymore.

- factory.ai - generated dev docs

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
