### PR TITLE
feat: when viper writes to drconfig, allowlist certain fields

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,7 @@ linters:
     - dupword
     - errname
     - exhaustive
+    - forbidigo
     - loggercheck
     - misspell
     - nestif
@@ -23,6 +24,25 @@ linters:
     - usestdlibvars
     - wsl_v5
   settings:
+    forbidigo:
+      analyze-types: true
+      forbid:
+        - pattern: ^viper\.WriteConfig$
+          msg: >-
+            Do not call viper.WriteConfig() directly. Use config.UpdateConfigFile(...)
+            so that only allowlisted keys (config.PersistableKeys) are written to
+            drconfig.yaml. Direct calls leak transient flags such as --yes into the
+            config file. See docs/development/configuration.md.
+        - pattern: ^viper\.SafeWriteConfig$
+          msg: >-
+            Do not call viper.SafeWriteConfig() directly. Use config.UpdateConfigFile(...)
+            instead. See docs/development/configuration.md.
+        - pattern: ^viper\.BindPFlags$
+          msg: >-
+            Do not bulk-bind subcommand flags via viper.BindPFlags. Bind specific
+            persistent flags individually with viper.BindPFlag in cmd/root.go::init(),
+            and read subcommand flag values directly via cmd.Flags().GetX(...).
+            See docs/development/configuration.md.
     revive:
       rules:
         # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#error-strings
@@ -53,6 +73,25 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      # The allowlisted writer is the single legitimate caller of
+      # viper.WriteConfig (used to flush the curated key set to disk).
+      - path: internal/config/write\.go
+        linters:
+          - forbidigo
+      # cmd/root.go is the one place that may bind persistent root flags
+      # via viper.BindPFlags during the Option E migration window. Once
+      # Option E lands and only viper.BindPFlag is used, this exclusion
+      # can be removed.
+      - path: cmd/root\.go
+        linters:
+          - forbidigo
+      # Tests are allowed to call viper.WriteConfig / SafeWriteConfig as
+      # fixture setup to seed drconfig.yaml on disk before exercising the
+      # production write path.
+      - path: _test\.go
+        linters:
+          - forbidigo
     paths:
       - third_party$
       - builtin$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -80,9 +80,8 @@ linters:
         linters:
           - forbidigo
       # cmd/root.go is the one place that may bind persistent root flags
-      # via viper.BindPFlags during the Option E migration window. Once
-      # Option E lands and only viper.BindPFlag is used, this exclusion
-      # can be removed.
+      # via viper.BindPFlags. TODO Remove this exclusion if we completely
+      # disallow viper.BindPFlags.
       - path: cmd/root\.go
         linters:
           - forbidigo

