### PR TITLE
[CFX-6015] assertNextOnSameHost() for API calls

### DIFF
--- a/internal/drapi/filesapi/allfiles.go
+++ b/internal/drapi/filesapi/allfiles.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/workload/fileops"
 )
@@ -52,7 +51,7 @@ func (c *httpClient) AllFiles(catalogID, versionID string) (map[string]FileMeta,
 			break
 		}
 
-		if err := assertNextOnSameHost(page.Next); err != nil {
+		if err := drapi.AssertNextOnSameHost(page.Next); err != nil {
 			return nil, err
 		}
 
@@ -60,29 +59,6 @@ func (c *httpClient) AllFiles(catalogID, versionID string) (map[string]FileMeta,
 	}
 
 	return out, nil
-}
-
-// assertNextOnSameHost rejects pagination cursors that switch scheme or
-// host away from the configured API base. drapi attaches the bearer
-// token to whatever URL it gets, so a compromised or buggy server
-// response that sets Next to an attacker-controlled origin would leak
-// credentials on the next page request.
-func assertNextOnSameHost(rawNextURL string) error {
-	next, err := url.Parse(rawNextURL)
-	if err != nil {
-		return fmt.Errorf("pagination: parse Next URL: %w", err)
-	}
-
-	base, err := url.Parse(config.GetBaseURL())
-	if err != nil {
-		return fmt.Errorf("pagination: parse API base URL: %w", err)
-	}
-
-	if next.Scheme != base.Scheme || next.Host != base.Host {
-		return fmt.Errorf("pagination: Next URL host %q does not match API base host %q", next.Host, base.Host)
-	}
-
-	return nil
 }
 
 func allFilesURL(catalogID, versionID string) (string, error) {

--- a/internal/drapi/filesapi/versions.go
+++ b/internal/drapi/filesapi/versions.go
@@ -61,7 +61,7 @@ func (c *httpClient) ListVersions(catalogID string, limit int) ([]CatalogVersion
 			break
 		}
 
-		if err := assertNextOnSameHost(page.Next); err != nil {
+		if err := drapi.AssertNextOnSameHost(page.Next); err != nil {
 			return nil, err
 		}
 

--- a/internal/drapi/llms.go
+++ b/internal/drapi/llms.go
@@ -87,6 +87,14 @@ func GetLLMs() (*LLMList, error) {
 			}
 		}
 
+		if llmList.Next == "" {
+			break
+		}
+
+		if err = AssertNextOnSameHost(llmList.Next); err != nil {
+			return nil, err
+		}
+
 		url = llmList.Next
 	}
 

--- a/internal/drapi/pagination.go
+++ b/internal/drapi/pagination.go
@@ -1,0 +1,45 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drapi
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/datarobot/cli/internal/config"
+)
+
+// AssertNextOnSameHost rejects pagination cursors that switch scheme or
+// host away from the configured API base. drapi attaches the bearer
+// token to whatever URL it gets, so a compromised or buggy server
+// response that sets Next to an attacker-controlled origin would leak
+// credentials on the next page request.
+func AssertNextOnSameHost(rawNextURL string) error {
+	next, err := url.Parse(rawNextURL)
+	if err != nil {
+		return fmt.Errorf("pagination: parse Next URL: %w", err)
+	}
+
+	base, err := url.Parse(config.GetBaseURL())
+	if err != nil {
+		return fmt.Errorf("pagination: parse API base URL: %w", err)
+	}
+
+	if next.Scheme != base.Scheme || next.Host != base.Host {
+		return fmt.Errorf("pagination: Next URL host %q does not match API base host %q", next.Host, base.Host)
+	}
+
+	return nil
+}

--- a/internal/drapi/templates.go
+++ b/internal/drapi/templates.go
@@ -140,6 +140,15 @@ func GetTemplates() (*TemplateList, error) {
 		}
 
 		templates = append(templates, templateList.Templates...)
+
+		if templateList.Next == "" {
+			break
+		}
+
+		if err = AssertNextOnSameHost(templateList.Next); err != nil {
+			return nil, err
+		}
+
 		url = templateList.Next
 	}
 

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -385,6 +385,14 @@ func ListArtifacts(limit int, status Status) ([]Artifact, error) {
 			return all[:limit], nil
 		}
 
+		if list.Next == "" {
+			break
+		}
+
+		if err := drapi.AssertNextOnSameHost(list.Next); err != nil {
+			return nil, err
+		}
+
 		pageURL = list.Next
 	}
 


### PR DESCRIPTION
---

# RATIONALE

@wojtekwdr  introduced `assertNextOnSameHost()` in #470 to guard the files API paginator against SSRF-style credential leakage: if a compromised or buggy server response sets `Next` to an attacker-controlled origin, `drapi` would attach the bearer token to that request. The guard was implemented as a private function inside filesapi.

Several other paginated API callers in the codebase (`GetTemplates`, `GetLLMs`, `ListArtifacts`) had the same vulnerability with no equivalent protection.

## CHANGES

- **pagination.go** — extracted `assertNextOnSameHost` from `filesapi` and exported it as `drapi.AssertNextOnSameHost`, keeping the original security comment explaining the threat model.
- **allfiles.go** — removed the now-duplicate private copy; updated call site to use the shared function.
- **versions.go** — updated call site to use the shared function.
- **templates.go** (`GetTemplates`) — added `AssertNextOnSameHost` guard before following each `Next` cursor.
- **llms.go** (`GetLLMs`) — added `AssertNextOnSameHost` guard before following each `Next` cursor.
- **artifact.go** (`ListArtifacts`) — added `AssertNextOnSameHost` guard before following each `Next` cursor.

All packages build cleanly and tests pass (`task lint` reports 0 issues).

## RELATED

- #470 — original `assertNextOnSameHost` introduction


## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b81083e3283b840b11ce80595d548f7ce8969159. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->