### PR TITLE
[CFX-5781][CFX-5782][CFX-5783] dr deps install -y

### DIFF
--- a/cmd/dependencies/cmd.go
+++ b/cmd/dependencies/cmd.go
@@ -16,6 +16,7 @@ package dependencies
 
 import (
 	"github.com/datarobot/cli/cmd/dependencies/check"
+	"github.com/datarobot/cli/cmd/dependencies/install"
 	"github.com/spf13/cobra"
 )
 
@@ -29,6 +30,7 @@ func Cmd() *cobra.Command {
 
 	cmd.AddCommand(
 		check.Cmd(),
+		install.Cmd(),
 	)
 
 	return cmd

--- a/cmd/dependencies/install/cmd.go
+++ b/cmd/dependencies/install/cmd.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/cmd/helpers"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/dependencies"
 	"github.com/datarobot/cli/internal/tools"
-	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/dependencies/install/cmd.go
+++ b/cmd/dependencies/install/cmd.go
@@ -20,8 +20,8 @@ import (
 	"github.com/datarobot/cli/cmd/helpers"
 	"github.com/datarobot/cli/internal/dependencies"
 	"github.com/datarobot/cli/internal/tools"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 type Options struct {
@@ -39,8 +39,8 @@ func Cmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, `Assume "yes" as answer to the install prompt.`)
 
 	// Bind flag to viper to enable env var support (DATAROBOT_CLI_NON_INTERACTIVE)
-	_ = viper.BindPFlag("yes", cmd.Flags().Lookup("yes"))
-	_ = viper.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindPFlag("yes", cmd.Flags().Lookup("yes"))
+	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	return cmd
 }
@@ -56,7 +56,7 @@ func RunE(cmd *cobra.Command, _ []string) error {
 
 	prerequisites := append(missingTools, wrongVersionTools...)
 
-	if !viper.GetBool("yes") {
+	if !viperx.GetBool("yes") {
 		yes, err := helpers.Confirm(cmd.OutOrStdout(), cmd.InOrStdin(), "\nInstall now? (y/n): ")
 		if err != nil {
 			cmd.SilenceUsage = true

--- a/cmd/dependencies/install/cmd.go
+++ b/cmd/dependencies/install/cmd.go
@@ -1,0 +1,78 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"fmt"
+
+	"github.com/datarobot/cli/cmd/helpers"
+	"github.com/datarobot/cli/internal/dependencies"
+	"github.com/datarobot/cli/internal/tools"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type Options struct {
+	Yes bool
+}
+
+var opts Options
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "📦 Install missing template dependencies",
+		RunE:  RunE,
+	}
+	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, `Assume "yes" as answer to the install prompt.`)
+
+	// Bind flag to viper to enable env var support (DATAROBOT_CLI_NON_INTERACTIVE)
+	_ = viper.BindPFlag("yes", cmd.Flags().Lookup("yes"))
+	_ = viper.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+
+	return cmd
+}
+
+func RunE(cmd *cobra.Command, _ []string) error {
+	missingTools, wrongVersionTools, missingMsgs, wrongVersionMsgs := tools.CheckPrerequisites()
+	if len(missingMsgs) == 0 && len(wrongVersionMsgs) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "✅ All dependencies are already up to date.")
+		return nil
+	}
+
+	fmt.Fprintln(cmd.OutOrStderr(), tools.PrerequisitesMsg(missingMsgs, wrongVersionMsgs))
+
+	prerequisites := append(missingTools, wrongVersionTools...)
+
+	if !viper.GetBool("yes") {
+		yes, err := helpers.Confirm(cmd.OutOrStdout(), cmd.InOrStdin(), "\nInstall now? (y/n): ")
+		if err != nil {
+			cmd.SilenceUsage = true
+			return err
+		}
+
+		if !yes {
+			return nil
+		}
+	}
+
+	err := dependencies.InstallPrerequisites(cmd.OutOrStdout(), prerequisites)
+	if err != nil {
+		cmd.SilenceUsage = true
+		return err
+	}
+
+	return nil
+}

--- a/cmd/helpers/helpers.go
+++ b/cmd/helpers/helpers.go
@@ -12,35 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package check
+package helpers
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
-
-	"github.com/datarobot/cli/internal/tools"
-	"github.com/spf13/cobra"
+	"io"
+	"strings"
 )
 
-func Cmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "check",
-		Short: "✅ Check template dependencies",
-		RunE:  RunE,
+func Confirm(w io.Writer, r io.Reader, msg string) (bool, error) {
+	fmt.Fprint(w, msg)
+
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		return false, errors.New("failed to read user input")
 	}
 
