### PR TITLE
feat: wrap viper to narrow the usable interface; allowlist only certain fields during writes

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,10 +7,10 @@ linters:
     - bodyclose
     - contextcheck
     - cyclop
+    - depguard
     - dupword
     - errname
     - exhaustive
-    - forbidigo
     - loggercheck
     - misspell
     - nestif
@@ -24,25 +24,24 @@ linters:
     - usestdlibvars
     - wsl_v5
   settings:
-    forbidigo:
-      analyze-types: true
-      forbid:
-        - pattern: ^viper\.WriteConfig$
-          msg: >-
-            Do not call viper.WriteConfig() directly. Use config.UpdateConfigFile(...)
-            so that only allowlisted keys (config.PersistableKeys) are written to
-            drconfig.yaml. Direct calls leak transient flags such as --yes into the
-            config file. See docs/development/configuration.md.
-        - pattern: ^viper\.SafeWriteConfig$
-          msg: >-
-            Do not call viper.SafeWriteConfig() directly. Use config.UpdateConfigFile(...)
-            instead. See docs/development/configuration.md.
-        - pattern: ^viper\.BindPFlags$
-          msg: >-
-            Do not bulk-bind subcommand flags via viper.BindPFlags. Bind specific
-            persistent flags individually with viper.BindPFlag in cmd/root.go::init(),
-            and read subcommand flag values directly via cmd.Flags().GetX(...).
-            See docs/development/configuration.md.
+    depguard:
+      rules:
+        no-raw-viper:
+          # Production and test code outside internal/config/** must not
+          # import viper directly. Use internal/config/viperx instead,
+          # which exposes only the safe subset of viper's API (no
+          # WriteConfig / SafeWriteConfig / BindPFlags). See
+          # docs/development/configuration.md for the full contract.
+          list-mode: lax
+          files:
+            - "!**/internal/config/**"
+          deny:
+            - pkg: github.com/spf13/viper
+              desc: >-
+                Import internal/config/viperx instead of github.com/spf13/viper.
+                The wrapper omits WriteConfig, SafeWriteConfig, and BindPFlags
+                by design so transient flag state cannot leak into
+                drconfig.yaml. See docs/development/configuration.md.
     revive:
       rules:
         # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#error-strings
@@ -73,24 +72,6 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-    rules:
-      # The allowlisted writer is the single legitimate caller of
-      # viper.WriteConfig (used to flush the curated key set to disk).
-      - path: internal/config/write\.go
-        linters:
-          - forbidigo
-      # cmd/root.go is the one place that may bind persistent root flags
-      # via viper.BindPFlags. TODO Remove this exclusion if we completely
-      # disallow viper.BindPFlags.
-      - path: cmd/root\.go
-        linters:
-          - forbidigo
-      # Tests are allowed to call viper.WriteConfig / SafeWriteConfig as
-      # fixture setup to seed drconfig.yaml on disk before exercising the
-      # production write path.
-      - path: _test\.go
-        linters:
-          - forbidigo
     paths:
       - third_party$
       - builtin$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,7 @@ linters:
     - dupword
     - errname
     - exhaustive
+    - forbidigo
     - loggercheck
     - misspell
     - nestif
@@ -23,6 +24,25 @@ linters:
     - usestdlibvars
     - wsl_v5
   settings:
+    forbidigo:
+      analyze-types: true
+      forbid:
+        - pattern: ^viper\.WriteConfig$
+          msg: >-
+            Do not call viper.WriteConfig() directly. Use config.UpdateConfigFile(...)
+            so that only allowlisted keys (config.PersistableKeys) are written to
+            drconfig.yaml. Direct calls leak transient flags such as --yes into the
+            config file. See docs/development/configuration.md.
+        - pattern: ^viper\.SafeWriteConfig$
+          msg: >-
+            Do not call viper.SafeWriteConfig() directly. Use config.UpdateConfigFile(...)
+            instead. See docs/development/configuration.md.
+        - pattern: ^viper\.BindPFlags$
+          msg: >-
+            Do not bulk-bind subcommand flags via viper.BindPFlags. Bind specific
+            persistent flags individually with viper.BindPFlag in cmd/root.go::init(),
+            and read subcommand flag values directly via cmd.Flags().GetX(...).
+            See docs/development/configuration.md.
     revive:
       rules:
         # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#error-strings
@@ -53,6 +73,25 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      # The allowlisted writer is the single legitimate caller of
+      # viper.WriteConfig (used to flush the curated key set to disk).
+      - path: internal/config/write\.go
+        linters:
+          - forbidigo
+      # cmd/root.go is the one place that may bind persistent root flags
+      # via viper.BindPFlags during the Option E migration window. Once
+      # Option E lands and only viper.BindPFlag is used, this exclusion
+      # can be removed.
+      - path: cmd/root\.go
+        linters:
+          - forbidigo
+      # Tests are allowed to call viper.WriteConfig / SafeWriteConfig as
+      # fixture setup to seed drconfig.yaml on disk before exercising the
+      # production write path.
+      - path: _test\.go
+        linters:
+          - forbidigo
     paths:
       - third_party$
       - builtin$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -80,9 +80,8 @@ linters:
         linters:
           - forbidigo
       # cmd/root.go is the one place that may bind persistent root flags
-      # via viper.BindPFlags during the Option E migration window. Once
-      # Option E lands and only viper.BindPFlag is used, this exclusion
-      # can be removed.
+      # via viper.BindPFlags. TODO Remove this exclusion if we completely
+      # disallow viper.BindPFlags.
       - path: cmd/root\.go
         linters:
           - forbidigo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,54 @@ When upgrading the Go version in `go.mod`, you may need to update golangci-lint 
 
 The `GOLANGCI_LINT_VERSION` is pinned to ensure reproducible builds across all development environments. The binary is installed as a standalone pre-built artifact, not via `go install`, so version mismatches between your project's Go version and golangci-lint's internal Go version are handled automatically.
 
+## Configuration & Flag Binding
+
+The CLI persists user configuration to `drconfig.yaml` via viper. To prevent
+transient command flags from leaking into the config file, follow these rules.
+For full details, see [docs/development/configuration.md](docs/development/configuration.md).
+
+**Quick reference:**
+
+- **Outside `internal/config/`, do not import `github.com/spf13/viper` directly.**
+  Use `internal/config/viperx`. Direct imports are blocked by `depguard`.
+- **Never call `viper.WriteConfig()` directly** (and `viperx` does not expose it).
+  Use `config.UpdateConfigFile(keys ...string)`, which only writes keys listed
+  in `config.PersistableKeys` (`internal/config/write.go`).
+- **Never bulk-bind subcommand flags to viper.** `viperx` does not expose
+  `BindPFlags`. Bind only specific persistent flags explicitly via
+  `viperx.BindPFlag` in `cmd/root.go::init()`.
+- **Read transient flags directly from cobra**: `cmd.Flags().GetBool("yes")`.
+  Do not bind them with `viperx.BindPFlag`.
+- **Env-var override for a transient flag:** register only the env var via
+  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and OR the two sources at the call site:
+  `yesFlag, _ := cmd.Flags().GetBool("yes"); yes := yesFlag || viperx.GetBool("yes")`.
+- **To make a key persistable**, add it to `config.PersistableKeys` and have the
+  write site call `config.UpdateConfigFile("my-key")`.
+
+## Configuration & Flag Binding
+
+The CLI persists user configuration to `drconfig.yaml` via viper. To prevent
+transient command flags from leaking into the config file, follow these rules.
+For full details, see [docs/development/configuration.md](docs/development/configuration.md).
+
+**Quick reference:**
+
+- **Outside `internal/config/`, do not import `github.com/spf13/viper` directly.**
+  Use `internal/config/viperx`. Direct imports are blocked by `depguard`.
+- **Never call `viper.WriteConfig()` directly** (and `viperx` does not expose it).
+  Use `config.UpdateConfigFile(keys ...string)`, which only writes keys listed
+  in `config.PersistableKeys` (`internal/config/write.go`).
+- **Never bulk-bind subcommand flags to viper.** `viperx` does not expose
+  `BindPFlags`. Bind only specific persistent flags explicitly via
+  `viperx.BindPFlag` in `cmd/root.go::init()`.
+- **Read transient flags directly from cobra**: `cmd.Flags().GetBool("yes")`.
+  Do not bind them with `viperx.BindPFlag`.
+- **Env-var override for a transient flag:** register only the env var via
+  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and OR the two sources at the call site:
+  `yesFlag, _ := cmd.Flags().GetBool("yes"); yes := yesFlag || viperx.GetBool("yes")`.
+- **To make a key persistable**, add it to `config.PersistableKeys` and have the
+  write site call `config.UpdateConfigFile("my-key")`.
+
 ## Feature Gates
 
 Feature gates allow commands to be hidden until ready for release. For comprehensive documentation including implementation details, see [docs/development/feature-gates.md](docs/development/feature-gates.md).

--- a/cmd/auth/login/cmd.go
+++ b/cmd/auth/login/cmd.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/spf13/cobra"
-	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop

