### PR TITLE
[RAPTOR-16926] add dr workload code checkout command

### DIFF
--- a/cmd/workload/code/checkout/checkout.go
+++ b/cmd/workload/code/checkout/checkout.go
@@ -29,12 +29,17 @@ import (
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/drapi/filesapi"
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/fileops"
 	"github.com/datarobot/cli/internal/workload/sync"
 	"github.com/datarobot/cli/internal/workload/wapi"
 )
 
 const (
-	checkoutMetaFile     = ".checkout-meta.json"
+	checkoutMetaFile = ".checkout-meta.json"
+
+	// Standard Unix modes; the snapshot is for the invoking user's own
+	// inspection, not multi-user sharing — modes here aren't load-bearing
+	// for safety, only for letting the user read/traverse what we wrote.
 	checkoutDirPerm      = 0o755
 	checkoutMetaFilePerm = 0o644
 )
@@ -71,42 +76,57 @@ func runDownload(out io.Writer, format workload.OutputFormat, dir, verArg string
 		return err
 	}
 
+	if err := stageAndInstall(deps.Files, pre, parent, files, totalSize, startedAt); err != nil {
+		return err
+	}
+
+	if err := wapi.AppendHistory(dir, checkoutHistoryEntry(startedAt, pre.versionID, len(files), totalSize, time.Since(startedAt))); err != nil {
+		return fmt.Errorf("append history: %w", err)
+	}
+
+	return renderDownloadResult(out, format, downloadView(dir, pre.versionID, pre.checkoutDir, files))
+}
+
+// stageAndInstall downloads files into a sibling temp dir, writes metadata,
+// and atomically swaps it into place. The temp dir is removed on any failure
+// before the swap; after a successful swap it has been renamed away.
+func stageAndInstall(c filesapi.Client, pre preflightResult, parent string, files map[string]filesapi.FileMeta, totalSize int64, startedAt time.Time) error {
 	// Dot-prefix so listCheckoutNames skips it; sibling of finalDir so the swap rename is intra-filesystem.
 	tempDir, err := os.MkdirTemp(parent, ".tmp-"+pre.versionID+"-")
 	if err != nil {
 		return fmt.Errorf("create temp checkout dir: %w", err)
 	}
 
-	if err := downloadAll(deps.Files, pre.catalogID, pre.versionID, tempDir, files); err != nil {
-		_ = os.RemoveAll(tempDir)
+	installed := false
 
+	defer func() {
+		if !installed {
+			_ = os.RemoveAll(tempDir)
+		}
+	}()
+
+	if err := downloadAll(c, pre.catalogID, pre.versionID, tempDir, files); err != nil {
 		return err
 	}
 
 	meta := checkoutMeta{
 		VersionID:    pre.versionID,
-		CheckedOutAt: time.Now().UTC(),
+		CheckedOutAt: startedAt.UTC(),
 		FileCount:    len(files),
 		TotalSize:    totalSize,
 	}
 
 	if err := writeCheckoutMeta(tempDir, meta); err != nil {
-		_ = os.RemoveAll(tempDir)
-
 		return err
 	}
 
 	if err := swapCheckoutDir(tempDir, pre.checkoutDir); err != nil {
-		_ = os.RemoveAll(tempDir)
-
 		return err
 	}
 
-	if err := wapi.AppendHistory(dir, checkoutHistoryEntry(pre.versionID, len(files), totalSize, time.Since(startedAt))); err != nil {
-		return fmt.Errorf("append history: %w", err)
-	}
+	installed = true
 
-	return renderDownloadResult(out, format, downloadView(dir, pre.versionID, pre.checkoutDir, files))
+	return nil
 }
 
 // Backup-rename swap so a failed install can be rolled back to the previous snapshot.
@@ -120,6 +140,9 @@ func swapCheckoutDir(tempDir, finalDir string) error {
 
 	var hasOld bool
 
+	// TOCTOU window: another process could create or remove finalDir between
+	// the Stat and the Rename. Acceptable for a single-user CLI — concurrent
+	// `dr` invocations against the same checkout dir are not supported.
 	if _, err := os.Stat(finalDir); err == nil {
 		if err := os.Rename(finalDir, backupDir); err != nil {
 			return fmt.Errorf("back up existing checkout dir: %w", err)
@@ -131,11 +154,18 @@ func swapCheckoutDir(tempDir, finalDir string) error {
 	}
 
 	if err := os.Rename(tempDir, finalDir); err != nil {
+		installErr := fmt.Errorf("install checkout dir: %w", err)
+
 		if hasOld {
-			_ = os.Rename(backupDir, finalDir)
+			if rbErr := os.Rename(backupDir, finalDir); rbErr != nil {
+				return errors.Join(
+					installErr,
+					fmt.Errorf("rollback failed; previous snapshot stranded at %s: %w", backupDir, rbErr),
+				)
+			}
 		}
 
-		return fmt.Errorf("install checkout dir: %w", err)
+		return installErr
 	}
 
 	if hasOld {
@@ -145,9 +175,9 @@ func swapCheckoutDir(tempDir, finalDir string) error {
 	return nil
 }
 
-func checkoutHistoryEntry(versionID string, fileCount int, totalSize int64, duration time.Duration) wapi.HistoryEntry {
+func checkoutHistoryEntry(startedAt time.Time, versionID string, fileCount int, totalSize int64, duration time.Duration) wapi.HistoryEntry {
 	return wapi.HistoryEntry{
-		"ts":       time.Now().UTC().Format(time.RFC3339),
+		"ts":       startedAt.UTC().Format(time.RFC3339),
 		"op":       "checkout",
 		"version":  versionID,
 		"files":    fileCount,
@@ -172,8 +202,7 @@ func preflight(dir, verArg string, deps Deps) (preflightResult, error) {
 		return preflightResult{}, errors.New("no code has been synced yet. Run 'dr workload code sync' first")
 	}
 
-	// Fetched only to surface a 404 before any download work begins.
-	if _, err := fetchArtifact(deps.GetArtifact, cfg.ArtifactID); err != nil {
+	if err := probeArtifact(deps.GetArtifact, cfg.ArtifactID); err != nil {
 		return preflightResult{}, err
 	}
 
@@ -201,18 +230,19 @@ func prepareCheckoutsParent(parent string, totalSize int64) error {
 	return nil
 }
 
-func fetchArtifact(get func(string) (*workload.Artifact, error), artifactID string) (*workload.Artifact, error) {
-	art, err := get(artifactID)
-	if err != nil {
+// probeArtifact surfaces a 404 before any download work begins. The artifact
+// payload is discarded; preflight only needs to confirm the ID resolves.
+func probeArtifact(get func(string) (*workload.Artifact, error), artifactID string) error {
+	if _, err := get(artifactID); err != nil {
 		var httpErr *drapi.HTTPError
 		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-			return nil, fmt.Errorf("artifact %s not found", artifactID)
+			return fmt.Errorf("artifact %s not found", artifactID)
 		}
 
-		return nil, fmt.Errorf("fetch artifact %s: %w", artifactID, err)
+		return fmt.Errorf("fetch artifact %s: %w", artifactID, err)
 	}
 
-	return art, nil
+	return nil
 }
 
 // Accepts the full ID or any unique prefix.
@@ -255,6 +285,12 @@ func downloadAll(c filesapi.Client, catalogID, versionID, checkoutDir string, fi
 	}
 
 	sort.Strings(paths)
+
+	for _, path := range paths {
+		if err := fileops.SafeRelPath(path); err != nil {
+			return fmt.Errorf("server returned unsafe path %q: %w", path, err)
+		}
+	}
 
 	for _, path := range paths {
 		if err := downloadOne(c, catalogID, versionID, checkoutDir, path); err != nil {

--- a/cmd/workload/code/checkout/checkout.go
+++ b/cmd/workload/code/checkout/checkout.go
@@ -1,0 +1,399 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkout
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/datarobot/cli/internal/workload/wapi"
+)
+
+const (
+	checkoutMetaFile     = ".checkout-meta.json"
+	checkoutDirPerm      = 0o755
+	checkoutMetaFilePerm = 0o644
+)
+
+type checkoutMeta struct {
+	VersionID    string    `json:"versionId"`
+	CheckedOutAt time.Time `json:"checkedOutAt"`
+	FileCount    int       `json:"fileCount"`
+	TotalSize    int64     `json:"totalSize"`
+}
+
+func runDownload(out io.Writer, format workload.OutputFormat, dir, verArg string, deps Deps) error {
+	startedAt := time.Now()
+
+	pre, err := preflight(dir, verArg, deps)
+	if err != nil {
+		return err
+	}
+
+	files, err := deps.Files.AllFiles(pre.catalogID, pre.versionID)
+	if err != nil {
+		return fmt.Errorf("list files for version %s: %w", pre.versionID, err)
+	}
+
+	var totalSize int64
+
+	for _, m := range files {
+		totalSize += m.Size
+	}
+
+	parent := wapi.CheckoutsDir(dir)
+
+	if err := prepareCheckoutsParent(parent, totalSize); err != nil {
+		return err
+	}
+
+	// Dot-prefix so listCheckoutNames skips it; sibling of finalDir so the swap rename is intra-filesystem.
+	tempDir, err := os.MkdirTemp(parent, ".tmp-"+pre.versionID+"-")
+	if err != nil {
+		return fmt.Errorf("create temp checkout dir: %w", err)
+	}
+
+	if err := downloadAll(deps.Files, pre.catalogID, pre.versionID, tempDir, files); err != nil {
+		_ = os.RemoveAll(tempDir)
+
+		return err
+	}
+
+	meta := checkoutMeta{
+		VersionID:    pre.versionID,
+		CheckedOutAt: time.Now().UTC(),
+		FileCount:    len(files),
+		TotalSize:    totalSize,
+	}
+
+	if err := writeCheckoutMeta(tempDir, meta); err != nil {
+		_ = os.RemoveAll(tempDir)
+
+		return err
+	}
+
+	if err := swapCheckoutDir(tempDir, pre.checkoutDir); err != nil {
+		_ = os.RemoveAll(tempDir)
+
+		return err
+	}
+
+	if err := wapi.AppendHistory(dir, checkoutHistoryEntry(pre.versionID, len(files), totalSize, time.Since(startedAt))); err != nil {
+		return fmt.Errorf("append history: %w", err)
+	}
+
+	return renderDownloadResult(out, format, downloadView(dir, pre.versionID, pre.checkoutDir, files))
+}
+
+// Backup-rename swap so a failed install can be rolled back to the previous snapshot.
+func swapCheckoutDir(tempDir, finalDir string) error {
+	backupDir := filepath.Join(filepath.Dir(finalDir), ".bak-"+filepath.Base(finalDir))
+
+	// Clear any leftover backup from a previously interrupted swap.
+	if err := os.RemoveAll(backupDir); err != nil {
+		return fmt.Errorf("clear stale backup dir: %w", err)
+	}
+
+	var hasOld bool
+
+	if _, err := os.Stat(finalDir); err == nil {
+		if err := os.Rename(finalDir, backupDir); err != nil {
+			return fmt.Errorf("back up existing checkout dir: %w", err)
+		}
+
+		hasOld = true
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat existing checkout dir: %w", err)
+	}
+
+	if err := os.Rename(tempDir, finalDir); err != nil {
+		if hasOld {
+			_ = os.Rename(backupDir, finalDir)
+		}
+
+		return fmt.Errorf("install checkout dir: %w", err)
+	}
+
+	if hasOld {
+		_ = os.RemoveAll(backupDir)
+	}
+
+	return nil
+}
+
+func checkoutHistoryEntry(versionID string, fileCount int, totalSize int64, duration time.Duration) wapi.HistoryEntry {
+	return wapi.HistoryEntry{
+		"ts":       time.Now().UTC().Format(time.RFC3339),
+		"op":       "checkout",
+		"version":  versionID,
+		"files":    fileCount,
+		"size":     totalSize,
+		"duration": duration.Round(time.Millisecond).String(),
+	}
+}
+
+type preflightResult struct {
+	catalogID   string
+	versionID   string
+	checkoutDir string
+}
+
+func preflight(dir, verArg string, deps Deps) (preflightResult, error) {
+	cfg, err := wapi.LoadConfig(dir)
+	if err != nil {
+		return preflightResult{}, fmt.Errorf("read .wapi/config.json: %w", err)
+	}
+
+	if cfg.CatalogID == nil || *cfg.CatalogID == "" {
+		return preflightResult{}, errors.New("no code has been synced yet. Run 'dr workload code sync' first")
+	}
+
+	// Fetched only to surface a 404 before any download work begins.
+	if _, err := fetchArtifact(deps.GetArtifact, cfg.ArtifactID); err != nil {
+		return preflightResult{}, err
+	}
+
+	versionID, err := resolveVersion(deps.Files, *cfg.CatalogID, verArg)
+	if err != nil {
+		return preflightResult{}, err
+	}
+
+	return preflightResult{
+		catalogID:   *cfg.CatalogID,
+		versionID:   versionID,
+		checkoutDir: wapi.CheckoutDir(dir, versionID),
+	}, nil
+}
+
+func prepareCheckoutsParent(parent string, totalSize int64) error {
+	if err := os.MkdirAll(parent, checkoutDirPerm); err != nil {
+		return fmt.Errorf("create .wapi/.checkouts dir: %w", err)
+	}
+
+	if err := sync.EnsureSpaceFor(parent, totalSize); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func fetchArtifact(get func(string) (*workload.Artifact, error), artifactID string) (*workload.Artifact, error) {
+	art, err := get(artifactID)
+	if err != nil {
+		var httpErr *drapi.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("artifact %s not found", artifactID)
+		}
+
+		return nil, fmt.Errorf("fetch artifact %s: %w", artifactID, err)
+	}
+
+	return art, nil
+}
+
+// Accepts the full ID or any unique prefix.
+func resolveVersion(c filesapi.Client, catalogID, arg string) (string, error) {
+	if arg == "" {
+		return "", errors.New("version argument is empty")
+	}
+
+	versions, err := c.ListVersions(catalogID, 0)
+	if err != nil {
+		return "", fmt.Errorf("list versions: %w", err)
+	}
+
+	var matches []string
+
+	for _, v := range versions {
+		if v.ID == arg {
+			return v.ID, nil
+		}
+
+		if strings.HasPrefix(v.ID, arg) {
+			matches = append(matches, v.ID)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("version %q not found", arg)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("version prefix %q is ambiguous — matches %d versions; use more characters", arg, len(matches))
+	}
+}
+
+func downloadAll(c filesapi.Client, catalogID, versionID, checkoutDir string, files map[string]filesapi.FileMeta) error {
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		if err := downloadOne(c, catalogID, versionID, checkoutDir, path); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Server-side hashes are not re-verified: TLS covers transit corruption and the snapshot is read-only.
+func downloadOne(c filesapi.Client, catalogID, versionID, checkoutDir, path string) error {
+	dst := filepath.Join(checkoutDir, filepath.FromSlash(path))
+
+	if err := os.MkdirAll(filepath.Dir(dst), checkoutDirPerm); err != nil {
+		return fmt.Errorf("mkdir parent for %s: %w", path, err)
+	}
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", path, err)
+	}
+
+	_, _, err = c.DownloadFile(catalogID, versionID, path, out)
+	if cerr := out.Close(); err == nil {
+		err = cerr
+	}
+
+	if err != nil {
+		_ = os.Remove(dst)
+
+		return fmt.Errorf("download %s: %w", path, err)
+	}
+
+	return nil
+}
+
+func writeCheckoutMeta(checkoutDir string, meta checkoutMeta) error {
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode checkout meta: %w", err)
+	}
+
+	path := filepath.Join(checkoutDir, checkoutMetaFile)
+	if err := os.WriteFile(path, data, checkoutMetaFilePerm); err != nil {
+		return fmt.Errorf("write checkout meta: %w", err)
+	}
+
+	return nil
+}
+
+func runClean(out io.Writer, format workload.OutputFormat, dir, arg string) error {
+	checkoutsDir := wapi.CheckoutsDir(dir)
+
+	names, err := listCheckoutNames(checkoutsDir)
+	if err != nil {
+		return err
+	}
+
+	if arg == "" {
+		if len(names) == 0 {
+			return renderCleanResult(out, format, cleanResult{Removed: []string{}})
+		}
+
+		if err := os.RemoveAll(checkoutsDir); err != nil {
+			return fmt.Errorf("remove %s: %w", checkoutsDir, err)
+		}
+
+		return renderCleanResult(out, format, cleanResult{Removed: names})
+	}
+
+	resolved, err := resolveLocalCheckout(names, arg)
+	if err != nil {
+		return err
+	}
+
+	target := wapi.CheckoutDir(dir, resolved)
+	if err := os.RemoveAll(target); err != nil {
+		return fmt.Errorf("remove %s: %w", target, err)
+	}
+
+	return renderCleanResult(out, format, cleanResult{Removed: []string{resolved}})
+}
+
+// Exact name wins; otherwise arg is treated as a unique prefix.
+func resolveLocalCheckout(names []string, arg string) (string, error) {
+	if arg == "" {
+		return "", errors.New("checkout argument is empty")
+	}
+
+	var matches []string
+
+	for _, n := range names {
+		if n == arg {
+			return n, nil
+		}
+
+		if strings.HasPrefix(n, arg) {
+			matches = append(matches, n)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("checkout %q not found locally", arg)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("checkout prefix %q is ambiguous — matches %d directories", arg, len(matches))
+	}
+}
+
+// Missing parent dir yields an empty slice with no error.
+func listCheckoutNames(checkoutsDir string) ([]string, error) {
+	entries, err := os.ReadDir(checkoutsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("read %s: %w", checkoutsDir, err)
+	}
+
+	names := make([]string, 0, len(entries))
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+
+		name := e.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names, nil
+}

--- a/cmd/workload/code/checkout/cmd.go
+++ b/cmd/workload/code/checkout/cmd.go
@@ -1,0 +1,160 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkout
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/datarobot/cli/cmd/workload/code/internal/dirprompt"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/wapi"
+	"github.com/spf13/cobra"
+)
+
+type Deps struct {
+	GetArtifact   func(string) (*workload.Artifact, error)
+	Files         filesapi.Client
+	PromptDir     dirprompt.PromptFunc
+	PromptVersion dirprompt.PromptNoDefaultFunc
+}
+
+func defaultDeps() Deps {
+	return Deps{
+		GetArtifact:   workload.GetArtifact,
+		Files:         filesapi.New(),
+		PromptDir:     dirprompt.AskWithDefault,
+		PromptVersion: dirprompt.Ask,
+	}
+}
+
+func init() {
+	// Per project rules: bind only the env var, read the flag directly from cobra.
+	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+}
+
+func Cmd() *cobra.Command {
+	return cmdWithDeps(defaultDeps())
+}
+
+func cmdWithDeps(deps Deps) *cobra.Command {
+	var outputFormat workload.OutputFormat
+
+	c := &cobra.Command{
+		Use:          "checkout [<ver>]",
+		Short:        "Download a version snapshot for read-only inspection.",
+		SilenceUsage: true,
+		Args:         cobra.MaximumNArgs(1),
+		Long: `Download a specific catalog version into '.wapi/.checkouts/<version-id>/'
+for read-only inspection. The working directory and '.wapi/' sync state
+are never modified.
+
+The version argument may be a full version ID or any unique prefix.
+If omitted (and --yes is not set), you will be prompted.
+
+With --clean, remove existing checkout directories instead of downloading:
+no positional argument removes all checkouts; a positional argument
+removes only the matching one.
+
+Run 'dr workload code init <artifact-id>' first to link a project
+directory to an artifact.
+
+Example:
+  dr workload code checkout
+  dr workload code checkout abcdef12
+  dr workload code checkout abcdef12 --dir ./service
+  dr workload code checkout --clean
+  dr workload code checkout abcdef12 --clean`,
+		PreRunE: auth.EnsureAuthenticatedE,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCheckout(cmd, args, outputFormat, deps)
+		},
+	}
+
+	c.Flags().String("dir", "", "Project directory (default: current directory).")
+	c.Flags().Bool("clean", false, "Remove checkout directories instead of downloading.")
+	c.Flags().BoolP("yes", "y", false, "Skip interactive prompts.")
+
+	workload.AddOutputFlag(c, &outputFormat)
+
+	return c
+}
+
+func runCheckout(cmd *cobra.Command, args []string, outputFormat workload.OutputFormat, deps Deps) error {
+	yesFlag, _ := cmd.Flags().GetBool("yes")
+	yes := yesFlag || viperx.GetBool("yes")
+
+	dirFlag, _ := cmd.Flags().GetString("dir")
+	clean, _ := cmd.Flags().GetBool("clean")
+
+	dir, err := resolveProjectDir(dirFlag, yes, deps.PromptDir)
+	if err != nil {
+		return err
+	}
+
+	if !wapi.Exists(dir) {
+		return errors.New("not linked to an artifact. Run 'dr workload code init <id>' first")
+	}
+
+	if clean {
+		var arg string
+
+		if len(args) == 1 {
+			arg = args[0]
+		}
+
+		return runClean(cmd.OutOrStdout(), outputFormat, dir, arg)
+	}
+
+	verArg, err := resolveVersionArg(cmd.ErrOrStderr(), args, yes, deps.PromptVersion)
+	if err != nil {
+		return err
+	}
+
+	return runDownload(cmd.OutOrStdout(), outputFormat, dir, verArg, deps)
+}
+
+func resolveProjectDir(dirFlag string, yes bool, prompt dirprompt.PromptFunc) (string, error) {
+	dir, err := dirprompt.ResolveDir(dirFlag, yes, prompt)
+	if err != nil {
+		return "", err
+	}
+
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolve dir %s: %w", dir, err)
+	}
+
+	return abs, nil
+}
+
+func resolveVersionArg(stderr io.Writer, args []string, yes bool, prompt dirprompt.PromptNoDefaultFunc) (string, error) {
+	if len(args) == 1 {
+		return args[0], nil
+	}
+
+	if yes {
+		return "", errors.New("a version argument is required (or pass --clean to remove checkouts)")
+	}
+
+	fmt.Fprintln(stderr, "Run 'dr workload code versions' to list available versions.")
+
+	return prompt("Code version ID")
+}

--- a/cmd/workload/code/checkout/cmd_test.go
+++ b/cmd/workload/code/checkout/cmd_test.go
@@ -169,10 +169,10 @@ func newTestCmd(t *testing.T, dir string, deps Deps, args []string) (*cobra.Comm
 
 const (
 	verA = "abcdef1234567890abcdef1234567890"
-	// verB shares verA's 8-char prefix "abcdef12" so the ambiguous-prefix
-	// test resolves to two matches.
-	verB = "abcdef12fffffffabcdef12fffffff00"
-	verC = "11112222333344445555666677778888"
+	// verAmbiguous shares verA's 8-char prefix "abcdef12", so a query for that
+	// prefix matches both — resolveVersion must reject it as ambiguous.
+	verAmbiguous = "abcdef12fffffffabcdef12fffffff00"
+	verC         = "11112222333344445555666677778888"
 )
 
 func TestCheckout_NotLinked(t *testing.T) {
@@ -251,7 +251,7 @@ func TestCheckout_VersionResolution(t *testing.T) {
 		versions                   []filesapi.CatalogVersion
 	}{
 		{"happy short prefix", "abcdef12", "", verA, []filesapi.CatalogVersion{{ID: verA}, {ID: verC}}},
-		{"ambiguous", "abcdef12", "ambiguous", "", []filesapi.CatalogVersion{{ID: verA}, {ID: verB}}},
+		{"ambiguous", "abcdef12", "ambiguous", "", []filesapi.CatalogVersion{{ID: verA}, {ID: verAmbiguous}}},
 		{"not found", "99999999", `"99999999"`, "", []filesapi.CatalogVersion{{ID: verA}}},
 	}
 
@@ -334,6 +334,43 @@ func TestCheckout_JSONOutput(t *testing.T) {
 	require.Len(t, got.Files, 2)
 	assert.Equal(t, "a.txt", got.Files[0].Path)
 	assert.Equal(t, "b.txt", got.Files[1].Path)
+}
+
+func TestCheckout_RejectsUnsafePath(t *testing.T) {
+	cases := []struct {
+		name     string
+		path     string
+		wantHint string
+	}{
+		{"parent escape", "../etc/passwd", "escapes project root"},
+		{"absolute path", "/etc/passwd", "absolute path not allowed"},
+		{"backslash", "evil\\path", "backslash in path"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := initLinkedDir(t, "cat-1")
+
+			fc := &fakeClient{
+				versions: []filesapi.CatalogVersion{{ID: verA}},
+				content:  map[string][]byte{tc.path: []byte("evil")},
+			}
+
+			deps := fakeDeps(draftArtifact("art-abc-123"), fc)
+
+			cmd, _ := newTestCmd(t, dir, deps, []string{verA})
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unsafe path")
+			assert.Contains(t, err.Error(), tc.wantHint)
+
+			_, dlCalls := fc.callCounts()
+			assert.Zero(t, dlCalls, "DownloadFile must not be called when validation rejects a path")
+
+			assert.NoDirExists(t, wapi.CheckoutDir(dir, verA))
+		})
+	}
 }
 
 func TestCheckout_DownloadErrorRemovesPartial(t *testing.T) {

--- a/cmd/workload/code/checkout/cmd_test.go
+++ b/cmd/workload/code/checkout/cmd_test.go
@@ -1,0 +1,470 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkout
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	gosync "sync"
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/wapi"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClient is a minimal in-memory filesapi.Client for cmd-level tests.
+// Only the three methods checkout uses are implemented; the rest panic.
+// The mutex guards counters + content under any concurrent access.
+type fakeClient struct {
+	mu gosync.Mutex
+
+	versions []filesapi.CatalogVersion
+	content  map[string][]byte
+
+	allFilesErr error
+	downloadErr error
+
+	allFilesCalls int
+	downloadCalls int
+}
+
+func (f *fakeClient) ListVersions(_ string, _ int) ([]filesapi.CatalogVersion, error) {
+	return f.versions, nil
+}
+
+func (f *fakeClient) AllFiles(_, _ string) (map[string]filesapi.FileMeta, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.allFilesCalls++
+
+	if f.allFilesErr != nil {
+		return nil, f.allFilesErr
+	}
+
+	out := make(map[string]filesapi.FileMeta, len(f.content))
+
+	for path, data := range f.content {
+		sum := sha256.Sum256(data)
+		out[path] = filesapi.FileMeta{Hash: hex.EncodeToString(sum[:]), Size: int64(len(data))}
+	}
+
+	return out, nil
+}
+
+func (f *fakeClient) DownloadFile(_, _, path string, w io.Writer) (string, int64, error) {
+	f.mu.Lock()
+	f.downloadCalls++
+	err := f.downloadErr
+	data, ok := f.content[path]
+	f.mu.Unlock()
+
+	if err != nil {
+		return "", 0, err
+	}
+
+	if !ok {
+		return "", 0, errors.New("not found")
+	}
+
+	n, err := w.Write(data)
+
+	return "", int64(n), err
+}
+
+func (f *fakeClient) callCounts() (all, dl int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return f.allFilesCalls, f.downloadCalls
+}
+
+// Panicking stubs for the rest of filesapi.Client.
+func (*fakeClient) CreateCatalog() (*filesapi.CatalogResp, error)                { panic("unused") }
+func (*fakeClient) CreateStage(string) (*filesapi.StageResp, error)              { panic("unused") }
+func (*fakeClient) UploadToStage(string, string, string, int64, io.Reader) error { panic("unused") }
+func (*fakeClient) ApplyStage(string, string, string) (*filesapi.ApplyStageResp, error) {
+	panic("unused")
+}
+
+func (*fakeClient) UploadFromZipNew(string, int64, io.Reader) (*filesapi.FromFileResp, error) {
+	panic("unused")
+}
+
+func (*fakeClient) UploadFromZipExisting(string, string, string, int64, io.Reader) (*filesapi.FromFileResp, error) {
+	panic("unused")
+}
+func (*fakeClient) PollStatus(string) (*filesapi.StatusResp, error) { panic("unused") }
+func (*fakeClient) DeleteFiles(string, []string) (*filesapi.DeleteFilesResp, error) {
+	panic("unused")
+}
+
+func fakeDeps(art *workload.Artifact, fc *fakeClient) Deps {
+	return Deps{
+		GetArtifact: func(_ string) (*workload.Artifact, error) { return art, nil },
+		Files:       fc,
+	}
+}
+
+func draftArtifact(id string) *workload.Artifact {
+	return &workload.Artifact{ID: id, Name: "my-agent", Status: "draft"}
+}
+
+func initLinkedDir(t *testing.T, catalogID string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{ArtifactID: "art-abc-123"}))
+
+	if catalogID != "" {
+		cfg, err := wapi.LoadConfig(dir)
+		require.NoError(t, err)
+
+		cfg.CatalogID = &catalogID
+		require.NoError(t, wapi.SaveConfig(dir, cfg))
+	}
+
+	return dir
+}
+
+func newTestCmd(t *testing.T, dir string, deps Deps, args []string) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+
+	cmd := cmdWithDeps(deps)
+	cmd.PreRunE = nil
+
+	var buf bytes.Buffer
+
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	require.NoError(t, cmd.Flags().Set("dir", dir))
+
+	cmd.SetArgs(args)
+
+	return cmd, &buf
+}
+
+const (
+	verA = "abcdef1234567890abcdef1234567890"
+	// verB shares verA's 8-char prefix "abcdef12" so the ambiguous-prefix
+	// test resolves to two matches.
+	verB = "abcdef12fffffffabcdef12fffffff00"
+	verC = "11112222333344445555666677778888"
+)
+
+func TestCheckout_NotLinked(t *testing.T) {
+	cmd, _ := newTestCmd(t, t.TempDir(), Deps{}, []string{"abcdef12"})
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not linked")
+}
+
+func TestCheckout_NoCatalog(t *testing.T) {
+	cmd, _ := newTestCmd(t, initLinkedDir(t, ""), Deps{}, []string{"abcdef12"})
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no code has been synced yet")
+}
+
+func TestCheckout_HappyPath_FullID(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1")
+
+	fc := &fakeClient{
+		versions: []filesapi.CatalogVersion{{ID: verA}},
+		content: map[string][]byte{
+			"agent.py":        []byte("print('hello')\n"),
+			"utils/helper.py": []byte("def helper(): return 1\n"),
+		},
+	}
+
+	deps := fakeDeps(draftArtifact("art-abc-123"), fc)
+
+	cmd, buf := newTestCmd(t, dir, deps, []string{verA})
+
+	require.NoError(t, cmd.Execute())
+
+	out := buf.String()
+	assert.Contains(t, out, "Downloading version "+verA)
+	assert.Contains(t, out, "Checked out to: "+filepath.Join(".wapi", ".checkouts", verA))
+	assert.Contains(t, out, "read-only snapshot")
+
+	checkoutDir := wapi.CheckoutDir(dir, verA)
+	gotAgent, err := os.ReadFile(filepath.Join(checkoutDir, "agent.py"))
+	require.NoError(t, err)
+	assert.Equal(t, "print('hello')\n", string(gotAgent))
+
+	metaData, err := os.ReadFile(filepath.Join(checkoutDir, ".checkout-meta.json"))
+	require.NoError(t, err)
+
+	var meta checkoutMeta
+	require.NoError(t, json.Unmarshal(metaData, &meta))
+	assert.Equal(t, verA, meta.VersionID)
+	assert.Equal(t, 2, meta.FileCount)
+
+	historyData, err := os.ReadFile(filepath.Join(dir, ".wapi", "history.log"))
+	require.NoError(t, err)
+
+	lines := bytes.Split(bytes.TrimRight(historyData, "\n"), []byte("\n"))
+	require.GreaterOrEqual(t, len(lines), 2, "expected init + checkout entries")
+
+	var entry map[string]any
+
+	require.NoError(t, json.Unmarshal(lines[len(lines)-1], &entry))
+	assert.Equal(t, "checkout", entry["op"])
+	assert.Equal(t, verA, entry["version"])
+	assert.EqualValues(t, 2, entry["files"])
+
+	// Working dir + sync state untouched.
+	cfg, err := wapi.LoadConfig(dir)
+	require.NoError(t, err)
+	assert.Nil(t, cfg.LastSyncedVersionID)
+}
+
+func TestCheckout_VersionResolution(t *testing.T) {
+	cases := []struct {
+		name, arg, wantErr, wantID string
+		versions                   []filesapi.CatalogVersion
+	}{
+		{"happy short prefix", "abcdef12", "", verA, []filesapi.CatalogVersion{{ID: verA}, {ID: verC}}},
+		{"ambiguous", "abcdef12", "ambiguous", "", []filesapi.CatalogVersion{{ID: verA}, {ID: verB}}},
+		{"not found", "99999999", `"99999999"`, "", []filesapi.CatalogVersion{{ID: verA}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := initLinkedDir(t, "cat-1")
+			fc := &fakeClient{versions: tc.versions, content: map[string][]byte{"x.txt": {0}}}
+			deps := fakeDeps(draftArtifact("art-abc-123"), fc)
+
+			cmd, _ := newTestCmd(t, dir, deps, []string{tc.arg})
+
+			err := cmd.Execute()
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.DirExists(t, wapi.CheckoutDir(dir, tc.wantID))
+		})
+	}
+}
+
+func TestCheckout_RecheckoutRefetches(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1")
+
+	fc := &fakeClient{
+		versions: []filesapi.CatalogVersion{{ID: verA}},
+		content:  map[string][]byte{"a.txt": []byte("first")},
+	}
+
+	deps := fakeDeps(draftArtifact("art-abc-123"), fc)
+
+	cmd1, _ := newTestCmd(t, dir, deps, []string{verA})
+	require.NoError(t, cmd1.Execute())
+
+	allFilesBefore, downloadBefore := fc.callCounts()
+
+	fc.mu.Lock()
+	fc.content["a.txt"] = []byte("second")
+	fc.mu.Unlock()
+
+	cmd2, buf := newTestCmd(t, dir, deps, []string{verA})
+	require.NoError(t, cmd2.Execute())
+
+	allFilesAfter, downloadAfter := fc.callCounts()
+
+	assert.Contains(t, buf.String(), "Downloading version "+verA)
+	assert.Greater(t, allFilesAfter, allFilesBefore, "AllFiles should be re-called on refetch")
+	assert.Greater(t, downloadAfter, downloadBefore, "DownloadFile should be re-called on refetch")
+
+	got, err := os.ReadFile(filepath.Join(wapi.CheckoutDir(dir, verA), "a.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "second", string(got))
+}
+
+func TestCheckout_JSONOutput(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1")
+
+	fc := &fakeClient{
+		versions: []filesapi.CatalogVersion{{ID: verA}},
+		content:  map[string][]byte{"a.txt": []byte("a"), "b.txt": []byte("bb")},
+	}
+
+	deps := fakeDeps(draftArtifact("art-abc-123"), fc)
+
+	cmd, buf := newTestCmd(t, dir, deps, []string{verA})
+	require.NoError(t, cmd.Flags().Set("output-format", "json"))
+
+	require.NoError(t, cmd.Execute())
+
+	var got downloadResult
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+
+	assert.Equal(t, verA, got.VersionID)
+	assert.Equal(t, 2, got.FileCount)
+	assert.Equal(t, int64(3), got.TotalSize)
+	require.Len(t, got.Files, 2)
+	assert.Equal(t, "a.txt", got.Files[0].Path)
+	assert.Equal(t, "b.txt", got.Files[1].Path)
+}
+
+func TestCheckout_DownloadErrorRemovesPartial(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1")
+
+	fc := &fakeClient{
+		versions:    []filesapi.CatalogVersion{{ID: verA}},
+		content:     map[string][]byte{"a.txt": []byte("a")},
+		downloadErr: errors.New("network died"),
+	}
+
+	deps := fakeDeps(draftArtifact("art-abc-123"), fc)
+
+	cmd, _ := newTestCmd(t, dir, deps, []string{verA})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "network died")
+
+	assert.NoDirExists(t, wapi.CheckoutDir(dir, verA))
+}
+
+func TestCheckout_RecheckoutFailurePreservesOld(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1")
+
+	fc := &fakeClient{
+		versions: []filesapi.CatalogVersion{{ID: verA}},
+		content:  map[string][]byte{"a.txt": []byte("first")},
+	}
+
+	deps := fakeDeps(draftArtifact("art-abc-123"), fc)
+
+	cmd1, _ := newTestCmd(t, dir, deps, []string{verA})
+	require.NoError(t, cmd1.Execute())
+
+	checkoutDir := wapi.CheckoutDir(dir, verA)
+	assert.DirExists(t, checkoutDir)
+
+	fc.mu.Lock()
+	fc.downloadErr = errors.New("network died")
+	fc.mu.Unlock()
+
+	cmd2, _ := newTestCmd(t, dir, deps, []string{verA})
+	require.Error(t, cmd2.Execute())
+
+	assert.DirExists(t, checkoutDir, "old snapshot must survive a failed re-checkout")
+
+	got, err := os.ReadFile(filepath.Join(checkoutDir, "a.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "first", string(got))
+}
+
+func TestCheckout_CleanAll(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1")
+
+	require.NoError(t, os.MkdirAll(wapi.CheckoutDir(dir, verA), 0o755))
+	require.NoError(t, os.MkdirAll(wapi.CheckoutDir(dir, verC), 0o755))
+
+	cmd, buf := newTestCmd(t, dir, Deps{}, nil)
+	require.NoError(t, cmd.Flags().Set("clean", "true"))
+
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, buf.String(), "Removed 2 checkouts")
+	assert.NoDirExists(t, wapi.CheckoutsDir(dir))
+}
+
+func TestCheckout_CleanOne(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1")
+
+	require.NoError(t, os.MkdirAll(wapi.CheckoutDir(dir, verA), 0o755))
+	require.NoError(t, os.MkdirAll(wapi.CheckoutDir(dir, verC), 0o755))
+
+	cmd, buf := newTestCmd(t, dir, Deps{}, []string{verA})
+	require.NoError(t, cmd.Flags().Set("clean", "true"))
+
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, buf.String(), "Removed checkout "+verA)
+	assert.NoDirExists(t, wapi.CheckoutDir(dir, verA))
+	assert.DirExists(t, wapi.CheckoutDir(dir, verC))
+}
+
+func TestCheckout_CleanAllJSONEmptyArray(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1")
+
+	cmd, buf := newTestCmd(t, dir, Deps{}, nil)
+	require.NoError(t, cmd.Flags().Set("clean", "true"))
+	require.NoError(t, cmd.Flags().Set("output-format", "json"))
+
+	require.NoError(t, cmd.Execute())
+
+	var got cleanResult
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &got))
+	assert.NotNil(t, got.Removed, "Removed must serialize as [] not null")
+	assert.Empty(t, got.Removed)
+}
+
+func TestCheckout_YesWithoutVersionErrors(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1")
+
+	cmd, _ := newTestCmd(t, dir, Deps{}, nil)
+	require.NoError(t, cmd.Flags().Set("yes", "true"))
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version argument is required")
+}
+
+func TestCheckout_PromptsForVersionWhenMissing(t *testing.T) {
+	dir := initLinkedDir(t, "cat-1")
+
+	fc := &fakeClient{
+		versions: []filesapi.CatalogVersion{{ID: verA}},
+		content:  map[string][]byte{"a.txt": []byte("a")},
+	}
+
+	deps := fakeDeps(draftArtifact("art-abc-123"), fc)
+
+	var promptedLabel string
+
+	deps.PromptVersion = func(label string) (string, error) {
+		promptedLabel = label
+
+		return verA, nil
+	}
+
+	cmd, buf := newTestCmd(t, dir, deps, nil)
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "Code version ID", promptedLabel)
+	assert.Contains(t, buf.String(), "dr workload code versions")
+	assert.DirExists(t, wapi.CheckoutDir(dir, verA))
+}

--- a/cmd/workload/code/checkout/display.go
+++ b/cmd/workload/code/checkout/display.go
@@ -1,0 +1,137 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkout
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/datarobot/cli/internal/workload"
+)
+
+type downloadResult struct {
+	VersionID   string         `json:"versionId"`
+	CheckoutDir string         `json:"checkoutDir"`
+	FileCount   int            `json:"fileCount"`
+	TotalSize   int64          `json:"totalSize"`
+	Files       []downloadFile `json:"files"`
+}
+
+type downloadFile struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+	Hash string `json:"hash"`
+}
+
+type cleanResult struct {
+	Removed []string `json:"removed"`
+}
+
+// checkoutDir is rendered relative to projectDir so output is portable.
+func downloadView(projectDir, versionID, checkoutDir string, files map[string]filesapi.FileMeta) downloadResult {
+	rows := make([]downloadFile, 0, len(files))
+
+	var total int64
+
+	for path, meta := range files {
+		rows = append(rows, downloadFile{Path: path, Size: meta.Size, Hash: meta.Hash})
+
+		total += meta.Size
+	}
+
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Path < rows[j].Path })
+
+	rel, err := filepath.Rel(projectDir, checkoutDir)
+	if err != nil {
+		rel = checkoutDir
+	}
+
+	return downloadResult{
+		VersionID:   versionID,
+		CheckoutDir: rel,
+		FileCount:   len(files),
+		TotalSize:   total,
+		Files:       rows,
+	}
+}
+
+func renderDownloadResult(out io.Writer, format workload.OutputFormat, r downloadResult) error {
+	if format == workload.OutputFormatJSON {
+		return encodeJSON(out, r)
+	}
+
+	fmt.Fprintf(out, "Downloading version %s (%d files, %s)...\n", r.VersionID, r.FileCount, humanBytes(r.TotalSize))
+
+	for _, f := range r.Files {
+		fmt.Fprintf(out, "  ↓ %s (%s)\n", f.Path, humanBytes(f.Size))
+	}
+
+	fmt.Fprintf(out, "Checked out to: %s\n\n", r.CheckoutDir)
+	fmt.Fprintln(out, "This is a read-only snapshot. Your working directory and sync state")
+	fmt.Fprintln(out, "are untouched.")
+
+	return nil
+}
+
+func renderCleanResult(out io.Writer, format workload.OutputFormat, r cleanResult) error {
+	if format == workload.OutputFormatJSON {
+		return encodeJSON(out, r)
+	}
+
+	switch len(r.Removed) {
+	case 0:
+		fmt.Fprintln(out, "No checkouts to remove.")
+	case 1:
+		fmt.Fprintf(out, "Removed checkout %s\n", r.Removed[0])
+	default:
+		fmt.Fprintf(out, "Removed %d checkouts:\n", len(r.Removed))
+
+		for _, name := range r.Removed {
+			fmt.Fprintf(out, "  - %s\n", name)
+		}
+	}
+
+	return nil
+}
+
+func encodeJSON(out io.Writer, v any) error {
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+
+	return enc.Encode(v)
+}
+
+// 1 KB = 1024 B (binary), matching sync-engine accounting.
+func humanBytes(n int64) string {
+	const unit = 1024
+
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+
+	suffix := []string{"KB", "MB", "GB", "TB", "PB"}[exp]
+
+	return fmt.Sprintf("%.1f %s", float64(n)/float64(div), suffix)
+}

--- a/cmd/workload/code/checkout/display.go
+++ b/cmd/workload/code/checkout/display.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/datarobot/cli/cmd/workload/code/internal/format"
 	"github.com/datarobot/cli/internal/drapi/filesapi"
 	"github.com/datarobot/cli/internal/workload"
 )
@@ -71,15 +72,15 @@ func downloadView(projectDir, versionID, checkoutDir string, files map[string]fi
 	}
 }
 
