### PR TITLE
[RAPTOR-16924] workload code sync engine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/ulikunitz/xz v0.5.15
+	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0
 	golang.org/x/text v0.30.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -80,6 +81,5 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
 )

--- a/internal/workload/sync/classify.go
+++ b/internal/workload/sync/classify.go
@@ -1,0 +1,188 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+// Classification names a cell of the three-way (BASE x LOCAL x REMOTE) truth
+// table. Each Classification maps to exactly one Action.
+type Classification int
+
+const (
+	ClsUnchanged Classification = iota
+	ClsLocalModified
+	ClsRemoteModified
+	ClsConverged
+	ClsConflict
+	ClsLocalAdded
+	ClsRemoteAdded
+	ClsAddConflict
+	ClsLocalDeleted
+	ClsRemoteDeleted
+	ClsBothDeleted
+	ClsDelEditConflict // local edited, remote deleted
+	ClsEditDelConflict // local deleted, remote edited
+	ClsBothAddedSame
+)
+
+var classificationNames = map[Classification]string{
+	ClsUnchanged:       "UNCHANGED",
+	ClsLocalModified:   "LOCAL_MODIFIED",
+	ClsRemoteModified:  "REMOTE_MODIFIED",
+	ClsConverged:       "CONVERGED",
+	ClsConflict:        "CONFLICT",
+	ClsLocalAdded:      "LOCAL_ADDED",
+	ClsRemoteAdded:     "REMOTE_ADDED",
+	ClsAddConflict:     "ADD_CONFLICT",
+	ClsLocalDeleted:    "LOCAL_DELETED",
+	ClsRemoteDeleted:   "REMOTE_DELETED",
+	ClsBothDeleted:     "BOTH_DELETED",
+	ClsDelEditConflict: "DEL_EDIT_CONFLICT",
+	ClsEditDelConflict: "EDIT_DEL_CONFLICT",
+	ClsBothAddedSame:   "BOTH_ADDED_SAME",
+}
+
+func (c Classification) String() string {
+	if name, ok := classificationNames[c]; ok {
+		return name
+	}
+
+	return "UNKNOWN"
+}
+
+// IsConflict reports whether the classification represents a conflict.
+func (c Classification) IsConflict() bool {
+	switch c {
+	case ClsConflict, ClsAddConflict, ClsDelEditConflict, ClsEditDelConflict:
+		return true
+	case ClsUnchanged, ClsLocalModified, ClsRemoteModified, ClsConverged,
+		ClsLocalAdded, ClsRemoteAdded, ClsLocalDeleted, ClsRemoteDeleted,
+		ClsBothDeleted, ClsBothAddedSame:
+		return false
+	}
+
+	return false
+}
+
+// Action is the operation applied to a path during Phase 5.
+type Action int
+
+const (
+	ActSkip Action = iota
+	ActUploadModify
+	ActUploadAdd
+	ActUploadDelete
+	ActDownloadModify
+	ActDownloadAdd
+	ActDownloadDelete
+	ActConflictCopy
+	ActDownloadOverDel
+)
+
+// ActionFor returns the action for a Classification. EDIT_DEL_CONFLICT maps
+// to ActDownloadOverDel rather than ActConflictCopy because the user already
+// deleted that file, so no .LOCAL copy is kept.
+func ActionFor(c Classification) Action {
+	switch c {
+	case ClsUnchanged, ClsConverged, ClsBothDeleted, ClsBothAddedSame:
+		return ActSkip
+	case ClsLocalModified:
+		return ActUploadModify
+	case ClsLocalAdded:
+		return ActUploadAdd
+	case ClsLocalDeleted:
+		return ActUploadDelete
+	case ClsRemoteModified:
+		return ActDownloadModify
+	case ClsRemoteAdded:
+		return ActDownloadAdd
+	case ClsRemoteDeleted:
+		return ActDownloadDelete
+	case ClsConflict, ClsAddConflict, ClsDelEditConflict:
+		return ActConflictCopy
+	case ClsEditDelConflict:
+		return ActDownloadOverDel
+	}
+
+	return ActSkip
+}
+
+// Classify maps the (base, local, remote) triple to a Classification. An
+// empty hash means absent on that side.
+func Classify(baseHash, localHash, remoteHash string) Classification {
+	bExists := baseHash != ""
+	lExists := localHash != ""
+	rExists := remoteHash != ""
+
+	if !bExists {
+		return classifyAbsentBase(localHash, remoteHash, lExists, rExists)
+	}
+
+	return classifyPresentBase(baseHash, localHash, remoteHash, lExists, rExists)
+}
+
+func classifyAbsentBase(localHash, remoteHash string, lExists, rExists bool) Classification {
+	switch {
+	case !lExists && !rExists:
+		return ClsUnchanged
+	case lExists && !rExists:
+		return ClsLocalAdded
+	case !lExists && rExists:
+		return ClsRemoteAdded
+	case localHash == remoteHash:
+		return ClsBothAddedSame
+	}
+
+	return ClsAddConflict
+}
+
+func classifyPresentBase(base, local, remote string, lExists, rExists bool) Classification {
+	if !lExists || !rExists {
+		return classifyDeletionInvolvedWithBase(base, local, remote, lExists, rExists)
+	}
+
+	return classifyBothPresentWithBase(base, local, remote)
+}
+
+func classifyDeletionInvolvedWithBase(base, local, remote string, lExists, rExists bool) Classification {
+	switch {
+	case !lExists && !rExists:
+		return ClsBothDeleted
+	case !lExists && remote == base:
+		return ClsLocalDeleted
+	case !lExists:
+		return ClsEditDelConflict
+	case !rExists && local == base:
+		return ClsRemoteDeleted
+	}
+
+	return ClsDelEditConflict
+}
+
+func classifyBothPresentWithBase(base, local, remote string) Classification {
+	localChanged := local != base
+	remoteChanged := remote != base
+
+	switch {
+	case !localChanged && !remoteChanged:
+		return ClsUnchanged
+	case localChanged && !remoteChanged:
+		return ClsLocalModified
+	case !localChanged && remoteChanged:
+		return ClsRemoteModified
+	case local == remote:
+		return ClsConverged
+	}
+
+	return ClsConflict
+}

--- a/internal/workload/sync/classify_test.go
+++ b/internal/workload/sync/classify_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassify(t *testing.T) {
+	const (
+		x = "X"
+		y = "Y"
+		z = "Z"
+	)
+
+	cases := []struct {
+		name           string
+		base, lh, rh   string
+		want           Classification
+		expectedAction Action
+	}{
+		// BASE present (file existed at last sync)
+		{name: "Unchanged_X_X_X", base: x, lh: x, rh: x, want: ClsUnchanged, expectedAction: ActSkip},
+		{name: "LocalModified_X_Y_X", base: x, lh: y, rh: x, want: ClsLocalModified, expectedAction: ActUploadModify},
+		{name: "RemoteModified_X_X_Y", base: x, lh: x, rh: y, want: ClsRemoteModified, expectedAction: ActDownloadModify},
+		{name: "Converged_X_Y_Y", base: x, lh: y, rh: y, want: ClsConverged, expectedAction: ActSkip},
+		{name: "Conflict_X_Y_Z", base: x, lh: y, rh: z, want: ClsConflict, expectedAction: ActConflictCopy},
+		{name: "LocalDeleted_X_empty_X", base: x, lh: "", rh: x, want: ClsLocalDeleted, expectedAction: ActUploadDelete},
+		{name: "RemoteDeleted_X_X_empty", base: x, lh: x, rh: "", want: ClsRemoteDeleted, expectedAction: ActDownloadDelete},
+		{name: "BothDeleted_X_empty_empty", base: x, lh: "", rh: "", want: ClsBothDeleted, expectedAction: ActSkip},
+		{name: "DelEditConflict_X_Y_empty", base: x, lh: y, rh: "", want: ClsDelEditConflict, expectedAction: ActConflictCopy},
+		{name: "EditDelConflict_X_empty_Y", base: x, lh: "", rh: y, want: ClsEditDelConflict, expectedAction: ActDownloadOverDel},
+
+		// BASE absent (new file on at least one side)
+		{name: "LocalAdded_empty_Y_empty", base: "", lh: y, rh: "", want: ClsLocalAdded, expectedAction: ActUploadAdd},
+		{name: "RemoteAdded_empty_empty_Y", base: "", lh: "", rh: y, want: ClsRemoteAdded, expectedAction: ActDownloadAdd},
+		{name: "AddConflict_empty_Y_Z", base: "", lh: y, rh: z, want: ClsAddConflict, expectedAction: ActConflictCopy},
+		{name: "BothAddedSame_empty_Y_Y", base: "", lh: y, rh: y, want: ClsBothAddedSame, expectedAction: ActSkip},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Classify(tc.base, tc.lh, tc.rh)
+			assert.Equal(t, tc.want, got, "classification: %s", got)
+			assert.Equal(t, tc.expectedAction, ActionFor(got))
+		})
+	}
+}
+
+func TestIsConflict(t *testing.T) {
+	conflicts := []Classification{ClsConflict, ClsAddConflict, ClsDelEditConflict, ClsEditDelConflict}
+	for _, c := range conflicts {
+		assert.True(t, c.IsConflict(), "%s should be a conflict", c)
+	}
+
+	nonConflicts := []Classification{
+		ClsUnchanged, ClsLocalModified, ClsRemoteModified, ClsConverged,
+		ClsLocalAdded, ClsRemoteAdded, ClsLocalDeleted, ClsRemoteDeleted,
+		ClsBothDeleted, ClsBothAddedSame,
+	}
+
+	for _, c := range nonConflicts {
+		assert.False(t, c.IsConflict(), "%s should NOT be a conflict", c)
+	}
+}
+
+func TestClassificationStringIsExhaustive(t *testing.T) {
+	all := []Classification{
+		ClsUnchanged, ClsLocalModified, ClsRemoteModified, ClsConverged, ClsConflict,
+		ClsLocalAdded, ClsRemoteAdded, ClsAddConflict, ClsLocalDeleted, ClsRemoteDeleted,
+		ClsBothDeleted, ClsDelEditConflict, ClsEditDelConflict, ClsBothAddedSame,
+	}
+
+	for _, c := range all {
+		assert.NotEqual(t, "UNKNOWN", c.String(), "classification %d has no name", c)
+	}
+}

--- a/internal/workload/sync/diff.go
+++ b/internal/workload/sync/diff.go
@@ -1,0 +1,82 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import "github.com/datarobot/cli/internal/drapi/filesapi"
+
+// FileEntry is the minimal per-file shape needed by Diff.
+type FileEntry struct {
+	Hash string
+	Size int64
+}
+
+type (
+	LocalManifest  = map[string]FileEntry
+	RemoteManifest = map[string]FileEntry
+	BaseManifest   = map[string]FileEntry
+)
+
+// Diff produces a SyncPlan from the three input manifests. The result is
+// returned unsorted; callers must call Sort before display or execution.
+func Diff(base, local, remote BaseManifest) *SyncPlan {
+	plan := &SyncPlan{}
+
+	for path := range pathUnion(base, local, remote) {
+		b := base[path]
+		l := local[path]
+		r := remote[path]
+
+		cls := Classify(b.Hash, l.Hash, r.Hash)
+		act := ActionFor(cls)
+
+		if act == ActSkip {
+			continue
+		}
+
+		plan.Append(FileAction{
+			Path:           path,
+			Classification: cls,
+			Action:         act,
+			LocalSize:      l.Size,
+			RemoteSize:     r.Size,
+			LocalHash:      l.Hash,
+			RemoteHash:     r.Hash,
+		})
+	}
+
+	return plan
+}
+
+func pathUnion(maps ...BaseManifest) map[string]struct{} {
+	out := make(map[string]struct{})
+
+	for _, m := range maps {
+		for k := range m {
+			out[k] = struct{}{}
+		}
+	}
+
+	return out
+}
+
+// FromFilesAPI converts a filesapi-shaped manifest into the diff shape.
+func FromFilesAPI(remote map[string]filesapi.FileMeta) RemoteManifest {
+	out := make(RemoteManifest, len(remote))
+	for k, v := range remote {
+		out[k] = FileEntry{Hash: v.Hash, Size: v.Size}
+	}
+
+	return out
+}

--- a/internal/workload/sync/diff_test.go
+++ b/internal/workload/sync/diff_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func entry(hash string, size int64) FileEntry { return FileEntry{Hash: hash, Size: size} }
+
+func TestDiff_FastPathUnchanged(t *testing.T) {
+	base := BaseManifest{
+		"a.py": entry("aaa", 1),
+		"b.py": entry("bbb", 2),
+	}
+	plan := Diff(base, base, base)
+
+	assert.True(t, plan.IsEmpty())
+	assert.False(t, plan.HasConflicts())
+}
+
+func TestDiff_PushOnly(t *testing.T) {
+	base := BaseManifest{"a.py": entry("aaa", 10)}
+	local := BaseManifest{"a.py": entry("aaa-local", 11), "new.py": entry("new", 5)}
+	remote := base // remote unchanged
+
+	plan := Diff(base, local, remote)
+	plan.Sort()
+
+	assert.Len(t, plan.Uploads, 2)
+	assert.Empty(t, plan.Downloads)
+	assert.Empty(t, plan.Deletes)
+	assert.Empty(t, plan.Conflicts)
+	assert.Equal(t, "a.py", plan.Uploads[0].Path)
+	assert.Equal(t, ClsLocalModified, plan.Uploads[0].Classification)
+	assert.Equal(t, "new.py", plan.Uploads[1].Path)
+	assert.Equal(t, ClsLocalAdded, plan.Uploads[1].Classification)
+}
+
+func TestDiff_PullOnly(t *testing.T) {
+	base := BaseManifest{"a.py": entry("aaa", 10)}
+	local := base // local unchanged
+	remote := BaseManifest{"a.py": entry("aaa-remote", 12), "new.py": entry("rem", 7)}
+
+	plan := Diff(base, local, remote)
+	plan.Sort()
+
+	assert.Empty(t, plan.Uploads)
+	assert.Len(t, plan.Downloads, 2)
+	assert.Empty(t, plan.Deletes)
+	assert.Empty(t, plan.Conflicts)
+}
+
+func TestDiff_Conflict(t *testing.T) {
+	base := BaseManifest{"shared.py": entry("X", 10)}
+	local := BaseManifest{"shared.py": entry("Y", 11)}
+	remote := BaseManifest{"shared.py": entry("Z", 12)}
+
+	plan := Diff(base, local, remote)
+
+	assert.Empty(t, plan.Uploads)
+	assert.Empty(t, plan.Downloads)
+	assert.Len(t, plan.Conflicts, 1)
+	assert.True(t, plan.HasConflicts())
+	assert.Equal(t, ClsConflict, plan.Conflicts[0].Classification)
+}
+
+func TestDiff_Deletes(t *testing.T) {
+	base := BaseManifest{
+		"a.py": entry("aaa", 10),
+		"b.py": entry("bbb", 20),
+	}
+	local := BaseManifest{"a.py": entry("aaa", 10)}  // user deleted b.py
+	remote := BaseManifest{"b.py": entry("bbb", 20)} // teammate deleted a.py
+
+	plan := Diff(base, local, remote)
+	plan.Sort()
+
+	assert.Empty(t, plan.Uploads)
+	assert.Empty(t, plan.Downloads)
+	assert.Len(t, plan.Deletes, 2)
+
+	gotPaths := []string{plan.Deletes[0].Path, plan.Deletes[1].Path}
+	assert.Contains(t, gotPaths, "a.py")
+	assert.Contains(t, gotPaths, "b.py")
+}
+
+func TestDiff_BytesAccounting(t *testing.T) {
+	base := BaseManifest{}
+	local := BaseManifest{"big.bin": entry("L", 1024)}
+	remote := BaseManifest{"other.bin": entry("R", 2048)}
+
+	plan := Diff(base, local, remote)
+
+	assert.Equal(t, int64(1024), plan.TotalUploadBytes())
+	assert.Equal(t, int64(2048), plan.TotalDownloadBytes())
+}
+
+func TestFromFilesAPI_RoundTrip(t *testing.T) {
+	in := map[string]filesapi.FileMeta{
+		"a.py": {Hash: "aaa", Size: 10},
+		"b.py": {Hash: "bbb", Size: 20},
+	}
+
+	got := FromFilesAPI(in)
+
+	assert.Len(t, got, 2)
+	assert.Equal(t, FileEntry{Hash: "aaa", Size: 10}, got["a.py"])
+	assert.Equal(t, FileEntry{Hash: "bbb", Size: 20}, got["b.py"])
+}

--- a/internal/workload/sync/diskspace.go
+++ b/internal/workload/sync/diskspace.go
@@ -1,0 +1,59 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import "fmt"
+
+// availableBytesFn is a test seam swapped by the disk-space tests to
+// simulate "disk almost full" without writing GiB to a real fs.
+var availableBytesFn = realAvailableBytes
+
+func availableBytes(path string) (int64, error) {
+	return availableBytesFn(path)
+}
+
+// EnsureSpaceFor checks that path's filesystem has at least
+// neededBytes + DiskSpaceMarginMB free.
+func EnsureSpaceFor(path string, neededBytes int64) error {
+	free, err := availableBytes(path)
+	if err != nil {
+		return err
+	}
+
+	const mib = 1024 * 1024
+
+	required := neededBytes + DiskSpaceMarginMB*mib
+	if free >= required {
+		return nil
+	}
+
+	return &InsufficientSpaceError{
+		NeededBytes: required,
+		FreeBytes:   free,
+		Path:        path,
+	}
+}
+
+// InsufficientSpaceError is returned when EnsureSpaceFor's check fails.
+type InsufficientSpaceError struct {
+	NeededBytes int64
+	FreeBytes   int64
+	Path        string
+}
+
+func (e *InsufficientSpaceError) Error() string {
+	const mib = 1024 * 1024
+	return fmt.Sprintf("not enough disk space at %s: need %d MiB, %d MiB free", e.Path, e.NeededBytes/mib, e.FreeBytes/mib)
+}

--- a/internal/workload/sync/diskspace_test.go
+++ b/internal/workload/sync/diskspace_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureSpaceFor_Sufficient(t *testing.T) {
+	t.Cleanup(restoreAvailableBytesFn(availableBytesFn))
+
+	availableBytesFn = func(string) (int64, error) {
+		return 10 * 1024 * 1024 * 1024, nil // 10 GiB free
+	}
+
+	require.NoError(t, EnsureSpaceFor("/anywhere", 1024*1024)) // 1 MiB needed
+}
+
+func TestEnsureSpaceFor_Insufficient(t *testing.T) {
+	t.Cleanup(restoreAvailableBytesFn(availableBytesFn))
+
+	availableBytesFn = func(string) (int64, error) {
+		return 50 * 1024 * 1024, nil // 50 MiB free
+	}
+
+	const mib = 1024 * 1024
+
+	err := EnsureSpaceFor("/anywhere", 100*mib) // need 100 + margin(100) = 200 MiB
+
+	var ise *InsufficientSpaceError
+
+	require.ErrorAs(t, err, &ise)
+	assert.Equal(t, int64(50*mib), ise.FreeBytes)
+}
+
+func TestEnsureSpaceFor_StatfsError(t *testing.T) {
+	t.Cleanup(restoreAvailableBytesFn(availableBytesFn))
+
+	bad := errors.New("simulated statfs failure")
+	availableBytesFn = func(string) (int64, error) { return 0, bad }
+
+	err := EnsureSpaceFor("/anywhere", 1)
+	require.ErrorIs(t, err, bad)
+}
+
+func restoreAvailableBytesFn(prev func(string) (int64, error)) func() {
+	return func() { availableBytesFn = prev }
+}

