### PR TITLE
[CFX-5780] Add versions.yaml schema and validation

### DIFF
--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -41,7 +41,7 @@ These flags are available for all commands:
 | [`dotenv`](dotenv.md)   | Manage environment variables.                       |
 | [`self`](self.md)       | CLI utility commands (update, version, completion, plugin). |
 | [`plugin`](plugins.md)  | Inspect and manage CLI plugins.                     |
-| `dependencies`         | Check template dependencies (advanced).            |
+| [`dependencies`](dependencies.md) | Check and install template dependencies (advanced). |
 
 ### Command tree
 
@@ -67,7 +67,8 @@ dr
 │   └── run            Execute tasks
 ├── dotenv             Environment configuration
 ├── dependencies       Template dependencies (advanced)
-│   └── check          Check template dependencies
+│   ├── check          Check template dependencies
+│   └── install        Install missing template dependencies
 ├── plugin             Inspect and manage CLI plugins (alias: plugins)
 │   ├── list           List installed plugins
 │   ├── install        Install a plugin
@@ -228,8 +229,9 @@ For detailed documentation on each command, see:
   - `update`&mdash;update CLI to latest version.
   - `version`&mdash;show CLI version and build information.
 
-- **dependencies**&mdash;template dependency checks (advanced).
-  - `check`&mdash;verify that required tools (e.g. Task, Git) are installed.
+- **[dependencies](dependencies.md)**&mdash;template dependency management (advanced).
+  - `check`&mdash;verify that required tools are installed and meet minimum version requirements.
+  - `install`&mdash;install missing or out-of-date tools; supports `--yes`/`-y` and `DATAROBOT_CLI_NON_INTERACTIVE` for non-interactive use.
 
 - **[plugin](plugins.md)**&mdash;inspect and manage installed CLI plugins (alias: `plugins`).
 

