### PR TITLE
[CFX-5919] Skip directory up-walk when custom output is provided in 'dr dotenv setup'

### DIFF
--- a/cmd/component/shared/listItem.go
+++ b/cmd/component/shared/listItem.go
@@ -28,7 +28,8 @@ type ListItem struct {
 }
 
 func (i ListItem) Title() string {
-	return fmt.Sprintf("%s (%s)",
+	return fmt.Sprintf(
+		"%s (%s)",
 		i.component.ComponentDetails.Name,
 		i.component.FileName,
 	)

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -231,7 +231,7 @@ func init() {
 	SetupCmd.Flags().Bool("if-needed", false, "Only run setup if '.env' file doesn't exist or there are missing env vars.")
 	SetupCmd.Flags().BoolP("all", "a", false, "Show all prompts including those with default values already set.")
 	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for automation).")
-	SetupCmd.Flags().StringP("output", "o", "", "Directory where the .env file should be written (defaults to repository root).")
+	SetupCmd.Flags().StringP("output", "o", "", "Directory where the '.env' file should be written (defaults to repository root). This option skips the logic of finding the repository root.")
 	SetupCmd.MarkFlagsMutuallyExclusive("yes", "all")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper.

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -112,18 +112,24 @@ This wizard will help you:
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		outputDir, _ := cmd.Flags().GetString("output")
 
-		repositoryRoot, err := ensureInRepo()
-		if err != nil {
-			return err
-		}
+		var repositoryRoot string
 
-		var dotenvFile string
+		var err error
 
+		var isCustomOutput bool
+
+		// If --output is provided, use it as the repository root without walking up the directory tree
 		if outputDir != "" {
-			dotenvFile = filepath.Join(outputDir, ".env")
+			repositoryRoot = outputDir
+			isCustomOutput = true
 		} else {
-			dotenvFile = filepath.Join(repositoryRoot, ".env")
+			repositoryRoot, err = ensureInRepo()
+			if err != nil {
+				return err
+			}
 		}
+
+		dotenvFile := filepath.Join(repositoryRoot, ".env")
 
 		// Check if we should skip when .env exists and all required variables are set
 		flagIfNeededSet, _ := cmd.Flags().GetBool("if-needed")
@@ -154,8 +160,10 @@ This wizard will help you:
 				return err
 			}
 
-			// Update state after successful completion
-			_ = state.UpdateAfterDotenvSetup(repositoryRoot)
+			// Update state after successful completion (skip if custom output directory)
+			if !isCustomOutput {
+				_ = state.UpdateAfterDotenvSetup(repositoryRoot)
+			}
 
 			return nil
 		}
@@ -210,8 +218,10 @@ This wizard will help you:
 			}
 		}
 
-		// Update state after successful completion
-		_ = state.UpdateAfterDotenvSetup(repositoryRoot)
+		// Update state after successful completion (skip if custom output directory)
+		if !isCustomOutput {
+			_ = state.UpdateAfterDotenvSetup(repositoryRoot)
+		}
 
 		return nil
 	},

--- a/cmd/dotenv/cmd_test.go
+++ b/cmd/dotenv/cmd_test.go
@@ -159,3 +159,85 @@ func TestSetupCmd_OutputFlagCreatesDirectory(t *testing.T) {
 	_, err = os.Stat(outputDir)
 	require.NoError(t, err, "Expected output directory to be created")
 }
