### PR TITLE
[CFX-5786][CFX-5787] `dr start -y` installs deps , `dr start` asks to install deps

### DIFF
--- a/cmd/dependencies/check/cmd.go
+++ b/cmd/dependencies/check/cmd.go
@@ -33,11 +33,9 @@ func Cmd() *cobra.Command {
 }
 
 func RunE(cmd *cobra.Command, _ []string) error {
-	missing := tools.MissingPrerequisites()
-
-	if missing != "" {
-		cmd.SilenceUsage = true
-		return errors.New(missing)
+	_, _, missingMsgs, wrongVersionMsgs := tools.CheckPrerequisites()
+	if len(missingMsgs) > 0 || len(wrongVersionMsgs) > 0 {
+		return errors.New(tools.PrerequisitesMsg(missingMsgs, wrongVersionMsgs))
 	}
 
 	fmt.Fprintln(cmd.OutOrStdout(), "✅ All dependencies are already up to date.")

--- a/cmd/dependencies/check/cmd.go
+++ b/cmd/dependencies/check/cmd.go
@@ -35,6 +35,7 @@ func Cmd() *cobra.Command {
 func RunE(cmd *cobra.Command, _ []string) error {
 	_, _, missingMsgs, wrongVersionMsgs := tools.CheckPrerequisites()
 	if len(missingMsgs) > 0 || len(wrongVersionMsgs) > 0 {
+		cmd.SilenceUsage = true
 		return errors.New(tools.PrerequisitesMsg(missingMsgs, wrongVersionMsgs))
 	}
 

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -20,6 +20,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/cmd/templates/setup"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
@@ -102,6 +103,10 @@ The following actions will be performed:
 	}
 
 	cmd.Flags().BoolVarP(&opts.AnswerYes, "yes", "y", false, "Assume \"yes\" as answer to all prompts.")
+
+	// Bind flag to viper to enable env var support (DATAROBOT_CLI_NON_INTERACTIVE)
+	_ = viperx.BindPFlag("yes", cmd.Flags().Lookup("yes"))
+	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.Track(cmd)
 

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -15,6 +15,7 @@
 package start
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -26,6 +27,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/datarobot/cli/internal/dependencies"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/internal/state"
@@ -50,11 +52,13 @@ type Model struct {
 	hideMenu             bool
 	quitting             bool
 	err                  error
-	stepCompleteMessage  string // Optional message from the completed step
-	quickstartScriptPath string // Path to the quickstart script to execute
-	selfUpdate           bool   // Whether to ask for self update
-	waitingToExecute     bool   // Whether to wait for user input before proceeding
-	needTemplateSetup    bool   // Whether we need to run template setup after quitting
+	stepCompleteMessage  string               // Optional message from the completed step
+	quickstartScriptPath string               // Path to the quickstart script to execute
+	selfUpdate           bool                 // Whether to ask for self update
+	waitingToExecute     bool                 // Whether to wait for user input before proceeding
+	waitingToInstall     bool                 // Whether to wait for user confirmation before installing deps
+	depsToInstall        []tools.Prerequisite // Deps to install when user confirms
+	needTemplateSetup    bool                 // Whether we need to run template setup after quitting
 	repoRoot             string
 }
 
@@ -73,6 +77,16 @@ type startScriptCompleteMsg struct{ err error }
 
 type stepErrorMsg struct {
 	err error // Error encountered during step execution
+}
+
+type depsMissingMsg struct {
+	prerequisites []tools.Prerequisite
+	message       string
+}
+
+type depsInstallCompleteMsg struct {
+	err    error
+	output string
 }
 
 // err messages used in the start command.
@@ -185,6 +199,16 @@ func (m Model) execSelfUpdate() tea.Cmd {
 	})
 }
 
+func (m Model) execInstallDeps() tea.Cmd {
+	return func() tea.Msg {
+		var buf bytes.Buffer
+
+		err := dependencies.InstallPrerequisites(&buf, m.depsToInstall)
+
+		return depsInstallCompleteMsg{err: err, output: buf.String()}
+	}
+}
+
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -215,6 +239,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		return m, tea.Quit
+
+	case depsMissingMsg:
+		return m.handleDepsMissing(msg)
+
+	case depsInstallCompleteMsg:
+		return m.handleDepsInstallComplete(msg)
 	}
 
 	return m, nil
