### PR TITLE
[RAPTOR-17277] Wire telemetry for dr workload commands

### DIFF
--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/datarobot/cli/cmd/workload"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,6 +54,42 @@ func TestTelemetryWiring_AllCoreCommandsTracked(t *testing.T) {
 		t.Run(path, func(t *testing.T) {
 			cmd := findCommandByPath(RootCmd.Command, path)
 			require.NotNilf(t, cmd, "command %q not found in static command tree", path)
+
+			assert.Containsf(t, cmd.Annotations, "telemetry",
+				"command %q must be wired to telemetry via telemetry.Track / TrackWith", path)
+		})
+	}
+}
+
+// expectedWorkloadTrackedCommands enumerates leaf commands under
+// `dr workload` that must be wired to fire a telemetry event. The
+// `dr workload` subtree is hidden from the live RootCmd by
+// cli.CommandAdder when DATAROBOT_CLI_FEATURE_WORKLOAD is unset
+// (the default in CI), so this test walks a freshly-built subtree
+// produced by workload.Cmd() instead of the global RootCmd.
+//
+// Paths are relative to workload.Cmd() (no "dr" prefix) because
+// findCommandByPath matches against the root's Name(), which is
+// "workload" for the standalone subtree.
+var expectedWorkloadTrackedCommands = []string{
+	"workload code init",
+	"workload code versions",
+	"workload artifact get",
+	"workload artifact list",
+	"workload artifact create",
+}
+
+// TestTelemetryWiring_AllWorkloadCommandsTracked walks the workload
+// subtree (built via workload.Cmd() to bypass the feature-gate filter
+// in cli.CommandAdder) and asserts each entry has the "telemetry"
+// annotation set by telemetry.Track / TrackWith.
+func TestTelemetryWiring_AllWorkloadCommandsTracked(t *testing.T) {
+	workloadRoot := workload.Cmd()
+
+	for _, path := range expectedWorkloadTrackedCommands {
+		t.Run("dr "+path, func(t *testing.T) {
+			cmd := findCommandByPath(workloadRoot, path)
+			require.NotNilf(t, cmd, "command %q not found in workload subtree", path)
 
 			assert.Containsf(t, cmd.Annotations, "telemetry",
 				"command %q must be wired to telemetry via telemetry.Track / TrackWith", path)

--- a/cmd/workload/artifact/create/cmd.go
+++ b/cmd/workload/artifact/create/cmd.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/spf13/cobra"
 )
@@ -87,6 +88,12 @@ Example:
 	workload.AddOutputFlag(cmd, &outputFormat)
 	cmd.Flags().StringVar(&specFile, "spec-file", "", "Path to JSON spec file (required)")
 	_ = cmd.MarkFlagRequired("spec-file")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		return map[string]any{
+			"output_format": string(outputFormat),
+		}
+	})
 
 	return cmd
 }

--- a/cmd/workload/artifact/get/cmd.go
+++ b/cmd/workload/artifact/get/cmd.go
@@ -16,6 +16,7 @@ package get
 
 import (
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/spf13/cobra"
 )
@@ -51,6 +52,13 @@ Example:
 	}
 
 	workload.AddOutputFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"artifact_id":   telemetry.FirstArg(args),
+			"output_format": string(outputFormat),
+		}
+	})
 
 	return cmd
 }

--- a/cmd/workload/artifact/list/cmd.go
+++ b/cmd/workload/artifact/list/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/spf13/cobra"
 )
@@ -65,6 +66,16 @@ Example:
 	workload.AddOutputFlag(cmd, &outputFormat)
 	workload.AddStatusFlag(cmd, &status)
 	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of artifacts to return")
+
+	telemetry.TrackWith(cmd, func(c *cobra.Command, _ []string) map[string]any {
+		limit, _ := c.Flags().GetInt("limit")
+
+		return map[string]any{
+			"limit":         limit,
+			"output_format": string(outputFormat),
+			"status":        string(status),
+		}
+	})
 
 	return cmd
 }

--- a/cmd/workload/code/init/cmd.go
+++ b/cmd/workload/code/init/cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/spf13/cobra"
@@ -73,6 +74,17 @@ Example:
 	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	workload.AddOutputFlag(c, &outputFormat)
+
+	telemetry.TrackWith(c, func(cmd *cobra.Command, args []string) map[string]any {
+		yesFlag, _ := cmd.Flags().GetBool("yes")
+		yes := yesFlag || viperx.GetBool("yes")
+
+		return map[string]any{
+			"artifact_id":   telemetry.FirstArg(args),
+			"yes":           yes,
+			"output_format": string(outputFormat),
+		}
+	})
 
 	return c
 }

--- a/cmd/workload/code/versions/cmd.go
+++ b/cmd/workload/code/versions/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/spf13/cobra"
@@ -83,6 +84,15 @@ Example:
 	c.Flags().Int("limit", 100, "Maximum number of versions to return.")
 
 	workload.AddOutputFlag(c, &outputFormat)
+
+	telemetry.TrackWith(c, func(cmd *cobra.Command, _ []string) map[string]any {
+		limit, _ := cmd.Flags().GetInt("limit")
+
+		return map[string]any{
+			"limit":         limit,
+			"output_format": string(outputFormat),
+		}
+	})
 
 	return c
 }


### PR DESCRIPTION
# RATIONALE

Follow-up from #478 (RAPTOR-16922) — Cursor Bugbot flagged that `dr workload code versions` was missing telemetry wiring; while auditing, **none** of the existing `dr workload` leaf commands had it, so the whole subtree was unwired and the root `PersistentPreRunE` could not fire events for any of them.

## CHANGES

- Wire `telemetry.TrackWith` in five leaf commands: `dr workload code init`, `code versions`, `artifact get`, `artifact list`, `artifact create`. Properties follow the established repo pattern — positional ID via `telemetry.FirstArg`, `output_format` everywhere, plus `yes`/`limit`/`status` where they meaningfully shape behavior. Standard-type flags read via `cmd.Flags().Get…` (matches `plugin install`); custom `pflag.Value` types (`OutputFormat`, `Status`) use closed-over locals (matches the `code sync` precedent).
- Add `TestTelemetryWiring_AllWorkloadCommandsTracked` in `cmd/telemetry_wiring_test.go` that walks `workload.Cmd()` directly to bypass `cli.CommandAdder`'s feature-gate filter — the `dr workload` subtree is hidden from the live `RootCmd` when `DATAROBOT_CLI_FEATURE_WORKLOAD` is unset (the CI default), so the existing `RootCmd`-walking test cannot cover it.
- `dr workload code sync` is intentionally out of scope here and is tracked under RAPTOR-16925.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- \`/trigger-smoke-test\` or \`/trigger-test-smoke\` - Run smoke tests
- \`/trigger-install-test\` or \`/trigger-test-install\` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- \`run-smoke-tests\` or \`go\` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The \`run-smoke-tests\` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses \`/approve-smoke-tests\` to run smoke tests (results will set the check)
> - A maintainer uses \`/skip-smoke-tests\` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds telemetry annotations and a targeted wiring test without changing workload command behavior or data handling.
> 
> **Overview**
> Adds telemetry wiring for `dr workload` leaf commands so they emit events via `telemetry.TrackWith`, including key command-shaping properties like `artifact_id`, `output_format`, `limit`, `status`, and `yes`.
> 
> Extends `cmd/telemetry_wiring_test.go` with a dedicated workload-subtree test that builds `workload.Cmd()` directly (bypassing the feature gate) and asserts the workload commands are annotated for telemetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c9430ed1de6a5b09ea39b9518eb2b900924faa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->