### PR TITLE
[RAPTOR-17278] style dr workload artifact list table

### DIFF
--- a/internal/workload/output.go
+++ b/internal/workload/output.go
@@ -19,6 +19,10 @@ import (
 	"fmt"
 	"os"
 	"text/tabwriter"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"github.com/datarobot/cli/tui"
 )
 
 const (
@@ -102,9 +106,25 @@ func printArtifactsTable(artifacts []Artifact) {
 		return
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	cellStyle := tui.BaseTextStyle.Padding(0, 1)
 
-	fmt.Fprintln(w, "ARTIFACT ID\tNAME\tSTATUS\tCATALOG ID\tVERSION ID\tUPDATED")
+	dimStyle := tui.DimStyle.Padding(0, 1)
+
+	t := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(tui.TableBorderStyle).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return cellStyle.Bold(true)
+			}
+
+			if col == 5 {
+				return dimStyle
+			}
+
+			return cellStyle
+		}).
+		Headers("ARTIFACT ID", "NAME", "STATUS", "CATALOG ID", "VERSION ID", "UPDATED")
 
 	for _, a := range artifacts {
 		catalogID, versionID := emptyValuePlaceholder, emptyValuePlaceholder
@@ -116,8 +136,8 @@ func printArtifactsTable(artifacts []Artifact) {
 
 		updated := a.UpdatedAt.UTC().Format(timestampFormat)
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", a.ID, a.Name, a.Status, catalogID, versionID, updated)
+		t.Row(a.ID, a.Name, a.Status, catalogID, versionID, updated)
 	}
 
-	w.Flush()
+	fmt.Fprintln(os.Stdout, t.Render())
 }


### PR DESCRIPTION
# RATIONALE

The `dr workload artifact list` table was rendered with `tabwriter`, which doesn't match the styled lipgloss tables used elsewhere in the workload command tree (e.g. `dr workload code versions`). This aligns the artifact list with the rest of the CLI's table styling for consistency.

## CHANGES

- Replace `tabwriter` rendering in `printArtifactsTable` with a `lipgloss/table` using `tui.BaseTextStyle`, `tui.DimStyle` (for the UPDATED column), and `tui.TableBorderStyle` with a rounded border.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.