### PR TITLE
[RAPTOR-17278] style dr workload artifact list table

### DIFF
--- a/internal/workload/output.go
+++ b/internal/workload/output.go
@@ -18,7 +18,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"text/tabwriter"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"github.com/datarobot/cli/tui"
 )
 
 const (
@@ -102,9 +107,29 @@ func printArtifactsTable(artifacts []Artifact) {
 		return
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	cellStyle := tui.BaseTextStyle.Padding(0, 1)
 
-	fmt.Fprintln(w, "ARTIFACT ID\tNAME\tSTATUS\tCATALOG ID\tVERSION ID\tUPDATED")
+	dimStyle := tui.DimStyle.Padding(0, 1)
+
+	headers := []string{"ARTIFACT ID", "NAME", "STATUS", "CATALOG ID", "VERSION ID", "UPDATED"}
+
+	updatedCol := slices.Index(headers, "UPDATED")
+
+	t := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(tui.TableBorderStyle).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return cellStyle.Bold(true)
+			}
+
+			if col == updatedCol {
+				return dimStyle
+			}
+
+			return cellStyle
+		}).
+		Headers(headers...)
 
 	for _, a := range artifacts {
 		catalogID, versionID := emptyValuePlaceholder, emptyValuePlaceholder
@@ -116,8 +141,8 @@ func printArtifactsTable(artifacts []Artifact) {
 
 		updated := a.UpdatedAt.UTC().Format(timestampFormat)
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", a.ID, a.Name, a.Status, catalogID, versionID, updated)
+		t.Row(a.ID, a.Name, a.Status, catalogID, versionID, updated)
 	}
 
-	w.Flush()
+	fmt.Fprintln(os.Stdout, t.Render())
 }


### PR DESCRIPTION
# RATIONALE

The `dr workload artifact list` table was rendered with `tabwriter`, which doesn't match the styled lipgloss tables used elsewhere in the workload command tree (e.g. `dr workload code versions`). This aligns the artifact list with the rest of the CLI's table styling for consistency.

## CHANGES

- Replace `tabwriter` rendering in `printArtifactsTable` with a `lipgloss/table` using `tui.BaseTextStyle`, `tui.DimStyle` (for the UPDATED column), and `tui.TableBorderStyle` with a rounded border.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that alters CLI table rendering but not artifact data or API behavior.
> 
> **Overview**
> Updates `printArtifactsTable` to render artifacts using a styled `lipgloss/table` (rounded border + `tui.TableBorderStyle`) instead of `tabwriter`.
> 
> Adds per-cell styling via `tui.BaseTextStyle` and `tui.DimStyle`, including dimming the `UPDATED` column, and prints the rendered table to stdout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd66d0c8fab7d6b9fd836a2674ea3b6d4430d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->