### PR TITLE
[CFX-5206] fix(telemetry): set DeviceID on Amplitude events using OS machine ID

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -24,6 +24,7 @@ If you're new to developing the CLI, start here:
 - **[Plugins](plugins.md)**&mdash;develop and test CLI plugins, understand the plugin system architecture.
 - **[Remote plugins](remote-plugins.md)**&mdash;create and distribute remote plugins, plugin registry management.
 - **[Releasing](releasing.md)**&mdash;release process, versioning strategy, and GoReleaser configuration.
+- **[Telemetry](telemetry.md)**&mdash;how anonymous usage analytics are collected, how to add events, and how to opt out.
 
 ## Quick reference
 

--- a/docs/development/structure.md
+++ b/docs/development/structure.md
@@ -28,6 +28,7 @@ cli/
 │   ├── repo/                # Repository detection
 │   ├── shell/               # Shell utilities
 │   ├── task/                # Task discovery and execution
+│   ├── telemetry/           # Anonymous usage analytics (Amplitude)
 │   ├── tools/               # Tool prerequisites
 │   └── version/             # Version information
 ├── tui/                     # Terminal UI components

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -1,0 +1,85 @@
+# Telemetry
+
+The CLI collects anonymous usage analytics via [Amplitude](https://amplitude.com/) to help the DataRobot team understand how the tool is used.
+
+## How it works
+
+Telemetry is implemented in `internal/telemetry/`. On each CLI invocation a `Client` is created with a set of `CommonProperties`, events are queued via `Client.Track()`, and the queue is flushed at process exit via `Client.Flush()`.
+
+When telemetry is disabled or the Amplitude API key is absent (all dev builds), every operation is a safe no-op — events are logged to the debug logger instead of being sent over the network.
+
+## Opting out
+
+Users can disable telemetry in three ways, in order of precedence:
+
+| Method | How |
+|---|---|
+| Flag | `dr --disable-telemetry <command>` |
+| Environment variable | `DATAROBOT_CLI_DISABLE_TELEMETRY=true` |
+| Config file | `disable-telemetry: true` in `drconfig.yaml` |
+
+## Device ID
+
+Amplitude requires a `device_id` or `user_id` on every event. The CLI uses a stable device identifier obtained in this order:
+
+1. **OS-provided machine ID** — via [`github.com/denisbrodbeck/machineid`](https://github.com/denisbrodbeck/machineid), which reads:
+   - `IOPlatformUUID` on macOS
+   - `/etc/machine-id` on Linux
+   - `HKLM\SOFTWARE\Microsoft\Cryptography\MachineGuid` on Windows
+
+   The raw value is HMAC-SHA256'd with the app ID `"dr"` before use, so the actual system identifier is never sent to Amplitude.
+
+2. **Persisted random UUID** — if the OS identifier is unavailable, a random UUID is generated and written to `~/.config/datarobot/device_id` (respects `$XDG_CONFIG_HOME`). The same value is reused on subsequent invocations.
+
+3. **Session-scoped fallback** — if the config directory is also inaccessible, a fresh ID prefixed with `"fallback-"` is generated for that session only.
+
+## Adding a new event
+
+All event constructors live in `internal/telemetry/events.go`. Add a new function following the existing pattern:
+
+```go
+func NewMyCommandEvent(param string) types.Event {
+    return types.Event{
+        EventType: "dr my command",
+        EventProperties: map[string]any{
+            "param": param,
+        },
+    }
+}
+```
+
+Then call it from the command's `RunE` or `PersistentPostRunE`:
+
+```go
+telemetryClient.Track(telemetry.NewMyCommandEvent(param))
+```
+
+Common properties (`session_id`, `device_id`, `cli_version`, `os_info`, etc.) are merged automatically by `Client.Track()` — do not add them to individual event constructors.
+
+## Common properties
+
+The following are attached to every event:
+
+### Top-level event fields
+
+| Field | Source |
+|---|---|
+| `user_id` | DataRobot user ID from the API (empty if unauthenticated) |
+| `device_id` | OS machine ID (hashed) or persisted UUID — see [Device ID](#device-id) above |
+
+### Event properties
+
+| Property | Source |
+|---|---|
+| `session_id` | Random UUID generated once per process invocation |
+| `user_id` | Same as the top-level `user_id` field |
+| `cli_version` | Set at build time via ldflags |
+| `install_method` | Set at build time via ldflags (`release`, `source`, etc.) |
+| `os_info` | `runtime.GOOS/runtime.GOARCH` |
+| `environment` | `US`, `EU`, `JP`, or `custom` — derived from endpoint URL |
+| `datarobot_instance` | Base URL of the configured DataRobot instance |
+| `template_name` | Best-effort from `.datarobot/answers/` in the current repo |
+
+## Dev builds
+
+`AmplitudeAPIKey` is empty in dev builds (it is injected via ldflags in release builds only). When the key is empty, `IsEnabled()` returns `false` and all `Track` calls log to the debug logger. Run with `--debug` to see telemetry events in `.dr-tui-debug.log`.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
       - Authentication: development/authentication.md
       - Releasing: development/releasing.md
       - Plugins: development/plugins.md
+      - Telemetry: development/telemetry.md
 
 # Exclude patterns to avoid processing non-documentation files
 exclude_docs: |

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/charmbracelet/log v1.0.0
 	github.com/charmbracelet/x/exp/teatest v0.0.0-20250818131617-61d774aefe53
 	github.com/codeclysm/extract/v4 v4.0.0
+	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/gitsight/go-vcsurl v1.0.1
 	github.com/google/go-cmp v0.7.0
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
+github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=

--- a/internal/telemetry/deviceid.go
+++ b/internal/telemetry/deviceid.go
@@ -1,0 +1,34 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"github.com/datarobot/cli/internal/log"
+	"github.com/denisbrodbeck/machineid"
+)
+
+// getMachineID returns a stable OS-provided machine identifier, hashed
+// for privacy. Returns an empty string if the identifier cannot be obtained.
+func getMachineID() string {
+	id, err := machineid.ProtectedID("dr")
+	if err != nil {
+		// Errors at this point will cause telemetry to be less effective
+		// or to fail outright, depending on if we have user-id.
+		log.Warn("Failed to get machine ID:", err)
+		return ""
+	}
+
+	return id
+}

--- a/internal/telemetry/deviceid_test.go
+++ b/internal/telemetry/deviceid_test.go
@@ -27,6 +27,22 @@ func TestGetMachineID_IsStable(t *testing.T) {
 	assert.Equal(t, id1, id2, "machine ID should be stable across calls")
 }
 
+func TestGetMachineID_ReturnsNonEmpty(t *testing.T) {
+	id := getMachineID()
+
+	assert.NotEmpty(t, id, "expected a machine ID on this platform")
+}
+
+// machineid.ProtectedID returns a HMAC-SHA256 hex string: 32 bytes = 64 hex chars.
+func TestGetMachineID_IsHexString(t *testing.T) {
+	id := getMachineID()
+	if id == "" {
+		t.Skip("machine ID not available on this platform")
+	}
+
+	assert.Regexp(t, `^[0-9a-f]{64}$`, id, "machine ID should be 64-char lowercase hex")
+}
+
 func TestGetOrCreateDeviceID_IsStable(t *testing.T) {
 	id1 := getOrCreateDeviceID()
 	id2 := getOrCreateDeviceID()

--- a/internal/telemetry/deviceid_test.go
+++ b/internal/telemetry/deviceid_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMachineID_IsStable(t *testing.T) {
+	id1 := getMachineID()
+	id2 := getMachineID()
+
+	assert.Equal(t, id1, id2, "machine ID should be stable across calls")
+}
+
+func TestGetOrCreateDeviceID_IsStable(t *testing.T) {
+	id1 := getOrCreateDeviceID()
+	id2 := getOrCreateDeviceID()
+
+	assert.NotEmpty(t, id1)
+	assert.Equal(t, id1, id2, "device ID should be stable across calls")
+}

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -134,8 +134,8 @@ func deriveEnvironment(baseURL string) string {
 }
 
 const (
-	deviceIDFileName = "device_id"
-	deviceIDFallbackPrefix   = "fallback-"
+	deviceIDFileName       = "device_id"
+	deviceIDFallbackPrefix = "fallback-"
 )
 
 // getOrCreateDeviceID returns a stable device identifier.

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -37,6 +37,7 @@ import (
 type CommonProperties struct {
 	// TODO CFX-5206 figure out proper SessionID
 	SessionID string // UUID v4, unique per process invocation
+	DeviceID  string // UUID v4, stable per installation, persisted to disk
 	// TODO CFX-5206 figure out proper UserID
 	UserID            string // Placeholder for future user ID implementation
 	CLIVersion        string // CLI version from version.Version (ldflags)
@@ -54,6 +55,7 @@ type CommonProperties struct {
 func CollectCommonProperties() *CommonProperties {
 	props := &CommonProperties{
 		SessionID:     generateSessionID(),
+		DeviceID:      getOrCreateDeviceID(),
 		CLIVersion:    version.Version,
 		InstallMethod: InstallMethod,
 		OSInfo:        runtime.GOOS + "/" + runtime.GOARCH,
@@ -125,6 +127,43 @@ func deriveEnvironment(baseURL string) string {
 	default:
 		return "custom"
 	}
+}
+
+const deviceIDFileName = "device_id"
+
+// getOrCreateDeviceID returns a stable device identifier. It first attempts to
+// use an OS-provided machine ID (hashed for privacy). If that is unavailable,
+// it falls back to a randomly generated UUID that is persisted to the config
+// directory so it remains stable across invocations. If the file cannot be
+// read or written, a fresh UUID is returned for this session only.
+func getOrCreateDeviceID() string {
+	if id := getMachineID(); id != "" {
+		return id
+	}
+
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		return generateSessionID()
+	}
+
+	deviceIDPath := filepath.Join(configDir, deviceIDFileName)
+
+	data, err := os.ReadFile(deviceIDPath)
+	if err == nil {
+		id := strings.TrimSpace(string(data))
+
+		if id != "" {
+			return id
+		}
+	}
+
+	id := generateSessionID()
+
+	if mkErr := os.MkdirAll(configDir, 0o700); mkErr == nil {
+		_ = os.WriteFile(deviceIDPath, []byte(id), 0o600)
+	}
+
+	return id
 }
 
 // getTemplateName attempts to extract the template name from the .datarobot/answers directory.

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -97,7 +97,10 @@ func (p *CommonProperties) AsMap() map[string]interface{} {
 	}
 }
 
-// generateSessionID creates a UUID v4 for the session.
+// generateSessionID generates a UUID v4 for the current CLI session.
+// This value is not persisted and will be different on each invocation.
+// The default implementation uses crypto/rand, but if that fails, then
+// fallback to a timestamp-based ID with a "-fallback" suffix to indicate it's not a true UUID.
 func generateSessionID() string {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
@@ -131,34 +134,43 @@ func deriveEnvironment(baseURL string) string {
 
 const deviceIDFileName = "device_id"
 
-// getOrCreateDeviceID returns a stable device identifier. It first attempts to
-// use an OS-provided machine ID (hashed for privacy). If that is unavailable,
-// it falls back to a randomly generated UUID that is persisted to the config
-// directory so it remains stable across invocations. If the file cannot be
-// read or written, a fresh UUID is returned for this session only.
+// getOrCreateDeviceID returns a stable device identifier.
 func getOrCreateDeviceID() string {
+	// First try to get machine ID from OS
 	if id := getMachineID(); id != "" {
 		return id
 	}
 
+	// Try to read existing device ID from file in the config directory
 	configDir, err := config.GetConfigDir()
 	if err != nil {
+		// If we can't get the config directory, we won't be able to persist a device ID,
+		// so we just generate a new one for this session. These IDs will be suffixed with
+		// "-fallback".
 		return generateSessionID()
 	}
 
+	// Try to read existing device ID from file
 	deviceIDPath := filepath.Join(configDir, deviceIDFileName)
 
 	data, err := os.ReadFile(deviceIDPath)
 	if err == nil {
+		// If we successfully read a device ID from the file, use it (after trimming whitespace).
 		id := strings.TrimSpace(string(data))
 
 		if id != "" {
+			// If the ID is not empty, return it. Otherwise, we'll generate a new one below.
 			return id
 		}
 	}
 
+	// If we couldn't get a machine ID or read an existing device ID, generate a new one
+	// and save it for future sessions. NOTE: Ignore errors at this point, since we can
+	// still function without p
 	id := generateSessionID()
 
+	// At this point, ignore any errors we might have with persisting the session ID, as
+	// telemetry will stil function without it, it will just be less stable.
 	if mkErr := os.MkdirAll(configDir, 0o700); mkErr == nil {
 		_ = os.WriteFile(deviceIDPath, []byte(id), 0o600)
 	}

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -100,11 +100,12 @@ func (p *CommonProperties) AsMap() map[string]interface{} {
 // generateSessionID generates a UUID v4 for the current CLI session.
 // This value is not persisted and will be different on each invocation.
 // The default implementation uses crypto/rand, but if that fails, then
-// fallback to a timestamp-based ID with a "-fallback" suffix to indicate it's not a true UUID.
+// fallback to a timestamp-based ID with a "-fallback" suffix to
+// indicate it's not a true UUID.
 func generateSessionID() string {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
-		// Fallback to timestamp-based ID if crypto fails
+		// Fallback to timestamp-based ID if crypto random generation fails
 		return time.Now().UTC().Format(time.RFC3339) + "-fallback"
 	}
 
@@ -145,9 +146,9 @@ func getOrCreateDeviceID() string {
 	configDir, err := config.GetConfigDir()
 	if err != nil {
 		// If we can't get the config directory, we won't be able to persist a device ID,
-		// so we just generate a new one for this session. These IDs will be suffixed with
-		// "-fallback".
-		return generateSessionID()
+		// so we just generate a new one for this session. These IDs will be prefixed with
+		// "fallback-" to indicate it is not a true device ID.
+		return "fallback-" + generateSessionID()
 	}
 
 	// Try to read existing device ID from file
@@ -166,11 +167,11 @@ func getOrCreateDeviceID() string {
 
 	// If we couldn't get a machine ID or read an existing device ID, generate a new one
 	// and save it for future sessions. NOTE: Ignore errors at this point, since we can
-	// still function without p
-	id := generateSessionID()
+	// still function without persisting.
+	id := "fallback-" + generateSessionID()
 
-	// At this point, ignore any errors we might have with persisting the session ID, as
-	// telemetry will stil function without it, it will just be less stable.
+	// At this point, ignore any errors we might have with persisting the device ID, as
+	// telemetry will still function without it, it will just be less stable.
 	if mkErr := os.MkdirAll(configDir, 0o700); mkErr == nil {
 		_ = os.WriteFile(deviceIDPath, []byte(id), 0o600)
 	}

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -102,7 +102,7 @@ func generateSessionID() string {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
 		// Fallback to timestamp-based ID if crypto fails
-		return time.Now().Format("20060102150405") + "-fallback"
+		return time.Now().UTC().Format(time.RFC3339) + "-fallback"
 	}
 
 	// Set version (4) and variant (RFC 4122) bits

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -100,13 +100,13 @@ func (p *CommonProperties) AsMap() map[string]interface{} {
 // generateSessionID generates a UUID v4 for the current CLI session.
 // This value is not persisted and will be different on each invocation.
 // The default implementation uses crypto/rand, but if that fails, then
-// fallback to a timestamp-based ID with a "-fallback" suffix to
+// fallback to a timestamp-based ID with a "fallback-" prefix to
 // indicate it's not a true UUID.
 func generateSessionID() string {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
 		// Fallback to timestamp-based ID if crypto random generation fails
-		return time.Now().UTC().Format(time.RFC3339) + "-fallback"
+		return "fallback-" + time.Now().UTC().Format(time.RFC3339)
 	}
 
 	// Set version (4) and variant (RFC 4122) bits

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -106,7 +106,7 @@ func generateSessionID() string {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
 		// Fallback to timestamp-based ID if crypto random generation fails
-		return "fallback-" + time.Now().UTC().Format(time.RFC3339)
+		return deviceIDFallbackPrefix + time.Now().UTC().Format(time.RFC3339)
 	}
 
 	// Set version (4) and variant (RFC 4122) bits
@@ -133,7 +133,10 @@ func deriveEnvironment(baseURL string) string {
 	}
 }
 
-const deviceIDFileName = "device_id"
+const (
+	deviceIDFileName = "device_id"
+	deviceIDFallbackPrefix   = "fallback-"
+)
 
 // getOrCreateDeviceID returns a stable device identifier.
 func getOrCreateDeviceID() string {
@@ -147,8 +150,8 @@ func getOrCreateDeviceID() string {
 	if err != nil {
 		// If we can't get the config directory, we won't be able to persist a device ID,
 		// so we just generate a new one for this session. These IDs will be prefixed with
-		// "fallback-" to indicate it is not a true device ID.
-		return "fallback-" + generateSessionID()
+		// deviceIDFallbackPrefix to indicate it is not a true device ID.
+		return deviceIDFallbackPrefix + generateSessionID()
 	}
 
 	// Try to read existing device ID from file
@@ -168,7 +171,7 @@ func getOrCreateDeviceID() string {
 	// If we couldn't get a machine ID or read an existing device ID, generate a new one
 	// and save it for future sessions. NOTE: Ignore errors at this point, since we can
 	// still function without persisting.
-	id := "fallback-" + generateSessionID()
+	id := deviceIDFallbackPrefix + generateSessionID()
 
 	// At this point, ignore any errors we might have with persisting the device ID, as
 	// telemetry will still function without it, it will just be less stable.

--- a/internal/telemetry/properties_test.go
+++ b/internal/telemetry/properties_test.go
@@ -57,6 +57,7 @@ func TestCommonPropertiesAsMap(t *testing.T) {
 	m := props.AsMap()
 
 	assert.Equal(t, "session-123", m["session_id"])
+	assert.Equal(t, "user-456", m["user_id"])
 	assert.Equal(t, "v0.1.0", m["cli_version"])
 	assert.Equal(t, "source", m["install_method"])
 	assert.Equal(t, "darwin/arm64", m["os_info"])
@@ -117,6 +118,47 @@ func TestGetOrCreateDeviceID_ReadsExistingID(t *testing.T) {
 	id := getOrCreateDeviceID()
 
 	assert.Equal(t, existingID, id)
+}
+
+func TestGetOrCreateDeviceID_IgnoresBlankFile(t *testing.T) {
+	if getMachineID() != "" {
+		t.Skip("OS machine ID available; file fallback not exercised")
+	}
+
+	tmpDir := t.TempDir()
+
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, "datarobot")
+
+	err := os.MkdirAll(configDir, 0o700)
+
+	require.NoError(t, err)
+
+	// Write a blank file — should be treated as absent and regenerated
+	err = os.WriteFile(filepath.Join(configDir, deviceIDFileName), []byte("   "), 0o600)
+
+	require.NoError(t, err)
+
+	id := getOrCreateDeviceID()
+
+	assert.NotEmpty(t, id)
+	assert.Contains(t, id, "fallback-", "blank file should trigger fallback ID generation")
+}
+
+func TestGetOrCreateDeviceID_FallbackIDHasPrefix(t *testing.T) {
+	if getMachineID() != "" {
+		t.Skip("OS machine ID available; file fallback not exercised")
+	}
+
+	tmpDir := t.TempDir()
+
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	id := getOrCreateDeviceID()
+
+	assert.NotEmpty(t, id)
+	assert.Contains(t, id, "fallback-")
 }
 
 func TestCollectCommonProperties_SetsDeviceID(t *testing.T) {

--- a/internal/telemetry/properties_test.go
+++ b/internal/telemetry/properties_test.go
@@ -15,11 +15,14 @@
 package telemetry
 
 import (
+	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGenerateSessionID_ReturnsValidUUID(t *testing.T) {
@@ -41,6 +44,7 @@ func TestGenerateSessionID_UniqueSessions(t *testing.T) {
 func TestCommonPropertiesAsMap(t *testing.T) {
 	props := &CommonProperties{
 		SessionID:         "session-123",
+		DeviceID:          "device-789",
 		UserID:            "user-456",
 		CLIVersion:        "v0.1.0",
 		InstallMethod:     "source",
@@ -53,7 +57,6 @@ func TestCommonPropertiesAsMap(t *testing.T) {
 	m := props.AsMap()
 
 	assert.Equal(t, "session-123", m["session_id"])
-	assert.Equal(t, "user-456", m["user_id"])
 	assert.Equal(t, "v0.1.0", m["cli_version"])
 	assert.Equal(t, "source", m["install_method"])
 	assert.Equal(t, "darwin/arm64", m["os_info"])
@@ -62,6 +65,68 @@ func TestCommonPropertiesAsMap(t *testing.T) {
 	assert.Equal(t, "base", m["template_name"])
 	// Verify CWD is not included
 	assert.NotContains(t, m, "cwd")
+}
+
+func TestGetOrCreateDeviceID_CreatesAndPersists(t *testing.T) {
+	if getMachineID() != "" {
+		t.Skip("OS machine ID available; file fallback not exercised")
+	}
+
+	tmpDir := t.TempDir()
+
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	id1 := getOrCreateDeviceID()
+
+	assert.NotEmpty(t, id1)
+
+	// Second call should return the same ID
+	id2 := getOrCreateDeviceID()
+
+	assert.Equal(t, id1, id2)
+
+	// File should exist
+	deviceIDPath := filepath.Join(tmpDir, "datarobot", deviceIDFileName)
+	data, err := os.ReadFile(deviceIDPath)
+
+	require.NoError(t, err)
+	assert.Equal(t, id1, string(data))
+}
+
+func TestGetOrCreateDeviceID_ReadsExistingID(t *testing.T) {
+	if getMachineID() != "" {
+		t.Skip("OS machine ID available; file fallback not exercised")
+	}
+
+	tmpDir := t.TempDir()
+
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	configDir := filepath.Join(tmpDir, "datarobot")
+
+	err := os.MkdirAll(configDir, 0o700)
+
+	require.NoError(t, err)
+
+	existingID := "abcdef1234567890abcdef1234567890"
+
+	err = os.WriteFile(filepath.Join(configDir, deviceIDFileName), []byte(existingID), 0o600)
+
+	require.NoError(t, err)
+
+	id := getOrCreateDeviceID()
+
+	assert.Equal(t, existingID, id)
+}
+
+func TestCollectCommonProperties_SetsDeviceID(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	props := CollectCommonProperties()
+
+	assert.NotEmpty(t, props.DeviceID)
 }
 
 func TestDeriveEnvironment_US(t *testing.T) {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -92,8 +92,9 @@ func (c *Client) Track(event types.Event) {
 
 		event.EventProperties = commonMap
 
-		// Set UserID as top-level field (required by Amplitude)
+		// Set UserID and DeviceID as top-level fields (required by Amplitude)
 		event.UserID = c.props.UserID
+		event.DeviceID = c.props.DeviceID
 	}
 
 	c.amp.Track(event)

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -140,6 +140,37 @@ func TestTrack_MergesCommonProperties(t *testing.T) {
 	client.Track(event)
 }
 
+func TestTrack_SetsDeviceIDFromProps(t *testing.T) {
+	originalAPIKey := AmplitudeAPIKey
+
+	defer func() { AmplitudeAPIKey = originalAPIKey }()
+
+	AmplitudeAPIKey = ""
+	props := &CommonProperties{
+		DeviceID:   "test-device-id",
+		UserID:     "test-user",
+		CLIVersion: "v0.1.0",
+	}
+
+	client := NewClient(props)
+
+	// Verify the props are stored correctly so Track will use them
+	assert.Equal(t, "test-device-id", client.props.DeviceID)
+}
+
+func TestTrack_DeviceIDNotEmptyAfterCollect(t *testing.T) {
+	originalAPIKey := AmplitudeAPIKey
+
+	defer func() { AmplitudeAPIKey = originalAPIKey }()
+
+	AmplitudeAPIKey = ""
+
+	props := CollectCommonProperties()
+	client := NewClient(props)
+
+	assert.NotEmpty(t, client.props.DeviceID, "DeviceID should be set from OS machine ID or fallback")
+}
+
 func TestFlush_NoOpWhenDisabled(t *testing.T) {
 	// Save original value
 	originalAPIKey := AmplitudeAPIKey


### PR DESCRIPTION
# RATIONALE

In testing, I wasn't actually setting device_id in Amplitude events. Amplitude requires either device_id OR user_id, and we don't have user_id at the moment.

```
2026/05/01 13:06:28 INFO  HTTP response code: 400 Bad Request
2026/05/01 13:06:28 INFO  HTTP response body: {"events_with_missing_fields":{"device_id":[0],"user_id":[0]},"code":400,"error":"Request missing required field"}
```

## CHANGES

Adds `denisbrodbeck/machineid` as a project dependency, to allow us to retrieve the user's machine-id in an OS-agnostic way. [The project](https://github.com/denisbrodbeck/machineid) is MIT licensed.

Retrieves the machine ID for use as an Amplitude Device ID. This could be considered PII, as it is relatively stable data, so we hash it with SHA-256 against the app name ("dr" in this case). (All handled by `denisbrodbeck/machineid`)

Stores the hash in the config directory (i.e. ~/.config/datarobot/) as `device_id`.

Reads that hash to CommonProperties for use in telemetry event generation.

In case `getMachineId()` does not work -- as in the case of DataRobot Codespaces, Notebooks, and other container-based environments -- we fallback to a randomly generated UUID, again persisted in the config directory.

In case we can't access the config directory for persistence, just use a randomly generated UUID.

Adds a bunch of unit tests, as well as the dev docs.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches telemetry identifiers and persists a new `device_id` file under the user config dir, which could affect analytics correctness and has privacy/PII considerations, but it is isolated to telemetry and heavily covered by tests.
> 
> **Overview**
> Fixes Amplitude telemetry emission by **populating `device_id` on events** (in addition to `user_id`) and adding a stable device identifier to `CommonProperties`.
> 
> Introduces OS-derived machine IDs (via `denisbrodbeck/machineid` protected/hash) with a fallback that **persists a generated ID to the config dir** (`device_id`) when machine ID isn’t available, plus a session-only fallback when persistence is impossible.
> 
> Adds unit tests for machine/device ID stability and persistence behavior, and updates dev docs/MkDocs navigation with a new `development/telemetry.md` guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3a240724973a2797c205bf9221b60c257605fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->