-	return cmd
-}
+	answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
 
-func RunE(cmd *cobra.Command, _ []string) error {
-	missing := tools.MissingPrerequisites()
-
-	if missing != "" {
-		cmd.SilenceUsage = true
-		return errors.New(missing)
+	if answer != "y" && answer != "yes" {
+		return false, nil
 	}
 
-	fmt.Fprintln(cmd.OutOrStdout(), "✅ All dependencies are already up to date.")
-
-	return nil
+	return true, nil
 }

--- a/cmd/helpers/helpers_test.go
+++ b/cmd/helpers/helpers_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfirm_PrintsPrompt(t *testing.T) {
+	var out bytes.Buffer
+
+	_, _ = Confirm(&out, strings.NewReader("y\n"), "Install now? (y/n): ")
+
+	assert.Equal(t, "Install now? (y/n): ", out.String())
+}
+
+func TestConfirm_AcceptsY(t *testing.T) {
+	ok, err := Confirm(&bytes.Buffer{}, strings.NewReader("y\n"), "")
+
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestConfirm_AcceptsYes(t *testing.T) {
+	ok, err := Confirm(&bytes.Buffer{}, strings.NewReader("yes\n"), "")
+
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestConfirm_AcceptsCaseInsensitive(t *testing.T) {
+	for _, input := range []string{"Y\n", "YES\n", "Yes\n"} {
+		ok, err := Confirm(&bytes.Buffer{}, strings.NewReader(input), "")
+
+		require.NoError(t, err)
+		assert.True(t, ok, "input %q should be accepted", input)
+	}
+}
+
+func TestConfirm_RejectsN(t *testing.T) {
+	ok, err := Confirm(&bytes.Buffer{}, strings.NewReader("n\n"), "")
+
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestConfirm_RejectsArbitraryInput(t *testing.T) {
+	ok, err := Confirm(&bytes.Buffer{}, strings.NewReader("maybe\n"), "")
+
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestConfirm_EOFReturnsError(t *testing.T) {
+	ok, err := Confirm(&bytes.Buffer{}, strings.NewReader(""), "")
+
+	require.Error(t, err)
+	assert.False(t, ok)
+}

--- a/internal/dependencies/installer.go
+++ b/internal/dependencies/installer.go
@@ -1,0 +1,90 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dependencies
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+
+	"github.com/datarobot/cli/internal/repo"
+	"github.com/datarobot/cli/internal/state"
+	"github.com/datarobot/cli/internal/tools"
+)
+
+func InstallPrerequisites(w io.Writer, prerequisites []tools.Prerequisite) error {
+	// Install prerequisites sequentially via ExecuteShLine(), stopping on the first failure
+	for _, prerequisite := range prerequisites {
+		installCmd, err := prerequisite.PlatformInstallCommand()
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(w, "📦 Installing %s...\n", prerequisite.Name)
+
+		exitCode, err := ExecuteShLine(installCmd, w)
+		if err != nil {
+			return fmt.Errorf("failed to start install for %q: %w\n  command: %s", prerequisite.Name, err, installCmd)
+		}
+
+		if exitCode != 0 {
+			return fmt.Errorf("install failed for %q (exit code %d)\n  Please run manually: %s\n  Or check %s", prerequisite.Name, exitCode, installCmd, prerequisite.URL)
+		}
+
+		fmt.Fprintf(w, "✅ %s installed\n", prerequisite.Name)
+	}
+
+	fmt.Fprintf(w, "\n✅ All dependencies installed successfully.\n")
+
+	// Update state after successful installs.
+	// Executed only after all installs succeed to avoid state inconsistency if an install fails.
+	// This is necessary to avoid prompting the user to install already installed dependencies on the next run.
+	repoRoot, err := repo.FindRepoRoot()
+	if err != nil {
+		return err
+	}
+
+	err = state.UpdateAfterDepsInstall(repoRoot)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ExecuteShLine executes shellCmd via sh -c, streaming stdout and stderr
+// to w in real time. Handles pipe-based commands (e.g. curl ... | sh).
+// Returns the process exit code; a non-nil error indicates the process could
+// not be started (not a non-zero exit).
+func ExecuteShLine(shellCmd string, w io.Writer) (int, error) {
+	cmd := exec.Command("sh", "-c", shellCmd)
+
+	cmd.Stdout = w
+	cmd.Stderr = w
+
+	err := cmd.Run()
+	if err == nil {
+		return 0, nil
+	}
+
+	var exitErr *exec.ExitError
+
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), nil
+	}
+
+	return 1, err
+}

--- a/internal/dependencies/installer_test.go
+++ b/internal/dependencies/installer_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dependencies
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/datarobot/cli/internal/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errWriter is an io.Writer that always returns an error.
+// It triggers the non-ExitError path in ExecuteShLine by failing the
+// stdout/stderr copy goroutine that exec.Cmd runs internally.
+type errWriter struct{}
+
+func (errWriter) Write(_ []byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestExecuteShLine_Success(t *testing.T) {
+	var buf bytes.Buffer
+
+	code, err := ExecuteShLine("echo hello", &buf)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, buf.String(), "hello")
+}
+
+func TestExecuteShLine_NonZeroExitCode(t *testing.T) {
+	var buf bytes.Buffer
+
+	code, err := ExecuteShLine("exit 42", &buf)
+
+	require.NoError(t, err)
+	assert.Equal(t, 42, code)
+}
+
+func TestExecuteShLine_MultiLineOutput(t *testing.T) {
+	var buf bytes.Buffer
+
+	code, err := ExecuteShLine("echo line1; echo line2; echo line3", &buf)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+
+	output := buf.String()
+
+	assert.Contains(t, output, "line1")
+	assert.Contains(t, output, "line2")
+	assert.Contains(t, output, "line3")
+	assert.Equal(t, 3, strings.Count(output, "\n"))
+}
+
+func TestExecuteShLine_PipeCommand(t *testing.T) {
+	var buf bytes.Buffer
+
+	code, err := ExecuteShLine("echo piped_value | cat", &buf)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, buf.String(), "piped_value")
+}
+
+func TestExecuteShLine_StderrCaptured(t *testing.T) {
+	var buf bytes.Buffer
+
+	code, err := ExecuteShLine("echo error_output >&2", &buf)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, code)
+	assert.Contains(t, buf.String(), "error_output")
+}
+
+func TestExecuteShLine_CommandNotFound(t *testing.T) {
+	var buf bytes.Buffer
+
+	code, err := ExecuteShLine("nonexistent_command_dr_cli_test_xyz", &buf)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, code)
+}
+
+func TestExecuteShLine_OutputBeforeFailure(t *testing.T) {
+	var buf bytes.Buffer
+
+	// Verifies output is captured even when the command exits non-zero.
+	code, err := ExecuteShLine("echo before_fail; exit 2", &buf)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, code)
+	assert.Contains(t, buf.String(), "before_fail")
+}
+
+func TestExecuteShLine_WriterError(t *testing.T) {
+	// errWriter fails on the first Write call, which causes the exec copy
+	// goroutine to error. cmd.Wait() surfaces that as a non-ExitError, so
+	// ExecuteShLine returns (1, err) with a non-nil error.
+	code, err := ExecuteShLine("echo hello", errWriter{})
+
+	assert.Equal(t, 1, code)
+	assert.Error(t, err)
+}
+
+func TestExecuteShLine_WriterErrorPreservesMessage(t *testing.T) {
+	code, err := ExecuteShLine("echo hello", errWriter{})
+
+	assert.Equal(t, 1, code)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write failed")
+}
+
+// --- InstallPrerequisites tests ---
+
+// setupFakeRepo creates a temp dir with the .datarobot/cli structure required
+// by repo.FindRepoRoot(), changes the working directory into it, and restores
+// it via t.Cleanup.
+func setupFakeRepo(t *testing.T) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+
+	resolved, err := filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, err)
+
+	tmpDir = resolved
+
+	localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
+
+	err = os.MkdirAll(localStateDir, 0o755)
+	require.NoError(t, err)
+
+	versionsFile := filepath.Join(localStateDir, "versions.yaml")
+
+	err = os.WriteFile(versionsFile, []byte("tools: []\n"), 0o644)
+	require.NoError(t, err)
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWd))
+	})
+
+	require.NoError(t, os.Chdir(tmpDir))
+
+	return tmpDir
+}
+
+// prereq builds a Prerequisite with the same install command on all platforms.
+func prereq(name, installCmd string) tools.Prerequisite {
+	return tools.Prerequisite{
+		Name: name,
+		Install: tools.InstallCommands{
+			MacOS:   installCmd,
+			Linux:   installCmd,
+			Windows: installCmd,
+		},
+	}
+}
+
+func TestInstallPrerequisites_Empty(t *testing.T) {
+	setupFakeRepo(t)
+
+	var out bytes.Buffer
+
+	err := InstallPrerequisites(&out, nil)
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "successfully")
+}
+
+func TestInstallPrerequisites_Success(t *testing.T) {
+	setupFakeRepo(t)
+
+	var out bytes.Buffer
+
+	err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "echo install-uv")})
+
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "install-uv")
+	assert.Contains(t, out.String(), "successfully")
+}
+
+func TestInstallPrerequisites_FailureShowsRawCommand(t *testing.T) {
+	var out bytes.Buffer
+
+	err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "exit 1")})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exit 1")
+}
+
+func TestInstallPrerequisites_NoPlatformCommand(t *testing.T) {
+	var out bytes.Buffer
+
+	dep := tools.Prerequisite{Name: "uv"}
+
+	err := InstallPrerequisites(&out, []tools.Prerequisite{dep})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uv")
+}
+
+func TestInstallPrerequisites_AbortsOnFirstFailure(t *testing.T) {
+	var out bytes.Buffer
+
+	deps := []tools.Prerequisite{
+		{
+			Name: "uv",
+			Install: tools.InstallCommands{
+				MacOS:   "exit 1",
+				Linux:   "exit 1",
+				Windows: "exit 1",
+			},
+		},
+		{
+			Name: "task",
+			Install: tools.InstallCommands{
+				MacOS:   "echo install-task",
+				Linux:   "echo install-task",
+				Windows: "echo install-task",
+			},
+		},
+	}
+
+	err := InstallPrerequisites(&out, deps)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uv")
+	assert.NotContains(t, out.String(), "install-task")
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -35,6 +35,8 @@ type state struct {
 	LastTemplatesSetup *time.Time `yaml:"last_templates_setup,omitempty"`
 	// LastDotenvSetup is an ISO8601-compliant timestamp of the last successful `dr dotenv setup` run
 	LastDotenvSetup *time.Time `yaml:"last_dotenv_setup,omitempty"`
+	// LastDepsInstall is an ISO8601-compliant timestamp of the last successful `dr dependencies install` run
+	LastDepsInstall *time.Time `yaml:"last_deps_install,omitempty"`
 }
 
 // getStatePath determines the appropriate location for the state file.
@@ -140,6 +142,19 @@ func UpdateAfterTemplatesSetup(repoRoot string) error {
 
 	now := time.Now().UTC()
 	existingState.LastTemplatesSetup = &now
+
+	return existingState.update()
+}
+
+// UpdateAfterDepsInstall updates the state file after a successful `dr dependencies install` run.
+func UpdateAfterDepsInstall(repoRoot string) error {
+	existingState, err := load(repoRoot)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	existingState.LastDepsInstall = &now
 
 	return existingState.update()
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -152,3 +152,51 @@ func TestUpdateAfterSuccessfulRun(t *testing.T) {
 	assert.True(t, loadedState.LastStart.After(beforeUpdate) || loadedState.LastStart.Equal(beforeUpdate))
 	assert.True(t, loadedState.LastStart.Before(afterUpdate) || loadedState.LastStart.Equal(afterUpdate))
 }
+
+func TestUpdateAfterDepsInstall(t *testing.T) {
+	tmpDir := t.TempDir()
+	localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
+	err := os.MkdirAll(localStateDir, 0o755)
+	require.NoError(t, err)
+
+	beforeUpdate := time.Now().UTC()
+
+	err = UpdateAfterDepsInstall(tmpDir)
+	require.NoError(t, err)
+
+	afterUpdate := time.Now().UTC()
+
+	loadedState, err := load(tmpDir)
+	require.NoError(t, err)
+
+	require.NotNil(t, loadedState.LastDepsInstall)
+	assert.NotEmpty(t, loadedState.CLIVersion)
+	assert.True(t, loadedState.LastDepsInstall.After(beforeUpdate) || loadedState.LastDepsInstall.Equal(beforeUpdate))
+	assert.True(t, loadedState.LastDepsInstall.Before(afterUpdate) || loadedState.LastDepsInstall.Equal(afterUpdate))
+}
+
+func TestUpdateAfterDepsInstall_PreservesOtherFields(t *testing.T) {
+	tmpDir := t.TempDir()
+	localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
+	err := os.MkdirAll(localStateDir, 0o755)
+	require.NoError(t, err)
+
+	// Write initial state with a LastStart timestamp.
+	err = UpdateAfterSuccessfulRun(tmpDir)
+	require.NoError(t, err)
+
+	stateBefore, err := load(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, stateBefore.LastStart)
+
+	// Now run deps install — LastStart must survive.
+	err = UpdateAfterDepsInstall(tmpDir)
+	require.NoError(t, err)
+
+	stateAfter, err := load(tmpDir)
+	require.NoError(t, err)
+
+	require.NotNil(t, stateAfter.LastDepsInstall)
+	require.NotNil(t, stateAfter.LastStart)
+	assert.Equal(t, stateBefore.LastStart.Unix(), stateAfter.LastStart.Unix())
+}

--- a/internal/tools/prerequisites.go
+++ b/internal/tools/prerequisites.go
@@ -18,27 +18,83 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/datarobot/cli/internal/misc/regexp2"
 	"github.com/datarobot/cli/internal/version"
 )
 
+// InstallCommands holds platform-specific install commands for a dependency.
+type InstallCommands struct {
+	MacOS   string `yaml:"macos"`
+	Linux   string `yaml:"linux"`
+	Windows string `yaml:"windows"`
+}
+
 // Prerequisite represents a required tool
 type Prerequisite struct {
 	Key            string
-	Name           string `yaml:"name"`
-	MinimumVersion string `yaml:"minimum-version"`
-	Command        string `yaml:"command"`
-	URL            string `yaml:"url"`
+	Name           string          `yaml:"name"`
+	MinimumVersion string          `yaml:"minimum-version"`
+	Command        string          `yaml:"command"`
+	URL            string          `yaml:"url"`
+	Install        InstallCommands `yaml:"install"`
+}
+
+// PlatformInstallCommand returns the install command for the current OS.
+// Returns an error if no command is defined for this platform.
+func (p Prerequisite) PlatformInstallCommand() (string, error) {
+	var cmd string
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = p.Install.MacOS
+	case "linux":
+		cmd = p.Install.Linux
+	case "windows":
+		cmd = p.Install.Windows
+	default:
+		return "", fmt.Errorf("unsupported platform %q", runtime.GOOS)
+	}
+
+	if cmd == "" {
+		return "", fmt.Errorf("no install command defined for %q on %s", p.Name, runtime.GOOS)
+	}
+
+	return cmd, nil
+}
+
+var pythonInstallCmd = InstallCommands{
+	MacOS: "brew install python",
+	Linux: "sudo apt-get install python3",
+	// Windows: "Download and install Python from https://www.python.org/downloads/windows/",
+}
+
+var uvInstallCmd = InstallCommands{
+	MacOS: "brew install uv",
+	Linux: "curl -Ls https://astral.sh/uv/install.sh | sh",
+	// Windows: "iwr -useb https://astral.sh/uv/install.ps1 | iex",
+}
+
+var taskInstallCmd = InstallCommands{
+	MacOS: "brew install go-task/tap/go-task",
+	Linux: "curl -sL https://taskfile.dev/install.sh | sh",
+	// Windows: "iwr -useb https://taskfile.dev/install.ps1 | iex",
+}
+
+var pulumiInstallCmd = InstallCommands{
+	MacOS: "brew install pulumi",
+	Linux: "curl -fsSL https://get.pulumi.com | sh",
+	// Windows: "iwr -useb https://get.pulumi.com/windows-installer.exe -OutFile pulumi-installer.exe; Start-Process -FilePath pulumi-installer.exe -Wait",
 }
 
 // RequiredTools lists all tools required for the quickstart process
 var RequiredTools = []Prerequisite{
-	{Name: "Python", Command: "python3", URL: "https://www.python.org/downloads/"},
-	{Name: "uv", Command: "uv", URL: "https://docs.astral.sh/uv/getting-started/installation/"},
-	{Name: "task", Command: "task", URL: "https://taskfile.dev/docs/installation"},
-	{Name: "pulumi", Command: "pulumi", URL: "https://www.pulumi.com/docs/get-started/download-install/"},
+	{Name: "Python", Command: "python3", URL: "https://www.python.org/downloads/", Install: pythonInstallCmd},
+	{Name: "uv", Command: "uv", URL: "https://docs.astral.sh/uv/getting-started/installation/", Install: uvInstallCmd},
+	{Name: "task", Command: "task", URL: "https://taskfile.dev/docs/installation", Install: taskInstallCmd},
+	{Name: "pulumi", Command: "pulumi", URL: "https://www.pulumi.com/docs/get-started/download-install/", Install: pulumiInstallCmd},
 }
 
 func CheckPrerequisite(name string) error {
@@ -53,41 +109,64 @@ func CheckPrerequisite(name string) error {
 	return nil
 }
 
-// MissingPrerequisites verifies that all required tools are installed
-func MissingPrerequisites() string {
+// CheckPrerequisites returns lists of missing prerequisites, wrongVersion prerequisites, and error messages to display to the user.
+func CheckPrerequisites() ([]Prerequisite, []Prerequisite, []string, []string) {
 	prerequisites, err := GetRequirements()
 	if err == nil {
 		RequiredTools = prerequisites
 	}
 
 	var (
-		missing      []string
-		wrongVersion []string
+		missingTools      []Prerequisite
+		wrongVersionTools []Prerequisite
+		missingMsgs       []string
+		wrongVersionMsgs  []string
 	)
 
 	for _, tool := range RequiredTools {
 		if !isInstalled(tool.Command) {
-			missing = append(missing, tool.Name)
+			missingTools = append(missingTools, tool)
+			missingMsgs = append(missingMsgs, fmt.Sprintf("%s %s (%s)", tool.Name, tool.MinimumVersion, tool.URL))
 		} else if ver, ok := isVersionInstalled(tool); !ok {
-			wrongVersion = append(wrongVersion, ver)
+			wrongVersionTools = append(wrongVersionTools, tool)
+			wrongVersionMsgs = append(wrongVersionMsgs, ver)
 		}
 	}
 
-	if len(missing) == 0 && len(wrongVersion) == 0 {
-		return ""
-	}
+	return missingTools, wrongVersionTools, missingMsgs, wrongVersionMsgs
+}
 
+// PrerequisitesMsg formats the message to display to the user about missing/wrong-version prerequisites.
+func PrerequisitesMsg(missingMsgs []string, wrongVersionMsgs []string) string {
 	result := make([]string, 0)
 
-	if len(missing) > 0 {
-		result = append(result, "Missing required tools:\n\n"+strings.Join(missing, "\n"))
+	if len(missingMsgs) > 0 {
+		result = append(result, "\n ❌ Missing required tools:\n")
+
+		for _, msg := range missingMsgs {
+			result = append(result, "\t- "+msg)
+		}
 	}
 
-	if len(wrongVersion) > 0 {
-		result = append(result, "Wrong versions of tools:\n\n"+strings.Join(wrongVersion, "\n"))
+	if len(wrongVersionMsgs) > 0 {
+		result = append(result, "\n ⚠️ Wrong versions of tools:\n")
+
+		for _, msg := range wrongVersionMsgs {
+			result = append(result, "\t- "+msg)
+		}
 	}
 
-	return strings.Join(result, "\n")
+	return strings.Join(result, "\n") + "\n"
+}
+
+// MissingPrerequisites returns a message describing missing prerequisites, or an empty string if all prerequisites are satisfied.
+func MissingPrerequisites() string {
+	_, _, missingMsgs, wrongVersionMsgs := CheckPrerequisites()
+	if len(missingMsgs) > 0 || len(wrongVersionMsgs) > 0 {
+		return PrerequisitesMsg(missingMsgs, wrongVersionMsgs)
+	}
+
+	return ""
 }
 
 func commandArgs(fullCommand string) (string, []string) {

--- a/internal/tools/prerequisites_test.go
+++ b/internal/tools/prerequisites_test.go
@@ -15,10 +15,12 @@
 package tools
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/datarobot/cli/internal/version"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSufficientVersionTrue(t *testing.T) {
@@ -115,4 +117,211 @@ func TestSufficientSelfVersion(t *testing.T) {
 			assert.Equal(t, tt.expected, result, "version=%s minimal=%s", tt.versionValue, tt.minimalVersion)
 		})
 	}
+}
+
+func TestPrerequisitesMsg_BothEmpty(t *testing.T) {
+	out := PrerequisitesMsg(nil, nil)
+
+	assert.Equal(t, "\n", out)
+}
+
+func TestPrerequisitesMsg_MissingOnly(t *testing.T) {
+	out := PrerequisitesMsg([]string{"uv 0.4.0 (https://example.com)"}, nil)
+
+	assert.Contains(t, out, "Missing required tools")
+	assert.Contains(t, out, "uv 0.4.0")
+	assert.NotContains(t, out, "Wrong versions")
+}
+
+func TestPrerequisitesMsg_WrongVersionOnly(t *testing.T) {
+	out := PrerequisitesMsg(nil, []string{"task (minimal: v3.35.0, installed: v3.32.0)"})
+
+	assert.Contains(t, out, "Wrong versions of tools")
+	assert.Contains(t, out, "task (minimal: v3.35.0")
+	assert.NotContains(t, out, "Missing required")
+}
+
+func TestPrerequisitesMsg_Both(t *testing.T) {
+	out := PrerequisitesMsg(
+		[]string{"uv 0.4.0 (https://example.com)"},
+		[]string{"task (minimal: v3.35.0, installed: v3.32.0)"},
+	)
+
+	assert.Contains(t, out, "Missing required tools")
+	assert.Contains(t, out, "uv 0.4.0")
+	assert.Contains(t, out, "Wrong versions of tools")
+	assert.Contains(t, out, "task (minimal: v3.35.0")
+}
+
+func TestPrerequisitesMsg_MultipleEntries(t *testing.T) {
+	out := PrerequisitesMsg([]string{"uv", "pulumi"}, []string{"task"})
+
+	assert.Contains(t, out, "\t- uv")
+	assert.Contains(t, out, "\t- pulumi")
+	assert.Contains(t, out, "\t- task")
+}
+
+func TestPrerequisitesMsg_EndsWithNewline(t *testing.T) {
+	out := PrerequisitesMsg([]string{"uv"}, nil)
+
+	assert.True(t, len(out) > 0 && out[len(out)-1] == '\n')
+}
+
+func TestMissingPrerequisites_AllSatisfied(t *testing.T) {
+	orig := RequiredTools
+
+	defer func() { RequiredTools = orig }()
+
+	RequiredTools = []Prerequisite{
+		{Name: "sh", Command: "sh"},
+	}
+
+	assert.Empty(t, MissingPrerequisites())
+}
+
+func TestMissingPrerequisites_MissingTool(t *testing.T) {
+	orig := RequiredTools
+
+	defer func() { RequiredTools = orig }()
+
+	RequiredTools = []Prerequisite{
+		{Name: "FakeTool", Command: "nonexistent_dr_fake_tool_xyz", URL: "https://example.com"},
+	}
+
+	out := MissingPrerequisites()
+
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "FakeTool")
+}
+
+func TestMissingPrerequisites_WrongVersion(t *testing.T) {
+	orig := RequiredTools
+
+	defer func() { RequiredTools = orig }()
+
+	RequiredTools = []Prerequisite{
+		{Name: "Echo", Command: "echo 1.0.0", MinimumVersion: "2.0.0"},
+	}
+
+	out := MissingPrerequisites()
+
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, "Echo")
+}
+
+func TestCheckPrerequisites_AllSatisfied(t *testing.T) {
+	orig := RequiredTools
+
+	defer func() { RequiredTools = orig }()
+
+	// "sh" is always present and has no version constraint.
+	RequiredTools = []Prerequisite{
+		{Name: "sh", Command: "sh"},
+	}
+
+	missing, wrongVer, missingMsgs, wrongVerMsgs := CheckPrerequisites()
+
+	assert.Empty(t, missing)
+	assert.Empty(t, wrongVer)
+	assert.Empty(t, missingMsgs)
+	assert.Empty(t, wrongVerMsgs)
+}
+
+func TestCheckPrerequisites_MissingTool(t *testing.T) {
+	orig := RequiredTools
+
+	defer func() { RequiredTools = orig }()
+
+	RequiredTools = []Prerequisite{
+		{Name: "FakeTool", Command: "nonexistent_dr_fake_tool_xyz", URL: "https://example.com"},
+	}
+
+	missing, wrongVer, missingMsgs, wrongVerMsgs := CheckPrerequisites()
+
+	require.Len(t, missing, 1)
+	assert.Equal(t, "FakeTool", missing[0].Name)
+	assert.Empty(t, wrongVer)
+	assert.Len(t, missingMsgs, 1)
+	assert.Contains(t, missingMsgs[0], "FakeTool")
+	assert.Contains(t, missingMsgs[0], "https://example.com")
+	assert.Empty(t, wrongVerMsgs)
+}
+
+func TestCheckPrerequisites_WrongVersion(t *testing.T) {
+	orig := RequiredTools
+
+	defer func() { RequiredTools = orig }()
+
+	// "echo 1.0.0" is always installed; its output "1.0.0" is insufficient vs "2.0.0".
+	RequiredTools = []Prerequisite{
+		{Name: "Echo", Command: "echo 1.0.0", MinimumVersion: "2.0.0", URL: "https://example.com"},
+	}
+
+	missing, wrongVer, missingMsgs, wrongVerMsgs := CheckPrerequisites()
+
+	assert.Empty(t, missing)
+	assert.Empty(t, missingMsgs)
+	require.Len(t, wrongVer, 1)
+	assert.Equal(t, "Echo", wrongVer[0].Name)
+	assert.Len(t, wrongVerMsgs, 1)
+	assert.Contains(t, wrongVerMsgs[0], "Echo")
+}
+
+func TestCheckPrerequisites_Mixed(t *testing.T) {
+	orig := RequiredTools
+
+	defer func() { RequiredTools = orig }()
+
+	RequiredTools = []Prerequisite{
+		{Name: "sh", Command: "sh"},
+		{Name: "FakeTool", Command: "nonexistent_dr_fake_tool_xyz"},
+		{Name: "Echo", Command: "echo 1.0.0", MinimumVersion: "2.0.0"},
+	}
+
+	missing, wrongVer, missingMsgs, wrongVerMsgs := CheckPrerequisites()
+
+	require.Len(t, missing, 1)
+	assert.Equal(t, "FakeTool", missing[0].Name)
+	require.Len(t, wrongVer, 1)
+	assert.Equal(t, "Echo", wrongVer[0].Name)
+	assert.Len(t, missingMsgs, 1)
+	assert.Len(t, wrongVerMsgs, 1)
+}
+
+func TestPlatformInstallCommand_CurrentPlatform(t *testing.T) {
+	p := Prerequisite{
+		Name: "uv",
+		Install: InstallCommands{
+			MacOS:   "brew install uv",
+			Linux:   "curl -Ls https://astral.sh/uv/install.sh | sh",
+			Windows: "powershell install uv",
+		},
+	}
+
+	var expected string
+
+	switch runtime.GOOS {
+	case "darwin":
+		expected = p.Install.MacOS
+	case "linux":
+		expected = p.Install.Linux
+	case "windows":
+		expected = p.Install.Windows
+	default:
+		t.Skipf("unsupported platform %q", runtime.GOOS)
+	}
+
+	cmd, err := p.PlatformInstallCommand()
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, cmd)
+}
+
+func TestPlatformInstallCommand_EmptyCommandReturnsError(t *testing.T) {
+	p := Prerequisite{Name: "uv"} // all install commands are zero-value empty strings
+
+	_, err := p.PlatformInstallCommand()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uv")
 }


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->
[CFX-5781]
Create the new shared package internal/dependencies/installer.go. Implement the core install function: given a dep name and a shell command string, spawn a subprocess via sh -c, stream stdout/stderr to the terminal in real time, and return the exit code. Handle pipe-based commands (e.g. curl ... | sh). Add unit/integration tests using a benign shell command (e.g. echo).