@@ -228,41 +258,14 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	}
 
+	// If we're waiting for user confirmation to install missing deps
+	if m.waitingToInstall {
+		return m.handleInstallConfirmKey(msg)
+	}
+
 	// If we're waiting for user confirmation to execute the script
 	if m.waitingToExecute {
-		switch msg.String() {
-		case "y", "Y", "enter":
-			// Punch it, Chewie!
-			m.waitingToExecute = false
-			m.stepCompleteMessage = ""
-
-			if m.selfUpdate {
-				return m, m.execSelfUpdate()
-			}
-
-			if m.quickstartScriptPath != "" {
-				return m, m.execQuickstartScript()
-			}
-
-			return m.executeNextStep()
-		case "n", "N", "q", "esc":
-			// Just hang on. Hang on, Dak.
-			if m.selfUpdate {
-				m.selfUpdate = false
-				return m.handleStepComplete(stepCompleteMsg{})
-			}
-
-			// User chose to not execute script, so update state and quit
-			if m.repoRoot != "" {
-				_ = state.UpdateAfterSuccessfulRun(m.repoRoot)
-			}
-
-			m.quitting = true
-
-			return m, tea.Quit
-		}
-		// Ignore other keys when waiting
-		return m, nil
+		return m.handleWaitingToExecuteKey(msg)
 	}
 
 	// Normal key handling when not waiting
