### PR TITLE
[RAPTOR-16922] add dr workload code versions command

### DIFF
--- a/cmd/workload/code/cmd.go
+++ b/cmd/workload/code/cmd.go
@@ -16,6 +16,7 @@ package code
 
 import (
 	initcmd "github.com/datarobot/cli/cmd/workload/code/init"
+	"github.com/datarobot/cli/cmd/workload/code/versions"
 	"github.com/spf13/cobra"
 )
 
@@ -50,6 +51,7 @@ Example:
 	}
 
 	cmd.AddCommand(initcmd.Cmd())
+	cmd.AddCommand(versions.Cmd())
 
 	return cmd
 }

--- a/cmd/workload/code/versions/cmd.go
+++ b/cmd/workload/code/versions/cmd.go
@@ -29,13 +29,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Test seams.
-var (
-	getArtifactFn = workload.GetArtifact
-	newClientFn   = filesapi.New
-)
+// Deps holds the externally-injected collaborators for the versions
+// command. Tests build a Deps with fakes and pass it to cmdWithDeps;
+// production callers go through Cmd() which uses defaultDeps().
+type Deps struct {
+	GetArtifact func(string) (*workload.Artifact, error)
+	Files       filesapi.Client
+}
+
+func defaultDeps() Deps {
+	return Deps{
+		GetArtifact: workload.GetArtifact,
+		Files:       filesapi.New(),
+	}
+}
 
 func Cmd() *cobra.Command {
+	return cmdWithDeps(defaultDeps())
+}
+
+func cmdWithDeps(deps Deps) *cobra.Command {
 	var outputFormat workload.OutputFormat
 
 	c := &cobra.Command{
@@ -62,24 +75,24 @@ Example:
   dr workload code versions --output-format json`,
 		PreRunE: auth.EnsureAuthenticatedE,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runVersions(cmd, outputFormat)
+			return runVersions(cmd, outputFormat, deps)
 		},
 	}
 
 	c.Flags().String("dir", "", "Project directory (default: current directory).")
-	c.Flags().Int("limit", 0, "Maximum number of versions to show (0 = all).")
+	c.Flags().Int("limit", 100, "Maximum number of versions to return.")
 
 	workload.AddOutputFlag(c, &outputFormat)
 
 	return c
 }
 
-func runVersions(cmd *cobra.Command, outputFormat workload.OutputFormat) error {
+func runVersions(cmd *cobra.Command, outputFormat workload.OutputFormat, deps Deps) error {
 	dirFlag, _ := cmd.Flags().GetString("dir")
 	limit, _ := cmd.Flags().GetInt("limit")
 
-	if limit < 0 {
-		return fmt.Errorf("invalid --limit %d: must be >= 0 (0 = unlimited)", limit)
+	if limit <= 0 {
+		return fmt.Errorf("invalid --limit %d: must be positive", limit)
 	}
 
 	cfg, err := loadProjectConfig(dirFlag)
@@ -87,7 +100,7 @@ func runVersions(cmd *cobra.Command, outputFormat workload.OutputFormat) error {
 		return err
 	}
 
-	v, err := buildView(cfg, limit)
+	v, err := buildView(cfg, limit, deps)
 	if err != nil {
 		return err
 	}
@@ -122,8 +135,8 @@ func loadProjectConfig(dirFlag string) (wapi.Config, error) {
 	return cfg, nil
 }
 
-func buildView(cfg wapi.Config, limit int) (view, error) {
-	art, err := getArtifactFn(cfg.ArtifactID)
+func buildView(cfg wapi.Config, limit int, deps Deps) (view, error) {
+	art, err := deps.GetArtifact(cfg.ArtifactID)
 	if err != nil {
 		var httpErr *drapi.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
@@ -133,7 +146,7 @@ func buildView(cfg wapi.Config, limit int) (view, error) {
 		return view{}, fmt.Errorf("fetch artifact %s: %w", cfg.ArtifactID, err)
 	}
 
-	versions, err := newClientFn().ListVersions(*cfg.CatalogID, limit)
+	versions, err := deps.Files.ListVersions(*cfg.CatalogID, limit)
 	if err != nil {
 		var httpErr *drapi.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {

--- a/cmd/workload/code/versions/cmd.go
+++ b/cmd/workload/code/versions/cmd.go
@@ -1,0 +1,167 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versions
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/wapi"
+	"github.com/spf13/cobra"
+)
+
+// Test seams.
+var (
+	getArtifactFn = workload.GetArtifact
+	newClientFn   = filesapi.New
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat workload.OutputFormat
+
+	c := &cobra.Command{
+		Use:          "versions",
+		Short:        "List catalog versions for the linked artifact.",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Long: `List the catalog version history for the workload artifact this
+project directory is linked to.
+
+The output marks the version that the artifact's codeRef currently
+points to with '*', and reports which version the local '.wapi/'
+state was last synced to.
+
+By default output is a human-readable table; use --output-format json
+for machine-parseable output.
+
+Run 'dr workload code init <artifact-id>' first to link a project
+directory to an artifact.
+
+Example:
+  dr workload code versions
+  dr workload code versions --limit 10
+  dr workload code versions --output-format json`,
+		PreRunE: auth.EnsureAuthenticatedE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runVersions(cmd, outputFormat)
+		},
+	}
+
+	c.Flags().String("dir", "", "Project directory (default: current directory).")
+	c.Flags().Int("limit", 0, "Maximum number of versions to show (0 = all).")
+
+	workload.AddOutputFlag(c, &outputFormat)
+
+	return c
+}
+
+func runVersions(cmd *cobra.Command, outputFormat workload.OutputFormat) error {
+	dirFlag, _ := cmd.Flags().GetString("dir")
+	limit, _ := cmd.Flags().GetInt("limit")
+
+	if limit < 0 {
+		return fmt.Errorf("invalid --limit %d: must be >= 0 (0 = unlimited)", limit)
+	}
+
+	cfg, err := loadProjectConfig(dirFlag)
+	if err != nil {
+		return err
+	}
+
+	v, err := buildView(cfg, limit)
+	if err != nil {
+		return err
+	}
+
+	return render(cmd.OutOrStdout(), outputFormat, v)
+}
+
+func loadProjectConfig(dirFlag string) (wapi.Config, error) {
+	dir := dirFlag
+	if dir == "" {
+		dir = "."
+	}
+
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return wapi.Config{}, fmt.Errorf("resolve dir %s: %w", dir, err)
+	}
+
+	if !wapi.Exists(absDir) {
+		return wapi.Config{}, errors.New("not linked to an artifact. Run 'dr workload code init <id>' first")
+	}
+
+	cfg, err := wapi.LoadConfig(absDir)
+	if err != nil {
+		return wapi.Config{}, fmt.Errorf("read .wapi/config.json: %w", err)
+	}
+
+	if cfg.CatalogID == nil || *cfg.CatalogID == "" {
+		return wapi.Config{}, errors.New("no code has been synced yet. Run 'dr workload code sync' first")
+	}
+
+	return cfg, nil
+}
+
+func buildView(cfg wapi.Config, limit int) (view, error) {
+	art, err := getArtifactFn(cfg.ArtifactID)
+	if err != nil {
+		var httpErr *drapi.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return view{}, fmt.Errorf("artifact %s not found", cfg.ArtifactID)
+		}
+
+		return view{}, fmt.Errorf("fetch artifact %s: %w", cfg.ArtifactID, err)
+	}
+
+	versions, err := newClientFn().ListVersions(*cfg.CatalogID, limit)
+	if err != nil {
+		var httpErr *drapi.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return view{}, fmt.Errorf("catalog %s not found", *cfg.CatalogID)
+		}
+
+		return view{}, fmt.Errorf("list versions: %w", err)
+	}
+
+	currentVersionID := ""
+	if codeRef := workload.ExtractCodeRef(*art); codeRef != nil {
+		currentVersionID = codeRef.CatalogVersionID
+	}
+
+	syncedVersionID := ""
+	if cfg.LastSyncedVersionID != nil {
+		syncedVersionID = *cfg.LastSyncedVersionID
+	}
+
+	return newView(*art, versions, currentVersionID, syncedVersionID), nil
+}
+
+func render(out io.Writer, format workload.OutputFormat, v view) error {
+	if format == workload.OutputFormatJSON {
+		return renderJSON(out, v)
+	}
+
+	renderText(out, v)
+
+	return nil
+}

--- a/cmd/workload/code/versions/cmd_test.go
+++ b/cmd/workload/code/versions/cmd_test.go
@@ -84,27 +84,20 @@ func (*fakeClient) DeleteFiles(string, []string) (*filesapi.DeleteFilesResp, err
 	panic("unused")
 }
 
-// withSeams installs test doubles for getArtifactFn and newClientFn for
-// the duration of t.
-func withSeams(t *testing.T, art *workload.Artifact, fc *fakeClient) {
-	t.Helper()
-
-	origArt := getArtifactFn
-	origCli := newClientFn
-
-	getArtifactFn = func(_ string) (*workload.Artifact, error) { return art, nil }
-	newClientFn = func() filesapi.Client { return fc }
-
-	t.Cleanup(func() {
-		getArtifactFn = origArt
-		newClientFn = origCli
-	})
+// fakeDeps builds a Deps with simple closures over the given artifact
+// and fake client. Tests that need to vary error returns construct a
+// Deps inline instead.
+func fakeDeps(art *workload.Artifact, fc *fakeClient) Deps {
+	return Deps{
+		GetArtifact: func(_ string) (*workload.Artifact, error) { return art, nil },
+		Files:       fc,
+	}
 }
 
-func newTestCmd(t *testing.T, dir string) (*cobra.Command, *bytes.Buffer) {
+func newTestCmd(t *testing.T, dir string, deps Deps) (*cobra.Command, *bytes.Buffer) {
 	t.Helper()
 
-	cmd := Cmd()
+	cmd := cmdWithDeps(deps)
 	cmd.PreRunE = nil
 
 	var buf bytes.Buffer
@@ -160,7 +153,7 @@ func initLinkedDir(t *testing.T, catalogID, syncedVersion string) string {
 func TestVersions_NotLinked(t *testing.T) {
 	dir := t.TempDir()
 
-	cmd, _ := newTestCmd(t, dir)
+	cmd, _ := newTestCmd(t, dir, Deps{})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -172,7 +165,7 @@ func TestVersions_NoCatalog(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{ArtifactID: "art-abc-123"}))
 
-	cmd, _ := newTestCmd(t, dir)
+	cmd, _ := newTestCmd(t, dir, Deps{})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -182,8 +175,7 @@ func TestVersions_NoCatalog(t *testing.T) {
 func TestVersions_TextOutput(t *testing.T) {
 	dir := initLinkedDir(t, "cat-1", "v2")
 
-	withSeams(
-		t,
+	deps := fakeDeps(
 		draftArtifact("art-abc-123", "my-agent", "v3aaaaaaaaaaaa"),
 		&fakeClient{
 			versions: []filesapi.CatalogVersion{
@@ -194,7 +186,7 @@ func TestVersions_TextOutput(t *testing.T) {
 		},
 	)
 
-	cmd, buf := newTestCmd(t, dir)
+	cmd, buf := newTestCmd(t, dir, deps)
 
 	require.NoError(t, cmd.Execute())
 
@@ -211,14 +203,9 @@ func TestVersions_LimitFlagPropagates(t *testing.T) {
 	dir := initLinkedDir(t, "cat-1", "")
 
 	fc := &fakeClient{}
+	deps := fakeDeps(draftArtifact("art-abc-123", "my-agent", ""), fc)
 
-	withSeams(
-		t,
-		draftArtifact("art-abc-123", "my-agent", ""),
-		fc,
-	)
-
-	cmd, _ := newTestCmd(t, dir)
+	cmd, _ := newTestCmd(t, dir, deps)
 	require.NoError(t, cmd.Flags().Set("limit", "5"))
 
 	require.NoError(t, cmd.Execute())
@@ -229,8 +216,7 @@ func TestVersions_LimitFlagPropagates(t *testing.T) {
 func TestVersions_JSONOutput(t *testing.T) {
 	dir := initLinkedDir(t, "cat-1", "")
 
-	withSeams(
-		t,
+	deps := fakeDeps(
 		draftArtifact("art-abc-123", "my-agent", "v3aaaaaaaaaaaa"),
 		&fakeClient{
 			versions: []filesapi.CatalogVersion{
@@ -240,7 +226,7 @@ func TestVersions_JSONOutput(t *testing.T) {
 		},
 	)
 
-	cmd, buf := newTestCmd(t, dir)
+	cmd, buf := newTestCmd(t, dir, deps)
 	require.NoError(t, cmd.Flags().Set("output-format", "json"))
 
 	require.NoError(t, cmd.Execute())
@@ -258,13 +244,12 @@ func TestVersions_JSONOutput(t *testing.T) {
 func TestVersions_ListVersionsErrorPropagates(t *testing.T) {
 	dir := initLinkedDir(t, "cat-1", "")
 
-	withSeams(
-		t,
+	deps := fakeDeps(
 		draftArtifact("art-abc-123", "my-agent", ""),
 		&fakeClient{listErr: errors.New("boom")},
 	)
 
-	cmd, _ := newTestCmd(t, dir)
+	cmd, _ := newTestCmd(t, dir, deps)
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -272,30 +257,35 @@ func TestVersions_ListVersionsErrorPropagates(t *testing.T) {
 	assert.Contains(t, err.Error(), "boom")
 }
 
-func TestVersions_NegativeLimitRejected(t *testing.T) {
-	dir := initLinkedDir(t, "cat-1", "")
+func TestVersions_NonPositiveLimitRejected(t *testing.T) {
+	cases := []string{"-5", "0"}
 
-	cmd, _ := newTestCmd(t, dir)
-	require.NoError(t, cmd.Flags().Set("limit", "-5"))
+	for _, val := range cases {
+		t.Run(val, func(t *testing.T) {
+			dir := initLinkedDir(t, "cat-1", "")
 
-	err := cmd.Execute()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid --limit -5")
-	assert.Contains(t, err.Error(), "0 = unlimited")
+			cmd, _ := newTestCmd(t, dir, Deps{})
+			require.NoError(t, cmd.Flags().Set("limit", val))
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid --limit "+val)
+			assert.Contains(t, err.Error(), "must be positive")
+		})
+	}
 }
 
 func TestVersions_ArtifactNotFoundSpecialized(t *testing.T) {
 	dir := initLinkedDir(t, "cat-1", "")
 
-	origArt := getArtifactFn
-
-	t.Cleanup(func() { getArtifactFn = origArt })
-
-	getArtifactFn = func(_ string) (*workload.Artifact, error) {
-		return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "test"}
+	deps := Deps{
+		GetArtifact: func(_ string) (*workload.Artifact, error) {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "test"}
+		},
+		Files: &fakeClient{},
 	}
 
-	cmd, _ := newTestCmd(t, dir)
+	cmd, _ := newTestCmd(t, dir, deps)
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -305,13 +295,12 @@ func TestVersions_ArtifactNotFoundSpecialized(t *testing.T) {
 func TestVersions_CatalogNotFoundSpecialized(t *testing.T) {
 	dir := initLinkedDir(t, "cat-1", "")
 
-	withSeams(
-		t,
+	deps := fakeDeps(
 		draftArtifact("art-abc-123", "my-agent", ""),
 		&fakeClient{listErr: &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "test"}},
 	)
 
-	cmd, _ := newTestCmd(t, dir)
+	cmd, _ := newTestCmd(t, dir, deps)
 
 	err := cmd.Execute()
 	require.Error(t, err)

--- a/cmd/workload/code/versions/cmd_test.go
+++ b/cmd/workload/code/versions/cmd_test.go
@@ -1,0 +1,319 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versions
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/wapi"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClient is a minimal in-memory filesapi.Client so the cmd tests
+// don't have to spin up an httptest server.
+type fakeClient struct {
+	versions   []filesapi.CatalogVersion
+	listErr    error
+	gotCatalog string
+	gotLimit   int
+	listCalls  int
+}
+
+func (f *fakeClient) ListVersions(catalogID string, limit int) ([]filesapi.CatalogVersion, error) {
+	f.listCalls++
+	f.gotCatalog = catalogID
+	f.gotLimit = limit
+
+	return f.versions, f.listErr
+}
+
+// Unused interface methods.
+func (*fakeClient) CreateCatalog() (*filesapi.CatalogResp, error) { panic("unused") }
+
+func (*fakeClient) CreateStage(string) (*filesapi.StageResp, error) {
+	panic("unused")
+}
+
+func (*fakeClient) UploadToStage(string, string, string, int64, io.Reader) error {
+	panic("unused")
+}
+
+func (*fakeClient) ApplyStage(string, string, string) (*filesapi.ApplyStageResp, error) {
+	panic("unused")
+}
+
+func (*fakeClient) UploadFromZipNew(string, int64, io.Reader) (*filesapi.FromFileResp, error) {
+	panic("unused")
+}
+
+func (*fakeClient) UploadFromZipExisting(string, string, string, int64, io.Reader) (*filesapi.FromFileResp, error) {
+	panic("unused")
+}
+func (*fakeClient) PollStatus(string) (*filesapi.StatusResp, error) { panic("unused") }
+func (*fakeClient) AllFiles(string, string) (map[string]filesapi.FileMeta, error) {
+	panic("unused")
+}
+
+func (*fakeClient) DownloadFile(string, string, string, io.Writer) (string, int64, error) {
+	panic("unused")
+}
+
+func (*fakeClient) DeleteFiles(string, []string) (*filesapi.DeleteFilesResp, error) {
+	panic("unused")
+}
+
+// withSeams installs test doubles for getArtifactFn and newClientFn for
+// the duration of t.
+func withSeams(t *testing.T, art *workload.Artifact, fc *fakeClient) {
+	t.Helper()
+
+	origArt := getArtifactFn
+	origCli := newClientFn
+
+	getArtifactFn = func(_ string) (*workload.Artifact, error) { return art, nil }
+	newClientFn = func() filesapi.Client { return fc }
+
+	t.Cleanup(func() {
+		getArtifactFn = origArt
+		newClientFn = origCli
+	})
+}
+
+func newTestCmd(t *testing.T, dir string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+
+	cmd := Cmd()
+	cmd.PreRunE = nil
+
+	var buf bytes.Buffer
+
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	require.NoError(t, cmd.Flags().Set("dir", dir))
+
+	return cmd, &buf
+}
+
+func draftArtifact(id, name, currentVersion string) *workload.Artifact {
+	a := &workload.Artifact{ID: id, Name: name, Status: "draft"}
+
+	if currentVersion == "" {
+		return a
+	}
+
+	a.Spec = workload.Spec{
+		ContainerGroups: []workload.ContainerGroup{{
+			Containers: []workload.Container{{
+				CodeRef: &workload.CodeRef{Datarobot: &workload.DatarobotCodeRef{
+					CatalogID:        "cat-1",
+					CatalogVersionID: currentVersion,
+				}},
+			}},
+		}},
+	}
+
+	return a
+}
+
+func initLinkedDir(t *testing.T, catalogID, syncedVersion string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{ArtifactID: "art-abc-123"}))
+
+	cfg, err := wapi.LoadConfig(dir)
+	require.NoError(t, err)
+
+	cfg.CatalogID = &catalogID
+	if syncedVersion != "" {
+		cfg.LastSyncedVersionID = &syncedVersion
+	}
+
+	require.NoError(t, wapi.SaveConfig(dir, cfg))
+
+	return dir
+}
+
+func TestVersions_NotLinked(t *testing.T) {
+	dir := t.TempDir()
+
+	cmd, _ := newTestCmd(t, dir)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not linked")
+}
+
+func TestVersions_NoCatalog(t *testing.T) {
+	// init creates .wapi/ with no catalogId set.
+	dir := t.TempDir()
+	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{ArtifactID: "art-abc-123"}))
+
+	cmd, _ := newTestCmd(t, dir)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has been synced")
+}
+
+func TestVersions_TextOutput(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1", "v2")
+
+	withSeams(
+		t,
+		draftArtifact("art-abc-123", "my-agent", "v3aaaaaaaaaaaa"),
+		&fakeClient{
+			versions: []filesapi.CatalogVersion{
+				{ID: "v3aaaaaaaaaaaa", CreatedAt: "2026-04-10T14:30:00Z", NumFiles: 47, TotalSize: 2412544},
+				{ID: "v2bbbbbbbbbbbb", CreatedAt: "2026-04-10T10:15:00Z", NumFiles: 46, TotalSize: 2300000},
+				{ID: "v1ccccccccccccc", CreatedAt: "2026-04-09T16:45:00Z", NumFiles: 45, TotalSize: 2100000},
+			},
+		},
+	)
+
+	cmd, buf := newTestCmd(t, dir)
+
+	require.NoError(t, cmd.Execute())
+
+	out := buf.String()
+	assert.Contains(t, out, "Artifact: my-agent (art-abc-123)")
+	assert.Contains(t, out, "Status:   DRAFT")
+	assert.Contains(t, out, "VERSION ID")
+	assert.Contains(t, out, "* v3aaaaaa")
+	assert.Contains(t, out, "v2bbbbbb")
+	assert.Contains(t, out, "* = current")
+}
+
+func TestVersions_LimitFlagPropagates(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1", "")
+
+	fc := &fakeClient{}
+
+	withSeams(
+		t,
+		draftArtifact("art-abc-123", "my-agent", ""),
+		fc,
+	)
+
+	cmd, _ := newTestCmd(t, dir)
+	require.NoError(t, cmd.Flags().Set("limit", "5"))
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "cat-1", fc.gotCatalog)
+	assert.Equal(t, 5, fc.gotLimit)
+}
+
+func TestVersions_JSONOutput(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1", "")
+
+	withSeams(
+		t,
+		draftArtifact("art-abc-123", "my-agent", "v3aaaaaaaaaaaa"),
+		&fakeClient{
+			versions: []filesapi.CatalogVersion{
+				{ID: "v3aaaaaaaaaaaa", CreatedAt: "2026-04-10T14:30:00Z", NumFiles: 1, TotalSize: 100},
+				{ID: "v2bbbbbbbbbbbb", CreatedAt: "2026-04-10T10:15:00Z", NumFiles: 1, TotalSize: 50},
+			},
+		},
+	)
+
+	cmd, buf := newTestCmd(t, dir)
+	require.NoError(t, cmd.Flags().Set("output-format", "json"))
+
+	require.NoError(t, cmd.Execute())
+
+	var got []jsonRow
+
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	require.Len(t, got, 2)
+	assert.Equal(t, "v3aaaaaaaaaaaa", got[0].VersionID)
+	assert.Equal(t, "v3aaaaaa", got[0].VersionShort)
+	assert.True(t, got[0].IsCurrent)
+	assert.False(t, got[1].IsCurrent)
+}
+
+func TestVersions_ListVersionsErrorPropagates(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1", "")
+
+	withSeams(
+		t,
+		draftArtifact("art-abc-123", "my-agent", ""),
+		&fakeClient{listErr: errors.New("boom")},
+	)
+
+	cmd, _ := newTestCmd(t, dir)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list versions")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestVersions_NegativeLimitRejected(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1", "")
+
+	cmd, _ := newTestCmd(t, dir)
+	require.NoError(t, cmd.Flags().Set("limit", "-5"))
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --limit -5")
+	assert.Contains(t, err.Error(), "0 = unlimited")
+}
+
+func TestVersions_ArtifactNotFoundSpecialized(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1", "")
+
+	origArt := getArtifactFn
+
+	t.Cleanup(func() { getArtifactFn = origArt })
+
+	getArtifactFn = func(_ string) (*workload.Artifact, error) {
+		return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "test"}
+	}
+
+	cmd, _ := newTestCmd(t, dir)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Equal(t, "artifact art-abc-123 not found", err.Error())
+}
+
+func TestVersions_CatalogNotFoundSpecialized(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1", "")
+
+	withSeams(
+		t,
+		draftArtifact("art-abc-123", "my-agent", ""),
+		&fakeClient{listErr: &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "test"}},
+	)
+
+	cmd, _ := newTestCmd(t, dir)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Equal(t, "catalog cat-1 not found", err.Error())
+}

--- a/cmd/workload/code/versions/view.go
+++ b/cmd/workload/code/versions/view.go
@@ -18,12 +18,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
-	"text/tabwriter"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
 	"github.com/datarobot/cli/internal/drapi/filesapi"
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/tui"
 )
 
 const shortVersionLen = 8
@@ -89,8 +92,32 @@ func renderText(out io.Writer, v view) {
 		return
 	}
 
-	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "VERSION ID\tFILES\tSIZE\tCREATED AT")
+	markerStyle := tui.BaseTextStyle.
+		Foreground(tui.GetAdaptiveColor(tui.DrPurple, tui.DrPurpleDark)).
+		Padding(0, 1)
+
+	cellStyle := tui.BaseTextStyle.Padding(0, 1)
+
+	dimStyle := tui.DimStyle.Padding(0, 1)
+
+	t := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(tui.TableBorderStyle).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return cellStyle.Bold(true)
+			}
+
+			switch col {
+			case 0:
+				return markerStyle
+			case 3:
+				return dimStyle
+			default:
+				return cellStyle
+			}
+		}).
+		Headers("VERSION ID", "FILES", "SIZE", "CREATED AT")
 
 	for _, row := range v.Versions {
 		marker := "  "
@@ -98,17 +125,15 @@ func renderText(out io.Writer, v view) {
 			marker = "* "
 		}
 
-		fmt.Fprintf(
-			w, "%s%s\t%d\t%s\t%s\n",
-			marker,
-			row.Short,
-			row.NumFiles,
+		t.Row(
+			marker+row.Short,
+			strconv.Itoa(row.NumFiles),
 			humanBytes(row.TotalSize),
 			formatCreatedAt(row.CreatedAt),
 		)
 	}
 
-	w.Flush()
+	fmt.Fprintln(out, t.Render())
 
 	if v.CurrentVersionID != "" {
 		fmt.Fprintln(out, "\n* = current (artifact codeRef)")

--- a/cmd/workload/code/versions/view.go
+++ b/cmd/workload/code/versions/view.go
@@ -1,0 +1,185 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versions
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/datarobot/cli/internal/workload"
+)
+
+const shortVersionLen = 8
+
+// view is the rendered shape, decoupled from the API types.
+type view struct {
+	ArtifactID       string
+	ArtifactName     string
+	ArtifactStatus   string
+	Versions         []versionRow
+	CurrentVersionID string
+	SyncedVersionID  string
+}
+
+type versionRow struct {
+	ID        string
+	Short     string
+	CreatedAt string
+	NumFiles  int
+	TotalSize int64
+	IsCurrent bool
+}
+
+func newView(art workload.Artifact, vs []filesapi.CatalogVersion, currentID, syncedID string) view {
+	rows := make([]versionRow, len(vs))
+	for i, v := range vs {
+		rows[i] = versionRow{
+			ID:        v.ID,
+			Short:     shortID(v.ID),
+			CreatedAt: v.CreatedAt,
+			NumFiles:  v.NumFiles,
+			TotalSize: v.TotalSize,
+			IsCurrent: v.ID == currentID,
+		}
+	}
+
+	return view{
+		ArtifactID:       art.ID,
+		ArtifactName:     art.Name,
+		ArtifactStatus:   strings.ToUpper(art.Status),
+		Versions:         rows,
+		CurrentVersionID: currentID,
+		SyncedVersionID:  syncedID,
+	}
+}
+
+func shortID(id string) string {
+	if len(id) > shortVersionLen {
+		return id[:shortVersionLen]
+	}
+
+	return id
+}
+
+// renderText prints the human-readable table.
+func renderText(out io.Writer, v view) {
+	fmt.Fprintf(out, "Artifact: %s (%s)\n", v.ArtifactName, v.ArtifactID)
+	fmt.Fprintf(out, "Status:   %s\n\n", v.ArtifactStatus)
+
+	if len(v.Versions) == 0 {
+		fmt.Fprintln(out, "No versions found.")
+
+		return
+	}
+
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "VERSION ID\tFILES\tSIZE\tCREATED AT")
+
+	for _, row := range v.Versions {
+		marker := "  "
+		if row.IsCurrent {
+			marker = "* "
+		}
+
+		fmt.Fprintf(
+			w, "%s%s\t%d\t%s\t%s\n",
+			marker,
+			row.Short,
+			row.NumFiles,
+			humanBytes(row.TotalSize),
+			formatCreatedAt(row.CreatedAt),
+		)
+	}
+
+	w.Flush()
+
+	if v.CurrentVersionID != "" {
+		fmt.Fprintln(out, "\n* = current (artifact codeRef)")
+	}
+
+	if v.SyncedVersionID != "" {
+		fmt.Fprintf(out, "Local synced to: %s\n", shortID(v.SyncedVersionID))
+	}
+}
+
+// jsonRow is the output schema for --output-format json.
+type jsonRow struct {
+	VersionID    string `json:"versionId"`
+	VersionShort string `json:"versionShort"`
+	CreatedAt    string `json:"createdAt"`
+	FileCount    int    `json:"fileCount"`
+	TotalSize    int64  `json:"totalSize"`
+	IsCurrent    bool   `json:"isCurrent"`
+}
+
+func renderJSON(out io.Writer, v view) error {
+	rows := make([]jsonRow, len(v.Versions))
+	for i, r := range v.Versions {
+		rows[i] = jsonRow{
+			VersionID:    r.ID,
+			VersionShort: r.Short,
+			CreatedAt:    r.CreatedAt,
+			FileCount:    r.NumFiles,
+			TotalSize:    r.TotalSize,
+			IsCurrent:    r.IsCurrent,
+		}
+	}
+
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+
+	return enc.Encode(rows)
+}
+
+func formatCreatedAt(s string) string {
+	if s == "" {
+		return "—"
+	}
+
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		t, err = time.Parse(time.RFC3339, s)
+		if err != nil {
+			return s
+		}
+	}
+
+	return t.UTC().Format("2006-01-02 15:04 UTC")
+}
+
+// humanBytes renders an int64 byte count as KB/MB/GB with one decimal.
+// 1 KB = 1024 B (binary), matching how engine and limits already think.
+func humanBytes(n int64) string {
+	const unit = 1024
+
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+
+	suffix := []string{"KB", "MB", "GB", "TB", "PB"}[exp]
+
+	return fmt.Sprintf("%.1f %s", float64(n)/float64(div), suffix)
+}

--- a/internal/drapi/filesapi/client.go
+++ b/internal/drapi/filesapi/client.go
@@ -29,6 +29,7 @@ type Client interface {
 	AllFiles(catalogID, versionID string) (map[string]FileMeta, error)
 	DownloadFile(catalogID, versionID, path string, w io.Writer) (string, int64, error)
 	DeleteFiles(catalogID string, paths []string) (*DeleteFilesResp, error)
+	ListVersions(catalogID string, limit int) ([]CatalogVersion, error)
 }
 
 func New() Client {

--- a/internal/drapi/filesapi/types.go
+++ b/internal/drapi/filesapi/types.go
@@ -126,3 +126,21 @@ type DeleteFilesResult struct {
 	Path            string `json:"path"`
 	NumFilesDeleted int    `json:"numFilesDeleted"`
 }
+
+type CatalogVersionsResp struct {
+	Data       []CatalogVersion `json:"data"`
+	Count      int              `json:"count"`
+	TotalCount int              `json:"totalCount"`
+	Next       string           `json:"next"`
+	Previous   string           `json:"previous"`
+}
+
+// CatalogVersion is a single entry in the version-history listing for a
+// catalog. CreatedAt is RFC 3339 with optional microseconds; callers parse
+// it as needed.
+type CatalogVersion struct {
+	ID        string `json:"catalogVersionId"`
+	CreatedAt string `json:"creationDate"`
+	NumFiles  int    `json:"numFiles"`
+	TotalSize int64  `json:"size"`
+}

--- a/internal/drapi/filesapi/versions.go
+++ b/internal/drapi/filesapi/versions.go
@@ -1,0 +1,72 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesapi
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// versionsPageSize controls the per-request page size for ListVersions.
+// The server caps this server-side; we set the requested page size to a
+// large round number so a typical artifact's full history fits in one or
+// two round trips.
+const versionsPageSize = 100
+
+// ListVersions returns the catalog's version history newest-first. When
+// limit > 0 the result is truncated to that many entries (pagination
+// stops as soon as the cap is reached). When limit <= 0 every page is
+// followed until the server returns no Next cursor.
+func (c *httpClient) ListVersions(catalogID string, limit int) ([]CatalogVersion, error) {
+	q := url.Values{}
+	q.Set("orderBy", "-created")
+	q.Set("limit", strconv.Itoa(versionsPageSize))
+
+	pageURL, err := drapi.EndpointURL("/files/"+catalogID+"/versions/", q)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]CatalogVersion, 0)
+
+	for pageURL != "" {
+		var page CatalogVersionsResp
+
+		if err := drapi.GetJSON(pageURL, "versions", &page); err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.Data {
+			out = append(out, v)
+			if limit > 0 && len(out) >= limit {
+				return out, nil
+			}
+		}
+
+		if page.Next == "" {
+			break
+		}
+
+		if err := assertNextOnSameHost(page.Next); err != nil {
+			return nil, err
+		}
+
+		pageURL = page.Next
+	}
+
+	return out, nil
+}

--- a/internal/drapi/filesapi/versions_test.go
+++ b/internal/drapi/filesapi/versions_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filesapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListVersions_SinglePage(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/files/cid-1/versions/", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "-created", r.URL.Query().Get("orderBy"))
+
+		page := CatalogVersionsResp{
+			Data: []CatalogVersion{
+				{ID: "v3", CreatedAt: "2026-04-10T14:30:00Z", NumFiles: 47, TotalSize: 2412544},
+				{ID: "v2", CreatedAt: "2026-04-10T10:15:00Z", NumFiles: 46, TotalSize: 2300000},
+				{ID: "v1", CreatedAt: "2026-04-09T16:45:00Z", NumFiles: 45, TotalSize: 2100000},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(page))
+	})
+
+	startServer(t, mux)
+
+	got, err := New().ListVersions("cid-1", 0)
+	require.NoError(t, err)
+	assert.Len(t, got, 3)
+	assert.Equal(t, "v3", got[0].ID)
+	assert.Equal(t, 47, got[0].NumFiles)
+	assert.Equal(t, int64(2412544), got[0].TotalSize)
+}
+
+func TestListVersions_Pagination(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/files/cid-1/versions/", func(w http.ResponseWriter, r *http.Request) {
+		offset := r.URL.Query().Get("offset")
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if offset == "" {
+			page1 := CatalogVersionsResp{
+				Data: []CatalogVersion{
+					{ID: "v5", CreatedAt: "2026-04-10T14:30:00Z", NumFiles: 5, TotalSize: 500},
+					{ID: "v4", CreatedAt: "2026-04-10T13:30:00Z", NumFiles: 4, TotalSize: 400},
+				},
+			}
+
+			page1.Next = "http://" + r.Host + r.URL.Path + "?offset=2"
+			assert.NoError(t, json.NewEncoder(w).Encode(page1))
+
+			return
+		}
+
+		page2 := CatalogVersionsResp{
+			Data: []CatalogVersion{
+				{ID: "v3", CreatedAt: "2026-04-10T12:30:00Z", NumFiles: 3, TotalSize: 300},
+			},
+		}
+		assert.NoError(t, json.NewEncoder(w).Encode(page2))
+	})
+
+	startServer(t, mux)
+
+	got, err := New().ListVersions("cid-1", 0)
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	assert.Equal(t, "v5", got[0].ID)
+	assert.Equal(t, "v3", got[2].ID)
+}
+
+func TestListVersions_LimitTruncatesMidPage(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/files/cid-1/versions/", func(w http.ResponseWriter, _ *http.Request) {
+		page := CatalogVersionsResp{
+			Data: []CatalogVersion{
+				{ID: "v5"}, {ID: "v4"}, {ID: "v3"}, {ID: "v2"}, {ID: "v1"},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(page))
+	})
+
+	startServer(t, mux)
+
+	got, err := New().ListVersions("cid-1", 2)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "v5", got[0].ID)
+	assert.Equal(t, "v4", got[1].ID)
+}
+
+func TestListVersions_RejectsCrossHostNext(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/files/cid-1/versions/", func(w http.ResponseWriter, _ *http.Request) {
+		page := CatalogVersionsResp{
+			Data: []CatalogVersion{{ID: "v1"}},
+		}
+		page.Next = "https://attacker.example/api/v2/files/cid-1/versions/?offset=1"
+
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(page))
+	})
+
+	startServer(t, mux)
+
+	got, err := New().ListVersions("cid-1", 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "host")
+	assert.Nil(t, got)
+}
+
+// TestListVersions_DecodesRealServerShape pins the JSON field names used
+// by the FilesAPI versions endpoint (catalogVersionId, creationDate,
+// numFiles, size) so a future field rename in CatalogVersion can't
+// silently break decoding.
+func TestListVersions_DecodesRealServerShape(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/files/cid-1/versions/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"count": 1,
+			"totalCount": 1,
+			"next": null,
+			"previous": null,
+			"data": [{
+				"catalogId": "cid-1",
+				"catalogVersionId": "ver-abc-1",
+				"numFiles": 3,
+				"creationDate": "2026-04-30T13:54:38.562000Z",
+				"isLatest": true,
+				"createdBy": "test",
+				"isStage": false,
+				"size": 615
+			}]
+		}`))
+	})
+
+	startServer(t, mux)
+
+	got, err := New().ListVersions("cid-1", 0)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "ver-abc-1", got[0].ID)
+	assert.Equal(t, "2026-04-30T13:54:38.562000Z", got[0].CreatedAt)
+	assert.Equal(t, 3, got[0].NumFiles)
+	assert.Equal(t, int64(615), got[0].TotalSize)
+}
+
+func TestListVersions_EmptyResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/files/cid-1/versions/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(CatalogVersionsResp{}))
+	})
+
+	startServer(t, mux)
+
+	got, err := New().ListVersions("cid-1", 0)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}


