### PR TITLE
[CFX-6012] Improve CLI telemetry and logging

### DIFF
--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -637,6 +637,7 @@ task build
 When you enable debug mode, the CLI:
 
 - Prints detailed log messages to stderr and `.dr-tui-debug.log` file in the home directory.
+- Third-party SDK logs (for example, `[amplitude]` prefixed messages from the telemetry HTTP client) also appear. See [Telemetry SDK log routing](telemetry.md#sdk-log-routing) for how these are level-routed.
 
 When adding new debug output:
 

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -623,27 +623,9 @@ dlv debug main.go -- templates list
 
 ### Debug logging
 
-Enable debug logging to see detailed execution information:
+See the [user guide](../user-guide/configuration.md#logging) for how `--verbose` and `--debug` flags work and where log files are written.
 
-```bash
-# Enable debug mode (use task run)
-task run -- --debug templates list
-
-# Or with built binary
-task build
-./dist/dr --debug templates list
-```
-
-When you enable debug mode, the CLI:
-
-- Prints detailed log messages to stderr and `.dr-tui-debug.log` file in the home directory.
-- Third-party SDK logs (for example, `[amplitude]` prefixed messages from the telemetry HTTP client) also appear. See [Telemetry SDK log routing](telemetry.md#sdk-log-routing) for how these are level-routed.
-
-When adding new debug output:
-
-- Never log user-provided input (including prompt responses), and avoid logging secrets (tokens, passwords, etc.).
-
-### Add debug statements
+### Adding debug output
 
 ```go
 import (
@@ -656,6 +638,9 @@ log.Info("Processing started")
 log.Warn("Unexpected condition")
 log.Error("Operation failed", "error", err)
 ```
+
+> [!WARNING]
+> Never log user-provided input (including prompt responses), and avoid logging secrets (tokens, passwords, etc.).
 
 ## Release process
 

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -178,11 +178,11 @@ dr foo --debug
 
 The Amplitude SDK emits its own internal logs (HTTP responses, client lifecycle, etc.) via a custom logger adapter in `amplitudeLogger`. All Amplitude SDK log entries are prefixed with `[amplitude]` for traceability in debug log files.
 
-The adapter demotes Amplitude's INFO-level logs (e.g. `HTTP response code`, `HTTP response body`) to DEBUG when the app's log level is above INFO. This keeps them off stderr by default while still capturing them in the debug log file.
+The adapter demotes Amplitude's INFO-level logs (e.g. `HTTP response code`, `HTTP response body`) to DEBUG when the app's log level is above INFO. This keeps them off stderr by default while still capturing them in the debug log file (see [Logging](../../user-guide/configuration.md#logging)).
 
 | CLI flags | Amplitude INFO appears as | Visible on stderr? |
 |---|---|---|
-| *(default)* | DEBUG | No (only in `.dr-tui-debug.log`) |
+| *(default)* | DEBUG | No |
 | `--verbose` | INFO | Yes |
 | `--debug` | INFO | Yes |
 

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -174,6 +174,20 @@ dr foo --debug
 # .dr-tui-debug.log will include "Telemetry event (dry-run)" entries
 ```
 
+## SDK log routing
+
+The Amplitude SDK emits its own internal logs (HTTP responses, client lifecycle, etc.) via a custom logger adapter in `amplitudeLogger`. All Amplitude SDK log entries are prefixed with `[amplitude]` for traceability in debug log files.
+
+The adapter demotes Amplitude's INFO-level logs (e.g. `HTTP response code`, `HTTP response body`) to DEBUG when the app's log level is above INFO. This keeps them off stderr by default while still capturing them in the debug log file.
+
+| CLI flags | Amplitude INFO appears as | Visible on stderr? |
+|---|---|---|
+| *(default)* | DEBUG | No (only in `.dr-tui-debug.log`) |
+| `--verbose` | INFO | Yes |
+| `--debug` | INFO | Yes |
+
+WARN and ERROR messages from the SDK always pass through at their original level.
+
 ## Testing
 
 Run the telemetry test suite:

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -244,23 +244,33 @@ Or via environment:
 export DR_TEMPLATES_DIR=~/workspace/datarobot
 ```
 
-### Debugging configuration
+### Logging
 
-Enable debug logging to see detailed execution information:
+The CLI supports two verbosity levels controlled by global flags or config keys:
+
+| Flag | Config key | Level | Use for |
+|---|---|---|---|
+| `--verbose` | `verbose: true` | INFO | Operational detail (e.g., HTTP request summary, progress) |
+| `--debug` | `debug: true` | DEBUG | Full execution tracing (e.g., request/response bodies, internal state) |
+
+Set permanently in your config file:
 
 ```yaml
+verbose: true
 debug: true
 ```
 
-Or temporarily enable it with the `--debug` flag:
+Or enable per-invocation:
 
 ```bash
+dr --verbose templates list
 dr --debug templates list
 ```
 
-When you enable debug mode, the CLI:
-- Prints detailed log messages to stderr.
-- Creates a `.dr-tui-debug.log` file in the home directory for terminal UI debug information.
+When debug mode is enabled, the CLI writes a `.dr-tui-debug.log` file in your home directory alongside stderr output. This file captures all DEBUG-level messages including third-party SDK logs (for example, `[amplitude]` prefixed telemetry HTTP traces).
+
+> [!WARNING]
+> Debug output may contain sensitive data. Never share debug logs publicly without reviewing them first. The CLI redacts known sensitive config keys (tokens, passwords) from debug output, but command output and API responses may still expose project data.
 
 ## Configuration examples
 

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -41,6 +41,7 @@ func init() {
 
 var (
 	level        log.Level
+	verbose      bool
 	fileWriter   io.WriteCloser
 	stderrLogger *log.Logger
 	fileLogger   *log.Logger
@@ -51,10 +52,13 @@ func Start() {
 	// Debug takes precedence
 	if viperx.GetBool("debug") {
 		level = log.DebugLevel
+		verbose = true
 	} else if viperx.GetBool("verbose") {
 		level = log.InfoLevel
+		verbose = true
 	} else {
 		level = log.Default().GetLevel()
+		verbose = false
 	}
 
 	StartStderr()

--- a/internal/log/pkg.go
+++ b/internal/log/pkg.go
@@ -35,6 +35,11 @@ func GetLevel() log.Level {
 	return level
 }
 
+// IsVerbose reports whether the user explicitly enabled verbose or debug output.
+func IsVerbose() bool {
+	return verbose
+}
+
 func Debug(msg interface{}, keyvals ...interface{}) {
 	Log(DebugLevel, msg, keyvals...)
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -60,7 +60,7 @@ func (l *amplitudeLogger) Debugf(msg string, args ...any) {
 }
 
 func (l *amplitudeLogger) Infof(msg string, args ...any) {
-	if log.GetLevel() <= log.InfoLevel {
+	if log.IsVerbose() {
 		log.Infof(amplitudeLogPrefix+msg, args...)
 	} else {
 		log.Debugf(amplitudeLogPrefix+msg, args...)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -97,7 +97,7 @@ func NewClient(props *CommonProperties) *Client {
 // the event is logged via log.Debug instead.
 func (c *Client) Track(event types.Event) {
 	if c.amp == nil {
-		log.Debug("Telemetry event (dry-run)", "type", event.EventType, "properties", event.EventProperties)
+		log.Debug("[amplitude] Telemetry event (dry-run)", "type", event.EventType, "properties", event.EventProperties)
 		return
 	}
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -46,22 +46,30 @@ type Client struct {
 }
 
 // amplitudeLogger adapts the internal log package to Amplitude's Logger interface.
-// Routes Amplitude's INFO logs to DEBUG by default, or to INFO if --verbose is set.
+// Amplitude's INFO logs (HTTP responses, variable additions) are demoted to DEBUG
+// when the app's log level is above INFO, keeping stderr clean by default.
+// All messages are prefixed with [amplitude] for traceability in debug log files.
 type amplitudeLogger struct{}
 
-func (l *amplitudeLogger) Debugf(msg string, args ...any) { log.Debugf(msg, args...) }
+func (l *amplitudeLogger) Debugf(msg string, args ...any) {
+	log.Debugf("[amplitude] "+msg, args...)
+}
+
 func (l *amplitudeLogger) Infof(msg string, args ...any) {
-	// Routes Amplitude's INFO logs to DEBUG by default, or to INFO if --verbose is set.
-	// TODO consider adding a separate --amplitude-verbose flag to avoid coupling this
-	// to the CLI's global verbosity settings
-	if viperx.GetBool("verbose") || viperx.GetBool("debug") {
-		log.Infof(msg, args...)
+	if log.GetLevel() <= log.InfoLevel {
+		log.Infof("[amplitude] "+msg, args...)
 	} else {
-		log.Debugf(msg, args...)
+		log.Debugf("[amplitude] "+msg, args...)
 	}
 }
-func (l *amplitudeLogger) Warnf(msg string, args ...any)  { log.Warnf(msg, args...) }
-func (l *amplitudeLogger) Errorf(msg string, args ...any) { log.Errorf(msg, args...) }
+
+func (l *amplitudeLogger) Warnf(msg string, args ...any) {
+	log.Warnf("[amplitude] "+msg, args...)
+}
+
+func (l *amplitudeLogger) Errorf(msg string, args ...any) {
+	log.Errorf("[amplitude] "+msg, args...)
+}
 
 // NewClient creates a telemetry client. If IsEnabled() returns true, it initializes
 // a real Amplitude client. Otherwise, it returns a no-op client that logs

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -45,6 +45,10 @@ type Client struct {
 	props *CommonProperties
 }
 
+// amplitudeLogPrefix is applied to all Amplitude SDK log entries for
+// traceability in debug log files.
+const amplitudeLogPrefix = "[amplitude] "
+
 // amplitudeLogger adapts the internal log package to Amplitude's Logger interface.
 // Amplitude's INFO logs (HTTP responses, variable additions) are demoted to DEBUG
 // when the app's log level is above INFO, keeping stderr clean by default.
@@ -52,23 +56,23 @@ type Client struct {
 type amplitudeLogger struct{}
 
 func (l *amplitudeLogger) Debugf(msg string, args ...any) {
-	log.Debugf("[amplitude] "+msg, args...)
+	log.Debugf(amplitudeLogPrefix+msg, args...)
 }
 
 func (l *amplitudeLogger) Infof(msg string, args ...any) {
 	if log.GetLevel() <= log.InfoLevel {
-		log.Infof("[amplitude] "+msg, args...)
+		log.Infof(amplitudeLogPrefix+msg, args...)
 	} else {
-		log.Debugf("[amplitude] "+msg, args...)
+		log.Debugf(amplitudeLogPrefix+msg, args...)
 	}
 }
 
 func (l *amplitudeLogger) Warnf(msg string, args ...any) {
-	log.Warnf("[amplitude] "+msg, args...)
+	log.Warnf(amplitudeLogPrefix+msg, args...)
 }
 
 func (l *amplitudeLogger) Errorf(msg string, args ...any) {
-	log.Errorf("[amplitude] "+msg, args...)
+	log.Errorf(amplitudeLogPrefix+msg, args...)
 }
 
 // NewClient creates a telemetry client. If IsEnabled() returns true, it initializes
@@ -97,7 +101,7 @@ func NewClient(props *CommonProperties) *Client {
 // the event is logged via log.Debug instead.
 func (c *Client) Track(event types.Event) {
 	if c.amp == nil {
-		log.Debug("[amplitude] Telemetry event (dry-run)", "type", event.EventType, "properties", event.EventProperties)
+		log.Debug(amplitudeLogPrefix+"Telemetry event (dry-run)", "type", event.EventType, "properties", event.EventProperties)
 		return
 	}
 


### PR DESCRIPTION
# RATIONALE

Follow up from https://github.com/datarobot-oss/cli/pull/474:  I realized I should just use `log.GetLevel`.

Also, there's a lot of docs on logging and telemetry, wanted to clean that up a bit


## CHANGES

- prefix all logs from Amplitude logger with `[amplitude]`
- use `log.GetLevel` check rather than `viperx` check, this makes things a little DRYer
- add a check for verbosity in `internal/log/logger`

- Clean up the dev docs around logging and telemetry.
- Add warnings in docs about logging sensitive information.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global logging and telemetry SDK log routing, which can change what appears on stderr and in debug logs; low functional risk but could impact troubleshooting/noise and inadvertently surface more data if misconfigured.
> 
> **Overview**
> Improves CLI logging/telemetry signal by **routing Amplitude SDK logs through the internal logger with a `[amplitude]` prefix**, and by demoting Amplitude INFO logs to DEBUG unless the user explicitly enables `--verbose`/`--debug`.
> 
> Adds `log.IsVerbose()` (backed by a new `verbose` state set during logger startup) and updates telemetry dry-run logging to use the same prefix for easier traceability.
> 
> Cleans up and consolidates docs: moves detailed logging guidance into the user guide, documents `--verbose` vs `--debug` behavior and log destinations, adds a new section on Amplitude SDK log routing, and adds warnings about sensitive data in debug output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e916a8a6ab6914d44ba0823bc314b63fd98548d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->