### PR TITLE
bugfix(drapi): don't hammer the version API

### DIFF
--- a/.cursor/bugbot-testing.md
+++ b/.cursor/bugbot-testing.md
@@ -79,49 +79,7 @@ func TestProcessMissingResource(t *testing.T) {
 
 ## Test Seams and Mocking
 
-Design code using **dependency inversion**: depend on abstractions (interfaces), not concrete types. This makes tests simple and code decoupled.
-
-**Anti-pattern** (tight coupling to concrete types):
-```go
-// Bad: Function tightly coupled to concrete *http.Client
-func Fetch(ctx context.Context, path string) ([]byte, error) {
-    // Creates HTTP client internally; cannot mock in tests
-    client := &http.Client{}
-    resp, err := client.Get(ctx, path)
-    // ...
-}
-
-// Test must make real HTTP calls
-func TestFetch(t *testing.T) {
-    data, err := Fetch(context.Background(), "/path")  // Real HTTP!
-    assert.NoError(t, err)
-}
-```
-
-**Correct pattern** (dependency inversion via interface):
-```go
-// Good: Depend on abstraction, not concrete type
-type HTTPClient interface {
-    Get(ctx context.Context, path string) ([]byte, error)
-}
-
-func Fetch(ctx context.Context, client HTTPClient, path string) ([]byte, error) {
-    data, err := client.Get(ctx, path)
-    // ...
-}
-
-// Test uses mock; no real HTTP calls
-type mockClient struct { data []byte; err error }
-func (m *mockClient) Get(ctx context.Context, path string) ([]byte, error) {
-    return m.data, m.err
-}
-
-func TestFetch(t *testing.T) {
-    client := &mockClient{data: []byte("test")}
-    data, err := Fetch(context.Background(), client, "/path")
-    assert.NoError(t, err)
-}
-```
+Design code using **dependency inversion**: depend on abstractions (interfaces), not concrete types. Avoid using exported mutable state or global variables in tests. Prefer function variables or interfaces that can be overridden in tests.
 
 **What to flag**: Real API calls in tests, complex setup, functions depending on concrete types (not interfaces), global state, creating dependencies internally instead of accepting them.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,8 +149,10 @@ All PRs are reviewed against **bugbot rules** in [.cursor/BUGBOT.md](.cursor/BUG
 **When working on code**, apply these quick principles:
 - **Concurrency**: Recover from panics, capture loop variables, pair WaitGroups, close channels safely
 - **Errors**: Wrap with context, specialize messages (404 vs 500), log before returning
+- **Caching**: When caching expensive operations, memoize both success and failure
 - **Commands**: Use `lipgloss/table` + `tui.TableBorderStyle`, consistent styling, test output formatting
 - **Platforms**: Add build tags, match signatures, test on target platforms
+- **sync.Once**: Use for expensive one-time initialization
 
 Refer to [.cursor/BUGBOT.md](.cursor/BUGBOT.md) for detailed rules and examples during PR review.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,7 @@ import (
 	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/log"
 	internalPlugin "github.com/datarobot/cli/internal/plugin"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -81,6 +82,8 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 			if err != nil {
 				return err
 			}
+
+			drapi.Init(config.GetAPIKey)
 
 			// Initialize telemetry client
 			// Always collect common properties for logging (even in dry-run mode),

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -86,11 +86,6 @@ func VerifyToken(ctx context.Context, datarobotEndpoint, token string) error {
 	return nil
 }
 
-// GetAPITokenFunc is the function used by drapi to fetch the API token. It is a
-// package-level variable so tests can inject a stub without going through GetAPIKey.
-// Production code must never reassign this.
-var GetAPITokenFunc = GetAPIKey //nolint:gochecknoglobals
-
 func GetAPIKey(ctx context.Context) (string, error) {
 	viperEndpoint := viper.GetString(DataRobotURL)
 	viperToken := viper.GetString(DataRobotAPIKey)

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -86,7 +86,10 @@ func VerifyToken(ctx context.Context, datarobotEndpoint, token string) error {
 	return nil
 }
 
-var GetAPITokenFunc = GetAPIKey
+// GetAPITokenFunc is the function used by drapi to fetch the API token. It is a
+// package-level variable so tests can inject a stub without going through GetAPIKey.
+// Production code must never reassign this.
+var GetAPITokenFunc = GetAPIKey //nolint:gochecknoglobals
 
 func GetAPIKey(ctx context.Context) (string, error) {
 	viperEndpoint := viper.GetString(DataRobotURL)

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -86,6 +86,8 @@ func VerifyToken(ctx context.Context, datarobotEndpoint, token string) error {
 	return nil
 }
 
+var GetAPITokenFunc = GetAPIKey
+
 func GetAPIKey(ctx context.Context) (string, error) {
 	viperEndpoint := viper.GetString(DataRobotURL)
 	viperToken := viper.GetString(DataRobotAPIKey)

--- a/internal/drapi/auth.go
+++ b/internal/drapi/auth.go
@@ -26,7 +26,7 @@ import (
 // (e.g. multipart streaming uploads in drapi/filesapi) can reuse the
 // canonical drapi auth-injection logic instead of re-implementing it.
 //
-// Reuses the package-level `token` memoization declared in get.go.
+// Reuses the package-level token/errToken memoization via resolveToken() (declared in get.go).
 func SetAuthHeaders(req *http.Request) error {
 	var err error
 

--- a/internal/drapi/auth.go
+++ b/internal/drapi/auth.go
@@ -15,7 +15,6 @@
 package drapi
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/datarobot/cli/internal/config"
@@ -29,13 +28,10 @@ import (
 //
 // Reuses the package-level `token` memoization declared in get.go.
 func SetAuthHeaders(req *http.Request) error {
-	if token == "" {
-		var err error
+	var err error
 
-		token, err = config.GetAPIKey(context.Background())
-		if err != nil {
-			return err
-		}
+	if token, err = resolveToken(); err != nil {
+		return err
 	}
 
 	req.Header.Set("Authorization", "Bearer "+token)

--- a/internal/drapi/auth_test.go
+++ b/internal/drapi/auth_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestSetAuthHeaders_AuthorizationAndUserAgent(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	req, err := http.NewRequest(http.MethodGet, "http://example/", nil)
 	require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestSetAuthHeaders_AuthorizationAndUserAgent(t *testing.T) {
 }
 
 func TestSetAuthHeaders_TraceHeaderEnabled(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	viperx.Reset()
 	t.Cleanup(viperx.Reset)
@@ -52,7 +52,7 @@ func TestSetAuthHeaders_TraceHeaderEnabled(t *testing.T) {
 }
 
 func TestSetAuthHeaders_TraceHeaderDisabled(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	viperx.Reset()
 	t.Cleanup(viperx.Reset)
@@ -70,7 +70,7 @@ func TestSetAuthHeaders_TraceHeaderDisabled(t *testing.T) {
 // config.GetAPIKey on subsequent calls — the second SetAuthHeaders call
 // must succeed without contacting config (which would fail in this test env).
 func TestSetAuthHeaders_MemoizesToken(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	for range 2 {
 		req, err := http.NewRequest(http.MethodGet, "http://example/", nil)
@@ -86,7 +86,7 @@ func TestSetAuthHeaders_MemoizesToken(t *testing.T) {
 // test env), the error is returned rather than silently producing a request
 // with an empty bearer.
 func TestSetAuthHeaders_PropagatesTokenError(t *testing.T) {
-	defer resetTokenForTest(t, "")()
+	StubAPIToken(t, "")
 
 	viperx.Reset()
 	t.Cleanup(viperx.Reset)

--- a/internal/drapi/delete.go
+++ b/internal/drapi/delete.go
@@ -16,7 +16,6 @@ package drapi
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -28,11 +27,8 @@ import (
 func Delete(url, info string, body any) (*http.Response, error) {
 	var err error
 
-	if token == "" {
-		token, err = config.GetAPIKey(context.Background())
-		if err != nil {
-			return nil, err
-		}
+	if token, err = resolveToken(); err != nil {
+		return nil, err
 	}
 
 	payload, err := json.Marshal(body)

--- a/internal/drapi/delete.go
+++ b/internal/drapi/delete.go
@@ -27,6 +27,7 @@ import (
 func Delete(url, info string, body any) (*http.Response, error) {
 	var err error
 
+	// resolveToken memoizes both success and failure; see get.go for rationale.
 	if token, err = resolveToken(); err != nil {
 		return nil, err
 	}

--- a/internal/drapi/delete_test.go
+++ b/internal/drapi/delete_test.go
@@ -28,7 +28,7 @@ import (
 // io.EOF — making a successful delete look like a failure to callers
 // that pass a non-nil v (e.g. DeleteFiles always passes &resp).
 func TestDeleteJSON_204NoContent(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
@@ -45,7 +45,7 @@ func TestDeleteJSON_204NoContent(t *testing.T) {
 }
 
 func TestDeleteJSON_200WithBody(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -63,7 +63,7 @@ func TestDeleteJSON_200WithBody(t *testing.T) {
 }
 
 func TestDeleteJSON_NonSuccess(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -52,7 +52,7 @@ func GetToken() string {
 // SetToken sets the cached API token.
 func SetToken(value string) {
 	token = value
-	errToken = nil
+	errToken = nil // clear any cached auth failure so the new token gets a fresh attempt
 }
 
 // resolveToken returns the memoized token, calling GetAPIKey at most once per

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
@@ -38,21 +39,28 @@ func (e *HTTPError) Error() string {
 }
 
 var (
-	token    string
-	errToken error
+	tokenOnce sync.Once
+	tokenFunc func(context.Context) (string, error) = config.GetAPIKey
+	token     string
+	errToken  error
 )
 
-// resolveToken returns the memoized token, calling config.GetAPITokenFunc at most once
-// per process. Both the token and any auth failure are cached so that a bad or expired
-// credential does not produce a /api/v2/version/ probe on every subsequent API call.
-func resolveToken() (string, error) {
-	if errToken != nil {
-		return "", errToken
-	}
+// Init sets the function drapi uses to fetch the API token. Must be called once at
+// application startup before any API call is made. Calling Init again (e.g. in tests)
+// resets the memoized cache so the new function is used on the next call.
+func Init(fn func(context.Context) (string, error)) {
+	tokenFunc = fn
+	tokenOnce = sync.Once{}
+	token = ""
+	errToken = nil
+}
 
-	if token == "" {
-		token, errToken = config.GetAPITokenFunc(context.Background())
-	}
+// resolveToken returns the memoized token. tokenOnce guarantees the fetch happens
+// exactly once per Init call, safe for concurrent callers.
+func resolveToken() (string, error) {
+	tokenOnce.Do(func() {
+		token, errToken = tokenFunc(context.Background())
+	})
 
 	return token, errToken
 }

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
@@ -37,40 +38,38 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("HTTP error: %d %s (url: %s)", e.StatusCode, http.StatusText(e.StatusCode), e.URL)
 }
 
-var token string
-
-// errToken caches the first GetAPIKey failure so subsequent calls within the
-// same process do not retry VerifyToken (and hit /api/v2/version/) on every
-// API call when the configured token is invalid.
-var errToken error
+var (
+	token     string
+	errToken  error
+	tokenOnce sync.Once
+)
 
 // GetToken returns the current cached API token.
 func GetToken() string {
 	return token
 }
 
-// SetToken sets the cached API token.
+// SetToken is a test seam: it seeds the package-level token and resets the
+// sync.Once so tests can inject a known value without going through GetAPIKey.
+// Production code has no reason to call this.
 func SetToken(value string) {
 	token = value
-	errToken = nil // clear any cached auth failure so the new token gets a fresh attempt
+	errToken = nil
+	tokenOnce = sync.Once{}
 }
 
-// resolveToken returns the memoized token, calling GetAPIKey at most once per
-// process. Both the token and any auth failure are cached so that a bad or
-// expired credential does not produce a /api/v2/version/ probe on every API call.
+// resolveToken calls GetAPIKey at most once per process lifetime, caching both
+// the token and any auth failure so a bad or expired credential does not
+// produce a /api/v2/version/ probe on every subsequent API call.
 func resolveToken() (string, error) {
-	if errToken != nil {
-		return "", errToken
-	}
-
-	if token == "" {
-		token, errToken = config.GetAPIKey(context.Background())
-		if errToken != nil {
-			return "", errToken
+	tokenOnce.Do(func() {
+		// Skip fetch if a token was pre-seeded via SetToken (test seam).
+		if token == "" {
+			token, errToken = config.GetAPIKey(context.Background())
 		}
-	}
+	})
 
-	return token, nil
+	return token, errToken
 }
 
 const DefaultGetTimeoutSecs = 30

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
@@ -39,35 +38,26 @@ func (e *HTTPError) Error() string {
 }
 
 var (
-	token     string
-	errToken  error
-	tokenOnce sync.Once
+	token    string
+	errToken error
 )
 
-// GetToken returns the current cached API token.
-func GetToken() string {
-	return token
-}
+// GetAPITokenFunc is the function used to fetch the API token. It is a package-level
+// variable so tests can inject a stub without going through config.GetAPIKey.
+// Production code must never reassign this.
+var GetAPITokenFunc = config.GetAPIKey //nolint:gochecknoglobals
 
-// SetToken is a test seam: it seeds the package-level token and resets the
-// sync.Once so tests can inject a known value without going through GetAPIKey.
-// Production code has no reason to call this.
-func SetToken(value string) {
-	token = value
-	errToken = nil
-	tokenOnce = sync.Once{}
-}
-
-// resolveToken calls GetAPIKey at most once per process lifetime, caching both
-// the token and any auth failure so a bad or expired credential does not
-// produce a /api/v2/version/ probe on every subsequent API call.
+// resolveToken returns the memoized token, calling GetAPITokenFunc at most once per
+// process. Both the token and any auth failure are cached so that a bad or expired
+// credential does not produce a /api/v2/version/ probe on every subsequent API call.
 func resolveToken() (string, error) {
-	tokenOnce.Do(func() {
-		// Skip fetch if a token was pre-seeded via SetToken (test seam).
-		if token == "" {
-			token, errToken = config.GetAPIKey(context.Background())
-		}
-	})
+	if errToken != nil {
+		return "", errToken
+	}
+
+	if token == "" {
+		token, errToken = GetAPITokenFunc(context.Background())
+	}
 
 	return token, errToken
 }

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -39,6 +39,11 @@ func (e *HTTPError) Error() string {
 
 var token string
 
+// tokenErr caches the first GetAPIKey failure so subsequent calls within the
+// same process do not retry VerifyToken (and hit /api/v2/version/) on every
+// API call when the configured token is invalid.
+var tokenErr error
+
 // GetToken returns the current cached API token.
 func GetToken() string {
 	return token
@@ -47,6 +52,25 @@ func GetToken() string {
 // SetToken sets the cached API token.
 func SetToken(value string) {
 	token = value
+	tokenErr = nil
+}
+
+// resolveToken returns the memoized token, calling GetAPIKey at most once per
+// process. Both the token and any auth failure are cached so that a bad or
+// expired credential does not produce a /api/v2/version/ probe on every API call.
+func resolveToken() (string, error) {
+	if tokenErr != nil {
+		return "", tokenErr
+	}
+
+	if token == "" {
+		token, tokenErr = config.GetAPIKey(context.Background())
+		if tokenErr != nil {
+			return "", tokenErr
+		}
+	}
+
+	return token, nil
 }
 
 const DefaultGetTimeoutSecs = 30
@@ -57,14 +81,9 @@ func Get(url, info string, timeoutSecs ...int) (*http.Response, error) {
 		timeout = timeoutSecs[0]
 	}
 
-	var err error
-
-	// memoize token to avoid extra VerifyToken() calls
-	if token == "" {
-		token, err = config.GetAPIKey(context.Background())
-		if err != nil {
-			return nil, err
-		}
+	tok, err := resolveToken()
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -72,7 +91,7 @@ func Get(url, info string, timeoutSecs ...int) (*http.Response, error) {
 		return nil, err
 	}
 
-	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Authorization", "Bearer "+tok)
 	req.Header.Add("User-Agent", config.GetUserAgentHeader())
 
 	if config.IsAPIConsumerTrackingEnabled() {

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -42,13 +42,8 @@ var (
 	errToken error
 )
 
-// GetAPITokenFunc is the function used to fetch the API token. It is a package-level
-// variable so tests can inject a stub without going through config.GetAPIKey.
-// Production code must never reassign this.
-var GetAPITokenFunc = config.GetAPIKey //nolint:gochecknoglobals
-
-// resolveToken returns the memoized token, calling GetAPITokenFunc at most once per
-// process. Both the token and any auth failure are cached so that a bad or expired
+// resolveToken returns the memoized token, calling config.GetAPITokenFunc at most once
+// per process. Both the token and any auth failure are cached so that a bad or expired
 // credential does not produce a /api/v2/version/ probe on every subsequent API call.
 func resolveToken() (string, error) {
 	if errToken != nil {
@@ -56,7 +51,7 @@ func resolveToken() (string, error) {
 	}
 
 	if token == "" {
-		token, errToken = GetAPITokenFunc(context.Background())
+		token, errToken = config.GetAPITokenFunc(context.Background())
 	}
 
 	return token, errToken

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -39,10 +39,10 @@ func (e *HTTPError) Error() string {
 
 var token string
 
-// tokenErr caches the first GetAPIKey failure so subsequent calls within the
+// errToken caches the first GetAPIKey failure so subsequent calls within the
 // same process do not retry VerifyToken (and hit /api/v2/version/) on every
 // API call when the configured token is invalid.
-var tokenErr error
+var errToken error
 
 // GetToken returns the current cached API token.
 func GetToken() string {
@@ -52,21 +52,21 @@ func GetToken() string {
 // SetToken sets the cached API token.
 func SetToken(value string) {
 	token = value
-	tokenErr = nil
+	errToken = nil
 }
 
 // resolveToken returns the memoized token, calling GetAPIKey at most once per
 // process. Both the token and any auth failure are cached so that a bad or
 // expired credential does not produce a /api/v2/version/ probe on every API call.
 func resolveToken() (string, error) {
-	if tokenErr != nil {
-		return "", tokenErr
+	if errToken != nil {
+		return "", errToken
 	}
 
 	if token == "" {
-		token, tokenErr = config.GetAPIKey(context.Background())
-		if tokenErr != nil {
-			return "", tokenErr
+		token, errToken = config.GetAPIKey(context.Background())
+		if errToken != nil {
+			return "", errToken
 		}
 	}
 

--- a/internal/drapi/patch.go
+++ b/internal/drapi/patch.go
@@ -16,7 +16,6 @@ package drapi
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -28,11 +27,8 @@ import (
 func Patch(url, info string, body any) (*http.Response, error) {
 	var err error
 
-	if token == "" {
-		token, err = config.GetAPIKey(context.Background())
-		if err != nil {
-			return nil, err
-		}
+	if token, err = resolveToken(); err != nil {
+		return nil, err
 	}
 
 	payload, err := json.Marshal(body)

--- a/internal/drapi/patch.go
+++ b/internal/drapi/patch.go
@@ -27,6 +27,7 @@ import (
 func Patch(url, info string, body any) (*http.Response, error) {
 	var err error
 
+	// resolveToken memoizes both success and failure; see get.go for rationale.
 	if token, err = resolveToken(); err != nil {
 		return nil, err
 	}

--- a/internal/drapi/patch_test.go
+++ b/internal/drapi/patch_test.go
@@ -28,7 +28,7 @@ import (
 // decode would surface io.EOF on an empty body, masking a successful
 // patch from any caller that passes non-nil v.
 func TestPatchJSON_204NoContent(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
@@ -45,7 +45,7 @@ func TestPatchJSON_204NoContent(t *testing.T) {
 }
 
 func TestPatchJSON_200WithBody(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/drapi/post.go
+++ b/internal/drapi/post.go
@@ -27,6 +27,7 @@ import (
 func Post(url, info string, body any) (*http.Response, error) {
 	var err error
 
+	// resolveToken memoizes both success and failure; see get.go for rationale.
 	if token, err = resolveToken(); err != nil {
 		return nil, err
 	}

--- a/internal/drapi/post.go
+++ b/internal/drapi/post.go
@@ -16,7 +16,6 @@ package drapi
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -28,11 +27,8 @@ import (
 func Post(url, info string, body any) (*http.Response, error) {
 	var err error
 
-	if token == "" {
-		token, err = config.GetAPIKey(context.Background())
-		if err != nil {
-			return nil, err
-		}
+	if token, err = resolveToken(); err != nil {
+		return nil, err
 	}
 
 	payload, err := json.Marshal(body)

--- a/internal/drapi/post_test.go
+++ b/internal/drapi/post_test.go
@@ -25,8 +25,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// resetTokenForTest seeds the package-level token so Post() does not call
-// config.GetAPIKey() (which would require a configured environment).
+// resetTokenForTest seeds the package-level token so verb helpers do not call
+// config.GetAPIKey() (which would require a configured environment), and clears
+// errToken so a cached auth failure from a prior test does not bleed through.
 // Returns a cleanup function the test should defer.
 func resetTokenForTest(t *testing.T, value string) func() {
 	t.Helper()

--- a/internal/drapi/post_test.go
+++ b/internal/drapi/post_test.go
@@ -15,9 +15,7 @@
 package drapi
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -27,30 +25,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// resetTokenForTest seeds the package-level token directly (same-package access)
-// and stubs GetAPITokenFunc so verb helpers never call config.GetAPIKey.
-// Returns a cleanup function the test should defer.
-func resetTokenForTest(t *testing.T, value string) func() {
-	t.Helper()
-
-	prevToken, prevErr, prevFunc := token, errToken, GetAPITokenFunc
-	token, errToken = value, nil
-
-	if value == "" {
-		GetAPITokenFunc = func(_ context.Context) (string, error) {
-			return "", errors.New("empty token")
-		}
-	} else {
-		GetAPITokenFunc = func(_ context.Context) (string, error) { return value, nil }
-	}
-
-	return func() {
-		token, errToken, GetAPITokenFunc = prevToken, prevErr, prevFunc
-	}
-}
-
 func TestPost_Created(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
@@ -67,7 +43,7 @@ func TestPost_Created(t *testing.T) {
 }
 
 func TestPost_OK(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -84,7 +60,7 @@ func TestPost_OK(t *testing.T) {
 }
 
 func TestPost_NonSuccess(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
@@ -102,7 +78,7 @@ func TestPost_NonSuccess(t *testing.T) {
 }
 
 func TestPost_Unauthorized(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
@@ -120,14 +96,14 @@ func TestPost_Unauthorized(t *testing.T) {
 }
 
 func TestPost_NetworkError(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	_, err := Post("http://127.0.0.1:1/does-not-exist", "", map[string]string{}) //nolint:bodyclose // network error path returns nil resp
 	require.Error(t, err)
 }
 
 func TestPost_SetsHeaders(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	var (
 		gotAuth        string
@@ -155,7 +131,7 @@ func TestPost_SetsHeaders(t *testing.T) {
 }
 
 func TestPost_SendsBody(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	var gotBody []byte
 
@@ -182,7 +158,7 @@ func TestPost_SendsBody(t *testing.T) {
 }
 
 func TestPostJSON_Decode(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
@@ -202,7 +178,7 @@ func TestPostJSON_Decode(t *testing.T) {
 }
 
 func TestPostJSON_DecodeError(t *testing.T) {
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)

--- a/internal/drapi/post_test.go
+++ b/internal/drapi/post_test.go
@@ -15,6 +15,7 @@
 package drapi
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -25,17 +26,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// resetTokenForTest seeds the package-level token via SetToken (the test seam)
-// so verb helpers do not call config.GetAPIKey() (which requires a configured
-// environment). Returns a cleanup function the test should defer.
+// resetTokenForTest seeds the package-level token directly (same-package access)
+// and stubs GetAPITokenFunc so verb helpers never call config.GetAPIKey.
+// Returns a cleanup function the test should defer.
 func resetTokenForTest(t *testing.T, value string) func() {
 	t.Helper()
 
-	previous := token
+	prevToken, prevErr, prevFunc := token, errToken, GetAPITokenFunc
+	token, errToken = value, nil
+	GetAPITokenFunc = func(_ context.Context) (string, error) { return value, nil }
 
-	SetToken(value)
-
-	return func() { SetToken(previous) }
+	return func() {
+		token, errToken, GetAPITokenFunc = prevToken, prevErr, prevFunc
+	}
 }
 
 func TestPost_Created(t *testing.T) {

--- a/internal/drapi/post_test.go
+++ b/internal/drapi/post_test.go
@@ -25,22 +25,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// resetTokenForTest seeds the package-level token so verb helpers do not call
-// config.GetAPIKey() (which would require a configured environment), and clears
-// errToken so a cached auth failure from a prior test does not bleed through.
-// Returns a cleanup function the test should defer.
+// resetTokenForTest seeds the package-level token via SetToken (the test seam)
+// so verb helpers do not call config.GetAPIKey() (which requires a configured
+// environment). Returns a cleanup function the test should defer.
 func resetTokenForTest(t *testing.T, value string) func() {
 	t.Helper()
 
-	previousToken := token
-	previousErr := errToken
-	token = value
-	errToken = nil
+	previous := token
 
-	return func() {
-		token = previousToken
-		errToken = previousErr
-	}
+	SetToken(value)
+
+	return func() { SetToken(previous) }
 }
 
 func TestPost_Created(t *testing.T) {

--- a/internal/drapi/post_test.go
+++ b/internal/drapi/post_test.go
@@ -31,10 +31,15 @@ import (
 func resetTokenForTest(t *testing.T, value string) func() {
 	t.Helper()
 
-	previous := token
+	previousToken := token
+	previousErr := errToken
 	token = value
+	errToken = nil
 
-	return func() { token = previous }
+	return func() {
+		token = previousToken
+		errToken = previousErr
+	}
 }
 
 func TestPost_Created(t *testing.T) {

--- a/internal/drapi/post_test.go
+++ b/internal/drapi/post_test.go
@@ -17,6 +17,7 @@ package drapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -34,7 +35,14 @@ func resetTokenForTest(t *testing.T, value string) func() {
 
 	prevToken, prevErr, prevFunc := token, errToken, GetAPITokenFunc
 	token, errToken = value, nil
-	GetAPITokenFunc = func(_ context.Context) (string, error) { return value, nil }
+
+	if value == "" {
+		GetAPITokenFunc = func(_ context.Context) (string, error) {
+			return "", errors.New("empty token")
+		}
+	} else {
+		GetAPITokenFunc = func(_ context.Context) (string, error) { return value, nil }
+	}
 
 	return func() {
 		token, errToken, GetAPITokenFunc = prevToken, prevErr, prevFunc

--- a/internal/drapi/testutil_test.go
+++ b/internal/drapi/testutil_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// StubAPIToken seeds the package-level token and stubs GetAPITokenFunc for the
+// duration of the test. Cleanup is registered via t.Cleanup — no defer needed.
+// Pass an empty string to simulate a missing/invalid token (GetAPITokenFunc
+// will return an error, matching the real behaviour when no credentials exist).
+func StubAPIToken(t *testing.T, tok string) {
+	t.Helper()
+
+	prevToken, prevErr, prevFunc := token, errToken, GetAPITokenFunc
+
+	token, errToken = tok, nil
+
+	if tok == "" {
+		GetAPITokenFunc = func(_ context.Context) (string, error) {
+			return "", errors.New("empty token")
+		}
+	} else {
+		GetAPITokenFunc = func(_ context.Context) (string, error) { return tok, nil }
+	}
+
+	t.Cleanup(func() {
+		token, errToken, GetAPITokenFunc = prevToken, prevErr, prevFunc
+	})
+}

--- a/internal/drapi/testutil_test.go
+++ b/internal/drapi/testutil_test.go
@@ -15,21 +15,29 @@
 package drapi
 
 import (
+	"context"
+	"errors"
 	"testing"
 
-	"github.com/datarobot/cli/internal/testutil"
+	"github.com/datarobot/cli/internal/config"
 )
 
-// StubAPIToken resets the unexported token cache and delegates the
-// config.GetAPITokenFunc swap to testutil.StubAPIToken. Tests outside this
-// package (e.g. internal/telemetry) call testutil.StubAPIToken directly —
-// they cannot access the unexported cache vars.
+// StubAPIToken sets a fake token for the duration of the test and restores
+// the real GetAPIKey on cleanup. Pass "" to simulate a missing token.
 func StubAPIToken(t *testing.T, tok string) {
 	t.Helper()
 
-	token, errToken = tok, nil
+	var fn func(context.Context) (string, error)
 
-	t.Cleanup(func() { token, errToken = "", nil })
+	if tok == "" {
+		fn = func(_ context.Context) (string, error) {
+			return "", errors.New("empty token")
+		}
+	} else {
+		fn = func(_ context.Context) (string, error) { return tok, nil }
+	}
 
-	testutil.StubAPIToken(t, tok)
+	Init(fn)
+
+	t.Cleanup(func() { Init(config.GetAPIKey) })
 }

--- a/internal/drapi/testutil_test.go
+++ b/internal/drapi/testutil_test.go
@@ -15,19 +15,15 @@
 package drapi
 
 import (
-	"context"
-	"errors"
 	"testing"
+
+	"github.com/datarobot/cli/internal/testutil"
 )
 
-// StubAPIToken seeds the package-level token cache and stubs GetAPITokenFunc for
-// the duration of the test. Cleanup is registered via t.Cleanup — no defer needed.
-// Pass an empty string to simulate a missing/invalid token (GetAPITokenFunc will
-// return an error, matching real behaviour when no credentials exist).
-//
-// Note: this is a same-package test helper with access to unexported cache vars.
-// Tests outside package drapi (e.g. internal/telemetry) use their own equivalent
-// that only swaps GetAPITokenFunc — they cannot reach the cache vars directly.
+// StubAPIToken resets the unexported token cache and delegates the
+// config.GetAPITokenFunc swap to testutil.StubAPIToken. Tests outside this
+// package (e.g. internal/telemetry) call testutil.StubAPIToken directly —
+// they cannot access the unexported cache vars.
 func StubAPIToken(t *testing.T, tok string) {
 	t.Helper()
 
@@ -35,15 +31,5 @@ func StubAPIToken(t *testing.T, tok string) {
 
 	t.Cleanup(func() { token, errToken = "", nil })
 
-	origFunc := GetAPITokenFunc
-
-	if tok == "" {
-		GetAPITokenFunc = func(_ context.Context) (string, error) {
-			return "", errors.New("empty token")
-		}
-	} else {
-		GetAPITokenFunc = func(_ context.Context) (string, error) { return tok, nil }
-	}
-
-	t.Cleanup(func() { GetAPITokenFunc = origFunc })
+	testutil.StubAPIToken(t, tok)
 }

--- a/internal/drapi/testutil_test.go
+++ b/internal/drapi/testutil_test.go
@@ -20,16 +20,22 @@ import (
 	"testing"
 )
 
-// StubAPIToken seeds the package-level token and stubs GetAPITokenFunc for the
-// duration of the test. Cleanup is registered via t.Cleanup — no defer needed.
-// Pass an empty string to simulate a missing/invalid token (GetAPITokenFunc
-// will return an error, matching the real behaviour when no credentials exist).
+// StubAPIToken seeds the package-level token cache and stubs GetAPITokenFunc for
+// the duration of the test. Cleanup is registered via t.Cleanup — no defer needed.
+// Pass an empty string to simulate a missing/invalid token (GetAPITokenFunc will
+// return an error, matching real behaviour when no credentials exist).
+//
+// Note: this is a same-package test helper with access to unexported cache vars.
+// Tests outside package drapi (e.g. internal/telemetry) use their own equivalent
+// that only swaps GetAPITokenFunc — they cannot reach the cache vars directly.
 func StubAPIToken(t *testing.T, tok string) {
 	t.Helper()
 
-	prevToken, prevErr, prevFunc := token, errToken, GetAPITokenFunc
-
 	token, errToken = tok, nil
+
+	t.Cleanup(func() { token, errToken = "", nil })
+
+	origFunc := GetAPITokenFunc
 
 	if tok == "" {
 		GetAPITokenFunc = func(_ context.Context) (string, error) {
@@ -39,7 +45,5 @@ func StubAPIToken(t *testing.T, tok string) {
 		GetAPITokenFunc = func(_ context.Context) (string, error) { return tok, nil }
 	}
 
-	t.Cleanup(func() {
-		token, errToken, GetAPITokenFunc = prevToken, prevErr, prevFunc
-	})
+	t.Cleanup(func() { GetAPITokenFunc = origFunc })
 }

--- a/internal/telemetry/userid.go
+++ b/internal/telemetry/userid.go
@@ -53,7 +53,6 @@ func GetUserID(_ context.Context) (string, error) {
 
 	var info AccountInfo
 
-	//nolint:contextcheck // GetJSON does not yet accept context; ctx is reserved for future use
 	if err := drapi.GetJSON(url, "", &info); err != nil {
 		return "", err
 	}

--- a/internal/telemetry/userid.go
+++ b/internal/telemetry/userid.go
@@ -53,7 +53,7 @@ func GetUserID(_ context.Context) (string, error) {
 
 	var info AccountInfo
 
-	//nolint:contextcheck // resolveToken inside GetJSON uses context.Background(); ctx threading is a future improvement
+	//nolint:contextcheck // GetJSON does not yet accept context; ctx is reserved for future use
 	if err := drapi.GetJSON(url, "", &info); err != nil {
 		return "", err
 	}

--- a/internal/telemetry/userid.go
+++ b/internal/telemetry/userid.go
@@ -53,6 +53,7 @@ func GetUserID(_ context.Context) (string, error) {
 
 	var info AccountInfo
 
+	//nolint:contextcheck // resolveToken inside GetJSON uses context.Background(); ctx threading is a future improvement
 	if err := drapi.GetJSON(url, "", &info); err != nil {
 		return "", err
 	}

--- a/internal/telemetry/userid_test.go
+++ b/internal/telemetry/userid_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -27,7 +28,6 @@ import (
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
-	"github.com/datarobot/cli/internal/drapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,8 +50,8 @@ func TestGetOrCreateUserID_FreshAPIUID(t *testing.T) {
 	}))
 	defer server.Close()
 
+	StubAPIToken(t, "test-token")
 	defer viperx.Reset()
-	defer resetTokenForTest(t, "test-token")()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 	viperx.Set(config.DataRobotAPIKey, "test-token")
@@ -87,8 +87,8 @@ func TestGetOrCreateUserID_FilePermissions(t *testing.T) {
 	}))
 	defer server.Close()
 
+	StubAPIToken(t, "test-token")
 	defer viperx.Reset()
-	defer resetTokenForTest(t, "test-token")()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 	viperx.Set(config.DataRobotAPIKey, "test-token")
@@ -107,8 +107,8 @@ func TestGetOrCreateUserID_CacheHit(t *testing.T) {
 
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
-	defer viperx.Reset()
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
+defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, "https://test.example.com/api/v2")
 	viperx.Set(config.DataRobotAPIKey, "test-token")
@@ -149,8 +149,8 @@ func TestGetOrCreateUserID_CacheMiss_EndpointChanged(t *testing.T) {
 	}))
 	defer server.Close()
 
+	StubAPIToken(t, "test-token")
 	defer viperx.Reset()
-	defer resetTokenForTest(t, "test-token")()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 
@@ -190,8 +190,8 @@ func TestGetOrCreateUserID_CacheMiss_TokenChanged(t *testing.T) {
 	}))
 	defer server.Close()
 
+	StubAPIToken(t, "new-token")
 	defer viperx.Reset()
-	defer resetTokenForTest(t, "new-token")()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 
@@ -231,8 +231,8 @@ func TestGetOrCreateUserID_CacheMiss_NoFile(t *testing.T) {
 	}))
 	defer server.Close()
 
+	StubAPIToken(t, "test-token")
 	defer viperx.Reset()
-	defer resetTokenForTest(t, "test-token")()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 
@@ -253,8 +253,8 @@ func TestGetOrCreateUserID_CacheMiss_CorruptJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
+	StubAPIToken(t, "test-token")
 	defer viperx.Reset()
-	defer resetTokenForTest(t, "test-token")()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 
@@ -285,8 +285,8 @@ func TestGetOrCreateUserID_TokenChange_UpdatesCache(t *testing.T) {
 	}))
 	defer server.Close()
 
+	StubAPIToken(t, "new-token")
 	defer viperx.Reset()
-	defer resetTokenForTest(t, "new-token")()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 	viperx.Set(config.DataRobotAPIKey, "new-token")
@@ -339,8 +339,8 @@ func TestRetrieveUserID_APIFailureReturnsError(t *testing.T) {
 	}))
 	server.Close()
 
+	StubAPIToken(t, "test-token")
 	defer viperx.Reset()
-	defer resetTokenForTest(t, "test-token")()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 
@@ -358,7 +358,7 @@ func TestGetUserID_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -374,7 +374,7 @@ func TestGetUserID_Unauthorized(t *testing.T) {
 	}))
 	defer server.Close()
 
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -392,7 +392,7 @@ func TestGetUserID_EmptyUID(t *testing.T) {
 	}))
 	defer server.Close()
 
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -409,7 +409,7 @@ func TestGetUserID_NetworkError(t *testing.T) {
 	}))
 	server.Close()
 
-	defer resetTokenForTest(t, "test-token")()
+	StubAPIToken(t, "test-token")
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -419,11 +419,25 @@ func TestGetUserID_NetworkError(t *testing.T) {
 	assert.Empty(t, uid)
 }
 
-func resetTokenForTest(t *testing.T, tok string) func() {
+// StubAPIToken stubs GetAPITokenFunc for the duration of the test. Cleanup is
+// registered via t.Cleanup — no defer needed.
+// Pass an empty string to simulate a missing/invalid token (GetAPITokenFunc will
+// return an error, matching real behaviour when no credentials exist).
+//
+// Note: this is a same-package test helper that differs from the one in
+// internal/drapi because this helper cannot access unexported cache vars in drapi.
+func StubAPIToken(t *testing.T, tok string) func() {
 	t.Helper()
 
-	original := drapi.GetAPITokenFunc
-	drapi.GetAPITokenFunc = func(_ context.Context) (string, error) { return tok, nil }
+	origFunc := config.GetAPITokenFunc
 
-	return func() { drapi.GetAPITokenFunc = original }
+	if tok == "" {
+		config.GetAPITokenFunc = func(_ context.Context) (string, error) {
+			return "", errors.New("empty token")
+		}
+	} else {
+		config.GetAPITokenFunc = func(_ context.Context) (string, error) { return tok, nil }
+	}
+
+	t.Cleanup(func() { config.GetAPITokenFunc = origFunc })
 }

--- a/internal/telemetry/userid_test.go
+++ b/internal/telemetry/userid_test.go
@@ -19,7 +19,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,7 +50,8 @@ func TestGetOrCreateUserID_FreshAPIUID(t *testing.T) {
 	}))
 	defer server.Close()
 
-	StubAPIToken(t, "test-token")
+	testutil.StubAPIToken(t, "test-token")
+
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -87,7 +88,8 @@ func TestGetOrCreateUserID_FilePermissions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	StubAPIToken(t, "test-token")
+	testutil.StubAPIToken(t, "test-token")
+
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -107,8 +109,9 @@ func TestGetOrCreateUserID_CacheHit(t *testing.T) {
 
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
-	StubAPIToken(t, "test-token")
-defer viperx.Reset()
+	testutil.StubAPIToken(t, "test-token")
+
+	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, "https://test.example.com/api/v2")
 	viperx.Set(config.DataRobotAPIKey, "test-token")
@@ -149,7 +152,8 @@ func TestGetOrCreateUserID_CacheMiss_EndpointChanged(t *testing.T) {
 	}))
 	defer server.Close()
 
-	StubAPIToken(t, "test-token")
+	testutil.StubAPIToken(t, "test-token")
+
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -190,7 +194,8 @@ func TestGetOrCreateUserID_CacheMiss_TokenChanged(t *testing.T) {
 	}))
 	defer server.Close()
 
-	StubAPIToken(t, "new-token")
+	testutil.StubAPIToken(t, "new-token")
+
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -231,7 +236,8 @@ func TestGetOrCreateUserID_CacheMiss_NoFile(t *testing.T) {
 	}))
 	defer server.Close()
 
-	StubAPIToken(t, "test-token")
+	testutil.StubAPIToken(t, "test-token")
+
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -253,7 +259,8 @@ func TestGetOrCreateUserID_CacheMiss_CorruptJSON(t *testing.T) {
 	}))
 	defer server.Close()
 
-	StubAPIToken(t, "test-token")
+	testutil.StubAPIToken(t, "test-token")
+
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -285,7 +292,8 @@ func TestGetOrCreateUserID_TokenChange_UpdatesCache(t *testing.T) {
 	}))
 	defer server.Close()
 
-	StubAPIToken(t, "new-token")
+	testutil.StubAPIToken(t, "new-token")
+
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -339,7 +347,8 @@ func TestRetrieveUserID_APIFailureReturnsError(t *testing.T) {
 	}))
 	server.Close()
 
-	StubAPIToken(t, "test-token")
+	testutil.StubAPIToken(t, "test-token")
+
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -358,7 +367,8 @@ func TestGetUserID_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	StubAPIToken(t, "test-token")
+	testutil.StubAPIToken(t, "test-token")
+
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -374,7 +384,8 @@ func TestGetUserID_Unauthorized(t *testing.T) {
 	}))
 	defer server.Close()
 
-	StubAPIToken(t, "test-token")
+	testutil.StubAPIToken(t, "test-token")
+
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -392,7 +403,8 @@ func TestGetUserID_EmptyUID(t *testing.T) {
 	}))
 	defer server.Close()
 
-	StubAPIToken(t, "test-token")
+	testutil.StubAPIToken(t, "test-token")
+
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -409,7 +421,8 @@ func TestGetUserID_NetworkError(t *testing.T) {
 	}))
 	server.Close()
 
-	StubAPIToken(t, "test-token")
+	testutil.StubAPIToken(t, "test-token")
+
 	defer viperx.Reset()
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
@@ -417,27 +430,4 @@ func TestGetUserID_NetworkError(t *testing.T) {
 	uid, err := GetUserID(context.Background())
 	require.Error(t, err)
 	assert.Empty(t, uid)
-}
-
-// StubAPIToken stubs GetAPITokenFunc for the duration of the test. Cleanup is
-// registered via t.Cleanup — no defer needed.
-// Pass an empty string to simulate a missing/invalid token (GetAPITokenFunc will
-// return an error, matching real behaviour when no credentials exist).
-//
-// Note: this is a same-package test helper that differs from the one in
-// internal/drapi because this helper cannot access unexported cache vars in drapi.
-func StubAPIToken(t *testing.T, tok string) func() {
-	t.Helper()
-
-	origFunc := config.GetAPITokenFunc
-
-	if tok == "" {
-		config.GetAPITokenFunc = func(_ context.Context) (string, error) {
-			return "", errors.New("empty token")
-		}
-	} else {
-		config.GetAPITokenFunc = func(_ context.Context) (string, error) { return tok, nil }
-	}
-
-	t.Cleanup(func() { config.GetAPITokenFunc = origFunc })
 }

--- a/internal/telemetry/userid_test.go
+++ b/internal/telemetry/userid_test.go
@@ -419,12 +419,11 @@ func TestGetUserID_NetworkError(t *testing.T) {
 	assert.Empty(t, uid)
 }
 
-func resetTokenForTest(t *testing.T, token string) func() {
-	original := drapi.GetToken()
+func resetTokenForTest(t *testing.T, tok string) func() {
+	t.Helper()
 
-	drapi.SetToken(token)
+	original := drapi.GetAPITokenFunc
+	drapi.GetAPITokenFunc = func(_ context.Context) (string, error) { return tok, nil }
 
-	return func() {
-		drapi.SetToken(original)
-	}
+	return func() { drapi.GetAPITokenFunc = original }
 }

--- a/internal/testutil/drapi.go
+++ b/internal/testutil/drapi.go
@@ -20,26 +20,25 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
 )
 
-// StubAPIToken replaces config.GetAPITokenFunc for the duration of the test and
-// restores it via t.Cleanup — no defer needed. Pass an empty string to simulate
-// a missing/invalid token (the stub returns an error, matching real behaviour).
-//
-// Tests inside package drapi should use their own StubAPIToken wrapper
-// (drapi/testutil_test.go) which also resets the unexported token cache.
+// StubAPIToken injects a fake token into drapi for the duration of the test,
+// restoring the real GetAPIKey on cleanup. Pass "" to simulate a missing token.
 func StubAPIToken(t *testing.T, tok string) {
 	t.Helper()
 
-	original := config.GetAPITokenFunc
+	var fn func(context.Context) (string, error)
 
 	if tok == "" {
-		config.GetAPITokenFunc = func(_ context.Context) (string, error) {
+		fn = func(_ context.Context) (string, error) {
 			return "", errors.New("empty token")
 		}
 	} else {
-		config.GetAPITokenFunc = func(_ context.Context) (string, error) { return tok, nil }
+		fn = func(_ context.Context) (string, error) { return tok, nil }
 	}
 
-	t.Cleanup(func() { config.GetAPITokenFunc = original })
+	drapi.Init(fn)
+
+	t.Cleanup(func() { drapi.Init(config.GetAPIKey) })
 }

--- a/internal/testutil/drapi.go
+++ b/internal/testutil/drapi.go
@@ -1,0 +1,45 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/datarobot/cli/internal/config"
+)
+
+// StubAPIToken replaces config.GetAPITokenFunc for the duration of the test and
+// restores it via t.Cleanup — no defer needed. Pass an empty string to simulate
+// a missing/invalid token (the stub returns an error, matching real behaviour).
+//
+// Tests inside package drapi should use their own StubAPIToken wrapper
+// (drapi/testutil_test.go) which also resets the unexported token cache.
+func StubAPIToken(t *testing.T, tok string) {
+	t.Helper()
+
+	original := config.GetAPITokenFunc
+
+	if tok == "" {
+		config.GetAPITokenFunc = func(_ context.Context) (string, error) {
+			return "", errors.New("empty token")
+		}
+	} else {
+		config.GetAPITokenFunc = func(_ context.Context) (string, error) { return tok, nil }
+	}
+
+	t.Cleanup(func() { config.GetAPITokenFunc = original })
+}


### PR DESCRIPTION
# RATIONALE

When `GetAPIKey` fails (i.e. API token expires after 12 hours), the cached `internal.drapi.get.token` variable stayed empty. This causes every subsequent API call in the process to invoke `GET /api/v2/version` via `VerifyToken`.

We've seen in https://datarobot.slack.com/archives/C07GTBE7UAE/p1778257695531299 this possibly happening. Maybe it's a CI job gone awry, or a user's script or agent gone awry. Not sure.

This can be properly fixed by caching not just the API token, but also the error response when verifying a token.

## CHANGES

- track GetAPIKey failure in `errToken` alongside `token`, which live in `internal/drapi`.
- memoize these values by a new `resolveToken()` function that lives in `internal/drapi`.
- replace all duplicated cache miss logic throughout the package with `resolveToken()`

- remove GetToken/SetToken test seams (which while documented as such, are still part of the "exported production interface" for `internal/drapi`.
- add a new `GetAPITokenFunc` function variable in `internal/config` that defaults to `GetAPIKey()`, but can be overridden in tests.
- override `GetAPITokenFunc` as a generic test fixture, but also in in `internal/drapi` where we have an additional cache to reset

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared API authentication/caching used by all HTTP verbs; incorrect memoization or initialization order could break requests or mask token refresh behavior.
> 
> **Overview**
> Fixes `internal/drapi` token caching to **memoize both the API token and token-fetch failure** via `sync.Once` (`resolveToken` + `errToken`), preventing repeated `GetAPIKey`/verification calls when the token is missing/expired.
> 
> Updates all verb helpers (`Get`, `Post`, `Patch`, `Delete`) and `SetAuthHeaders` to use the new resolver, adds `drapi.Init(config.GetAPIKey)` at CLI startup, and refactors tests to use a new `StubAPIToken` helper (including a shared `internal/testutil` version for non-`drapi` packages). Documentation is tweaked to emphasize avoiding global mutable state in tests and to call out memoizing failures in caches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7ece8939500b02deb013531d2cfaa9a51891cb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->