--- a/cmd/dotenv/pulumiModel.go
+++ b/cmd/dotenv/pulumiModel.go
@@ -240,13 +240,9 @@ func (m pulumiLoginModel) handlePassphraseAccepted() (tea.Model, tea.Cmd) {
 }
 
 func (m pulumiLoginModel) savePassphraseToConfig() error {
-	if err := config.CreateConfigFileDirIfNotExists(); err != nil {
-		return fmt.Errorf("failed to create config: %w", err)
-	}
-
 	viper.Set(pulumiConfigPassphraseKey, m.generatedPassphrase)
 
-	if err := viper.WriteConfig(); err != nil {
+	if err := config.UpdateConfigFile(pulumiConfigPassphraseKey); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
 	}
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -256,12 +256,9 @@ func WaitForAPIKeyCallback(ctx context.Context, datarobotHost string) (string, e
 }
 
 func WriteConfigFileSilent() error {
-	// Ensure the config directory and file exist before writing the config file
-	if err := config.CreateConfigFileDirIfNotExists(); err != nil {
-		return err
-	}
-
-	err := viper.WriteConfig()
+	// Only persist allowlisted keys (see config.PersistableKeys). This avoids
+	// writing transient flags such as --yes back to drconfig.yaml.
+	err := config.UpdateConfigFile()
 	if err != nil {
 		log.Error(err)
 		return err

--- a/internal/auth/writeConfig_test.go
+++ b/internal/auth/writeConfig_test.go
@@ -166,7 +166,7 @@ func TestWriteConfigFileSilent_PreservesExtraFields(t *testing.T) {
 	assert.Equal(t, 42, viper.GetInt("another_field"))
 }
 
-func TestWriteConfigFileSilent_FailsWhenMultipleFieldsChanged(t *testing.T) {
+func TestWriteConfigFileSilent_OnlyAllowlistedFieldsWritten(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "auth-test-*")
 	require.NoError(t, err)
 
@@ -220,14 +220,71 @@ func TestWriteConfigFileSilent_FailsWhenMultipleFieldsChanged(t *testing.T) {
 	err = yaml.Unmarshal(rawYaml, &configMap)
 	require.NoError(t, err)
 
-	// This test verifies that WriteConfigFileSilent DOES write all changes
-	// (not just the token), which means the caller must be careful to only
-	// modify the token field before calling it
+	// Allowlisted keys (endpoint, token) ARE written.
+	assert.Equal(t, "new-token", configMap["token"],
+		"Allowlisted token field should be written")
 	assert.NotEqual(t, initialConfig["endpoint"], configMap["endpoint"],
-		"When endpoint is modified in viper, it IS written to the file")
-	assert.Contains(t, configMap, "extra_field",
-		"When extra fields are added to viper, they ARE written to the file")
+		"Allowlisted endpoint field should be written")
 
-	// This test demonstrates that the responsibility for maintaining config
-	// integrity lies with the caller, not with WriteConfigFileSilent
+	// Non-allowlisted keys (extra_field) are NOT written, even if set in viper.
+	assert.NotContains(t, configMap, "extra_field",
+		"Non-allowlisted fields must not leak into drconfig.yaml")
+}
+
+func TestWriteConfigFileSilent_TransientFlagsNotPersisted(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "auth-test-*")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(tempDir)
+
+	testutil.SetTestHomeDir(t, tempDir)
+
+	viper.Reset()
+
+	defer viper.Reset()
+
+	err = config.CreateConfigFileDirIfNotExists()
+	require.NoError(t, err)
+
+	configDir := filepath.Join(tempDir, ".config", "datarobot")
+	configFile := filepath.Join(configDir, "drconfig.yaml")
+
+	initialConfig := map[string]interface{}{
+		"endpoint": "https://app.datarobot.com/api/v2",
+		"token":    "original-token-12345",
+	}
+
+	initialYaml, err := yaml.Marshal(initialConfig)
+	require.NoError(t, err)
+
+	err = os.WriteFile(configFile, initialYaml, 0o644)
+	require.NoError(t, err)
+
+	err = config.ReadConfigFile("")
+	require.NoError(t, err)
+
+	// Simulate transient command flags being bound to viper.
+	viper.Set("yes", true)
+	viper.Set("verbose", true)
+	viper.Set("force-interactive", true)
+	viper.Set("debug", true)
+
+	// Also legitimately update an allowlisted key.
+	viper.Set("token", "new-token-after-flags")
+
+	_ = WriteConfigFileSilent()
+
+	rawYaml, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+
+	var configMap map[string]interface{}
+
+	err = yaml.Unmarshal(rawYaml, &configMap)
+	require.NoError(t, err)
+
+	assert.Equal(t, "new-token-after-flags", configMap["token"])
+	assert.NotContains(t, configMap, "yes")
+	assert.NotContains(t, configMap, "verbose")
+	assert.NotContains(t, configMap, "force-interactive")
+	assert.NotContains(t, configMap, "debug")
 }

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -142,12 +142,12 @@ func SaveURLToConfig(newURL string) error {
 		viper.Set(DataRobotURL, "")
 		viper.Set(DataRobotAPIKey, "")
 
-		return viper.WriteConfig()
+		return UpdateConfigFile(DataRobotURL, DataRobotAPIKey)
 	}
 
 	viper.Set(DataRobotURL, newURL+DRAPIURLSuffix)
 
-	return viper.WriteConfig()
+	return UpdateConfigFile(DataRobotURL)
 }
 
 // SetURLToConfig is a helper function that sets the DataRobot URL with the DRAPIURLSuffix in the config object.

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -1,0 +1,174 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+// PersistableKeys is the allowlist of viper keys that may be written back to
+// drconfig.yaml. Any key not in this set is intentionally NOT persisted, even
+// if it is currently set in the live viper config (e.g. transient flags such
+// as --yes, --verbose, --force-interactive).
+//
+// To add a new persistable key, add it here. Keys may use viper dotted-path
+// notation (e.g. "pulumi.config.passphrase") for nested values, but the
+// current callers all use flat top-level keys.
+var PersistableKeys = map[string]struct{}{
+	DataRobotURL:               {},
+	DataRobotAPIKey:            {},
+	APIConsumerTrackingEnabled: {},
+	"ssl_verify":               {},
+	"pulumi_config_passphrase": {},
+}
+
+// UpdateConfigFile writes only the allowlisted keys from viper back to the
+// drconfig.yaml file on disk, preserving any other fields that already exist
+// in the file but are not currently tracked by viper.
+//
+// This replaces direct calls to viper.WriteConfig(), which would otherwise
+// serialize the entire viper.AllSettings() map -- including transient command
+// flags such as --yes that should never be persisted.
+//
+// The keys argument optionally restricts the write to a subset of the
+// allowlist. If keys is empty, all allowlisted keys currently set in viper
+// are written. Any key passed in that is not in the allowlist is ignored.
+func UpdateConfigFile(keys ...string) error {
+	if err := CreateConfigFileDirIfNotExists(); err != nil {
+		return err
+	}
+
+	configFile, err := resolveConfigFilePath()
+	if err != nil {
+		return err
+	}
+
+	existing, err := readYAMLFile(configFile)
+	if err != nil {
+		return err
+	}
+
+	applyAllowedKeys(existing, keys)
+
+	out, err := yaml.Marshal(existing)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(configFile, out, 0o600); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	return nil
+}
+
+// resolveConfigFilePath returns the active drconfig.yaml path, falling back
+// to the default location if viper has not yet recorded a config file used.
+func resolveConfigFilePath() (string, error) {
+	if configFile := viper.ConfigFileUsed(); configFile != "" {
+		return configFile, nil
+	}
+
+	dir, err := GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, configFileName), nil
+}
+
+// applyAllowedKeys overlays values from viper onto target for each key in
+// the allowlist. If keys is empty, all keys in PersistableKeys are
+// considered. Keys not in PersistableKeys are silently ignored.
+func applyAllowedKeys(target map[string]interface{}, keys []string) {
+	candidates := keys
+	if len(candidates) == 0 {
+		candidates = make([]string, 0, len(PersistableKeys))
+
+		for k := range PersistableKeys {
+			candidates = append(candidates, k)
+		}
+	}
+
+	for _, key := range candidates {
+		if _, ok := PersistableKeys[key]; !ok {
+			continue
+		}
+
+		if !viper.IsSet(key) {
+			continue
+		}
+
+		setNestedKey(target, key, viper.Get(key))
+	}
+}
+
+// readYAMLFile reads a YAML file into a generic map. If the file does not
+// exist or is empty, an empty map is returned.
+func readYAMLFile(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]interface{}{}, nil
+		}
+
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	if len(data) == 0 {
+		return map[string]interface{}{}, nil
+	}
+
+	out := map[string]interface{}{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	if out == nil {
+		out = map[string]interface{}{}
+	}
+
+	return out, nil
+}
+
+// setNestedKey sets a value at a dotted-path key in a nested map, creating
+// intermediate maps as needed. Keys without dots are set at the top level.
+func setNestedKey(m map[string]interface{}, key string, value interface{}) {
+	parts := strings.Split(key, ".")
+
+	cur := m
+
+	for i, p := range parts {
+		if i == len(parts)-1 {
+			cur[p] = value
+			return
+		}
+
+		next, ok := cur[p].(map[string]interface{})
+		if !ok {
+			next = map[string]interface{}{}
+			cur[p] = next
+		}
+
+		cur = next
+	}
+}