--- a/docs/commands/dependencies.md
+++ b/docs/commands/dependencies.md
@@ -1,0 +1,202 @@
+# `dr dependencies` - Dependency management
+
+The `dr dependencies` command checks and installs the prerequisite tools required by your DataRobot template.
+
+## Synopsis
+
+```bash
+dr dependencies <command> [flags]
+```
+
+## Description
+
+The `dependencies` command verifies that required tools (such as Python, uv, Task, Pulumi, NodeJS ...) are installed and meet the minimum version requirements declared in your project's `.datarobot/cli/versions.yaml` file. Use it to diagnose missing tools before running other commands, or to install missing tools in one step.
+
+## Subcommands
+
+### `check`
+
+Verify that all required template dependencies are installed and meet the minimum version requirements.
+
+```bash
+dr dependencies check
+```
+
+**Example output:**
+
+```bash
+# All dependencies satisfied
+$ dr dependencies check
+✅ All dependencies are already up to date.
+
+# Missing or wrong-version tools
+$ dr dependencies check
+ ❌ Missing required tools:
+
+	- uv  (https://docs.astral.sh/uv/getting-started/installation/)
+
+ ⚠️ Wrong versions of tools:
+
+	- Python (minimal: v3.9.0, installed: v3.8.0)
+	  https://www.python.org/downloads/
+```
+
+Exit code is non-zero when any tool is missing or has an insufficient version.
+
+### `install`
+
+Install missing or out-of-date template dependencies. The command first checks prerequisites, reports what is missing, then prompts you for confirmation before running each tool's platform-specific install command.
+
+```bash
+dr dependencies install [flags]
+```
+
+**Flags:**
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--yes` | `-y` | Assume "yes" as answer to the install prompt &mdash; skip interactive confirmation. |
+
+**Environment variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `DATAROBOT_CLI_NON_INTERACTIVE` | Equivalent to `--yes`. Set to any truthy value to skip the install prompt. |
+
+**Example — set for a single command:**
+
+```bash
+DATAROBOT_CLI_NON_INTERACTIVE=true dr dependencies install
+```
+
+**Example — export for the current shell session:**
+
+```bash
+export DATAROBOT_CLI_NON_INTERACTIVE=true
+dr dependencies install
+```
+
+**Example — interactive:**
+
+```bash
+$ dr dependencies install
+
+ ❌ Missing required tools:
+
+	- uv  (https://docs.astral.sh/uv/getting-started/installation/)
+
+Install now? (y/n): y
+Installing uv...
+```
+
+**Example — non-interactive:**
+
+```bash
+$ dr dependencies install --yes
+# or
+$ DATAROBOT_CLI_NON_INTERACTIVE=true dr dependencies install
+```
+
+**Example — nothing to install:**
+
+```bash
+$ dr dependencies install
+✅ All dependencies are already up to date.
+```
+
+## Examples
+
+### Check before running tasks
+
+```bash
+# Verify dependencies are in place before starting development
+dr dependencies check
+dr run dev
+```
+
+### Install all missing tools at once
+
+```bash
+# Install without being prompted for confirmation
+dr dependencies install -y
+```
+
+### CI/CD usage
+
+```bash
+# In a CI pipeline where stdin is not available
+DATAROBOT_CLI_NON_INTERACTIVE=true dr dependencies install
+```
+
+## `versions.yaml` schema
+
+The CLI reads tool requirements from `.datarobot/cli/versions.yaml` in your repository. Each top-level key is a tool identifier; the value is a map with the following fields:
+
+```yaml
+<tool-key>:
+  name: string            # Display name shown in messages
+  minimum-version: semver # Minimum acceptable version (e.g. "3.9.0")
+  command: string         # Command used to check/run the tool (e.g. "python3")
+  url: string             # URL shown when the tool is missing or outdated
+  install:
+    macos: string         # Install command for macOS (e.g. "brew install python")
+    linux: string         # Install command for Linux (e.g. "sudo apt-get install python3")
+    windows: string       # Install command for Windows (optional)
+```
+
+**Field rules:**
+
+| Field | Required | Format | Notes |
+|-------|----------|--------|-------|
+| `name` | Yes | string | — |
+| `minimum-version` | Yes | semver | Must be a valid semantic version, e.g. `3.9.0` |
+| `command` | Yes | string | — |
+| `url` | Yes | string | — |
+| `install.macos` | Yes | string | — |
+| `install.linux` | Yes | string | — |
+| `install.windows` | No | string | Optional for Milestone 1 |
+
+**Validation behavior:**
+
+The CLI validates the file on load and logs diagnostics without failing the command:
+
+- Missing required field (`name`, `minimum-version`, `command`, `url`, `install.macos`, `install.linux`) → **WARN** logged.
+- `minimum-version` present but not a valid semantic version → **WARN** logged.
+- `install` block entirely absent → **WARN** logged.
+- Required install command missing **for the current platform** → **ERROR** logged.
+- Required install command missing for a non-current platform → **WARN** logged.
+
+**Example:**
+
+```yaml
+---
+dr:
+  name: DataRobot CLI
+  minimum-version: 0.2.0
+  command: dr self version
+  url: https://github.com/datarobot-oss/cli
+  install:
+    macos: brew install datarobot-cli
+    linux: curl -fsSL https://get.datarobot.com/cli | sh
+python:
+  name: Python
+  minimum-version: 3.9.0
+  command: python3
+  url: https://www.python.org/downloads/
+  install:
+    macos: brew install python
+    linux: sudo apt-get install python3
+uv:
+  name: uv Python package manager
+  minimum-version: 1.7.0
+  command: uv self version
+  url: https://docs.astral.sh/uv/getting-started/installation/
+  install:
+    macos: brew install uv
+    linux: curl -Ls https://astral.sh/uv/install.sh | sh
+```
+
+## See also
+
+- [Quick start](../../README.md#quick-start) - Initial setup guide
+- [run](run.md) - Execute template tasks

--- a/docs/commands/start.md
+++ b/docs/commands/start.md
@@ -249,12 +249,20 @@ dr:
   minimum-version: 0.2.0
   command: dr self version
   url: https://github.com/datarobot-oss/cli
+  install:
+    macos: brew install datarobot-cli
+    linux: curl -fsSL https://get.datarobot.com/cli | sh
 uv:
   name: uv Python package manager
   minimum-version: 1.7.0
   command: uv self version
   url: https://docs.astral.sh/uv/getting-started/installation/
+  install:
+    macos: brew install uv
+    linux: curl -Ls https://astral.sh/uv/install.sh | sh
 ```
+
+For the full schema reference, required fields, and validation behavior, see [`dr dependencies`](dependencies.md#versionsyaml-schema).
 
 The repository check runs before start-command detection. If the current directory is not within a DataRobot repository (no `.datarobot/` directory), the command launches the template setup wizard instead of continuing to look for a start command.
 

--- a/internal/tools/validation.go
+++ b/internal/tools/validation.go
@@ -1,0 +1,147 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"fmt"
+	"runtime"
+	"slices"
+	"strings"
+
+	semver "github.com/Masterminds/semver/v3"
+
+	"github.com/datarobot/cli/internal/log"
+)
+
+const formatSemver = "semver"
+
+// FieldRule defines validation constraints for a single string field.
+type FieldRule struct {
+	Required bool
+	Format   string // "semver" validates semantic version format when non-empty
+}
+
+// InstallCommandsSchema defines validation constraints for InstallCommands fields.
+type InstallCommandsSchema struct {
+	MacOS   FieldRule
+	Linux   FieldRule
+	Windows FieldRule
+}
+
+func (s InstallCommandsSchema) validate(key string, ic InstallCommands) []string {
+	return slices.Concat(
+		s.validatePlatform(key, "install.macos", ic.MacOS, s.MacOS, "darwin"),
+		s.validatePlatform(key, "install.linux", ic.Linux, s.Linux, "linux"),
+		s.validatePlatform(key, "install.windows", ic.Windows, s.Windows, "windows"),
+	)
+}
+
+func (s InstallCommandsSchema) validatePlatform(key, fieldName, value string, rule FieldRule, goos string) []string {
+	err := rule.validate(fieldName, value)
+	if err == nil {
+		return nil
+	}
+
+	if runtime.GOOS == goos {
+		return []string{fmt.Sprintf("[%s]: %s", key, err.Error())}
+	}
+
+	log.Warnf("versions.yaml [%s]: %s", key, err.Error())
+
+	return nil
+}
+
+// YAMLSchema defines the expected structure and constraints for versions.yaml entries.
+type YAMLSchema struct {
+	Name           FieldRule
+	MinimumVersion FieldRule
+	Command        FieldRule
+	URL            FieldRule
+	Install        InstallCommandsSchema
+}
+
+var InstallCommandsSchemaRequired = InstallCommandsSchema{
+	MacOS:   FieldRule{},
+	Linux:   FieldRule{},
+	Windows: FieldRule{},
+}
+
+// versionsYamlSchema is the authoritative schema for versions.yaml.
+var versionsYamlSchema = YAMLSchema{
+	Name:           FieldRule{Required: true},
+	MinimumVersion: FieldRule{Format: formatSemver},
+	Command:        FieldRule{Required: true},
+	URL:            FieldRule{},
+	Install:        InstallCommandsSchema{},
+}
+
+func (r FieldRule) validate(fieldName, value string) error {
+	if r.Required && value == "" {
+		return fmt.Errorf("'%s' is required", fieldName)
+	}
+
+	if r.Format == formatSemver && value != "" {
+		if _, err := semver.NewVersion(value); err != nil {
+			return fmt.Errorf("'%s' %q is not a valid semantic version", fieldName, value)
+		}
+	}
+
+	return nil
+}
+
+// Validate checks every entry in the parsed versions.yaml against this schema.
+func (s YAMLSchema) Validate(data versionsYaml) error {
+	var errs []string
+
+	for key, p := range data {
+		entryErrs := s.validateEntry(key, p)
+
+		errs = append(errs, entryErrs...)
+	}
+
+	if len(errs) == 0 {
+		log.Warnf("versions.yaml passed validation with schema: %+v", s)
+		return fmt.Errorf("versions.yaml passed validation with schema: %+v", s)
+		// return nil
+	}
+
+	slices.Sort(errs)
+
+	return fmt.Errorf("validation errors:\n%s", strings.Join(errs, "\n"))
+}
+
+func (s YAMLSchema) validateEntry(key string, p Prerequisite) []string {
+	var issues []string
+
+	if err := s.Name.validate("name", p.Name); err != nil {
+		issues = append(issues, fmt.Sprintf("[%s]: %s", key, err.Error()))
+	}
+
+	if err := s.MinimumVersion.validate("minimum-version", p.MinimumVersion); err != nil {
+		issues = append(issues, fmt.Sprintf("[%s]: %s", key, err.Error()))
+	}
+
+	if err := s.Command.validate("command", p.Command); err != nil {
+		issues = append(issues, fmt.Sprintf("[%s]: %s", key, err.Error()))
+	}
+
+	if err := s.URL.validate("url", p.URL); err != nil {
+		issues = append(issues, fmt.Sprintf("[%s]: %s", key, err.Error()))
+	}
+
+	issues = append(issues, s.Install.validate(key, p.Install)...)
+
+	return issues
+}

--- a/internal/tools/validation.go
+++ b/internal/tools/validation.go
@@ -15,10 +15,7 @@
 package tools
 
 import (
-	"fmt"
 	"runtime"
-	"slices"
-	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
 
@@ -40,29 +37,6 @@ type InstallCommandsSchema struct {
 	Windows FieldRule
 }
 
-func (s InstallCommandsSchema) validate(key string, ic InstallCommands) []string {
-	return slices.Concat(
-		s.validatePlatform(key, "install.macos", ic.MacOS, s.MacOS, "darwin"),
-		s.validatePlatform(key, "install.linux", ic.Linux, s.Linux, "linux"),
-		s.validatePlatform(key, "install.windows", ic.Windows, s.Windows, "windows"),
-	)
-}
-
-func (s InstallCommandsSchema) validatePlatform(key, fieldName, value string, rule FieldRule, goos string) []string {
-	err := rule.validate(fieldName, value)
-	if err == nil {
-		return nil
-	}
-
-	if runtime.GOOS == goos {
-		return []string{fmt.Sprintf("[%s]: %s", key, err.Error())}
-	}
-
-	log.Warnf("versions.yaml [%s]: %s", key, err.Error())
-
-	return nil
-}
-
 // YAMLSchema defines the expected structure and constraints for versions.yaml entries.
 type YAMLSchema struct {
 	Name           FieldRule
@@ -72,76 +46,75 @@ type YAMLSchema struct {
 	Install        InstallCommandsSchema
 }
 
-var InstallCommandsSchemaRequired = InstallCommandsSchema{
-	MacOS:   FieldRule{},
-	Linux:   FieldRule{},
-	Windows: FieldRule{},
+// installCommandsSchema is the authoritative schema for InstallCommands in versions.yaml.
+// As for Milestone 1, we decided to make Windows install command optional .
+// We can always add a warning in validation if Windows command is not provided, but it won't be a hard requirement.
+var installCommandsSchema = InstallCommandsSchema{
+	MacOS: FieldRule{Required: true},
+	Linux: FieldRule{Required: true},
+	// InstallCommands for Windows is optional for now.
+	Windows: FieldRule{Required: false},
 }
 
 // versionsYamlSchema is the authoritative schema for versions.yaml.
 var versionsYamlSchema = YAMLSchema{
 	Name:           FieldRule{Required: true},
-	MinimumVersion: FieldRule{Format: formatSemver},
+	MinimumVersion: FieldRule{Required: true, Format: formatSemver},
 	Command:        FieldRule{Required: true},
-	URL:            FieldRule{},
-	Install:        InstallCommandsSchema{},
+	URL:            FieldRule{Required: true},
+	Install:        installCommandsSchema,
 }
 
-func (r FieldRule) validate(fieldName, value string) error {
+// validate logs a warning if value violates the field rule.
+func (r FieldRule) validate(key, fieldName, value string) {
 	if r.Required && value == "" {
-		return fmt.Errorf("'%s' is required", fieldName)
+		log.Warnf("versions.yaml [%s]: '%s' is required", key, fieldName)
+
+		return
 	}
 
 	if r.Format == formatSemver && value != "" {
 		if _, err := semver.NewVersion(value); err != nil {
-			return fmt.Errorf("'%s' %q is not a valid semantic version", fieldName, value)
+			log.Warnf("versions.yaml [%s]: '%s' %q is not a valid semantic version", key, fieldName, value)
 		}
 	}
-
-	return nil
 }
 
-// Validate checks every entry in the parsed versions.yaml against this schema.
-func (s YAMLSchema) Validate(data versionsYaml) error {
-	var errs []string
-
+// Validate checks every entry in the parsed versions.yaml and logs warnings for violations.
+func (s YAMLSchema) Validate(data versionsYaml) {
 	for key, p := range data {
-		entryErrs := s.validateEntry(key, p)
-
-		errs = append(errs, entryErrs...)
+		s.Name.validate(key, "name", p.Name)
+		s.MinimumVersion.validate(key, "minimum-version", p.MinimumVersion)
+		s.Command.validate(key, "command", p.Command)
+		s.URL.validate(key, "url", p.URL)
+		s.Install.validate(key, p.Install)
 	}
-
-	if len(errs) == 0 {
-		log.Warnf("versions.yaml passed validation with schema: %+v", s)
-		return fmt.Errorf("versions.yaml passed validation with schema: %+v", s)
-		// return nil
-	}
-
-	slices.Sort(errs)
-
-	return fmt.Errorf("validation errors:\n%s", strings.Join(errs, "\n"))
 }
 
-func (s YAMLSchema) validateEntry(key string, p Prerequisite) []string {
-	var issues []string
+func (s InstallCommandsSchema) validate(key string, ic InstallCommands) {
+	// log.Warnf("InstallCommands for %s : \n %#v", key, ic)
+	if ic.MacOS == "" && ic.Linux == "" && ic.Windows == "" {
+		log.Warnf("versions.yaml [%s]: 'install' is not defined", key)
 
-	if err := s.Name.validate("name", p.Name); err != nil {
-		issues = append(issues, fmt.Sprintf("[%s]: %s", key, err.Error()))
+		return
 	}
 
-	if err := s.MinimumVersion.validate("minimum-version", p.MinimumVersion); err != nil {
-		issues = append(issues, fmt.Sprintf("[%s]: %s", key, err.Error()))
+	s.validatePlatform(key, "install.macos", ic.MacOS, s.MacOS, "darwin")
+	s.validatePlatform(key, "install.linux", ic.Linux, s.Linux, "linux")
+	s.validatePlatform(key, "install.windows", ic.Windows, s.Windows, "windows")
+}
+
+func (s InstallCommandsSchema) validatePlatform(key, fieldName, value string, rule FieldRule, goos string) {
+	if !rule.Required || value != "" {
+		return
 	}
 
-	if err := s.Command.validate("command", p.Command); err != nil {
-		issues = append(issues, fmt.Sprintf("[%s]: %s", key, err.Error()))
+	// For now it's only warning if the install command for the current platform is missing
+	if runtime.GOOS == goos {
+		log.Errorf("versions.yaml [%s]: '%s' is required for the current platform", key, fieldName)
+
+		return
 	}
 
-	if err := s.URL.validate("url", p.URL); err != nil {
-		issues = append(issues, fmt.Sprintf("[%s]: %s", key, err.Error()))
-	}
-
-	issues = append(issues, s.Install.validate(key, p.Install)...)
-
-	return issues
+	log.Warnf("versions.yaml [%s]: '%s' is required", key, fieldName)
 }

--- a/internal/tools/validation.go
+++ b/internal/tools/validation.go
@@ -91,8 +91,9 @@ func (s YAMLSchema) Validate(data versionsYaml) {
 	}
 }
 
+// validate checks that install commands are provided
+// according to the InstallCommandsSchema rules, with special attention to the current platform.
 func (s InstallCommandsSchema) validate(key string, ic InstallCommands) {
-	// log.Warnf("InstallCommands for %s : \n %#v", key, ic)
 	if ic.MacOS == "" && ic.Linux == "" && ic.Windows == "" {
 		log.Warnf("versions.yaml [%s]: 'install' is not defined", key)
 
@@ -104,6 +105,7 @@ func (s InstallCommandsSchema) validate(key string, ic InstallCommands) {
 	s.validatePlatform(key, "install.windows", ic.Windows, s.Windows, "windows")
 }
 
+// validatePlatform logs Error if the install command for the current platform is missing and it's required, otherwise logs a warning.
 func (s InstallCommandsSchema) validatePlatform(key, fieldName, value string, rule FieldRule, goos string) {
 	if !rule.Required || value != "" {
 		return

--- a/internal/tools/validation_test.go
+++ b/internal/tools/validation_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFieldRuleValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		rule      FieldRule
+		fieldName string
+		value     string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:      "required field present",
+			rule:      FieldRule{Required: true},
+			fieldName: "name",
+			value:     "Python",
+			wantErr:   false,
+		},
+		{
+			name:      "required field missing",
+			rule:      FieldRule{Required: true},
+			fieldName: "name",
+			value:     "",
+			wantErr:   true,
+			errSubstr: "'name' is required",
+		},
+		{
+			name:      "semver field valid",
+			rule:      FieldRule{Format: formatSemver},
+			fieldName: "minimum-version",
+			value:     "3.9.0",
+			wantErr:   false,
+		},
+		{
+			name:      "semver field empty is allowed",
+			rule:      FieldRule{Format: formatSemver},
+			fieldName: "minimum-version",
+			value:     "",
+			wantErr:   false,
+		},
+		{
+			name:      "semver field invalid",
+			rule:      FieldRule{Format: formatSemver},
+			fieldName: "minimum-version",
+			value:     "not-a-version",
+			wantErr:   true,
+			errSubstr: "'minimum-version'",
+		},
+		{
+			name:      "optional string field empty",
+			rule:      FieldRule{},
+			fieldName: "url",
+			value:     "",
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.rule.validate(tt.fieldName, tt.value)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInstallCommandsSchemaValidate(t *testing.T) {
+	schema := InstallCommandsSchema{
+		MacOS:   FieldRule{Required: true},
+		Linux:   FieldRule{Required: true},
+		Windows: FieldRule{Required: true},
+	}
+
+	t.Run("all platforms provided — no errors", func(t *testing.T) {
+		ic := InstallCommands{MacOS: "brew install x", Linux: "apt install x", Windows: "choco install x"}
+
+		errs := schema.validate("tool", ic)
+
+		assert.Empty(t, errs)
+	})
+
+	t.Run("current OS platform missing — error returned", func(t *testing.T) {
+		var ic InstallCommands
+
+		switch runtime.GOOS {
+		case "darwin":
+			ic = InstallCommands{Linux: "apt install x", Windows: "choco install x"}
+		case "linux":
+			ic = InstallCommands{MacOS: "brew install x", Windows: "choco install x"}
+		default:
+			ic = InstallCommands{MacOS: "brew install x", Linux: "apt install x"}
+		}
+
+		errs := schema.validate("tool", ic)
+
+		assert.Len(t, errs, 1)
+		assert.Contains(t, errs[0], "[tool]")
+	})
+
+	t.Run("only non-current OS platforms missing — no errors, warnings logged", func(t *testing.T) {
+		var ic InstallCommands
+
+		switch runtime.GOOS {
+		case "darwin":
+			ic = InstallCommands{MacOS: "brew install x"}
+		case "linux":
+			ic = InstallCommands{Linux: "apt install x"}
+		default:
+			ic = InstallCommands{Windows: "choco install x"}
+		}
+
+		errs := schema.validate("tool", ic)
+
+		assert.Empty(t, errs)
+	})
+}
+
+func TestYAMLSchemaValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     versionsYaml
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid with all fields",
+			input: versionsYaml{
+				"python": {Name: "Python", MinimumVersion: "3.9.0", Command: "python3", URL: "https://python.org"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with name and command",
+			input: versionsYaml{
+				"dr": {Name: "DataRobot CLI", Command: "dr"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with name, command, and semver minimum-version",
+			input: versionsYaml{
+				"node": {Name: "Node.js", Command: "node", MinimumVersion: "18.0.0"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			input: versionsYaml{
+				"python": {MinimumVersion: "3.9.0"},
+			},
+			wantErr:   true,
+			errSubstr: "[python]",
+		},
+		{
+			name: "invalid minimum-version",
+			input: versionsYaml{
+				"python": {Name: "Python", MinimumVersion: "not-a-version"},
+			},
+			wantErr:   true,
+			errSubstr: "[python]",
+		},
+		{
+			name: "multiple invalid entries",
+			input: versionsYaml{
+				"python": {MinimumVersion: "3.9.0"},
+				"node":   {Name: "Node.js", MinimumVersion: "bad-version"},
+			},
+			wantErr:   true,
+			errSubstr: "validation errors",
+		},
+		{
+			name:    "empty map is valid",
+			input:   versionsYaml{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := versionsYamlSchema.Validate(tt.input)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/tools/validation_test.go
+++ b/internal/tools/validation_test.go
@@ -15,116 +15,189 @@
 package tools
 
 import (
+	"bytes"
+	"os"
 	"runtime"
 	"testing"
 
+	"github.com/datarobot/cli/internal/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// captureLog redirects os.Stderr to a pipe, reinitializes the logger, runs fn,
+// then returns everything written to the logger during fn's execution.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	origStderr := os.Stderr
+	os.Stderr = w
+
+	log.StartStderr()
+
+	fn()
+
+	w.Close()
+
+	os.Stderr = origStderr
+
+	t.Cleanup(log.StopStderr)
+
+	var buf bytes.Buffer
+
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+
+	r.Close()
+
+	return buf.String()
+}
+
+// TestVersionsYamlSchemaDefinition verifies the authoritative schema has the expected field rules.
+func TestVersionsYamlSchemaDefinition(t *testing.T) {
+	assert.True(t, versionsYamlSchema.Name.Required, "name must be required")
+	assert.True(t, versionsYamlSchema.MinimumVersion.Required, "minimum-version must be required")
+	assert.Equal(t, formatSemver, versionsYamlSchema.MinimumVersion.Format, "minimum-version must use semver format")
+	assert.True(t, versionsYamlSchema.Command.Required, "command must be required")
+	assert.True(t, versionsYamlSchema.URL.Required, "url must be required")
+}
+
+// TestInstallCommandsSchemaDefinition verifies platform rules: macOS and Linux required, Windows optional.
+func TestInstallCommandsSchemaDefinition(t *testing.T) {
+	assert.True(t, installCommandsSchema.MacOS.Required, "macOS install command must be required")
+	assert.True(t, installCommandsSchema.Linux.Required, "Linux install command must be required")
+	assert.False(t, installCommandsSchema.Windows.Required, "Windows install command must be optional")
+}
+
 func TestFieldRuleValidate(t *testing.T) {
-	tests := []struct {
-		name      string
-		rule      FieldRule
-		fieldName string
-		value     string
-		wantErr   bool
-		errSubstr string
-	}{
-		{
-			name:      "required field present",
-			rule:      FieldRule{Required: true},
-			fieldName: "name",
-			value:     "Python",
-			wantErr:   false,
-		},
-		{
-			name:      "required field missing",
-			rule:      FieldRule{Required: true},
-			fieldName: "name",
-			value:     "",
-			wantErr:   true,
-			errSubstr: "'name' is required",
-		},
-		{
-			name:      "semver field valid",
-			rule:      FieldRule{Format: formatSemver},
-			fieldName: "minimum-version",
-			value:     "3.9.0",
-			wantErr:   false,
-		},
-		{
-			name:      "semver field empty is allowed",
-			rule:      FieldRule{Format: formatSemver},
-			fieldName: "minimum-version",
-			value:     "",
-			wantErr:   false,
-		},
-		{
-			name:      "semver field invalid",
-			rule:      FieldRule{Format: formatSemver},
-			fieldName: "minimum-version",
-			value:     "not-a-version",
-			wantErr:   true,
-			errSubstr: "'minimum-version'",
-		},
-		{
-			name:      "optional string field empty",
-			rule:      FieldRule{},
-			fieldName: "url",
-			value:     "",
-			wantErr:   false,
-		},
-	}
+	t.Run("required field missing — WARN logged", func(t *testing.T) {
+		rule := FieldRule{Required: true}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.rule.validate(tt.fieldName, tt.value)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errSubstr)
-			} else {
-				assert.NoError(t, err)
-			}
+		output := captureLog(t, func() {
+			rule.validate("tool", "name", "")
 		})
-	}
+
+		assert.Contains(t, output, "WARN")
+		assert.Contains(t, output, "[tool]")
+		assert.Contains(t, output, "'name' is required")
+	})
+
+	t.Run("required field present — nothing logged", func(t *testing.T) {
+		rule := FieldRule{Required: true}
+
+		output := captureLog(t, func() {
+			rule.validate("tool", "name", "Python")
+		})
+
+		assert.Empty(t, output)
+	})
+
+	t.Run("semver field with invalid version — WARN logged", func(t *testing.T) {
+		rule := FieldRule{Format: formatSemver}
+
+		output := captureLog(t, func() {
+			rule.validate("tool", "minimum-version", "not-a-version")
+		})
+
+		assert.Contains(t, output, "WARN")
+		assert.Contains(t, output, "[tool]")
+		assert.Contains(t, output, "'minimum-version'")
+		assert.Contains(t, output, "not a valid semantic version")
+	})
+
+	t.Run("semver field with valid version — nothing logged", func(t *testing.T) {
+		rule := FieldRule{Format: formatSemver}
+
+		output := captureLog(t, func() {
+			rule.validate("tool", "minimum-version", "3.9.0")
+		})
+
+		assert.Empty(t, output)
+	})
+
+	t.Run("semver field empty and not required — nothing logged", func(t *testing.T) {
+		rule := FieldRule{Format: formatSemver}
+
+		output := captureLog(t, func() {
+			rule.validate("tool", "minimum-version", "")
+		})
+
+		assert.Empty(t, output)
+	})
+
+	t.Run("optional field empty — nothing logged", func(t *testing.T) {
+		rule := FieldRule{}
+
+		output := captureLog(t, func() {
+			rule.validate("tool", "command", "")
+		})
+
+		assert.Empty(t, output)
+	})
 }
 
 func TestInstallCommandsSchemaValidate(t *testing.T) {
 	schema := InstallCommandsSchema{
 		MacOS:   FieldRule{Required: true},
 		Linux:   FieldRule{Required: true},
-		Windows: FieldRule{Required: true},
+		Windows: FieldRule{Required: false},
 	}
 
-	t.Run("all platforms provided — no errors", func(t *testing.T) {
-		ic := InstallCommands{MacOS: "brew install x", Linux: "apt install x", Windows: "choco install x"}
+	t.Run("all platforms absent — WARN 'install is not defined'", func(t *testing.T) {
+		output := captureLog(t, func() {
+			schema.validate("tool", InstallCommands{})
+		})
 
-		errs := schema.validate("tool", ic)
-
-		assert.Empty(t, errs)
+		assert.Contains(t, output, "WARN")
+		assert.Contains(t, output, "[tool]")
+		assert.Contains(t, output, "'install' is not defined")
 	})
 
-	t.Run("current OS platform missing — error returned", func(t *testing.T) {
+	t.Run("all required platforms present — nothing logged", func(t *testing.T) {
+		ic := InstallCommands{MacOS: "brew install x", Linux: "apt install x"}
+
+		output := captureLog(t, func() {
+			schema.validate("tool", ic)
+		})
+
+		assert.Empty(t, output)
+	})
+
+	t.Run("Windows optional and absent — nothing logged for Windows", func(t *testing.T) {
+		ic := InstallCommands{MacOS: "brew install x", Linux: "apt install x"}
+
+		output := captureLog(t, func() {
+			schema.validate("tool", ic)
+		})
+
+		assert.NotContains(t, output, "install.windows")
+	})
+
+	t.Run("current platform missing — ERROR logged", func(t *testing.T) {
 		var ic InstallCommands
 
 		switch runtime.GOOS {
 		case "darwin":
-			ic = InstallCommands{Linux: "apt install x", Windows: "choco install x"}
+			ic = InstallCommands{Linux: "apt install x"}
 		case "linux":
-			ic = InstallCommands{MacOS: "brew install x", Windows: "choco install x"}
+			ic = InstallCommands{MacOS: "brew install x"}
 		default:
-			ic = InstallCommands{MacOS: "brew install x", Linux: "apt install x"}
+			t.Skip("current platform not covered by required fields in this schema")
 		}
 
-		errs := schema.validate("tool", ic)
+		output := captureLog(t, func() {
+			schema.validate("tool", ic)
+		})
 
-		assert.Len(t, errs, 1)
-		assert.Contains(t, errs[0], "[tool]")
+		assert.Contains(t, output, "ERRO")
+		assert.Contains(t, output, "[tool]")
+		assert.Contains(t, output, "required for the current platform")
 	})
 
-	t.Run("only non-current OS platforms missing — no errors, warnings logged", func(t *testing.T) {
+	t.Run("non-current platform missing — WARN logged", func(t *testing.T) {
 		var ic InstallCommands
 
 		switch runtime.GOOS {
@@ -133,85 +206,79 @@ func TestInstallCommandsSchemaValidate(t *testing.T) {
 		case "linux":
 			ic = InstallCommands{Linux: "apt install x"}
 		default:
-			ic = InstallCommands{Windows: "choco install x"}
+			t.Skip("current platform not covered by required fields in this schema")
 		}
 
-		errs := schema.validate("tool", ic)
+		output := captureLog(t, func() {
+			schema.validate("tool", ic)
+		})
 
-		assert.Empty(t, errs)
+		assert.Contains(t, output, "WARN")
+		assert.Contains(t, output, "[tool]")
+		assert.Contains(t, output, "is required")
 	})
 }
 
 func TestYAMLSchemaValidate(t *testing.T) {
-	tests := []struct {
-		name      string
-		input     versionsYaml
-		wantErr   bool
-		errSubstr string
-	}{
-		{
-			name: "valid with all fields",
-			input: versionsYaml{
-				"python": {Name: "Python", MinimumVersion: "3.9.0", Command: "python3", URL: "https://python.org"},
+	t.Run("fully valid entry — nothing logged, nil returned", func(t *testing.T) {
+		input := versionsYaml{
+			"python": {
+				Name: "Python", MinimumVersion: "3.9.0", Command: "python3", URL: "https://python.org",
+				Install: InstallCommands{MacOS: "brew install python", Linux: "apt install python3"},
 			},
-			wantErr: false,
-		},
-		{
-			name: "valid with name and command",
-			input: versionsYaml{
-				"dr": {Name: "DataRobot CLI", Command: "dr"},
-			},
-			wantErr: false,
-		},
-		{
-			name: "valid with name, command, and semver minimum-version",
-			input: versionsYaml{
-				"node": {Name: "Node.js", Command: "node", MinimumVersion: "18.0.0"},
-			},
-			wantErr: false,
-		},
-		{
-			name: "missing name",
-			input: versionsYaml{
-				"python": {MinimumVersion: "3.9.0"},
-			},
-			wantErr:   true,
-			errSubstr: "[python]",
-		},
-		{
-			name: "invalid minimum-version",
-			input: versionsYaml{
-				"python": {Name: "Python", MinimumVersion: "not-a-version"},
-			},
-			wantErr:   true,
-			errSubstr: "[python]",
-		},
-		{
-			name: "multiple invalid entries",
-			input: versionsYaml{
-				"python": {MinimumVersion: "3.9.0"},
-				"node":   {Name: "Node.js", MinimumVersion: "bad-version"},
-			},
-			wantErr:   true,
-			errSubstr: "validation errors",
-		},
-		{
-			name:    "empty map is valid",
-			input:   versionsYaml{},
-			wantErr: false,
-		},
-	}
+		}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := versionsYamlSchema.Validate(tt.input)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errSubstr)
-			} else {
-				assert.NoError(t, err)
-			}
+		output := captureLog(t, func() {
+			versionsYamlSchema.Validate(input)
 		})
-	}
+
+		assert.Empty(t, output)
+	})
+
+	t.Run("missing required fields — WARN logged, nil returned", func(t *testing.T) {
+		input := versionsYaml{
+			"python": {},
+		}
+
+		output := captureLog(t, func() {
+			versionsYamlSchema.Validate(input)
+		})
+
+		assert.Contains(t, output, "WARN")
+		assert.Contains(t, output, "[python]")
+	})
+
+	t.Run("invalid semver — WARN logged, nil returned", func(t *testing.T) {
+		input := versionsYaml{
+			"python": {Name: "Python", Command: "python3", URL: "https://python.org", MinimumVersion: "bad"},
+		}
+
+		output := captureLog(t, func() {
+			versionsYamlSchema.Validate(input)
+		})
+
+		assert.Contains(t, output, "WARN")
+		assert.Contains(t, output, "not a valid semantic version")
+	})
+
+	t.Run("no install commands — WARN 'install is not defined', nil returned", func(t *testing.T) {
+		input := versionsYaml{
+			"python": {Name: "Python", MinimumVersion: "3.9.0", Command: "python3", URL: "https://python.org"},
+		}
+
+		output := captureLog(t, func() {
+			versionsYamlSchema.Validate(input)
+		})
+
+		assert.Contains(t, output, "WARN")
+		assert.Contains(t, output, "'install' is not defined")
+	})
+
+	t.Run("empty map — nothing logged, nil returned", func(t *testing.T) {
+		output := captureLog(t, func() {
+			versionsYamlSchema.Validate(versionsYaml{})
+		})
+
+		assert.Empty(t, output)
+	})
 }

--- a/internal/tools/versions.go
+++ b/internal/tools/versions.go
@@ -49,6 +49,11 @@ func GetRequirements() ([]Prerequisite, error) {
 		return nil, fmt.Errorf("Failed to unmarshal versions yaml file %s: %w", yamlFile, err)
 	}
 
+	if err = versionsYamlSchema.Validate(fileParsed); err != nil {
+		fmt.Errorf("Versions yaml file %s failed schema validation: %w", yamlFile, err)
+		return nil, fmt.Errorf("Failed to validate versions yaml file %s: %w", yamlFile, err)
+	}
+
 	versions := make([]Prerequisite, 0, len(fileParsed))
 
 	for key, version := range fileParsed {

--- a/internal/tools/versions.go
+++ b/internal/tools/versions.go
@@ -49,10 +49,7 @@ func GetRequirements() ([]Prerequisite, error) {
 		return nil, fmt.Errorf("Failed to unmarshal versions yaml file %s: %w", yamlFile, err)
 	}
 
-	if err = versionsYamlSchema.Validate(fileParsed); err != nil {
-		fmt.Errorf("Versions yaml file %s failed schema validation: %w", yamlFile, err)
-		return nil, fmt.Errorf("Failed to validate versions yaml file %s: %w", yamlFile, err)
-	}
+	versionsYamlSchema.Validate(fileParsed)
 
 	versions := make([]Prerequisite, 0, len(fileParsed))
 


### PR DESCRIPTION
# RATIONALE
### GOAL
Not to break the process -> not to ruin UX of our customers. 

Invalid versions.yaml does not mean that user/customer doesn't have already installed required tools! !

versions.yaml validation is more for engineers who are implementing templates, plugins , etc.
### Current implementation :
Validate versions.yaml against schema and log warnings/errors without breaking process/throwing errors.
```
// installCommandsSchema is the authoritative schema for InstallCommands in versions.yaml.
// As for Milestone 1, we decided to make Windows install command optional .
// We can always add a warning in validation if Windows command is not provided, but it won't be a hard requirement.
var installCommandsSchema = InstallCommandsSchema{
	MacOS: FieldRule{Required: true},
	Linux: FieldRule{Required: true},
	// InstallCommands for Windows is optional for now.
	Windows: FieldRule{Required: false},
}

// versionsYamlSchema is the authoritative schema for versions.yaml.
var versionsYamlSchema = YAMLSchema{
	Name:           FieldRule{Required: true},
	MinimumVersion: FieldRule{Required: true, Format: formatSemver},
	Command:        FieldRule{Required: true},
	URL:            FieldRule{Required: true},
	Install:        installCommandsSchema,
}
```

The only small argument to go with this implementation instead of using `go-playground/validator` is that I prefer to use less third-party packages unless I have to. In this case there are only couple of structs and functions/methods to validate versions.yaml and log warnings/errors . 
I'm open to discuss this topic 😉 
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds `versions.yaml` validation that only logs warnings/errors on load and updates command docs; no changes to dependency resolution or execution flow beyond additional diagnostics.
> 
> **Overview**
> Adds an explicit `versions.yaml` schema/validator for template dependency requirements (required fields plus semver parsing, and platform-specific `install.*` checks) and runs it whenever `.datarobot/cli/versions.yaml` is loaded.
> 
> Introduces comprehensive unit tests for the validator’s logging behavior, and expands CLI docs by adding `dr dependencies` reference docs (including `install` usage/non-interactive mode) and linking/refreshing references from `start` and the command index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ea5a121facafbb41ded2e1bb94d27ffdb75b953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->