--- a/cmd/auth/login/cmd.go
+++ b/cmd/auth/login/cmd.go
@@ -24,14 +24,14 @@ import (
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop
 	// short-circuit if skip_auth is enabled. This allows users to avoid login prompts
 	// when authentication is intentionally disabled, say if the user is offline, or in
 	// a CI/CD environment, or in a script.
-	if viper.GetBool("skip_auth") {
+	if viperx.GetBool("skip_auth") {
 		err := errors.New("Login has been disabled via the '--skip-auth' flag.")
 		log.Error(err)
 
@@ -76,7 +76,7 @@ func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop
 	log.Info("💡 To change your DataRobot URL, run 'dr auth set-url'.")
 
 	// Clear existing token and get new one
-	viper.Set(config.DataRobotAPIKey, "")
+	viperx.Set(config.DataRobotAPIKey, "")
 
 	key, err := auth.WaitForAPIKeyCallback(cmd.Context(), datarobotHost)
 	if err != nil {
@@ -91,7 +91,7 @@ func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop
 		return nil
 	}
 
-	viper.Set(config.DataRobotAPIKey, strings.ReplaceAll(key, "\n", ""))
+	viperx.Set(config.DataRobotAPIKey, strings.ReplaceAll(key, "\n", ""))
 
 	err = auth.WriteConfigFile()
 	if err != nil {

--- a/cmd/auth/logout/cmd.go
+++ b/cmd/auth/logout/cmd.go
@@ -21,11 +21,11 @@ import (
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 func Run(_ *cobra.Command, _ []string) {
-	viper.Set(config.DataRobotAPIKey, "")
+	viperx.Set(config.DataRobotAPIKey, "")
 
 	err := auth.WriteConfigFile()
 	if err != nil {

--- a/cmd/auth/logout/cmd.go
+++ b/cmd/auth/logout/cmd.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/spf13/cobra"
-	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 func Run(_ *cobra.Command, _ []string) {

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -28,7 +28,7 @@ import (
 	"github.com/datarobot/cli/internal/state"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 func Cmd() *cobra.Command {
@@ -146,7 +146,13 @@ This wizard will help you:
 		variables, contents := envbuilder.VariablesFromLines(dotenvFileLines)
 
 		showAllPrompts, _ := cmd.Flags().GetBool("all")
-		yes := viper.GetBool("yes")
+		// Read --yes directly from flags rather than through viper to
+		// avoid the flag value leaking into viper.AllSettings() (and from
+		// there into drconfig.yaml on subsequent writes). The
+		// DATAROBOT_CLI_NON_INTERACTIVE environment variable still flows
+		// through viper via BindEnv below.
+		yesFlag, _ := cmd.Flags().GetBool("yes")
+		yes := yesFlag || viperx.GetBool("yes")
 
 		needsPulumi, pulumiLoggedIn, needsPassphrase := CheckPulumiSetup(repositoryRoot, variables)
 
@@ -195,9 +201,11 @@ func init() {
 	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for automation).")
 	SetupCmd.MarkFlagsMutuallyExclusive("yes", "all")
 
-	// Bind flag to viper to enable env var support (DATAROBOT_CLI_NON_INTERACTIVE)
-	_ = viper.BindPFlag("yes", SetupCmd.Flags().Lookup("yes"))
-	_ = viper.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper.
+	// The --yes flag itself is read directly from cmd.Flags() in RunE so
+	// that an explicit --yes does not leak into viper.AllSettings() and
+	// get persisted to drconfig.yaml on subsequent config writes.
+	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 }
 
 // shouldSkipSetup checks if setup should be skipped when --if-needed flag is set.

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -22,13 +22,13 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/envbuilder"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/internal/state"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
-	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 func Cmd() *cobra.Command {

--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/envbuilder"
 	"github.com/datarobot/cli/tui"
-	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 const (

--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -25,7 +25,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/internal/envbuilder"
 	"github.com/datarobot/cli/tui"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 const (
@@ -118,7 +118,7 @@ func (m Model) externalEditorCmd() *exec.Cmd {
 	// TODO we may want to refactor this in the future to
 	// use a separate viper instance for better testability
 	// rather than the global one.
-	editor := viper.GetString("external-editor")
+	editor := viperx.GetString("external-editor")
 
 	return exec.Command(editor, m.DotenvFile)
 }
@@ -517,7 +517,7 @@ func (m Model) View() string {
 }
 
 func (m Model) viewListScreen() string {
-	editor := viper.GetString("external-editor")
+	editor := viperx.GetString("external-editor")
 
 	var sb strings.Builder
 

--- a/cmd/dotenv/model_test.go
+++ b/cmd/dotenv/model_test.go
@@ -24,8 +24,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
-	"github.com/datarobot/cli/internal/envbuilder"
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/envbuilder"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/cmd/dotenv/model_test.go
+++ b/cmd/dotenv/model_test.go
@@ -25,7 +25,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/datarobot/cli/internal/envbuilder"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -104,7 +104,7 @@ type DotenvModelTestSuite struct {
 
 func (suite *DotenvModelTestSuite) SetupTest() {
 	// Reset viper to prevent user's drconfig.yaml values from leaking into tests.
-	viper.Reset()
+	viperx.Reset()
 
 	dir, _ := os.MkdirTemp("", "datarobot-config-test")
 	suite.tempDir = dir
@@ -389,7 +389,7 @@ func (suite *DotenvModelTestSuite) Test__externalEditorCmd() {
 	suite.T().Setenv("VISUAL", "nano")
 	suite.T().Setenv("EDITOR", "vim")
 	// Bind the env vars to viper
-	_ = viper.BindEnv("external-editor", "VISUAL", "EDITOR")
+	_ = viperx.BindEnv("external-editor", "VISUAL", "EDITOR")
 
 	cmd := m.externalEditorCmd()
 	suite.Contains(cmd.Path, "nano", "Expected VISUAL to take precedence")
@@ -398,7 +398,7 @@ func (suite *DotenvModelTestSuite) Test__externalEditorCmd() {
 	// Test EDITOR fallback
 	suite.T().Setenv("VISUAL", "")
 	// Bind the env vars to viper
-	_ = viper.BindEnv("external-editor", "VISUAL", "EDITOR")
+	_ = viperx.BindEnv("external-editor", "VISUAL", "EDITOR")
 
 	cmd = m.externalEditorCmd()
 	suite.Contains(cmd.Path, "vim", "Expected EDITOR as fallback")
@@ -406,15 +406,15 @@ func (suite *DotenvModelTestSuite) Test__externalEditorCmd() {
 	// Test when neither is set
 	suite.T().Setenv("EDITOR", "")
 	// Bind the env vars to viper
-	_ = viper.BindEnv("external-editor", "VISUAL", "EDITOR")
+	_ = viperx.BindEnv("external-editor", "VISUAL", "EDITOR")
 
 	cmd = m.externalEditorCmd()
 	suite.Contains(cmd.Path, "", "Expected empty editor when none is set")
 
 	// Test default value
-	viper.SetDefault("external-editor", "vi")
+	viperx.SetDefault("external-editor", "vi")
 	// Bind the env vars to viper; this should not override the default
-	_ = viper.BindEnv("external-editor", "VISUAL", "EDITOR")
+	_ = viperx.BindEnv("external-editor", "VISUAL", "EDITOR")
 
 	cmd = m.externalEditorCmd()
 	suite.Contains(cmd.Path, "vi", "Expected vi as default fallback")
@@ -506,25 +506,25 @@ func (suite *DotenvModelTestSuite) TestYes_ViperBinding() {
 
 	// Reset viper and bind the flag to simulate what happens in init()
 	// This mimics the actual command initialization
-	_ = viper.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	// Test that env var enables the flag
 	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "true")
 
-	suite.True(viper.GetBool("yes"), "Expected viper to read env var as true")
+	suite.True(viperx.GetBool("yes"), "Expected viper to read env var as true")
 
 	// Test that "1" also works
 	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "1")
 
-	suite.True(viper.GetBool("yes"), "Expected viper to read '1' as true")
+	suite.True(viperx.GetBool("yes"), "Expected viper to read '1' as true")
 
 	// Test that it's false when not set
 	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "")
 
-	suite.False(viper.GetBool("yes"), "Expected viper to read empty as false")
+	suite.False(viperx.GetBool("yes"), "Expected viper to read empty as false")
 
 	// Test that "false" works
 	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "false")
 
-	suite.False(viper.GetBool("yes"), "Expected viper to read 'false' as false")
+	suite.False(viperx.GetBool("yes"), "Expected viper to read 'false' as false")
 }

--- a/cmd/dotenv/promptModel_test.go
+++ b/cmd/dotenv/promptModel_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/envbuilder"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,12 +50,12 @@ func setupLLMTestServer(t *testing.T, catalogStatus int, catalogBody any) {
 		}
 	}))
 
-	viper.Set(config.DataRobotURL, srv.URL+"/api/v2")
-	viper.Set(config.DataRobotAPIKey, "test-token")
+	viperx.Set(config.DataRobotURL, srv.URL+"/api/v2")
+	viperx.Set(config.DataRobotAPIKey, "test-token")
 
 	t.Cleanup(func() {
 		srv.Close()
-		viper.Reset()
+		viperx.Reset()
 	})
 }
 

--- a/cmd/dotenv/promptModel_test.go
+++ b/cmd/dotenv/promptModel_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/envbuilder"
-	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/dotenv/pulumiModel.go
+++ b/cmd/dotenv/pulumiModel.go
@@ -28,7 +28,7 @@ import (
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/envbuilder"
 	"github.com/datarobot/cli/tui"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 const (
@@ -240,7 +240,7 @@ func (m pulumiLoginModel) handlePassphraseAccepted() (tea.Model, tea.Cmd) {
 }
 
 func (m pulumiLoginModel) savePassphraseToConfig() error {
-	viper.Set(pulumiConfigPassphraseKey, m.generatedPassphrase)
+	viperx.Set(pulumiConfigPassphraseKey, m.generatedPassphrase)
 
 	if err := config.UpdateConfigFile(pulumiConfigPassphraseKey); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
@@ -383,7 +383,7 @@ func CheckPulumiSetup(dir string, variables []envbuilder.Variable) (needsSetup, 
 	}
 
 	loggedIn := isPulumiLoggedIn()
-	passphraseSet := viper.GetString(pulumiConfigPassphraseKey) != ""
+	passphraseSet := viperx.GetString(pulumiConfigPassphraseKey) != ""
 
 	return needsPulumiSetup(prompts, loggedIn, passphraseSet), loggedIn, !passphraseSet
 }

--- a/cmd/dotenv/pulumiModel.go
+++ b/cmd/dotenv/pulumiModel.go
@@ -240,13 +240,9 @@ func (m pulumiLoginModel) handlePassphraseAccepted() (tea.Model, tea.Cmd) {
 }
 
 func (m pulumiLoginModel) savePassphraseToConfig() error {
-	if err := config.CreateConfigFileDirIfNotExists(); err != nil {
-		return fmt.Errorf("failed to create config: %w", err)
-	}
-
 	viper.Set(pulumiConfigPassphraseKey, m.generatedPassphrase)
 
-	if err := viper.WriteConfig(); err != nil {
+	if err := config.UpdateConfigFile(pulumiConfigPassphraseKey); err != nil {
 		return fmt.Errorf("failed to write config: %w", err)
 	}
 

--- a/cmd/dotenv/pulumiModel.go
+++ b/cmd/dotenv/pulumiModel.go
@@ -26,9 +26,9 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/envbuilder"
 	"github.com/datarobot/cli/tui"
-	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 const (

--- a/cmd/plugin/discovery.go
+++ b/cmd/plugin/discovery.go
@@ -27,13 +27,13 @@ import (
 	internalPlugin "github.com/datarobot/cli/internal/plugin"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 // RegisterPluginCommands discovers installed plugins and registers them as sub-commands
 // on rootCmd. The plugin group is only added when at least one plugin is found.
 func RegisterPluginCommands(rootCmd *cobra.Command) {
-	timeout := viper.GetDuration("plugin-discovery-timeout")
+	timeout := viperx.GetDuration("plugin-discovery-timeout")
 	if timeout <= 0 {
 		log.Debug("Plugin discovery disabled", "timeout", timeout)
 
@@ -133,7 +133,7 @@ func createPluginCommand(p internalPlugin.DiscoveredPlugin) *cobra.Command {
 // recorded only after a successful registry fetch, so skipped (cooldown-active)
 // invocations never push the timestamp forward.
 func checkAndPromptPluginUpdate(pluginName, installedVersion, pluginPath string) {
-	if viper.GetBool("skip-plugin-update-check") {
+	if viperx.GetBool("skip-plugin-update-check") {
 		return
 	}
 

--- a/cmd/plugin/discovery.go
+++ b/cmd/plugin/discovery.go
@@ -22,12 +22,12 @@ import (
 	"time"
 
 	"github.com/datarobot/cli/cmd/plugin/shared"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/misc/reader"
 	internalPlugin "github.com/datarobot/cli/internal/plugin"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
-	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 // RegisterPluginCommands discovers installed plugins and registers them as sub-commands

--- a/cmd/plugin/install/cmd.go
+++ b/cmd/plugin/install/cmd.go
@@ -21,7 +21,7 @@ import (
 	"github.com/datarobot/cli/internal/plugin"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 var (
@@ -66,7 +66,7 @@ Use --version to specify a version constraint:
 
 func runInstall(_ *cobra.Command, args []string) error {
 	finalRegistryURL := shared.NormalizeRegistryURL(registryURL)
-	if viper.GetBool("verbose") {
+	if viperx.GetBool("verbose") {
 		fmt.Printf("Fetching plugin registry from %s...\n", finalRegistryURL)
 	}
 

--- a/cmd/plugin/install/cmd.go
+++ b/cmd/plugin/install/cmd.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/cmd/plugin/shared"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/plugin"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
-	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 var (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,13 +34,13 @@ import (
 	"github.com/datarobot/cli/cmd/workload"
 	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
 	internalPlugin "github.com/datarobot/cli/internal/plugin"
 	"github.com/datarobot/cli/internal/telemetry"
 	internalVersion "github.com/datarobot/cli/internal/version"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
-	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 var configFilePath string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -241,14 +241,5 @@ func initializeConfig(_ *cobra.Command) error {
 		return fmt.Errorf("Failed to read config file: %w", err)
 	}
 
-	// NOTE: We deliberately do NOT bulk-bind subcommand flags into viper
-	// (no viperx.BindPFlags here, and viperx does not even expose it).
-	// Bulk-binding would slurp every subcommand flag (e.g. --yes, --all,
-	// --if-needed) into viper.AllSettings() and risk leaking transient
-	// flag state into drconfig.yaml on the next config write.
-	// Persistent root flags that need viper integration are bound
-	// individually with viperx.BindPFlag at the top of init(); subcommand
-	// flags should be read directly via cmd.Flags().GetX(...).
-
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ import (
 	internalVersion "github.com/datarobot/cli/internal/version"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 var configFilePath string
@@ -143,15 +143,15 @@ func init() {
 	RootCmd.PersistentFlags().Bool("disable-telemetry", false, "disable anonymous usage telemetry")
 
 	// Make some of these flags available via Viper
-	_ = viper.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config"))
-	_ = viper.BindPFlag("verbose", RootCmd.PersistentFlags().Lookup("verbose"))
-	_ = viper.BindPFlag("debug", RootCmd.PersistentFlags().Lookup("debug"))
-	_ = viper.BindPFlag("skip-auth", RootCmd.PersistentFlags().Lookup("skip-auth"))
-	_ = viper.BindPFlag("force-interactive", RootCmd.PersistentFlags().Lookup("force-interactive"))
-	_ = viper.BindPFlag("plugin-discovery-timeout", RootCmd.PersistentFlags().Lookup("plugin-discovery-timeout"))
-	_ = viper.BindPFlag("plugin-update-check-interval", RootCmd.PersistentFlags().Lookup("plugin-update-check-interval"))
-	_ = viper.BindPFlag("skip-plugin-update-check", RootCmd.PersistentFlags().Lookup("skip-plugin-update-check"))
-	_ = viper.BindPFlag("disable-telemetry", RootCmd.PersistentFlags().Lookup("disable-telemetry"))
+	_ = viperx.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config"))
+	_ = viperx.BindPFlag("verbose", RootCmd.PersistentFlags().Lookup("verbose"))
+	_ = viperx.BindPFlag("debug", RootCmd.PersistentFlags().Lookup("debug"))
+	_ = viperx.BindPFlag("skip-auth", RootCmd.PersistentFlags().Lookup("skip-auth"))
+	_ = viperx.BindPFlag("force-interactive", RootCmd.PersistentFlags().Lookup("force-interactive"))
+	_ = viperx.BindPFlag("plugin-discovery-timeout", RootCmd.PersistentFlags().Lookup("plugin-discovery-timeout"))
+	_ = viperx.BindPFlag("plugin-update-check-interval", RootCmd.PersistentFlags().Lookup("plugin-update-check-interval"))
+	_ = viperx.BindPFlag("skip-plugin-update-check", RootCmd.PersistentFlags().Lookup("skip-plugin-update-check"))
+	_ = viperx.BindPFlag("disable-telemetry", RootCmd.PersistentFlags().Lookup("disable-telemetry"))
 
 	// Add command groups (plugin group added conditionally by registerPluginCommands)
 	RootCmd.AddGroup(
@@ -204,33 +204,33 @@ func init() {
 
 // initializeConfig initializes the configuration by reading from
 // various sources such as environment variables and config files.
-func initializeConfig(cmd *cobra.Command) error {
+func initializeConfig(_ *cobra.Command) error {
 	var err error
 
 	// Set up Viper to process environment variables
 	// First automatically map any environment variables
 	// that are prefixed with DATAROBOT_CLI_ to config keys
-	viper.SetEnvPrefix("DATAROBOT_CLI")
-	viper.AutomaticEnv()
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viperx.SetEnvPrefix("DATAROBOT_CLI")
+	viperx.AutomaticEnv()
+	viperx.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	// map VISUAL and EDITOR to external-editor config key,
 	// but set a default value
-	viper.SetDefault("external-editor", "vi")
+	viperx.SetDefault("external-editor", "vi")
 
-	_ = viper.BindEnv("external-editor", "VISUAL", "EDITOR")
+	_ = viperx.BindEnv("external-editor", "VISUAL", "EDITOR")
 
 	// API consumer tracking is enabled by default.
 	// Set DATAROBOT_API_CONSUMER_TRACKING_ENABLED=false to opt out,
 	// matching the Python SDK convention.
-	viper.SetDefault(config.APIConsumerTrackingEnabled, true)
+	viperx.SetDefault(config.APIConsumerTrackingEnabled, true)
 
-	_ = viper.BindEnv(config.APIConsumerTrackingEnabled, "DATAROBOT_API_CONSUMER_TRACKING_ENABLED")
+	_ = viperx.BindEnv(config.APIConsumerTrackingEnabled, "DATAROBOT_API_CONSUMER_TRACKING_ENABLED")
 
 	// If DATAROBOT_CLI_CONFIG is set and no explicit --config flag was provided,
 	// use the environment variable value
 	if configFilePath == "" {
-		if envConfigPath := viper.GetString("config"); envConfigPath != "" {
+		if envConfigPath := viperx.GetString("config"); envConfigPath != "" {
 			configFilePath = envConfigPath
 		}
 	}
@@ -241,11 +241,14 @@ func initializeConfig(cmd *cobra.Command) error {
 		return fmt.Errorf("Failed to read config file: %w", err)
 	}
 
-	// Bind Cobra flags to Viper
-	err = viper.BindPFlags(cmd.Flags())
-	if err != nil {
-		return err
-	}
+	// NOTE: We deliberately do NOT bulk-bind subcommand flags into viper
+	// (no viperx.BindPFlags here, and viperx does not even expose it).
+	// Bulk-binding would slurp every subcommand flag (e.g. --yes, --all,
+	// --if-needed) into viper.AllSettings() and risk leaking transient
+	// flag state into drconfig.yaml on the next config write.
+	// Persistent root flags that need viper integration are bound
+	// individually with viperx.BindPFlag at the top of init(); subcommand
+	// flags should be read directly via cmd.Flags().GetX(...).
 
 	return nil
 }

--- a/cmd/templates/setup/loginModel.go
+++ b/cmd/templates/setup/loginModel.go
@@ -27,10 +27,10 @@ import (
 	"github.com/datarobot/cli/internal/assets"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/misc/open"
 	"github.com/datarobot/cli/tui"
-	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 type LoginModel struct {

--- a/cmd/templates/setup/loginModel.go
+++ b/cmd/templates/setup/loginModel.go
@@ -30,7 +30,7 @@ import (
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/misc/open"
 	"github.com/datarobot/cli/tui"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 type LoginModel struct {
@@ -148,7 +148,7 @@ func (lm LoginModel) waitForAPIKey() tea.Cmd {
 			return errMsg{errors.New("Interrupt request received.")}
 		}
 
-		viper.Set(config.DataRobotAPIKey, apiKey)
+		viperx.Set(config.DataRobotAPIKey, apiKey)
 
 		err := auth.WriteConfigFileSilent()
 		if err != nil {

--- a/cmd/templates/setup/loginModel_test.go
+++ b/cmd/templates/setup/loginModel_test.go
@@ -24,7 +24,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/datarobot/cli/internal/config"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/yaml.v3"
 )
@@ -97,7 +97,7 @@ func (suite *LoginModelTestSuite) AfterTest(suiteName, testName string) {
 	suite.T().Setenv("XDG_CONFIG_HOME", "")
 	suite.configFile = filepath.Join(suite.tempDir, ".config/datarobot/drconfig.yaml")
 
-	viper.Reset()
+	viperx.Reset()
 }
 
 func (suite *LoginModelTestSuite) TestLoginModel_Init_Press_1() {

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -17,6 +17,7 @@ If you're new to developing the CLI, start here:
 - **[Project structure](structure.md)**&mdash;understand the codebase organization, command structure, internal packages, and key design patterns.
 - **[Building](building.md)**&mdash;detailed guide on building the CLI, available tasks, and build configuration.
 - **[Authentication](authentication.md)**&mdash;learn about the OAuth authentication implementation, token management, and API integration.
+- **[Configuration](configuration.md)**&mdash;how viper, `drconfig.yaml`, flags, and env vars compose; the `internal/config/viperx` wrapper; rules for adding new flags or persisted keys.
 
 ### Advanced topics
 

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -113,8 +113,18 @@ You can still manually run `dr auth login` to refresh credentials or change acco
 
 ## Internal APIs
 
-The auth package writes configuration through Viper.
+The auth package writes configuration through the allowlisted writer in
+`internal/config` (`config.UpdateConfigFile`). It does **not** call
+`viper.WriteConfig()` directly, because that would serialize every key in
+`viper.AllSettings()`&mdash;including transient flags such as `--yes`&mdash;
+into `drconfig.yaml`. Outside `internal/config/...`, all viper access
+goes through the `internal/config/viperx` wrapper. See
+[Configuration](configuration.md) for the full contract.
 
-- `WriteConfigFileSilent()`&mdash;writes the config file and returns an error.
-- `WriteConfigFile()`&mdash;writes the config file, prints a success message, and returns an error.
-- `SetURLAction()`&mdash;prompts for a DataRobot URL, optionally overwrites an existing value, and returns a boolean indicating whether the URL changed.
+- `WriteConfigFileSilent()`&mdash;writes only allowlisted keys
+  (`config.PersistableKeys`) back to `drconfig.yaml` and returns an error.
+- `WriteConfigFile()`&mdash;writes the config file, prints a success
+  message, and returns an error.
+- `SetURLAction()`&mdash;prompts for a DataRobot URL, optionally
+  overwrites an existing value, and returns a boolean indicating whether
+  the URL changed.

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -1,0 +1,187 @@
+# Configuration & viper integration
+
+This guide covers how the CLI loads, reads, and writes its persistent
+configuration (`drconfig.yaml`), and the rules contributors must follow when
+adding new flags or persisted config keys.
+
+## Table of contents
+
+- [The viperx wrapper](#the-viperx-wrapper)
+- [Where config lives](#where-config-lives)
+- [How values reach viper](#how-values-reach-viper)
+- [Writing back to drconfig.yaml](#writing-back-to-drconfigyaml)
+- [Rules for new flags](#rules-for-new-flags)
+- [Rules for new env vars](#rules-for-new-env-vars)
+- [Rules for new persisted keys](#rules-for-new-persisted-keys)
+- [Common pitfalls](#common-pitfalls)
+
+## The viperx wrapper
+
+Outside of `internal/config/...`, **the only viper entry point is
+`internal/config/viperx`**. Direct imports of `github.com/spf13/viper`
+are blocked by `depguard` everywhere else in the tree.
+
+```go
+// good
+import "github.com/datarobot/cli/internal/config/viperx"
+
+if viperx.GetBool("debug") { /* ... */ }
+
+// blocked by golangci-lint outside internal/config/**
+import "github.com/spf13/viper"
+```
+
+`viperx` re-exports only the safe subset of viper's API. The following
+symbols are **deliberately not** re-exported:
+
+- `viper.WriteConfig`, `viper.SafeWriteConfig` — they serialize the entire
+  `viper.AllSettings()` map, leaking transient flag state into
+  `drconfig.yaml`. Use `config.UpdateConfigFile(...)` instead, which only
+  writes keys in the `config.PersistableKeys` allowlist.
+- `viper.BindPFlags(cmd.Flags())` — bulk-binds every subcommand flag into
+  viper, with the same leakage problem. Use `viperx.BindPFlag` for
+  individual persistent flags; read subcommand flags directly via
+  `cmd.Flags().GetX(...)`.
+
+If you need a viper symbol that is not currently re-exported, add it to
+`internal/config/viperx/viperx.go` consciously and document why. New
+additions should be reviewed for whether they expand the leakage surface.
+
+## Where config lives
+
+The CLI stores user configuration in a single YAML file:
+
+- Default location: `$XDG_CONFIG_HOME/datarobot/drconfig.yaml`
+  (falls back to `~/.config/datarobot/drconfig.yaml`)
+- Override with `--config <path>` or `DATAROBOT_CLI_CONFIG=<path>`
+
+Today this file holds connection credentials and a small set of sticky CLI
+preferences. It is **not** a dumping ground for transient flag state.
+
+## How values reach viper
+
+Viper resolves a key from these sources in priority order:
+
+1. Explicit `viperx.Set(key, value)` call (e.g. after a successful login)
+2. Flag bound via `viperx.BindPFlag(key, flag)` (only persistent root flags
+   today &mdash; see below)
+3. Environment variable bound via `viperx.BindEnv(key, "DATAROBOT_…")`
+   or auto-mapped via `viperx.SetEnvPrefix("DATAROBOT_CLI")`
+4. Value loaded from `drconfig.yaml`
+5. Default registered via `viperx.SetDefault`
+
+### Persistent root flags bound to viper
+
+Only the persistent root flags listed in `cmd/root.go::init()` are bound
+explicitly with `viperx.BindPFlag`. We do **not** bulk-bind subcommand
+flags (and `viperx` does not even expose a `BindPFlags` function), because
+that would slurp every subcommand flag (such as `--yes`, `--if-needed`)
+into `viper.AllSettings()` and risk leaking transient flag state into
+`drconfig.yaml`.
+
+### Subcommand flags
+
+Read subcommand flag values directly from cobra:
+
+```go
+yesFlag, _ := cmd.Flags().GetBool("yes")
+```
+
+If a subcommand flag also needs an environment variable override, register
+the env var only with `viperx.BindEnv(...)` and merge the two sources
+explicitly in your handler:
+
+```go
+// cmd/dotenv/cmd.go
+_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+
+// In RunE:
+yesFlag, _ := cmd.Flags().GetBool("yes")
+yes := yesFlag || viperx.GetBool("yes")
+```
+
+This keeps the explicit `--yes` flag value out of `viper.AllSettings()`
+while preserving env-var support.
+
+## Writing back to drconfig.yaml
+
+Use the allowlisted writer in `internal/config`:
+
+```go
+// Write all allowlisted keys that are currently set in viper:
+config.UpdateConfigFile()
+
+// Or write only specific keys (recommended when the call site knows
+// exactly what changed):
+config.UpdateConfigFile(config.DataRobotURL)
+config.UpdateConfigFile(config.DataRobotAPIKey, config.DataRobotURL)
+```
+
+`UpdateConfigFile` reads the existing YAML, overlays only the allowlisted
+keys (`config.PersistableKeys`), and writes the result back. Any other
+viper state &mdash; including transient flags such as `--yes`, `--verbose`,
+`--debug` &mdash; is intentionally dropped.
+
+The wrappers in the auth package (`auth.WriteConfigFileSilent`,
+`auth.WriteConfigFile`) call this writer under the hood.
+
+## Rules for new flags
+
+When adding a new flag, decide which category it falls into:
+
+| Category                                         | Bind to viper?     | Persist to drconfig.yaml?                |
+| ------------------------------------------------ | ------------------ | ---------------------------------------- |
+| Transient (per-invocation, e.g. `--yes`, `--all`) | No                 | No                                       |
+| Sticky preference (e.g. `--external-editor`)      | Yes (root only)    | Yes &mdash; add to `PersistableKeys`     |
+| Connection credential (e.g. `--token`)            | Yes                | Yes                                      |
+
+For transient flags:
+
+- Define with `cmd.Flags().Bool(...)`
+- Read with `cmd.Flags().GetBool(...)`
+- Do **not** call `viperx.BindPFlag(...)`
+
+## Rules for new env vars
+
+`viperx.AutomaticEnv()` with prefix `DATAROBOT_CLI` is enabled in
+`initializeConfig`, so any key you `viperx.Get` will already check
+`DATAROBOT_CLI_<KEY>` (with `-` replaced by `_`).
+
+For env vars that should map to a different name (e.g.
+`DATAROBOT_CLI_NON_INTERACTIVE` → key `yes`), use `viperx.BindEnv` and
+read the merged value as shown in [Subcommand flags](#subcommand-flags).
+
+## Rules for new persisted keys
+
+To make a key writable to `drconfig.yaml`:
+
+1. Add the key to `PersistableKeys` in `internal/config/write.go`
+2. Update its production write call sites to pass the key explicitly:
+   `config.UpdateConfigFile("my-new-key")`
+3. Add a regression test under `internal/auth/writeConfig_test.go` (or a
+   dedicated test file) verifying the key round-trips correctly and that
+   transient flags still do not leak.
+
+Use viper dotted-path notation if the value is nested, e.g.
+`"pulumi.config.passphrase"`. The writer handles nested map creation.
+
+## Common pitfalls
+
+- **Don't import `github.com/spf13/viper` outside `internal/config/`.**
+  `depguard` will reject it. Use `internal/config/viperx` instead.
+- **Don't add `viper.WriteConfig` or `BindPFlags` to `viperx`.** Those
+  omissions are deliberate. If you need to persist new state, extend
+  `config.PersistableKeys` and call `config.UpdateConfigFile`.
+- **Don't read transient flags through viper.** `viperx.GetBool("yes")`
+  hides whether the value came from a flag, an env var, or a stale
+  drconfig entry. Read flags directly from cobra and merge in env vars
+  explicitly.
+- **Don't write to `drconfig.yaml` from tests** without `viperx.Reset()`
+  and a temp `XDG_CONFIG_HOME`. See `internal/auth/writeConfig_test.go`
+  for the recommended test pattern.
+
+## See also
+
+- [Flag development guide](flags.md)
+- [Authentication flow](authentication.md)
+- [User configuration guide](../user-guide/configuration.md)

--- a/docs/development/flags.md
+++ b/docs/development/flags.md
@@ -212,7 +212,40 @@ cmd.MarkFlagsMutuallyExclusive("from-file", "release-date")
    dr mycommand --flag1
    ```
 
+## Viper binding rules
+
+The CLI deliberately limits which flags are bound to viper. Subcommand
+flags (such as `--yes`, `--all`, `--if-needed`) **must not** be bound via
+`viperx.BindPFlag`, and `cmd/root.go` does not bulk-bind subcommand flags
+either. Doing so would slurp those flag values into `viper.AllSettings()`
+and risk persisting them to `drconfig.yaml` on the next config write.
+
+Outside `internal/config/...`, all viper interaction goes through the
+`internal/config/viperx` wrapper, which omits `WriteConfig`,
+`SafeWriteConfig`, and `BindPFlags` by design. Direct
+`github.com/spf13/viper` imports are blocked by `depguard`.
+
+Quick rules for new flags:
+
+- **Transient flags** (per-invocation): read directly via
+  `cmd.Flags().GetBool(...)`. Do not bind to viper.
+- **Env-var override needed?** Register only the env var with
+  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and OR the two sources in your
+  handler:
+
+  ```go
+  yesFlag, _ := cmd.Flags().GetBool("yes")
+  yes := yesFlag || viperx.GetBool("yes")
+  ```
+
+- **Sticky CLI preferences** (rare): bind via `viperx.BindPFlag` *and*
+  add the key to `config.PersistableKeys` in `internal/config/write.go`.
+
+For full details and test patterns, see the
+[Configuration guide](configuration.md).
+
 ## See also
 
 - [Cobra documentation](https://cobra.dev/)
 - [Building guide](building.md) — General development setup and standards
+- [Configuration guide](configuration.md) — viper, drconfig.yaml, viperx, persisted keys

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -256,12 +256,9 @@ func WaitForAPIKeyCallback(ctx context.Context, datarobotHost string) (string, e
 }
 
 func WriteConfigFileSilent() error {
-	// Ensure the config directory and file exist before writing the config file
-	if err := config.CreateConfigFileDirIfNotExists(); err != nil {
-		return err
-	}
-
-	err := viper.WriteConfig()
+	// Only persist allowlisted keys (see config.PersistableKeys). This avoids
+	// writing transient flags such as --yes back to drconfig.yaml.
+	err := config.UpdateConfigFile()
 	if err != nil {
 		log.Error(err)
 		return err

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -30,7 +30,7 @@ import (
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 // APIKeyCallbackFunc is a variable that holds the function for retrieving API keys.
@@ -96,7 +96,7 @@ func EnsureAuthenticatedE(cmd *cobra.Command, _ []string) error {
 // triggers the login flow automatically. Returns true if authentication
 // is valid or was successfully obtained.
 func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
-	if viper.GetBool("skip_auth") {
+	if viperx.GetBool("skip_auth") {
 		log.Warn("Authentication checks are disabled via the '--skip-auth' flag. This may cause API calls to fail.")
 
 		return true
@@ -109,8 +109,8 @@ func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
 		// such as those used by the DataRobot platform or other SDKs
 		// and clients. If the DATAROBOT_CLI equivalents are not set,
 		// then Viper will fallback to these
-		_ = viper.BindEnv("endpoint", "DATAROBOT_ENDPOINT", "DATAROBOT_API_ENDPOINT")
-		_ = viper.BindEnv("token", "DATAROBOT_API_TOKEN")
+		_ = viperx.BindEnv("endpoint", "DATAROBOT_ENDPOINT", "DATAROBOT_API_ENDPOINT")
+		_ = viperx.BindEnv("token", "DATAROBOT_API_TOKEN")
 
 		return true
 	}
@@ -163,7 +163,7 @@ func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
 	log.Warn("No valid API key found. Starting authentication flow...")
 
 	// Auto-retrieve new credentials without prompting
-	viper.Set(config.DataRobotAPIKey, "")
+	viperx.Set(config.DataRobotAPIKey, "")
 
 	key, err := APIKeyCallbackFunc(ctx, datarobotHost)
 	if err != nil {
@@ -171,7 +171,7 @@ func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
 		return false
 	}
 
-	viper.Set(config.DataRobotAPIKey, strings.ReplaceAll(key, "\n", ""))
+	viperx.Set(config.DataRobotAPIKey, strings.ReplaceAll(key, "\n", ""))
 
 	err = WriteConfigFileSilent()
 	if err != nil {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -25,12 +25,12 @@ import (
 
 	"github.com/datarobot/cli/internal/assets"
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/misc/open"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
-	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 // APIKeyCallbackFunc is a variable that holds the function for retrieving API keys.

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -24,10 +24,11 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/testutil"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // setupTestEnvironment creates a temporary environment for testing authentication.
@@ -47,7 +48,7 @@ func setupTestEnvironment(t *testing.T) (*httptest.Server, func()) {
 	// Save original callback function.
 	originalCallback := APIKeyCallbackFunc
 
-	viper.Reset()
+	viperx.Reset()
 
 	// Create mock DataRobot API server.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -73,7 +74,7 @@ func setupTestEnvironment(t *testing.T) (*httptest.Server, func()) {
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
-	viper.Set(config.DataRobotURL, server.URL+"/api/v2")
+	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 
 	err = config.CreateConfigFileDirIfNotExists()
 	require.NoError(t, err)
@@ -81,7 +82,7 @@ func setupTestEnvironment(t *testing.T) (*httptest.Server, func()) {
 	cleanup := func() {
 		server.Close()
 		os.RemoveAll(tempDir)
-		viper.Reset()
+		viperx.Reset()
 
 		APIKeyCallbackFunc = originalCallback
 	}
@@ -93,7 +94,7 @@ func TestEnsureAuthenticated_MissingCredentials(t *testing.T) {
 	server, cleanup := setupTestEnvironment(t)
 	defer cleanup()
 
-	viper.Set(config.DataRobotAPIKey, "")
+	viperx.Set(config.DataRobotAPIKey, "")
 	os.Unsetenv("DATAROBOT_API_TOKEN")
 
 	// Mock the callback to simulate failure to retrieve API key.
@@ -114,7 +115,7 @@ func TestEnsureAuthenticated_ExpiredCredentials(t *testing.T) {
 	_, cleanup := setupTestEnvironment(t)
 	defer cleanup()
 
-	viper.Set(config.DataRobotAPIKey, "expired-token")
+	viperx.Set(config.DataRobotAPIKey, "expired-token")
 	os.Unsetenv("DATAROBOT_API_TOKEN")
 
 	apiKey, _ := config.GetAPIKey(context.Background())
@@ -133,7 +134,7 @@ func TestEnsureAuthenticated_ValidCredentials(t *testing.T) {
 	_, cleanup := setupTestEnvironment(t)
 	defer cleanup()
 
-	viper.Set(config.DataRobotAPIKey, "valid-token")
+	viperx.Set(config.DataRobotAPIKey, "valid-token")
 	os.Unsetenv("DATAROBOT_API_TOKEN")
 
 	apiKey, _ := config.GetAPIKey(context.Background())
@@ -165,10 +166,10 @@ func TestEnsureAuthenticated_SkipAuth(t *testing.T) {
 	defer cleanup()
 
 	// Set skip_auth flag to true
-	viper.Set("skip_auth", true)
+	viperx.Set("skip_auth", true)
 
 	// Don't set any credentials
-	viper.Set(config.DataRobotAPIKey, "")
+	viperx.Set(config.DataRobotAPIKey, "")
 
 	existingToken := os.Getenv("DATAROBOT_API_TOKEN")
 
@@ -200,9 +201,9 @@ func TestEnsureAuthenticated_DefaultUserAgent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	viper.Reset()
-	viper.Set(config.DataRobotURL, server.URL+"/api/v2")
-	viper.Set(config.DataRobotAPIKey, "valid-token")
+	viperx.Reset()
+	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
+	viperx.Set(config.DataRobotAPIKey, "valid-token")
 
 	os.Unsetenv("DATAROBOT_ENDPOINT")
 	os.Unsetenv("DATAROBOT_API_TOKEN")
@@ -224,11 +225,11 @@ func TestEnsureAuthenticated_NoURL(t *testing.T) {
 
 	testutil.SetTestHomeDir(t, tempDir)
 
-	viper.Reset()
+	viperx.Reset()
 
 	os.Unsetenv("DATAROBOT_ENDPOINT")
 	os.Unsetenv("DATAROBOT_API_TOKEN")
-	viper.Set(config.DataRobotURL, "")
+	viperx.Set(config.DataRobotURL, "")
 
 	baseURL := config.GetBaseURL()
 	assert.Empty(t, baseURL, "Expected GetBaseURL to return empty string")
@@ -244,26 +245,27 @@ func TestConfig_WriteAndRead(t *testing.T) {
 	homeDir, err := os.UserHomeDir()
 	require.NoError(t, err)
 
-	configFilePath := filepath.Join(homeDir, ".config", "datarobot", "drconfig.yaml")
-	viper.SetConfigFile(configFilePath)
+	configDir := filepath.Join(homeDir, ".config", "datarobot")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
 
-	viper.Set(config.DataRobotAPIKey, "test-token")
+	configFilePath := filepath.Join(configDir, "drconfig.yaml")
 
-	// SafeWriteConfig creates the file if it doesn't exist.
-	err = viper.SafeWriteConfig()
-	if err != nil {
-		// File might already exist, try WriteConfig.
-		err = viper.WriteConfig()
-		require.NoError(t, err)
-	}
+	// Write the config file directly rather than going through viper's
+	// (forbidden) WriteConfig. The production code path persists via
+	// config.UpdateConfigFile; this test only needs a seeded fixture.
+	fixture := map[string]any{config.DataRobotAPIKey: "test-token"}
 
-	viper.Reset()
-	viper.SetConfigFile(configFilePath)
+	data, err := yaml.Marshal(fixture)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configFilePath, data, 0o600))
 
-	err = viper.ReadInConfig()
+	viperx.Reset()
+	viperx.SetConfigFile(configFilePath)
+
+	err = viperx.ReadInConfig()
 	require.NoError(t, err)
 
-	token := viper.GetString(config.DataRobotAPIKey)
+	token := viperx.GetString(config.DataRobotAPIKey)
 	assert.Equal(t, "test-token", token, "Expected token to be persisted and read back")
 }
 
@@ -275,7 +277,7 @@ func TestConfig_ConfigFilePath(t *testing.T) {
 
 	testutil.SetTestHomeDir(t, tempDir)
 
-	viper.Reset()
+	viperx.Reset()
 
 	err = config.CreateConfigFileDirIfNotExists()
 	require.NoError(t, err)

--- a/internal/auth/writeConfig_test.go
+++ b/internal/auth/writeConfig_test.go
@@ -166,7 +166,7 @@ func TestWriteConfigFileSilent_PreservesExtraFields(t *testing.T) {
 	assert.Equal(t, 42, viper.GetInt("another_field"))
 }
 
-func TestWriteConfigFileSilent_FailsWhenMultipleFieldsChanged(t *testing.T) {
+func TestWriteConfigFileSilent_OnlyAllowlistedFieldsWritten(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "auth-test-*")
 	require.NoError(t, err)
 
@@ -220,14 +220,71 @@ func TestWriteConfigFileSilent_FailsWhenMultipleFieldsChanged(t *testing.T) {
 	err = yaml.Unmarshal(rawYaml, &configMap)
 	require.NoError(t, err)
 
-	// This test verifies that WriteConfigFileSilent DOES write all changes
-	// (not just the token), which means the caller must be careful to only
-	// modify the token field before calling it
+	// Allowlisted keys (endpoint, token) ARE written.
+	assert.Equal(t, "new-token", configMap["token"],
+		"Allowlisted token field should be written")
 	assert.NotEqual(t, initialConfig["endpoint"], configMap["endpoint"],
-		"When endpoint is modified in viper, it IS written to the file")
-	assert.Contains(t, configMap, "extra_field",
-		"When extra fields are added to viper, they ARE written to the file")
+		"Allowlisted endpoint field should be written")
 
-	// This test demonstrates that the responsibility for maintaining config
-	// integrity lies with the caller, not with WriteConfigFileSilent
+	// Non-allowlisted keys (extra_field) are NOT written, even if set in viper.
+	assert.NotContains(t, configMap, "extra_field",
+		"Non-allowlisted fields must not leak into drconfig.yaml")
+}
+
+func TestWriteConfigFileSilent_TransientFlagsNotPersisted(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "auth-test-*")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(tempDir)
+
+	testutil.SetTestHomeDir(t, tempDir)
+
+	viper.Reset()
+
+	defer viper.Reset()
+
+	err = config.CreateConfigFileDirIfNotExists()
+	require.NoError(t, err)
+
+	configDir := filepath.Join(tempDir, ".config", "datarobot")
+	configFile := filepath.Join(configDir, "drconfig.yaml")
+
+	initialConfig := map[string]interface{}{
+		"endpoint": "https://app.datarobot.com/api/v2",
+		"token":    "original-token-12345",
+	}
+
+	initialYaml, err := yaml.Marshal(initialConfig)
+	require.NoError(t, err)
+
+	err = os.WriteFile(configFile, initialYaml, 0o644)
+	require.NoError(t, err)
+
+	err = config.ReadConfigFile("")
+	require.NoError(t, err)
+
+	// Simulate transient command flags being bound to viper.
+	viper.Set("yes", true)
+	viper.Set("verbose", true)
+	viper.Set("force-interactive", true)
+	viper.Set("debug", true)
+
+	// Also legitimately update an allowlisted key.
+	viper.Set("token", "new-token-after-flags")
+
+	_ = WriteConfigFileSilent()
+
+	rawYaml, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+
+	var configMap map[string]interface{}
+
+	err = yaml.Unmarshal(rawYaml, &configMap)
+	require.NoError(t, err)
+
+	assert.Equal(t, "new-token-after-flags", configMap["token"])
+	assert.NotContains(t, configMap, "yes")
+	assert.NotContains(t, configMap, "verbose")
+	assert.NotContains(t, configMap, "force-interactive")
+	assert.NotContains(t, configMap, "debug")
 }

--- a/internal/auth/writeConfig_test.go
+++ b/internal/auth/writeConfig_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/testutil"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -35,9 +35,9 @@ func TestWriteConfigFileSilent_OnlyTokenChanged(t *testing.T) {
 
 	testutil.SetTestHomeDir(t, tempDir)
 
-	viper.Reset()
+	viperx.Reset()
 
-	defer viper.Reset()
+	defer viperx.Reset()
 
 	// Create config directory and file
 	err = config.CreateConfigFileDirIfNotExists()
@@ -64,28 +64,28 @@ func TestWriteConfigFileSilent_OnlyTokenChanged(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify initial values are loaded
-	assert.Equal(t, "https://app.datarobot.com/api/v2", viper.GetString("endpoint"))
-	assert.Equal(t, "original-token-12345", viper.GetString("token"))
-	assert.True(t, viper.GetBool("ssl_verify"))
+	assert.Equal(t, "https://app.datarobot.com/api/v2", viperx.GetString("endpoint"))
+	assert.Equal(t, "original-token-12345", viperx.GetString("token"))
+	assert.True(t, viperx.GetBool("ssl_verify"))
 
 	// Change only the token
-	viper.Set("token", "new-token-67890")
+	viperx.Set("token", "new-token-67890")
 
 	// Call WriteConfigFileSilent
 	_ = WriteConfigFileSilent()
 
 	// Reset viper and re-read the file to verify what was actually written
-	viper.Reset()
+	viperx.Reset()
 
 	err = config.ReadConfigFile("")
 	require.NoError(t, err)
 
 	// Verify token was changed
-	assert.Equal(t, "new-token-67890", viper.GetString("token"), "Token should be updated")
+	assert.Equal(t, "new-token-67890", viperx.GetString("token"), "Token should be updated")
 
 	// Verify endpoint and ssl_verify remain unchanged
-	assert.Equal(t, "https://app.datarobot.com/api/v2", viper.GetString("endpoint"), "Endpoint should remain unchanged")
-	assert.True(t, viper.GetBool("ssl_verify"), "ssl_verify should remain unchanged")
+	assert.Equal(t, "https://app.datarobot.com/api/v2", viperx.GetString("endpoint"), "Endpoint should remain unchanged")
+	assert.True(t, viperx.GetBool("ssl_verify"), "ssl_verify should remain unchanged")
 
 	// Read the raw YAML to ensure no extra fields were added
 	rawYaml, err := os.ReadFile(configFile)
@@ -119,9 +119,9 @@ func TestWriteConfigFileSilent_PreservesExtraFields(t *testing.T) {
 
 	testutil.SetTestHomeDir(t, tempDir)
 
-	viper.Reset()
+	viperx.Reset()
 
-	defer viper.Reset()
+	defer viperx.Reset()
 
 	err = config.CreateConfigFileDirIfNotExists()
 	require.NoError(t, err)
@@ -148,22 +148,22 @@ func TestWriteConfigFileSilent_PreservesExtraFields(t *testing.T) {
 	require.NoError(t, err)
 
 	// Change only the token
-	viper.Set("token", "updated-token-99999")
+	viperx.Set("token", "updated-token-99999")
 
 	_ = WriteConfigFileSilent()
 
 	// Reset and re-read
-	viper.Reset()
+	viperx.Reset()
 
 	err = config.ReadConfigFile("")
 	require.NoError(t, err)
 
 	// Verify all original fields are preserved
-	assert.Equal(t, "updated-token-99999", viper.GetString("token"))
-	assert.Equal(t, "https://app.datarobot.com/api/v2", viper.GetString("endpoint"))
-	assert.False(t, viper.GetBool("ssl_verify"))
-	assert.Equal(t, "custom_value", viper.GetString("custom_field"))
-	assert.Equal(t, 42, viper.GetInt("another_field"))
+	assert.Equal(t, "updated-token-99999", viperx.GetString("token"))
+	assert.Equal(t, "https://app.datarobot.com/api/v2", viperx.GetString("endpoint"))
+	assert.False(t, viperx.GetBool("ssl_verify"))
+	assert.Equal(t, "custom_value", viperx.GetString("custom_field"))
+	assert.Equal(t, 42, viperx.GetInt("another_field"))
 }
 
 func TestWriteConfigFileSilent_OnlyAllowlistedFieldsWritten(t *testing.T) {
@@ -174,9 +174,9 @@ func TestWriteConfigFileSilent_OnlyAllowlistedFieldsWritten(t *testing.T) {
 
 	testutil.SetTestHomeDir(t, tempDir)
 
-	viper.Reset()
+	viperx.Reset()
 
-	defer viper.Reset()
+	defer viperx.Reset()
 
 	err = config.CreateConfigFileDirIfNotExists()
 	require.NoError(t, err)
@@ -200,13 +200,13 @@ func TestWriteConfigFileSilent_OnlyAllowlistedFieldsWritten(t *testing.T) {
 	require.NoError(t, err)
 
 	// Intentionally modify multiple fields (this demonstrates incorrect usage)
-	viper.Set("token", "new-token")
-	viper.Set("endpoint", "https://different.datarobot.com/api/v2")
-	viper.Set("extra_field", "should_not_exist")
+	viperx.Set("token", "new-token")
+	viperx.Set("endpoint", "https://different.datarobot.com/api/v2")
+	viperx.Set("extra_field", "should_not_exist")
 
 	_ = WriteConfigFileSilent()
 
-	viper.Reset()
+	viperx.Reset()
 
 	err = config.ReadConfigFile("")
 	require.NoError(t, err)
@@ -226,7 +226,7 @@ func TestWriteConfigFileSilent_OnlyAllowlistedFieldsWritten(t *testing.T) {
 	assert.NotEqual(t, initialConfig["endpoint"], configMap["endpoint"],
 		"Allowlisted endpoint field should be written")
 
-	// Non-allowlisted keys (extra_field) are NOT written, even if set in viper.
+	// Non-allowlisted keys (extra_field) are NOT written, even if set in viperx.
 	assert.NotContains(t, configMap, "extra_field",
 		"Non-allowlisted fields must not leak into drconfig.yaml")
 }
@@ -239,9 +239,9 @@ func TestWriteConfigFileSilent_TransientFlagsNotPersisted(t *testing.T) {
 
 	testutil.SetTestHomeDir(t, tempDir)
 
-	viper.Reset()
+	viperx.Reset()
 
-	defer viper.Reset()
+	defer viperx.Reset()
 
 	err = config.CreateConfigFileDirIfNotExists()
 	require.NoError(t, err)
@@ -263,14 +263,14 @@ func TestWriteConfigFileSilent_TransientFlagsNotPersisted(t *testing.T) {
 	err = config.ReadConfigFile("")
 	require.NoError(t, err)
 
-	// Simulate transient command flags being bound to viper.
-	viper.Set("yes", true)
-	viper.Set("verbose", true)
-	viper.Set("force-interactive", true)
-	viper.Set("debug", true)
+	// Simulate transient command flags being bound to viperx.
+	viperx.Set("yes", true)
+	viperx.Set("verbose", true)
+	viperx.Set("force-interactive", true)
+	viperx.Set("debug", true)
 
 	// Also legitimately update an allowlisted key.
-	viper.Set("token", "new-token-after-flags")
+	viperx.Set("token", "new-token-after-flags")
 
 	_ = WriteConfigFileSilent()
 

--- a/internal/auth/writeConfig_test.go
+++ b/internal/auth/writeConfig_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/internal/config"
-	"github.com/datarobot/cli/internal/testutil"
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -142,12 +142,12 @@ func SaveURLToConfig(newURL string) error {
 		viper.Set(DataRobotURL, "")
 		viper.Set(DataRobotAPIKey, "")
 
-		return viper.WriteConfig()
+		return UpdateConfigFile(DataRobotURL, DataRobotAPIKey)
 	}
 
 	viper.Set(DataRobotURL, newURL+DRAPIURLSuffix)
 
-	return viper.WriteConfig()
+	return UpdateConfigFile(DataRobotURL)
 }
 
 // SetURLToConfig is a helper function that sets the DataRobot URL with the DRAPIURLSuffix in the config object.

--- a/internal/config/viperx/viperx.go
+++ b/internal/config/viperx/viperx.go
@@ -1,0 +1,90 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package viperx is the curated entry point to viper for the rest of the
+// CLI. It re-exports only the safe subset of viper's API that the project
+// is permitted to use.
+//
+// Why this package exists:
+//
+//   - viper.WriteConfig and viper.SafeWriteConfig serialize the entire
+//     viper.AllSettings() map, which includes every flag that has ever
+//     been bound (e.g. --yes, --verbose). Calling them directly leaks
+//     transient flag state into drconfig.yaml. Production code must
+//     instead call config.UpdateConfigFile, which writes only the
+//     allowlisted keys in config.PersistableKeys.
+//
+//   - viper.BindPFlags(cmd.Flags()) bulk-binds every subcommand flag to
+//     viper, with the same leakage problem. Persistent root flags are
+//     bound individually via BindPFlag in cmd/root.go::init(); subcommand
+//     flags are read directly from cobra (cmd.Flags().GetX(...)).
+//
+// Both APIs are intentionally NOT re-exported here. Direct imports of
+// github.com/spf13/viper outside internal/config/** are forbidden by
+// depguard. See docs/development/configuration.md for the full contract.
+//
+// To add a symbol:
+//
+//  1. Confirm it is safe (does not persist transient state).
+//  2. Add a re-export below.
+//  3. Document in docs/development/configuration.md if the addition
+//     introduces a new pattern.
+package viperx
+
+import (
+	"github.com/spf13/viper"
+)
+
+// ConfigFileNotFoundError mirrors viper.ConfigFileNotFoundError so
+// callers can do errors.As against it without importing viper.
+type ConfigFileNotFoundError = viper.ConfigFileNotFoundError
+
+// Reads / state inspection.
+var (
+	Get             = viper.Get
+	GetString       = viper.GetString
+	GetBool         = viper.GetBool
+	GetInt          = viper.GetInt
+	GetDuration     = viper.GetDuration
+	IsSet           = viper.IsSet
+	AllSettings     = viper.AllSettings
+	ConfigFileUsed  = viper.ConfigFileUsed
+)
+
+// Writes to live (in-memory) state. These do NOT persist to disk; use
+// config.UpdateConfigFile for that.
+var (
+	Set        = viper.Set
+	SetDefault = viper.SetDefault
+	Reset      = viper.Reset
+)
+
+// Bindings. BindPFlags (the bulk binder) is intentionally omitted.
+var (
+	BindEnv           = viper.BindEnv
+	BindPFlag         = viper.BindPFlag
+	SetEnvPrefix      = viper.SetEnvPrefix
+	SetEnvKeyReplacer = viper.SetEnvKeyReplacer
+	AutomaticEnv      = viper.AutomaticEnv
+)
+
+// Read path: configuring how viper finds and parses the config file.
+var (
+	SetConfigType = viper.SetConfigType
+	SetConfigName = viper.SetConfigName
+	SetConfigFile = viper.SetConfigFile
+	AddConfigPath = viper.AddConfigPath
+	ReadInConfig  = viper.ReadInConfig
+)
+

--- a/internal/config/viperx/viperx.go
+++ b/internal/config/viperx/viperx.go
@@ -52,14 +52,14 @@ type ConfigFileNotFoundError = viper.ConfigFileNotFoundError
 
 // Reads / state inspection.
 var (
-	Get             = viper.Get
-	GetString       = viper.GetString
-	GetBool         = viper.GetBool
-	GetInt          = viper.GetInt
-	GetDuration     = viper.GetDuration
-	IsSet           = viper.IsSet
-	AllSettings     = viper.AllSettings
-	ConfigFileUsed  = viper.ConfigFileUsed
+	Get            = viper.Get
+	GetString      = viper.GetString
+	GetBool        = viper.GetBool
+	GetInt         = viper.GetInt
+	GetDuration    = viper.GetDuration
+	IsSet          = viper.IsSet
+	AllSettings    = viper.AllSettings
+	ConfigFileUsed = viper.ConfigFileUsed
 )
 
 // Writes to live (in-memory) state. These do NOT persist to disk; use
@@ -87,4 +87,3 @@ var (
 	AddConfigPath = viper.AddConfigPath
 	ReadInConfig  = viper.ReadInConfig
 )
-

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -1,0 +1,174 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+// PersistableKeys is the allowlist of viper keys that may be written back to
+// drconfig.yaml. Any key not in this set is intentionally NOT persisted, even
+// if it is currently set in the live viper config (e.g. transient flags such
+// as --yes, --verbose, --force-interactive).
+//
+// To add a new persistable key, add it here. Keys may use viper dotted-path
+// notation (e.g. "pulumi.config.passphrase") for nested values, but the
+// current callers all use flat top-level keys.
+var PersistableKeys = map[string]struct{}{
+	DataRobotURL:               {},
+	DataRobotAPIKey:            {},
+	APIConsumerTrackingEnabled: {},
+	"ssl_verify":               {},
+	"pulumi_config_passphrase": {},
+}
+
+// UpdateConfigFile writes only the allowlisted keys from viper back to the
+// drconfig.yaml file on disk, preserving any other fields that already exist
+// in the file but are not currently tracked by viper.
+//
+// This replaces direct calls to viper.WriteConfig(), which would otherwise
+// serialize the entire viper.AllSettings() map -- including transient command
+// flags such as --yes that should never be persisted.
+//
+// The keys argument optionally restricts the write to a subset of the
+// allowlist. If keys is empty, all allowlisted keys currently set in viper
+// are written. Any key passed in that is not in the allowlist is ignored.
+func UpdateConfigFile(keys ...string) error {
+	if err := CreateConfigFileDirIfNotExists(); err != nil {
+		return err
+	}
+
+	configFile, err := resolveConfigFilePath()
+	if err != nil {
+		return err
+	}
+
+	existing, err := readYAMLFile(configFile)
+	if err != nil {
+		return err
+	}
+
+	applyAllowedKeys(existing, keys)
+
+	out, err := yaml.Marshal(existing)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(configFile, out, 0o600); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	return nil
+}
+
+// resolveConfigFilePath returns the active drconfig.yaml path, falling back
+// to the default location if viper has not yet recorded a config file used.
+func resolveConfigFilePath() (string, error) {
+	if configFile := viper.ConfigFileUsed(); configFile != "" {
+		return configFile, nil
+	}
+
+	dir, err := GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, configFileName), nil
+}
+
+// applyAllowedKeys overlays values from viper onto target for each key in
+// the allowlist. If keys is empty, all keys in PersistableKeys are
+// considered. Keys not in PersistableKeys are silently ignored.
+func applyAllowedKeys(target map[string]interface{}, keys []string) {
+	candidates := keys
+	if len(candidates) == 0 {
+		candidates = make([]string, 0, len(PersistableKeys))
+
+		for k := range PersistableKeys {
+			candidates = append(candidates, k)
+		}
+	}
+
+	for _, key := range candidates {
+		if _, ok := PersistableKeys[key]; !ok {
+			continue
+		}
+
+		if !viper.IsSet(key) {
+			continue
+		}
+
+		setNestedKey(target, key, viper.Get(key))
+	}
+}
+
+// readYAMLFile reads a YAML file into a generic map. If the file does not
+// exist or is empty, an empty map is returned.
+func readYAMLFile(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]interface{}{}, nil
+		}
+
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	if len(data) == 0 {
+		return map[string]interface{}{}, nil
+	}
+
+	out := map[string]interface{}{}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	if out == nil {
+		out = map[string]interface{}{}
+	}
+
+	return out, nil
+}
+
+// setNestedKey sets a value at a dotted-path key in a nested map, creating
+// intermediate maps as needed. Keys without dots are set at the top level.
+func setNestedKey(m map[string]interface{}, key string, value interface{}) {
+	parts := strings.Split(key, ".")
+
+	cur := m
+
+	for i, p := range parts {
+		if i == len(parts)-1 {
+			cur[p] = value
+			return
+		}
+
+		next, ok := cur[p].(map[string]interface{})
+		if !ok {
+			next = map[string]interface{}{}
+			cur[p] = next
+		}
+
+		cur = next
+	}
+}

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -42,8 +42,8 @@ var PersistableKeys = map[string]struct{}{
 }
 
 // UpdateConfigFile writes only the allowlisted keys from viper back to the
-// drconfig.yaml file on disk, preserving any other fields that already exist
-// in the file but are not currently tracked by viper.
+// drconfig.yaml file on disk, preserving any other fields and comments that
+// already exist in the file but are not currently tracked by viper.
 //
 // This replaces direct calls to viper.WriteConfig(), which would otherwise
 // serialize the entire viper.AllSettings() map -- including transient command
@@ -62,14 +62,19 @@ func UpdateConfigFile(keys ...string) error {
 		return err
 	}
 
-	existing, err := readYAMLFile(configFile)
+	rootNode, err := readYAMLNode(configFile)
 	if err != nil {
 		return err
 	}
 
-	applyAllowedKeys(existing, keys)
+	applyAllowedKeysToNode(rootNode, keys)
 
-	out, err := yaml.Marshal(existing)
+	docNode := &yaml.Node{
+		Kind:    yaml.DocumentNode,
+		Content: []*yaml.Node{rootNode},
+	}
+
+	out, err := yaml.Marshal(docNode)
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
@@ -96,10 +101,43 @@ func resolveConfigFilePath() (string, error) {
 	return filepath.Join(dir, configFileName), nil
 }
 
-// applyAllowedKeys overlays values from viper onto target for each key in
-// the allowlist. If keys is empty, all keys in PersistableKeys are
-// considered. Keys not in PersistableKeys are silently ignored.
-func applyAllowedKeys(target map[string]interface{}, keys []string) {
+// readYAMLNode reads a YAML file into a *yaml.Node, preserving comments and
+// structure. If the file does not exist or is empty, an empty map node is returned.
+// Returns the root mapping node (unwrapping the document node if necessary).
+func readYAMLNode(path string) (*yaml.Node, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}, nil
+		}
+
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	if len(data) == 0 {
+		return &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}, nil
+	}
+
+	doc := &yaml.Node{}
+	if err := yaml.Unmarshal(data, doc); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		return doc.Content[0], nil
+	}
+
+	if doc.Kind == 0 {
+		return &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}, nil
+	}
+
+	return doc, nil
+}
+
+// applyAllowedKeysToNode updates keys in a yaml.Node, preserving comments
+// and non-allowlisted keys. It navigates to nested keys using dotted notation
+// (e.g. "foo.bar.baz").
+func applyAllowedKeysToNode(node *yaml.Node, keys []string) {
 	candidates := keys
 	if len(candidates) == 0 {
 		candidates = make([]string, 0, len(PersistableKeys))
@@ -118,57 +156,122 @@ func applyAllowedKeys(target map[string]interface{}, keys []string) {
 			continue
 		}
 
-		setNestedKey(target, key, viper.Get(key))
+		setNestedKeyInNode(node, key, viper.Get(key))
 	}
 }
 
-// readYAMLFile reads a YAML file into a generic map. If the file does not
-// exist or is empty, an empty map is returned.
-func readYAMLFile(path string) (map[string]interface{}, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return map[string]interface{}{}, nil
-		}
+// Note: Keys NOT in candidates are preserved as-is from the existing node.
+// This is intentional to preserve custom fields written by users or other tools.
 
-		return nil, fmt.Errorf("failed to read config file: %w", err)
-	}
-
-	if len(data) == 0 {
-		return map[string]interface{}{}, nil
-	}
-
-	out := map[string]interface{}{}
-	if err := yaml.Unmarshal(data, &out); err != nil {
-		return nil, fmt.Errorf("failed to parse config file: %w", err)
-	}
-
-	if out == nil {
-		out = map[string]interface{}{}
-	}
-
-	return out, nil
-}
-
-// setNestedKey sets a value at a dotted-path key in a nested map, creating
-// intermediate maps as needed. Keys without dots are set at the top level.
-func setNestedKey(m map[string]interface{}, key string, value interface{}) {
+// setNestedKeyInNode sets a value at a dotted-path key in a yaml.Node,
+// creating intermediate nodes as needed. Comments on existing keys are preserved.
+func setNestedKeyInNode(node *yaml.Node, key string, value interface{}) {
 	parts := strings.Split(key, ".")
 
-	cur := m
+	for i, part := range parts {
+		if node.Kind != yaml.MappingNode {
+			node.Kind = yaml.MappingNode
+			node.Tag = "!!map"
+			node.Content = []*yaml.Node{}
+		}
 
-	for i, p := range parts {
+		keyNode, valNode := findOrCreateKeyInNode(node, part)
+
 		if i == len(parts)-1 {
-			cur[p] = value
+			encodeValueToNode(valNode, value)
 			return
 		}
 
-		next, ok := cur[p].(map[string]interface{})
-		if !ok {
-			next = map[string]interface{}{}
-			cur[p] = next
+		if valNode.Kind != yaml.MappingNode {
+			valNode.Kind = yaml.MappingNode
+			valNode.Tag = "!!map"
+			valNode.Content = []*yaml.Node{}
 		}
 
-		cur = next
+		node = valNode
+		_ = keyNode
+	}
+}
+
+// findOrCreateKeyInNode finds or creates a key in a mapping node, returning
+// both the key and value nodes. If the key exists, its existing value node
+// is returned (preserving any comments on that node). If the key doesn't exist,
+// a new entry is created.
+func findOrCreateKeyInNode(node *yaml.Node, key string) (*yaml.Node, *yaml.Node) {
+	if node.Content == nil {
+		node.Content = []*yaml.Node{}
+	}
+
+	for i := 0; i < len(node.Content); i += 2 {
+		if i+1 >= len(node.Content) {
+			break
+		}
+
+		keyNode := node.Content[i]
+		if keyNode.Value == key {
+			return keyNode, node.Content[i+1]
+		}
+	}
+
+	keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: key}
+	valNode := &yaml.Node{Kind: yaml.ScalarNode}
+
+	node.Content = append(node.Content, keyNode, valNode)
+
+	return keyNode, valNode
+}
+
+// encodeValueToNode encodes a Go value into a yaml.Node, handling common types.
+func encodeValueToNode(node *yaml.Node, value interface{}) {
+	switch v := value.(type) {
+	case string:
+		node.Kind = yaml.ScalarNode
+		node.Tag = "!!str"
+		node.Value = v
+
+	case int, int32, int64:
+		node.Kind = yaml.ScalarNode
+		node.Tag = "!!int"
+		node.Value = fmt.Sprintf("%v", v)
+
+	case float32, float64:
+		node.Kind = yaml.ScalarNode
+		node.Tag = "!!float"
+		node.Value = fmt.Sprintf("%v", v)
+
+	case bool:
+		node.Kind = yaml.ScalarNode
+		node.Tag = "!!bool"
+
+		if v {
+			node.Value = "true"
+		} else {
+			node.Value = "false"
+		}
+
+	case nil:
+		node.Kind = yaml.ScalarNode
+		node.Tag = "!!null"
+		node.Value = ""
+
+	default:
+		encoded, err := yaml.Marshal(v)
+		if err != nil {
+			node.Kind = yaml.ScalarNode
+			node.Value = fmt.Sprintf("%v", v)
+
+			return
+		}
+
+		tempNode := &yaml.Node{}
+
+		if err := yaml.Unmarshal(encoded, tempNode); err != nil {
+			node.Kind = yaml.ScalarNode
+			node.Value = fmt.Sprintf("%v", v)
+
+			return
+		}
+
+		*node = *tempNode
 	}
 }

--- a/internal/envbuilder/validator.go
+++ b/internal/envbuilder/validator.go
@@ -19,7 +19,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 // ValidationResult represents the validation status of a single variable.
@@ -118,7 +118,7 @@ func promptsWithValues(prompts []UserPrompt, variables Variables) []UserPrompt {
 			// Check if already set in environment
 			if _, ok := os.LookupEnv(prompts[p].Env); !ok {
 				// Not in environment, check viper config
-				if configValue := viper.GetString("pulumi_config_passphrase"); configValue != "" {
+				if configValue := viperx.GetString("pulumi_config_passphrase"); configValue != "" {
 					prompts[p].Value = configValue
 				}
 			}

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/charmbracelet/log"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 const logLevelWidth = 5
@@ -49,9 +49,9 @@ var (
 // Start sets up and starts both stderr and file loggers
 func Start() {
 	// Debug takes precedence
-	if viper.GetBool("debug") {
+	if viperx.GetBool("debug") {
 		level = log.DebugLevel
-	} else if viper.GetBool("verbose") {
+	} else if viperx.GetBool("verbose") {
 		level = log.InfoLevel
 	} else {
 		level = log.Default().GetLevel()

--- a/internal/plugin/discover.go
+++ b/internal/plugin/discover.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/repo"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 // PluginRegistryTerminology is the user-facing term for the plugin registry
@@ -269,8 +269,8 @@ func discoverInDir(dir string, seen map[string]bool) ([]DiscoveredPlugin, []erro
 func getManifest(executable string) (*PluginManifest, error) {
 	// Default timeout if not configured
 	timeout := 500 * time.Millisecond
-	if viper.IsSet("plugin.manifest_timeout_ms") {
-		timeout = time.Duration(viper.GetInt("plugin.manifest_timeout_ms")) * time.Millisecond
+	if viperx.IsSet("plugin.manifest_timeout_ms") {
+		timeout = time.Duration(viperx.GetInt("plugin.manifest_timeout_ms")) * time.Millisecond
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/internal/plugin/discover.go
+++ b/internal/plugin/discover.go
@@ -25,9 +25,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/repo"
-	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 // PluginRegistryTerminology is the user-facing term for the plugin registry

--- a/internal/plugin/discover_test.go
+++ b/internal/plugin/discover_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -209,7 +209,7 @@ func (s *ManifestTestSuite) SetupTest() {
 	s.Require().NoError(err)
 
 	// Reset viper state for each test
-	viper.Reset()
+	viperx.Reset()
 }
 
 func (s *ManifestTestSuite) TearDownTest() {
@@ -217,7 +217,7 @@ func (s *ManifestTestSuite) TearDownTest() {
 		_ = os.RemoveAll(s.tempDir)
 	}
 
-	viper.Reset()
+	viperx.Reset()
 }
 
 func (s *ManifestTestSuite) TestGetManifestValid() {
@@ -247,7 +247,7 @@ func (s *ManifestTestSuite) TestGetManifestNonExistent() {
 
 func (s *ManifestTestSuite) TestGetManifestWithConfiguredTimeout() {
 	// Set a custom timeout via viper
-	viper.Set("plugin.manifest_timeout_ms", 1000)
+	viperx.Set("plugin.manifest_timeout_ms", 1000)
 
 	path := createMockPlugin(s.T(), s.tempDir, "dr-test", validManifest)
 

--- a/internal/plugin/exec.go
+++ b/internal/plugin/exec.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 // ExecutePlugin runs a plugin and returns its exit code
@@ -122,7 +122,7 @@ func buildPluginEnv(pluginPath string, requireAuth bool) []string {
 	}
 
 	// Set config path for all plugins
-	if configPath := viper.ConfigFileUsed(); configPath != "" {
+	if configPath := viperx.ConfigFileUsed(); configPath != "" {
 		env = append(env, "DATAROBOT_CONFIG="+configPath)
 	}
 
@@ -130,11 +130,11 @@ func buildPluginEnv(pluginPath string, requireAuth bool) []string {
 		return env
 	}
 
-	if endpoint := viper.GetString(config.DataRobotURL); endpoint != "" {
+	if endpoint := viperx.GetString(config.DataRobotURL); endpoint != "" {
 		env = append(env, "DATAROBOT_ENDPOINT="+endpoint)
 	}
 
-	if token := viper.GetString(config.DataRobotAPIKey); token != "" {
+	if token := viperx.GetString(config.DataRobotAPIKey); token != "" {
 		env = append(env, "DATAROBOT_API_TOKEN="+token)
 	}
 

--- a/internal/plugin/exec_test.go
+++ b/internal/plugin/exec_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/internal/config"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -169,9 +169,9 @@ func TestExecutePluginCustomUserAgent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	viper.Reset()
-	viper.Set(config.DataRobotURL, server.URL)
-	viper.Set(config.DataRobotAPIKey, "test-token")
+	viperx.Reset()
+	viperx.Set(config.DataRobotURL, server.URL)
+	viperx.Set(config.DataRobotAPIKey, "test-token")
 
 	os.Unsetenv("DATAROBOT_ENDPOINT")
 	os.Unsetenv("DATAROBOT_API_TOKEN")

--- a/internal/plugin/updatecheck.go
+++ b/internal/plugin/updatecheck.go
@@ -19,9 +19,9 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/state"
-	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 const (

--- a/internal/plugin/updatecheck.go
+++ b/internal/plugin/updatecheck.go
@@ -21,7 +21,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/state"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 const (
@@ -83,7 +83,7 @@ func CheckForUpdate(pluginName, installedVersion, registryURL string) *UpdateChe
 // shouldSkipCheck returns true when the update check should be skipped
 // because it is disabled or the cooldown has not elapsed.
 func shouldSkipCheck(pluginName string) bool {
-	interval := viper.GetDuration("plugin-update-check-interval")
+	interval := viperx.GetDuration("plugin-update-check-interval")
 	if interval <= 0 {
 		log.Debug("Plugin update check disabled via config", "plugin", pluginName)
 

--- a/internal/plugin/updatecheck_test.go
+++ b/internal/plugin/updatecheck_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/datarobot/cli/internal/state"
 	"github.com/datarobot/cli/internal/testutil"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -64,8 +64,8 @@ func TestCheckForUpdate(t *testing.T) {
 		tmpDir := t.TempDir()
 		testutil.SetTestHomeDir(t, tmpDir)
 
-		viper.Set("plugin-update-check-interval", time.Duration(0))
-		defer viper.Set("plugin-update-check-interval", nil)
+		viperx.Set("plugin-update-check-interval", time.Duration(0))
+		defer viperx.Set("plugin-update-check-interval", nil)
 
 		result := CheckForUpdate("assist", "0.1.0", "http://localhost/index.json")
 
@@ -76,8 +76,8 @@ func TestCheckForUpdate(t *testing.T) {
 		tmpDir := t.TempDir()
 		testutil.SetTestHomeDir(t, tmpDir)
 
-		viper.Set("plugin-update-check-interval", 24*time.Hour)
-		defer viper.Set("plugin-update-check-interval", nil)
+		viperx.Set("plugin-update-check-interval", 24*time.Hour)
+		defer viperx.Set("plugin-update-check-interval", nil)
 
 		// Set a recent check timestamp
 		state.SetLastPluginCheck("assist")
@@ -91,8 +91,8 @@ func TestCheckForUpdate(t *testing.T) {
 		tmpDir := t.TempDir()
 		testutil.SetTestHomeDir(t, tmpDir)
 
-		viper.Set("plugin-update-check-interval", 1*time.Millisecond)
-		defer viper.Set("plugin-update-check-interval", nil)
+		viperx.Set("plugin-update-check-interval", 1*time.Millisecond)
+		defer viperx.Set("plugin-update-check-interval", nil)
 
 		// Use a URL that will fail immediately
 		result := CheckForUpdate("assist", "0.1.0", "http://192.0.2.1:1/index.json")
@@ -104,8 +104,8 @@ func TestCheckForUpdate(t *testing.T) {
 		tmpDir := t.TempDir()
 		testutil.SetTestHomeDir(t, tmpDir)
 
-		viper.Set("plugin-update-check-interval", 1*time.Millisecond)
-		defer viper.Set("plugin-update-check-interval", nil)
+		viperx.Set("plugin-update-check-interval", 1*time.Millisecond)
+		defer viperx.Set("plugin-update-check-interval", nil)
 
 		registry := newTestRegistry("assist", "0.1.13")
 		srv := serveRegistry(t, registry)
@@ -119,8 +119,8 @@ func TestCheckForUpdate(t *testing.T) {
 		tmpDir := t.TempDir()
 		testutil.SetTestHomeDir(t, tmpDir)
 
-		viper.Set("plugin-update-check-interval", 1*time.Millisecond)
-		defer viper.Set("plugin-update-check-interval", nil)
+		viperx.Set("plugin-update-check-interval", 1*time.Millisecond)
+		defer viperx.Set("plugin-update-check-interval", nil)
 
 		registry := newTestRegistry("assist", "0.2.0")
 		srv := serveRegistry(t, registry)
@@ -137,8 +137,8 @@ func TestCheckForUpdate(t *testing.T) {
 		tmpDir := t.TempDir()
 		testutil.SetTestHomeDir(t, tmpDir)
 
-		viper.Set("plugin-update-check-interval", 1*time.Millisecond)
-		defer viper.Set("plugin-update-check-interval", nil)
+		viperx.Set("plugin-update-check-interval", 1*time.Millisecond)
+		defer viperx.Set("plugin-update-check-interval", nil)
 
 		registry := newTestRegistry("other-plugin", "1.0.0")
 		srv := serveRegistry(t, registry)
@@ -152,8 +152,8 @@ func TestCheckForUpdate(t *testing.T) {
 		tmpDir := t.TempDir()
 		testutil.SetTestHomeDir(t, tmpDir)
 
-		viper.Set("plugin-update-check-interval", 1*time.Millisecond)
-		defer viper.Set("plugin-update-check-interval", nil)
+		viperx.Set("plugin-update-check-interval", 1*time.Millisecond)
+		defer viperx.Set("plugin-update-check-interval", nil)
 
 		registry := newTestRegistry("assist", "0.1.0")
 		srv := serveRegistry(t, registry)
@@ -167,8 +167,8 @@ func TestCheckForUpdate(t *testing.T) {
 		tmpDir := t.TempDir()
 		testutil.SetTestHomeDir(t, tmpDir)
 
-		viper.Set("plugin-update-check-interval", 1*time.Millisecond)
-		defer viper.Set("plugin-update-check-interval", nil)
+		viperx.Set("plugin-update-check-interval", 1*time.Millisecond)
+		defer viperx.Set("plugin-update-check-interval", nil)
 
 		registry := newTestRegistry("assist", "0.2.0")
 		srv := serveRegistry(t, registry)
@@ -184,8 +184,8 @@ func TestCheckForUpdate(t *testing.T) {
 		tmpDir := t.TempDir()
 		testutil.SetTestHomeDir(t, tmpDir)
 
-		viper.Set("plugin-update-check-interval", 1*time.Millisecond)
-		defer viper.Set("plugin-update-check-interval", nil)
+		viperx.Set("plugin-update-check-interval", 1*time.Millisecond)
+		defer viperx.Set("plugin-update-check-interval", nil)
 
 		registry := newTestRegistry("assist", "0.2.0")
 		srv := serveRegistry(t, registry)
@@ -200,8 +200,8 @@ func TestCheckForUpdate(t *testing.T) {
 		tmpDir := t.TempDir()
 		testutil.SetTestHomeDir(t, tmpDir)
 
-		viper.Set("plugin-update-check-interval", 1*time.Millisecond)
-		defer viper.Set("plugin-update-check-interval", nil)
+		viperx.Set("plugin-update-check-interval", 1*time.Millisecond)
+		defer viperx.Set("plugin-update-check-interval", nil)
 
 		registry := newTestRegistry("assist", "0.1.13")
 		srv := serveRegistry(t, registry)
@@ -217,8 +217,8 @@ func TestCheckForUpdate(t *testing.T) {
 	})
 
 	t.Run("returns nil when registry returns HTTP error", func(t *testing.T) {
-		viper.Set("plugin-update-check-interval", 1*time.Millisecond)
-		defer viper.Set("plugin-update-check-interval", nil)
+		viperx.Set("plugin-update-check-interval", 1*time.Millisecond)
+		defer viperx.Set("plugin-update-check-interval", nil)
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/internal/plugin/updatecheck_test.go
+++ b/internal/plugin/updatecheck_test.go
@@ -21,9 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/state"
 	"github.com/datarobot/cli/internal/testutil"
-	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/state/dotenv_test.go
+++ b/internal/state/dotenv_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -197,17 +197,17 @@ func TestDotenvSetupTracking(t *testing.T) {
 		assert.True(t, HasCompletedDotenvSetup(tmpDir))
 
 		// Set force-interactive flag
-		oldValue := viper.GetBool("force-interactive")
+		oldValue := viperx.GetBool("force-interactive")
 
-		viper.Set("force-interactive", true)
+		viperx.Set("force-interactive", true)
 
-		defer viper.Set("force-interactive", oldValue)
+		defer viperx.Set("force-interactive", oldValue)
 
 		// Now should return false even though state file exists
 		assert.False(t, HasCompletedDotenvSetup(tmpDir))
 
 		// Reset flag
-		viper.Set("force-interactive", oldValue)
+		viperx.Set("force-interactive", oldValue)
 
 		// Should return true again
 		assert.True(t, HasCompletedDotenvSetup(tmpDir))

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -19,8 +19,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/datarobot/cli/internal/version"
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/version"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/datarobot/cli/internal/version"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"gopkg.in/yaml.v3"
 )
 
@@ -148,7 +148,7 @@ func UpdateAfterTemplatesSetup(repoRoot string) error {
 // If force-interactive flag is set, this always returns false to force re-execution.
 func HasCompletedDotenvSetup(repoRoot string) bool {
 	// Check if we should force the wizard to run
-	if viper.GetBool("force-interactive") {
+	if viperx.GetBool("force-interactive") {
 		return false
 	}
 

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -28,7 +28,7 @@ import (
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/internal/version"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 // CommonProperties holds the set of properties attached to every telemetry
@@ -60,7 +60,7 @@ func CollectCommonProperties() *CommonProperties {
 	}
 
 	// Get DataRobot instance info from config
-	if endpoint := viper.GetString(config.DataRobotURL); endpoint != "" {
+	if endpoint := viperx.GetString(config.DataRobotURL); endpoint != "" {
 		if baseURL, err := config.SchemeHostOnly(endpoint); err == nil {
 			props.DataRobotInstance = baseURL
 			props.Environment = deriveEnvironment(baseURL)

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -25,10 +25,10 @@ import (
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/internal/version"
-	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 // CommonProperties holds the set of properties attached to every telemetry

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/amplitude/analytics-go/amplitude"
 	"github.com/amplitude/analytics-go/amplitude/types"
-	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/log"
 )
 
 // AmplitudeAPIKey is set at build time via ldflags. Dev builds have an empty value,

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -28,7 +28,7 @@ import (
 	"github.com/amplitude/analytics-go/amplitude"
 	"github.com/amplitude/analytics-go/amplitude/types"
 	"github.com/datarobot/cli/internal/log"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 )
 
 // AmplitudeAPIKey is set at build time via ldflags. Dev builds have an empty value,
@@ -128,7 +128,7 @@ func (c *Client) Flush(timeout time.Duration) {
 // opted out via the disable-telemetry flag/env var/config key.
 func IsEnabled() bool {
 	// Check if telemetry is explicitly disabled
-	if viper.GetBool("disable-telemetry") {
+	if viperx.GetBool("disable-telemetry") {
 		return false
 	}
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/amplitude/analytics-go/amplitude/types"
-	"github.com/spf13/viper"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,7 +31,7 @@ func TestNewClient_DisabledWhenAPIKeyEmpty(t *testing.T) {
 
 	AmplitudeAPIKey = ""
 
-	viper.Set("disable-telemetry", false)
+	viperx.Set("disable-telemetry", false)
 
 	client := NewClient(nil)
 
@@ -47,7 +47,7 @@ func TestNewClient_DisabledWhenFlagSet(t *testing.T) {
 
 	AmplitudeAPIKey = "test-key"
 
-	viper.Set("disable-telemetry", true)
+	viperx.Set("disable-telemetry", true)
 
 	client := NewClient(nil)
 
@@ -55,7 +55,7 @@ func TestNewClient_DisabledWhenFlagSet(t *testing.T) {
 	assert.Nil(t, client.amp)
 
 	// Cleanup
-	viper.Set("disable-telemetry", false)
+	viperx.Set("disable-telemetry", false)
 }
 
 func TestNewClient_EnabledWhenAPIKeySetAndNotDisabled(t *testing.T) {
@@ -66,7 +66,7 @@ func TestNewClient_EnabledWhenAPIKeySetAndNotDisabled(t *testing.T) {
 
 	AmplitudeAPIKey = "test-key"
 
-	viper.Set("disable-telemetry", false)
+	viperx.Set("disable-telemetry", false)
 
 	client := NewClient(nil)
 
@@ -101,7 +101,7 @@ func TestTrack_NoOpWhenDisabled(t *testing.T) {
 
 	AmplitudeAPIKey = ""
 
-	viper.Set("disable-telemetry", false)
+	viperx.Set("disable-telemetry", false)
 
 	client := NewClient(nil)
 	event := types.Event{
@@ -161,7 +161,7 @@ func TestIsEnabled_FalseWhenAPIKeyEmpty(t *testing.T) {
 
 	AmplitudeAPIKey = ""
 
-	viper.Set("disable-telemetry", false)
+	viperx.Set("disable-telemetry", false)
 
 	assert.False(t, IsEnabled())
 }
@@ -174,12 +174,12 @@ func TestIsEnabled_FalseWhenDisableFlagSet(t *testing.T) {
 
 	AmplitudeAPIKey = "test-key"
 
-	viper.Set("disable-telemetry", true)
+	viperx.Set("disable-telemetry", true)
 
 	assert.False(t, IsEnabled())
 
 	// Cleanup
-	viper.Set("disable-telemetry", false)
+	viperx.Set("disable-telemetry", false)
 }
 
 func TestIsEnabled_TrueWhenAPIKeySetAndNotDisabled(t *testing.T) {
@@ -190,7 +190,7 @@ func TestIsEnabled_TrueWhenAPIKeySetAndNotDisabled(t *testing.T) {
 
 	AmplitudeAPIKey = "test-key"
 
-	viper.Set("disable-telemetry", false)
+	viperx.Set("disable-telemetry", false)
 
 	assert.True(t, IsEnabled())
 }


### PR DESCRIPTION
# RATIONALE

We only want viper to write certain configuration properties to drconfig.yaml when `WriteConfig()` and `SafeWriteConfig()` are invoked. `--yes` is not one of them.

I think the ideal way to handle this would be to use separate viper instances to separate reading and writing of drconfig.yaml, but that is a larger refactor that needs more discussion and thought.

So let me break down the problem a bit more:  let's hide viper's write interface as much as possible, through a combination of a new viperx module that delegates to viper and better linting.

I will also write specific logic out to the YAML file directly; Yuriy did similar work with .env in the past.

Hacky, but more manageable I think.

## CHANGES

I made a lot of changes in this PR, so I asked Factory to break down the changeset.

### MAIN FILES

internal/config/viperx/viperx.go - safe viper wrapper
internal/config/write.go - YAML-preserving config updates
internal/auth/auth.go - now uses safe write API
.golangci.yaml - Enforcement via linting
docs/development/configuration.md - User documentation

### 578aeb2 - refactor: wrap viper and hide unsafe write interface
Created internal/config/viperx/viperx.go wrapper package
Re-exports only safe viper APIs to prevent misuse
Intentionally omits: WriteConfig(), SafeWriteConfig(), BindPFlags()
Enforces configuration safety at the API level via depguard

### a133424 - feat: when viper writes to drconfig, allowlist certain fields
Introduced config.UpdateConfigFile() as safe replacement for viper.WriteConfig()
Implements allowlist pattern in PersistableKeys (endpoint, token, ssl_verify, pulumi_config_passphrase)
Prevents transient command flags (--yes, --verbose, --debug) from leaking into drconfig.yaml
Updates auth package to use new safe write API
Adds comprehensive tests for field preservation and allowlisting

### 9739831 - chore: extend linter to disallow viper.WriteConfig and SafeWriteConfig
Added golangci-lint depguard rules to prevent direct viper imports outside internal/config/
Enforces usage of viperx wrapper package
Compile-time protection against unsafe configuration patterns

### 08d90c8 - docs: consolidate configuration stuff
Consolidated docs on how configuration should work, into docs/development/configuration.md
Documents allowlist pattern, persistent vs transient flags
Examples of correct config binding and read patterns
Explains viper wrapper design rationale

### e41dfa2 - feat: preserve YAML comments and structure in config updates (Latest)
Problem: Previous implementation used yaml.Unmarshal() → map → yaml.Marshal(), losing all comments
Solution: Use yaml.v3 Node types to preserve AST during round-trip
Implementation:
readYAMLNode(): Parses YAML into node tree preserving all formatting
applyAllowedKeysToNode(): Updates only allowlisted keys
setNestedKeyInNode(), findOrCreateKeyInNode(): Navigate/modify nodes while preserving structure
encodeValueToNode(): Proper type-tagged node encoding
Verification: All 4 WriteConfig tests pass; comment preservation validated

## IMPACT

### BEFORE

viper.WriteConfig() would serialize entire viper state → corrupts config with transient flags
Map-based round-trip → loses user comments and formatting

### AFTER

Safe API prevents accidental misuse via compile-time checks
Comments and custom fields preserved across updates
Clear allowlist prevents flag leakage
Comprehensive test coverage ensures correctness

## TESTING

https://github.com/user-attachments/assets/2eb49d5e-0cd8-48fd-905a-c4e02afc30b0

## TESTING

The new depguard linter rule looks like this in practice:

```
╰─ ❌201 ❯ task lint
🧹 Checking go.mod…
🧹 Checking formatting…
🧹 Vetting…
🧹 Linting…
cmd/root.go:44:2: import 'github.com/spf13/viper' is not allowed from list 'no-raw-viper': Import internal/config/viperx instead of github.com/spf13/viper. The wrapper omits WriteConfig, SafeWriteConfig, and BindPFlags by design so transient flag state cannot leak into drconfig.yaml. See docs/development/configuration.md. (depguard)
        "github.com/spf13/viper"
        ^
cmd/root.go:146:18: Error return value of `viper.BindPFlags` is not checked (errcheck)
        viper.BindPFlags(RootCmd.PersistentFlags())
                        ^
2 issues:
* depguard: 1
* errcheck: 1
task: Failed to run task "lint": exit status 1
```

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e41dfa2bcd2a8811826b9469bdf0c45bb2dce27e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->