### PR TITLE
[CFX-5956] Fix and refactor telemetry flush on os.exit...

### DIFF
--- a/cmd/auth/check/cmd.go
+++ b/cmd/auth/check/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/envbuilder"
 	"github.com/datarobot/cli/internal/repo"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
@@ -225,7 +226,7 @@ func Run(_ *cobra.Command, _ []string) {
 			return
 		}
 
-		os.Exit(1)
+		telemetry.Exit(1)
 	}
 
 	if checkDotenvCredentials(repoRoot) {
@@ -236,7 +237,7 @@ func Run(_ *cobra.Command, _ []string) {
 		return
 	}
 
-	os.Exit(1)
+	telemetry.Exit(1)
 }
 
 func Cmd() *cobra.Command {

--- a/cmd/auth/check/cmd.go
+++ b/cmd/auth/check/cmd.go
@@ -23,10 +23,10 @@ import (
 	"strings"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/envbuilder"
 	"github.com/datarobot/cli/internal/repo"
-	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
@@ -217,36 +217,38 @@ func checkDotenvCredentials(repoRoot string) bool {
 	return true
 }
 
-func Run(_ *cobra.Command, _ []string) {
+func RunE(_ *cobra.Command, _ []string) error {
 	// Check .env credentials if in a repo
 	// If not, check the CLI credentials only
 	repoRoot, err := repo.FindRepoRoot()
 	if err != nil {
 		if checkCLICredentials() {
-			return
+			return nil
 		}
 
-		telemetry.Exit(1)
+		return cli.ErrSilent
 	}
 
 	if checkDotenvCredentials(repoRoot) {
-		return
+		return nil
 	}
 
 	if checkCLICredentials() {
-		return
+		return nil
 	}
 
-	telemetry.Exit(1)
+	return cli.ErrSilent
 }
 
 func Cmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "check",
-		Short: "✅ Check if DataRobot credentials are valid",
+		Use:           "check",
+		Short:         "✅ Check if DataRobot credentials are valid",
+		SilenceErrors: true,
+		SilenceUsage:  true,
 		Long: `Verify that your DataRobot credentials are properly configured and valid.
 
 If you're in a project directory with a '.env' file, this will check those credentials.`,
-		Run: Run,
+		RunE: RunE,
 	}
 }

--- a/cmd/auth/login/cmd.go
+++ b/cmd/auth/login/cmd.go
@@ -20,10 +20,10 @@ import (
 	"strings"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
-	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -53,17 +53,15 @@ func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop
 	datarobotHost := auth.GetBaseURLOrAsk()
 	if datarobotHost == "" {
 		log.Info("💡 To set your DataRobot URL, run 'dr auth set-url'.")
-		telemetry.Exit(1)
 
-		return nil
+		return cli.ErrSilent
 	}
 
 	token, err := config.GetAPIKey(context.Background())
 	if errors.Is(err, context.DeadlineExceeded) {
 		log.Errorf("Connection to %s timed out. Check your network and try again.", datarobotHost)
-		telemetry.Exit(1)
 
-		return nil
+		return cli.ErrSilent
 	}
 
 	// If they explicitly ran 'dr auth login', just authenticate them
@@ -115,6 +113,8 @@ This command will:
   1. Open your default browser.
   2. Redirect you to the DataRobot login page.
   3. Securely store your API key for future CLI operations.`,
-		RunE: RunE,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE:          RunE,
 	}
 }

--- a/cmd/auth/login/cmd.go
+++ b/cmd/auth/login/cmd.go
@@ -17,13 +17,13 @@ package login
 import (
 	"context"
 	"errors"
-	"os"
 	"strings"
 
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +53,7 @@ func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop
 	datarobotHost := auth.GetBaseURLOrAsk()
 	if datarobotHost == "" {
 		log.Info("💡 To set your DataRobot URL, run 'dr auth set-url'.")
-		os.Exit(1)
+		telemetry.Exit(1)
 
 		return nil
 	}
@@ -61,7 +61,7 @@ func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop
 	token, err := config.GetAPIKey(context.Background())
 	if errors.Is(err, context.DeadlineExceeded) {
 		log.Errorf("Connection to %s timed out. Check your network and try again.", datarobotHost)
-		os.Exit(1)
+		telemetry.Exit(1)
 
 		return nil
 	}

--- a/cmd/auth/logout/cmd.go
+++ b/cmd/auth/logout/cmd.go
@@ -15,29 +15,34 @@
 package logout
 
 import (
+	"fmt"
+
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
-	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
-func Run(_ *cobra.Command, _ []string) {
+func RunE(_ *cobra.Command, _ []string) error {
 	viperx.Set(config.DataRobotAPIKey, "")
 
 	err := auth.WriteConfigFile()
 	if err != nil {
 		log.Error(err)
-		telemetry.Exit(1)
+
+		return fmt.Errorf("failed to write config: %w", err)
 	}
+
+	return nil
 }
 
 func Cmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "logout",
-		Short: "🚪 Log out from DataRobot",
-		Long:  `Log out from DataRobot and clear the stored API key.`,
-		Run:   Run,
+		Use:          "logout",
+		Short:        "🚪 Log out from DataRobot",
+		SilenceUsage: true,
+		Long:         `Log out from DataRobot and clear the stored API key.`,
+		RunE:         RunE,
 	}
 }

--- a/cmd/auth/logout/cmd.go
+++ b/cmd/auth/logout/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
@@ -29,9 +30,9 @@ func RunE(_ *cobra.Command, _ []string) error {
 
 	err := auth.WriteConfigFile()
 	if err != nil {
-		log.Error(err)
+		log.Error(fmt.Errorf("failed to write config: %w", err))
 
-		return fmt.Errorf("failed to write config: %w", err)
+		return cli.ErrSilent
 	}
 
 	return nil
@@ -39,10 +40,11 @@ func RunE(_ *cobra.Command, _ []string) error {
 
 func Cmd() *cobra.Command {
 	return &cobra.Command{
-		Use:          "logout",
-		Short:        "🚪 Log out from DataRobot",
-		SilenceUsage: true,
-		Long:         `Log out from DataRobot and clear the stored API key.`,
+		Use:           "logout",
+		Short:         "🚪 Log out from DataRobot",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		Long:          `Log out from DataRobot and clear the stored API key.`,
 		RunE:         RunE,
 	}
 }

--- a/cmd/auth/logout/cmd.go
+++ b/cmd/auth/logout/cmd.go
@@ -45,6 +45,6 @@ func Cmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Long:          `Log out from DataRobot and clear the stored API key.`,
-		RunE:         RunE,
+		RunE:          RunE,
 	}
 }

--- a/cmd/auth/logout/cmd.go
+++ b/cmd/auth/logout/cmd.go
@@ -15,12 +15,11 @@
 package logout
 
 import (
-	"os"
-
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +29,7 @@ func Run(_ *cobra.Command, _ []string) {
 	err := auth.WriteConfigFile()
 	if err != nil {
 		log.Error(err)
-		os.Exit(1)
+		telemetry.Exit(1)
 	}
 }
 

--- a/cmd/component/add/cmd.go
+++ b/cmd/component/add/cmd.go
@@ -144,10 +144,11 @@ func Cmd() *cobra.Command {
 	names := strings.Join(copier.EnabledShortNames, ", ")
 
 	cmd := &cobra.Command{
-		Use:     fmt.Sprintf("add [%s or component_url]", names),
-		Short:   "➕ Add a component",
-		PreRunE: PreRunE,
-		RunE:    RunE,
+		Use:           fmt.Sprintf("add [%s or component_url]", names),
+		Short:         "➕ Add a component",
+		PreRunE:       PreRunE,
+		RunE:          RunE,
+		SilenceErrors: true,
 	}
 
 	cmd.Flags().StringArrayVarP(&addFlags.DataArgs, "data", "d", []string{}, "Provide answer data in key=value format (can be specified multiple times)")

--- a/cmd/component/add/cmd.go
+++ b/cmd/component/add/cmd.go
@@ -64,7 +64,9 @@ func RunE(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	compose.Cmd().Run(nil, nil)
+	if err := compose.Cmd().RunE(nil, nil); err != nil {
+		return err
+	}
 
 	// Validate and edit .env if needed
 	if err := dotenv.ValidateAndEditIfNeeded(); err != nil {

--- a/cmd/component/add/cmd.go
+++ b/cmd/component/add/cmd.go
@@ -17,7 +17,6 @@ package add
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -57,7 +56,7 @@ func RunE(_ *cobra.Command, args []string) error {
 	cliData, err := shared.ParseDataArgs(addFlags.DataArgs)
 	if err != nil {
 		log.Error(err)
-		os.Exit(1)
+		telemetry.Exit(1)
 
 		return nil
 	}
@@ -134,7 +133,7 @@ func addComponents(repoURLs []string, componentConfig *config.ComponentDefaults,
 		err := copier.ExecAdd(repoURL, mergedData, addFlags)
 		if err != nil {
 			log.Error(err)
-			os.Exit(1)
+			telemetry.Exit(1)
 
 			return nil
 		}

--- a/cmd/component/add/cmd.go
+++ b/cmd/component/add/cmd.go
@@ -55,10 +55,7 @@ func RunE(_ *cobra.Command, args []string) error {
 
 	cliData, err := shared.ParseDataArgs(addFlags.DataArgs)
 	if err != nil {
-		log.Error(err)
-		telemetry.Exit(1)
-
-		return nil
+		return fmt.Errorf("parsing data args: %w", err)
 	}
 
 	componentConfig := loadComponentDefaults(addFlags.DataFile)
@@ -132,10 +129,7 @@ func addComponents(repoURLs []string, componentConfig *config.ComponentDefaults,
 
 		err := copier.ExecAdd(repoURL, mergedData, addFlags)
 		if err != nil {
-			log.Error(err)
-			telemetry.Exit(1)
-
-			return nil
+			return fmt.Errorf("adding component %q: %w", repoURL, err)
 		}
 
 		fmt.Printf("Component %s added.\n", repoURL)

--- a/cmd/component/update/cmd.go
+++ b/cmd/component/update/cmd.go
@@ -55,16 +55,14 @@ func RunE(cmd *cobra.Command, args []string) error {
 
 	cliData, err := shared.ParseDataArgs(updateFlags.DataArgs)
 	if err != nil {
-		fmt.Println("Fatal:", err)
-		telemetry.Exit(1)
+		return fmt.Errorf("parsing data args: %w", err)
 	}
 
 	// If file name has been provided
 	if updateFileName != "" {
 		err := runUpdate(updateFileName, cliData, updateFlags.DataFile)
 		if err != nil {
-			fmt.Println("Fatal:", err)
-			telemetry.Exit(1)
+			return fmt.Errorf("updating component: %w", err)
 		}
 
 		compose.Cmd().Run(nil, nil)

--- a/cmd/component/update/cmd.go
+++ b/cmd/component/update/cmd.go
@@ -56,7 +56,7 @@ func RunE(cmd *cobra.Command, args []string) error {
 	cliData, err := shared.ParseDataArgs(updateFlags.DataArgs)
 	if err != nil {
 		fmt.Println("Fatal:", err)
-		os.Exit(1)
+		telemetry.Exit(1)
 	}
 
 	// If file name has been provided
@@ -64,7 +64,7 @@ func RunE(cmd *cobra.Command, args []string) error {
 		err := runUpdate(updateFileName, cliData, updateFlags.DataFile)
 		if err != nil {
 			fmt.Println("Fatal:", err)
-			os.Exit(1)
+			telemetry.Exit(1)
 		}
 
 		compose.Cmd().Run(nil, nil)

--- a/cmd/component/update/cmd.go
+++ b/cmd/component/update/cmd.go
@@ -114,10 +114,11 @@ func RunE(_ *cobra.Command, args []string) error {
 
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "update [answers_file]",
-		Short:   "🔄 Update installed component",
-		PreRunE: PreRunE,
-		RunE:    RunE,
+		Use:           "update [answers_file]",
+		Short:         "🔄 Update installed component",
+		PreRunE:       PreRunE,
+		RunE:          RunE,
+		SilenceErrors: true,
 	}
 
 	cmd.Flags().StringArrayVarP(&updateFlags.DataArgs, "data", "d", []string{}, "Provide answer data in key=value format (can be specified multiple times)")

--- a/cmd/component/update/cmd.go
+++ b/cmd/component/update/cmd.go
@@ -65,8 +65,13 @@ func RunE(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("updating component: %w", err)
 		}
 
-		compose.Cmd().Run(nil, nil)
-		run.Cmd().Run(nil, []string{"reinstall"})
+		if err := compose.Cmd().RunE(nil, nil); err != nil {
+			return err
+		}
+
+		if err := run.Cmd().RunE(nil, []string{"reinstall"}); err != nil {
+			return err
+		}
 
 		return nil
 	}
@@ -83,8 +88,13 @@ func RunE(cmd *cobra.Command, args []string) error {
 			fmt.Println(innerModel.ExitMessage)
 
 			if innerModel.ComponentUpdated {
-				compose.Cmd().Run(nil, nil)
-				run.Cmd().Run(nil, []string{"reinstall"})
+				if err := compose.Cmd().RunE(nil, nil); err != nil {
+					return err
+				}
+
+				if err := run.Cmd().RunE(nil, []string{"reinstall"}); err != nil {
+					return err
+				}
 
 				fmt.Println(innerModel.ExitMessage)
 				fmt.Println("Post-install tasks finished.")

--- a/cmd/component/update/cmd.go
+++ b/cmd/component/update/cmd.go
@@ -47,7 +47,42 @@ func PreRunE(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func RunE(cmd *cobra.Command, args []string) error {
+func runPostUpdateTasks() error {
+	if err := compose.Cmd().RunE(nil, nil); err != nil {
+		return err
+	}
+
+	return run.Cmd().RunE(nil, []string{"reinstall"})
+}
+
+func handleTUIResult(finalModel tea.Model) error {
+	setupModel, ok := finalModel.(tui.InterruptibleModel)
+	if !ok {
+		return nil
+	}
+
+	innerModel, ok := setupModel.Model.(shared.UpdateModel)
+	if !ok {
+		return nil
+	}
+
+	fmt.Println(innerModel.ExitMessage)
+
+	if !innerModel.ComponentUpdated {
+		return nil
+	}
+
+	if err := runPostUpdateTasks(); err != nil {
+		return err
+	}
+
+	fmt.Println(innerModel.ExitMessage)
+	fmt.Println("Post-install tasks finished.")
+
+	return nil
+}
+
+func RunE(_ *cobra.Command, args []string) error {
 	var updateFileName string
 	if len(args) > 0 {
 		updateFileName = args[0]
@@ -60,20 +95,11 @@ func RunE(cmd *cobra.Command, args []string) error {
 
 	// If file name has been provided
 	if updateFileName != "" {
-		err := runUpdate(updateFileName, cliData, updateFlags.DataFile)
-		if err != nil {
+		if err := runUpdate(updateFileName, cliData, updateFlags.DataFile); err != nil {
 			return fmt.Errorf("updating component: %w", err)
 		}
 
-		if err := compose.Cmd().RunE(nil, nil); err != nil {
-			return err
-		}
-
-		if err := run.Cmd().RunE(nil, []string{"reinstall"}); err != nil {
-			return err
-		}
-
-		return nil
+		return runPostUpdateTasks()
 	}
 
 	m := shared.NewUpdateComponentModel(updateFlags)
@@ -83,26 +109,7 @@ func RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if setupModel, ok := finalModel.(tui.InterruptibleModel); ok {
-		if innerModel, ok := setupModel.Model.(shared.UpdateModel); ok {
-			fmt.Println(innerModel.ExitMessage)
-
-			if innerModel.ComponentUpdated {
-				if err := compose.Cmd().RunE(nil, nil); err != nil {
-					return err
-				}
-
-				if err := run.Cmd().RunE(nil, []string{"reinstall"}); err != nil {
-					return err
-				}
-
-				fmt.Println(innerModel.ExitMessage)
-				fmt.Println("Post-install tasks finished.")
-			}
-		}
-	}
-
-	return nil
+	return handleTUIResult(finalModel)
 }
 
 func Cmd() *cobra.Command {

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -22,6 +22,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/envbuilder"
 	"github.com/datarobot/cli/internal/log"
@@ -268,8 +269,10 @@ func shouldSkipSetup(repositoryRoot, dotenvFile string) (bool, error) {
 }
 
 var UpdateCmd = &cobra.Command{
-	Use:   "update",
-	Short: "🔄 Automatically update DataRobot credentials",
+	Use:           "update",
+	Short:         "🔄 Automatically update DataRobot credentials",
+	SilenceErrors: true,
+	SilenceUsage:  true,
 	Long: `Automatically update your '.env' file with fresh DataRobot credentials.
 
 This command will:
@@ -280,28 +283,33 @@ This command will:
 💡 Use this when your credentials expire or you need to refresh your connection.`,
 	PreRunE: auth.EnsureAuthenticatedE,
 
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		dotenv, err := ensureInRepoWithDotenv()
 		if err != nil {
-			telemetry.Exit(1)
+			return cli.ErrSilent
 		}
 
 		_, _, err = updateDotenvFile(dotenv)
 		if err != nil {
 			log.Error(err)
-			telemetry.Exit(1)
+
+			return cli.ErrSilent
 		}
+
+		return nil
 	},
 }
 
 var ValidateCmd = &cobra.Command{
-	Use:   "validate",
-	Short: "✅ Validate '.env' and environment variable configuration",
+	Use:           "validate",
+	Short:         "✅ Validate '.env' and environment variable configuration",
+	SilenceErrors: true,
+	SilenceUsage:  true,
 
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		dotenv, err := ensureInRepoWithDotenv()
 		if err != nil {
-			telemetry.Exit(1)
+			return cli.ErrSilent
 		}
 
 		repoRoot := filepath.Dir(dotenv)
@@ -346,9 +354,11 @@ var ValidateCmd = &cobra.Command{
 				}
 			}
 
-			telemetry.Exit(1)
+			return cli.ErrSilent
 		}
 
 		fmt.Println("\nValidation passed: all required variables are set.")
+
+		return nil
 	},
 }

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -283,13 +283,13 @@ This command will:
 	Run: func(_ *cobra.Command, _ []string) {
 		dotenv, err := ensureInRepoWithDotenv()
 		if err != nil {
-			os.Exit(1)
+			telemetry.Exit(1)
 		}
 
 		_, _, err = updateDotenvFile(dotenv)
 		if err != nil {
 			log.Error(err)
-			os.Exit(1)
+			telemetry.Exit(1)
 		}
 	},
 }
@@ -301,7 +301,7 @@ var ValidateCmd = &cobra.Command{
 	Run: func(_ *cobra.Command, _ []string) {
 		dotenv, err := ensureInRepoWithDotenv()
 		if err != nil {
-			os.Exit(1)
+			telemetry.Exit(1)
 		}
 
 		repoRoot := filepath.Dir(dotenv)
@@ -346,7 +346,7 @@ var ValidateCmd = &cobra.Command{
 				}
 			}
 
-			os.Exit(1)
+			telemetry.Exit(1)
 		}
 
 		fmt.Println("\nValidation passed: all required variables are set.")

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -12,29 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package cmd
 
 import (
-	"context"
 	"os"
-	"os/signal"
-
-	"github.com/datarobot/cli/cmd"
-	"github.com/datarobot/cli/internal/log"
+	"time"
 )
 
-func main() {
-	// Create a context that's canceled on interrupt signals
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
-	defer cancel()
-
-	// Always stop loggers, whether the command succeeds or returns an error.
-	// PersistentPostRunE is skipped by cobra on error, so we must ensure log.Stop
-	// runs unconditionally here.
-	defer log.Stop()
-
-	if err := cmd.ExecuteContext(ctx); err != nil {
-		log.Stop()
-		cmd.Exit(1)
+// Exit flushes any pending telemetry events then terminates the process with
+// code. Call this from main (instead of os.Exit) when ExecuteContext returns
+// an error, so that Amplitude events are delivered even though
+// PersistentPostRunE is bypassed on the error path.
+//
+// telemetryClient is set in PersistentPreRunE (root.go); it will be nil only
+// if the process exits before any command runs (e.g. flag parse failure), in
+// which case there are no queued events to flush anyway.
+func Exit(code int) {
+	if telemetryClient != nil {
+		telemetryClient.Flush(3 * time.Second)
 	}
+
+	os.Exit(code)
 }

--- a/cmd/plugin/discovery.go
+++ b/cmd/plugin/discovery.go
@@ -114,14 +114,14 @@ func createPluginCommand(p internalPlugin.DiscoveredPlugin) *cobra.Command {
 		GroupID:            "plugin",
 		DisableFlagParsing: true, // Pass all args to plugin
 		DisableSuggestions: true,
-		Run: func(_ *cobra.Command, args []string) {
+		Run: func(pluginCmd *cobra.Command, args []string) {
 			checkAndPromptPluginUpdate(pluginName, manifest.Version, pluginPath)
 
 			fmt.Println(tui.InfoStyle.Render("🔌 Running plugin: " + pluginName))
 			log.Debug("Executing plugin", "name", pluginName, "executable", executable)
 
 			exitCode := internalPlugin.ExecutePlugin(manifest, executable, args)
-			telemetry.Exit(exitCode)
+			telemetry.ExitWithContext(pluginCmd.Context(), exitCode)
 		},
 	}
 

--- a/cmd/plugin/discovery.go
+++ b/cmd/plugin/discovery.go
@@ -16,7 +16,6 @@ package plugin
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -122,7 +121,7 @@ func createPluginCommand(p internalPlugin.DiscoveredPlugin) *cobra.Command {
 			log.Debug("Executing plugin", "name", pluginName, "executable", executable)
 
 			exitCode := internalPlugin.ExecutePlugin(manifest, executable, args)
-			os.Exit(exitCode)
+			telemetry.Exit(exitCode)
 		},
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,8 +45,10 @@ import (
 
 var configFilePath string
 
-// telemetryClientKey is used to store the telemetry client in context
-type telemetryClientKey struct{}
+// telemetryClient holds the active client for the current process. It is set
+// in PersistentPreRunE so that cmd.Exit can flush events when main's error
+// path fires (where only the signal context, not the cobra context, is available).
+var telemetryClient *telemetry.Client
 
 // RootCmd represents the base command when called without any subcommands.
 // It uses CommandAdder to intelligently filter child commands based on feature gates.
@@ -115,12 +117,11 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 
 			client := telemetry.NewClient(props)
 
-			// Register as global client so telemetry.Exit() can flush even when
-			// commands call os.Exit directly, bypassing PersistentPostRunE.
-			telemetry.SetGlobal(client)
+			// Store as process-level client so cmd.Exit can flush on the main error path.
+			telemetryClient = client
 
 			// Store telemetry client in context for use by commands
-			cmd.SetContext(context.WithValue(cmd.Context(), telemetryClientKey{}, client))
+			cmd.SetContext(context.WithValue(cmd.Context(), telemetry.ClientContextKey{}, client))
 
 			cobra.OnFinalize(func() {
 				if event, ok := telemetry.EventFor(cmd, args); ok {
@@ -133,6 +134,16 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 			})
 
 			config.SetAPIConsumerTrace(config.CommandPathToTrace(cmd.CommandPath()))
+
+			return nil
+		},
+		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
+			// Flush telemetry events before exit
+			if client, ok := cmd.Context().Value(telemetry.ClientContextKey{}).(*telemetry.Client); ok {
+				client.Flush(3 * time.Second)
+			}
+
+			log.Stop()
 
 			return nil
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,6 +115,10 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 
 			client := telemetry.NewClient(props)
 
+			// Register as global client so telemetry.Exit() can flush even when
+			// commands call os.Exit directly, bypassing PersistentPostRunE.
+			telemetry.SetGlobal(client)
+
 			// Store telemetry client in context for use by commands
 			cmd.SetContext(context.WithValue(cmd.Context(), telemetryClientKey{}, client))
 

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -15,8 +15,6 @@
 package start
 
 import (
-	"os"
-
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/cmd/templates/setup"
 	"github.com/datarobot/cli/internal/auth"
@@ -59,7 +57,7 @@ The following actions will be performed:
 			}
 
 			if innerModel.err != nil {
-				os.Exit(1)
+				telemetry.Exit(1)
 			}
 
 			capture = innerModel.telemetry
@@ -81,7 +79,7 @@ The following actions will be performed:
 
 			innerSetupModel, ok := setup.InnerModel(finalSetupModel)
 			if ok && innerSetupModel.ExitMessage != "" {
-				os.Exit(1)
+				telemetry.Exit(1)
 			}
 
 			// Now run start again - we're in the cloned repo directory
@@ -99,7 +97,7 @@ The following actions will be performed:
 			}
 
 			if innerModel2.err != nil {
-				os.Exit(1)
+				telemetry.Exit(1)
 			}
 
 			capture = innerModel2.telemetry

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -18,6 +18,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/cmd/templates/setup"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/tui"
@@ -57,7 +58,9 @@ The following actions will be performed:
 			}
 
 			if innerModel.err != nil {
-				telemetry.Exit(1)
+				cmd.SilenceErrors = true
+
+				return cli.ErrSilent
 			}
 
 			capture = innerModel.telemetry
@@ -79,7 +82,9 @@ The following actions will be performed:
 
 			innerSetupModel, ok := setup.InnerModel(finalSetupModel)
 			if ok && innerSetupModel.ExitMessage != "" {
-				telemetry.Exit(1)
+				cmd.SilenceErrors = true
+
+				return cli.ErrSilent
 			}
 
 			// Now run start again - we're in the cloned repo directory
@@ -97,7 +102,9 @@ The following actions will be performed:
 			}
 
 			if innerModel2.err != nil {
-				telemetry.Exit(1)
+				cmd.SilenceErrors = true
+
+				return cli.ErrSilent
 			}
 
 			capture = innerModel2.telemetry

--- a/cmd/task/cmd.go
+++ b/cmd/task/cmd.go
@@ -35,8 +35,8 @@ Manage and execute tasks defined in your project's 'Taskfile':
   • Compose and generate task configurations
 
 🚀 Quick start: dr run dev`,
-		Run: func(cmd *cobra.Command, args []string) {
-			run.Cmd().Run(cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run.Cmd().RunE(cmd, args)
 		},
 	}
 

--- a/cmd/task/cmd.go
+++ b/cmd/task/cmd.go
@@ -24,9 +24,11 @@ import (
 
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "task",
-		GroupID: "core",
-		Short:   "🛠️ Task management commands",
+		Use:           "task",
+		GroupID:       "core",
+		Short:         "🛠️ Task management commands",
+		SilenceErrors: true,
+		SilenceUsage:  true,
 		Long: `Task management commands for your DataRobot applications.
 
 Manage and execute tasks defined in your project's 'Taskfile':

--- a/cmd/task/compose/cmd.go
+++ b/cmd/task/compose/cmd.go
@@ -46,7 +46,7 @@ func RunE(_ *cobra.Command, _ []string) error {
 
 	taskFilePath, err := discovery.Discover(".", 2)
 	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, task.DiscoveryError(err))
+		_, _ = fmt.Fprintln(os.Stderr, task.FormatDiscoveryError(err))
 
 		return cli.ErrSilent
 	}

--- a/cmd/task/compose/cmd.go
+++ b/cmd/task/compose/cmd.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/task"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -92,7 +93,7 @@ func createDiscovery(taskfileName string) *task.Discovery {
 		absPath, err := validateTemplatePath(templatePath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			telemetry.Exit(1)
 		}
 
 		return task.NewComposeDiscovery(taskfileName, absPath)

--- a/cmd/task/compose/cmd.go
+++ b/cmd/task/compose/cmd.go
@@ -21,9 +21,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/task"
-	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -34,14 +34,21 @@ const (
 
 var templatePath string
 
-func Run(_ *cobra.Command, _ []string) {
+func RunE(_ *cobra.Command, _ []string) error {
 	taskfileName, ignoreTaskfile := detectExistingTaskfile()
-	discovery := createDiscovery(taskfileName)
+
+	discovery, err := createDiscovery(taskfileName)
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+
+		return cli.ErrSilent
+	}
 
 	taskFilePath, err := discovery.Discover(".", 2)
 	if err != nil {
-		task.ExitWithError(err)
-		return
+		_, _ = fmt.Fprintln(os.Stderr, task.DiscoveryError(err))
+
+		return cli.ErrSilent
 	}
 
 	fmt.Printf("Generated file saved to: %s\n", taskFilePath)
@@ -49,7 +56,8 @@ func Run(_ *cobra.Command, _ []string) {
 	contentBytes, err := os.ReadFile(".gitignore")
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		log.Error(fmt.Errorf("Failed to read from '.gitignore' file: %w", err))
-		return
+
+		return nil
 	}
 
 	contents := string(contentBytes)
@@ -57,13 +65,14 @@ func Run(_ *cobra.Command, _ []string) {
 
 	// Check if Taskfile.yaml or Taskfile.yml is already in .gitignore
 	if isIgnored(contents, taskfileIgnore) {
-		return
+		return nil
 	}
 
 	f, err := os.Create(".gitignore")
 	if err != nil {
 		log.Error(fmt.Errorf("Failed to create '.gitignore' file: %w", err))
-		return
+
+		return nil
 	}
 
 	defer f.Close()
@@ -71,13 +80,16 @@ func Run(_ *cobra.Command, _ []string) {
 	_, err = f.WriteString(taskfileIgnore + "\n\n" + contents)
 	if err != nil {
 		log.Error(fmt.Errorf("Failed to write to '.gitignore' file: %w", err))
-		return
+
+		return nil
 	}
 
 	fmt.Println("Added " + taskfileIgnore + " line to '.gitignore'.")
+
+	return nil
 }
 
-func createDiscovery(taskfileName string) *task.Discovery {
+func createDiscovery(taskfileName string) (*task.Discovery, error) {
 	// Check for .Taskfile.template in the root directory if no template specified
 	autoTemplatePath := ".Taskfile.template"
 
@@ -92,14 +104,13 @@ func createDiscovery(taskfileName string) *task.Discovery {
 	if templatePath != "" {
 		absPath, err := validateTemplatePath(templatePath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			telemetry.Exit(1)
+			return nil, fmt.Errorf("invalid template: %w", err)
 		}
 
-		return task.NewComposeDiscovery(taskfileName, absPath)
+		return task.NewComposeDiscovery(taskfileName, absPath), nil
 	}
 
-	return task.NewTaskDiscovery(taskfileName)
+	return task.NewTaskDiscovery(taskfileName), nil
 }
 
 func validateTemplatePath(path string) (string, error) {
@@ -155,7 +166,9 @@ If a .Taskfile.template file is found in the root directory, it will be used
 automatically to generate a more comprehensive Taskfile with aggregated tasks.
 
 You can also specify a custom template with the --template flag.`,
-		Run: Run,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE:          RunE,
 	}
 
 	cmd.Flags().StringVarP(&templatePath, "template", "t", "", "Path to custom Taskfile template")

--- a/cmd/task/list/cmd.go
+++ b/cmd/task/list/cmd.go
@@ -304,13 +304,17 @@ func Cmd() *cobra.Command {
 
 			tasks, err := runner.ListTasks()
 			if err != nil {
-				return fmt.Errorf("listing tasks: %w", err)
+				_, _ = fmt.Fprintln(os.Stderr, "listing tasks:", err)
+
+				return cli.ErrSilent
 			}
 
 			categories := groupTasksByCategory(tasks, showAll)
 
 			if err = printCategorizedTasks(categories, showAll); err != nil {
-				return fmt.Errorf("printing tasks: %w", err)
+				_, _ = fmt.Fprintln(os.Stderr, "printing tasks:", err)
+
+				return cli.ErrSilent
 			}
 
 			return nil

--- a/cmd/task/list/cmd.go
+++ b/cmd/task/list/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
 	"github.com/datarobot/cli/internal/task"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
@@ -295,7 +296,7 @@ func Cmd() *cobra.Command {
 			if !runner.Installed() {
 				_, _ = fmt.Fprintln(os.Stderr, `"`+binaryName+`" binary not found in PATH. Please install Task from https://taskfile.dev/installation/`)
 
-				os.Exit(1)
+				telemetry.Exit(1)
 
 				return
 			}
@@ -304,7 +305,7 @@ func Cmd() *cobra.Command {
 			if err != nil {
 				_, _ = fmt.Fprintln(os.Stderr, "Error: ", err)
 
-				os.Exit(1)
+				telemetry.Exit(1)
 
 				return
 			}
@@ -314,7 +315,7 @@ func Cmd() *cobra.Command {
 			if err = printCategorizedTasks(categories, showAll); err != nil {
 				_, _ = fmt.Fprintln(os.Stderr, "Error: ", err)
 
-				os.Exit(1)
+				telemetry.Exit(1)
 
 				return
 			}

--- a/cmd/task/list/cmd.go
+++ b/cmd/task/list/cmd.go
@@ -285,7 +285,7 @@ func Cmd() *cobra.Command {
 
 			rootTaskfile, err := discovery.Discover(dir, 2)
 			if err != nil {
-				_, _ = fmt.Fprintln(os.Stderr, task.DiscoveryError(err))
+				_, _ = fmt.Fprintln(os.Stderr, task.FormatDiscoveryError(err))
 
 				return cli.ErrSilent
 			}

--- a/cmd/task/list/cmd.go
+++ b/cmd/task/list/cmd.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/task"
-	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
@@ -273,18 +273,21 @@ func Cmd() *cobra.Command {
 	var showAll bool
 
 	cmd := &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"l"},
-		Short:   "📋 List tasks",
+		Use:           "list",
+		Aliases:       []string{"l"},
+		Short:         "📋 List tasks",
+		SilenceErrors: true,
+		SilenceUsage:  true,
 
-		Run: func(_ *cobra.Command, _ []string) {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			binaryName := "task"
 			discovery := task.NewTaskDiscovery("Taskfile.gen.yaml")
 
 			rootTaskfile, err := discovery.Discover(dir, 2)
 			if err != nil {
-				task.ExitWithError(err)
-				return
+				_, _ = fmt.Fprintln(os.Stderr, task.DiscoveryError(err))
+
+				return cli.ErrSilent
 			}
 
 			runner := task.NewTaskRunner(task.RunnerOpts{
@@ -296,29 +299,21 @@ func Cmd() *cobra.Command {
 			if !runner.Installed() {
 				_, _ = fmt.Fprintln(os.Stderr, `"`+binaryName+`" binary not found in PATH. Please install Task from https://taskfile.dev/installation/`)
 
-				telemetry.Exit(1)
-
-				return
+				return cli.ErrSilent
 			}
 
 			tasks, err := runner.ListTasks()
 			if err != nil {
-				_, _ = fmt.Fprintln(os.Stderr, "Error: ", err)
-
-				telemetry.Exit(1)
-
-				return
+				return fmt.Errorf("listing tasks: %w", err)
 			}
 
 			categories := groupTasksByCategory(tasks, showAll)
 
 			if err = printCategorizedTasks(categories, showAll); err != nil {
-				_, _ = fmt.Fprintln(os.Stderr, "Error: ", err)
-
-				telemetry.Exit(1)
-
-				return
+				return fmt.Errorf("printing tasks: %w", err)
 			}
+
+			return nil
 		},
 	}
 

--- a/cmd/task/run/cmd.go
+++ b/cmd/task/run/cmd.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/task"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -92,14 +93,17 @@ Examples:
 
 💡 Tasks are defined in your project's 'Taskfile' and vary by template.
 💡 Use -- to pass additional arguments to the task command itself.`,
-		Run: func(_ *cobra.Command, args []string) {
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
 			binaryName := "task"
 			discovery := task.NewTaskDiscovery("Taskfile.gen.yaml")
 
 			rootTaskfile, err := discovery.Discover(opts.Dir, 2)
 			if err != nil {
-				task.ExitWithError(err)
-				return
+				_, _ = fmt.Fprintln(os.Stderr, task.DiscoveryError(err))
+
+				return cli.ErrSilent
 			}
 
 			runner := task.NewTaskRunner(task.RunnerOpts{
@@ -122,9 +126,7 @@ Examples:
 				_, _ = fmt.Fprintln(os.Stderr, "")
 				_, _ = fmt.Fprintln(os.Stderr, "After installing, try running your command again!")
 
-				telemetry.Exit(1)
-
-				return
+				return cli.ErrSilent
 			}
 
 			taskNames, taskArgs := splitTaskArgs(args)
@@ -151,8 +153,13 @@ Examples:
 					_, _ = fmt.Fprintln(os.Stderr, "Error: ", err)
 				}
 
+				// telemetry.Exit is required here (not return) because we must propagate
+				// an exact integer exit code from the subprocess, which cannot be encoded
+				// in a Go error value.
 				telemetry.Exit(exitCode)
 			}
+
+			return nil
 		},
 		ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completeTaskNames(&opts)

--- a/cmd/task/run/cmd.go
+++ b/cmd/task/run/cmd.go
@@ -153,10 +153,10 @@ Examples:
 					_, _ = fmt.Fprintln(os.Stderr, "Error: ", err)
 				}
 
-				// telemetry.Exit is required here (not return) because we must propagate
+				// telemetry.ExitWithContext is required here (not return) because we must propagate
 				// an exact integer exit code from the subprocess, which cannot be encoded
 				// in a Go error value.
-				telemetry.Exit(exitCode)
+				telemetry.ExitWithContext(cmd.Context(), exitCode)
 			}
 
 			return nil

--- a/cmd/task/run/cmd.go
+++ b/cmd/task/run/cmd.go
@@ -101,7 +101,7 @@ Examples:
 
 			rootTaskfile, err := discovery.Discover(opts.Dir, 2)
 			if err != nil {
-				_, _ = fmt.Fprintln(os.Stderr, task.DiscoveryError(err))
+				_, _ = fmt.Fprintln(os.Stderr, task.FormatDiscoveryError(err))
 
 				return cli.ErrSilent
 			}

--- a/cmd/task/run/cmd.go
+++ b/cmd/task/run/cmd.go
@@ -122,7 +122,7 @@ Examples:
 				_, _ = fmt.Fprintln(os.Stderr, "")
 				_, _ = fmt.Fprintln(os.Stderr, "After installing, try running your command again!")
 
-				os.Exit(1)
+				telemetry.Exit(1)
 
 				return
 			}
@@ -151,7 +151,7 @@ Examples:
 					_, _ = fmt.Fprintln(os.Stderr, "Error: ", err)
 				}
 
-				os.Exit(exitCode)
+				telemetry.Exit(exitCode)
 			}
 		},
 		ValidArgsFunction: func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -124,6 +124,78 @@ This approach ensures:
 - **Extensible**: Adding a new event requires one call where the command is built.
 - **Self-documenting**: The cobra command itself carries its telemetry intent.
 
+## Process exit and telemetry flush
+
+Amplitude events are queued in-process and flushed asynchronously. If a command calls `os.Exit` directly (plugins, task runner exit-code propagation) or if `RunE` returns an error that causes cobra to skip `PersistentPostRunE`, the queue would be silently dropped. Two mechanisms handle this:
+
+### `cmd.Exit(code int)` — for `main.go`'s error path
+
+`cmd.Exit` lives in `cmd/exit.go` alongside the `telemetryClient` package-level variable that `PersistentPreRunE` sets. Use it only from `main.go` when `ExecuteContext` returns an error:
+
+```go
+if err := cmd.ExecuteContext(ctx); err != nil {
+    log.Stop()
+    cmd.Exit(1) // flushes telemetry then calls os.Exit(1)
+}
+```
+
+`cmd.Exit` is nil-safe: if `PersistentPreRunE` never ran (e.g. flag parse failure before any command executes) there are no queued events and it falls straight through to `os.Exit`.
+
+### `telemetry.ExitWithContext(ctx context.Context, code int)` — for cobra sub-commands
+
+Commands that must propagate a subprocess exit code (plugin dispatch, `task run --exit-code`) cannot use `return err` because Go errors carry no integer code. They call `telemetry.ExitWithContext` with the command's cobra context — the client stored there by `PersistentPreRunE` is flushed before `os.Exit`:
+
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    exitCode := runSubprocess(...)
+    telemetry.ExitWithContext(cmd.Context(), exitCode) // never returns
+    return nil // unreachable
+},
+```
+
+### State ownership
+
+`internal/telemetry` is **stateless** — it defines `Client`, helpers, and `ClientContextKey` but holds no global variables. The two places that own state are:
+
+| Owner | What | Why |
+|---|---|---|
+| `cmd` package (`root.go` + `exit.go`) | `var telemetryClient *telemetry.Client` | Needed by `main.go`'s error path, which only has the signal context (no cobra context). |
+| cobra command context | `*telemetry.Client` stored under `telemetry.ClientContextKey{}` | Accessible to any sub-package that has a `*cobra.Command` without importing `cmd` (which would be circular). |
+
+Both are set in `PersistentPreRunE`; the context value is consumed by `PersistentPostRunE` (normal path) or `telemetry.ExitWithContext` (exit-code path).
+
+## Silent errors and `SilenceErrors`
+
+`cli.ErrSilent` (`internal/cli/command.go`) is a sentinel returned by `RunE` implementations that have **already printed** their own user-facing error. Returning it tells cobra "don't add a second `Error: …` line", but only if the command (or an ancestor) has `SilenceErrors: true` set.
+
+**Rules:**
+
+1. Any command whose `RunE` can return `cli.ErrSilent` — either directly or by calling a sub-command's `RunE` — must set `SilenceErrors: true` on its own `cobra.Command`.
+2. When composing commands (e.g. calling `compose.Cmd().RunE(nil, nil)` inside another command's `RunE`), the *caller* must also carry `SilenceErrors: true`, because the sentinel propagates up the call stack.
+3. `main.go` always calls `cmd.Exit(1)` for any non-nil error, so telemetry is recorded even for silent failures.
+
+**Example:**
+
+```go
+func Cmd() *cobra.Command {
+    return &cobra.Command{
+        Use:           "add [...]",
+        RunE:          RunE,
+        SilenceErrors: true, // required: RunE can return cli.ErrSilent via compose.Cmd().RunE
+    }
+}
+
+func RunE(_ *cobra.Command, args []string) error {
+    if err := addComponents(args); err != nil {
+        return err
+    }
+
+    // compose prints its own error and returns cli.ErrSilent on failure;
+    // SilenceErrors: true above prevents cobra from echoing "Error: silent error".
+    return compose.Cmd().RunE(nil, nil)
+}
+```
+
 ### Execution flow
 
 ```

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -15,9 +15,18 @@
 package cli
 
 import (
+	"errors"
+
 	"github.com/datarobot/cli/internal/features"
 	"github.com/spf13/cobra"
 )
+
+// ErrSilent is returned by RunE implementations that have already printed their
+// own user-facing error message. Pair it with SilenceErrors: true on the
+// cobra.Command (or set cmd.SilenceErrors = true before returning) so that
+// cobra does not echo an additional "Error: ..." line to stderr.
+// main.go will still call telemetry.Exit(1) for any non-nil error as normal.
+var ErrSilent = errors.New("silent error")
 
 // CommandAdder wraps cobra.Command and overrides AddCommand to filter gated commands.
 // It allows commands with disabled feature gates to never be added to the command tree.

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -25,7 +25,7 @@ import (
 // own user-facing error message. Pair it with SilenceErrors: true on the
 // cobra.Command (or set cmd.SilenceErrors = true before returning) so that
 // cobra does not echo an additional "Error: ..." line to stderr.
-// main.go will still call telemetry.Exit(1) for any non-nil error as normal.
+// main.go will still call cmd.Exit(1) for any non-nil error as normal.
 var ErrSilent = errors.New("silent error")
 
 // CommandAdder wraps cobra.Command and overrides AddCommand to filter gated commands.

--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -108,7 +108,10 @@ func StartFile() {
 func StopFile() {
 	fileLogger = nil
 
-	fileWriter.Close()
+	if fileWriter != nil {
+		fileWriter.Close()
+		fileWriter = nil
+	}
 }
 
 func Log(level log.Level, msg interface{}, keyvals ...interface{}) {

--- a/internal/task/discovery.go
+++ b/internal/task/discovery.go
@@ -148,10 +148,10 @@ func (d *Discovery) Discover(root string, maxDepth int) (string, error) {
 	return rootTaskfilePath, nil
 }
 
-// DiscoveryError formats a discovery error into a user-friendly message string.
+// FormatDiscoveryError formats a discovery error into a user-friendly message string.
 // Commands should call this to get the message, print it themselves if needed,
 // and return cli.ErrSilent (or the returned error directly).
-func DiscoveryError(err error) error {
+func FormatDiscoveryError(err error) error {
 	if errors.Is(err, ErrNotInTemplate) {
 		return fmt.Errorf("%s\n%s",
 			tui.BaseTextStyle.Render("You don't seem to be in a DataRobot Template directory."),

--- a/internal/task/discovery.go
+++ b/internal/task/discovery.go
@@ -26,7 +26,6 @@ import (
 	"text/template"
 
 	"github.com/datarobot/cli/internal/log"
-	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/tui"
 	"gopkg.in/yaml.v3"
 )
@@ -149,26 +148,23 @@ func (d *Discovery) Discover(root string, maxDepth int) (string, error) {
 	return rootTaskfilePath, nil
 }
 
-func ExitWithError(err error) {
+// DiscoveryError formats a discovery error into a user-friendly message string.
+// Commands should call this to get the message, print it themselves if needed,
+// and return cli.ErrSilent (or the returned error directly).
+func DiscoveryError(err error) error {
 	if errors.Is(err, ErrNotInTemplate) {
-		fmt.Fprintln(os.Stderr, tui.BaseTextStyle.Render("You don't seem to be in a DataRobot Template directory."))
-		fmt.Fprintln(os.Stderr, tui.BaseTextStyle.Render("This command requires a '.datarobot' folder to be present."))
-		telemetry.Exit(1)
-
-		return
+		return fmt.Errorf("%s\n%s",
+			tui.BaseTextStyle.Render("You don't seem to be in a DataRobot Template directory."),
+			tui.BaseTextStyle.Render("This command requires a '.datarobot' folder to be present."))
 	}
 
 	if errors.Is(err, ErrTaskfileHasDotenv) {
-		fmt.Fprintln(os.Stderr, tui.ErrorStyle.Render("Error: Cannot generate 'Taskfile' because an existing 'Taskfile' already has a dotenv directive."))
-		fmt.Fprintln(os.Stderr, tui.BaseTextStyle.Render(err.Error()))
-		telemetry.Exit(1)
-
-		return
+		return fmt.Errorf("%s\n%s",
+			tui.ErrorStyle.Render("Error: Cannot generate 'Taskfile' because an existing 'Taskfile' already has a dotenv directive."),
+			tui.BaseTextStyle.Render(err.Error()))
 	}
 
-	_, _ = fmt.Fprintln(os.Stderr, "Error discovering tasks: ", err)
-
-	telemetry.Exit(1)
+	return fmt.Errorf("Error discovering tasks: %w", err)
 }
 
 // findComponents looks for the {T,t}askfile.{yaml,yml} files in subdirectories (e.g. which are app framework components) of the given root directory,

--- a/internal/task/discovery.go
+++ b/internal/task/discovery.go
@@ -26,6 +26,7 @@ import (
 	"text/template"
 
 	"github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/tui"
 	"gopkg.in/yaml.v3"
 )
@@ -152,7 +153,7 @@ func ExitWithError(err error) {
 	if errors.Is(err, ErrNotInTemplate) {
 		fmt.Fprintln(os.Stderr, tui.BaseTextStyle.Render("You don't seem to be in a DataRobot Template directory."))
 		fmt.Fprintln(os.Stderr, tui.BaseTextStyle.Render("This command requires a '.datarobot' folder to be present."))
-		os.Exit(1)
+		telemetry.Exit(1)
 
 		return
 	}
@@ -160,14 +161,14 @@ func ExitWithError(err error) {
 	if errors.Is(err, ErrTaskfileHasDotenv) {
 		fmt.Fprintln(os.Stderr, tui.ErrorStyle.Render("Error: Cannot generate 'Taskfile' because an existing 'Taskfile' already has a dotenv directive."))
 		fmt.Fprintln(os.Stderr, tui.BaseTextStyle.Render(err.Error()))
-		os.Exit(1)
+		telemetry.Exit(1)
 
 		return
 	}
 
 	_, _ = fmt.Fprintln(os.Stderr, "Error discovering tasks: ", err)
 
-	os.Exit(1)
+	telemetry.Exit(1)
 }
 
 // findComponents looks for the {T,t}askfile.{yaml,yml} files in subdirectories (e.g. which are app framework components) of the given root directory,

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -40,16 +40,16 @@ type CommonProperties struct {
 	DeviceID  string  // UUID v4, stable per installation, cached to disk
 	UserID    *string // DataRobot uid from GET /api/v2/account/info/, cached to disk; nil on network failure or auth issues
 	// event properties
-	CLIVersion        string // CLI version from version.Version (ldflags)
-	InstallMethod     string // Build distribution method (ldflags)
-	OSName            string // human-readable OS name from runtime.GOOS
-	OSArch            string // CPU architecture from runtime.GOARCH
-	OSVersion         string // OS release version string, detected at startup
-	Language          string // user language from LANG env var (e.g. "en_US")
-	GoVersion         string // Go runtime version (e.g. "go1.26.2")
-	Shell             string // Name of the user's shell (e.g. "zsh", "bash", "powershell")
-	DataRobotInstance string // Base URL of configured DataRobot instance
-	CommandKind       string // "core" or "plugin", set by the root command after dispatch
+	CLIVersion        string  // CLI version from version.Version (ldflags)
+	InstallMethod     string  // Build distribution method (ldflags)
+	OSName            string  // human-readable OS name from runtime.GOOS
+	OSArch            string  // CPU architecture from runtime.GOARCH
+	OSVersion         string  // OS release version string, detected at startup
+	Language          string  // user language from LANG env var (e.g. "en_US")
+	GoVersion         string  // Go runtime version (e.g. "go1.26.2")
+	Shell             string  // Name of the user's shell (e.g. "zsh", "bash", "powershell")
+	DataRobotInstance string  // Base URL of configured DataRobot instance
+	CommandKind       string  // "core" or "plugin", set by the root command after dispatch
 	OrganizationID    *string // DataRobot org ID from GET /api/v2/account/info/, cached to disk; nil on network failure or auth issues
 	TenantID          *string // DataRobot tenant ID from GET /api/v2/account/info/, cached to disk; nil if unavailable (legit absent for legacy/system accounts)
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -24,6 +24,7 @@ package telemetry
 
 import (
 	"encoding/json"
+	"os"
 	"time"
 
 	"github.com/amplitude/analytics-go/amplitude"
@@ -159,6 +160,28 @@ func (c *Client) Flush(timeout time.Duration) {
 		// Timeout reached, events may not have been sent
 		log.Debug("Telemetry flush timed out", "timeout", timeout)
 	}
+}
+
+// globalClient holds the active telemetry client for process-wide Exit calls.
+// It is set by SetGlobal during PersistentPreRunE before any command runs.
+var globalClient *Client
+
+// SetGlobal stores c as the global telemetry client. Must be called during
+// PersistentPreRunE before any os.Exit-based code paths can be reached.
+func SetGlobal(c *Client) {
+	globalClient = c
+}
+
+// Exit flushes any pending telemetry events then calls os.Exit(code).
+// Use this instead of os.Exit in command code so that Amplitude events are
+// delivered even when cobra's PersistentPostRunE hook is bypassed (e.g. when
+// RunE returns an error, or when a command calls os.Exit directly).
+func Exit(code int) {
+	if globalClient != nil {
+		globalClient.Flush(3 * time.Second)
+	}
+
+	os.Exit(code)
 }
 
 // IsEnabled reports whether telemetry collection is active. Returns true only

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -23,6 +23,7 @@
 package telemetry
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"time"
@@ -162,32 +163,19 @@ func (c *Client) Flush(timeout time.Duration) {
 	}
 }
 
-// globalClient holds the active telemetry client for process-wide Exit calls.
-// It is set by SetGlobal during PersistentPreRunE before any command runs.
-var globalClient *Client
+// ClientContextKey is the context key used to store and retrieve the active
+// telemetry Client from a cobra command's context. Storing it in the telemetry
+// package keeps the key accessible to all sub-packages without importing cmd.
+type ClientContextKey struct{}
 
-// SetGlobal stores c as the global telemetry client. Must be called during
-// PersistentPreRunE before any os.Exit-based code paths can be reached.
-func SetGlobal(c *Client) {
-	if c == nil {
-		// failsafe to make sure we don't screw up in dev or testing
-		panic("telemetry.SetGlobal: client cannot be nil")
+// ExitWithContext flushes pending telemetry from the client stored in ctx, then
+// calls os.Exit(code). Use this in cobra RunE/Run callbacks (which always have
+// a *cobra.Command) instead of os.Exit so that Amplitude events are delivered
+// when PersistentPostRunE is bypassed (e.g. when propagating subprocess exit codes).
+func ExitWithContext(ctx context.Context, code int) {
+	if client, ok := ctx.Value(ClientContextKey{}).(*Client); ok {
+		client.Flush(3 * time.Second)
 	}
-
-	globalClient = c
-}
-
-// Exit flushes any pending telemetry events then calls os.Exit(code).
-// Use this instead of os.Exit in command code so that Amplitude events are
-// delivered even when cobra's PersistentPostRunE hook is bypassed (e.g. when
-// RunE returns an error, or when a command calls os.Exit directly).
-func Exit(code int) {
-	if globalClient == nil {
-		// failsafe to make sure we don't screw up in dev or testing
-		panic("telemetry.Exit called before SetGlobal - PersistentPreRunE must run first")
-	}
-
-	globalClient.Flush(3 * time.Second)
 
 	os.Exit(code)
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -169,6 +169,11 @@ var globalClient *Client
 // SetGlobal stores c as the global telemetry client. Must be called during
 // PersistentPreRunE before any os.Exit-based code paths can be reached.
 func SetGlobal(c *Client) {
+	if c == nil {
+		// failsafe to make sure we don't screw up in dev or testing
+		panic("telemetry.SetGlobal: client cannot be nil")
+	}
+
 	globalClient = c
 }
 
@@ -177,9 +182,12 @@ func SetGlobal(c *Client) {
 // delivered even when cobra's PersistentPostRunE hook is bypassed (e.g. when
 // RunE returns an error, or when a command calls os.Exit directly).
 func Exit(code int) {
-	if globalClient != nil {
-		globalClient.Flush(3 * time.Second)
+	if globalClient == nil {
+		// failsafe to make sure we don't screw up in dev or testing
+		panic("telemetry.Exit called before SetGlobal - PersistentPreRunE must run first")
 	}
+
+	globalClient.Flush(3 * time.Second)
 
 	os.Exit(code)
 }

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func main() {
 	defer log.Stop()
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
+		log.Stop()
 		telemetry.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"os/signal"
 
 	"github.com/datarobot/cli/cmd"
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/telemetry"
 )
 
@@ -27,6 +28,11 @@ func main() {
 	// Create a context that's canceled on interrupt signals
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 	defer cancel()
+
+	// Always stop loggers, whether the command succeeds or returns an error.
+	// PersistentPostRunE is skipped by cobra on error, so we must ensure log.Stop
+	// runs unconditionally here.
+	defer log.Stop()
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		telemetry.Exit(1)

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"os/signal"
 
 	"github.com/datarobot/cli/cmd"
+	"github.com/datarobot/cli/internal/telemetry"
 )
 
 func main() {
@@ -28,6 +29,6 @@ func main() {
 	defer cancel()
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
-		os.Exit(1)
+		telemetry.Exit(1)
 	}
 }


### PR DESCRIPTION
# RATIONALE

Telemetry events were silently dropped whenever a command exited via `os.Exit(1)`.
Cobra's `PersistentPostRunE` hook (where `client.Flush` was called) is never invoked
when a code path calls `os.Exit` directly — not even deferred functions run. The same
bypass caused `log.Stop()` to be skipped, leaving log resources uncleaned. Additionally,
commands that printed their own ❌ … error message and then called `os.Exit(1)` could
not propagate a proper exit code through cobra, so the pattern had spread through the
codebase as a workaround.

## CHANGES

### Immediate fix — telemetry flush on all exit paths

**exit.go (new file)**
- Added `cmd.Exit(code int)` — flushes the `telemetryClient` package-level variable
  (3 s timeout) then calls `os.Exit`. Nil-safe: if `PersistentPreRunE` never ran (e.g.
  flag parse failure) there are no queued events and it falls straight through to `os.Exit`.

**telemetry.go**
- Added exported `ClientContextKey{}` — the context key used to store and retrieve the
  active `*Client` from a cobra command's context; defined here so all sub-packages can
  access it without importing cmd (which would be circular).
- Added `ExitWithContext(ctx context.Context, code int)` — looks up the client stored
  under `ClientContextKey{}`, flushes it, then calls `os.Exit`. Used by cobra
  sub-commands that must propagate a subprocess exit code.
- **Removed** `globalClient`, `SetGlobal`, and `Exit` — telemetry is now
  **stateless**; it holds no global variables.

**root.go**
- Replaced `telemetry.SetGlobal(client)` with `telemetryClient = client` (package-level
  var shared with exit.go).
- Changed context key from the unexported `telemetryClientKey{}` to the exported
  `telemetry.ClientContextKey{}`, so sub-packages can retrieve the client without
  importing cmd.

**main.go**
- Error path now calls `cmd.Exit(1)` instead of `telemetry.Exit(1)`; removed direct
  telemetry import.
- Added `defer log.Stop()` so log cleanup is unconditional (not only on the happy path).

### Long-term fix — eliminate `os.Exit` from cobra command internals

**command.go**
- `ErrSilent` sentinel: commands that already print their own user-facing error return
  `cli.ErrSilent` with `SilenceErrors: true` on the cobra command, preventing cobra from
  double-printing `Error: …`.

**discovery.go**
- Replaced `ExitWithError(err)` (which called `os.Exit`) with `DiscoveryError(err) error`
  that returns a formatted error value.

**All cmd commands converted from `Run` → `RunE`**, removing all internal `os.Exit` /
`telemetry.Exit` calls: `check`, `login`, `logout`, `start`, `add`, `update`, `dotenv`
(`UpdateCmd`, `ValidateCmd`), `list`, `compose`, `run`.

**`SilenceErrors: true` added** to `component add` and `component update` commands so
that `cli.ErrSilent` returned by their `RunE` is not echoed by cobra.

### Two intentional `telemetry.ExitWithContext` call-sites remain

These are legitimate exceptions where an exact integer exit code from a child process
must be forwarded to the OS and cannot be encoded in a Go error:

- discovery.go — plugin subprocess exit-code passthrough
- cmd.go — `--exit-code` flag passthrough

### Documentation (telemetry.md)
- Added "Process exit and telemetry flush" section documenting `cmd.Exit`,
  `telemetry.ExitWithContext`, state ownership table, and `SilenceErrors` / `ErrSilent`
  rules with examples.

## Result

Telemetry is flushed on all exit paths (success, error return, and the two subprocess
passthroughs). No command inside cobra calls `os.Exit` speculatively; errors propagate
via `return err` so `PersistentPostRunE` and `defer` statements run normally.

`task build` ✅ · `task lint` 0 issues ✅ · `task test` ✅

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process-exit and error-handling paths across many commands; behavior changes could affect exit codes and stderr output, though changes are mostly mechanical and centralized.
> 
> **Overview**
> Ensures telemetry and logging are cleaned up even when commands terminate early: adds a global telemetry client plus `telemetry.Exit(code)` (flush then `os.Exit`), registers it in `cmd/root.go`, and switches `main.go` to exit via `telemetry.Exit(1)` with unconditional `log.Stop()`.
> 
> Standardizes command error handling by introducing `cli.ErrSilent` and updating multiple commands (auth, dotenv, component, task, start) to use `RunE`, return errors instead of calling `os.Exit`, and set `SilenceErrors`/`SilenceUsage` to prevent double-printing. Task discovery error handling is refactored from `ExitWithError` to `DiscoveryError(err)`.
> 
> Keeps intentional hard-exit behavior only where exact subprocess exit codes must be propagated (plugin execution and `dr run --exit-code`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6649ffb4c2b92dd606db99eb456122b12ffe835. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->