### PR TITLE
[CFX-5956] lint: enforce telemetry-safe exit paths via forbidigo

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,7 +37,7 @@ linters:
             Call telemetry.Exit() instead of os.Exit() so pending telemetry is
             flushed before the process exits. Only main.go and
             internal/telemetry/telemetry.go may call os.Exit directly.
-        - pattern: '^log\.Fatalf?$'
+        - pattern: '^log\.Fatal(f|ln)?$'
           msg: >-
             log.Fatal/Fatalf calls os.Exit internally and bypasses telemetry
             flush. Return an error or call telemetry.Exit(1) instead.

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,6 +4,7 @@ run:
 linters:
   enable:
     - asasalint
+    - forbidigo
     - bodyclose
     - contextcheck
     - cyclop
@@ -29,6 +30,17 @@ linters:
     # - wrapcheck # disabled until we can resolve lints
     - wsl_v5
   settings:
+    forbidigo:
+      forbid:
+        - pattern: '^os\.Exit$'
+          msg: >-
+            Call telemetry.Exit() instead of os.Exit() so pending telemetry is
+            flushed before the process exits. Only main.go and
+            internal/telemetry/telemetry.go may call os.Exit directly.
+        - pattern: '^log\.Fatalf?$'
+          msg: >-
+            log.Fatal/Fatalf calls os.Exit internally and bypasses telemetry
+            flush. Return an error or call telemetry.Exit(1) instead.
     depguard:
       rules:
         no-raw-viper:
@@ -74,6 +86,9 @@ linters:
         - sortslice
         - tests
   exclusions:
