### PR TITLE
[CFX-5957] - Set SilenceUsage in root.cmd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,6 +77,8 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 			// before ANY command execution should go here.
 			log.Start()
 
+			cmd.SilenceUsage = true // don’t spam usage for runtime errors
+
 			err := initializeConfig(cmd)
 			if err != nil {
 				return err


### PR DESCRIPTION
# RATIONALE

don’t spam usage for runtime errors

## CHANGES

setting cmd.SilenceUsage = true in the RootCmd PersistentPreRunE hook

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
<img width="3402" height="1533" alt="Screenshot from 2026-05-08 10-46-47" src="https://github.com/user-attachments/assets/96805ef2-bae1-4567-8908-187cf421ac34" />

## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single Cobra setting change that only affects CLI error/usage output, not command behavior or data handling.
> 
> **Overview**
> Sets `cmd.SilenceUsage = true` in `RootCmd`’s `PersistentPreRunE` so the CLI no longer prints full usage text on runtime errors across all commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52fa9f1663374dbf71c82887d1ae7c32211aa9ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->