### PR TITLE
[CFX-6050] refactor(telemetry): remove environment

### DIFF
--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -19,7 +19,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
@@ -50,7 +49,6 @@ type CommonProperties struct {
 	Language          string // user language from LANG env var (e.g. "en_US")
 	GoVersion         string // Go runtime version (e.g. "go1.26.2")
 	Shell             string // Name of the user's shell (e.g. "zsh", "bash", "powershell")
-	Environment       string // US, EU, JP, or custom — from endpoint URL
 	DataRobotInstance string // Base URL of configured DataRobot instance
 	CommandKind       string // "core" or "plugin", set by the root command after dispatch
 }
@@ -88,7 +86,6 @@ func CollectCommonProperties() *CommonProperties {
 	if endpoint := viperx.GetString(config.DataRobotURL); endpoint != "" {
 		if baseURL, err := config.SchemeHostOnly(endpoint); err == nil {
 			props.DataRobotInstance = baseURL
-			props.Environment = deriveEnvironment(baseURL)
 		}
 	}
 
@@ -110,7 +107,6 @@ func (p *CommonProperties) AsMap() map[string]any {
 		"os_arch":            p.OSArch,
 		"go_version":         p.GoVersion,
 		"shell":              p.Shell,
-		"environment":        p.Environment,
 		"datarobot_instance": p.DataRobotInstance,
 		"command_kind":       p.CommandKind,
 	}
@@ -123,23 +119,6 @@ func (p *CommonProperties) AsMap() map[string]any {
 // invocation. Amplitude's top-level session_id field expects an integer value.
 func generateSessionID() int64 {
 	return time.Now().UnixMilli()
-}
-
-// deriveEnvironment determines the DataRobot environment (US/EU/JP/custom)
-// from the endpoint URL.
-// TODO Is this really necessary? Can we remove this and just report
-// the base URL?
-func deriveEnvironment(baseURL string) string {
-	switch {
-	case strings.Contains(baseURL, "app.datarobot.com"):
-		return "US"
-	case strings.Contains(baseURL, "app.eu.datarobot.com"):
-		return "EU"
-	case strings.Contains(baseURL, "app.jp.datarobot.com"):
-		return "JP"
-	default:
-		return "custom"
-	}
 }
 
 const (

--- a/internal/telemetry/properties_test.go
+++ b/internal/telemetry/properties_test.go
@@ -61,7 +61,6 @@ func TestCommonPropertiesAsMap(t *testing.T) {
 		CLIVersion:        "v0.1.0",
 		InstallMethod:     "source",
 		Shell:             "zsh",
-		Environment:       "US",
 		DataRobotInstance: "https://app.datarobot.com",
 		CommandKind:       "core",
 	}
@@ -70,7 +69,6 @@ func TestCommonPropertiesAsMap(t *testing.T) {
 
 	assert.Equal(t, "source", m["install_method"])
 	assert.Equal(t, "zsh", m["shell"])
-	assert.Equal(t, "US", m["environment"])
 	assert.Equal(t, "https://app.datarobot.com", m["datarobot_instance"])
 	assert.Equal(t, "core", m["command_kind"])
 	// Verify CWD is not included
@@ -248,22 +246,6 @@ func TestCommonPropertiesAsMap_DefaultCommandKindIsEmpty(t *testing.T) {
 	// collected properties default to an empty string.
 	assert.Empty(t, m["command_kind"])
 	assert.Contains(t, m, "command_kind")
-}
-
-func TestDeriveEnvironment_US(t *testing.T) {
-	assert.Equal(t, "US", deriveEnvironment("https://app.datarobot.com"))
-}
-
-func TestDeriveEnvironment_EU(t *testing.T) {
-	assert.Equal(t, "EU", deriveEnvironment("https://app.eu.datarobot.com"))
-}
-
-func TestDeriveEnvironment_JP(t *testing.T) {
-	assert.Equal(t, "JP", deriveEnvironment("https://app.jp.datarobot.com"))
-}
-
-func TestDeriveEnvironment_Custom(t *testing.T) {
-	assert.Equal(t, "custom", deriveEnvironment("https://custom.internal.company.com"))
 }
 
 func TestCollectCommonProperties_GeneratesSessionID(t *testing.T) {


### PR DESCRIPTION
# RATIONALE

environment, which is one of US/EU/JP/custom, is not a useful field. It duplicates datarobot_instance, but custom is also not a useful piece of information when that could refer to literally any instance that isn't MTS prod.

confirmed with @shreyaag-dr that we don't need this!

## CHANGES

- remove CommonProperties.environment

## TESTING

Before:

```log
2026/05/18 11:58:23 DEBUG [amplitude] Track event: 
    {"event_type":"dr start","app_version":"v0.2.66-6-gf5986cb9197d96a","platform":"CLI","os_name":"macOS","os_version":"15.7.5","language":"en-US","ip":"$remote","session_id":1779130703211,"event_properties":{"command_kind":"core","datarobot_instance":"https://app.datarobot.com","environment":"US","go_version":"go1.26.3","install_method":"source","os_arch":"arm64","shell":"zsh"}}
```

After:

```log
2026/05/18 11:56:12 DEBUG [amplitude] Track event: 
    {"event_type":"dr start","app_version":"v0.2.66-8-g9675756ba6c24c2","platform":"CLI","os_name":"macOS","os_version":"15.7.5","language":"en-US","ip":"$remote","session_id":1779130572236,"event_properties":{"command_kind":"core","datarobot_instance":"https://app.datarobot.com","go_version":"go1.26.3","install_method":"source","os_arch":"arm64","shell":"zsh"}}
```

environment is gone

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a redundant telemetry field and related parsing logic/tests, affecting only the shape of emitted analytics events.
> 
> **Overview**
> **Removes the `environment` telemetry property** from `CommonProperties`, so Amplitude events no longer include the derived US/EU/JP/custom value.
> 
> Cleans up associated implementation by dropping `deriveEnvironment`, its `strings` dependency, the `CollectCommonProperties` assignment, and the related unit test assertions/coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04c13eb578cd1c4c800c74651576cf885086e187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->