--- a/internal/workload/sync/diskspace_unix.go
+++ b/internal/workload/sync/diskspace_unix.go
@@ -31,5 +31,5 @@ func realAvailableBytes(path string) (int64, error) {
 	}
 
 	//nolint:gosec // Bavail * Bsize fits in int64 on every supported FS.
-	return int64(st.Bavail) * int64(st.Bsize), nil
+	return int64(st.Bavail * uint64(st.Bsize)), nil
 }

--- a/internal/workload/sync/diskspace_unix.go
+++ b/internal/workload/sync/diskspace_unix.go
@@ -1,0 +1,35 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package sync
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// realAvailableBytes uses Bavail (not Bfree) because Bavail excludes
+// blocks reserved for the superuser.
+func realAvailableBytes(path string) (int64, error) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return 0, fmt.Errorf("statfs %s: %w", path, err)
+	}
+
+	//nolint:gosec // Bavail * Bsize fits in int64 on every supported FS.
+	return int64(st.Bavail) * int64(st.Bsize), nil
+}

--- a/internal/workload/sync/diskspace_windows.go
+++ b/internal/workload/sync/diskspace_windows.go
@@ -1,0 +1,26 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package sync
+
+import "math"
+
+// realAvailableBytes on Windows returns effectively unlimited space so
+// EnsureSpaceFor never blocks. A proper GetDiskFreeSpaceEx-backed
+// implementation is tracked in RAPTOR-16928.
+func realAvailableBytes(_ string) (int64, error) {
+	return math.MaxInt64, nil
+}

--- a/internal/workload/sync/display/diff.go
+++ b/internal/workload/sync/display/diff.go
@@ -1,0 +1,204 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/sergi/go-diff/diffmatchpatch"
+)
+
+// ContentFetcher returns the local and remote bytes for a path.
+type ContentFetcher interface {
+	LocalContent(path string) ([]byte, error)
+	RemoteContent(path string) ([]byte, error)
+}
+
+const devNull = "/dev/null"
+
+// PrintDiffs writes a per-file unified-style diff for every plan entry
+// that has bytes worth showing. Fetcher errors are rendered inline so a
+// single missing object does not suppress the rest of the report.
+func PrintDiffs(w io.Writer, plan *sync.SyncPlan, fetcher ContentFetcher) error {
+	if plan == nil || fetcher == nil {
+		return nil
+	}
+
+	dmp := diffmatchpatch.New()
+
+	rows := make([]sync.FileAction, 0, len(plan.Uploads)+len(plan.Downloads)+len(plan.Deletes)+len(plan.Conflicts))
+	rows = append(rows, plan.Uploads...)
+	rows = append(rows, plan.Downloads...)
+	rows = append(rows, plan.Deletes...)
+	rows = append(rows, plan.Conflicts...)
+
+	for _, fa := range rows {
+		if !shouldDiff(fa) {
+			continue
+		}
+
+		if err := printOneDiff(w, fa, fetcher, dmp); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func shouldDiff(fa sync.FileAction) bool {
+	switch fa.Classification {
+	case sync.ClsLocalAdded, sync.ClsLocalModified, sync.ClsLocalDeleted,
+		sync.ClsRemoteAdded, sync.ClsRemoteModified, sync.ClsRemoteDeleted,
+		sync.ClsConflict, sync.ClsAddConflict,
+		sync.ClsDelEditConflict, sync.ClsEditDelConflict:
+		return true
+	case sync.ClsUnchanged, sync.ClsConverged, sync.ClsBothDeleted, sync.ClsBothAddedSame:
+		return false
+	}
+
+	return false
+}
+
+func printOneDiff(w io.Writer, fa sync.FileAction, fetcher ContentFetcher, dmp *diffmatchpatch.DiffMatchPatch) error {
+	aHeader, bHeader := headerFor(fa)
+
+	a, b, err := loadDiffPair(fa, fetcher)
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "--- %s\n*** %s ***\n", fa.Path, err.Error())
+		return nil
+	}
+
+	if _, err := fmt.Fprintf(w, "--- %s\n+++ %s\n", aHeader, bHeader); err != nil {
+		return err
+	}
+
+	diffs := dmp.DiffMain(string(a), string(b), false)
+	pretty := dmp.DiffPrettyText(diffs)
+
+	if _, err := fmt.Fprint(w, pretty); err != nil {
+		return err
+	}
+
+	if len(pretty) > 0 && pretty[len(pretty)-1] != '\n' {
+		_, _ = fmt.Fprintln(w)
+	}
+
+	return nil
+}
+
+type headerLabels struct {
+	left, right func(path string) string
+}
+
+var headerTable = map[sync.Classification]headerLabels{
+	sync.ClsLocalAdded:      {staticLabel(devNull), suffixLabel(" (local; new file)")},
+	sync.ClsLocalModified:   {suffixLabel(" (remote)"), suffixLabel(" (local)")},
+	sync.ClsLocalDeleted:    {suffixLabel(" (remote)"), staticLabel(devNull)},
+	sync.ClsRemoteAdded:     {staticLabel(devNull), suffixLabel(" (remote; new file)")},
+	sync.ClsRemoteModified:  {suffixLabel(" (local)"), suffixLabel(" (remote)")},
+	sync.ClsRemoteDeleted:   {suffixLabel(" (local)"), staticLabel(devNull)},
+	sync.ClsConflict:        {suffixLabel(" (local)"), suffixLabel(" (remote, wins)")},
+	sync.ClsAddConflict:     {suffixLabel(" (local)"), suffixLabel(" (remote, wins)")},
+	sync.ClsDelEditConflict: {suffixLabel(" (local edit)"), staticLabel(devNull + " (remote deleted)")},
+	sync.ClsEditDelConflict: {staticLabel(devNull + " (local deleted)"), suffixLabel(" (remote)")},
+}
+
+func headerFor(fa sync.FileAction) (string, string) {
+	h, ok := headerTable[fa.Classification]
+	if !ok {
+		return fa.Path, fa.Path
+	}
+
+	return h.left(fa.Path), h.right(fa.Path)
+}
+
+func staticLabel(s string) func(string) string { return func(string) string { return s } }
+func suffixLabel(suffix string) func(string) string {
+	return func(path string) string { return path + suffix }
+}
+
+// loadDiffPair returns the (before, after) byte pair for a classification.
+// A nil slice on either side means that side has no content; DiffMain
+// treats it as empty and produces all-add or all-delete output.
+func loadDiffPair(fa sync.FileAction, fetcher ContentFetcher) ([]byte, []byte, error) {
+	switch fa.Classification {
+	case sync.ClsLocalAdded:
+		return localOnly(fa, fetcher, false)
+	case sync.ClsLocalModified, sync.ClsConflict, sync.ClsAddConflict:
+		return localAndRemote(fa, fetcher, false)
+	case sync.ClsLocalDeleted:
+		return remoteOnly(fa, fetcher, true)
+	case sync.ClsRemoteAdded:
+		return remoteOnly(fa, fetcher, false)
+	case sync.ClsRemoteModified:
+		return localAndRemote(fa, fetcher, true)
+	case sync.ClsRemoteDeleted:
+		return localOnly(fa, fetcher, true)
+	case sync.ClsDelEditConflict:
+		return localOnly(fa, fetcher, true)
+	case sync.ClsEditDelConflict:
+		return remoteOnly(fa, fetcher, false)
+	case sync.ClsUnchanged, sync.ClsConverged, sync.ClsBothDeleted, sync.ClsBothAddedSame:
+		return nil, nil, nil
+	}
+
+	return nil, nil, fmt.Errorf("unsupported classification for diff: %s", fa.Classification)
+}
+
+func localOnly(fa sync.FileAction, fetcher ContentFetcher, asBefore bool) ([]byte, []byte, error) {
+	local, err := fetcher.LocalContent(fa.Path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if asBefore {
+		return local, nil, nil
+	}
+
+	return nil, local, nil
+}
+
+func remoteOnly(fa sync.FileAction, fetcher ContentFetcher, asBefore bool) ([]byte, []byte, error) {
+	remote, err := fetcher.RemoteContent(fa.Path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if asBefore {
+		return remote, nil, nil
+	}
+
+	return nil, remote, nil
+}
+
+func localAndRemote(fa sync.FileAction, fetcher ContentFetcher, localFirst bool) ([]byte, []byte, error) {
+	local, err := fetcher.LocalContent(fa.Path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	remote, err := fetcher.RemoteContent(fa.Path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if localFirst {
+		return local, remote, nil
+	}
+
+	return remote, local, nil
+}

--- a/internal/workload/sync/display/diff_test.go
+++ b/internal/workload/sync/display/diff_test.go
@@ -1,0 +1,273 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeFetcher struct {
+	local     map[string]string
+	remote    map[string]string
+	localErr  error
+	remoteErr error
+}
+
+func (f *fakeFetcher) LocalContent(path string) ([]byte, error) {
+	if f.localErr != nil {
+		return nil, f.localErr
+	}
+
+	v, ok := f.local[path]
+	if !ok {
+		return nil, errors.New("local not found: " + path)
+	}
+
+	return []byte(v), nil
+}
+
+func (f *fakeFetcher) RemoteContent(path string) ([]byte, error) {
+	if f.remoteErr != nil {
+		return nil, f.remoteErr
+	}
+
+	v, ok := f.remote[path]
+	if !ok {
+		return nil, errors.New("remote not found: " + path)
+	}
+
+	return []byte(v), nil
+}
+
+func TestPrintDiffs(t *testing.T) {
+	cases := []struct {
+		name     string
+		plan     *sync.SyncPlan
+		local    map[string]string
+		remote   map[string]string
+		want     []string
+		notWant  []string
+		assertEq func(t *testing.T, out string)
+	}{
+		{
+			name: "LOCAL_ADDED renders new file content",
+			plan: &sync.SyncPlan{Uploads: []sync.FileAction{
+				{Path: "test.py", Classification: sync.ClsLocalAdded, Action: sync.ActUploadAdd},
+			}},
+			local: map[string]string{"test.py": "print('hi')\n"},
+			want:  []string{"+++ test.py (local; new file)", "--- /dev/null", "print('hi')"},
+		},
+		{
+			name: "LOCAL_MODIFIED renders both versions",
+			plan: &sync.SyncPlan{Uploads: []sync.FileAction{
+				{Path: "agent.py", Classification: sync.ClsLocalModified, Action: sync.ActUploadModify},
+			}},
+			// Disjoint character sets so per-side runs stay contiguous
+			// in dmp.DiffPrettyText output.
+			local:  map[string]string{"agent.py": "AAAA\n"},
+			remote: map[string]string{"agent.py": "ZZZZ\n"},
+			want:   []string{"--- agent.py (remote)", "+++ agent.py (local)", "AAAA", "ZZZZ"},
+		},
+		{
+			name: "LOCAL_DELETED renders deleted content",
+			plan: &sync.SyncPlan{Deletes: []sync.FileAction{
+				{Path: "old.py", Classification: sync.ClsLocalDeleted, Action: sync.ActUploadDelete},
+			}},
+			remote: map[string]string{"old.py": "going away\n"},
+			want:   []string{"--- old.py (remote)", "+++ /dev/null", "going away"},
+		},
+		{
+			name: "REMOTE_ADDED renders pulled content",
+			plan: &sync.SyncPlan{Downloads: []sync.FileAction{
+				{Path: "pulled.py", Classification: sync.ClsRemoteAdded, Action: sync.ActDownloadAdd},
+			}},
+			remote: map[string]string{"pulled.py": "from remote\n"},
+			want:   []string{"--- /dev/null", "+++ pulled.py (remote; new file)", "from remote"},
+		},
+		{
+			name: "REMOTE_MODIFIED renders both versions",
+			plan: &sync.SyncPlan{Downloads: []sync.FileAction{
+				{Path: "config.py", Classification: sync.ClsRemoteModified, Action: sync.ActDownloadModify},
+			}},
+			local:  map[string]string{"config.py": "AAAA\n"},
+			remote: map[string]string{"config.py": "ZZZZ\n"},
+			want:   []string{"--- config.py (local)", "+++ config.py (remote)", "AAAA", "ZZZZ"},
+		},
+		{
+			name: "REMOTE_DELETED renders local content as deletion",
+			plan: &sync.SyncPlan{Deletes: []sync.FileAction{
+				{Path: "removed.py", Classification: sync.ClsRemoteDeleted, Action: sync.ActDownloadDelete},
+			}},
+			local: map[string]string{"removed.py": "still here\n"},
+			want:  []string{"--- removed.py (local)", "+++ /dev/null", "still here"},
+		},
+		{
+			name: "CONFLICT renders local vs remote",
+			plan: &sync.SyncPlan{Conflicts: []sync.FileAction{
+				{Path: "shared.py", Classification: sync.ClsConflict, Action: sync.ActConflictCopy},
+			}},
+			local:  map[string]string{"shared.py": "AAAA\n"},
+			remote: map[string]string{"shared.py": "ZZZZ\n"},
+			want:   []string{"--- shared.py (local)", "+++ shared.py (remote, wins)", "AAAA", "ZZZZ"},
+		},
+		{
+			name: "ADD_CONFLICT renders local vs remote",
+			plan: &sync.SyncPlan{Conflicts: []sync.FileAction{
+				{Path: "race.py", Classification: sync.ClsAddConflict, Action: sync.ActConflictCopy},
+			}},
+			local:  map[string]string{"race.py": "11111\n"},
+			remote: map[string]string{"race.py": "99999\n"},
+			want:   []string{"--- race.py (local)", "+++ race.py (remote, wins)", "11111", "99999"},
+		},
+		{
+			name: "DEL_EDIT_CONFLICT renders the local edit as a deletion",
+			plan: &sync.SyncPlan{Conflicts: []sync.FileAction{
+				{Path: "doomed.py", Classification: sync.ClsDelEditConflict, Action: sync.ActConflictCopy},
+			}},
+			local: map[string]string{"doomed.py": "local edit text\n"},
+			want:  []string{"--- doomed.py (local edit)", "+++ /dev/null (remote deleted)", "local edit text"},
+		},
+		{
+			name: "EDIT_DEL_CONFLICT renders remote as restoration",
+			plan: &sync.SyncPlan{Downloads: []sync.FileAction{
+				{Path: "restored.py", Classification: sync.ClsEditDelConflict, Action: sync.ActDownloadOverDel},
+			}},
+			remote: map[string]string{"restored.py": "remote restored\n"},
+			want:   []string{"--- /dev/null (local deleted)", "+++ restored.py (remote)", "remote restored"},
+		},
+		{
+			name: "UNCHANGED is skipped",
+			plan: &sync.SyncPlan{Uploads: []sync.FileAction{
+				{Path: "same.py", Classification: sync.ClsUnchanged, Action: sync.ActSkip},
+			}},
+			notWant: []string{"same.py"},
+			assertEq: func(t *testing.T, out string) {
+				assert.Empty(t, out, "UNCHANGED row must produce no output")
+			},
+		},
+		{
+			name: "fetcher error is reported inline, not fatal",
+			plan: &sync.SyncPlan{Uploads: []sync.FileAction{
+				{Path: "broken.py", Classification: sync.ClsLocalModified, Action: sync.ActUploadModify},
+			}},
+			local: map[string]string{"broken.py": "ok\n"},
+			want:  []string{"--- broken.py", "*** ", "remote not found: broken.py", " ***"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fetcher := &fakeFetcher{local: tc.local, remote: tc.remote}
+
+			var buf bytes.Buffer
+
+			err := PrintDiffs(&buf, tc.plan, fetcher)
+			require.NoError(t, err)
+
+			out := buf.String()
+
+			for _, frag := range tc.want {
+				assert.Contains(t, out, frag, "expected output to contain %q\n--- output ---\n%s", frag, out)
+			}
+
+			for _, frag := range tc.notWant {
+				assert.NotContains(t, out, frag)
+			}
+
+			if tc.assertEq != nil {
+				tc.assertEq(t, out)
+			}
+		})
+	}
+}
+
+func TestPrintDiffs_NilPlan_NoOp(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := PrintDiffs(&buf, nil, &fakeFetcher{})
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+func TestPrintDiffs_NilFetcher_NoOp(t *testing.T) {
+	plan := &sync.SyncPlan{Uploads: []sync.FileAction{
+		{Path: "x.py", Classification: sync.ClsLocalAdded, Action: sync.ActUploadAdd},
+	}}
+
+	var buf bytes.Buffer
+
+	err := PrintDiffs(&buf, plan, nil)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+func TestPrintDiffs_EmptyPlan(t *testing.T) {
+	var buf bytes.Buffer
+
+	err := PrintDiffs(&buf, &sync.SyncPlan{}, &fakeFetcher{})
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+}
+
+func TestShouldDiff_AllClassifications(t *testing.T) {
+	cases := map[sync.Classification]bool{
+		sync.ClsLocalAdded:      true,
+		sync.ClsLocalModified:   true,
+		sync.ClsLocalDeleted:    true,
+		sync.ClsRemoteAdded:     true,
+		sync.ClsRemoteModified:  true,
+		sync.ClsRemoteDeleted:   true,
+		sync.ClsConflict:        true,
+		sync.ClsAddConflict:     true,
+		sync.ClsDelEditConflict: true,
+		sync.ClsEditDelConflict: true,
+		sync.ClsUnchanged:       false,
+		sync.ClsConverged:       false,
+		sync.ClsBothDeleted:     false,
+		sync.ClsBothAddedSame:   false,
+	}
+
+	for cls, want := range cases {
+		got := shouldDiff(sync.FileAction{Classification: cls})
+		assert.Equal(t, want, got, "shouldDiff(%s)", cls)
+	}
+}
+
+func TestHeaderFor_HasDevNullForAddDelete(t *testing.T) {
+	cases := []struct {
+		cls       sync.Classification
+		left, rt  string
+		bothSides bool
+	}{
+		{sync.ClsLocalAdded, devNull, "(local; new file)", false},
+		{sync.ClsLocalDeleted, "(remote)", devNull, false},
+		{sync.ClsRemoteAdded, devNull, "(remote; new file)", false},
+		{sync.ClsRemoteDeleted, "(local)", devNull, false},
+		{sync.ClsDelEditConflict, "(local edit)", devNull, false},
+		{sync.ClsEditDelConflict, devNull, "(remote)", false},
+	}
+
+	for _, tc := range cases {
+		l, r := headerFor(sync.FileAction{Path: "x.py", Classification: tc.cls})
+		assert.Contains(t, l, tc.left, "%s left header", tc.cls)
+		assert.Contains(t, r, tc.rt, "%s right header", tc.cls)
+	}
+}

--- a/internal/workload/sync/display/doc.go
+++ b/internal/workload/sync/display/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package display renders sync.SyncPlan and sync.Result into the human
+// and JSON shapes the CLI command emits.
+package display

--- a/internal/workload/sync/display/json.go
+++ b/internal/workload/sync/display/json.go
@@ -1,0 +1,139 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/datarobot/cli/internal/workload/sync"
+)
+
+// PlanJSON is the JSON shape emitted for --output-format=json with
+// --dry-run or --diff.
+type PlanJSON struct {
+	Uploads   []FileActionJSON `json:"uploads"`
+	Downloads []FileActionJSON `json:"downloads"`
+	Deletes   []FileActionJSON `json:"deletes"`
+	Conflicts []FileActionJSON `json:"conflicts"`
+	Stats     PlanStatsJSON    `json:"stats"`
+}
+
+type FileActionJSON struct {
+	Path           string `json:"path"`
+	Classification string `json:"classification"`
+	LocalSize      int64  `json:"localSize,omitempty"`
+	RemoteSize     int64  `json:"remoteSize,omitempty"`
+	LocalHash      string `json:"localHash,omitempty"`
+	RemoteHash     string `json:"remoteHash,omitempty"`
+}
+
+type PlanStatsJSON struct {
+	UploadCount     int    `json:"uploadCount"`
+	DownloadCount   int    `json:"downloadCount"`
+	DeleteCount     int    `json:"deleteCount"`
+	ConflictCount   int    `json:"conflictCount"`
+	UploadBytes     int64  `json:"uploadBytes"`
+	DownloadBytes   int64  `json:"downloadBytes"`
+	OldVersionShort string `json:"oldVersionShort,omitempty"`
+}
+
+// RenderPlanJSON writes plan as pretty-printed JSON to w.
+func RenderPlanJSON(w io.Writer, plan *sync.SyncPlan) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	if plan == nil {
+		return enc.Encode(PlanJSON{})
+	}
+
+	out := PlanJSON{
+		Uploads:   actionsJSON(plan.Uploads),
+		Downloads: actionsJSON(plan.Downloads),
+		Deletes:   actionsJSON(plan.Deletes),
+		Conflicts: actionsJSON(plan.Conflicts),
+		Stats: PlanStatsJSON{
+			UploadCount:     len(plan.Uploads),
+			DownloadCount:   len(plan.Downloads),
+			DeleteCount:     len(plan.Deletes),
+			ConflictCount:   len(plan.Conflicts),
+			UploadBytes:     plan.TotalUploadBytes(),
+			DownloadBytes:   plan.TotalDownloadBytes(),
+			OldVersionShort: plan.OldVersionShort,
+		},
+	}
+
+	if err := enc.Encode(out); err != nil {
+		return fmt.Errorf("encode plan json: %w", err)
+	}
+
+	return nil
+}
+
+type ResultJSON struct {
+	OldVersion      string   `json:"oldVersion,omitempty"`
+	NewVersion      string   `json:"newVersion,omitempty"`
+	UploadedCount   int      `json:"uploadedCount"`
+	DownloadedCount int      `json:"downloadedCount"`
+	DeletedCount    int      `json:"deletedCount"`
+	ConflictCount   int      `json:"conflictCount"`
+	ConflictCopies  []string `json:"conflictCopies,omitempty"`
+	DurationMS      int64    `json:"durationMs"`
+}
+
+// RenderResultJSON writes result as pretty-printed JSON to w.
+func RenderResultJSON(w io.Writer, r *sync.Result) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	if r == nil {
+		return enc.Encode(ResultJSON{})
+	}
+
+	out := ResultJSON{
+		OldVersion:      r.OldVersion,
+		NewVersion:      r.NewVersion,
+		UploadedCount:   r.UploadedCount,
+		DownloadedCount: r.DownloadedCount,
+		DeletedCount:    r.DeletedCount,
+		ConflictCount:   r.ConflictCount,
+		ConflictCopies:  r.ConflictCopies,
+		DurationMS:      r.Duration.Milliseconds(),
+	}
+
+	if err := enc.Encode(out); err != nil {
+		return fmt.Errorf("encode result json: %w", err)
+	}
+
+	return nil
+}
+
+func actionsJSON(in []sync.FileAction) []FileActionJSON {
+	out := make([]FileActionJSON, len(in))
+
+	for i, fa := range in {
+		out[i] = FileActionJSON{
+			Path:           fa.Path,
+			Classification: fa.Classification.String(),
+			LocalSize:      fa.LocalSize,
+			RemoteSize:     fa.RemoteSize,
+			LocalHash:      fa.LocalHash,
+			RemoteHash:     fa.RemoteHash,
+		}
+	}
+
+	return out
+}

--- a/internal/workload/sync/display/plan.go
+++ b/internal/workload/sync/display/plan.go
@@ -1,0 +1,131 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/datarobot/cli/internal/workload/sync"
+)
+
+// PrintPlan writes the human-readable sync plan to w. Empty plans print
+// "Up to date." and return.
+func PrintPlan(w io.Writer, plan *sync.SyncPlan) error {
+	if plan == nil || plan.IsEmpty() {
+		_, err := fmt.Fprintln(w, "Up to date.")
+		return err
+	}
+
+	_, _ = fmt.Fprintln(w, "Sync plan:")
+
+	if err := printGroup(w, "↑ UPLOAD", plan.Uploads, markerForUpload); err != nil {
+		return err
+	}
+
+	if err := printGroup(w, "↓ DOWNLOAD", plan.Downloads, markerForDownload); err != nil {
+		return err
+	}
+
+	if err := printGroup(w, "✕ DELETE", plan.Deletes, markerForDelete); err != nil {
+		return err
+	}
+
+	if err := printGroup(w, "⚠ CONFLICT (remote wins)", plan.Conflicts, markerForConflict); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func printGroup(w io.Writer, header string, files []sync.FileAction, marker func(sync.FileAction) string) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	if _, err := fmt.Fprintf(w, "  %s (%d):\n", header, len(files)); err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	for _, fa := range files {
+		size := formatSize(displaySize(fa))
+
+		if _, err := fmt.Fprintf(tw, "    %s\t%s\t%s\n", marker(fa), fa.Path, size); err != nil {
+			return err
+		}
+	}
+
+	return tw.Flush()
+}
+
+func displaySize(fa sync.FileAction) int64 {
+	switch fa.Action {
+	case sync.ActUploadModify, sync.ActUploadAdd, sync.ActUploadDelete:
+		return fa.LocalSize
+	case sync.ActDownloadModify, sync.ActDownloadAdd, sync.ActDownloadDelete, sync.ActDownloadOverDel, sync.ActConflictCopy:
+		return fa.RemoteSize
+	case sync.ActSkip:
+		return 0
+	}
+
+	return 0
+}
+
+func markerForUpload(fa sync.FileAction) string {
+	if fa.Classification == sync.ClsLocalAdded {
+		return "A"
+	}
+
+	return "M"
+}
+
+func markerForDownload(fa sync.FileAction) string {
+	switch fa.Classification {
+	case sync.ClsRemoteAdded:
+		return "A"
+	case sync.ClsRemoteDeleted:
+		return "D"
+	case sync.ClsUnchanged, sync.ClsLocalModified, sync.ClsRemoteModified, sync.ClsConverged,
+		sync.ClsConflict, sync.ClsLocalAdded, sync.ClsAddConflict, sync.ClsLocalDeleted,
+		sync.ClsBothDeleted, sync.ClsDelEditConflict, sync.ClsEditDelConflict, sync.ClsBothAddedSame:
+		return "M"
+	}
+
+	return "M"
+}
+
+func markerForDelete(_ sync.FileAction) string {
+	return "D"
+}
+
+func markerForConflict(_ sync.FileAction) string {
+	return "⚠"
+}
+
+func formatSize(n int64) string {
+	switch {
+	case n < 1024:
+		return fmt.Sprintf("%d B", n)
+	case n < 1024*1024:
+		return fmt.Sprintf("%.1f KiB", float64(n)/1024.0)
+	case n < 1024*1024*1024:
+		return fmt.Sprintf("%.1f MiB", float64(n)/1024.0/1024.0)
+	}
+
+	return fmt.Sprintf("%.1f GiB", float64(n)/1024.0/1024.0/1024.0)
+}

--- a/internal/workload/sync/display/plan_test.go
+++ b/internal/workload/sync/display/plan_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintPlan_Empty(t *testing.T) {
+	var buf bytes.Buffer
+
+	require.NoError(t, PrintPlan(&buf, &sync.SyncPlan{}))
+	assert.Equal(t, "Up to date.\n", buf.String())
+}
+
+func TestPrintPlan_Full(t *testing.T) {
+	plan := &sync.SyncPlan{
+		Uploads: []sync.FileAction{
+			{Path: "agent.py", Classification: sync.ClsLocalModified, Action: sync.ActUploadModify, LocalSize: 1234},
+			{Path: "new.py", Classification: sync.ClsLocalAdded, Action: sync.ActUploadAdd, LocalSize: 256},
+		},
+		Downloads: []sync.FileAction{
+			{Path: "config.yaml", Classification: sync.ClsRemoteModified, Action: sync.ActDownloadModify, RemoteSize: 890},
+		},
+		Deletes: []sync.FileAction{
+			{Path: "old.py", Classification: sync.ClsLocalDeleted, Action: sync.ActUploadDelete, LocalSize: 0},
+		},
+		Conflicts: []sync.FileAction{
+			{Path: "shared.py", Classification: sync.ClsConflict, Action: sync.ActConflictCopy, RemoteSize: 100},
+		},
+	}
+
+	var buf bytes.Buffer
+
+	require.NoError(t, PrintPlan(&buf, plan))
+
+	out := buf.String()
+	assert.Contains(t, out, "Sync plan:")
+	assert.Contains(t, out, "↑ UPLOAD (2):")
+	assert.Contains(t, out, "M  agent.py")
+	assert.Contains(t, out, "A  new.py")
+	assert.Contains(t, out, "↓ DOWNLOAD (1):")
+	assert.Contains(t, out, "✕ DELETE (1):")
+	assert.Contains(t, out, "⚠ CONFLICT (remote wins) (1):")
+	assert.Contains(t, out, "shared.py")
+}
+
+func TestPrintResult_FullCounts(t *testing.T) {
+	r := &sync.Result{
+		OldVersion:      "abcdefgh12345",
+		NewVersion:      "12345678abcde",
+		UploadedCount:   3,
+		DownloadedCount: 2,
+		DeletedCount:    1,
+		ConflictCount:   1,
+		ConflictCopies:  []string{"shared.py.LOCAL.20260410T143052Z"},
+		Duration:        500 * time.Millisecond,
+	}
+
+	var buf bytes.Buffer
+
+	require.NoError(t, PrintResult(&buf, r))
+
+	out := stripANSI(buf.String())
+	assert.Contains(t, out, "Sync complete: abcdefgh → 12345678  (↑3 ↓2 ✕1 ⚠1)")
+	assert.Contains(t, out, "Conflict copies saved:")
+	assert.Contains(t, out, "shared.py.LOCAL.20260410T143052Z")
+}
+
+func TestPrintResult_FirstSyncEmptyOld(t *testing.T) {
+	r := &sync.Result{NewVersion: "ee0011ff", UploadedCount: 5}
+
+	var buf bytes.Buffer
+
+	require.NoError(t, PrintResult(&buf, r))
+	assert.Contains(t, stripANSI(buf.String()), "∅ → ee0011ff")
+}
+
+func TestPrintResult_NoChanges(t *testing.T) {
+	r := &sync.Result{OldVersion: "abcdefgh", NewVersion: "abcdefgh"}
+
+	var buf bytes.Buffer
+
+	require.NoError(t, PrintResult(&buf, r))
+	assert.Contains(t, stripANSI(buf.String()), "(no changes)")
+}
+
+func stripANSI(s string) string {
+	for {
+		i := strings.Index(s, "\x1b[")
+		if i == -1 {
+			return s
+		}
+
+		j := strings.Index(s[i:], "m")
+		if j == -1 {
+			return s
+		}
+
+		s = s[:i] + s[i+j+1:]
+	}
+}
+
+func TestFormatSize(t *testing.T) {
+	cases := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KiB"},
+		{1024 * 1024, "1.0 MiB"},
+		{1024 * 1024 * 1024, "1.0 GiB"},
+	}
+
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, formatSize(tc.n))
+	}
+}