### PR DESCRIPTION
# RATIONALE

We only want viper to write certain configuration properties to drconfig.yaml when `WriteConfig()` and `SafeWriteConfig()` are invoked. `--yes` is not one of them.

I think the ideal way to handle this would be to use separate viper instances to separate reading and writing of drconfig.yaml, but that is a larger refactor that needs more discussion and thought. This seems like a simpler way of handling things for now, with a bit of a hack.

## CHANGES

1. Create a new `internal/config/viperx` module that wraps a viper instance.
2. This module exports a subset of the viper interface that is currently, actually used.
3. swap all imports of `github.com/spf13/viper` with `internal/config/viperx`.
4. Adds [depguard](https://github.com/OpenPeeDeeP/depguard) as a dependency.
5. Creates `depguard` rule that denies use of `github.com/spf13/viper` package outside of `internal/config/**`.

## TESTING

The new depguard linter rule looks like this in practice:

```
╰─ ❌201 ❯ task lint
🧹 Checking go.mod…
🧹 Checking formatting…
🧹 Vetting…
🧹 Linting…
cmd/root.go:44:2: import 'github.com/spf13/viper' is not allowed from list 'no-raw-viper': Import internal/config/viperx instead of github.com/spf13/viper. The wrapper omits WriteConfig, SafeWriteConfig, and BindPFlags by design so transient flag state cannot leak into drconfig.yaml. See docs/development/configuration.md. (depguard)
        "github.com/spf13/viper"
        ^
cmd/root.go:146:18: Error return value of `viper.BindPFlags` is not checked (errcheck)
        viper.BindPFlags(RootCmd.PersistentFlags())
                        ^
2 issues:
* depguard: 1
* errcheck: 1
task: Failed to run task "lint": exit status 1
```

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