+
+func TestSetupCmd_OutputFlag_SkipsGitRepositorySearch(t *testing.T) {
+	// Reset viper to prevent leaking config
+	viperx.Reset()
+
+	// Create a target DataRobot app directory with proper structure
+	targetAppDir := setupTestRepo(t)
+
+	// Create a completely separate directory that is NOT a DataRobot app
+	nonAppDir := t.TempDir()
+	// Ensure it doesn't have .datarobot structure
+	_, err := os.Stat(filepath.Join(nonAppDir, ".datarobot"))
+	require.Error(t, err, "Non-app directory should not have .datarobot folder")
+
+	// Change to the NON-APP directory
+	originalWd, _ := os.Getwd()
+
+	defer func() {
+		_ = os.Chdir(originalWd)
+	}()
+
+	err = os.Chdir(nonAppDir)
+	require.NoError(t, err)
+
+	// Verify we are indeed in a non-app directory by checking ensureInRepo would fail
+	_, err = ensureInRepo()
+	require.Error(t, err, "ensureInRepo should fail when not in app directory")
+	assert.Contains(t, err.Error(), "Not in git repository")
+
+	// Now test that setupNonInteractive succeeds when using targetAppDir as the repo root
+	// This proves we skipped the directory walk because we're not in an app directory
+	dotenvPath := filepath.Join(targetAppDir, ".env")
+
+	err = setupNonInteractive(targetAppDir, dotenvPath)
+	require.NoError(t, err, "setupNonInteractive should succeed with explicit repo root even when not in app directory")
+
+	// Verify .env file was created in the target directory
+	_, err = os.Stat(dotenvPath)
+	require.NoError(t, err, "Expected .env file to exist in target app directory")
+
+	// Verify contents
+	contents, err := os.ReadFile(dotenvPath)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(contents), "TEST_VAR=\"test_default\"", "Expected .env to contain default value")
+}
+
+func TestSetupCmd_OutputFlag_DoesNotCreateStateFile(t *testing.T) {
+	// Reset viper to prevent leaking config
+	viperx.Reset()
+
+	// Create a target DataRobot app directory
+	targetAppDir := setupTestRepo(t)
+	outputDir := t.TempDir()
+
+	// Change to the app directory
+	originalWd, _ := os.Getwd()
+
+	defer func() {
+		_ = os.Chdir(originalWd)
+	}()
+
+	err := os.Chdir(targetAppDir)
+	require.NoError(t, err)
+
+	// Run setup with --output flag (simulating the behavior)
+	err = setupNonInteractive(outputDir, filepath.Join(outputDir, ".env"))
+	require.NoError(t, err, "setupNonInteractive should succeed")
+
+	// Verify .env file was created in the output directory
+	dotenvPath := filepath.Join(outputDir, ".env")
+
+	_, err = os.Stat(dotenvPath)
+	require.NoError(t, err, "Expected .env file to exist in output directory")
+
+	// Verify state file was NOT created in the output directory (bug fix)
+	statePath := filepath.Join(outputDir, ".datarobot", "cli", "state.yaml")
+
+	_, err = os.Stat(statePath)
+	require.Error(t, err, "State file should NOT be created when using --output flag")
+	assert.True(t, os.IsNotExist(err), "State file should not exist in output directory")
+}

--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -513,7 +513,8 @@ func (m Model) viewListScreen() string {
 	if m.skippedPrompts > 0 {
 		sb.WriteString(tui.DimStyle.Render(fmt.Sprintf(
 			"Skipped %d prompt(s) with default values. Use --all to configure them.",
-			m.skippedPrompts)))
+			m.skippedPrompts,
+		)))
 		sb.WriteString("\n\n")
 	}
 

--- a/cmd/plugin/discovery.go
+++ b/cmd/plugin/discovery.go
@@ -167,7 +167,8 @@ func checkAndPromptPluginUpdate(pluginName, installedVersion, pluginPath string)
 	// An update is available — prompt the user
 	fmt.Println(tui.InfoStyle.Render(
 		fmt.Sprintf("Plugin %q update available: v%s → v%s",
-			result.PluginName, result.InstalledVersion, result.LatestVersion.Version)))
+			result.PluginName, result.InstalledVersion, result.LatestVersion.Version),
+	))
 	fmt.Print(tui.DimStyle.Render("Do you want to update? [Y/n] "))
 
 	if !askYesNo() {

--- a/cmd/templates/clone/model.go
+++ b/cmd/templates/clone/model.go
@@ -273,13 +273,16 @@ func (m Model) View() string {
 	if m.exists {
 		if m.repoURL == m.template.Repository.URL {
 			sb.WriteString(tui.InfoStyle.Render(fmt.Sprintf(
-				"\n💡 Directory '%s' exists and will be updated from origin\n", m.Dir)))
+				"\n💡 Directory '%s' exists and will be updated from origin\n", m.Dir,
+			)))
 		} else if m.repoURL != "" {
 			sb.WriteString(tui.ErrorStyle.Render(fmt.Sprintf(
-				"\n⚠️ Directory '%s' contains a different repository: '%s'\n", m.Dir, m.repoURL)))
+				"\n⚠️ Directory '%s' contains a different repository: '%s'\n", m.Dir, m.repoURL,
+			)))
 		} else {
 			sb.WriteString(tui.ErrorStyle.Render(fmt.Sprintf(
-				"\n⚠️ Directory '%s' already exists\n", m.Dir)))
+				"\n⚠️ Directory '%s' already exists\n", m.Dir,
+			)))
 		}
 	}
 

