### PR TITLE
[BUZZOK-30268] Fix Taskfile discovery on Windows

### DIFF
--- a/internal/envbuilder/discover_test.go
+++ b/internal/envbuilder/discover_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -167,4 +168,40 @@ func (suite *DiscoverTestSuite) TestDiscoverFindsNestedFiles() {
 	suite.Contains(foundPaths, suite.tempDir+"/.datarobot/parakeet.yaml")
 	suite.Contains(foundPaths, suite.tempDir+"/.datarobot/another_parakeet.yaml")
 	suite.Contains(foundPaths, suite.tempDir+"/.datarobot/parakeet/yet_another_parakeet.yml")
+}
+
+func TestDepth(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected int
+	}{
+		{
+			name:     "current directory",
+			path:     ".",
+			expected: 0,
+		},
+		{
+			name:     "single level",
+			path:     "dir",
+			expected: 1,
+		},
+		{
+			name:     "two levels",
+			path:     "dir/subdir",
+			expected: 2,
+		},
+		{
+			name:     "three levels",
+			path:     "dir/subdir/nested",
+			expected: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := depth(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/internal/envbuilder/discovery.go
+++ b/internal/envbuilder/discovery.go
@@ -26,12 +26,14 @@ import (
 
 // depth gets our current directory depth by file path
 func depth(path string) int {
-	if path == "." {
+	// Windows uses backslashes, so we normalize to forward slashes
+	normalized := filepath.ToSlash(path)
+	if normalized == "." {
 		return 0
 	}
 
 	// +1 to count the root directory itself
-	return strings.Count(path, "/") + 1
+	return strings.Count(normalized, "/") + 1
 }
 
 func Discover(root string, maxDepth int) ([]string, error) {

--- a/internal/task/discovery.go
+++ b/internal/task/discovery.go
@@ -84,12 +84,14 @@ type taskfileMetadata struct {
 
 // depth gets our current directory depth by file path
 func depth(path string) int {
-	if path == "." {
+	// Windows uses backslashes, so we normalize to forward slashes
+	normalized := filepath.ToSlash(path)
+	if normalized == "." {
 		return 0
 	}
 
 	// +1 to count the root directory itself
-	return strings.Count(path, "/") + 1
+	return strings.Count(normalized, "/") + 1
 }
 
 type Discovery struct {
@@ -207,12 +209,13 @@ func (d *Discovery) findComponents(root string, maxDepth int) ([]componentInclud
 			return nil
 		}
 
+		slashRel := filepath.ToSlash(relPath)
 		dirPath := filepath.ToSlash(filepath.Dir(relPath))
 		dirName := filepath.ToSlash(filepath.Base(dirPath))
 
 		includes = append(includes, componentInclude{
 			Name:     dirName,
-			Taskfile: "./" + relPath,
+			Taskfile: "./" + slashRel,
 			Dir:      "./" + dirPath,
 		})
 

--- a/internal/task/discovery_test.go
+++ b/internal/task/discovery_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestDiscoveryTestSuite(t *testing.T) {
+	suite.Run(t, new(DiscoveryTestSuite))
+}
+
+type DiscoveryTestSuite struct {
+	suite.Suite
+	tempDir string
+}
+
+func (suite *DiscoveryTestSuite) SetupTest() {
+	dir, err := os.MkdirTemp("", "task_discovery_test")
+	suite.Require().NoError(err)
+	suite.tempDir = dir
+}
+
+func (suite *DiscoveryTestSuite) TearDownTest() {
+	os.RemoveAll(suite.tempDir)
+}
+
+func TestDepth(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected int
+	}{
+		{
+			name:     "current directory",
+			path:     ".",
+			expected: 0,
+		},
+		{
+			name:     "single level",
+			path:     "dir",
+			expected: 1,
+		},
+		{
+			name:     "two levels",
+			path:     "dir/subdir",
+			expected: 2,
+		},
+		{
+			name:     "three levels",
+			path:     "dir/subdir/nested",
+			expected: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := depth(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func (suite *DiscoveryTestSuite) TestFindComponentsNormalizesWindowsPaths() {
+	discovery := &Discovery{
+		RootTaskfileName: "Taskfile.yaml",
+	}
+
+	// Create nested taskfile structure:
+	//   tempDir/
+	//   ├── component1/
+	//   │   └── taskfile.yaml
+	//   └── nested/
+	//       └── component2/
+	//           └── taskfile.yaml
+	comp1Dir := filepath.Join(suite.tempDir, "component1")
+	comp2Dir := filepath.Join(suite.tempDir, "nested", "component2")
+
+	suite.Require().NoError(os.MkdirAll(comp1Dir, os.ModePerm))
+	suite.Require().NoError(os.MkdirAll(comp2Dir, os.ModePerm))
+
+	// Each taskfile.yaml contains:
+	// tasks:
+	//   test:
+	//     cmds:
+	//       - echo test
+	comp1File := filepath.Join(comp1Dir, "taskfile.yaml")
+	comp2File := filepath.Join(comp2Dir, "taskfile.yaml")
+
+	taskfileContent := "tasks:\n  test:\n    cmds:\n      - echo test\n"
+	suite.Require().NoError(os.WriteFile(comp1File, []byte(taskfileContent), 0o644))
+	suite.Require().NoError(os.WriteFile(comp2File, []byte(taskfileContent), 0o644))
+
+	includes, err := discovery.findComponents(suite.tempDir, 5)
+
+	suite.Require().NoError(err)
+	suite.Len(includes, 2)
+
+	// Verify that paths use forward slashes, not backslashes
+	for _, include := range includes {
+		suite.NotContains(include.Taskfile, "\\", "Taskfile path should not contain backslashes")
+		suite.NotContains(include.Dir, "\\", "Dir path should not contain backslashes")
+		suite.True(filepath.IsAbs(include.Taskfile) || include.Taskfile[0] == '.', "Path should be relative or absolute")
+	}
+}
+
+func (suite *DiscoveryTestSuite) TestFindComponentsRespectsMaxDepth() {
+	discovery := &Discovery{
+		RootTaskfileName: "Taskfile.yaml",
+	}
+
+	// Create nested structure with different depths:
+	//   tempDir/
+	//   ├── shallow/
+	//   │   └── taskfile.yaml (depth 1)
+	//   └── a/b/c/d/
+	//       └── taskfile.yaml (depth 4)
+	shallow := filepath.Join(suite.tempDir, "shallow")
+	deep := filepath.Join(suite.tempDir, "a", "b", "c", "d")
+
+	suite.Require().NoError(os.MkdirAll(shallow, os.ModePerm))
+	suite.Require().NoError(os.MkdirAll(deep, os.ModePerm))
+
+	// Each taskfile.yaml contains minimal structure:
+	// tasks: {}
+	suite.Require().NoError(os.WriteFile(filepath.Join(shallow, "taskfile.yaml"), []byte("tasks: {}"), 0o644))
+	suite.Require().NoError(os.WriteFile(filepath.Join(deep, "taskfile.yaml"), []byte("tasks: {}"), 0o644))
+
+	// Test with maxDepth=2 - should find shallow (depth 1) but not deep (depth 4)
+	includes, err := discovery.findComponents(suite.tempDir, 2)
+	suite.Require().NoError(err)
+
+	// Should only find the shallow component
+	suite.Len(includes, 1)
+	suite.Equal("shallow", includes[0].Name)
+}
+
+func (suite *DiscoveryTestSuite) TestFindComponentsSkipsHiddenDirs() {
+	discovery := &Discovery{
+		RootTaskfileName: "Taskfile.yaml",
+	}
+
+	// Create visible and hidden directories:
+	//   tempDir/
+	//   ├── visible/
+	//   │   └── taskfile.yaml (should be discovered)
+	//   └── .hidden/
+	//       └── taskfile.yaml (should be skipped)
+	visibleDir := filepath.Join(suite.tempDir, "visible")
+	hiddenDir := filepath.Join(suite.tempDir, ".hidden")
+
+	suite.Require().NoError(os.MkdirAll(visibleDir, os.ModePerm))
+	suite.Require().NoError(os.MkdirAll(hiddenDir, os.ModePerm))
+
+	// Each taskfile.yaml contains minimal structure:
+	// tasks: {}
+	suite.Require().NoError(os.WriteFile(filepath.Join(visibleDir, "taskfile.yaml"), []byte("tasks: {}"), 0o644))
+	suite.Require().NoError(os.WriteFile(filepath.Join(hiddenDir, "taskfile.yaml"), []byte("tasks: {}"), 0o644))
+
+	includes, err := discovery.findComponents(suite.tempDir, 5)
+
+	suite.Require().NoError(err)
+	suite.Len(includes, 1)
+	suite.Equal("visible", includes[0].Name)
+}


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

CLI fails to find a Taskfile properly on Windows with error message "No start command or quickstart script found". This PR fixes this error by normalizing path to forward slashed when calculating depth.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

Before:
<img width="923" height="792" alt="image" src="https://github.com/user-attachments/assets/13a2e4a0-0ec5-491e-8e86-fce112a8e3e6" />
After:
<img width="973" height="1032" alt="image" src="https://github.com/user-attachments/assets/6c7dd015-ce9a-4344-913a-c784e3e3894a" />



## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix limited to path normalization in discovery utilities, with added tests to lock in behavior across platforms.
> 
> **Overview**
> Fixes component discovery on Windows by normalizing file paths to forward slashes before calculating `depth`, ensuring max-depth checks behave consistently.
> 
> Also normalizes discovered Taskfile include paths (`Taskfile`/`Dir`) to use forward slashes, and adds targeted unit tests for `depth`, Windows path normalization, max-depth handling, and hidden-directory skipping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a83dba0df180968e119f067a7208f110da7dd43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->