### PR TITLE
Added GA to the pages site

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -5,6 +5,11 @@ repo_url: https://github.com/datarobot-oss/cli
 repo_name: datarobot-oss/cli
 edit_uri: edit/main/docs/
 
+extra:
+  analytics:
+    provider: google
+    property: G-MTV90FWR73
+
 theme:
   name: material
   features:


### PR DESCRIPTION
# RATIONALE
I'm interested in tracking dev-docs usage on the CLI mkdocs site


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk since it only updates documentation site configuration, but it introduces third-party tracking which may have privacy/compliance implications.
> 
> **Overview**
> Enables Google Analytics tracking on the MkDocs dev-docs site by adding an `extra.analytics` configuration with a Google measurement ID (`G-MTV90FWR73`) in `docs/mkdocs.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61ba8ccc0080948d1579daff780de0497ed8a025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->