+    rules:
+      - linters: [forbidigo]
+        path: "^main\\.go$|internal/telemetry/telemetry\\.go|internal/log/pkg\\.go|_test\\.go$"
     generated: lax
     presets:
       - comments

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -78,7 +78,12 @@ var EditCmd = &cobra.Command{
 		screen := editorScreen
 
 		if repo.IsInRepo() {
-			if handleExtraEnvVars(variables) {
+			useWizard, err := handleExtraEnvVars(variables)
+			if err != nil {
+				return err
+			}
+
+			if useWizard {
 				screen = wizardScreen
 			}
 		}

--- a/cmd/dotenv/helpers.go
+++ b/cmd/dotenv/helpers.go
@@ -108,7 +108,12 @@ func ValidateAndEditIfNeeded() error {
 	variables := envbuilder.ParseVariablesOnly(dotenvFileLines)
 	screen := editorScreen
 
-	if handleExtraEnvVars(variables) {
+	useWizard, err := handleExtraEnvVars(variables)
+	if err != nil {
+		return err
+	}
+
+	if useWizard {
 		screen = wizardScreen
 	}
 

--- a/cmd/dotenv/variables.go
+++ b/cmd/dotenv/variables.go
@@ -19,21 +19,20 @@ import (
 	"strings"
 
 	"github.com/datarobot/cli/internal/envbuilder"
-	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/tui"
 )
 
-func handleExtraEnvVars(variables envbuilder.Variables) bool { //nolint: cyclop
+func handleExtraEnvVars(variables envbuilder.Variables) (bool, error) { //nolint: cyclop
 	repoRoot, err := repo.FindRepoRoot()
 	if err != nil {
-		log.Fatalf("Error determining repo root: %v", err)
+		return false, fmt.Errorf("error determining repo root: %w", err)
 	}
 
 	userPrompts, err := envbuilder.GatherUserPrompts(repoRoot, variables)
 	if err != nil {
-		log.Fatalf("Error gathering user prompts: %v", err)
+		return false, fmt.Errorf("error gathering user prompts: %w", err)
 	}
 
 	// Create a new empty string set
@@ -83,11 +82,11 @@ func handleExtraEnvVars(variables envbuilder.Variables) bool { //nolint: cyclop
 
 		selectedOption, err := reader.ReadString()
 		if err != nil {
-			log.Fatalf("Error reading user reply: %v", err)
+			return false, fmt.Errorf("error reading user reply: %w", err)
 		}
 
-		return strings.ToLower(strings.TrimSpace(selectedOption)) == "y"
+		return strings.ToLower(strings.TrimSpace(selectedOption)) == "y", nil
 	}
 
-	return false
+	return false, nil
 }

--- a/cmd/dotenv/variables.go
+++ b/cmd/dotenv/variables.go
@@ -24,6 +24,17 @@ import (
 	"github.com/datarobot/cli/tui"
 )
 
+// handleExtraEnvVars detects and prompts the user to configure component-specific environment variables.
+// It gathers user prompts from the parakeet template configuration and compares them against
+// the provided variables. If extra variables are found (defined in the template but not in variables),
+// it displays them and prompts the user to configure them interactively.
+//
+// Parameters:
+//   - variables: the current environment variables already set or parsed from .env
+//
+// Returns:
+//   - bool: true if user answered 'y' to configure the extra variables (launch wizard), false otherwise
+//   - error: if determining repo root, gathering prompts, or reading user input fails
 func handleExtraEnvVars(variables envbuilder.Variables) (bool, error) { //nolint: cyclop
 	repoRoot, err := repo.FindRepoRoot()
 	if err != nil {

--- a/cmd/dotenv/variables.go
+++ b/cmd/dotenv/variables.go
@@ -25,7 +25,7 @@ import (
 )
 
 // handleExtraEnvVars detects and prompts the user to configure component-specific environment variables.
-// It gathers user prompts from the parakeet template configuration and compares them against
+// It gathers user prompts from the application template configuration and compares them against
 // the provided variables. If extra variables are found (defined in the template but not in variables),
 // it displays them and prompts the user to configure them interactively.
 //

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -32,5 +32,6 @@ func Exit(code int) {
 		telemetryClient.Flush(3 * time.Second)
 	}
 
-	os.Exit(code)
+	// This is the only place in the codebase that should call os.Exit
+	os.Exit(code) //nolint:forbidigo
 }

--- a/cmd/self/update/cmd.go
+++ b/cmd/self/update/cmd.go
@@ -146,6 +146,14 @@ with your default shell.
 	return cmd
 }
 
+// backupExecutable creates a backup of the current CLI executable before updating.
+// It renames the existing executable to a versioned backup file (e.g., dr_v1.2.3).
+// If a backup from the same version already exists, it is removed first to avoid conflicts.
+//
+// Returns:
+//   - executable: absolute path to the original CLI executable
+//   - backup: absolute path to the backup file (with version suffix)
+//   - error: if determining the executable path, removing old backups, or creating the backup fails
 func backupExecutable() (string, string, error) {
 	executable, err := os.Executable()
 	if err != nil {

--- a/cmd/self/update/cmd.go
+++ b/cmd/self/update/cmd.go
@@ -107,11 +107,17 @@ with your default shell.
 			switch runtime.GOOS {
 			case "windows":
 				command = "irm https://raw.githubusercontent.com/datarobot-oss/cli/main/install.ps1 | iex"
-				executable, backup = backupExecutable()
+
+				var err error
+
+				executable, backup, err = backupExecutable()
+				if err != nil {
+					return err
+				}
 			case "darwin", "linux":
 				command = "curl -fsSL https://raw.githubusercontent.com/datarobot-oss/cli/main/install.sh | sh"
 			default:
-				log.Fatalf("Could not determine OS: %s\n", runtime.GOOS)
+				return fmt.Errorf("could not determine OS: %s", runtime.GOOS)
 			}
 
 			execCmd := exec.Command(shell, "-c", command)
@@ -122,15 +128,13 @@ with your default shell.
 			if err := execCmd.Run(); err != nil {
 				if runtime.GOOS == "windows" {
 					// rename back if update failed
-					err = os.Rename(backup, executable)
-					if err != nil {
+					revertErr := os.Rename(backup, executable)
+					if revertErr != nil {
 						log.Errorf("Could not revert executable from backup: %s\n", backup)
 					}
 				}
 
-				log.Fatalf("Command execution failed: %v\n", err)
-
-				return err
+				return fmt.Errorf("command execution failed: %w", err)
 			}
 
 			return nil
@@ -142,10 +146,10 @@ with your default shell.
 	return cmd
 }
 
-func backupExecutable() (string, string) {
+func backupExecutable() (string, string, error) {
 	executable, err := os.Executable()
 	if err != nil {
-		log.Fatal("Could not determine current executable\n")
+		return "", "", fmt.Errorf("could not determine current executable: %w", err)
 	}
 
 	dir, file := filepath.Split(executable)
@@ -157,14 +161,14 @@ func backupExecutable() (string, string) {
 	if fsutil.FileExists(backup) {
 		err = os.Remove(backup)
 		if err != nil {
-			log.Fatalf("Could not remove old backup executable: %s\n", backup)
+			return "", "", fmt.Errorf("could not remove old backup executable %s: %w", backup, err)
 		}
 	}
 
 	err = os.Rename(executable, backup)
 	if err != nil {
-		log.Fatalf("Could not backup current executable\n")
+		return "", "", fmt.Errorf("could not backup current executable: %w", err)
 	}
 
-	return executable, backup
+	return executable, backup, nil
 }

--- a/cmd/templates/list/cmd.go
+++ b/cmd/templates/list/cmd.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/drapi"
-	"github.com/datarobot/cli/internal/log"
 	"github.com/spf13/cobra"
 )
 
@@ -50,11 +49,7 @@ start building AI applications. Each template includes:
 
 💡 Use 'dr templates setup' for an interactive selection experience.`,
 	PreRunE: auth.EnsureAuthenticatedE,
-	Run: func(_ *cobra.Command, _ []string) {
-		err := Run()
-		if err != nil {
-			log.Fatal(err)
-			return
-		}
+	RunE: func(_ *cobra.Command, _ []string) error {
+		return Run()
 	},
 }

--- a/cmd/templates/list/cmd.go
+++ b/cmd/templates/list/cmd.go
@@ -22,6 +22,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Run fetches and displays all available DataRobot AI application templates.
+// It queries the DataRobot API to retrieve the list of templates and prints each one
+// in a tab-separated format (ID and Name).
+//
+// Returns:
+//   - error: if the API request fails or if the template list cannot be retrieved
 func Run() error {
 	templateList, err := drapi.GetTemplates()
 	if err != nil {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -83,6 +83,8 @@ func (l *amplitudeLogger) Errorf(msg string, args ...any) {
 // events via the internal/log debug logger for development visibility.
 func NewClient(props *CommonProperties) *Client {
 	if !IsEnabled() {
+		log.Debug("Telemetry client initialized (debug log)")
+
 		return &Client{amp: nil, props: props}
 	}
 
@@ -90,6 +92,8 @@ func NewClient(props *CommonProperties) *Client {
 	config.Logger = &amplitudeLogger{}
 
 	client := amplitude.NewClient(config)
+
+	log.Debug("Telemetry client initialized (Amplitude)")
 
 	return &Client{
 		amp:   client,
@@ -136,6 +140,8 @@ func (c *Client) Track(event types.Event) {
 		return
 	}
 
+	log.Debug("Telemetry event tracked", "event_type", event.EventType)
+
 	c.amp.Track(event)
 }
 
@@ -144,8 +150,12 @@ func (c *Client) Track(event types.Event) {
 // PersistentPostRunE). Safe to call on a no-op client.
 func (c *Client) Flush(timeout time.Duration) {
 	if c.amp == nil {
+		log.Debug("Telemetry flush skipped (client disabled)")
+
 		return
 	}
+
+	log.Debug("Telemetry flush started", "timeout", timeout)
 
 	done := make(chan struct{})
 
@@ -156,7 +166,7 @@ func (c *Client) Flush(timeout time.Duration) {
 
 	select {
 	case <-done:
-		// Successfully flushed
+		log.Debug("Telemetry flush completed")
 	case <-time.After(timeout):
 		// Timeout reached, events may not have been sent
 		log.Debug("Telemetry flush timed out", "timeout", timeout)


### PR DESCRIPTION
## RATIONALE

PR [#504](https://github.com/datarobot-oss/cli/pull/504) eliminates direct `os.Exit` calls from cobra command internals so telemetry is flushed before process exit. This PR adds `forbidigo` rules to prevent the pattern from being reintroduced.

## CHANGES

Two rules added to `.golangci.yaml`:

| Pattern | Reason |
|---|---|
| `^os\.Exit$` | Direct exit bypasses `PersistentPostRunE` and drops pending telemetry events |
| `^log\.Fatalf?$` | `log.Fatal/Fatalf` call `os.Exit` internally — same problem |

**Exclusions:**
- `main.go` — owns process exit
- `internal/telemetry/telemetry.go` — the `Exit()` implementation itself
- `internal/log/pkg.go` — `Fatal` implementation; cannot import `internal/telemetry` without a cycle
- `*_test.go` — `TestMain` legitimately uses `os.Exit(m.Run())`

Fixed a number of pre-existing violations that were not introduced by this PR:
- `cmd/self/update/cmd.go` — 4× `log.Fatalf`/`log.Fatal`
- `cmd/templates/list/cmd.go` — 1× `log.Fatal`
- `cmd/dotenv/variables.go` — 3× `log.Fatalf`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because enabling `forbidigo` can newly fail CI/builds if existing or future code uses `os.Exit`/`log.Fatal*` outside the allowed paths.
> 
> **Overview**
> Adds `forbidigo` to GolangCI and introduces rules that **ban direct `os.Exit` and `log.Fatal/Fatalf`** usage, directing callers to `telemetry.Exit()`/error returns so telemetry is flushed before exit.
> 
> Configures explicit exclusions so `main.go`, `internal/telemetry/telemetry.go`, `internal/log/pkg.go`, and `*_test.go` can still use these patterns where necessary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0b0891f1cc78bff559156f3ac0fb848783c0864. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->