### PR TITLE
[CFX-6052] Add Template Name to event properties

### DIFF
--- a/cmd/component/add/cmd.go
+++ b/cmd/component/add/cmd.go
@@ -155,7 +155,7 @@ func Cmd() *cobra.Command {
 	cmd.Flags().StringVar(&addFlags.DataFile, "data-file", "", "Path to YAML file with default answers (follows copier data_file semantics)")
 	cmd.Flags().BoolVar(&addFlags.Trust, "trust", true, "Trust the template repository (required for migrations)")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+	telemetry.TrackWithProject(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
 			"component_name": telemetry.FirstArg(args),
 		}

--- a/cmd/component/update/cmd.go
+++ b/cmd/component/update/cmd.go
@@ -129,7 +129,7 @@ func Cmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&updateFlags.Overwrite, "overwrite", "w", false, "Overwrite files even if they exist.")
 	cmd.Flags().BoolVar(&updateFlags.Trust, "trust", true, "Trust the template repository (required for migrations)")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+	telemetry.TrackWithProject(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
 			"component_name": telemetry.FirstArg(args),
 		}

--- a/cmd/dependencies/check/cmd.go
+++ b/cmd/dependencies/check/cmd.go
@@ -44,7 +44,7 @@ func Cmd() *cobra.Command {
 		},
 	}
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWithProject(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
 			"missing_deps":          result.MissingMsgs,
 			"wrong_version_deps":    result.WrongVersionMsgs,

--- a/cmd/dependencies/install/cmd.go
+++ b/cmd/dependencies/install/cmd.go
@@ -90,7 +90,7 @@ func Cmd() *cobra.Command {
 
 	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWithProject(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
 			"missing_deps":          checkResult.MissingMsgs,
 			"wrong_version_deps":    checkResult.WrongVersionMsgs,

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -241,9 +241,9 @@ func init() {
 	// get persisted to drconfig.yaml on subsequent config writes.
 	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 
-	telemetry.Track(SetupCmd)
-	telemetry.Track(UpdateCmd)
-	telemetry.Track(ValidateCmd)
+	telemetry.TrackInProject(SetupCmd)
+	telemetry.TrackInProject(UpdateCmd)
+	telemetry.TrackInProject(ValidateCmd)
 }
 
 // shouldSkipSetup checks if setup should be skipped when --if-needed flag is set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,8 +119,8 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 
 			client := telemetry.NewClient(props)
 
-			// Store as process-level client so cmd.Exit can flush on the main error path.
-			telemetryClient = client
+			// Store telemetry client in context for use by commands
+			cmd.SetContext(telemetry.NewContext(cmd.Context(), client))
 
 			// Store telemetry client in context for use by commands
 			cmd.SetContext(context.WithValue(cmd.Context(), telemetry.ClientContextKey{}, client))
@@ -141,7 +141,7 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
 			// Flush telemetry events before exit
-			if client, ok := cmd.Context().Value(telemetry.ClientContextKey{}).(*telemetry.Client); ok {
+			if client, ok := telemetry.ClientFromContext(cmd.Context()); ok {
 				client.Flush(3 * time.Second)
 			}
 

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -129,7 +129,7 @@ The following actions will be performed:
 
 	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWithProject(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
 			"validation_violations": capture.validationViolations,
 			"missing_deps":          capture.missingMsgs,

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -15,6 +15,7 @@
 package start
 
 import (
+	"github.com/amplitude/analytics-go/amplitude/types"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/cmd/templates/setup"
 	"github.com/datarobot/cli/internal/auth"
@@ -85,6 +86,17 @@ The following actions will be performed:
 				cmd.SilenceErrors = true
 
 				return cli.ErrSilent
+			}
+
+			if ok && innerSetupModel.Template().Name != "" {
+				if client, ok := telemetry.ClientFromContext(cmd.Context()); ok {
+					client.Track(types.Event{
+						EventType: "dr template setup",
+						EventProperties: map[string]any{
+							"template_name": innerSetupModel.Template().Name,
+						},
+					})
+				}
 			}
 
 			// Now run start again - we're in the cloned repo directory

--- a/cmd/task/cmd.go
+++ b/cmd/task/cmd.go
@@ -48,7 +48,7 @@ Manage and execute tasks defined in your project's 'Taskfile':
 		run.Cmd(),
 	)
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+	telemetry.TrackWithProject(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
 			"task_name": telemetry.FirstArg(args),
 		}

--- a/cmd/task/run/cmd.go
+++ b/cmd/task/run/cmd.go
@@ -182,7 +182,7 @@ Examples:
 	// Mark mutually exclusive flags
 	cmd.MarkFlagsMutuallyExclusive("parallel", "watch")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+	telemetry.TrackWithProject(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
 			"task_name": telemetry.FirstArg(args),
 		}

--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -43,6 +43,7 @@ var expectedTrackedCommands = []string{
 	"dr component add",
 	"dr component update",
 	"dr template setup",
+	"dr template list",
 	"dr plugin install",
 	"dr plugin uninstall",
 	"dr plugin update",

--- a/cmd/templates/list/cmd.go
+++ b/cmd/templates/list/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -57,4 +58,8 @@ start building AI applications. Each template includes:
 			return
 		}
 	},
+}
+
+func init() {
+	telemetry.Track(Cmd)
 }

--- a/cmd/templates/setup/cmd.go
+++ b/cmd/templates/setup/cmd.go
@@ -17,6 +17,7 @@ package setup
 import (
 	"context"
 
+	"github.com/amplitude/analytics-go/amplitude/types"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -41,7 +42,20 @@ var Cmd = &cobra.Command{
 💡 Perfect for first-time users or someone starting a new project.`,
 	PreRunE: auth.EnsureAuthenticatedE,
 	RunE: func(cmd *cobra.Command, _ []string) error {
-		return RunTea(cmd.Context(), false)
+		finalModel, err := RunTea(cmd.Context(), false)
+
+		if innerModel, ok := InnerModel(finalModel); ok && innerModel.template.Name != "" {
+			if client, ok := telemetry.ClientFromContext(cmd.Context()); ok {
+				client.Track(types.Event{
+					EventType: cmd.CommandPath(),
+					EventProperties: map[string]any{
+						"template_name": innerModel.template.Name,
+					},
+				})
+			}
+		}
+
+		return err
 	},
 }
 
@@ -49,26 +63,15 @@ func init() {
 	telemetry.Track(Cmd)
 }
 
-// RunTea starts the template setup TUI, optionally from the start command
-func RunTea(ctx context.Context, fromStartCommand bool) error {
+// RunTea starts the template setup TUI, optionally from the start command.
+// It returns the final tea.Model so callers can inspect the result (e.g. to
+// read the selected template name for telemetry purposes).
+func RunTea(ctx context.Context, fromStartCommand bool) (tea.Model, error) {
 	m := NewModel(fromStartCommand)
 
-	_, err := tui.Run(m, tea.WithAltScreen(), tea.WithContext(ctx))
-	// TODO: Re-enable after further testing of component configure
-	// if err != nil {
-	// 	return err
-	// }
+	finalModel, err := tui.Run(m, tea.WithAltScreen(), tea.WithContext(ctx))
 
-	// // Check if we need to launch template setup after quitting
-	// if setupModel, ok := finalModel.(tui.InterruptibleModel); ok {
-	// 	if innerModel, ok := setupModel.Model.(Model); ok {
-	// 		if innerModel.dotenvSetupCompleted {
-	// 			return component.RunE(component.AddCmd, nil)
-	// 		}
-	// 	}
-	// }
-
-	return err
+	return finalModel, err
 }
 
 func InnerModel(finalModel tea.Model) (Model, bool) {

--- a/cmd/templates/setup/cmd.go
+++ b/cmd/templates/setup/cmd.go
@@ -17,7 +17,6 @@ package setup
 import (
 	"context"
 
-	"github.com/amplitude/analytics-go/amplitude/types"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -45,14 +44,9 @@ var Cmd = &cobra.Command{
 		finalModel, err := RunTea(cmd.Context(), false)
 
 		if innerModel, ok := InnerModel(finalModel); ok && innerModel.template.Name != "" {
-			if client, ok := telemetry.ClientFromContext(cmd.Context()); ok {
-				client.Track(types.Event{
-					EventType: cmd.CommandPath(),
-					EventProperties: map[string]any{
-						"template_name": innerModel.template.Name,
-					},
-				})
-			}
+			telemetry.TrackEventFromContext(cmd.Context(), cmd.CommandPath(), map[string]any{
+				"template_name": innerModel.template.Name,
+			})
 		}
 
 		return err

--- a/cmd/templates/setup/model.go
+++ b/cmd/templates/setup/model.go
@@ -92,6 +92,12 @@ func (k keyMap) FullHelp() [][]key.Binding {
 	}
 }
 
+// Template returns the drapi.Template selected during setup.
+// Returns a zero-value Template if setup did not complete normally.
+func (m Model) Template() drapi.Template {
+	return m.template
+}
+
 type (
 	getHostMsg         struct{}
 	authKeyStartMsg    struct{}
@@ -466,7 +472,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		}
 
 		// Update state for templates setup completion
-		_ = state.UpdateAfterTemplatesSetup(repoRoot)
+		_ = state.UpdateAfterTemplatesSetup(repoRoot, m.template.Name, m.template.ID)
 
 		return m, exit
 	case exitMsg:

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -37,6 +37,10 @@ type state struct {
 	LastDotenvSetup *time.Time `yaml:"last_dotenv_setup,omitempty"`
 	// LastSuccessDepsCheck is an ISO8601-compliant timestamp of the last successful `dr dependencies check` or `dr dependencies install` run
 	LastSuccessDepsCheck *time.Time `yaml:"last_success_deps_check,omitempty"`
+	// TemplateName is the human-readable name of the template used to create this project
+	TemplateName string `yaml:"template_name,omitempty"`
+	// TemplateID is the unique identifier of the template used to create this project
+	TemplateID string `yaml:"template_id,omitempty"`
 }
 
 // getStatePath determines the appropriate location for the state file.
@@ -133,7 +137,8 @@ func UpdateAfterDotenvSetup(repoRoot string) error {
 }
 
 // UpdateAfterTemplatesSetup updates the state file after a successful `dr templates setup` run.
-func UpdateAfterTemplatesSetup(repoRoot string) error {
+// templateName and templateID are persisted so downstream commands can include them in telemetry.
+func UpdateAfterTemplatesSetup(repoRoot, templateName, templateID string) error {
 	// Load existing state to preserve other fields
 	existingState, err := load(repoRoot)
 	if err != nil {
@@ -143,7 +148,26 @@ func UpdateAfterTemplatesSetup(repoRoot string) error {
 	now := time.Now().UTC()
 	existingState.LastTemplatesSetup = &now
 
+	if templateName != "" {
+		existingState.TemplateName = templateName
+	}
+
+	if templateID != "" {
+		existingState.TemplateID = templateID
+	}
+
 	return existingState.update()
+}
+
+// GetTemplateName returns the template name stored in the project state file.
+// Returns an empty string (without error) when the field is not set.
+func GetTemplateName(repoRoot string) (string, error) {
+	existingState, err := load(repoRoot)
+	if err != nil {
+		return "", err
+	}
+
+	return existingState.TemplateName, nil
 }
 
 // UpdateAfterSuccessDepsCheck updates the state file after a successful `dr dependencies check` or `dr dependencies install` run.

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -248,3 +248,64 @@ func TestUpdateAfterSuccessDepsCheck_PreservesOtherFields(t *testing.T) {
 	require.NotNil(t, stateAfter.LastStart)
 	assert.Equal(t, stateBefore.LastStart.Unix(), stateAfter.LastStart.Unix())
 }
+
+func TestUpdateAfterTemplatesSetup_PersistsTemplateName(t *testing.T) {
+	tmpDir := t.TempDir()
+	localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
+	err := os.MkdirAll(localStateDir, 0o755)
+	require.NoError(t, err)
+
+	err = UpdateAfterTemplatesSetup(tmpDir, "My Template", "template-id-123")
+	require.NoError(t, err)
+
+	loadedState, err := load(tmpDir)
+	require.NoError(t, err)
+
+	assert.Equal(t, "My Template", loadedState.TemplateName)
+	assert.Equal(t, "template-id-123", loadedState.TemplateID)
+	assert.NotNil(t, loadedState.LastTemplatesSetup)
+	assert.NotEmpty(t, loadedState.CLIVersion)
+}
+
+func TestUpdateAfterTemplatesSetup_EmptyNameNoOverwrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
+	err := os.MkdirAll(localStateDir, 0o755)
+	require.NoError(t, err)
+
+	// Write an initial template name
+	err = UpdateAfterTemplatesSetup(tmpDir, "Original Template", "orig-id")
+	require.NoError(t, err)
+
+	// Call again with empty strings — should preserve existing values
+	err = UpdateAfterTemplatesSetup(tmpDir, "", "")
+	require.NoError(t, err)
+
+	loadedState, err := load(tmpDir)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Original Template", loadedState.TemplateName)
+	assert.Equal(t, "orig-id", loadedState.TemplateID)
+}
+
+func TestGetTemplateName(t *testing.T) {
+	t.Run("returns empty string when state file does not exist", func(t *testing.T) {
+		name, err := GetTemplateName(t.TempDir())
+		require.NoError(t, err)
+		assert.Empty(t, name)
+	})
+
+	t.Run("returns stored template name", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
+		err := os.MkdirAll(localStateDir, 0o755)
+		require.NoError(t, err)
+
+		err = UpdateAfterTemplatesSetup(tmpDir, "Awesome App", "awesome-id")
+		require.NoError(t, err)
+
+		name, err := GetTemplateName(tmpDir)
+		require.NoError(t, err)
+		assert.Equal(t, "Awesome App", name)
+	})
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -156,6 +156,26 @@ func (c *Client) Track(event types.Event) {
 	c.amp.Track(event)
 }
 
+// TrackEvent fires a one-off telemetry event using an event type and a property
+// map, without requiring callers to import the Amplitude SDK types directly.
+// It is intended for supplemental events fired outside the normal cobra
+// PersistentPostRunE wiring (e.g. post-TUI events where the result is only
+// known after the model exits).
+func (c *Client) TrackEvent(eventType string, props map[string]any) {
+	c.Track(types.Event{
+		EventType:       eventType,
+		EventProperties: props,
+	})
+}
+
+// TrackEventFromContext is a convenience wrapper around ClientFromContext and
+// TrackEvent. It is a no-op when the context carries no telemetry client.
+func TrackEventFromContext(ctx context.Context, eventType string, props map[string]any) {
+	if client, ok := ClientFromContext(ctx); ok {
+		client.TrackEvent(eventType, props)
+	}
+}
+
 // Flush sends all queued events and blocks until delivery completes or the
 // timeout elapses. Should be called once at process exit (typically in
 // PersistentPostRunE). Safe to call on a no-op client.

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -34,6 +34,23 @@ import (
 	"github.com/datarobot/cli/internal/log"
 )
 
+// contextKey is the unexported key type used to store a *Client in a context.
+type contextKey struct{}
+
+// NewContext returns a copy of ctx with the given telemetry client stored in it.
+// Use ClientFromContext to retrieve it later.
+func NewContext(ctx context.Context, client *Client) context.Context {
+	return context.WithValue(ctx, contextKey{}, client)
+}
+
+// ClientFromContext retrieves the telemetry *Client stored by NewContext.
+// Returns the client and true if found, or nil and false if the context has no client.
+func ClientFromContext(ctx context.Context) (*Client, bool) {
+	client, ok := ctx.Value(contextKey{}).(*Client)
+
+	return client, ok
+}
+
 // AmplitudeAPIKey is set at build time via ldflags. Dev builds have an empty value,
 // which automatically disables telemetry.
 var AmplitudeAPIKey string

--- a/internal/telemetry/wire.go
+++ b/internal/telemetry/wire.go
@@ -18,6 +18,8 @@ import (
 	"sync"
 
 	"github.com/amplitude/analytics-go/amplitude/types"
+	"github.com/datarobot/cli/internal/repo"
+	"github.com/datarobot/cli/internal/state"
 	"github.com/spf13/cobra"
 )
 
@@ -30,6 +32,13 @@ const trackAnnotation = "telemetry"
 // For now this is a bool, because we may want to track when plugin commands are
 // migrated to core commands.
 const pluginAnnotation = "telemetry:plugin"
+
+// projectAnnotation is the cobra annotation key set by TrackInProject /
+// TrackWithProject to mark a command as project-scoped. EventFor automatically
+// injects "template_name" (read from the nearest project state file) into the
+// event when this annotation is present. Non-project commands (auth, self,
+// plugin, etc.) must NOT carry this annotation.
+const projectAnnotation = "telemetry:project"
 
 // annotationValue is the (otherwise unused) value stored under trackAnnotation
 // and pluginAnnotation. Cobra annotations are map[string]string, but we only
@@ -65,6 +74,21 @@ func TrackWith(cmd *cobra.Command, extract PropExtractor) {
 	if extract != nil {
 		commandProperties.Store(cmd, extract)
 	}
+}
+
+// TrackInProject marks cmd as tracked and project-scoped. EventFor will
+// automatically inject "template_name" into the event for this command.
+// Use for project commands that have no other dynamic properties.
+func TrackInProject(cmd *cobra.Command) {
+	setAnnotation(cmd, trackAnnotation)
+	setAnnotation(cmd, projectAnnotation)
+}
+
+// TrackWithProject is TrackWith plus the project-scoped annotation.
+// EventFor automatically injects "template_name"; extract should not include it.
+func TrackWithProject(cmd *cobra.Command, extract PropExtractor) {
+	TrackWith(cmd, extract)
+	setAnnotation(cmd, projectAnnotation)
 }
 
 // TrackPlugin marks cmd as a plugin command and registers a closure that
@@ -119,6 +143,10 @@ func EventFor(cmd *cobra.Command, args []string) (types.Event, bool) {
 		}
 	}
 
+	if _, ok := cmd.Annotations[projectAnnotation]; ok {
+		event.EventProperties["template_name"] = RepoTemplateName()
+	}
+
 	return event, true
 }
 
@@ -130,6 +158,24 @@ func FirstArg(args []string) string {
 	}
 
 	return ""
+}
+
+// RepoTemplateName returns the template name stored in the nearest project's
+// state file, or "" when called outside a DataRobot project or when the field
+// has not been set (e.g. repos not initially set up via the CLI).
+// All errors are silently swallowed to keep the telemetry path non-blocking.
+func RepoTemplateName() string {
+	repoRoot, err := repo.FindRepoRoot()
+	if err != nil {
+		return ""
+	}
+
+	name, err := state.GetTemplateName(repoRoot)
+	if err != nil {
+		return ""
+	}
+
+	return name
 }
 
 // setAnnotation stores key=annotationValue on cmd, allocating the


### PR DESCRIPTION
# RATIONALE

Template-related telemetry was incomplete: no event property identified which template
a project was created from, so it was impossible to understand which templates users
actually work with in practice. Two gaps existed:

1. **No persistence** — the selected template name/ID was only known in-memory during
   `dr template setup`; once the TUI exited the information was lost.
2. **No wiring** — project-scoped commands (`dr start`, `dr run`, `dr task`,
   `dr dotenv *`, `dr component *`, `dr dependency *`) had no way to attach
   `template_name` to their telemetry events.

## CHANGES

### `internal/state/state.go`
- Added `TemplateName string` (`yaml:"template_name,omitempty"`) and `TemplateID string`
  (`yaml:"template_id,omitempty"`) fields to the per-project `state` struct
  (`.datarobot/cli/state.yaml`).
- Updated `UpdateAfterTemplatesSetup(repoRoot string)` →
  `UpdateAfterTemplatesSetup(repoRoot, templateName, templateID string)` to persist
  the selected template alongside the setup timestamp.
- Added `GetTemplateName(repoRoot string) (string, error)` accessor.

### `internal/state/state_test.go`
- Added `TestUpdateAfterTemplatesSetup_PersistsTemplateName`,
  `TestUpdateAfterTemplatesSetup_PreservesExistingTemplateName`, and
  `TestGetTemplateName` to cover the new fields and accessor.

### `internal/telemetry/telemetry.go`
- Added `NewContext(ctx, client)` and `ClientFromContext(ctx)` helpers so any
  sub-command can store/retrieve the `*Client` from a `context.Context` without
  coupling to `cmd/root.go`'s private key type.

### `internal/telemetry/wire.go`
- Added `projectAnnotation` (`"telemetry:project"`) cobra annotation.
- Added `TrackInProject(cmd)` — like `Track` but sets the project annotation.
- Added `TrackWithProject(cmd, extract)` — like `TrackWith` but sets the project
  annotation.
- `EventFor` now auto-injects `"template_name"` (via `RepoTemplateName()`) into any
  event whose command carries the project annotation. Non-project commands are unaffected.
- Added `RepoTemplateName() string` — walks to the repo root, reads `state.yaml`,
  returns the stored template name or `""` on any error (non-blocking, safe outside
  a project).

### `cmd/root.go`
- Removed private `telemetryClientKey{}` type; replaced with `telemetry.NewContext` /
  `telemetry.ClientFromContext`.

### `cmd/templates/setup/cmd.go`
- `RunTea` now returns `(tea.Model, error)` so callers can inspect the result.
- After the TUI exits, `RunE` fires a supplemental telemetry event carrying
  `template_name` via `telemetry.ClientFromContext` (template is only known post-TUI).

### `cmd/templates/setup/model.go`
- Updated `UpdateAfterTemplatesSetup` call-site to pass `m.template.Name` and
  `m.template.ID`.

### `cmd/templates/list/cmd.go`
- Added `telemetry.Track(Cmd)` — `dr template list` was untracked.

### Project-scoped commands — `Track` / `TrackWith` → `TrackWithProject` / `TrackInProject`

`EventFor` now automatically injects `template_name` for any command with the project
annotation, so per-command extractors no longer need to reference it explicitly.

| Command | File | Change |
|---|---|---|
| `dr start` | `cmd/start/cmd.go` | `TrackWith` → `TrackWithProject`; supplemental event after inline template setup |
| `dr run` | `cmd/task/run/cmd.go` | `TrackWith` → `TrackWithProject` |
| `dr task` | `cmd/task/cmd.go` | `TrackWith` → `TrackWithProject` |
| `dr dotenv setup/update/validate` | `cmd/dotenv/cmd.go` | `Track` → `TrackInProject` (×3) |
| `dr component add` | `cmd/component/add/cmd.go` | `TrackWith` → `TrackWithProject` |
| `dr component update` | `cmd/component/update/cmd.go` | `TrackWith` → `TrackWithProject` |
| `dr dependency check` | `cmd/dependencies/check/cmd.go` | `TrackWith` → `TrackWithProject` |
| `dr dependency install` | `cmd/dependencies/install/cmd.go` | `TrackWith` → `TrackWithProject` |

### `cmd/telemetry_wiring_test.go`
- Added `"dr template list"`, `"dr dependency check"`, `"dr dependency install"` to
  `expectedTrackedCommands`.

### `docs/development/telemetry.md`
- Updated `template_name` source description.
- Added `TrackInProject`, `TrackWithProject`, `NewContext`, `ClientFromContext` to the
  Event Wiring table.
- Updated execution flow diagram with `NewContext` store step and optional
  post-TUI supplemental event step.
- Added "Command that fires a supplemental event after a TUI completes" how-to example.

## Result

Every project-scoped command now emits `template_name` in its telemetry event (when run
inside a project set up via the CLI). The template name is persisted to
`.datarobot/cli/state.yaml` once at setup time and read cheaply from disk on every
subsequent invocation — no network calls.

---
 
## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core telemetry wiring across many commands and adds on-disk state fields, which could affect event emission or state compatibility if miswired.
> 
> **Overview**
> **Adds template attribution to telemetry for project commands.** The selected template `name`/`id` is now persisted to `.datarobot/cli/state.yaml` during `dr templates setup`, with new state helpers and tests.
> 
> **Updates telemetry wiring.** Introduces project-scoped tracking helpers (`TrackInProject`/`TrackWithProject`) so `EventFor` auto-injects `template_name` (read from repo state) for commands like `start`, `run/task`, `dotenv`, `dependencies`, and `component` actions; `dr template list` is now tracked, and `templates setup`/`start` emit supplemental events carrying the chosen template after the TUI completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 642f03be77263a537aaab497f6b32a0fb8ebd95a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->