### PR TITLE
[CFX-6107] add dependabot smoke test reminder comment

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -203,6 +203,24 @@ jobs:
               labels: ['go']
             })
 
+  dependabot-reminder:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    name: Dependabot Smoke Test Reminder
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment smoke test instructions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '👋 **Maintainer reminder:** Smoke tests cannot run automatically on dependabot PRs due to GitHub secret restrictions.\n\nBefore merging, add the `run-smoke-tests` label and wait for the smoke tests to pass.'
+            });
+
   completion-tests:
     needs: [build, detect-changes]
     if: needs.detect-changes.outputs.completion == 'true'


### PR DESCRIPTION

A maintainer must manually add the run-smoke-tests label to get a passing run. This job posts a comment on every dependabot PR so that fact is visible at review time rather than discovered at merge time.

# RATIONALE

I was getting frustrated with the dependabot PRs always seeming to fail when smoke tests run automatically. (See #495 #496 #497).

Turns out that dependabot PRs do not have access to all GH Action secrets:

https://docs.github.com/en/code-security/reference/supply-chain-security/troubleshoot-dependabot/troubleshooting-dependabot-on-github-actions#accessing-secrets

> When a Dependabot event triggers a workflow, the only secrets available to the workflow are Dependabot secrets. GitHub Actions secrets are not available. You must therefore store any secrets that are used by a workflow triggered by Dependabot events as Dependabot secrets. For more information, see [Configuring access to private registries for Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot#storing-credentials-for-dependabot-to-use).

I am not necessarily convinced we want this to happen, yet, but we should do something about it.

## CHANGES

so for now just add a PR comment on all dependabot PRs stating that maintainers must run the smoke tests themselves.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a new GitHub Actions job that posts a PR comment when the actor is Dependabot; no build/test logic or production code is modified.
> 
> **Overview**
> Adds a new `dependabot-reminder` job to the PR checks workflow that runs only when `github.actor` is `dependabot[bot]`.
> 
> The job uses `actions/github-script` with `pull-requests: write` permission to automatically comment on Dependabot PRs reminding maintainers to apply the `run-smoke-tests` label (since smoke tests can’t run automatically due to secret restrictions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c9daba282896af092ed2980f7f53f1b74042805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->