### PR TITLE
[CFX-5961] fix: redact pulumi_config_passphrase in DebugViperConfig

### DIFF
--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -165,6 +165,23 @@ To make a key writable to `drconfig.yaml`:
 Use viper dotted-path notation if the value is nested, e.g.
 `"pulumi.config.passphrase"`. The writer handles nested map creation.
 
+### Marking keys as sensitive
+
+Sensitive keys (credentials, passphrases, tokens) must be redacted in debug output
+to prevent accidental exposure of secrets in logs. To mark a key as sensitive:
+
+1. Add the key to `sensitiveDebugKeys` in `internal/config/config.go`:
+
+   ```go
+   var sensitiveDebugKeys = map[string]struct{}{
+       "token":                    {},
+       "pulumi_config_passphrase": {},
+   }
+   ```
+
+2. When `--debug` is enabled, the key will be redacted as `****` in console output
+   from `DebugViperConfig()`.
+
 ## Common pitfalls
 
 - **Don't import `github.com/spf13/viper` outside `internal/config/`.**

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,6 +122,12 @@ func ReadConfigFile(filePath string) error {
 	return nil
 }
 
+// This is a list of keys that we want to redact
+// when printing out the viper configuration for
+// debugging. This is not a comprehensive list,
+// but it should cover the most common cases.
+// TODO There has to be a better way of marking sensitive data
+// perhaps with leebenson/conform?
 var sensitiveDebugKeys = map[string]struct{}{
 	"token":                    {},
 	"pulumi_config_passphrase": {},
@@ -141,8 +147,6 @@ func DebugViperConfig() (string, error) {
 
 	// Print out the viper configuration for debugging
 	// Alphabetically, and redacting sensitive information
-	// TODO There has to be a better way of marking sensitive data
-	// perhaps with leebenson/conform?
 	keys := make([]string, 0, len(viper.AllSettings()))
 	for key := range viper.AllSettings() {
 		keys = append(keys, key)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,6 +122,11 @@ func ReadConfigFile(filePath string) error {
 	return nil
 }
 
+var sensitiveDebugKeys = map[string]struct{}{
+	"token":                    {},
+	"pulumi_config_passphrase": {},
+}
+
 func DebugViperConfig() (string, error) {
 	var sb strings.Builder
 
@@ -148,8 +153,8 @@ func DebugViperConfig() (string, error) {
 	for _, key := range keys {
 		value := viper.Get(key)
 
-		// Skip token because its sensitive
-		if key == "token" {
+		// Redact sensitive keys
+		if _, sensitive := sensitiveDebugKeys[key]; sensitive {
 			fmt.Fprintf(&sb, "  %s: %s\n", key, "****")
 		} else {
 			fmt.Fprintf(&sb, "  %s: %v\n", key, value)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/yaml.v3"
 )
@@ -98,4 +100,45 @@ func (suite *ConfigTestSuite) TestCreateConfigFileDirWithXDGConfigHome() {
 	// Check if the file was created
 	expectedFileName := "/drconfig.yaml"
 	suite.FileExists(filepath.Join(expectedDir, expectedFileName), "Expected config file to be created in XDG_CONFIG_HOME")
+}
+
+func TestDebugViperConfig_RedactsPulumiConfigPassphrase(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	const secret = "SUPER_SECRET_PASSPHRASE"
+
+	viper.Set("pulumi_config_passphrase", secret)
+
+	output, err := DebugViperConfig()
+	require.NoError(t, err)
+	assert.Contains(t, output, "pulumi_config_passphrase")
+	assert.Contains(t, output, "****")
+	assert.NotContains(t, output, secret)
+}
+
+func TestDebugViperConfig_RedactsToken(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	const secret = "SUPER_SECRET_TOKEN"
+
+	viper.Set("token", secret)
+
+	output, err := DebugViperConfig()
+	require.NoError(t, err)
+	assert.Contains(t, output, "token")
+	assert.Contains(t, output, "****")
+	assert.NotContains(t, output, secret)
+}
+
+func TestDebugViperConfig_DoesNotRedactNonSensitiveKey(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set("debug", true)
+
+	output, err := DebugViperConfig()
+	require.NoError(t, err)
+	assert.Contains(t, output, "debug: true")
 }


### PR DESCRIPTION
# RATIONALE

The `pulumi_config_passphrase` key is being printed in plaintext via `dr self config` and --debug startup logs. Extend the existing token redaction to cover it via a sensitiveDebugKeys map.

(This was also a test of [factory.ai missions](https://docs.factory.ai/cli/features/missions).)

## CHANGES

Mark pulumi_config_passphrase as a sensitive debug key, similar to token, and hide it when we execute `dr self config`.

## TESTING

### BEFORE

```sh
╰─ ❯ dr self config
Configuration initialized. Using config file: /Users/aj.alon/.config/datarobot/drconfig.yaml

  all-commands: false
  api-consumer-tracking-enabled: true
  config: 
  debug: false
  disable-telemetry: false
  endpoint: https://staging.datarobot.com/api/v2
  external-editor: zed --wait
  force-interactive: false
  help: false
  plugin-discovery-timeout: 2s
  plugin-update-check-interval: 1h0m0s
  pulumi_config_passphrase: [**REDACTEDBYTHEEDITOR**]
  skip-auth: false
  skip-plugin-update-check: false
  token: ****
  verbose: false
  version: false
```

### AFTER

```sh
╰─ ❯ dr self config          
Configuration initialized. Using config file: /Users/aj.alon/.config/datarobot/drconfig.yaml

  api-consumer-tracking-enabled: true
  config: 
  debug: false
  disable-telemetry: false
  endpoint: https://staging.datarobot.com/api/v2
  external-editor: zed --wait
  force-interactive: false
  plugin-discovery-timeout: 2s
  plugin-update-check-interval: 1h0m0s
  pulumi_config_passphrase: ****
  skip-auth: false
  skip-plugin-update-check: false
  token: ****
  verbose: false
```

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to debug/log output formatting; main risk is accidental over/under-redaction of config keys in `DebugViperConfig()`.
> 
> **Overview**
> Prevents accidental secret leakage in `--debug` config dumps by generalizing redaction to a `sensitiveDebugKeys` allowlist and adding `pulumi_config_passphrase` alongside `token`.
> 
> Adds focused tests to ensure sensitive values are masked as `****` and that non-sensitive keys remain visible, and updates the developer configuration guide with instructions for marking keys as sensitive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 296f9346f6a745c3e595f2e925f601a3f8d80a2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->