--- a/cmd/workload/code/init/display.go
+++ b/cmd/workload/code/init/display.go
@@ -72,19 +72,22 @@ func renderInitResult(format workload.OutputFormat, result initResult) error {
 
 func printLinkedExistingCode(name, artifactID, verShort string) {
 	fmt.Println(tui.SuccessStyle.Render(
-		fmt.Sprintf("Linked to %s (%s) at version %s.", name, artifactID, verShort)))
+		fmt.Sprintf("Linked to %s (%s) at version %s.", name, artifactID, verShort),
+	))
 	fmt.Println(tui.DimStyle.Render("Run 'dr workload code sync' to reconcile any local changes."))
 }
 
 func printLinkedEmptyArtifact(name, artifactID string) {
 	fmt.Println(tui.SuccessStyle.Render(
-		fmt.Sprintf("Linked to empty artifact %s (%s).", name, artifactID)))
+		fmt.Sprintf("Linked to empty artifact %s (%s).", name, artifactID),
+	))
 	fmt.Println(tui.DimStyle.Render("Run 'dr workload code sync' to upload your files."))
 }
 
 func printAlreadyLinked(artifactID, dir string) {
 	fmt.Println(tui.ErrorStyle.Render(
-		fmt.Sprintf("Already linked to artifact %s; .wapi/ exists at %s.", artifactID, dir)))
+		fmt.Sprintf("Already linked to artifact %s; .wapi/ exists at %s.", artifactID, dir),
+	))
 	fmt.Println(tui.DimStyle.Render("Delete .wapi/ to re-init."))
 }
 

--- a/docs/commands/dotenv.md
+++ b/docs/commands/dotenv.md
@@ -57,7 +57,7 @@ dr dotenv setup [--if-needed]
 - `--if-needed`&mdash;Only run setup if `.env` file doesn't exist or validation fails. This flag is useful for automation scripts and CI/CD pipelines where you want to ensure configuration exists without prompting if it's already valid.
 - `-y, --yes`&mdash;Skip interactive prompts and auto-populate all environment variables with their default values (or empty strings if no default is provided). This is useful for CI/CD pipelines, automated testing, or quick development setup where you want to use all defaults. Variables with `generate: true` will still have random values auto-generated. Can also be enabled via `DATAROBOT_CLI_NON_INTERACTIVE=true` environment variable.
 - `-a, --all`&mdash;Show all prompts in the wizard, including those with default values already set. By default, prompts with defaults are skipped.
-- `-o, --output <directory>`&mdash;Specify a custom directory where the `.env` file should be written. By default, the `.env` file is written to the repository root. The directory will be created automatically if it doesn't exist. This is useful for managing multiple environment configurations or writing to a specific deployment directory.
+- `-o, --output <directory>`&mdash;Specify a custom directory where the `.env` file should be written. By default, the `.env` file is written to the repository root. The directory will be created automatically if it doesn't exist. This is useful for managing multiple environment configurations or writing to a specific deployment directory. This option skips the repository check and directory up-walk, allowing setup to run even when not executed from an app directory.
 
 **State tracking:**
 

--- a/tui/statusbar.go
+++ b/tui/statusbar.go
@@ -56,7 +56,8 @@ func RenderStatusBar(width int, s spinner.Model, message string, isLoading bool)
 		Width(width - w(statusKey) - 2).
 		Render(message)
 
-	bar := lipgloss.JoinHorizontal(lipgloss.Top,
+	bar := lipgloss.JoinHorizontal(
+		lipgloss.Top,
 		statusKey,
 		statusMsg,
 	)


### PR DESCRIPTION

When `--output <dir>` is used with 'dr dotenv setup', the directory up-walk to find the repository root will not be used, since `--output` implies a custom location which can be outside of the repository directory.

# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `dr dotenv setup` behavior when `--output` is provided, allowing execution outside a git repo and altering when CLI state is written; this could affect automation flows that relied on the previous repo check/state timestamp.
> 
> **Overview**
> `dr dotenv setup` now treats `--output` as the effective repository root, **skipping the directory up-walk/repo check** and writing `.env` directly to the provided directory.
> 
> When a custom output directory is used, the command **no longer writes/updates the CLI state file** (`state.UpdateAfterDotenvSetup`), and new tests and docs cover both the skipped repo search and the state-file behavior. Miscellaneous changes reformat several `fmt.Sprintf`/lipgloss calls without changing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0427fc560063f13529f5410d7b6c3dd1056ac9df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->