### PR DESCRIPTION
# RATIONALE

`dr workload code versions` command lists the catalog version history for the workload artifact that the current project directory is linked to.

The command depends on the `filesapi` package, which lives only on `wojtekw/RAPTOR-16924-foundation`, so this branch is stacked on top of foundation. Once foundation lands, this branch can be re-targeted to main with a simple rebase.

## CHANGES

### filesapi

- New `CatalogVersion` and `CatalogVersionsResp` types in `types.go`, with JSON tags matching the real wire shape (`catalogVersionId`, `creationDate`, `numFiles`, `size`).
- New `ListVersions(catalogID, limit)` method on `filesapi.Client`. Paginates through `Next` and reuses the cross-host safety check from `AllFiles`.
- A regression test pinning the JSON field names, so future renames cannot silently break decoding.

### cmd

- New `cmd/workload/code/versions/` package, registered alongside `init`.
- Auth gated through `PreRunE: auth.EnsureAuthenticatedE`, same as the other workload commands.
- Test seam vars (`getArtifactFn`, `newClientFn`) follow the precedent in `code/init`.
- 404 from the artifact GET or the version listing is specialized to `artifact X not found` and `catalog X not found`, mirroring init.
- `--limit` rejects negative values, and 0 means unlimited (per the spec).

### Display

