### PR TITLE
[CFX-5919] Adding --output param to 'dr dotenv setup'

### DIFF
--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -109,12 +109,20 @@ This wizard will help you:
 	PreRunE: auth.EnsureAuthenticatedE,
 
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		outputDir, _ := cmd.Flags().GetString("output")
+
 		repositoryRoot, err := ensureInRepo()
 		if err != nil {
 			return err
 		}
 
-		dotenvFile := filepath.Join(repositoryRoot, ".env")
+		var dotenvFile string
+
+		if outputDir != "" {
+			dotenvFile = filepath.Join(outputDir, ".env")
+		} else {
+			dotenvFile = filepath.Join(repositoryRoot, ".env")
+		}
 
 		// Check if we should skip when .env exists and all required variables are set
 		flagIfNeededSet, _ := cmd.Flags().GetBool("if-needed")
@@ -212,6 +220,7 @@ func init() {
 	SetupCmd.Flags().Bool("if-needed", false, "Only run setup if '.env' file doesn't exist or there are missing env vars.")
 	SetupCmd.Flags().BoolP("all", "a", false, "Show all prompts including those with default values already set.")
 	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for automation).")
+	SetupCmd.Flags().StringP("output", "o", "", "Directory where the .env file should be written (defaults to repository root).")
 	SetupCmd.MarkFlagsMutuallyExclusive("yes", "all")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper.

--- a/cmd/dotenv/cmd_test.go
+++ b/cmd/dotenv/cmd_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dotenv
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestRepo creates a temporary git repository with parakeet.yaml for testing
+func setupTestRepo(t *testing.T) string {
+	t.Helper()
+
+	repoDir := t.TempDir()
+
+	// Initialize git repository
+	cmd := exec.Command("git", "init")
+	cmd.Dir = repoDir
+
+	err := cmd.Run()
+	require.NoError(t, err, "Failed to initialize git repository")
+
+	// Create .datarobot directory
+	datarobotDir := filepath.Join(repoDir, ".datarobot")
+
+	err = os.MkdirAll(datarobotDir, 0o755)
+	require.NoError(t, err, "Failed to create .datarobot directory")
+
+	// Create parakeet.yaml with basic configuration
+	parakeetYaml := `root:
+  - env: TEST_VAR
+    type: string
+    default: "test_default"
+    optional: true
+    help: "A test variable"
+`
+	parakeetPath := filepath.Join(datarobotDir, "parakeet.yaml")
+
+	err = os.WriteFile(parakeetPath, []byte(parakeetYaml), 0o600)
+	require.NoError(t, err, "Failed to create parakeet.yaml")
+
+	return repoDir
+}
+
+func TestSetupCmd_OutputFlag(t *testing.T) {
+	// Reset viper to prevent leaking config
+	viperx.Reset()
+
+	repoDir := setupTestRepo(t)
+	outputDir := t.TempDir()
+
+	// Change to repository directory
+	originalWd, _ := os.Getwd()
+
+	defer func() {
+		_ = os.Chdir(originalWd)
+	}()
+
+	err := os.Chdir(repoDir)
+	require.NoError(t, err)
+
+	// Test the RunE function directly instead of executing the command
+	// to avoid cobra command state issues in tests
+	err = setupNonInteractive(repoDir, filepath.Join(outputDir, ".env"))
+	require.NoError(t, err, "setupNonInteractive should succeed")
+
+	// Verify .env file was created in the output directory
+	dotenvPath := filepath.Join(outputDir, ".env")
+
+	_, err = os.Stat(dotenvPath)
+	require.NoError(t, err, "Expected .env file to exist in output directory")
+
+	// Verify contents
+	contents, err := os.ReadFile(dotenvPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(contents), "TEST_VAR=\"test_default\"", "Expected .env to contain default value")
+}
+
+func TestSetupCmd_DefaultOutput(t *testing.T) {
+	// Reset viper to prevent leaking config
+	viperx.Reset()
+
+	repoDir := setupTestRepo(t)
+
+	// Change to repository directory
+	originalWd, _ := os.Getwd()
+
+	defer func() {
+		_ = os.Chdir(originalWd)
+	}()
+
+	err := os.Chdir(repoDir)
+	require.NoError(t, err)
+
+	// Test the RunE function directly - default output should use repo root
+	err = setupNonInteractive(repoDir, filepath.Join(repoDir, ".env"))
+	require.NoError(t, err, "setupNonInteractive should succeed")
+
+	// Verify .env file was created in the repository root
+	dotenvPath := filepath.Join(repoDir, ".env")
+
+	_, err = os.Stat(dotenvPath)
+	require.NoError(t, err, "Expected .env file to exist in repository root")
+
+	// Verify contents
+	contents, err := os.ReadFile(dotenvPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(contents), "TEST_VAR=\"test_default\"", "Expected .env to contain default value")
+}
+
+func TestSetupCmd_OutputFlagCreatesDirectory(t *testing.T) {
+	// Reset viper to prevent leaking config
+	viperx.Reset()
+
+	repoDir := setupTestRepo(t)
+	outputDir := filepath.Join(t.TempDir(), "nested", "path", "that", "does", "not", "exist")
+
+	// Change to repository directory
+	originalWd, _ := os.Getwd()
+
+	defer func() {
+		_ = os.Chdir(originalWd)
+	}()
+
+	err := os.Chdir(repoDir)
+	require.NoError(t, err)
+
+	// Test the RunE function directly with non-existent directory
+	err = setupNonInteractive(repoDir, filepath.Join(outputDir, ".env"))
+	require.NoError(t, err, "setupNonInteractive should succeed and create directory")
+
+	// Verify .env file was created in the nested output directory
+	dotenvPath := filepath.Join(outputDir, ".env")
+
+	_, err = os.Stat(dotenvPath)
+	require.NoError(t, err, "Expected .env file to exist in created output directory")
+
+	// Verify the directory was created
+	_, err = os.Stat(outputDir)
+	require.NoError(t, err, "Expected output directory to be created")
+}

