### PR TITLE
[CFX-6012] hide debug telemetry

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -46,10 +46,17 @@ type Client struct {
 }
 
 // amplitudeLogger adapts the internal log package to Amplitude's Logger interface.
+// Routes Amplitude's INFO logs to DEBUG by default, or to INFO if --verbose is set.
 type amplitudeLogger struct{}
 
 func (l *amplitudeLogger) Debugf(msg string, args ...any) { log.Debugf(msg, args...) }
-func (l *amplitudeLogger) Infof(msg string, args ...any)  { log.Infof(msg, args...) }
+func (l *amplitudeLogger) Infof(msg string, args ...any) {
+	if viperx.GetBool("verbose") || viperx.GetBool("debug") {
+		log.Infof(msg, args...)
+	} else {
+		log.Debugf(msg, args...)
+	}
+}
 func (l *amplitudeLogger) Warnf(msg string, args ...any)  { log.Warnf(msg, args...) }
 func (l *amplitudeLogger) Errorf(msg string, args ...any) { log.Errorf(msg, args...) }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -51,6 +51,9 @@ type amplitudeLogger struct{}
 
 func (l *amplitudeLogger) Debugf(msg string, args ...any) { log.Debugf(msg, args...) }
 func (l *amplitudeLogger) Infof(msg string, args ...any) {
+	// Routes Amplitude's INFO logs to DEBUG by default, or to INFO if --verbose is set.
+	// TODO consider adding a separate --amplitude-verbose flag to avoid coupling this
+	// to the CLI's global verbosity settings
 	if viperx.GetBool("verbose") || viperx.GetBool("debug") {
 		log.Infof(msg, args...)
 	} else {


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since it only changes log routing for Amplitude SDK messages; main impact is reduced default log verbosity, which could slightly hinder troubleshooting unless `--verbose`/`--debug` is enabled.
> 
> **Overview**
> **Reduces default telemetry-related log noise** by routing Amplitude SDK `INFO` logs to `DEBUG`.
> 
> When `--verbose` or `--debug` is enabled, Amplitude `INFO` logs continue to emit at `INFO`; otherwise they are downgraded to `DEBUG` via `amplitudeLogger.Infof`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82947863baf4a7eac5520bb1722d745a94f78085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->