Human output is a tab-aligned table with a `*` marker on the current `codeRef` row, and a trailing line that names the locally synced version. JSON output is a flat array of objects with `versionId`, `versionShort`, `createdAt`, `fileCount`, `totalSize`, and `isCurrent`.

## TESTING

Unit tests cover filesapi pagination, the limit cap, cross-host rejection, real-wire-shape decoding, and the empty case. Cmd tests cover not-linked, no-catalog, text and JSON output, the negative-limit rejection, and both 404 paths. Manually smoke-tested against staging on an artifact with four real versions.

## NOTES

Stacked on `wojtekw/RAPTOR-16924-foundation` (PR 470). Review foundation first. No changes outside the listed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI subcommand and a new Files API client method with pagination, which could affect users via incorrect listings or API error handling. Security risk is low, but it introduces new network calls and output formatting paths that should be validated against real server responses.
> 
> **Overview**
> Adds `dr workload code versions` under `dr workload code`, which reads the local `.wapi/` link state, fetches the linked artifact and its Files API catalog version history, and renders either a table or `--output-format json` output marking the artifact’s current `codeRef` version and the locally last-synced version.
> 
> Extends `internal/drapi/filesapi` with `ListVersions(catalogID, limit)` plus new response/types for decoding the versions endpoint, including cursor pagination with same-host enforcement. Includes unit tests for the command behavior (not-linked/no-catalog, limit validation, JSON/text output, 404 specialization) and for the Files API pagination/decoding edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 686930dddf7336077eac37e0d4bd73b7a53cfa2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->