-func renderDownloadResult(out io.Writer, format workload.OutputFormat, r downloadResult) error {
-	if format == workload.OutputFormatJSON {
+func renderDownloadResult(out io.Writer, outFmt workload.OutputFormat, r downloadResult) error {
+	if outFmt == workload.OutputFormatJSON {
 		return encodeJSON(out, r)
 	}
 
-	fmt.Fprintf(out, "Downloading version %s (%d files, %s)...\n", r.VersionID, r.FileCount, humanBytes(r.TotalSize))
+	fmt.Fprintf(out, "Downloading version %s (%d files, %s)...\n", r.VersionID, r.FileCount, format.Bytes(r.TotalSize))
 
 	for _, f := range r.Files {
-		fmt.Fprintf(out, "  ↓ %s (%s)\n", f.Path, humanBytes(f.Size))
+		fmt.Fprintf(out, "  ↓ %s (%s)\n", f.Path, format.Bytes(f.Size))
 	}
 
 	fmt.Fprintf(out, "Checked out to: %s\n\n", r.CheckoutDir)
@@ -89,8 +90,8 @@ func renderDownloadResult(out io.Writer, format workload.OutputFormat, r downloa
 	return nil
 }
 
-func renderCleanResult(out io.Writer, format workload.OutputFormat, r cleanResult) error {
-	if format == workload.OutputFormatJSON {
+func renderCleanResult(out io.Writer, outFmt workload.OutputFormat, r cleanResult) error {
+	if outFmt == workload.OutputFormatJSON {
 		return encodeJSON(out, r)
 	}
 
@@ -115,23 +116,4 @@ func encodeJSON(out io.Writer, v any) error {
 	enc.SetIndent("", "  ")
 
 	return enc.Encode(v)
-}
-
-// 1 KB = 1024 B (binary), matching sync-engine accounting.
-func humanBytes(n int64) string {
-	const unit = 1024
-
-	if n < unit {
-		return fmt.Sprintf("%d B", n)
-	}
-
-	div, exp := int64(unit), 0
-	for x := n / unit; x >= unit; x /= unit {
-		div *= unit
-		exp++
-	}
-
-	suffix := []string{"KB", "MB", "GB", "TB", "PB"}[exp]
-
-	return fmt.Sprintf("%.1f %s", float64(n)/float64(div), suffix)
 }

--- a/cmd/workload/code/cmd.go
+++ b/cmd/workload/code/cmd.go
@@ -15,6 +15,7 @@
 package code
 
 import (
+	"github.com/datarobot/cli/cmd/workload/code/checkout"
 	initcmd "github.com/datarobot/cli/cmd/workload/code/init"
 	"github.com/datarobot/cli/cmd/workload/code/versions"
 	"github.com/spf13/cobra"
@@ -37,9 +38,9 @@ Subcommands:
   init       Link a directory to an existing artifact and lay down the
              '.wapi/' state. Required before any other 'code' command.
   sync       Push local edits and pull remote changes (coming soon).
-  versions   List catalog versions for the linked artifact (coming soon).
+  versions   List catalog versions for the linked artifact.
   checkout   Download a prior version into '.wapi/.checkouts/' for
-             read-only inspection (coming soon).
+             read-only inspection.
 
 Artifacts must already exist before running 'init'. Create them via
 'dr workload artifact create' or in the DataRobot UI — these commands
@@ -52,6 +53,7 @@ Example:
 
 	cmd.AddCommand(initcmd.Cmd())
 	cmd.AddCommand(versions.Cmd())
+	cmd.AddCommand(checkout.Cmd())
 
 	return cmd
 }

--- a/cmd/workload/code/internal/format/format.go
+++ b/cmd/workload/code/internal/format/format.go
@@ -1,0 +1,37 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package format provides display helpers shared across workload-code commands.
+package format
+
+import "fmt"
+
+// Bytes renders n in base-1024 units, capping at PB to avoid suffix overflow.
+func Bytes(n int64) string {
+	const unit = 1024
+
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+
+	suffixes := []string{"KB", "MB", "GB", "TB", "PB"}
+	div, exp := int64(unit), 0
+
+	for x := n / unit; x >= unit && exp < len(suffixes)-1; x /= unit {
+		div *= unit
+		exp++
+	}
+
+	return fmt.Sprintf("%.1f %s", float64(n)/float64(div), suffixes[exp])
+}

--- a/cmd/workload/code/internal/format/format_test.go
+++ b/cmd/workload/code/internal/format/format_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package format
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBytes_Range(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   int64
+		want string
+	}{
+		{"zero", 0, "0 B"},
+		{"sub-unit", 512, "512 B"},
+		{"unit-edge", 1023, "1023 B"},
+		{"one-kb", 1024, "1.0 KB"},
+		{"one-and-half-kb", 1024 + 512, "1.5 KB"},
+		{"one-mb", 1024 * 1024, "1.0 MB"},
+		{"one-gb", 1024 * 1024 * 1024, "1.0 GB"},
+		{"one-tb", int64(1024) * 1024 * 1024 * 1024, "1.0 TB"},
+		{"one-pb", int64(1024) * 1024 * 1024 * 1024 * 1024, "1.0 PB"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, Bytes(tc.in))
+		})
+	}
+}
+
+// Regression: prior implementation indexed past the suffix slice for n >= 1024^5,
+// causing an index-out-of-range panic. The capped loop holds at PB.
+func TestBytes_NoPanicAtExtreme(t *testing.T) {
+	t.Parallel()
+
+	got := Bytes(int64(1) << 60)
+	assert.True(t, strings.HasSuffix(got, " PB"), "expected PB suffix, got %q", got)
+
+	got = Bytes(math.MaxInt64)
+	assert.True(t, strings.HasSuffix(got, " PB"), "expected PB suffix at MaxInt64, got %q", got)
+}

--- a/cmd/workload/code/versions/cmd_test.go
+++ b/cmd/workload/code/versions/cmd_test.go
@@ -194,8 +194,8 @@ func TestVersions_TextOutput(t *testing.T) {
 	assert.Contains(t, out, "Artifact: my-agent (art-abc-123)")
 	assert.Contains(t, out, "Status:   DRAFT")
 	assert.Contains(t, out, "VERSION ID")
-	assert.Contains(t, out, "* v3aaaaaa")
-	assert.Contains(t, out, "v2bbbbbb")
+	assert.Contains(t, out, "* v3aaaaaaaaaaaa")
+	assert.Contains(t, out, "v2bbbbbbbbbbbb")
 	assert.Contains(t, out, "* = current")
 }
 

--- a/cmd/workload/code/versions/view.go
+++ b/cmd/workload/code/versions/view.go
@@ -126,7 +126,7 @@ func renderText(out io.Writer, v view) {
 		}
 
 		t.Row(
-			marker+row.Short,
+			marker+row.ID,
 			strconv.Itoa(row.NumFiles),
 			humanBytes(row.TotalSize),
 			formatCreatedAt(row.CreatedAt),
@@ -140,7 +140,7 @@ func renderText(out io.Writer, v view) {
 	}
 
 	if v.SyncedVersionID != "" {
-		fmt.Fprintf(out, "Local synced to: %s\n", shortID(v.SyncedVersionID))
+		fmt.Fprintf(out, "Local synced to: %s\n", v.SyncedVersionID)
 	}
 }
 

--- a/cmd/workload/code/versions/view.go
+++ b/cmd/workload/code/versions/view.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
+	"github.com/datarobot/cli/cmd/workload/code/internal/format"
 	"github.com/datarobot/cli/internal/drapi/filesapi"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/tui"
@@ -128,7 +129,7 @@ func renderText(out io.Writer, v view) {
 		t.Row(
 			marker+row.ID,
 			strconv.Itoa(row.NumFiles),
-			humanBytes(row.TotalSize),
+			format.Bytes(row.TotalSize),
 			formatCreatedAt(row.CreatedAt),
 		)
 	}
@@ -187,24 +188,4 @@ func formatCreatedAt(s string) string {
 	}
 
 	return t.UTC().Format("2006-01-02 15:04 UTC")
-}
-
-// humanBytes renders an int64 byte count as KB/MB/GB with one decimal.
-// 1 KB = 1024 B (binary), matching how engine and limits already think.
-func humanBytes(n int64) string {
-	const unit = 1024
-
-	if n < unit {
-		return fmt.Sprintf("%d B", n)
-	}
-
-	div, exp := int64(unit), 0
-	for x := n / unit; x >= unit; x /= unit {
-		div *= unit
-		exp++
-	}
-
-	suffix := []string{"KB", "MB", "GB", "TB", "PB"}[exp]
-
-	return fmt.Sprintf("%.1f %s", float64(n)/float64(div), suffix)
 }

--- a/internal/workload/wapi/paths.go
+++ b/internal/workload/wapi/paths.go
@@ -22,9 +22,10 @@ import (
 
 // Exported names used by external callers (tests, sync commands).
 const (
-	DirName         = ".wapi"
-	HistoryFile     = "history.log"
-	ManifestVersion = 1
+	DirName          = ".wapi"
+	HistoryFile      = "history.log"
+	ManifestVersion  = 1
+	CheckoutsDirName = ".checkouts"
 )
 
 // Internal layout constants. Stay private so consumers go through the
@@ -77,4 +78,17 @@ func wapiignorePath(projectDir string) string {
 // Returns false if .wapi exists as a file rather than a directory.
 func Exists(projectDir string) bool {
 	return fsutil.DirExists(wapiDir(projectDir))
+}
+
+// CheckoutsDir is the parent directory holding read-only version snapshots
+// produced by `dr workload code checkout`. Each snapshot is a sub-directory
+// named after the full catalog version ID.
+func CheckoutsDir(projectDir string) string {
+	return filepath.Join(wapiDir(projectDir), CheckoutsDirName)
+}
+
+// CheckoutDir is the snapshot directory for a single version, identified by
+// its full catalog version ID.
+func CheckoutDir(projectDir, versionID string) string {
+	return filepath.Join(CheckoutsDir(projectDir), versionID)
 }


### PR DESCRIPTION
# RATIONALE

Adds the third leg of the workload-code triad (`init` → `versions` → `checkout`) so users can pull a specific catalog version into a side directory for read-only inspection without disturbing their working tree or `.wapi/` sync state.

## CHANGES

- New `dr workload code checkout [<ver>]` command that downloads a catalog version into `.wapi/.checkouts/<version-id>/`, accepting either a full version ID or any unique prefix; prompts when omitted unless `--yes` is set.
- `--clean` removes all checkouts (no arg) or one by name/unique prefix; both human and `--output-format json` renderings supported.
- Downloads stage into a sibling `.tmp-*` dir, then a backup-rename swap (`.bak-<ver>` → final, with rollback on rename failure) installs the snapshot, so a failed re-checkout falls back to the previous one.
- `dr workload code versions` table now prints full version IDs, so users can copy a unique prefix straight into `checkout`.
- Adds `wapi.CheckoutsDir` / `wapi.CheckoutDir` helpers and a `.checkouts` constant to the layout.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

## TESTING

- `go test ./cmd/workload/code/checkout/... -race -count=1` — happy path, version resolution (full ID, prefix, ambiguous), re-checkout refetch, partial-cleanup on download error, rollback preserves old snapshot, `--clean` all/one, JSON output, `--yes` without arg, prompt fallback.
- `task lint` — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new filesystem download/install and cleanup flows (temp staging + atomic rename/rollback) that could affect local `.wapi/.checkouts` contents if edge cases aren’t handled correctly; other changes are output-only.
> 
> **Overview**
> Adds `dr workload code checkout [<ver>]` to download a catalog version into `.wapi/.checkouts/<version-id>/` for read-only inspection, including prompting (unless `--yes`), unique-prefix version resolution, JSON/text output, and `--clean` to remove one or all local checkouts.
> 
> Implements a safer install path by staging downloads in a sibling temp dir, validating server file paths, writing `.checkout-meta.json`, then swapping into place with backup/rollback semantics and recording a `checkout` entry in `.wapi/history.log`.
> 
> Updates `dr workload code versions` rendering to show full version IDs (and full “local synced to” ID) and centralizes byte-size formatting in a new shared `format.Bytes` helper with regression tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 563cfce089596770cf15d8ae383722be0ea092da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->