@@ -313,6 +316,85 @@ func (m Model) handleStepComplete(msg stepCompleteMsg) (tea.Model, tea.Cmd) {
 
 	// Move to next step
 	return m.executeNextStep()
+}
+
+func (m Model) handleDepsMissing(msg depsMissingMsg) (tea.Model, tea.Cmd) {
+	m.depsToInstall = msg.prerequisites
+	m.stepCompleteMessage = msg.message
+
+	if m.opts.AnswerYes {
+		return m, m.execInstallDeps()
+	}
+
+	m.waitingToInstall = true
+
+	return m, nil
+}
+
+func (m Model) handleDepsInstallComplete(msg depsInstallCompleteMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		m.err = msg.err
+
+		return m, tea.Quit
+	}
+
+	m.stepCompleteMessage = msg.output
+
+	return m.executeNextStep()
+}
+
+func (m Model) handleWaitingToExecuteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "y", "Y", "enter":
+		// Punch it, Chewie!
+		m.waitingToExecute = false
+		m.stepCompleteMessage = ""
+
+		if m.selfUpdate {
+			return m, m.execSelfUpdate()
+		}
+
+		if m.quickstartScriptPath != "" {
+			return m, m.execQuickstartScript()
+		}
+
+		return m.executeNextStep()
+	case "n", "N", "q", "esc":
+		// Just hang on. Hang on, Dak.
+		if m.selfUpdate {
+			m.selfUpdate = false
+
+			return m.handleStepComplete(stepCompleteMsg{})
+		}
+
+		// User chose to not execute script, so update state and quit
+		if m.repoRoot != "" {
+			_ = state.UpdateAfterSuccessfulRun(m.repoRoot)
+		}
+
+		m.quitting = true
+
+		return m, tea.Quit
+	}
+
+	// Ignore other keys when waiting
+	return m, nil
+}
+
+func (m Model) handleInstallConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "y", "Y", "enter":
+		m.waitingToInstall = false
+		m.stepCompleteMessage = ""
+
+		return m, m.execInstallDeps()
+	case "n", "N", "q", "esc":
+		m.err = errors.New("Installation cancelled. Run 'dr dependencies install' to install missing dependencies.")
+
+		return m, tea.Quit
+	}
+
+	return m, nil
 }
 
 func (m *Model) updateFromStepComplete(msg stepCompleteMsg) {
@@ -378,7 +460,9 @@ func (m Model) View() string { //nolint: cyclop
 	if !m.done && !m.quitting {
 		sb.WriteString("\n")
 
-		if m.waitingToExecute {
+		if m.waitingToInstall {
+			sb.WriteString(tui.DimStyle.Render("Press 'y' or ENTER to install, 'n' to cancel"))
+		} else if m.waitingToExecute {
 			sb.WriteString(tui.DimStyle.Render("Press 'y' or ENTER to confirm, 'n' to cancel"))
 		} else if !m.selfUpdate {
 			sb.WriteString(tui.Footer())
@@ -422,22 +506,19 @@ func checkSelfVersion(_ *Model) tea.Msg {
 }
 
 func checkPrerequisites(_ *Model) tea.Msg {
-	// Return stepErrorMsg{err} if prerequisites are not met
+	missingTools, wrongVersionTools, missingMsgs, wrongVersionMsgs := tools.CheckPrerequisites()
 
-	// Do we have the required tools?
-	missing := tools.MissingPrerequisites()
-
-	if missing != "" {
-		return stepErrorMsg{err: errors.New(missing)}
+	if len(missingMsgs) == 0 && len(wrongVersionMsgs) == 0 {
+		return stepCompleteMsg{}
 	}
 
-	// TODO Is template configuration correct?
-	// TODO Do we need to validate the directory structure?
+	prerequisites := append(missingTools, wrongVersionTools...)
+	message := tools.PrerequisitesMsg(missingMsgs, wrongVersionMsgs)
 
-	// Are we working hard?
-	// time.Sleep(500 * time.Millisecond) // Simulate work
-
-	return stepCompleteMsg{}
+	return depsMissingMsg{
+		prerequisites: prerequisites,
+		message:       message,
+	}
 }
 
 // func validateEnvironment(m *Model) tea.Msg {

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -27,6 +27,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/dependencies"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/repo"
@@ -322,7 +323,7 @@ func (m Model) handleDepsMissing(msg depsMissingMsg) (tea.Model, tea.Cmd) {
 	m.depsToInstall = msg.prerequisites
 	m.stepCompleteMessage = msg.message
 
-	if m.opts.AnswerYes {
+	if viperx.GetBool("yes") {
 		return m, m.execInstallDeps()
 	}
 
@@ -586,8 +587,9 @@ func findAndExecuteStart(m *Model) tea.Msg {
 		time.Sleep(preExecutionDelay)
 
 		// Found a quickstart script
-		// If '--yes' flag is set, don't wait for confirmation
-		waitForConfirmation := !m.opts.AnswerYes
+		// Don't wait for confirmation if '--yes' flag is set or
+		// DATAROBOT_CLI_NON_INTERACTIVE env var is true
+		waitForConfirmation := !viperx.GetBool("yes")
 
 		return stepCompleteMsg{
 			message:              fmt.Sprintf("Found quickstart script at: %s\n", quickstartScript),

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -107,10 +107,10 @@ func NewStartModel(opts Options) Model {
 		steps: []step{
 			{description: "Starting application quickstart process...", fn: startQuickstart},
 			{description: "Checking DataRobot CLI version...", fn: checkSelfVersion},
-			{description: "Checking template prerequisites...", fn: checkPrerequisites},
 			// TODO Implement validateEnvironment
 			// {description: "Validating environment...", fn: validateEnvironment},
 			{description: "Checking repository setup...", fn: checkRepository},
+			{description: "Checking template prerequisites...", fn: checkPrerequisites},
 			{description: "Finding and executing start command...", fn: findAndExecuteStart},
 		},
 		opts:     opts,

--- a/cmd/start/model_test.go
+++ b/cmd/start/model_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -181,7 +182,10 @@ func TestHandleDepsMissing_WaitsForConfirmation(t *testing.T) {
 }
 
 func TestHandleDepsMissing_AutoInstallsWhenAnswerYes(t *testing.T) {
-	m := Model{opts: Options{AnswerYes: true}}
+	viperx.Set("yes", true)
+	t.Cleanup(func() { viperx.Set("yes", false) })
+
+	m := Model{}
 
 	msg := depsMissingMsg{
 		prerequisites: []tools.Prerequisite{{Name: "uv"}},

--- a/cmd/start/model_test.go
+++ b/cmd/start/model_test.go
@@ -15,13 +15,28 @@
 package start
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/internal/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// chdir changes to dir for the duration of the test, restoring the original on cleanup.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+
+	original, err := os.Getwd()
+	require.NoError(t, err)
+
+	require.NoError(t, os.Chdir(dir))
+
+	t.Cleanup(func() { _ = os.Chdir(original) })
+}
 
 func TestCheckSelfVersion_EmptyDirectory(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dr-test-*")
@@ -87,4 +102,203 @@ func TestCheckSelfVersion_WithVersionRequirement(t *testing.T) {
 	// In dev mode, version check always passes, so no update prompt
 	assert.False(t, completeMsg.selfUpdate, "In dev mode, should not prompt for update")
 	assert.False(t, completeMsg.waiting)
+}
+
+// setRequiredTools overrides tools.RequiredTools for the duration of the test,
+// restoring the original value on cleanup. The caller must be in a directory
+// without a .datarobot/answers/ ancestor so GetRequirements() fails and the
+// override is not replaced by a real versions.yaml.
+func setRequiredTools(t *testing.T, prereqs []tools.Prerequisite) {
+	t.Helper()
+
+	orig := tools.RequiredTools
+
+	t.Cleanup(func() { tools.RequiredTools = orig })
+
+	tools.RequiredTools = prereqs
+}
+
+// --- checkPrerequisites ---
+
+func TestCheckPrerequisites_AllSatisfied(t *testing.T) {
+	chdir(t, t.TempDir())
+	setRequiredTools(t, []tools.Prerequisite{
+		{Name: "sh", Command: "sh"},
+	})
+
+	msg := checkPrerequisites(nil)
+
+	_, ok := msg.(stepCompleteMsg)
+	assert.True(t, ok, "expected stepCompleteMsg when all deps are satisfied")
+}
+
+func TestCheckPrerequisites_MissingTool(t *testing.T) {
+	chdir(t, t.TempDir())
+	setRequiredTools(t, []tools.Prerequisite{
+		{Name: "FakeTool", Command: "nonexistent_dr_fake_xyz", URL: "https://example.com"},
+	})
+
+	msg := checkPrerequisites(nil)
+
+	depsMsg, ok := msg.(depsMissingMsg)
+	require.True(t, ok, "expected depsMissingMsg when a tool is missing")
+	require.Len(t, depsMsg.prerequisites, 1)
+	assert.Equal(t, "FakeTool", depsMsg.prerequisites[0].Name)
+	assert.Contains(t, depsMsg.message, "FakeTool")
+}
+
+func TestCheckPrerequisites_WrongVersionTool(t *testing.T) {
+	chdir(t, t.TempDir())
+	setRequiredTools(t, []tools.Prerequisite{
+		{Name: "Echo", Command: "echo 1.0.0", MinimumVersion: "2.0.0", URL: "https://example.com"},
+	})
+
+	msg := checkPrerequisites(nil)
+
+	depsMsg, ok := msg.(depsMissingMsg)
+	require.True(t, ok, "expected depsMissingMsg when tool has wrong version")
+	require.Len(t, depsMsg.prerequisites, 1)
+	assert.Equal(t, "Echo", depsMsg.prerequisites[0].Name)
+}
+
+// --- handleDepsMissing ---
+
+func TestHandleDepsMissing_WaitsForConfirmation(t *testing.T) {
+	m := Model{}
+
+	msg := depsMissingMsg{
+		prerequisites: []tools.Prerequisite{{Name: "uv"}},
+		message:       "missing: uv",
+	}
+
+	result, cmd := m.handleDepsMissing(msg)
+
+	resultModel := result.(Model)
+	assert.True(t, resultModel.waitingToInstall)
+	assert.Equal(t, "missing: uv", resultModel.stepCompleteMessage)
+	assert.Equal(t, msg.prerequisites, resultModel.depsToInstall)
+	assert.Nil(t, cmd)
+}
+
+func TestHandleDepsMissing_AutoInstallsWhenAnswerYes(t *testing.T) {
+	m := Model{opts: Options{AnswerYes: true}}
+
+	msg := depsMissingMsg{
+		prerequisites: []tools.Prerequisite{{Name: "uv"}},
+		message:       "missing: uv",
+	}
+
+	result, cmd := m.handleDepsMissing(msg)
+
+	resultModel := result.(Model)
+	assert.False(t, resultModel.waitingToInstall)
+	assert.NotNil(t, cmd)
+}
+
+// --- handleInstallConfirmKey ---
+
+func TestHandleInstallConfirmKey_ConfirmKeys(t *testing.T) {
+	confirmKeys := []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune("y")},
+		{Type: tea.KeyRunes, Runes: []rune("Y")},
+		{Type: tea.KeyEnter},
+	}
+
+	for _, key := range confirmKeys {
+		m := Model{waitingToInstall: true}
+
+		result, cmd := m.handleInstallConfirmKey(key)
+
+		resultModel := result.(Model)
+		assert.False(t, resultModel.waitingToInstall, "key %q should clear waitingToInstall", key.String())
+		assert.NotNil(t, cmd, "key %q should return an install Cmd", key.String())
+	}
+}
+
+func TestHandleInstallConfirmKey_CancelKeys(t *testing.T) {
+	cancelKeys := []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune("n")},
+		{Type: tea.KeyRunes, Runes: []rune("N")},
+		{Type: tea.KeyRunes, Runes: []rune("q")},
+		{Type: tea.KeyEsc},
+	}
+
+	for _, key := range cancelKeys {
+		m := Model{waitingToInstall: true}
+
+		result, _ := m.handleInstallConfirmKey(key)
+
+		resultModel := result.(Model)
+		require.Error(t, resultModel.err, "key %q should set an error", key.String())
+		assert.Contains(t, resultModel.err.Error(), "Installation cancelled", "key %q error message", key.String())
+	}
+}
+
+func TestHandleInstallConfirmKey_OtherKeysIgnored(t *testing.T) {
+	m := Model{waitingToInstall: true}
+
+	result, cmd := m.handleInstallConfirmKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+
+	resultModel := result.(Model)
+	assert.True(t, resultModel.waitingToInstall, "unknown key should not clear waitingToInstall")
+	assert.Nil(t, cmd, "unknown key should return nil Cmd")
+}
+
+// --- handleDepsInstallComplete ---
+
+func TestHandleDepsInstallComplete_Success(t *testing.T) {
+	m := Model{
+		steps: []step{
+			{description: "step 1", fn: startQuickstart},
+			{description: "step 2", fn: startQuickstart},
+		},
+		current: 0,
+	}
+
+	msg := depsInstallCompleteMsg{err: nil, output: "✅ All dependencies installed successfully.\n"}
+
+	result, cmd := m.handleDepsInstallComplete(msg)
+
+	resultModel := result.(Model)
+	assert.Equal(t, 1, resultModel.current, "should advance to next step on success")
+	assert.Equal(t, msg.output, resultModel.stepCompleteMessage)
+	assert.NotNil(t, cmd)
+}
+
+func TestHandleDepsInstallComplete_Error(t *testing.T) {
+	m := Model{}
+
+	installErr := errors.New("install failed for \"uv\" (exit code 1)")
+	msg := depsInstallCompleteMsg{err: installErr}
+
+	result, _ := m.handleDepsInstallComplete(msg)
+
+	resultModel := result.(Model)
+	assert.Equal(t, installErr, resultModel.err)
+}
+
+// --- View ---
+
+func TestView_WaitingToInstall_ShowsInstallFooter(t *testing.T) {
+	m := Model{
+		steps:            []step{{description: "Checking prerequisites...", fn: startQuickstart}},
+		waitingToInstall: true,
+	}
+
+	view := m.View()
+
+	assert.Contains(t, view, "install")
+	assert.NotContains(t, view, "confirm")
+}
+
+func TestView_WaitingToExecute_ShowsConfirmFooter(t *testing.T) {
+	m := Model{
+		steps:            []step{{description: "Finding start command...", fn: startQuickstart}},
+		waitingToExecute: true,
+	}
+
+	view := m.View()
+
+	assert.Contains(t, view, "confirm")
+	assert.NotContains(t, view, "install")
 }

--- a/docs/commands/start.md
+++ b/docs/commands/start.md
@@ -30,8 +30,8 @@ The command streamlines the process of getting your DataRobot application up and
 
 1. **Starting application quickstart process**&mdash;displays the quickstart flow.
 2. **Checking DataRobot CLI version**&mdash;verifies that your CLI version meets the template's minimum requirements (from `.datarobot/cli/versions.yaml`). If not, prompts to run `dr self update`.
-3. **Checking template prerequisites**&mdash;verifies that required tools (e.g. Task, Git) are installed.
-4. **Checking repository setup**&mdash;verifies you're in a DataRobot repository (contains `.datarobot/`). If not, the command launches the interactive `dr templates setup` wizard; after setup completes, `dr start` runs again in the cloned directory.
+3. **Checking repository setup**&mdash;verifies you're in a DataRobot repository (contains `.datarobot/`). If not, the command launches the interactive `dr templates setup` wizard; after setup completes, `dr start` runs again in the cloned directory.
+4. **Checking template prerequisites**&mdash;verifies that required tools (e.g. uv, Task) are installed and meet the minimum version requirements. If any are missing or out of date, you're prompted to install them inline; press `y` to install or `n` to cancel. Passing `--yes` skips the prompt and installs automatically.
 5. **Finding and executing start command**&mdash;searches for a start command in this order:
    - **`task start`**&mdash;if the Taskfile defines a `start` task, it runs immediately (no confirmation).
    - **Executable quickstart script**&mdash;if an executable script in `.datarobot/cli/bin/` matches `quickstart*`, you're prompted to run it (unless `--yes` is used), then it executes.
@@ -113,8 +113,8 @@ DataRobot AI Application Quickstart
 
   ✓ Starting application quickstart process...
   ✓ Checking DataRobot CLI version...
-  ✓ Checking template prerequisites...
   ✓ Checking repository setup...
+  ✓ Checking template prerequisites...
   → Finding and executing start command...
 
 Found quickstart script at: .datarobot/cli/bin/quickstart.sh
@@ -127,7 +127,6 @@ If you're not in a DataRobot repository, the repository step will trigger templa
 ```text
   ✓ Starting application quickstart process...
   ✓ Checking DataRobot CLI version...
-  ✓ Checking template prerequisites...
   → Checking repository setup...
 
 Not in a DataRobot repository. Launching template setup...
@@ -140,8 +139,8 @@ If you're already in a repository but no start command or quickstart script exis
 ```text
   ✓ Starting application quickstart process...
   ✓ Checking DataRobot CLI version...
-  ✓ Checking template prerequisites...
   ✓ Checking repository setup...
+  ✓ Checking template prerequisites...
   → Finding and executing start command...
 
 No start command or quickstart script found.
@@ -238,7 +237,11 @@ If the user declines to execute the script, the command exits gracefully and sti
 
 ### Prerequisites checked
 
-The "Checking template prerequisites" step verifies that tools required by the template (e.g. Task, Git) are installed. If any are missing, the command exits with an error.
+The "Checking template prerequisites" step verifies that tools required by the template (e.g. uv, Task) are installed and meet the minimum version requirements. If any are missing or out of date, the command lists the affected tools and prompts you to install them inline:
+
+- Press `y` or ENTER to install all missing or outdated tools in sequence.
+- Press `n` to cancel; the command exits with a message directing you to `dr dependencies install`.
+- Pass `--yes` (or set `DATAROBOT_CLI_NON_INTERACTIVE=true`) to skip the prompt and install automatically.
 
 Required tools and minimum versions can be configured in the template by creating `.datarobot/cli/versions.yaml`:
 
@@ -281,12 +284,22 @@ No manual intervention is needed - the command handles this gracefully.
 
 ### Missing prerequisites
 
-```bash
-$ dr start
-Error: required tool 'git' not found
+When prerequisites are missing or out of date, `dr start` shows an interactive install prompt:
 
-# Solution: Install the missing tool
+```text
+  ✓ Starting application quickstart process...
+  ✓ Checking DataRobot CLI version...
+  ✓ Checking repository setup...
+  → Checking template prerequisites...
+
+ ❌ Missing required tools:
+
+	- uv  (https://docs.astral.sh/uv/getting-started/installation/)
+
+Press 'y' or ENTER to install, 'n' to cancel
 ```
+
+Press `y` to install all listed tools in sequence, or `n` to exit with a message directing you to run `dr dependencies install` manually. To install without a prompt, run `dr start --yes` or use `dr dependencies install`.
 
 ### Script execution failure
 

--- a/internal/tools/prerequisites.go
+++ b/internal/tools/prerequisites.go
@@ -159,16 +159,6 @@ func PrerequisitesMsg(missingMsgs []string, wrongVersionMsgs []string) string {
 	return strings.Join(result, "\n") + "\n"
 }
 
-// MissingPrerequisites returns a message describing missing prerequisites, or an empty string if all prerequisites are satisfied.
-func MissingPrerequisites() string {
-	_, _, missingMsgs, wrongVersionMsgs := CheckPrerequisites()
-	if len(missingMsgs) > 0 || len(wrongVersionMsgs) > 0 {
-		return PrerequisitesMsg(missingMsgs, wrongVersionMsgs)
-	}
-
-	return ""
-}
-
 func commandArgs(fullCommand string) (string, []string) {
 	command := strings.Split(fullCommand, " ")
 

--- a/internal/tools/prerequisites_test.go
+++ b/internal/tools/prerequisites_test.go
@@ -167,48 +167,6 @@ func TestPrerequisitesMsg_EndsWithNewline(t *testing.T) {
 	assert.True(t, len(out) > 0 && out[len(out)-1] == '\n')
 }
 
-func TestMissingPrerequisites_AllSatisfied(t *testing.T) {
-	orig := RequiredTools
-
-	defer func() { RequiredTools = orig }()
-
-	RequiredTools = []Prerequisite{
-		{Name: "sh", Command: "sh"},
-	}
-
-	assert.Empty(t, MissingPrerequisites())
-}
-
-func TestMissingPrerequisites_MissingTool(t *testing.T) {
-	orig := RequiredTools
-
-	defer func() { RequiredTools = orig }()
-
-	RequiredTools = []Prerequisite{
-		{Name: "FakeTool", Command: "nonexistent_dr_fake_tool_xyz", URL: "https://example.com"},
-	}
-
-	out := MissingPrerequisites()
-
-	assert.NotEmpty(t, out)
-	assert.Contains(t, out, "FakeTool")
-}
-
-func TestMissingPrerequisites_WrongVersion(t *testing.T) {
-	orig := RequiredTools
-
-	defer func() { RequiredTools = orig }()
-
-	RequiredTools = []Prerequisite{
-		{Name: "Echo", Command: "echo 1.0.0", MinimumVersion: "2.0.0"},
-	}
-
-	out := MissingPrerequisites()
-
-	assert.NotEmpty(t, out)
-	assert.Contains(t, out, "Echo")
-}
-
 func TestCheckPrerequisites_AllSatisfied(t *testing.T) {
 	orig := RequiredTools
 


### PR DESCRIPTION
# RATIONALE

Modify cmd/start/ so that after dr dependencies check generates a report of missing deps, a Bubble Tea y/n prompt is shown listing the affected deps. If user selects n, mark the step failed with a clear message and stop. If y, invoke internal/dependencies/installer.go for each dep in sequence. On full success, update state.yaml and proceed. On any failure, mark the step in error and surface the raw install command. Reuses all installer logic from Milestone 1 — no new install logic here.

Acceptance criteria: Happy path (y → installs → proceeds) and rejection path (n → stops with message) work correctly in a manual test.


Wire the --yes flag through the Check Prerequisites step in cmd/start/ so that when present, the install prompt is bypassed and the install sequence begins automatically. Must not trigger any confirmation dialogs under any circumstances.

Acceptance criteria: dr start --yes with missing deps auto-installs without any user interaction.


<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
Finally removed `func MissingPrerequisites` from internal/tools/prerequisites.go ! 😎 (including tests)
Previously it was used by `checkPrerequisites` from cmd/start/model.go, but already not ...

Had to move waitingToExcute handler into separate func due to complexity errors

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `dr start` to install missing/outdated prerequisites (including non-interactive auto-install), which can execute platform-specific install commands and alters the quickstart flow/control paths.
> 
> **Overview**
> `dr start` now treats missing/outdated template prerequisites as an interactive (or non-interactive) install step: it displays the prerequisite report, prompts to install inline, runs `dependencies.InstallPrerequisites` on confirmation, and aborts with a clear error if the user cancels.
> 
> The `--yes` flag is wired through Viper (and `DATAROBOT_CLI_NON_INTERACTIVE`) to bypass both the new dependency-install prompt and the quickstart-script confirmation prompt. The quickstart step order is adjusted to check repository setup before prerequisites.
> 
> `dr dependencies check` is updated to use `tools.CheckPrerequisites`/`PrerequisitesMsg` directly, and the deprecated `tools.MissingPrerequisites` helper (and its tests) is removed; docs and tests are expanded to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 881bfa97e41048d28f6a7bc7e5fdfbb355107ba0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->