--- a/cmd/dotenv/template.go
+++ b/cmd/dotenv/template.go
@@ -231,6 +231,12 @@ func writeContents(cleanContents, dotenvFile string) error {
 		}
 	}
 
+	// Ensure the directory exists
+	dir := filepath.Dir(dotenvFile)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
 	f, err := os.Create(dotenvFile)
 	if err != nil {
 		return err

--- a/docs/commands/dotenv.md
+++ b/docs/commands/dotenv.md
@@ -109,8 +109,6 @@ dr dotenv setup --output /path/to/config
 # Creates .env file at /path/to/config/.env (directory created if needed)
 ```
 
-**Use cases:** Writing to a specific deployment directory, managing multiple environment configurations (dev/staging/prod), or generating config files outside the repository.
-
 The wizard guides you through:
 
 1. DataRobot credentials (auto-populated if authenticated).

--- a/docs/commands/dotenv.md
+++ b/docs/commands/dotenv.md
@@ -57,6 +57,7 @@ dr dotenv setup [--if-needed]
 - `--if-needed`&mdash;Only run setup if `.env` file doesn't exist or validation fails. This flag is useful for automation scripts and CI/CD pipelines where you want to ensure configuration exists without prompting if it's already valid.
 - `-y, --yes`&mdash;Skip interactive prompts and auto-populate all environment variables with their default values (or empty strings if no default is provided). This is useful for CI/CD pipelines, automated testing, or quick development setup where you want to use all defaults. Variables with `generate: true` will still have random values auto-generated. Can also be enabled via `DATAROBOT_CLI_NON_INTERACTIVE=true` environment variable.
 - `-a, --all`&mdash;Show all prompts in the wizard, including those with default values already set. By default, prompts with defaults are skipped.
+- `-o, --output <directory>`&mdash;Specify a custom directory where the `.env` file should be written. By default, the `.env` file is written to the repository root. The directory will be created automatically if it doesn't exist. This is useful for managing multiple environment configurations or writing to a specific deployment directory.
 
 **State tracking:**
 
@@ -100,6 +101,15 @@ Or using environment variable:
 cd my-template
 DATAROBOT_CLI_NON_INTERACTIVE=true dr dotenv setup
 ```
+
+Custom output directory:
+```bash
+cd my-template
+dr dotenv setup --output /path/to/config
+# Creates .env file at /path/to/config/.env (directory created if needed)
+```
+
+**Use cases:** Writing to a specific deployment directory, managing multiple environment configurations (dev/staging/prod), or generating config files outside the repository.
 
 The wizard guides you through:
 


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

Adding --output param to 'dr dotenv setup'. This allows to write the `.env` file to a custom location.

Usage: `dr dotenv setup --output <path_to_dir>`

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CLI enhancement that changes only the destination path and ensures directories exist before writing; minimal impact beyond file I/O behavior.
> 
> **Overview**
> `dr dotenv setup` now supports `-o, --output <directory>` to write the generated `.env` file outside the repository root, while keeping the default behavior unchanged.
> 
> The `.env` writer now ensures the target directory exists before creating the file, and new tests cover default output, custom output, and auto-creation of nested output directories. Documentation is updated with the new flag and an example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07aa58f8f84f8d080995debfebb33cadeed703cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->