--- a/internal/workload/sync/display/result.go
+++ b/internal/workload/sync/display/result.go
@@ -1,0 +1,83 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/datarobot/cli/tui"
+)
+
+// PrintResult emits the one-line summary for a successful sync. Zero
+// counts are omitted from the trailing parens.
+func PrintResult(w io.Writer, r *sync.Result) error {
+	if r == nil {
+		return nil
+	}
+
+	old := sync.ShortVer(r.OldVersion)
+	if old == "" {
+		old = "∅"
+	}
+
+	newVer := sync.ShortVer(r.NewVersion)
+	counts := formatCounts(r)
+
+	line := fmt.Sprintf("Sync complete: %s → %s  %s", old, newVer, counts)
+	styled := tui.SuccessStyle.Render(line)
+
+	if _, err := fmt.Fprintln(w, styled); err != nil {
+		return err
+	}
+
+	if len(r.ConflictCopies) > 0 {
+		_, _ = fmt.Fprintln(w, tui.DimStyle.Render("Conflict copies saved:"))
+
+		for _, p := range r.ConflictCopies {
+			_, _ = fmt.Fprintln(w, tui.DimStyle.Render("  "+p))
+		}
+	}
+
+	return nil
+}
+
+func formatCounts(r *sync.Result) string {
+	parts := make([]string, 0, 4)
+
+	if r.UploadedCount > 0 {
+		parts = append(parts, fmt.Sprintf("↑%d", r.UploadedCount))
+	}
+
+	if r.DownloadedCount > 0 {
+		parts = append(parts, fmt.Sprintf("↓%d", r.DownloadedCount))
+	}
+
+	if r.DeletedCount > 0 {
+		parts = append(parts, fmt.Sprintf("✕%d", r.DeletedCount))
+	}
+
+	if r.ConflictCount > 0 {
+		parts = append(parts, fmt.Sprintf("⚠%d", r.ConflictCount))
+	}
+
+	if len(parts) == 0 {
+		return "(no changes)"
+	}
+
+	return "(" + strings.Join(parts, " ") + ")"
+}

--- a/internal/workload/sync/doc.go
+++ b/internal/workload/sync/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sync is the engine behind `dr workload code sync`. It walks the
+// project, builds a three-way diff against base and remote manifests,
+// executes the plan with rollback safety, and updates .wapi/ state on
+// success. The CLI command in cmd/workload/code/sync wires it in.
+package sync

