### PR TITLE
[CFX-6014] Add SessionID as a top-level property

### DIFF
--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -84,6 +84,7 @@ These map to Amplitude's built-in fields and power native segmentation (version 
 |---|---|
 | `user_id` | DataRobot `uid` from `GET /api/v2/account/info/`, cached to disk with endpoint + token fingerprint validation; empty (anonymous) if unauthenticated or cache miss — see [User ID](#user-id) |
 | `device_id` | OS machine ID (hashed) or persisted UUID — see [Device ID](#device-id) above |
+| `session_id` | Unix millisecond timestamp generated once per process invocation — Amplitude uses this as the built-in Session ID for session-based analysis |
 | `app_version` | CLI version set at build time via ldflags |
 | `platform` | Always `"CLI"` |
 | `os_name` | OS name (e.g. `"macOS"`) |
@@ -95,7 +96,6 @@ These map to Amplitude's built-in fields and power native segmentation (version 
 
 | Property | Source |
 | --- | --- |
-| `session_id` | UUID v4 generated per process invocation |
 | `install_method` | Set at build time via ldflags (`release`, `source`, etc.) |
 | `os_arch` | CPU architecture from `runtime.GOARCH` |
 | `go_version` | Go runtime version (e.g. `go1.26.3`) from `runtime.Version()` |

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -38,7 +38,7 @@ type CommonProperties struct {
 	// 2. CollectCommonProperties() function
 
 	// top-level fields
-	SessionID string  // UUID v4, unique per process invocation
+	SessionID int64   // Unix ms timestamp, unique per process invocation
 	DeviceID  string  // UUID v4, stable per installation, cached to disk
 	UserID    *string // DataRobot uid from GET /api/v2/account/info/, cached to disk; nil if unavailable
 	// event properties
@@ -102,11 +102,10 @@ func CollectCommonProperties() *CommonProperties {
 }
 
 // AsMap returns the properties as a map[string]any suitable for
-// merging into Amplitude event properties. Note: UserID is not included
-// here as it's set as a top-level Amplitude event field, not an event property.
+// merging into Amplitude event properties. Note: UserID, DeviceID, and SessionID
+// are not included here as they are set as top-level Amplitude event fields.
 func (p *CommonProperties) AsMap() map[string]any {
 	m := map[string]any{
-		"session_id":         p.SessionID,
 		"install_method":     p.InstallMethod,
 		"os_arch":            p.OSArch,
 		"go_version":         p.GoVersion,
@@ -119,23 +118,11 @@ func (p *CommonProperties) AsMap() map[string]any {
 	return m
 }
 
-// generateSessionID generates a UUID v4 for the current CLI session.
-// This value is not persisted and will be different on each invocation.
-// The default implementation uses crypto/rand, but if that fails, then
-// fallback to a timestamp-based ID with a "fallback-" prefix to
-// indicate it's not a true UUID.
-func generateSessionID() string {
-	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		// Fallback to timestamp-based ID if crypto random generation fails
-		return deviceIDFallbackPrefix + time.Now().UTC().Format(time.RFC3339)
-	}
-
-	// Set version (4) and variant (RFC 4122) bits
-	b[6] = (b[6] & 0x0f) | 0x40
-	b[8] = (b[8] & 0x3f) | 0x80
-
-	return hex.EncodeToString(b)
+// generateSessionID returns a Unix timestamp in milliseconds for the current
+// CLI session. This value is not persisted and will be different on each
+// invocation. Amplitude's top-level session_id field expects an integer value.
+func generateSessionID() int64 {
+	return time.Now().UnixMilli()
 }
 
 // deriveEnvironment determines the DataRobot environment (US/EU/JP/custom)
@@ -181,9 +168,23 @@ func getOrCreateDeviceID() string {
 	// IDs are ephemeral (e.g., certain container orchestration systems). This way we
 	// could intentionally pass in a stable ID. Honestly, though, I think being able
 	// to write out a device_id file is good enough.
-	id := deviceIDFallbackPrefix + generateSessionID()
+	id := deviceIDFallbackPrefix + randomHexID()
 
 	writeTextCacheFile(deviceIDFileName, id)
 
 	return id
+}
+
+// randomHexID generates a random 32-character hex string used as a device ID fallback.
+func randomHexID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return time.Now().UTC().Format(time.RFC3339)
+	}
+
+	// Set version (4) and variant (RFC 4122) bits
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	return hex.EncodeToString(b)
 }

--- a/internal/telemetry/properties_test.go
+++ b/internal/telemetry/properties_test.go
@@ -45,7 +45,9 @@ func TestGenerateSessionID_ReturnsValidTimestamp(t *testing.T) {
 
 func TestGenerateSessionID_UniqueSessions(t *testing.T) {
 	id1 := generateSessionID()
+
 	time.Sleep(2 * time.Millisecond)
+
 	id2 := generateSessionID()
 
 	assert.NotEqual(t, id1, id2, "session IDs should be unique")

--- a/internal/telemetry/properties_test.go
+++ b/internal/telemetry/properties_test.go
@@ -20,9 +20,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
@@ -34,17 +34,18 @@ func ptrString(s string) *string {
 	return &s
 }
 
-func TestGenerateSessionID_ReturnsValidUUID(t *testing.T) {
+func TestGenerateSessionID_ReturnsValidTimestamp(t *testing.T) {
+	before := time.Now().UnixMilli()
 	id := generateSessionID()
+	after := time.Now().UnixMilli()
 
-	// UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
-	uuidPattern := regexp.MustCompile(`^[0-9a-f]{32}$`)
-	assert.True(t, uuidPattern.MatchString(id), "session ID should be 32 hex characters")
-	assert.NotEmpty(t, id)
+	assert.GreaterOrEqual(t, id, before)
+	assert.LessOrEqual(t, id, after)
 }
 
 func TestGenerateSessionID_UniqueSessions(t *testing.T) {
 	id1 := generateSessionID()
+	time.Sleep(2 * time.Millisecond)
 	id2 := generateSessionID()
 
 	assert.NotEqual(t, id1, id2, "session IDs should be unique")
@@ -52,7 +53,7 @@ func TestGenerateSessionID_UniqueSessions(t *testing.T) {
 
 func TestCommonPropertiesAsMap(t *testing.T) {
 	props := &CommonProperties{
-		SessionID:         "session-123",
+		SessionID:         1234567890,
 		DeviceID:          "device-789",
 		UserID:            ptrString("user-456"),
 		CLIVersion:        "v0.1.0",
@@ -65,7 +66,6 @@ func TestCommonPropertiesAsMap(t *testing.T) {
 
 	m := props.AsMap()
 
-	assert.Equal(t, "session-123", m["session_id"])
 	assert.Equal(t, "source", m["install_method"])
 	assert.Equal(t, "zsh", m["shell"])
 	assert.Equal(t, "US", m["environment"])
@@ -73,7 +73,8 @@ func TestCommonPropertiesAsMap(t *testing.T) {
 	assert.Equal(t, "core", m["command_kind"])
 	// Verify CWD is not included
 	assert.NotContains(t, m, "cwd")
-	// user_id is a top-level Amplitude field, not an event property
+	// session_id, user_id, and device_id are top-level Amplitude fields, not event properties
+	assert.NotContains(t, m, "session_id")
 	assert.NotContains(t, m, "user_id")
 }
 
@@ -264,10 +265,12 @@ func TestDeriveEnvironment_Custom(t *testing.T) {
 }
 
 func TestCollectCommonProperties_GeneratesSessionID(t *testing.T) {
+	before := time.Now().UnixMilli()
 	props := CollectCommonProperties()
+	after := time.Now().UnixMilli()
 
-	assert.NotEmpty(t, props.SessionID)
-	assert.Len(t, props.SessionID, 32)
+	assert.GreaterOrEqual(t, props.SessionID, before)
+	assert.LessOrEqual(t, props.SessionID, after)
 }
 
 func TestCollectCommonProperties_SetsInstallMethod(t *testing.T) {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -110,12 +110,13 @@ func (c *Client) Track(event types.Event) {
 
 		event.EventProperties = commonMap
 
-		// Set UserID and DeviceID as top-level fields (required by Amplitude)
+		// Set UserID, DeviceID, and SessionID as top-level fields (required by Amplitude)
 		if c.props.UserID != nil {
 			event.UserID = *c.props.UserID
 		}
 
 		event.DeviceID = c.props.DeviceID
+		event.SessionID = int(c.props.SessionID)
 
 		// Populate Amplitude EventOptions for built-in segmentation
 		event.AppVersion = c.props.CLIVersion

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -125,7 +125,7 @@ func TestTrack_MergesCommonProperties(t *testing.T) {
 	props := &CommonProperties{
 		UserID:     ptrString("test-user"),
 		CLIVersion: "v0.1.0",
-		SessionID:  "session-123",
+		SessionID:  1234567890,
 	}
 
 	client := NewClient(props)


### PR DESCRIPTION
telemetry: move session_id to top-level Amplitude field

Previously, session_id was sent as a string event property (UUID v4),
causing Amplitude to show it as a custom property while the built-in
top-level Session ID field defaulted to -1.

Change CommonProperties.SessionID from string to int64 (Unix ms
timestamp), remove it from AsMap(), and set event.SessionID in Track()
alongside UserID and DeviceID. Amplitude's EventOptions.SessionID is an
int and expects a Unix millisecond timestamp.

Extract randomHexID() for the device ID fallback path, which previously
reused generateSessionID().


# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts telemetry payload shape and types (string→int64) and casts `SessionID` to `int` when sending, which could affect analytics correctness and has a small 32-bit overflow risk.
> 
> **Overview**
> Telemetry now reports `session_id` using Amplitude’s **top-level** `EventOptions.SessionID` field instead of a custom event property. `CommonProperties.SessionID` is changed from a UUID string to a Unix-millisecond `int64`, removed from `AsMap()`, and populated in `Client.Track()` alongside `UserID`/`DeviceID`.
> 
> The device-id fallback generation is decoupled from session IDs by introducing `randomHexID()` for the `fallback-` path, and tests are updated to validate timestamp-based session IDs and the new top-level field behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e11b7e64bbf8449cf04deac3eff6d786991038da. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->