Acceptance criteria: A command's output appears line-by-line as it runs; non-zero exit codes are correctly captured and returned.

[CFX-5782]
Create the new dr dependencies install subcommand and register it under the existing dr dependencies group. Behavior for this milestone: run dr dependencies check, filter to missing deps only (outdated handled in Milestone 3), list them, prompt y/n, and invoke internal/dependencies/installer.go for each in sequence. If all satisfied, print "All dependencies are already up to date." and exit 0. On full success, update state.yaml. On any failure, abort (per Option A in the spec), surface the raw install command, and exit non-zero.

Acceptance criteria: Key test cases pass — all satisfied → clean exit; missing deps + y → installs + state updated; missing deps + n → aborts cleanly; partial failure → aborts, state unchanged.

[CFX-5783]
Wire the --yes flag into cmd/dependencies/install.go so the y/n prompt is skipped entirely and the install sequence begins automatically. Must not trigger any confirmation dialogs. Add a test asserting no prompt is shown when --yes is passed with missing deps.

Acceptance criteria: dr dependencies install --yes with missing deps auto-installs without any user interaction.

Also works : `DATAROBOT_CLI_NON_INTERACTIVE=true dr deps install`

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Runs external shell install commands (`sh -c`) and updates repo-local state, so failures or unexpected commands could impact developer environments; scope is contained to dependency tooling with good test coverage.
> 
> **Overview**
> Adds `dr dependencies install` under the existing dependencies command group to detect missing/outdated prerequisites, display a structured summary, optionally prompt for confirmation (skippable via `--yes`/`DATAROBOT_CLI_NON_INTERACTIVE`), and then install each prerequisite sequentially while streaming command output.
> 
> Introduces `internal/dependencies` installer utilities that execute platform-specific install commands via `sh -c`, abort on first failure while surfacing the raw command, and update repo state (`last_deps_install`) only after all installs succeed; also improves `dr dependencies check` to print a success message when nothing is missing.
> 
> Extends the prerequisites model to include per-OS install commands and refactors prerequisite checking to return structured results plus a formatted message, with comprehensive new unit tests across prompting, prerequisite evaluation, install execution, and state updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d50830bee8689b66d7930cf14178bcb82f2f6b71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->