--- a/internal/workload/sync/download.go
+++ b/internal/workload/sync/download.go
@@ -15,7 +15,6 @@
 package sync
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -27,13 +26,18 @@ import (
 
 // downloadFiles pulls files in parallel up to DownloadConcurrency. Each
 // download streams to disk and computes SHA-256 in the same pass so
-// post-download verification is free.
-func downloadFiles(ctx context.Context, e *Engine, catalogID, versionID string, files []FileAction) error {
+// post-download verification is free. The first error closes done to
+// stop other workers from picking up the next file.
+func downloadFiles(e *Engine, catalogID, versionID string, files []FileAction) error {
 	if len(files) == 0 {
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+
+	var cancelOnce sync.Once
+
+	cancel := func() { cancelOnce.Do(func() { close(done) }) }
 	defer cancel()
 
 	sem := make(chan struct{}, DownloadConcurrency)
@@ -51,7 +55,7 @@ func downloadFiles(ctx context.Context, e *Engine, catalogID, versionID string, 
 
 			select {
 			case sem <- struct{}{}:
-			case <-ctx.Done():
+			case <-done:
 				return
 			}
 

--- a/internal/workload/sync/download.go
+++ b/internal/workload/sync/download.go
@@ -1,0 +1,125 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// downloadFiles pulls files in parallel up to DownloadConcurrency. Each
+// download streams to disk and computes SHA-256 in the same pass so
+// post-download verification is free.
+func downloadFiles(ctx context.Context, e *Engine, catalogID, versionID string, files []FileAction) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sem := make(chan struct{}, DownloadConcurrency)
+	errCh := make(chan error, len(files))
+
+	var wg sync.WaitGroup
+
+	for _, fa := range files {
+		fa := fa
+
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+
+			defer func() { <-sem }()
+
+			if err := downloadOne(e, catalogID, versionID, fa); err != nil {
+				select {
+				case errCh <- err:
+					cancel()
+				default:
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	if err := <-errCh; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// downloadOne streams the remote file to disk, hashing as it writes.
+// Empty RemoteHash skips verification (e.g. synthesized EDIT_DEL_CONFLICT).
+func downloadOne(e *Engine, catalogID, versionID string, fa FileAction) error {
+	dst := filepath.Join(e.projectDir, filepath.FromSlash(fa.Path))
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("mkdir parent for %s: %w", fa.Path, err)
+	}
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", fa.Path, err)
+	}
+
+	h := sha256.New()
+	mw := io.MultiWriter(out, h)
+
+	_, n, err := e.files.DownloadFile(catalogID, versionID, fa.Path, mw)
+
+	closeErr := out.Close()
+
+	if err != nil {
+		_ = os.Remove(dst)
+		return fmt.Errorf("download %s: %w", fa.Path, err)
+	}
+
+	if closeErr != nil {
+		_ = os.Remove(dst)
+		return fmt.Errorf("close %s: %w", fa.Path, closeErr)
+	}
+
+	if fa.RemoteSize > 0 && n != fa.RemoteSize {
+		_ = os.Remove(dst)
+		return fmt.Errorf("download size mismatch on %s: expected %d, got %d", fa.Path, fa.RemoteSize, n)
+	}
+
+	if fa.RemoteHash != "" {
+		got := hex.EncodeToString(h.Sum(nil))
+		if got != fa.RemoteHash {
+			_ = os.Remove(dst)
+			return fmt.Errorf("checksum mismatch on %s: expected %s, got %s", fa.Path, fa.RemoteHash, got)
+		}
+	}
+
+	return nil
+}

--- a/internal/workload/sync/download.go
+++ b/internal/workload/sync/download.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/datarobot/cli/internal/log"
 )
 
 // downloadFiles pulls files in parallel up to DownloadConcurrency. Each
@@ -52,6 +54,7 @@ func downloadFiles(e *Engine, catalogID, versionID string, files []FileAction) e
 
 		go func() {
 			defer wg.Done()
+			defer recoverWorkerPanic("downloading "+fa.Path, errCh, cancel)
 
 			select {
 			case sem <- struct{}{}:
@@ -126,4 +129,22 @@ func downloadOne(e *Engine, catalogID, versionID string, fa FileAction) error {
 	}
 
 	return nil
+}
+
+// recoverWorkerPanic is a deferred handler for parallel-worker goroutines.
+// On panic it logs the value and forwards a synthesized error to errCh so
+// the orchestrator returns a real error instead of silent success.
+func recoverWorkerPanic(label string, errCh chan<- error, cancel func()) {
+	r := recover()
+	if r == nil {
+		return
+	}
+
+	log.Errorf("panic %s: %v", label, r)
+
+	select {
+	case errCh <- fmt.Errorf("panic %s: %v", label, r):
+		cancel()
+	default:
+	}
 }

--- a/internal/workload/sync/engine.go
+++ b/internal/workload/sync/engine.go
@@ -1,0 +1,212 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/wapi"
+)
+
+// Options configures the Engine.
+type Options struct {
+	DryRun    bool
+	ShowDiffs bool
+	Yes       bool
+}
+
+// Result is the outcome of a successful sync.
+type Result struct {
+	OldVersion      string // full version ID; "" before first sync
+	NewVersion      string
+	UploadedCount   int
+	DownloadedCount int
+	DeletedCount    int
+	ConflictCount   int
+	ConflictCopies  []string // *.LOCAL.<ts> paths created during sync
+	Duration        time.Duration
+}
+
+var ErrNoPlan = errors.New("sync engine: Execute called before Plan")
+
+// Engine wires the sync pipeline. Construct with New, call Plan, Execute,
+// or Run, then Close to release the project lock.
+type Engine struct {
+	projectDir string
+	opts       Options
+
+	files           filesapi.Client
+	getArtifactFn   func(string) (*workload.Artifact, error)
+	patchArtifactFn func(artifactID, catalogID, catalogVersionID string) error
+	nowFn           func() time.Time
+
+	config         wapi.Config
+	base           BaseManifest
+	artifact       *workload.Artifact
+	remoteVer      string
+	drifted        bool
+	local          LocalManifest
+	remote         RemoteManifest
+	plan           *SyncPlan
+	lock           *SyncLock
+	rollback       *Rollback
+	newCatalogID   string
+	newVersionID   string
+	conflictCopies []string
+	result         *Result
+	startedAt      time.Time
+	staleNote      bool
+}
+
+// New constructs an Engine bound to projectDir.
+func New(projectDir string, opts Options) (*Engine, error) {
+	if projectDir == "" {
+		return nil, errors.New("sync.New: projectDir is required")
+	}
+
+	return &Engine{
+		projectDir:      projectDir,
+		opts:            opts,
+		files:           filesapi.New(),
+		getArtifactFn:   workload.GetArtifact,
+		patchArtifactFn: workload.PatchArtifactCodeRef,
+		nowFn:           time.Now,
+	}, nil
+}
+
+// SetFilesClient swaps the FilesAPI client. Test seam.
+func (e *Engine) SetFilesClient(c filesapi.Client) { e.files = c }
+
+// SetGetArtifactFn swaps the artifact-fetch function. Test seam.
+func (e *Engine) SetGetArtifactFn(fn func(string) (*workload.Artifact, error)) { e.getArtifactFn = fn }
+
+// SetPatchArtifactFn swaps the artifact codeRef patch function. Test seam.
+func (e *Engine) SetPatchArtifactFn(fn func(string, string, string) error) {
+	e.patchArtifactFn = fn
+}
+
+// SetNowFn swaps time.Now for deterministic timestamps. Test seam.
+func (e *Engine) SetNowFn(fn func() time.Time) { e.nowFn = fn }
+
+// Plan runs phases 0-4 and returns the SyncPlan. The lock acquired in
+// Phase 0 is held until Close, Execute, or Run releases it.
+func (e *Engine) Plan(ctx context.Context) (*SyncPlan, error) {
+	e.startedAt = e.nowFn()
+
+	err := runPhases(ctx, e,
+		phase{name: "preflight", run: phase0Preflight},
+		phase{name: "gather", run: phase1Gather},
+		phase{name: "manifests", run: phase2Manifests},
+		phase{name: "diff", run: phase3Diff},
+		phase{name: "preview", run: phase4Preview},
+	)
+	if err != nil {
+		_ = e.releaseLock()
+
+		return nil, err
+	}
+
+	return e.plan, nil
+}
+
+// Execute runs phases 5-6 against the plan returned by Plan. The lock
+// is released on completion (success or error).
+func (e *Engine) Execute(ctx context.Context, plan *SyncPlan) (*Result, error) {
+	if e.plan == nil || plan == nil {
+		_ = e.releaseLock()
+
+		return nil, ErrNoPlan
+	}
+
+	if plan != e.plan {
+		// Caller may have shallow-copied the plan; the engine's own
+		// plan remains the source of truth.
+		_ = plan
+	}
+
+	defer func() { _ = e.releaseLock() }()
+
+	if err := runPhases(ctx, e,
+		phase{name: "execute", run: phase5Execute},
+		phase{name: "state", run: phase6State},
+	); err != nil {
+		return nil, err
+	}
+
+	return e.result, nil
+}
+
+// Run is Plan + Execute. With DryRun or ShowDiffs it stops after Plan.
+func (e *Engine) Run(ctx context.Context) (*Result, error) {
+	plan, err := e.Plan(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if e.opts.DryRun || e.opts.ShowDiffs || plan.IsEmpty() {
+		_ = e.releaseLock()
+
+		return &Result{
+			OldVersion: ptrOrEmpty(e.config.LastSyncedVersionID),
+			Duration:   e.nowFn().Sub(e.startedAt),
+		}, nil
+	}
+
+	return e.Execute(ctx, plan)
+}
+
+// Close releases the project lock. Idempotent.
+func (e *Engine) Close() error {
+	return e.releaseLock()
+}
+
+// StaleRollbackRestored reports whether Phase 0 restored a stale rollback
+// from a previously crashed sync.
+func (e *Engine) StaleRollbackRestored() bool { return e.staleNote }
+
+func (e *Engine) releaseLock() error {
+	if e.lock == nil {
+		return nil
+	}
+
+	err := e.lock.Release()
+	e.lock = nil
+
+	return err
+}
+
+func ptrOrEmpty(s *string) string {
+	if s == nil {
+		return ""
+	}
+
+	return *s
+}
+
+// resolveExistingCatalogID returns the catalog ID to reuse for an upload.
+// Config wins because it is pinned for the artifact's DRAFT lifetime; the
+// artifact's codeRef is the fallback for first-sync against an existing
+// artifact. Returns "" when neither source has a catalog.
+func resolveExistingCatalogID(e *Engine) string {
+	if e.config.CatalogID != nil && *e.config.CatalogID != "" {
+		return *e.config.CatalogID
+	}
+
+	return refFromArtifact(e).CatalogID
+}

--- a/internal/workload/sync/engine.go
+++ b/internal/workload/sync/engine.go
@@ -15,7 +15,6 @@
 package sync
 
 import (
-	"context"
 	"errors"
 	"time"
 
@@ -106,10 +105,11 @@ func (e *Engine) SetNowFn(fn func() time.Time) { e.nowFn = fn }
 
 // Plan runs phases 0-4 and returns the SyncPlan. The lock acquired in
 // Phase 0 is held until Close, Execute, or Run releases it.
-func (e *Engine) Plan(ctx context.Context) (*SyncPlan, error) {
+func (e *Engine) Plan() (*SyncPlan, error) {
 	e.startedAt = e.nowFn()
 
-	err := runPhases(ctx, e,
+	err := runPhases(
+		e,
 		phase{name: "preflight", run: phase0Preflight},
 		phase{name: "gather", run: phase1Gather},
 		phase{name: "manifests", run: phase2Manifests},
@@ -127,7 +127,7 @@ func (e *Engine) Plan(ctx context.Context) (*SyncPlan, error) {
 
 // Execute runs phases 5-6 against the plan returned by Plan. The lock
 // is released on completion (success or error).
-func (e *Engine) Execute(ctx context.Context, plan *SyncPlan) (*Result, error) {
+func (e *Engine) Execute(plan *SyncPlan) (*Result, error) {
 	if e.plan == nil || plan == nil {
 		_ = e.releaseLock()
 
@@ -142,7 +142,8 @@ func (e *Engine) Execute(ctx context.Context, plan *SyncPlan) (*Result, error) {
 
 	defer func() { _ = e.releaseLock() }()
 
-	if err := runPhases(ctx, e,
+	if err := runPhases(
+		e,
 		phase{name: "execute", run: phase5Execute},
 		phase{name: "state", run: phase6State},
 	); err != nil {
@@ -153,8 +154,8 @@ func (e *Engine) Execute(ctx context.Context, plan *SyncPlan) (*Result, error) {
 }
 
 // Run is Plan + Execute. With DryRun or ShowDiffs it stops after Plan.
-func (e *Engine) Run(ctx context.Context) (*Result, error) {
-	plan, err := e.Plan(ctx)
+func (e *Engine) Run() (*Result, error) {
+	plan, err := e.Plan()
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +169,7 @@ func (e *Engine) Run(ctx context.Context) (*Result, error) {
 		}, nil
 	}
 
-	return e.Execute(ctx, plan)
+	return e.Execute(plan)
 }
 
 // Close releases the project lock. Idempotent.

--- a/internal/workload/sync/engine.go
+++ b/internal/workload/sync/engine.go
@@ -16,9 +16,11 @@ package sync
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/wapi"
 )
@@ -44,16 +46,49 @@ type Result struct {
 
 var ErrNoPlan = errors.New("sync engine: Execute called before Plan")
 
+// artifactStore is the small surface of the workload artifact API the
+// engine depends on. The default implementation delegates to the
+// workload package; tests inject a fake.
+type artifactStore interface {
+	Get(artifactID string) (*workload.Artifact, error)
+	PatchCodeRef(artifactID, catalogID, catalogVersionID string) error
+}
+
+type workloadArtifactStore struct{}
+
+func (workloadArtifactStore) Get(id string) (*workload.Artifact, error) {
+	return workload.GetArtifact(id)
+}
+
+func (workloadArtifactStore) PatchCodeRef(artifactID, catalogID, catalogVersionID string) error {
+	return workload.PatchArtifactCodeRef(artifactID, catalogID, catalogVersionID)
+}
+
+// Deps are the external dependencies injected into an Engine. Use
+// defaultDeps for production wiring; tests build their own.
+type Deps struct {
+	Files     filesapi.Client
+	Artifacts artifactStore
+	Now       func() time.Time
+}
+
+func defaultDeps() Deps {
+	return Deps{
+		Files:     filesapi.New(),
+		Artifacts: workloadArtifactStore{},
+		Now:       time.Now,
+	}
+}
+
 // Engine wires the sync pipeline. Construct with New, call Plan, Execute,
 // or Run, then Close to release the project lock.
 type Engine struct {
 	projectDir string
 	opts       Options
 
-	files           filesapi.Client
-	getArtifactFn   func(string) (*workload.Artifact, error)
-	patchArtifactFn func(artifactID, catalogID, catalogVersionID string) error
-	nowFn           func() time.Time
+	files     filesapi.Client
+	artifacts artifactStore
+	nowFn     func() time.Time
 
 	config         wapi.Config
 	base           BaseManifest
@@ -73,35 +108,26 @@ type Engine struct {
 	staleNote      bool
 }
 
-// New constructs an Engine bound to projectDir.
+// New constructs an Engine bound to projectDir with production deps.
 func New(projectDir string, opts Options) (*Engine, error) {
+	return newWithDeps(projectDir, opts, defaultDeps())
+}
+
+// newWithDeps is the test seam: callers in this package supply a custom
+// Deps to inject fakes for Files, Artifacts, or Now.
+func newWithDeps(projectDir string, opts Options, deps Deps) (*Engine, error) {
 	if projectDir == "" {
 		return nil, errors.New("sync.New: projectDir is required")
 	}
 
 	return &Engine{
-		projectDir:      projectDir,
-		opts:            opts,
-		files:           filesapi.New(),
-		getArtifactFn:   workload.GetArtifact,
-		patchArtifactFn: workload.PatchArtifactCodeRef,
-		nowFn:           time.Now,
+		projectDir: projectDir,
+		opts:       opts,
+		files:      deps.Files,
+		artifacts:  deps.Artifacts,
+		nowFn:      deps.Now,
 	}, nil
 }
-
-// SetFilesClient swaps the FilesAPI client. Test seam.
-func (e *Engine) SetFilesClient(c filesapi.Client) { e.files = c }
-
-// SetGetArtifactFn swaps the artifact-fetch function. Test seam.
-func (e *Engine) SetGetArtifactFn(fn func(string) (*workload.Artifact, error)) { e.getArtifactFn = fn }
-
-// SetPatchArtifactFn swaps the artifact codeRef patch function. Test seam.
-func (e *Engine) SetPatchArtifactFn(fn func(string, string, string) error) {
-	e.patchArtifactFn = fn
-}
-
-// SetNowFn swaps time.Now for deterministic timestamps. Test seam.
-func (e *Engine) SetNowFn(fn func() time.Time) { e.nowFn = fn }
 
 // Plan runs phases 0-4 and returns the SyncPlan. The lock acquired in
 // Phase 0 is held until Close, Execute, or Run releases it.
@@ -117,21 +143,18 @@ func (e *Engine) Plan() (*SyncPlan, error) {
 		phase{name: "preview", run: phase4Preview},
 	)
 	if err != nil {
-		_ = e.releaseLock()
-
-		return nil, err
+		return nil, e.joinReleaseErr(err)
 	}
 
 	return e.plan, nil
 }
 
 // Execute runs phases 5-6 against the plan returned by Plan. The lock
-// is released on completion (success or error).
-func (e *Engine) Execute(plan *SyncPlan) (*Result, error) {
+// is released on completion (success or error). A failure to release
+// the lock is joined into the returned error so callers see both.
+func (e *Engine) Execute(plan *SyncPlan) (_ *Result, retErr error) {
 	if e.plan == nil || plan == nil {
-		_ = e.releaseLock()
-
-		return nil, ErrNoPlan
+		return nil, e.joinReleaseErr(ErrNoPlan)
 	}
 
 	if plan != e.plan {
@@ -140,7 +163,9 @@ func (e *Engine) Execute(plan *SyncPlan) (*Result, error) {
 		_ = plan
 	}
 
-	defer func() { _ = e.releaseLock() }()
+	defer func() {
+		retErr = e.joinReleaseErr(retErr)
+	}()
 
 	if err := runPhases(
 		e,
@@ -161,7 +186,9 @@ func (e *Engine) Run() (*Result, error) {
 	}
 
 	if e.opts.DryRun || e.opts.ShowDiffs || plan.IsEmpty() {
-		_ = e.releaseLock()
+		if relErr := e.releaseLock(); relErr != nil {
+			return nil, fmt.Errorf("release lock: %w", relErr)
+		}
 
 		return &Result{
 			OldVersion: ptrOrEmpty(e.config.LastSyncedVersionID),
@@ -189,7 +216,23 @@ func (e *Engine) releaseLock() error {
 	err := e.lock.Release()
 	e.lock = nil
 
+	if err != nil {
+		log.Warn("failed to release sync lock", "err", err, "project", e.projectDir)
+	}
+
 	return err
+}
+
+// joinReleaseErr releases the lock and joins any release failure with
+// err. The primary err is preserved; a release failure is reported
+// alongside so callers see both. Returns nil if both are nil.
+func (e *Engine) joinReleaseErr(err error) error {
+	relErr := e.releaseLock()
+	if relErr == nil {
+		return err
+	}
+
+	return errors.Join(err, fmt.Errorf("release lock: %w", relErr))
 }
 
 func ptrOrEmpty(s *string) string {

--- a/internal/workload/sync/engine_test.go
+++ b/internal/workload/sync/engine_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	stdsync "sync"
 	"testing"
+	"time"
 
 	"github.com/datarobot/cli/internal/drapi/filesapi"
 	"github.com/datarobot/cli/internal/workload"
@@ -29,6 +30,30 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeArtifactStore is the in-memory artifactStore used by engine tests.
+// Each test sets only the function fields it needs; the rest panic to
+// surface unexpected interactions.
+type fakeArtifactStore struct {
+	GetFn   func(id string) (*workload.Artifact, error)
+	PatchFn func(artifactID, catalogID, catalogVersionID string) error
+}
+
+func (f *fakeArtifactStore) Get(id string) (*workload.Artifact, error) {
+	if f.GetFn == nil {
+		return nil, errors.New("fakeArtifactStore.Get: no GetFn configured")
+	}
+
+	return f.GetFn(id)
+}
+
+func (f *fakeArtifactStore) PatchCodeRef(artifactID, catalogID, catalogVersionID string) error {
+	if f.PatchFn == nil {
+		return nil
+	}
+
+	return f.PatchFn(artifactID, catalogID, catalogVersionID)
+}
 
 // fakeFilesClient is the in-memory FilesAPI fake used by engine tests.
 // Unexpected methods return errors so off-happy-path drift fails loudly.
@@ -113,6 +138,10 @@ func (f *fakeFilesClient) DeleteFiles(_ string, paths []string) (*filesapi.Delet
 	return &filesapi.DeleteFilesResp{}, nil
 }
 
+func (f *fakeFilesClient) ListVersions(_ string, _ int) ([]filesapi.CatalogVersion, error) {
+	return nil, errors.New("fakeFilesClient: ListVersions not expected")
+}
+
 func initProject(t *testing.T, files map[string]string) string {
 	t.Helper()
 
@@ -155,15 +184,18 @@ func TestEngine_Plan_FirstSyncEmptyArtifact(t *testing.T) {
 		"utils/helper.py": "def help(): pass\n",
 	})
 
-	e, err := New(dir, Options{})
+	e, err := newWithDeps(dir, Options{}, Deps{
+		Files: &fakeFilesClient{},
+		Artifacts: &fakeArtifactStore{
+			GetFn: func(id string) (*workload.Artifact, error) {
+				return draftArtifact(id, "", ""), nil
+			},
+		},
+		Now: time.Now,
+	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() { _ = e.Close() })
-
-	e.SetGetArtifactFn(func(id string) (*workload.Artifact, error) {
-		return draftArtifact(id, "", ""), nil
-	})
-	e.SetFilesClient(&fakeFilesClient{})
 
 	plan, err := e.Plan()
 	require.NoError(t, err)
@@ -207,18 +239,21 @@ func TestEngine_Plan_FastPathUpToDate(t *testing.T) {
 
 	calledAllFiles := false
 
-	e, err := New(dir, Options{})
+	e, err := newWithDeps(dir, Options{}, Deps{
+		Files: &trackingFilesClient{
+			fakeFilesClient: fakeFilesClient{},
+			allFilesCalled:  &calledAllFiles,
+		},
+		Artifacts: &fakeArtifactStore{
+			GetFn: func(id string) (*workload.Artifact, error) {
+				return draftArtifact(id, cid, ver), nil
+			},
+		},
+		Now: time.Now,
+	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() { _ = e.Close() })
-
-	e.SetGetArtifactFn(func(id string) (*workload.Artifact, error) {
-		return draftArtifact(id, cid, ver), nil
-	})
-	e.SetFilesClient(&trackingFilesClient{
-		fakeFilesClient: fakeFilesClient{},
-		allFilesCalled:  &calledAllFiles,
-	})
 
 	plan, err := e.Plan()
 	require.NoError(t, err)
@@ -229,15 +264,18 @@ func TestEngine_Plan_FastPathUpToDate(t *testing.T) {
 func TestEngine_Plan_LockedArtifactRejected(t *testing.T) {
 	dir := initProject(t, nil)
 
-	e, err := New(dir, Options{})
+	e, err := newWithDeps(dir, Options{}, Deps{
+		Files: &fakeFilesClient{},
+		Artifacts: &fakeArtifactStore{
+			GetFn: func(id string) (*workload.Artifact, error) {
+				return &workload.Artifact{ID: id, Status: "LOCKED"}, nil
+			},
+		},
+		Now: time.Now,
+	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() { _ = e.Close() })
-
-	e.SetGetArtifactFn(func(id string) (*workload.Artifact, error) {
-		return &workload.Artifact{ID: id, Status: "LOCKED"}, nil
-	})
-	e.SetFilesClient(&fakeFilesClient{})
 
 	_, err = e.Plan()
 	require.Error(t, err)
@@ -263,25 +301,27 @@ func TestEngine_Run_FirstSyncStagePath(t *testing.T) {
 
 	fake := &fakeFilesClient{catalogID: "cid-new", stageID: "stage-1", versionID: "ver-1"}
 
-	e, err := New(dir, Options{Yes: true})
+	var patchedArtifactID, patchedCatalogID, patchedVersionID string
+
+	e, err := newWithDeps(dir, Options{Yes: true}, Deps{
+		Files: fake,
+		Artifacts: &fakeArtifactStore{
+			GetFn: func(id string) (*workload.Artifact, error) {
+				return draftArtifact(id, "", ""), nil
+			},
+			PatchFn: func(artifactID, catalogID, catalogVersionID string) error {
+				patchedArtifactID = artifactID
+				patchedCatalogID = catalogID
+				patchedVersionID = catalogVersionID
+
+				return nil
+			},
+		},
+		Now: time.Now,
+	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() { _ = e.Close() })
-
-	e.SetGetArtifactFn(func(id string) (*workload.Artifact, error) {
-		return draftArtifact(id, "", ""), nil
-	})
-	e.SetFilesClient(fake)
-
-	var patchedArtifactID, patchedCatalogID, patchedVersionID string
-
-	e.SetPatchArtifactFn(func(artifactID, catalogID, catalogVersionID string) error {
-		patchedArtifactID = artifactID
-		patchedCatalogID = catalogID
-		patchedVersionID = catalogVersionID
-
-		return nil
-	})
 
 	result, err := e.Run()
 	require.NoError(t, err)

--- a/internal/workload/sync/engine_test.go
+++ b/internal/workload/sync/engine_test.go
@@ -1,0 +1,332 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	stdsync "sync"
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/fileops"
+	"github.com/datarobot/cli/internal/workload/wapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFilesClient is the in-memory FilesAPI fake used by engine tests.
+// Unexpected methods return errors so off-happy-path drift fails loudly.
+type fakeFilesClient struct {
+	allFiles      map[string]filesapi.FileMeta
+	catalogID     string
+	versionID     string
+	stageID       string
+	uploadedFiles map[string][]byte
+	deletedPaths  []string
+	mu            stdsync.Mutex
+}
+
+func (f *fakeFilesClient) CreateCatalog() (*filesapi.CatalogResp, error) {
+	if f.catalogID == "" {
+		return nil, errors.New("fakeFilesClient.CreateCatalog: no catalogID configured")
+	}
+
+	return &filesapi.CatalogResp{CatalogID: f.catalogID, CatalogVersionID: ""}, nil
+}
+
+func (f *fakeFilesClient) CreateStage(_ string) (*filesapi.StageResp, error) {
+	if f.stageID == "" {
+		return nil, errors.New("fakeFilesClient.CreateStage: no stageID configured")
+	}
+
+	return &filesapi.StageResp{CatalogID: f.catalogID, StageID: f.stageID}, nil
+}
+
+func (f *fakeFilesClient) UploadToStage(_, _, name string, _ int64, body io.Reader) error {
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.uploadedFiles == nil {
+		f.uploadedFiles = map[string][]byte{}
+	}
+
+	f.uploadedFiles[name] = data
+
+	return nil
+}
+
+func (f *fakeFilesClient) ApplyStage(_, _, _ string) (*filesapi.ApplyStageResp, error) {
+	if f.versionID == "" {
+		return nil, errors.New("fakeFilesClient.ApplyStage: no versionID configured")
+	}
+
+	return &filesapi.ApplyStageResp{
+		CatalogID:        f.catalogID,
+		CatalogVersionID: f.versionID,
+		NumFiles:         len(f.uploadedFiles),
+	}, nil
+}
+
+func (f *fakeFilesClient) UploadFromZipNew(_ string, _ int64, _ io.Reader) (*filesapi.FromFileResp, error) {
+	return nil, errors.New("fakeFilesClient: UploadFromZipNew not expected")
+}
+
+func (f *fakeFilesClient) UploadFromZipExisting(_, _, _ string, _ int64, _ io.Reader) (*filesapi.FromFileResp, error) {
+	return nil, errors.New("fakeFilesClient: UploadFromZipExisting not expected")
+}
+
+func (f *fakeFilesClient) PollStatus(_ string) (*filesapi.StatusResp, error) {
+	return nil, errors.New("fakeFilesClient: PollStatus not expected")
+}
+
+func (f *fakeFilesClient) AllFiles(_, _ string) (map[string]filesapi.FileMeta, error) {
+	return f.allFiles, nil
+}
+
+func (f *fakeFilesClient) DownloadFile(_, _, _ string, _ io.Writer) (string, int64, error) {
+	return "", 0, errors.New("fakeFilesClient: DownloadFile not expected")
+}
+
+func (f *fakeFilesClient) DeleteFiles(_ string, paths []string) (*filesapi.DeleteFilesResp, error) {
+	f.deletedPaths = append(f.deletedPaths, paths...)
+	return &filesapi.DeleteFilesResp{}, nil
+}
+
+func initProject(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{ArtifactID: "art-abc-123"}))
+
+	for rel, body := range files {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
+	}
+
+	return dir
+}
+
+func draftArtifact(id, catalogID, versionID string) *workload.Artifact {
+	a := &workload.Artifact{ID: id, Name: id, Status: "DRAFT"}
+
+	if catalogID == "" {
+		return a
+	}
+
+	a.Spec = workload.Spec{
+		ContainerGroups: []workload.ContainerGroup{
+			{Containers: []workload.Container{
+				{CodeRef: &workload.CodeRef{Datarobot: &workload.DatarobotCodeRef{
+					CatalogID:        catalogID,
+					CatalogVersionID: versionID,
+				}}},
+			}},
+		},
+	}
+
+	return a
+}
+
+func TestEngine_Plan_FirstSyncEmptyArtifact(t *testing.T) {
+	dir := initProject(t, map[string]string{
+		"agent.py":        "print('hi')\n",
+		"utils/helper.py": "def help(): pass\n",
+	})
+
+	e, err := New(dir, Options{})
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = e.Close() })
+
+	e.SetGetArtifactFn(func(id string) (*workload.Artifact, error) {
+		return draftArtifact(id, "", ""), nil
+	})
+	e.SetFilesClient(&fakeFilesClient{})
+
+	plan, err := e.Plan(context.Background())
+	require.NoError(t, err)
+
+	uploadPaths := make([]string, 0, len(plan.Uploads))
+	for _, fa := range plan.Uploads {
+		uploadPaths = append(uploadPaths, fa.Path)
+	}
+
+	assert.ElementsMatch(t, []string{".wapiignore", "agent.py", "utils/helper.py"}, uploadPaths)
+	assert.Empty(t, plan.Downloads)
+	assert.Empty(t, plan.Deletes)
+	assert.Empty(t, plan.Conflicts)
+}
+
+func TestEngine_Plan_FastPathUpToDate(t *testing.T) {
+	// Fast path must skip AllFiles when artifact codeRef matches
+	// lastSyncedVersionId (no drift).
+	dir := initProject(t, map[string]string{"agent.py": "x"})
+
+	cfg, err := wapi.LoadConfig(dir)
+	require.NoError(t, err)
+
+	cid := "cid-1"
+	ver := "ver-1"
+	cfg.CatalogID = &cid
+	cfg.LastSyncedVersionID = &ver
+
+	require.NoError(t, wapi.SaveConfig(dir, cfg))
+
+	manifest := wapi.Manifest{Version: wapi.ManifestVersion, Files: map[string]wapi.FileMeta{}}
+
+	for _, rel := range []string{"agent.py", ".wapiignore"} {
+		hash, size, err := hashLocal(t, dir, rel)
+		require.NoError(t, err)
+
+		manifest.Files[rel] = wapi.FileMeta{Hash: hash, Size: size}
+	}
+
+	require.NoError(t, wapi.SaveManifest(dir, manifest))
+
+	calledAllFiles := false
+
+	e, err := New(dir, Options{})
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = e.Close() })
+
+	e.SetGetArtifactFn(func(id string) (*workload.Artifact, error) {
+		return draftArtifact(id, cid, ver), nil
+	})
+	e.SetFilesClient(&trackingFilesClient{
+		fakeFilesClient: fakeFilesClient{},
+		allFilesCalled:  &calledAllFiles,
+	})
+
+	plan, err := e.Plan(context.Background())
+	require.NoError(t, err)
+	assert.True(t, plan.IsEmpty(), "plan should be empty when local == base == remote: %+v", plan)
+	assert.False(t, calledAllFiles, "AllFiles must not be called when not drifted")
+}
+
+func TestEngine_Plan_LockedArtifactRejected(t *testing.T) {
+	dir := initProject(t, nil)
+
+	e, err := New(dir, Options{})
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = e.Close() })
+
+	e.SetGetArtifactFn(func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: id, Status: "LOCKED"}, nil
+	})
+	e.SetFilesClient(&fakeFilesClient{})
+
+	_, err = e.Plan(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "locked")
+}
+
+func TestEngine_Plan_NotLinked(t *testing.T) {
+	dir := t.TempDir()
+
+	e, err := New(dir, Options{})
+	require.NoError(t, err)
+
+	_, err = e.Plan(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not linked")
+}
+
+func TestEngine_Run_FirstSyncStagePath(t *testing.T) {
+	dir := initProject(t, map[string]string{
+		"agent.py":        "print('hi')\n",
+		"utils/helper.py": "def help(): pass\n",
+	})
+
+	fake := &fakeFilesClient{catalogID: "cid-new", stageID: "stage-1", versionID: "ver-1"}
+
+	e, err := New(dir, Options{Yes: true})
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = e.Close() })
+
+	e.SetGetArtifactFn(func(id string) (*workload.Artifact, error) {
+		return draftArtifact(id, "", ""), nil
+	})
+	e.SetFilesClient(fake)
+
+	var patchedArtifactID, patchedCatalogID, patchedVersionID string
+
+	e.SetPatchArtifactFn(func(artifactID, catalogID, catalogVersionID string) error {
+		patchedArtifactID = artifactID
+		patchedCatalogID = catalogID
+		patchedVersionID = catalogVersionID
+
+		return nil
+	})
+
+	result, err := e.Run(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "ver-1", result.NewVersion)
+	assert.Equal(t, 3, result.UploadedCount, "expect agent.py + utils/helper.py + .wapiignore")
+
+	assert.Len(t, fake.uploadedFiles, 3)
+	assert.Equal(t, []byte("print('hi')\n"), fake.uploadedFiles["agent.py"])
+
+	cfg, err := wapi.LoadConfig(dir)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.CatalogID)
+	assert.Equal(t, "cid-new", *cfg.CatalogID)
+	require.NotNil(t, cfg.LastSyncedVersionID)
+	assert.Equal(t, "ver-1", *cfg.LastSyncedVersionID)
+
+	manifest, err := wapi.LoadManifest(dir)
+	require.NoError(t, err)
+	assert.Len(t, manifest.Files, 3)
+
+	// First-sync stage path must PATCH the artifact's codeRef so the
+	// workload picks up the new catalog version. Without it, every
+	// successive sync would re-detect drift.
+	assert.NotEmpty(t, patchedArtifactID, "PatchArtifactCodeRef must be called after upload")
+	assert.Equal(t, "cid-new", patchedCatalogID)
+	assert.Equal(t, "ver-1", patchedVersionID)
+}
+
+type trackingFilesClient struct {
+	fakeFilesClient
+	allFilesCalled *bool
+}
+
+func (t *trackingFilesClient) AllFiles(cid, vid string) (map[string]filesapi.FileMeta, error) {
+	*t.allFilesCalled = true
+	return t.fakeFilesClient.AllFiles(cid, vid)
+}
+
+func hashLocal(t *testing.T, dir, rel string) (string, int64, error) {
+	t.Helper()
+
+	abs := filepath.Join(dir, filepath.FromSlash(rel))
+
+	return fileops.HashFile(abs)
+}

--- a/internal/workload/sync/engine_test.go
+++ b/internal/workload/sync/engine_test.go
@@ -15,7 +15,6 @@
 package sync
 
 import (
-	"context"
 	"errors"
 	"io"
 	"os"
@@ -166,7 +165,7 @@ func TestEngine_Plan_FirstSyncEmptyArtifact(t *testing.T) {
 	})
 	e.SetFilesClient(&fakeFilesClient{})
 
-	plan, err := e.Plan(context.Background())
+	plan, err := e.Plan()
 	require.NoError(t, err)
 
 	uploadPaths := make([]string, 0, len(plan.Uploads))
@@ -221,7 +220,7 @@ func TestEngine_Plan_FastPathUpToDate(t *testing.T) {
 		allFilesCalled:  &calledAllFiles,
 	})
 
-	plan, err := e.Plan(context.Background())
+	plan, err := e.Plan()
 	require.NoError(t, err)
 	assert.True(t, plan.IsEmpty(), "plan should be empty when local == base == remote: %+v", plan)
 	assert.False(t, calledAllFiles, "AllFiles must not be called when not drifted")
@@ -240,7 +239,7 @@ func TestEngine_Plan_LockedArtifactRejected(t *testing.T) {
 	})
 	e.SetFilesClient(&fakeFilesClient{})
 
-	_, err = e.Plan(context.Background())
+	_, err = e.Plan()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "locked")
 }
@@ -251,7 +250,7 @@ func TestEngine_Plan_NotLinked(t *testing.T) {
 	e, err := New(dir, Options{})
 	require.NoError(t, err)
 
-	_, err = e.Plan(context.Background())
+	_, err = e.Plan()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not linked")
 }
@@ -284,7 +283,7 @@ func TestEngine_Run_FirstSyncStagePath(t *testing.T) {
 		return nil
 	})
 
-	result, err := e.Run(context.Background())
+	result, err := e.Run()
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/internal/workload/sync/fetcher.go
+++ b/internal/workload/sync/fetcher.go
@@ -1,0 +1,60 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Fetcher returns a content fetcher backed by the engine's project
+// directory and FilesAPI client. Only valid while the engine is alive.
+func (e *Engine) Fetcher() *engineFetcher {
+	return &engineFetcher{e: e}
+}
+
+type engineFetcher struct {
+	e *Engine
+}
+
+func (f *engineFetcher) LocalContent(path string) ([]byte, error) {
+	abs := filepath.Join(f.e.projectDir, filepath.FromSlash(path))
+
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return nil, fmt.Errorf("read local %s: %w", path, err)
+	}
+
+	return data, nil
+}
+
+func (f *engineFetcher) RemoteContent(path string) ([]byte, error) {
+	codeRef := codeRefOrEmpty(f.e)
+	if codeRef.CatalogID == "" || codeRef.CatalogVersionID == "" {
+		return nil, errors.New("no remote version available (first sync)")
+	}
+
+	var buf bytes.Buffer
+
+	_, _, err := f.e.files.DownloadFile(codeRef.CatalogID, codeRef.CatalogVersionID, path, &buf)
+	if err != nil {
+		return nil, fmt.Errorf("download remote %s: %w", path, err)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/internal/workload/sync/limits.go
+++ b/internal/workload/sync/limits.go
@@ -1,0 +1,45 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+// Sync-engine orchestration tunables. File-level limits live in
+// internal/workload/fileops.
+const (
+	UploadConcurrency   = 4
+	DownloadConcurrency = 6
+
+	// UploadRetries is the per-file retry budget for transport failures
+	// (network reset, 5xx). Permanent 4xx errors are not retried.
+	UploadRetries = 3
+
+	UploadTimeoutSecs   = 300
+	DownloadTimeoutSecs = 300
+
+	// DiskSpaceMarginMB is the headroom required on top of the download
+	// size before Phase 5 begins, to prevent disk-full mid-sync.
+	DiskSpaceMarginMB = 100
+
+	// RollbackMaxFiles caps the rollback set so a single sync cannot
+	// produce a multi-gigabyte .wapi/.rollback/ tree.
+	RollbackMaxFiles = 1000
+
+	// Stage path is used when files <= threshold AND bytes <= threshold;
+	// zip path otherwise.
+	StageVsZipFileThreshold  = 20
+	StageVsZipBytesThreshold = 50 * 1024 * 1024
+
+	ZipPollIntervalMS  = 500
+	ZipPollTimeoutSecs = 600
+)

--- a/internal/workload/sync/phase0_preflight.go
+++ b/internal/workload/sync/phase0_preflight.go
@@ -15,7 +15,6 @@
 package sync
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -25,7 +24,7 @@ import (
 // phase0Preflight does stale-rollback recovery, .wapi/ presence check,
 // and acquires the project lock. Recovery runs before the lock so a
 // crashed-mid-sync process gets cleaned up by whoever runs next.
-func phase0Preflight(_ context.Context, e *Engine) error {
+func phase0Preflight(e *Engine) error {
 	restored, err := RestoreStaleIfPresent(e.projectDir)
 	if err != nil {
 		return fmt.Errorf("recover stale rollback: %w", err)

--- a/internal/workload/sync/phase0_preflight.go
+++ b/internal/workload/sync/phase0_preflight.go
@@ -1,0 +1,48 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/datarobot/cli/internal/workload/wapi"
+)
+
+// phase0Preflight does stale-rollback recovery, .wapi/ presence check,
+// and acquires the project lock. Recovery runs before the lock so a
+// crashed-mid-sync process gets cleaned up by whoever runs next.
+func phase0Preflight(_ context.Context, e *Engine) error {
+	restored, err := RestoreStaleIfPresent(e.projectDir)
+	if err != nil {
+		return fmt.Errorf("recover stale rollback: %w", err)
+	}
+
+	e.staleNote = restored
+
+	if !wapi.Exists(e.projectDir) {
+		return errors.New("not linked: run 'dr workload code init <artifact-id>' first")
+	}
+
+	lock, err := AcquireSyncLock(e.projectDir)
+	if err != nil {
+		return err
+	}
+
+	e.lock = lock
+
+	return nil
+}

--- a/internal/workload/sync/phase1_gather.go
+++ b/internal/workload/sync/phase1_gather.go
@@ -15,7 +15,6 @@
 package sync
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -25,7 +24,7 @@ import (
 
 // phase1Gather loads on-disk state, fetches the artifact, and computes
 // the drift flag that decides whether Phase 2 calls allFiles or fast-paths.
-func phase1Gather(_ context.Context, e *Engine) error {
+func phase1Gather(e *Engine) error {
 	cfg, err := wapi.LoadConfig(e.projectDir)
 	if err != nil {
 		return fmt.Errorf("read .wapi/config.json: %w", err)

--- a/internal/workload/sync/phase1_gather.go
+++ b/internal/workload/sync/phase1_gather.go
@@ -43,7 +43,7 @@ func phase1Gather(e *Engine) error {
 
 	e.base = baseFromManifest(manifest)
 
-	art, err := e.getArtifactFn(cfg.ArtifactID)
+	art, err := e.artifacts.Get(cfg.ArtifactID)
 	if err != nil {
 		return fmt.Errorf("fetch artifact %s: %w", cfg.ArtifactID, err)
 	}

--- a/internal/workload/sync/phase1_gather.go
+++ b/internal/workload/sync/phase1_gather.go
@@ -1,0 +1,74 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/wapi"
+)
+
+// phase1Gather loads on-disk state, fetches the artifact, and computes
+// the drift flag that decides whether Phase 2 calls allFiles or fast-paths.
+func phase1Gather(_ context.Context, e *Engine) error {
+	cfg, err := wapi.LoadConfig(e.projectDir)
+	if err != nil {
+		return fmt.Errorf("read .wapi/config.json: %w", err)
+	}
+
+	e.config = cfg
+
+	manifest, err := wapi.LoadManifest(e.projectDir)
+	if err != nil {
+		if errors.Is(err, wapi.ErrNotInitialized) {
+			return fmt.Errorf("manifest missing: %w", err)
+		}
+
+		return fmt.Errorf("read .wapi/manifest.json: %w", err)
+	}
+
+	e.base = baseFromManifest(manifest)
+
+	art, err := e.getArtifactFn(cfg.ArtifactID)
+	if err != nil {
+		return fmt.Errorf("fetch artifact %s: %w", cfg.ArtifactID, err)
+	}
+
+	if art.IsLocked() {
+		return errors.New("artifact is locked (immutable); cannot sync. Create a new draft artifact in the UI to continue")
+	}
+
+	e.artifact = art
+
+	if codeRef := workload.ExtractCodeRef(*art); codeRef != nil {
+		e.remoteVer = codeRef.CatalogVersionID
+	}
+
+	e.drifted = e.remoteVer != "" && e.remoteVer != ptrOrEmpty(cfg.LastSyncedVersionID)
+
+	return nil
+}
+
+func baseFromManifest(m wapi.Manifest) BaseManifest {
+	out := make(BaseManifest, len(m.Files))
+	for k, v := range m.Files {
+		out[k] = FileEntry{Hash: v.Hash, Size: v.Size}
+	}
+
+	return out
+}

--- a/internal/workload/sync/phase2_manifests.go
+++ b/internal/workload/sync/phase2_manifests.go
@@ -15,7 +15,6 @@
 package sync
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/datarobot/cli/internal/workload/fileops"
@@ -25,7 +24,7 @@ import (
 // phase2Manifests builds the LOCAL manifest by walking + hashing the
 // project, and either fetches REMOTE from FilesAPI (when drifted) or
 // copies it from BASE (the solo-developer fast path).
-func phase2Manifests(_ context.Context, e *Engine) error {
+func phase2Manifests(e *Engine) error {
 	matcher, err := ignore.New(e.projectDir)
 	if err != nil {
 		return fmt.Errorf("load .wapiignore: %w", err)

--- a/internal/workload/sync/phase2_manifests.go
+++ b/internal/workload/sync/phase2_manifests.go
@@ -1,0 +1,159 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/datarobot/cli/internal/workload/fileops"
+	"github.com/datarobot/cli/internal/workload/ignore"
+)
+
+// phase2Manifests builds the LOCAL manifest by walking + hashing the
+// project, and either fetches REMOTE from FilesAPI (when drifted) or
+// copies it from BASE (the solo-developer fast path).
+func phase2Manifests(_ context.Context, e *Engine) error {
+	matcher, err := ignore.New(e.projectDir)
+	if err != nil {
+		return fmt.Errorf("load .wapiignore: %w", err)
+	}
+
+	var skippedSymlinks []string
+
+	walkOnSymlink := func(rel, _ string) {
+		skippedSymlinks = append(skippedSymlinks, rel)
+	}
+
+	entries, err := fileops.Walk(e.projectDir, matcher.Match, walkOnSymlink)
+	if err != nil {
+		return fmt.Errorf("walk project directory: %w", err)
+	}
+
+	local, err := hashEntries(entries)
+	if err != nil {
+		return err
+	}
+
+	e.local = local
+
+	if cs := caseCollisionsFromManifest(local); len(cs) > 0 {
+		return fmt.Errorf("%s", fileops.FormatCaseCollisions(cs))
+	}
+
+	if !e.drifted {
+		// Nobody else changed the remote since our last sync; skip the
+		// allFiles round-trip and reuse BASE.
+		e.remote = copyManifest(e.base)
+
+		return nil
+	}
+
+	codeRef := codeRefOrEmpty(e)
+	if codeRef.CatalogID == "" || e.remoteVer == "" {
+		// First sync against an empty artifact: remote manifest is empty.
+		e.remote = RemoteManifest{}
+
+		return nil
+	}
+
+	remote, err := e.files.AllFiles(codeRef.CatalogID, e.remoteVer)
+	if err != nil {
+		return fmt.Errorf("fetch remote manifest: %w", err)
+	}
+
+	e.remote = FromFilesAPI(remote)
+
+	return nil
+}
+
+// hashEntries hashes each entry sequentially. Concurrency would help
+// only marginally for typical projects since Phase 5 network is the
+// real bottleneck.
+func hashEntries(entries []fileops.Entry) (LocalManifest, error) {
+	out := make(LocalManifest, len(entries))
+
+	for _, ent := range entries {
+		hash, size, err := fileops.HashFile(ent.AbsPath)
+		if err != nil {
+			return nil, fmt.Errorf("hash %s: %w", ent.RelPath, err)
+		}
+
+		out[ent.RelPath] = FileEntry{Hash: hash, Size: size}
+	}
+
+	return out, nil
+}
+
+func caseCollisionsFromManifest(m LocalManifest) []fileops.CaseCollision {
+	set := make(map[string]struct{}, len(m))
+	for k := range m {
+		set[k] = struct{}{}
+	}
+
+	return fileops.DetectCaseCollisions(set)
+}
+
+func copyManifest(in BaseManifest) BaseManifest {
+	out := make(BaseManifest, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
+}
+
+type codeRefRef struct {
+	CatalogID        string
+	CatalogVersionID string
+}
+
+func codeRefOrEmpty(e *Engine) codeRefRef {
+	if e.artifact == nil {
+		return codeRefRef{}
+	}
+
+	if e.config.CatalogID != nil && *e.config.CatalogID != "" {
+		// Local config's catalog ID is pinned for the DRAFT lifetime;
+		// the artifact's codeRef may have been bumped by another writer.
+		return codeRefRef{CatalogID: *e.config.CatalogID, CatalogVersionID: e.remoteVer}
+	}
+
+	if cr := refFromArtifact(e); cr.CatalogID != "" {
+		return cr
+	}
+
+	return codeRefRef{}
+}
+
+func refFromArtifact(e *Engine) codeRefRef {
+	if e.artifact == nil {
+		return codeRefRef{}
+	}
+
+	for _, group := range e.artifact.Spec.ContainerGroups {
+		for _, container := range group.Containers {
+			if container.CodeRef == nil || container.CodeRef.Datarobot == nil {
+				continue
+			}
+
+			dr := container.CodeRef.Datarobot
+
+			return codeRefRef{CatalogID: dr.CatalogID, CatalogVersionID: dr.CatalogVersionID}
+		}
+	}
+
+	return codeRefRef{}
+}

--- a/internal/workload/sync/phase3_diff.go
+++ b/internal/workload/sync/phase3_diff.go
@@ -1,0 +1,38 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import "context"
+
+// phase3Diff turns the three manifests into a SyncPlan.
+func phase3Diff(_ context.Context, e *Engine) error {
+	plan := Diff(e.base, e.local, e.remote)
+	plan.OldVersionShort = ShortVer(ptrOrEmpty(e.config.LastSyncedVersionID))
+	e.plan = plan
+
+	return nil
+}
+
+// ShortVer truncates a hex version ID to 8 chars for display. Inputs
+// shorter than 8 chars are returned unchanged.
+func ShortVer(s string) string {
+	const shortLen = 8
+
+	if len(s) > shortLen {
+		return s[:shortLen]
+	}
+
+	return s
+}

--- a/internal/workload/sync/phase3_diff.go
+++ b/internal/workload/sync/phase3_diff.go
@@ -14,10 +14,8 @@
 
 package sync
 
-import "context"
-
 // phase3Diff turns the three manifests into a SyncPlan.
-func phase3Diff(_ context.Context, e *Engine) error {
+func phase3Diff(e *Engine) error {
 	plan := Diff(e.base, e.local, e.remote)
 	plan.OldVersionShort = ShortVer(ptrOrEmpty(e.config.LastSyncedVersionID))
 	e.plan = plan

--- a/internal/workload/sync/phase4_preview.go
+++ b/internal/workload/sync/phase4_preview.go
@@ -14,11 +14,9 @@
 
 package sync
 
-import "context"
-
 // phase4Preview sorts the plan so display and Phase 5 see the same
 // deterministic ordering.
-func phase4Preview(_ context.Context, e *Engine) error {
+func phase4Preview(e *Engine) error {
 	if e.plan == nil {
 		return nil
 	}

--- a/internal/workload/sync/phase4_preview.go
+++ b/internal/workload/sync/phase4_preview.go
@@ -1,0 +1,29 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import "context"
+
+// phase4Preview sorts the plan so display and Phase 5 see the same
+// deterministic ordering.
+func phase4Preview(_ context.Context, e *Engine) error {
+	if e.plan == nil {
+		return nil
+	}
+
+	e.plan.Sort()
+
+	return nil
+}

--- a/internal/workload/sync/phase5_execute.go
+++ b/internal/workload/sync/phase5_execute.go
@@ -228,7 +228,7 @@ func applyRemoteDeletesAndUploads(e *Engine, codeRef codeRefRef) (string, string
 	}
 
 	if newVersionID != "" && newVersionID != codeRef.CatalogVersionID {
-		if err := e.patchArtifactFn(e.config.ArtifactID, newCatalogID, newVersionID); err != nil {
+		if err := e.artifacts.PatchCodeRef(e.config.ArtifactID, newCatalogID, newVersionID); err != nil {
 			return "", "", fmt.Errorf("update artifact codeRef: %w", err)
 		}
 	}

--- a/internal/workload/sync/phase5_execute.go
+++ b/internal/workload/sync/phase5_execute.go
@@ -1,0 +1,265 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// phase5Execute applies the SyncPlan in the order: disk-space check +
+// rollback dir, conflict copies, downloads + local-side deletes, remote
+// deletes, uploads. Any error after the rollback dir is created triggers
+// a Restore to pre-sync state.
+func phase5Execute(ctx context.Context, e *Engine) error {
+	if e.plan == nil || e.plan.IsEmpty() {
+		return nil
+	}
+
+	if len(e.plan.Uploads)+len(e.plan.Downloads)+len(e.plan.Deletes)+len(e.plan.Conflicts) > RollbackMaxFiles {
+		return fmt.Errorf("plan exceeds RollbackMaxFiles=%d; refusing to run", RollbackMaxFiles)
+	}
+
+	if err := EnsureSpaceFor(e.projectDir, e.plan.TotalDownloadBytes()); err != nil {
+		return err
+	}
+
+	rb, err := NewRollback(e.projectDir)
+	if err != nil {
+		return err
+	}
+
+	if err := executePlan(ctx, e, rb); err != nil {
+		_ = rb.Restore()
+		return err
+	}
+
+	// Phase 6 discards the rollback only after SaveConfig + SaveManifest
+	// succeed.
+	e.rollback = rb
+
+	return nil
+}
+
+func executePlan(ctx context.Context, e *Engine, rb *Rollback) error {
+	if err := applyConflictCopies(e, rb); err != nil {
+		return fmt.Errorf("conflict copies: %w", err)
+	}
+
+	codeRef := codeRefOrEmpty(e)
+
+	if err := applyDownloads(ctx, e, rb, codeRef); err != nil {
+		return fmt.Errorf("downloads: %w", err)
+	}
+
+	if err := applyLocalDeletes(e, rb); err != nil {
+		return fmt.Errorf("local deletes: %w", err)
+	}
+
+	newCatalogID, newVersionID, err := applyRemoteDeletesAndUploads(ctx, e, codeRef)
+	if err != nil {
+		return err
+	}
+
+	e.newCatalogID = newCatalogID
+	e.newVersionID = newVersionID
+
+	return nil
+}
+
+// applyConflictCopies renames each conflict's local file to
+// <path>.LOCAL.<ISO8601Z>. EDIT_DEL_CONFLICT is excluded since the user
+// already deleted that file.
+func applyConflictCopies(e *Engine, rb *Rollback) error {
+	stamp := e.nowFn().UTC().Format("20060102T150405Z")
+
+	for _, fa := range e.plan.Conflicts {
+		if fa.Classification == ClsEditDelConflict {
+			continue
+		}
+
+		src := filepath.Join(e.projectDir, filepath.FromSlash(fa.Path))
+		dst := src + ".LOCAL." + stamp
+
+		if err := rb.Backup(fa.Path); err != nil {
+			return err
+		}
+
+		if err := os.Rename(src, dst); err != nil {
+			return fmt.Errorf("rename %s -> %s: %w", fa.Path, dst, err)
+		}
+
+		rb.TrackCreated(dst)
+		e.conflictCopies = append(e.conflictCopies, dst)
+	}
+
+	return nil
+}
+
+// applyDownloads runs the download list plus the conflict-copy follow-up
+// downloads (remote wins, so remote bytes land at the original path).
+// REMOTE_DELETED files are removed locally instead.
+func applyDownloads(ctx context.Context, e *Engine, rb *Rollback, codeRef codeRefRef) error {
+	if codeRef.CatalogID == "" || codeRef.CatalogVersionID == "" {
+		return nil
+	}
+
+	if err := backupDownloadTargets(e, rb); err != nil {
+		return err
+	}
+
+	if err := removeLocalDeletedFiles(e); err != nil {
+		return err
+	}
+
+	pulls := pullList(e.plan)
+	if err := downloadFiles(ctx, e, codeRef.CatalogID, codeRef.CatalogVersionID, pulls); err != nil {
+		return err
+	}
+
+	for _, fa := range pulls {
+		rb.TrackCreated(filepath.Join(e.projectDir, filepath.FromSlash(fa.Path)))
+	}
+
+	return nil
+}
+
+func backupDownloadTargets(e *Engine, rb *Rollback) error {
+	for _, fa := range e.plan.Downloads {
+		if err := rb.Backup(fa.Path); err != nil {
+			return err
+		}
+	}
+
+	// ActDownloadDelete lives in plan.Deletes, so back those up here
+	// before removeLocalDeletedFiles removes them.
+	for _, fa := range e.plan.Deletes {
+		if fa.Action != ActDownloadDelete {
+			continue
+		}
+
+		if err := rb.Backup(fa.Path); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// removeLocalDeletedFiles removes local copies of REMOTE_DELETED files.
+// Missing-file errors are tolerated for idempotency under retry.
+func removeLocalDeletedFiles(e *Engine) error {
+	for _, fa := range e.plan.Deletes {
+		if fa.Action != ActDownloadDelete {
+			continue
+		}
+
+		abs := filepath.Join(e.projectDir, filepath.FromSlash(fa.Path))
+		if err := os.Remove(abs); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove %s: %w", fa.Path, err)
+		}
+	}
+
+	return nil
+}
+
+// pullList collects FileActions that need remote bytes pulled to disk.
+// DEL_EDIT_CONFLICT is skipped because the remote deleted that file;
+// only the local rename to .LOCAL.<ts> needs to happen.
+func pullList(plan *SyncPlan) []FileAction {
+	out := make([]FileAction, 0, len(plan.Downloads)+len(plan.Conflicts))
+	out = append(out, plan.Downloads...)
+
+	for _, fa := range plan.Conflicts {
+		if fa.Classification == ClsDelEditConflict {
+			continue
+		}
+
+		out = append(out, fa)
+	}
+
+	return out
+}
+
+// applyLocalDeletes is a no-op; applyDownloads already removed
+// REMOTE_DELETED files.
+func applyLocalDeletes(_ *Engine, _ *Rollback) error {
+	return nil
+}
+
+// applyRemoteDeletesAndUploads sends LOCAL_DELETED paths to FilesAPI,
+// runs the chosen Uploader for LOCAL_MODIFIED + LOCAL_ADDED, and PATCHes
+// the artifact's codeRef so the workload picks up the new version.
+func applyRemoteDeletesAndUploads(ctx context.Context, e *Engine, codeRef codeRefRef) (string, string, error) {
+	catalogID := codeRef.CatalogID
+	newCatalogID := catalogID
+	newVersionID := codeRef.CatalogVersionID
+
+	if vid, err := applyDeletes(e, catalogID); err != nil {
+		return "", "", err
+	} else if vid != "" {
+		newVersionID = vid
+	}
+
+	if len(e.plan.Uploads) > 0 {
+		uploader := ChooseUploader(e.plan)
+
+		cid, vid, err := uploader.ApplyUploads(ctx, e, e.plan.Uploads)
+		if err != nil {
+			return "", "", err
+		}
+
+		newCatalogID = cid
+		newVersionID = vid
+	}
+
+	if newVersionID != "" && newVersionID != codeRef.CatalogVersionID {
+		if err := e.patchArtifactFn(e.config.ArtifactID, newCatalogID, newVersionID); err != nil {
+			return "", "", fmt.Errorf("update artifact codeRef: %w", err)
+		}
+	}
+
+	return newCatalogID, newVersionID, nil
+}
+
+// applyDeletes runs the LOCAL_DELETED to remote-delete step. Returns the
+// new catalog version ID, or "" when nothing to delete or no catalog yet.
+func applyDeletes(e *Engine, catalogID string) (string, error) {
+	deletePaths := make([]string, 0)
+
+	for _, fa := range e.plan.Deletes {
+		if fa.Action == ActUploadDelete {
+			deletePaths = append(deletePaths, fa.Path)
+		}
+	}
+
+	if catalogID == "" || len(deletePaths) == 0 {
+		return "", nil
+	}
+
+	resp, err := e.files.DeleteFiles(catalogID, deletePaths)
+	if err != nil {
+		return "", fmt.Errorf("delete remote files: %w", err)
+	}
+
+	if resp == nil {
+		return "", nil
+	}
+
+	return resp.CatalogVersionID, nil
+}

--- a/internal/workload/sync/phase5_execute.go
+++ b/internal/workload/sync/phase5_execute.go
@@ -15,7 +15,6 @@
 package sync
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -26,7 +25,7 @@ import (
 // rollback dir, conflict copies, downloads + local-side deletes, remote
 // deletes, uploads. Any error after the rollback dir is created triggers
 // a Restore to pre-sync state.
-func phase5Execute(ctx context.Context, e *Engine) error {
+func phase5Execute(e *Engine) error {
 	if e.plan == nil || e.plan.IsEmpty() {
 		return nil
 	}
@@ -44,7 +43,7 @@ func phase5Execute(ctx context.Context, e *Engine) error {
 		return err
 	}
 
-	if err := executePlan(ctx, e, rb); err != nil {
+	if err := executePlan(e, rb); err != nil {
 		_ = rb.Restore()
 		return err
 	}
@@ -56,14 +55,14 @@ func phase5Execute(ctx context.Context, e *Engine) error {
 	return nil
 }
 
-func executePlan(ctx context.Context, e *Engine, rb *Rollback) error {
+func executePlan(e *Engine, rb *Rollback) error {
 	if err := applyConflictCopies(e, rb); err != nil {
 		return fmt.Errorf("conflict copies: %w", err)
 	}
 
 	codeRef := codeRefOrEmpty(e)
 
-	if err := applyDownloads(ctx, e, rb, codeRef); err != nil {
+	if err := applyDownloads(e, rb, codeRef); err != nil {
 		return fmt.Errorf("downloads: %w", err)
 	}
 
@@ -71,7 +70,7 @@ func executePlan(ctx context.Context, e *Engine, rb *Rollback) error {
 		return fmt.Errorf("local deletes: %w", err)
 	}
 
-	newCatalogID, newVersionID, err := applyRemoteDeletesAndUploads(ctx, e, codeRef)
+	newCatalogID, newVersionID, err := applyRemoteDeletesAndUploads(e, codeRef)
 	if err != nil {
 		return err
 	}
@@ -114,7 +113,7 @@ func applyConflictCopies(e *Engine, rb *Rollback) error {
 // applyDownloads runs the download list plus the conflict-copy follow-up
 // downloads (remote wins, so remote bytes land at the original path).
 // REMOTE_DELETED files are removed locally instead.
-func applyDownloads(ctx context.Context, e *Engine, rb *Rollback, codeRef codeRefRef) error {
+func applyDownloads(e *Engine, rb *Rollback, codeRef codeRefRef) error {
 	if codeRef.CatalogID == "" || codeRef.CatalogVersionID == "" {
 		return nil
 	}
@@ -128,7 +127,7 @@ func applyDownloads(ctx context.Context, e *Engine, rb *Rollback, codeRef codeRe
 	}
 
 	pulls := pullList(e.plan)
-	if err := downloadFiles(ctx, e, codeRef.CatalogID, codeRef.CatalogVersionID, pulls); err != nil {
+	if err := downloadFiles(e, codeRef.CatalogID, codeRef.CatalogVersionID, pulls); err != nil {
 		return err
 	}
 
@@ -205,7 +204,7 @@ func applyLocalDeletes(_ *Engine, _ *Rollback) error {
 // applyRemoteDeletesAndUploads sends LOCAL_DELETED paths to FilesAPI,
 // runs the chosen Uploader for LOCAL_MODIFIED + LOCAL_ADDED, and PATCHes
 // the artifact's codeRef so the workload picks up the new version.
-func applyRemoteDeletesAndUploads(ctx context.Context, e *Engine, codeRef codeRefRef) (string, string, error) {
+func applyRemoteDeletesAndUploads(e *Engine, codeRef codeRefRef) (string, string, error) {
 	catalogID := codeRef.CatalogID
 	newCatalogID := catalogID
 	newVersionID := codeRef.CatalogVersionID
@@ -219,7 +218,7 @@ func applyRemoteDeletesAndUploads(ctx context.Context, e *Engine, codeRef codeRe
 	if len(e.plan.Uploads) > 0 {
 		uploader := ChooseUploader(e.plan)
 
-		cid, vid, err := uploader.ApplyUploads(ctx, e, e.plan.Uploads)
+		cid, vid, err := uploader.ApplyUploads(e, e.plan.Uploads)
 		if err != nil {
 			return "", "", err
 		}

--- a/internal/workload/sync/phase6_state.go
+++ b/internal/workload/sync/phase6_state.go
@@ -15,7 +15,6 @@
 package sync
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -25,7 +24,7 @@ import (
 // phase6State writes the new BASE manifest, config, history entry, and
 // discards the rollback. Failures here do NOT roll back Phase 5 since
 // the remote has already advanced; the next sync will reconcile.
-func phase6State(_ context.Context, e *Engine) error {
+func phase6State(e *Engine) error {
 	if e.plan == nil {
 		return nil
 	}

--- a/internal/workload/sync/phase6_state.go
+++ b/internal/workload/sync/phase6_state.go
@@ -1,0 +1,148 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/datarobot/cli/internal/workload/wapi"
+)
+
+// phase6State writes the new BASE manifest, config, history entry, and
+// discards the rollback. Failures here do NOT roll back Phase 5 since
+// the remote has already advanced; the next sync will reconcile.
+func phase6State(_ context.Context, e *Engine) error {
+	if e.plan == nil {
+		return nil
+	}
+
+	now := e.nowFn().UTC()
+
+	cfg := e.config
+
+	if e.newCatalogID != "" {
+		cid := e.newCatalogID
+		cfg.CatalogID = &cid
+	}
+
+	versionForState := e.newVersionID
+	if versionForState == "" {
+		// Pull-only sync; persist the remote version observed in Phase 1.
+		versionForState = e.remoteVer
+	}
+
+	if versionForState != "" {
+		cfg.LastSyncedVersionID = &versionForState
+	}
+
+	if err := wapi.SaveConfig(e.projectDir, cfg); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+
+	manifest := buildNewBaseManifest(e, versionForState, now)
+	if err := wapi.SaveManifest(e.projectDir, manifest); err != nil {
+		return fmt.Errorf("save manifest: %w", err)
+	}
+
+	if err := wapi.AppendHistory(e.projectDir, syncHistoryEntry(e, now)); err != nil {
+		return fmt.Errorf("append history: %w", err)
+	}
+
+	if e.rollback != nil {
+		_ = e.rollback.Discard()
+		e.rollback = nil
+	}
+
+	e.config = cfg
+	e.populateResult(versionForState)
+
+	return nil
+}
+
+// buildNewBaseManifest computes NEW_BASE = REMOTE + uploads (local hashes)
+// - deletes, with conflicts resolved as remote-wins.
+func buildNewBaseManifest(e *Engine, syncedVersionID string, syncedAt time.Time) wapi.Manifest {
+	files := make(map[string]wapi.FileMeta, len(e.remote))
+
+	for path, fe := range e.remote {
+		files[path] = wapi.FileMeta{Hash: fe.Hash, Size: fe.Size}
+	}
+
+	for _, fa := range e.plan.Uploads {
+		files[fa.Path] = wapi.FileMeta{Hash: fa.LocalHash, Size: fa.LocalSize}
+	}
+
+	for _, fa := range e.plan.Deletes {
+		delete(files, fa.Path)
+	}
+
+	for _, fa := range e.plan.Conflicts {
+		if fa.RemoteHash == "" {
+			continue
+		}
+
+		files[fa.Path] = wapi.FileMeta{Hash: fa.RemoteHash, Size: fa.RemoteSize}
+	}
+
+	syncedAtCopy := syncedAt
+	versionCopy := syncedVersionID
+
+	return wapi.Manifest{
+		Version:         wapi.ManifestVersion,
+		SyncedAt:        &syncedAtCopy,
+		SyncedVersionID: &versionCopy,
+		Files:           files,
+	}
+}
+
+// syncHistoryEntry assembles the JSONL line written to .wapi/history.log.
+func syncHistoryEntry(e *Engine, now time.Time) wapi.HistoryEntry {
+	entry := wapi.HistoryEntry{
+		"ts":         now.Format(time.RFC3339),
+		"op":         "sync",
+		"version":    fmt.Sprintf("%s→%s", ShortVer(e.plan.OldVersionShort), ShortVer(e.newVersionID)),
+		"uploaded":   len(e.plan.Uploads),
+		"downloaded": len(e.plan.Downloads),
+		"deleted":    len(e.plan.Deletes),
+		"conflicts":  len(e.plan.Conflicts),
+		"duration":   e.nowFn().Sub(e.startedAt).Round(time.Millisecond).String(),
+	}
+
+	if len(e.plan.Conflicts) > 0 {
+		entry["conflict_files"] = e.plan.ConflictPaths()
+	}
+
+	return entry
+}
+
+func (e *Engine) populateResult(versionForState string) {
+	r := &Result{
+		OldVersion:      ptrOrEmpty(e.config.LastSyncedVersionID),
+		NewVersion:      versionForState,
+		UploadedCount:   len(e.plan.Uploads),
+		DownloadedCount: len(e.plan.Downloads),
+		DeletedCount:    len(e.plan.Deletes),
+		ConflictCount:   len(e.plan.Conflicts),
+		ConflictCopies:  e.conflictCopies,
+		Duration:        e.nowFn().Sub(e.startedAt),
+	}
+
+	// "Old" should be the version BEFORE Phase 6 overwrote config.
+	r.OldVersion = e.plan.OldVersionShort
+
+	e.result = r
+}

--- a/internal/workload/sync/pipeline.go
+++ b/internal/workload/sync/pipeline.go
@@ -1,0 +1,44 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"context"
+	"fmt"
+)
+
+// phase is a named step in the sync pipeline so runPhases can attach
+// the phase name to wrapped errors.
+type phase struct {
+	name string
+	run  func(ctx context.Context, e *Engine) error
+}
+
+// runPhases executes phases sequentially. The first error stops the
+// pipeline; the engine releases the lock on failure via deferred
+// releaseLock.
+func runPhases(ctx context.Context, e *Engine, phases ...phase) error {
+	for _, p := range phases {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("phase %s: %w", p.name, err)
+		}
+
+		if err := p.run(ctx, e); err != nil {
+			return fmt.Errorf("phase %s: %w", p.name, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/workload/sync/pipeline.go
+++ b/internal/workload/sync/pipeline.go
@@ -14,28 +14,21 @@
 
 package sync
 
-import (
-	"context"
-	"fmt"
-)
+import "fmt"
 
 // phase is a named step in the sync pipeline so runPhases can attach
 // the phase name to wrapped errors.
 type phase struct {
 	name string
-	run  func(ctx context.Context, e *Engine) error
+	run  func(e *Engine) error
 }
 
 // runPhases executes phases sequentially. The first error stops the
 // pipeline; the engine releases the lock on failure via deferred
 // releaseLock.
-func runPhases(ctx context.Context, e *Engine, phases ...phase) error {
+func runPhases(e *Engine, phases ...phase) error {
 	for _, p := range phases {
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("phase %s: %w", p.name, err)
-		}
-
-		if err := p.run(ctx, e); err != nil {
+		if err := p.run(e); err != nil {
 			return fmt.Errorf("phase %s: %w", p.name, err)
 		}
 	}

--- a/internal/workload/sync/plan.go
+++ b/internal/workload/sync/plan.go
@@ -1,0 +1,115 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import "sort"
+
+// FileAction is one row of the SyncPlan.
+type FileAction struct {
+	Path           string
+	Classification Classification
+	Action         Action
+	LocalSize      int64
+	RemoteSize     int64
+	LocalHash      string
+	RemoteHash     string
+}
+
+// SyncPlan is the blueprint Phase 5 executes and the structure the display
+// layer renders.
+type SyncPlan struct {
+	Uploads   []FileAction // LOCAL_MODIFIED + LOCAL_ADDED
+	Downloads []FileAction // REMOTE_MODIFIED + REMOTE_ADDED + EDIT_DEL_CONFLICT
+	Deletes   []FileAction // LOCAL_DELETED + REMOTE_DELETED
+	Conflicts []FileAction // CONFLICT + ADD_CONFLICT + DEL_EDIT_CONFLICT
+
+	// OldVersionShort is the 8-char prefix of the BASE manifest's
+	// syncedVersionId; empty before the first successful sync.
+	OldVersionShort string
+}
+
+// Append routes a FileAction into the right group based on its Action.
+// Skip actions are dropped.
+func (p *SyncPlan) Append(fa FileAction) {
+	switch fa.Action {
+	case ActSkip:
+	case ActUploadModify, ActUploadAdd:
+		p.Uploads = append(p.Uploads, fa)
+	case ActDownloadModify, ActDownloadAdd, ActDownloadOverDel:
+		p.Downloads = append(p.Downloads, fa)
+	case ActUploadDelete, ActDownloadDelete:
+		p.Deletes = append(p.Deletes, fa)
+	case ActConflictCopy:
+		// Conflicts also need the remote download (remote wins); the
+		// executor issues that download alongside the conflict copy.
+		p.Conflicts = append(p.Conflicts, fa)
+	}
+}
+
+// Sort orders every group by path. Call once after all Append calls.
+func (p *SyncPlan) Sort() {
+	for _, group := range [][]FileAction{p.Uploads, p.Downloads, p.Deletes, p.Conflicts} {
+		sort.Slice(group, func(i, j int) bool { return group[i].Path < group[j].Path })
+	}
+}
+
+// HasConflicts reports whether any conflict-class rows exist.
+func (p *SyncPlan) HasConflicts() bool {
+	return len(p.Conflicts) > 0
+}
+
+// IsEmpty reports whether the plan has nothing to do.
+func (p *SyncPlan) IsEmpty() bool {
+	return len(p.Uploads) == 0 && len(p.Downloads) == 0 && len(p.Deletes) == 0 && len(p.Conflicts) == 0
+}
+
+// TotalUploadBytes sums the bytes the upload step will push.
+func (p *SyncPlan) TotalUploadBytes() int64 {
+	var n int64
+
+	for _, fa := range p.Uploads {
+		n += fa.LocalSize
+	}
+
+	return n
+}
+
+// TotalDownloadBytes sums download bytes plus remote bytes for conflict
+// copies (since those also pull the remote).
+func (p *SyncPlan) TotalDownloadBytes() int64 {
+	var n int64
+
+	for _, fa := range p.Downloads {
+		n += fa.RemoteSize
+	}
+
+	for _, fa := range p.Conflicts {
+		n += fa.RemoteSize
+	}
+
+	return n
+}
+
+// ConflictPaths returns the conflict paths sorted alphabetically.
+func (p *SyncPlan) ConflictPaths() []string {
+	out := make([]string, 0, len(p.Conflicts))
+	for _, fa := range p.Conflicts {
+		out = append(out, fa.Path)
+	}
+
+	sort.Strings(out)
+
+	return out
+}

--- a/internal/workload/sync/rollback.go
+++ b/internal/workload/sync/rollback.go
@@ -1,0 +1,198 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+const rollbackDirName = ".rollback"
+
+// Rollback owns the .wapi/.rollback/ tree for a single sync run. Call
+// Backup before each destructive operation, then Discard on success or
+// Restore on failure. Newly created files go through TrackCreated so
+// Restore can remove them.
+type Rollback struct {
+	projectDir string
+	rollDir    string
+	created    []string
+}
+
+// NewRollback creates the rollback directory. Returns an error if a stale
+// rollback already exists; callers must run RestoreStaleIfPresent first.
+func NewRollback(projectDir string) (*Rollback, error) {
+	rollDir := filepath.Join(projectDir, ".wapi", rollbackDirName)
+
+	if err := os.Mkdir(rollDir, 0o755); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("rollback dir already exists: %s", rollDir)
+		}
+
+		return nil, fmt.Errorf("create rollback dir: %w", err)
+	}
+
+	return &Rollback{projectDir: projectDir, rollDir: rollDir}, nil
+}
+
+// Backup copies relPath into the rollback tree. Missing files are OK;
+// the absence is implicitly recorded.
+func (r *Rollback) Backup(relPath string) error {
+	src := filepath.Join(r.projectDir, filepath.FromSlash(relPath))
+
+	info, err := os.Stat(src)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
+		return fmt.Errorf("stat for backup %s: %w", src, err)
+	}
+
+	if !info.Mode().IsRegular() {
+		return nil
+	}
+
+	dst := filepath.Join(r.rollDir, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("mkdir rollback parent: %w", err)
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source for backup: %w", err)
+	}
+
+	defer func() { _ = in.Close() }()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create backup file: %w", err)
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("copy backup file: %w", err)
+	}
+
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close backup file: %w", err)
+	}
+
+	return nil
+}
+
+// TrackCreated records a file that Restore should remove.
+func (r *Rollback) TrackCreated(absPath string) {
+	r.created = append(r.created, absPath)
+}
+
+// Discard removes the rollback directory after a successful sync.
+func (r *Rollback) Discard() error {
+	if err := os.RemoveAll(r.rollDir); err != nil {
+		return fmt.Errorf("remove rollback dir: %w", err)
+	}
+
+	return nil
+}
+
+// Restore copies every backup back into the project directory and
+// removes files tracked in r.created.
+func (r *Rollback) Restore() error {
+	for _, abs := range r.created {
+		_ = os.Remove(abs)
+	}
+
+	return restoreFromDir(r.rollDir, r.projectDir)
+}
+
+// RestoreStaleIfPresent restores any existing .wapi/.rollback/ tree and
+// removes it. The bool indicates whether a restore happened so callers
+// can warn the user.
+func RestoreStaleIfPresent(projectDir string) (bool, error) {
+	rollDir := filepath.Join(projectDir, ".wapi", rollbackDirName)
+
+	info, err := os.Stat(rollDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("stat rollback dir: %w", err)
+	}
+
+	if !info.IsDir() {
+		return false, fmt.Errorf("%s exists but is not a directory", rollDir)
+	}
+
+	if err := restoreFromDir(rollDir, projectDir); err != nil {
+		return true, err
+	}
+
+	if err := os.RemoveAll(rollDir); err != nil {
+		return true, fmt.Errorf("remove rollback dir after restore: %w", err)
+	}
+
+	return true, nil
+}
+
+func restoreFromDir(rollDir, projectDir string) error {
+	return filepath.WalkDir(rollDir, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("walk rollback %s: %w", p, walkErr)
+		}
+
+		if d.IsDir() || !d.Type().IsRegular() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(rollDir, p)
+		if err != nil {
+			return fmt.Errorf("relativize rollback %s: %w", p, err)
+		}
+
+		dst := filepath.Join(projectDir, rel)
+
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return fmt.Errorf("mkdir restore parent: %w", err)
+		}
+
+		in, err := os.Open(p)
+		if err != nil {
+			return fmt.Errorf("open backup %s: %w", p, err)
+		}
+
+		out, err := os.Create(dst)
+		if err != nil {
+			_ = in.Close()
+			return fmt.Errorf("create restored file %s: %w", dst, err)
+		}
+
+		_, copyErr := io.Copy(out, in)
+
+		_ = in.Close()
+		_ = out.Close()
+
+		if copyErr != nil {
+			return fmt.Errorf("restore copy %s: %w", dst, copyErr)
+		}
+
+		return nil
+	})
+}

--- a/internal/workload/sync/rollback_test.go
+++ b/internal/workload/sync/rollback_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupProject(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".wapi"), 0o755))
+
+	return dir
+}
+
+func writeProjectFile(t *testing.T, dir, rel, body string) {
+	t.Helper()
+
+	full := filepath.Join(dir, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, []byte(body), 0o644))
+}
+
+func TestRollback_BackupAndRestore(t *testing.T) {
+	dir := setupProject(t)
+	writeProjectFile(t, dir, "agent.py", "original")
+	writeProjectFile(t, dir, "utils/helper.py", "old helper")
+
+	r, err := NewRollback(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, r.Backup("agent.py"))
+	require.NoError(t, r.Backup("utils/helper.py"))
+
+	// Simulate Phase 5 modifying the working tree.
+	writeProjectFile(t, dir, "agent.py", "BROKEN")
+	writeProjectFile(t, dir, "utils/helper.py", "BROKEN")
+	writeProjectFile(t, dir, "newly-created.txt", "leftover")
+	r.TrackCreated(filepath.Join(dir, "newly-created.txt"))
+
+	require.NoError(t, r.Restore())
+
+	got, err := os.ReadFile(filepath.Join(dir, "agent.py"))
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(got))
+
+	got, err = os.ReadFile(filepath.Join(dir, "utils/helper.py"))
+	require.NoError(t, err)
+	assert.Equal(t, "old helper", string(got))
+
+	_, err = os.Stat(filepath.Join(dir, "newly-created.txt"))
+	assert.ErrorIs(t, err, os.ErrNotExist, "tracked-created file should be removed")
+}
+
+func TestRollback_MissingFileNoop(t *testing.T) {
+	dir := setupProject(t)
+
+	r, err := NewRollback(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, r.Backup("never-existed.py"))
+
+	require.NoError(t, r.Discard())
+}
+
+func TestRollback_AlreadyExists(t *testing.T) {
+	dir := setupProject(t)
+	require.NoError(t, os.Mkdir(filepath.Join(dir, ".wapi", ".rollback"), 0o755))
+
+	_, err := NewRollback(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+func TestRestoreStaleIfPresent(t *testing.T) {
+	dir := setupProject(t)
+	writeProjectFile(t, dir, "agent.py", "WAS-BROKEN")
+
+	rollDir := filepath.Join(dir, ".wapi", ".rollback")
+	require.NoError(t, os.MkdirAll(rollDir, 0o755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(rollDir, "agent.py"), []byte("intact"), 0o644))
+
+	restored, err := RestoreStaleIfPresent(dir)
+	require.NoError(t, err)
+	assert.True(t, restored)
+
+	got, err := os.ReadFile(filepath.Join(dir, "agent.py"))
+	require.NoError(t, err)
+	assert.Equal(t, "intact", string(got))
+
+	_, err = os.Stat(rollDir)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestRestoreStaleIfPresent_None(t *testing.T) {
+	dir := setupProject(t)
+
+	restored, err := RestoreStaleIfPresent(dir)
+	require.NoError(t, err)
+	assert.False(t, restored)
+}

--- a/internal/workload/sync/synclock.go
+++ b/internal/workload/sync/synclock.go
@@ -1,0 +1,69 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const syncLockFile = "sync.lock"
+
+// SyncLock is the platform-specific exclusive lock for a sync run.
+type SyncLock struct {
+	path string
+	f    *os.File
+}
+
+// AcquireSyncLock opens .wapi/sync.lock and acquires an exclusive lock
+// without waiting. Cross-platform polish is tracked in RAPTOR-16928.
+func AcquireSyncLock(projectDir string) (*SyncLock, error) {
+	wapiDir := filepath.Join(projectDir, ".wapi")
+	if _, err := os.Stat(wapiDir); err != nil {
+		return nil, fmt.Errorf("acquire sync lock: %w", err)
+	}
+
+	path := filepath.Join(wapiDir, syncLockFile)
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open sync lock %s: %w", path, err)
+	}
+
+	if err := tryLockExclusive(f); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("another sync is already running on this project: %w", err)
+	}
+
+	return &SyncLock{path: path, f: f}, nil
+}
+
+// Release unlocks and closes the lock file. It does NOT remove the file
+// because that would race with another process that has the file open
+// but has not yet acquired the lock.
+func (l *SyncLock) Release() error {
+	if l == nil || l.f == nil {
+		return nil
+	}
+
+	_ = unlockExclusive(l.f)
+
+	if err := l.f.Close(); err != nil {
+		return fmt.Errorf("close sync lock: %w", err)
+	}
+
+	return nil
+}

--- a/internal/workload/sync/synclock_test.go
+++ b/internal/workload/sync/synclock_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncLock_AcquireRelease(t *testing.T) {
+	dir := setupProject(t)
+
+	lock, err := AcquireSyncLock(dir)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+
+	require.NoError(t, lock.Release())
+}
+
+func TestSyncLock_DoubleAcquireFailsOnUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("v1 sync lock is a no-op on windows; tracked in RAPTOR-16928")
+	}
+
+	dir := setupProject(t)
+
+	lock1, err := AcquireSyncLock(dir)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = lock1.Release() })
+
+	_, err = AcquireSyncLock(dir)
+	assert.Error(t, err, "second acquire on the same project must fail while the first is held")
+}
+
+func TestSyncLock_NoWapiDir(t *testing.T) {
+	dir := t.TempDir() // no .wapi/
+
+	_, err := AcquireSyncLock(dir)
+	assert.Error(t, err)
+}

--- a/internal/workload/sync/synclock_unix.go
+++ b/internal/workload/sync/synclock_unix.go
@@ -1,0 +1,30 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package sync
+
+import (
+	"os"
+	"syscall"
+)
+
+func tryLockExclusive(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+}
+
+func unlockExclusive(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/workload/sync/synclock_unix.go
+++ b/internal/workload/sync/synclock_unix.go
@@ -18,13 +18,14 @@ package sync
 
 import (
 	"os"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func tryLockExclusive(f *os.File) error {
-	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	return unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
 }
 
 func unlockExclusive(f *os.File) error {
-	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
 }

--- a/internal/workload/sync/synclock_windows.go
+++ b/internal/workload/sync/synclock_windows.go
@@ -1,0 +1,29 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package sync
+
+import "os"
+
+// tryLockExclusive on Windows is a no-op; LockFileEx is tracked in
+// RAPTOR-16928.
+func tryLockExclusive(_ *os.File) error {
+	return nil
+}
+
+func unlockExclusive(_ *os.File) error {
+	return nil
+}

--- a/internal/workload/sync/upload_stage.go
+++ b/internal/workload/sync/upload_stage.go
@@ -1,0 +1,137 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+)
+
+// StageUploader implements the stage-based workflow: create catalog if
+// missing, create stage, upload each file, apply stage.
+type StageUploader struct{}
+
+// ApplyUploads pushes files via the stage workflow.
+func (StageUploader) ApplyUploads(ctx context.Context, e *Engine, files []FileAction) (string, string, error) {
+	catalogID, err := ensureCatalog(e)
+	if err != nil {
+		return "", "", err
+	}
+
+	stage, err := e.files.CreateStage(catalogID)
+	if err != nil {
+		return "", "", fmt.Errorf("create stage: %w", err)
+	}
+
+	if err := uploadFilesParallel(ctx, e, catalogID, stage.StageID, files); err != nil {
+		return "", "", err
+	}
+
+	apply, err := e.files.ApplyStage(catalogID, stage.StageID, filesapi.OverwriteReplace)
+	if err != nil {
+		return "", "", fmt.Errorf("apply stage: %w", err)
+	}
+
+	return catalogID, apply.CatalogVersionID, nil
+}
+
+// ensureCatalog returns the catalog ID, creating a new one when neither
+// config nor artifact has one (first-sync against an empty artifact).
+func ensureCatalog(e *Engine) (string, error) {
+	if id := resolveExistingCatalogID(e); id != "" {
+		return id, nil
+	}
+
+	cat, err := e.files.CreateCatalog()
+	if err != nil {
+		return "", fmt.Errorf("create catalog: %w", err)
+	}
+
+	return cat.CatalogID, nil
+}
+
+// uploadFilesParallel uploads files up to UploadConcurrency. The first
+// error cancels the context; the function still waits for all workers
+// to return to avoid leaking goroutines past Phase 5.
+func uploadFilesParallel(ctx context.Context, e *Engine, catalogID, stageID string, files []FileAction) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sem := make(chan struct{}, UploadConcurrency)
+	errCh := make(chan error, len(files))
+
+	var wg sync.WaitGroup
+
+	for _, fa := range files {
+		fa := fa
+
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+
+			defer func() { <-sem }()
+
+			if err := uploadOneToStage(e, catalogID, stageID, fa); err != nil {
+				select {
+				case errCh <- err:
+					cancel()
+				default:
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	if err := <-errCh; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func uploadOneToStage(e *Engine, catalogID, stageID string, fa FileAction) error {
+	abs := filepath.Join(e.projectDir, filepath.FromSlash(fa.Path))
+
+	f, err := os.Open(abs)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", fa.Path, err)
+	}
+
+	defer func() { _ = f.Close() }()
+
+	if err := e.files.UploadToStage(catalogID, stageID, fa.Path, fa.LocalSize, f); err != nil {
+		return fmt.Errorf("upload %s: %w", fa.Path, err)
+	}
+
+	return nil
+}

--- a/internal/workload/sync/upload_stage.go
+++ b/internal/workload/sync/upload_stage.go
@@ -93,6 +93,7 @@ func uploadFilesParallel(e *Engine, catalogID, stageID string, files []FileActio
 
 		go func() {
 			defer wg.Done()
+			defer recoverWorkerPanic("uploading "+fa.Path, errCh, cancel)
 
 			select {
 			case sem <- struct{}{}:

--- a/internal/workload/sync/upload_stage.go
+++ b/internal/workload/sync/upload_stage.go
@@ -15,7 +15,6 @@
 package sync
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,7 +28,7 @@ import (
 type StageUploader struct{}
 
 // ApplyUploads pushes files via the stage workflow.
-func (StageUploader) ApplyUploads(ctx context.Context, e *Engine, files []FileAction) (string, string, error) {
+func (StageUploader) ApplyUploads(e *Engine, files []FileAction) (string, string, error) {
 	catalogID, err := ensureCatalog(e)
 	if err != nil {
 		return "", "", err
@@ -40,7 +39,7 @@ func (StageUploader) ApplyUploads(ctx context.Context, e *Engine, files []FileAc
 		return "", "", fmt.Errorf("create stage: %w", err)
 	}
 
-	if err := uploadFilesParallel(ctx, e, catalogID, stage.StageID, files); err != nil {
+	if err := uploadFilesParallel(e, catalogID, stage.StageID, files); err != nil {
 		return "", "", err
 	}
 
@@ -68,14 +67,18 @@ func ensureCatalog(e *Engine) (string, error) {
 }
 
 // uploadFilesParallel uploads files up to UploadConcurrency. The first
-// error cancels the context; the function still waits for all workers
-// to return to avoid leaking goroutines past Phase 5.
-func uploadFilesParallel(ctx context.Context, e *Engine, catalogID, stageID string, files []FileAction) error {
+// error closes done to stop other workers from starting; in-flight
+// workers still finish their current upload before the function returns.
+func uploadFilesParallel(e *Engine, catalogID, stageID string, files []FileAction) error {
 	if len(files) == 0 {
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+
+	var cancelOnce sync.Once
+
+	cancel := func() { cancelOnce.Do(func() { close(done) }) }
 	defer cancel()
 
 	sem := make(chan struct{}, UploadConcurrency)
@@ -93,7 +96,7 @@ func uploadFilesParallel(ctx context.Context, e *Engine, catalogID, stageID stri
 
 			select {
 			case sem <- struct{}{}:
-			case <-ctx.Done():
+			case <-done:
 				return
 			}
 

--- a/internal/workload/sync/upload_zip.go
+++ b/internal/workload/sync/upload_zip.go
@@ -1,0 +1,163 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"archive/zip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+)
+
+// ZipUploader implements the async zip workflow: build a zip locally,
+// POST it to FilesAPI, poll until terminal.
+type ZipUploader struct{}
+
+// ApplyUploads zips the files, POSTs, and polls until done.
+func (ZipUploader) ApplyUploads(ctx context.Context, e *Engine, files []FileAction) (string, string, error) {
+	zipPath, err := buildZip(e.projectDir, files)
+	if err != nil {
+		return "", "", err
+	}
+
+	defer func() { _ = os.Remove(zipPath) }()
+
+	zipFile, err := os.Open(zipPath)
+	if err != nil {
+		return "", "", fmt.Errorf("open built zip: %w", err)
+	}
+
+	defer func() { _ = zipFile.Close() }()
+
+	stat, err := zipFile.Stat()
+	if err != nil {
+		return "", "", fmt.Errorf("stat built zip: %w", err)
+	}
+
+	resp, err := postZip(e, zipFile, stat.Size())
+	if err != nil {
+		return "", "", err
+	}
+
+	// Small archives complete inline (201, no statusId); larger ones
+	// come back 202 with a statusId we then poll.
+	if resp.StatusID != "" {
+		if err := waitForCompletion(ctx, e, resp.StatusID); err != nil {
+			return "", "", err
+		}
+	}
+
+	return resp.CatalogID, resp.CatalogVersionID, nil
+}
+
+// buildZip writes a zip archive to a temp file. Buffering on disk
+// keeps very large zips from pinning a multi-GiB allocation.
+func buildZip(projectDir string, files []FileAction) (string, error) {
+	tmp, err := os.CreateTemp("", "wapi-sync-*.zip")
+	if err != nil {
+		return "", fmt.Errorf("create zip tempfile: %w", err)
+	}
+
+	defer func() { _ = tmp.Close() }()
+
+	zw := zip.NewWriter(tmp)
+
+	defer func() { _ = zw.Close() }()
+
+	for _, fa := range files {
+		abs := filepath.Join(projectDir, filepath.FromSlash(fa.Path))
+
+		if err := addToZip(zw, abs, fa.Path); err != nil {
+			_ = os.Remove(tmp.Name())
+			return "", err
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return "", fmt.Errorf("close zip writer: %w", err)
+	}
+
+	return tmp.Name(), nil
+}
+
+func addToZip(zw *zip.Writer, src, archivePath string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %s for zip: %w", src, err)
+	}
+
+	defer func() { _ = in.Close() }()
+
+	hdr := &zip.FileHeader{Name: archivePath, Method: zip.Deflate}
+
+	w, err := zw.CreateHeader(hdr)
+	if err != nil {
+		return fmt.Errorf("zip header for %s: %w", archivePath, err)
+	}
+
+	if _, err := io.Copy(w, in); err != nil {
+		return fmt.Errorf("copy %s into zip: %w", archivePath, err)
+	}
+
+	return nil
+}
+
+// postZip dispatches to UploadFromZipNew (first-sync, no catalog) or
+// UploadFromZipExisting (subsequent syncs).
+func postZip(e *Engine, body io.Reader, size int64) (*filesapi.FromFileResp, error) {
+	if id := resolveExistingCatalogID(e); id != "" {
+		return e.files.UploadFromZipExisting(id, "wapi-sync.zip", filesapi.OverwriteReplace, size, body)
+	}
+
+	return e.files.UploadFromZipNew("wapi-sync.zip", size, body)
+}
+
+// waitForCompletion polls until terminal status or ZipPollTimeoutSecs
+// elapses.
+func waitForCompletion(ctx context.Context, e *Engine, statusID string) error {
+	deadline := time.Now().Add(time.Duration(ZipPollTimeoutSecs) * time.Second)
+
+	for {
+		if time.Now().After(deadline) {
+			return errors.New("timeout waiting for archive extract")
+		}
+
+		resp, err := e.files.PollStatus(statusID)
+		if err != nil {
+			return fmt.Errorf("poll status %s: %w", statusID, err)
+		}
+
+		if filesapi.IsTerminalStatus(resp.Status) {
+			if filesapi.IsErrorStatus(resp.Status) {
+				return fmt.Errorf("zip extraction failed: %s (%s)", resp.Status, resp.Message)
+			}
+
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(ZipPollIntervalMS) * time.Millisecond):
+		}
+	}
+}

--- a/internal/workload/sync/upload_zip.go
+++ b/internal/workload/sync/upload_zip.go
@@ -16,7 +16,6 @@ package sync
 
 import (
 	"archive/zip"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -32,7 +31,7 @@ import (
 type ZipUploader struct{}
 
 // ApplyUploads zips the files, POSTs, and polls until done.
-func (ZipUploader) ApplyUploads(ctx context.Context, e *Engine, files []FileAction) (string, string, error) {
+func (ZipUploader) ApplyUploads(e *Engine, files []FileAction) (string, string, error) {
 	zipPath, err := buildZip(e.projectDir, files)
 	if err != nil {
 		return "", "", err
@@ -60,7 +59,7 @@ func (ZipUploader) ApplyUploads(ctx context.Context, e *Engine, files []FileActi
 	// Small archives complete inline (201, no statusId); larger ones
 	// come back 202 with a statusId we then poll.
 	if resp.StatusID != "" {
-		if err := waitForCompletion(ctx, e, resp.StatusID); err != nil {
+		if err := waitForCompletion(e, resp.StatusID); err != nil {
 			return "", "", err
 		}
 	}
@@ -133,7 +132,7 @@ func postZip(e *Engine, body io.Reader, size int64) (*filesapi.FromFileResp, err
 
 // waitForCompletion polls until terminal status or ZipPollTimeoutSecs
 // elapses.
-func waitForCompletion(ctx context.Context, e *Engine, statusID string) error {
+func waitForCompletion(e *Engine, statusID string) error {
 	deadline := time.Now().Add(time.Duration(ZipPollTimeoutSecs) * time.Second)
 
 	for {
@@ -154,10 +153,6 @@ func waitForCompletion(ctx context.Context, e *Engine, statusID string) error {
 			return nil
 		}
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(time.Duration(ZipPollIntervalMS) * time.Millisecond):
-		}
+		time.Sleep(time.Duration(ZipPollIntervalMS) * time.Millisecond)
 	}
 }

--- a/internal/workload/sync/uploader.go
+++ b/internal/workload/sync/uploader.go
@@ -14,13 +14,11 @@
 
 package sync
 
-import "context"
-
 // Uploader pushes a SyncPlan's Uploads and returns the resulting
 // (catalogID, newVersionID). When catalogID is empty (first-sync against
 // an empty artifact) the implementation creates a new catalog.
 type Uploader interface {
-	ApplyUploads(ctx context.Context, e *Engine, files []FileAction) (catalogID, versionID string, err error)
+	ApplyUploads(e *Engine, files []FileAction) (catalogID, versionID string, err error)
 }
 
 // ChooseUploader picks stage for small change sets (tight error semantics)

--- a/internal/workload/sync/uploader.go
+++ b/internal/workload/sync/uploader.go
@@ -1,0 +1,38 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import "context"
+
+// Uploader pushes a SyncPlan's Uploads and returns the resulting
+// (catalogID, newVersionID). When catalogID is empty (first-sync against
+// an empty artifact) the implementation creates a new catalog.
+type Uploader interface {
+	ApplyUploads(ctx context.Context, e *Engine, files []FileAction) (catalogID, versionID string, err error)
+}
+
+// ChooseUploader picks stage for small change sets (tight error semantics)
+// or zip for larger ones (lower per-file overhead).
+func ChooseUploader(plan *SyncPlan) Uploader {
+	if plan == nil || len(plan.Uploads) == 0 {
+		return &StageUploader{}
+	}
+
+	if len(plan.Uploads) <= StageVsZipFileThreshold && plan.TotalUploadBytes() <= int64(StageVsZipBytesThreshold) {
+		return &StageUploader{}
+	}
+
+	return &ZipUploader{}
+}


### PR DESCRIPTION
# RATIONALE

This is the second of three PRs implementing RAPTOR-16924 (`dr workload code sync`).

The first PR (foundation) added the low-level building blocks: the `filesapi` client, `fileops` for hashing and walking and path safety, and the `ignore` matcher. This PR builds on that and adds the sync engine itself, which orchestrates everything those building blocks expose.

The engine is internal-only at this stage. There's no new CLI surface and nothing touched in `cmd/`. Everything lives under `internal/workload/sync/` and is exercised by unit tests with fakes.

The third PR will wire the user-facing `dr workload code sync` command on top of this engine.

Worth reviewing the foundation PR first since this one sits directly on top of it.

## CHANGES

**`internal/workload/sync/`** is the new phased sync orchestrator.

- `engine.go` exposes the `Engine` struct and the `Run(ctx)` entrypoint that drives the seven phases.
- `phase0_preflight.go` through `phase6_state.go` are one file per phase: preflight (env checks), gather (local and remote scan), manifests (BASE / LOCAL / REMOTE), diff, preview, execute, state write.
- `classify.go` is the three-way diff classifier. It produces labels like `UNCHANGED`, `LOCAL_DELETED`, `REMOTE_DELETED`, `BOTH_DELETED`, `EDIT_DEL_CONFLICT`, `DEL_EDIT_CONFLICT`, `EDIT`, `EDIT_EDIT_CONFLICT`, etc.
- `diff.go` builds a sorted plan over classified files.
- `plan.go` defines the `SyncPlan` struct (uploads, downloads, deletes, conflicts) with size and count helpers.
- `rollback.go` is the copy-on-write `.wapi/.rollback/` mechanism that restores overwritten or deleted files on failure or crash.
- `synclock.go` (with a `_unix.go` and `_windows.go` build-tag pair) prevents concurrent syncs via flock. The Windows path is a v1 stub. Real implementation is tracked in RAPTOR-16928.
- `diskspace.go` (also a build-tag pair) does the pre-flight disk-space check against `DiskSpaceMarginMB`.
- `download.go` downloads a file and verifies its SHA-256 against the manifest. A mismatch aborts.
- `upload_stage.go`, `upload_zip.go` and `uploader.go` give us two upload strategies behind a common `Uploader` interface. Stage is for small change sets, zip is for large.
- `fetcher.go` abstracts artifact and remote manifest reads so tests can inject fakes.
- `pipeline.go` owns the phase ordering and phase-skipping logic.
- `limits.go` collects sync-wide constants like `UploadRetries`, `DiskSpaceMarginMB`, `RollbackMaxFiles` and the stage-vs-zip threshold.

**`internal/workload/sync/display/`** is the pure-presentation layer. The files in there (`plan.go`, `diff.go`, `result.go`, `json.go`) render plans, diffs and results for both humans and JSON consumers. No I/O happens in there.

## TESTING

- Unit tests across all phases. Fakes for filesapi, fetcher and uploader.
- Race detector clean.
- Heavier phases got more coverage (`phase5_execute`, `rollback`, `engine`, `classify`, `plan`).
- No smoke tests yet. The engine has no CLI entry point until the third PR lands.

## NOTES

- Built and tested against the rebased foundation, not against main.
- Comment volume is intentionally lean. `doc.go` files describe package boundaries and the phase files only call out the WHY when it isn't obvious.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a substantial new sync subsystem that reads/writes the working tree, performs remote uploads/downloads/deletes, and adds locking/rollback behavior; while internal-only, mistakes could cause data loss or incorrect remote state when later wired to the CLI.
> 
> **Overview**
> Adds a new internal `internal/workload/sync` engine to power upcoming `dr workload code sync`, including phased planning/execution (preflight→state), three-way BASE/LOCAL/REMOTE classification + diffing into a `SyncPlan`, and remote-wins conflict handling.
> 
> Implements safety mechanisms around execution: project-level locking (`.wapi/sync.lock` via `golang.org/x/sys/unix` on non-Windows), stale rollback recovery and per-run `.wapi/.rollback` backups, and a preflight disk-space check before downloads.
> 
> Adds parallel stage- or zip-based upload strategies, parallel downloads with size/checksum verification, and a `display` layer to render plans/results and per-file diffs plus JSON output; includes extensive unit tests with fakes across the new components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c8fd365d4248c813ccbfce9178d8e0188bc32ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->