### PR TITLE
[CFX-5794] Add telemetry track for check & install events

### DIFF
--- a/cmd/dependencies/check/cmd.go
+++ b/cmd/dependencies/check/cmd.go
@@ -46,8 +46,8 @@ func Cmd() *cobra.Command {
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
-			"missing_msgs":          result.MissingMsgs,
-			"wrong_version_msgs":    result.WrongVersionMsgs,
+			"missing_deps":          result.MissingMsgs,
+			"wrong_version_deps":    result.WrongVersionMsgs,
 			"validation_violations": result.ValidationViolations,
 		}
 	})

--- a/cmd/dependencies/check/cmd.go
+++ b/cmd/dependencies/check/cmd.go
@@ -18,28 +18,39 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/tools"
 	"github.com/spf13/cobra"
 )
 
 func Cmd() *cobra.Command {
+	var result tools.CheckResult
+
 	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "✅ Check template dependencies",
-		RunE:  RunE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			result = tools.CheckPrerequisites()
+
+			if len(result.MissingMsgs) > 0 || len(result.WrongVersionMsgs) > 0 {
+				cmd.SilenceUsage = true
+
+				return errors.New(tools.PrerequisitesMsg(result.MissingMsgs, result.WrongVersionMsgs))
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), "✅ All dependencies are already up to date.")
+
+			return nil
+		},
 	}
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		return map[string]any{
+			"missing_msgs":          result.MissingMsgs,
+			"wrong_version_msgs":    result.WrongVersionMsgs,
+			"validation_violations": result.ValidationViolations,
+		}
+	})
 
 	return cmd
-}
-
-func RunE(cmd *cobra.Command, _ []string) error {
-	_, _, missingMsgs, wrongVersionMsgs := tools.CheckPrerequisites()
-	if len(missingMsgs) > 0 || len(wrongVersionMsgs) > 0 {
-		cmd.SilenceUsage = true
-		return errors.New(tools.PrerequisitesMsg(missingMsgs, wrongVersionMsgs))
-	}
-
-	fmt.Fprintln(cmd.OutOrStdout(), "✅ All dependencies are already up to date.")
-
-	return nil
 }

--- a/cmd/dependencies/check/cmd_test.go
+++ b/cmd/dependencies/check/cmd_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckCmd_PropExtractor_AllSatisfied(t *testing.T) {
+	orig := tools.RequiredTools
+
+	defer func() { tools.RequiredTools = orig }()
+
+	tools.RequiredTools = []tools.Prerequisite{{Name: "sh", Command: "sh"}}
+
+	cmd := Cmd()
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+
+	event, ok := telemetry.EventFor(cmd, []string{})
+	require.True(t, ok)
+	assert.Empty(t, event.EventProperties["missing_msgs"])
+	assert.Empty(t, event.EventProperties["wrong_version_msgs"])
+	assert.Empty(t, event.EventProperties["validation_violations"])
+}
+
+func TestCheckCmd_PropExtractor_MissingDep(t *testing.T) {
+	orig := tools.RequiredTools
+
+	defer func() { tools.RequiredTools = orig }()
+
+	tools.RequiredTools = []tools.Prerequisite{
+		{Name: "FakeTool", Command: "nonexistent_dr_fake_xyz", URL: "https://example.com"},
+	}
+
+	cmd := Cmd()
+
+	err := cmd.RunE(cmd, []string{})
+	require.Error(t, err)
+
+	event, ok := telemetry.EventFor(cmd, []string{})
+	require.True(t, ok)
+
+	missingMsgs, _ := event.EventProperties["missing_msgs"].([]string)
+	require.Len(t, missingMsgs, 1)
+	assert.Contains(t, missingMsgs[0], "FakeTool")
+	assert.Empty(t, event.EventProperties["wrong_version_msgs"])
+}
+
+func TestCheckCmd_PropExtractor_WrongVersion(t *testing.T) {
+	orig := tools.RequiredTools
+
+	defer func() { tools.RequiredTools = orig }()
+
+	tools.RequiredTools = []tools.Prerequisite{
+		{Name: "Echo", Command: "echo 1.0.0", MinimumVersion: "2.0.0", URL: "https://example.com"},
+	}
+
+	cmd := Cmd()
+
+	err := cmd.RunE(cmd, []string{})
+	require.Error(t, err)
+
+	event, ok := telemetry.EventFor(cmd, []string{})
+	require.True(t, ok)
+
+	assert.Empty(t, event.EventProperties["missing_msgs"])
+
+	wrongVersionMsgs, _ := event.EventProperties["wrong_version_msgs"].([]string)
+	require.Len(t, wrongVersionMsgs, 1)
+	assert.Contains(t, wrongVersionMsgs[0], "Echo")
+}

--- a/cmd/dependencies/check/cmd_test.go
+++ b/cmd/dependencies/check/cmd_test.go
@@ -37,8 +37,8 @@ func TestCheckCmd_PropExtractor_AllSatisfied(t *testing.T) {
 
 	event, ok := telemetry.EventFor(cmd, []string{})
 	require.True(t, ok)
-	assert.Empty(t, event.EventProperties["missing_msgs"])
-	assert.Empty(t, event.EventProperties["wrong_version_msgs"])
+	assert.Empty(t, event.EventProperties["missing_deps"])
+	assert.Empty(t, event.EventProperties["wrong_version_deps"])
 	assert.Empty(t, event.EventProperties["validation_violations"])
 }
 
@@ -59,10 +59,10 @@ func TestCheckCmd_PropExtractor_MissingDep(t *testing.T) {
 	event, ok := telemetry.EventFor(cmd, []string{})
 	require.True(t, ok)
 
-	missingMsgs, _ := event.EventProperties["missing_msgs"].([]string)
+	missingMsgs, _ := event.EventProperties["missing_deps"].([]string)
 	require.Len(t, missingMsgs, 1)
 	assert.Contains(t, missingMsgs[0], "FakeTool")
-	assert.Empty(t, event.EventProperties["wrong_version_msgs"])
+	assert.Empty(t, event.EventProperties["wrong_version_deps"])
 }
 
 func TestCheckCmd_PropExtractor_WrongVersion(t *testing.T) {
@@ -82,9 +82,9 @@ func TestCheckCmd_PropExtractor_WrongVersion(t *testing.T) {
 	event, ok := telemetry.EventFor(cmd, []string{})
 	require.True(t, ok)
 
-	assert.Empty(t, event.EventProperties["missing_msgs"])
+	assert.Empty(t, event.EventProperties["missing_deps"])
 
-	wrongVersionMsgs, _ := event.EventProperties["wrong_version_msgs"].([]string)
+	wrongVersionMsgs, _ := event.EventProperties["wrong_version_deps"].([]string)
 	require.Len(t, wrongVersionMsgs, 1)
 	assert.Contains(t, wrongVersionMsgs[0], "Echo")
 }

--- a/cmd/dependencies/install/cmd.go
+++ b/cmd/dependencies/install/cmd.go
@@ -54,7 +54,7 @@ func Cmd() *cobra.Command {
 
 			prerequisites := append(checkResult.MissingTools, checkResult.WrongVersionTools...)
 
-			if !viperx.GetBool("yes") {
+			if !opts.Yes && !viperx.GetBool("yes") {
 				yes, err := helpers.Confirm(cmd.OutOrStdout(), cmd.InOrStdin(), "\nInstall now? (y/n): ")
 				if err != nil {
 					cmd.SilenceUsage = true
@@ -83,8 +83,6 @@ func Cmd() *cobra.Command {
 
 	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, `Assume "yes" as answer to the install prompt.`)
 
-	// Bind flag to viper to enable env var support (DATAROBOT_CLI_NON_INTERACTIVE)
-	_ = viperx.BindPFlag("yes", cmd.Flags().Lookup("yes"))
 	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {

--- a/cmd/dependencies/install/cmd.go
+++ b/cmd/dependencies/install/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/datarobot/cli/cmd/helpers"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/dependencies"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/tools"
 	"github.com/spf13/cobra"
 )
@@ -31,48 +32,70 @@ type Options struct {
 var opts Options
 
 func Cmd() *cobra.Command {
+	var (
+		checkResult    tools.CheckResult
+		installSuccess []string
+		installError   string
+	)
+
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "📦 Install missing template dependencies",
-		RunE:  RunE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			checkResult = tools.CheckPrerequisites()
+
+			if len(checkResult.MissingMsgs) == 0 && len(checkResult.WrongVersionMsgs) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "✅ All dependencies are already up to date.")
+
+				return nil
+			}
+
+			fmt.Fprintln(cmd.OutOrStderr(), tools.PrerequisitesMsg(checkResult.MissingMsgs, checkResult.WrongVersionMsgs))
+
+			prerequisites := append(checkResult.MissingTools, checkResult.WrongVersionTools...)
+
+			if !viperx.GetBool("yes") {
+				yes, err := helpers.Confirm(cmd.OutOrStdout(), cmd.InOrStdin(), "\nInstall now? (y/n): ")
+				if err != nil {
+					cmd.SilenceUsage = true
+
+					return err
+				}
+
+				if !yes {
+					return nil
+				}
+			}
+
+			var err error
+
+			installSuccess, err = dependencies.InstallPrerequisites(cmd.OutOrStdout(), prerequisites)
+			if err != nil {
+				installError = err.Error()
+				cmd.SilenceUsage = true
+
+				return err
+			}
+
+			return nil
+		},
 	}
+
 	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, `Assume "yes" as answer to the install prompt.`)
 
 	// Bind flag to viper to enable env var support (DATAROBOT_CLI_NON_INTERACTIVE)
 	_ = viperx.BindPFlag("yes", cmd.Flags().Lookup("yes"))
 	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		return map[string]any{
+			"missing_msgs":          checkResult.MissingMsgs,
+			"wrong_version_msgs":    checkResult.WrongVersionMsgs,
+			"validation_violations": checkResult.ValidationViolations,
+			"install_success":       installSuccess,
+			"install_error":         installError,
+		}
+	})
+
 	return cmd
-}
-
-func RunE(cmd *cobra.Command, _ []string) error {
-	missingTools, wrongVersionTools, missingMsgs, wrongVersionMsgs := tools.CheckPrerequisites()
-	if len(missingMsgs) == 0 && len(wrongVersionMsgs) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "✅ All dependencies are already up to date.")
-		return nil
-	}
-
-	fmt.Fprintln(cmd.OutOrStderr(), tools.PrerequisitesMsg(missingMsgs, wrongVersionMsgs))
-
-	prerequisites := append(missingTools, wrongVersionTools...)
-
-	if !viperx.GetBool("yes") {
-		yes, err := helpers.Confirm(cmd.OutOrStdout(), cmd.InOrStdin(), "\nInstall now? (y/n): ")
-		if err != nil {
-			cmd.SilenceUsage = true
-			return err
-		}
-
-		if !yes {
-			return nil
-		}
-	}
-
-	err := dependencies.InstallPrerequisites(cmd.OutOrStdout(), prerequisites)
-	if err != nil {
-		cmd.SilenceUsage = true
-		return err
-	}
-
-	return nil
 }

--- a/cmd/dependencies/install/cmd.go
+++ b/cmd/dependencies/install/cmd.go
@@ -36,12 +36,17 @@ func Cmd() *cobra.Command {
 		checkResult    tools.CheckResult
 		installSuccess []string
 		installError   string
+		yesFlag        bool
+		nonInteractive bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "📦 Install missing template dependencies",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			yesFlag = opts.Yes
+			nonInteractive = viperx.GetBool("yes")
+
 			checkResult = tools.CheckPrerequisites()
 
 			if len(checkResult.MissingMsgs) == 0 && len(checkResult.WrongVersionMsgs) == 0 {
@@ -54,7 +59,7 @@ func Cmd() *cobra.Command {
 
 			prerequisites := append(checkResult.MissingTools, checkResult.WrongVersionTools...)
 
-			if !opts.Yes && !viperx.GetBool("yes") {
+			if !yesFlag && !nonInteractive {
 				yes, err := helpers.Confirm(cmd.OutOrStdout(), cmd.InOrStdin(), "\nInstall now? (y/n): ")
 				if err != nil {
 					cmd.SilenceUsage = true
@@ -87,11 +92,13 @@ func Cmd() *cobra.Command {
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
-			"missing_msgs":          checkResult.MissingMsgs,
-			"wrong_version_msgs":    checkResult.WrongVersionMsgs,
+			"missing_deps":          checkResult.MissingMsgs,
+			"wrong_version_deps":    checkResult.WrongVersionMsgs,
 			"validation_violations": checkResult.ValidationViolations,
 			"install_success":       installSuccess,
 			"install_error":         installError,
+			"yes_flag":              yesFlag,
+			"non_interactive":       nonInteractive,
 		}
 	})
 

--- a/cmd/dependencies/install/cmd_test.go
+++ b/cmd/dependencies/install/cmd_test.go
@@ -18,11 +18,28 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeMissingTool is a prerequisite that is never present on the system but
+// installs instantly via echo, suitable for testing the install flow without
+// real tool installation.
+func fakeMissingTool(name string) tools.Prerequisite {
+	return tools.Prerequisite{
+		Name:    name,
+		Command: "nonexistent_dr_fake_xyz",
+		URL:     "https://example.com",
+		Install: tools.InstallCommands{
+			MacOS:   "echo installed",
+			Linux:   "echo installed",
+			Windows: "echo installed",
+		},
+	}
+}
 
 func TestInstallCmd_PropExtractor_AllSatisfied(t *testing.T) {
 	orig := tools.RequiredTools
@@ -43,32 +60,22 @@ func TestInstallCmd_PropExtractor_AllSatisfied(t *testing.T) {
 
 	event, ok := telemetry.EventFor(cmd, []string{})
 	require.True(t, ok)
-	assert.Empty(t, event.EventProperties["missing_msgs"])
+	assert.Empty(t, event.EventProperties["missing_deps"])
 	assert.Empty(t, event.EventProperties["install_success"])
 	assert.Empty(t, event.EventProperties["install_error"])
+	assert.Equal(t, false, event.EventProperties["yes_flag"])
+	assert.Equal(t, false, event.EventProperties["non_interactive"])
 }
 
-// TestInstallCmd_OptsYes_SkipsPromptAndInstalls verifies that opts.Yes=true
-// bypasses the interactive install prompt and that the PropExtractor captures
-// successful installs. The fake prerequisite uses "echo" as its install command
-// so the test runs without real tool installation.
-func TestInstallCmd_OptsYes_SkipsPromptAndInstalls(t *testing.T) {
+// TestInstallCmd_YesFlag_SkipsPromptAndInstalls verifies that --yes bypasses the
+// interactive prompt, that the install succeeds, and that the PropExtractor records
+// yes_flag=true / non_interactive=false.
+func TestInstallCmd_YesFlag_SkipsPromptAndInstalls(t *testing.T) {
 	orig := tools.RequiredTools
 
 	defer func() { tools.RequiredTools = orig }()
 
-	tools.RequiredTools = []tools.Prerequisite{
-		{
-			Name:    "FakeTool",
-			Command: "nonexistent_dr_fake_xyz",
-			URL:     "https://example.com",
-			Install: tools.InstallCommands{
-				MacOS:   "echo installed",
-				Linux:   "echo installed",
-				Windows: "echo installed",
-			},
-		},
-	}
+	tools.RequiredTools = []tools.Prerequisite{fakeMissingTool("FakeTool")}
 
 	cmd := Cmd()
 	require.NoError(t, cmd.Flags().Set("yes", "true"))
@@ -86,4 +93,38 @@ func TestInstallCmd_OptsYes_SkipsPromptAndInstalls(t *testing.T) {
 	installSuccess, _ := event.EventProperties["install_success"].([]string)
 	assert.Contains(t, installSuccess, "FakeTool")
 	assert.Empty(t, event.EventProperties["install_error"])
+	assert.Equal(t, true, event.EventProperties["yes_flag"])
+	assert.Equal(t, false, event.EventProperties["non_interactive"])
+}
+
+// TestInstallCmd_NonInteractive_SkipsPromptAndInstalls verifies that
+// DATAROBOT_CLI_NON_INTERACTIVE (viperx "yes") bypasses the interactive prompt
+// and that the PropExtractor records yes_flag=false / non_interactive=true.
+func TestInstallCmd_NonInteractive_SkipsPromptAndInstalls(t *testing.T) {
+	orig := tools.RequiredTools
+
+	defer func() { tools.RequiredTools = orig }()
+
+	viperx.Set("yes", true)
+	t.Cleanup(func() { viperx.Set("yes", false) })
+
+	tools.RequiredTools = []tools.Prerequisite{fakeMissingTool("FakeTool")}
+
+	cmd := Cmd()
+
+	var out bytes.Buffer
+
+	cmd.SetOut(&out)
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+
+	event, ok := telemetry.EventFor(cmd, []string{})
+	require.True(t, ok)
+
+	installSuccess, _ := event.EventProperties["install_success"].([]string)
+	assert.Contains(t, installSuccess, "FakeTool")
+	assert.Empty(t, event.EventProperties["install_error"])
+	assert.Equal(t, false, event.EventProperties["yes_flag"])
+	assert.Equal(t, true, event.EventProperties["non_interactive"])
 }

--- a/cmd/dependencies/install/cmd_test.go
+++ b/cmd/dependencies/install/cmd_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstallCmd_PropExtractor_AllSatisfied(t *testing.T) {
+	orig := tools.RequiredTools
+
+	defer func() { tools.RequiredTools = orig }()
+
+	tools.RequiredTools = []tools.Prerequisite{{Name: "sh", Command: "sh"}}
+
+	cmd := Cmd()
+
+	var out bytes.Buffer
+
+	cmd.SetOut(&out)
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "up to date")
+
+	event, ok := telemetry.EventFor(cmd, []string{})
+	require.True(t, ok)
+	assert.Empty(t, event.EventProperties["missing_msgs"])
+	assert.Empty(t, event.EventProperties["install_success"])
+	assert.Empty(t, event.EventProperties["install_error"])
+}
+
+// TestInstallCmd_OptsYes_SkipsPromptAndInstalls verifies that opts.Yes=true
+// bypasses the interactive install prompt and that the PropExtractor captures
+// successful installs. The fake prerequisite uses "echo" as its install command
+// so the test runs without real tool installation.
+func TestInstallCmd_OptsYes_SkipsPromptAndInstalls(t *testing.T) {
+	orig := tools.RequiredTools
+
+	defer func() { tools.RequiredTools = orig }()
+
+	tools.RequiredTools = []tools.Prerequisite{
+		{
+			Name:    "FakeTool",
+			Command: "nonexistent_dr_fake_xyz",
+			URL:     "https://example.com",
+			Install: tools.InstallCommands{
+				MacOS:   "echo installed",
+				Linux:   "echo installed",
+				Windows: "echo installed",
+			},
+		},
+	}
+
+	cmd := Cmd()
+	require.NoError(t, cmd.Flags().Set("yes", "true"))
+
+	var out bytes.Buffer
+
+	cmd.SetOut(&out)
+
+	err := cmd.RunE(cmd, []string{})
+	require.NoError(t, err)
+
+	event, ok := telemetry.EventFor(cmd, []string{})
+	require.True(t, ok)
+
+	installSuccess, _ := event.EventProperties["install_success"].([]string)
+	assert.Contains(t, installSuccess, "FakeTool")
+	assert.Empty(t, event.EventProperties["install_error"])
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -118,18 +118,16 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 			// Store telemetry client in context for use by commands
 			cmd.SetContext(context.WithValue(cmd.Context(), telemetryClientKey{}, client))
 
-			// Fire telemetry event for this command (safe before RunE which may call os.Exit)
-			if event, ok := telemetry.EventFor(cmd, args); ok {
-				client.Track(event)
-			}
-
 			config.SetAPIConsumerTrace(config.CommandPathToTrace(cmd.CommandPath()))
 
 			return nil
 		},
-		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
-			// Flush telemetry events before exit
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 			if client, ok := cmd.Context().Value(telemetryClientKey{}).(*telemetry.Client); ok {
+				if event, ok2 := telemetry.EventFor(cmd, args); ok2 {
+					client.Track(event)
+				}
+
 				client.Flush(3 * time.Second)
 			}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -118,20 +118,17 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 			// Store telemetry client in context for use by commands
 			cmd.SetContext(context.WithValue(cmd.Context(), telemetryClientKey{}, client))
 
-			config.SetAPIConsumerTrace(config.CommandPathToTrace(cmd.CommandPath()))
-
-			return nil
-		},
-		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
-			if client, ok := cmd.Context().Value(telemetryClientKey{}).(*telemetry.Client); ok {
-				if event, ok2 := telemetry.EventFor(cmd, args); ok2 {
+			cobra.OnFinalize(func() {
+				if event, ok := telemetry.EventFor(cmd, args); ok {
 					client.Track(event)
 				}
 
 				client.Flush(3 * time.Second)
-			}
 
-			log.Stop()
+				log.Stop()
+			})
+
+			config.SetAPIConsumerTrace(config.CommandPathToTrace(cmd.CommandPath()))
 
 			return nil
 		},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -104,6 +106,71 @@ func TestVersionFlag(t *testing.T) {
 			assert.NotEmpty(t, output, "Version output should not be empty")
 		})
 	}
+}
+
+// TestTelemetryPropExtractor_OnSuccessPath verifies that the DR CLI telemetry
+// event is produced correctly on the success path. Uses dr dependency check with
+// an echo-based tool (always satisfies the version check) so RunE returns nil.
+func TestTelemetryPropExtractor_OnSuccessPath(t *testing.T) {
+	orig := tools.RequiredTools
+
+	defer func() { tools.RequiredTools = orig }()
+
+	tools.RequiredTools = []tools.Prerequisite{
+		{Name: "echo-tool", Command: "echo 1.0.0", MinimumVersion: "1.0.0"},
+	}
+
+	cmd := RootCmd
+	cmd.SetArgs([]string{"dependency", "check"})
+
+	var outBuf bytes.Buffer
+
+	cmd.SetOut(&outBuf)
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	checkCmd := findCommandByPath(RootCmd.Command, "dr dependency check")
+	require.NotNil(t, checkCmd)
+
+	event, ok := telemetry.EventFor(checkCmd, []string{})
+	require.True(t, ok)
+	assert.Equal(t, "dr dependency check", event.EventType)
+	assert.Empty(t, event.EventProperties["missing_msgs"])
+	assert.Empty(t, event.EventProperties["wrong_version_msgs"])
+}
+
+// TestTelemetryPropExtractor_OnErrorPath verifies that the DR CLI telemetry event
+// is produced correctly on the error path. PersistentPostRunE (the previous approach)
+// was skipped on error, silently dropping telemetry for failed commands.
+func TestTelemetryPropExtractor_OnErrorPath(t *testing.T) {
+	orig := tools.RequiredTools
+
+	defer func() { tools.RequiredTools = orig }()
+
+	tools.RequiredTools = []tools.Prerequisite{
+		{Name: "FakeTool", Command: "nonexistent_dr_fake_xyz", URL: "https://example.com"},
+	}
+
+	cmd := RootCmd
+	cmd.SetArgs([]string{"dependency", "check"})
+
+	var errBuf bytes.Buffer
+
+	cmd.SetErr(&errBuf)
+
+	_ = cmd.Execute() // returns error: missing dep
+
+	checkCmd := findCommandByPath(RootCmd.Command, "dr dependency check")
+	require.NotNil(t, checkCmd)
+
+	event, ok := telemetry.EventFor(checkCmd, []string{})
+	require.True(t, ok)
+	assert.Equal(t, "dr dependency check", event.EventType)
+
+	missingMsgs, _ := event.EventProperties["missing_msgs"].([]string)
+	assert.NotEmpty(t, missingMsgs,
+		"PropExtractor must see missing_msgs populated by RunE even on the error path")
 }
 
 func TestWorkloadCommandNotPresentByDefault(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -136,8 +136,8 @@ func TestTelemetryPropExtractor_OnSuccessPath(t *testing.T) {
 	event, ok := telemetry.EventFor(checkCmd, []string{})
 	require.True(t, ok)
 	assert.Equal(t, "dr dependency check", event.EventType)
-	assert.Empty(t, event.EventProperties["missing_msgs"])
-	assert.Empty(t, event.EventProperties["wrong_version_msgs"])
+	assert.Empty(t, event.EventProperties["missing_deps"])
+	assert.Empty(t, event.EventProperties["wrong_version_deps"])
 }
 
 // TestTelemetryPropExtractor_OnErrorPath verifies that the DR CLI telemetry event
@@ -168,9 +168,9 @@ func TestTelemetryPropExtractor_OnErrorPath(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "dr dependency check", event.EventType)
 
-	missingMsgs, _ := event.EventProperties["missing_msgs"].([]string)
+	missingMsgs, _ := event.EventProperties["missing_deps"].([]string)
 	assert.NotEmpty(t, missingMsgs,
-		"PropExtractor must see missing_msgs populated by RunE even on the error path")
+		"PropExtractor must see missing_deps populated by RunE even on the error path")
 }
 
 func TestWorkloadCommandNotPresentByDefault(t *testing.T) {

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -110,8 +110,6 @@ The following actions will be performed:
 
 	cmd.Flags().BoolVarP(&opts.AnswerYes, "yes", "y", false, "Assume \"yes\" as answer to all prompts.")
 
-	// Bind flag to viper to enable env var support (DATAROBOT_CLI_NON_INTERACTIVE)
-	_ = viperx.BindPFlag("yes", cmd.Flags().Lookup("yes"))
 	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -115,10 +115,12 @@ The following actions will be performed:
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
 			"validation_violations": capture.validationViolations,
-			"missing_msgs":          capture.missingMsgs,
-			"wrong_version_msgs":    capture.wrongVersionMsgs,
+			"missing_deps":          capture.missingMsgs,
+			"wrong_version_deps":    capture.wrongVersionMsgs,
 			"install_success":       capture.installSuccess,
 			"install_error":         capture.installError,
+			"yes_flag":              capture.yesFlag,
+			"non_interactive":       capture.nonInteractive,
 		}
 	})
 

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -33,6 +33,8 @@ type Options struct {
 func Cmd() *cobra.Command { //nolint: cyclop
 	var opts Options
 
+	var capture telemetryCapture
+
 	cmd := &cobra.Command{
 		Use:     "start",
 		Aliases: []string{"quickstart"},
@@ -59,6 +61,8 @@ The following actions will be performed:
 			if innerModel.err != nil {
 				os.Exit(1)
 			}
+
+			capture = innerModel.telemetry
 
 			// Check if we do not need to launch template setup after quitting
 			if !innerModel.needTemplateSetup || !innerModel.done || innerModel.quitting {
@@ -98,6 +102,8 @@ The following actions will be performed:
 				os.Exit(1)
 			}
 
+			capture = innerModel2.telemetry
+
 			return nil
 		},
 	}
@@ -108,7 +114,15 @@ The following actions will be performed:
 	_ = viperx.BindPFlag("yes", cmd.Flags().Lookup("yes"))
 	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
 
-	telemetry.Track(cmd)
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		return map[string]any{
+			"validation_violations": capture.validationViolations,
+			"missing_msgs":          capture.missingMsgs,
+			"wrong_version_msgs":    capture.wrongVersionMsgs,
+			"install_success":       capture.installSuccess,
+			"install_error":         capture.installError,
+		}
+	})
 
 	return cmd
 }

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -99,6 +99,8 @@ type telemetryCapture struct {
 	wrongVersionMsgs     []string
 	installSuccess       []string
 	installError         string
+	yesFlag              bool
+	nonInteractive       bool
 }
 
 // err messages used in the start command.
@@ -127,6 +129,10 @@ func NewStartModel(opts Options) Model {
 		},
 		opts:     opts,
 		repoRoot: repoRoot,
+		telemetry: telemetryCapture{
+			yesFlag:        opts.AnswerYes,
+			nonInteractive: viperx.GetBool("yes"),
+		},
 	}
 }
 

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -61,6 +61,7 @@ type Model struct {
 	depsToInstall        []tools.Prerequisite // Deps to install when user confirms
 	needTemplateSetup    bool                 // Whether we need to run template setup after quitting
 	repoRoot             string
+	telemetry            telemetryCapture
 }
 
 type stepCompleteMsg struct {
@@ -83,11 +84,21 @@ type stepErrorMsg struct {
 type depsMissingMsg struct {
 	prerequisites []tools.Prerequisite
 	message       string
+	checkResult   tools.CheckResult
 }
 
 type depsInstallCompleteMsg struct {
-	err    error
-	output string
+	err       error
+	output    string
+	installed []string
+}
+
+type telemetryCapture struct {
+	validationViolations []string
+	missingMsgs          []string
+	wrongVersionMsgs     []string
+	installSuccess       []string
+	installError         string
 }
 
 // err messages used in the start command.
@@ -204,9 +215,9 @@ func (m Model) execInstallDeps() tea.Cmd {
 	return func() tea.Msg {
 		var buf bytes.Buffer
 
-		err := dependencies.InstallPrerequisites(&buf, m.depsToInstall)
+		installed, err := dependencies.InstallPrerequisites(&buf, m.depsToInstall)
 
-		return depsInstallCompleteMsg{err: err, output: buf.String()}
+		return depsInstallCompleteMsg{err: err, output: buf.String(), installed: installed}
 	}
 }
 
@@ -322,6 +333,9 @@ func (m Model) handleStepComplete(msg stepCompleteMsg) (tea.Model, tea.Cmd) {
 func (m Model) handleDepsMissing(msg depsMissingMsg) (tea.Model, tea.Cmd) {
 	m.depsToInstall = msg.prerequisites
 	m.stepCompleteMessage = msg.message
+	m.telemetry.validationViolations = msg.checkResult.ValidationViolations
+	m.telemetry.missingMsgs = msg.checkResult.MissingMsgs
+	m.telemetry.wrongVersionMsgs = msg.checkResult.WrongVersionMsgs
 
 	if viperx.GetBool("yes") {
 		return m, m.execInstallDeps()
@@ -333,7 +347,10 @@ func (m Model) handleDepsMissing(msg depsMissingMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleDepsInstallComplete(msg depsInstallCompleteMsg) (tea.Model, tea.Cmd) {
+	m.telemetry.installSuccess = msg.installed
+
 	if msg.err != nil {
+		m.telemetry.installError = msg.err.Error()
 		m.err = msg.err
 
 		return m, tea.Quit
@@ -511,18 +528,19 @@ func checkPrerequisites(m *Model) tea.Msg {
 		return stepCompleteMsg{message: "Recent successful dependency check detected, skipping prerequisites check...\n"}
 	}
 
-	missingTools, wrongVersionTools, missingMsgs, wrongVersionMsgs := tools.CheckPrerequisites()
+	result := tools.CheckPrerequisites()
 
-	if len(missingMsgs) == 0 && len(wrongVersionMsgs) == 0 {
+	if len(result.MissingMsgs) == 0 && len(result.WrongVersionMsgs) == 0 {
 		return stepCompleteMsg{}
 	}
 
-	prerequisites := append(missingTools, wrongVersionTools...)
-	message := tools.PrerequisitesMsg(missingMsgs, wrongVersionMsgs)
+	prerequisites := append(result.MissingTools, result.WrongVersionTools...)
+	message := tools.PrerequisitesMsg(result.MissingMsgs, result.WrongVersionMsgs)
 
 	return depsMissingMsg{
 		prerequisites: prerequisites,
 		message:       message,
+		checkResult:   result,
 	}
 }
 

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -93,6 +93,7 @@ type depsInstallCompleteMsg struct {
 	installed []string
 }
 
+// telemetryCapture holds data to be sent for telemetry after the cobra.Command completes or fails
 type telemetryCapture struct {
 	validationViolations []string
 	missingMsgs          []string

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -337,7 +337,7 @@ func (m Model) handleDepsMissing(msg depsMissingMsg) (tea.Model, tea.Cmd) {
 	m.telemetry.missingMsgs = msg.checkResult.MissingMsgs
 	m.telemetry.wrongVersionMsgs = msg.checkResult.WrongVersionMsgs
 
-	if viperx.GetBool("yes") {
+	if m.opts.AnswerYes || viperx.GetBool("yes") {
 		return m, m.execInstallDeps()
 	}
 
@@ -611,7 +611,7 @@ func findAndExecuteStart(m *Model) tea.Msg {
 		// Found a quickstart script
 		// Don't wait for confirmation if '--yes' flag is set or
 		// DATAROBOT_CLI_NON_INTERACTIVE env var is true
-		waitForConfirmation := !viperx.GetBool("yes")
+		waitForConfirmation := !m.opts.AnswerYes && !viperx.GetBool("yes")
 
 		return stepCompleteMsg{
 			message:              fmt.Sprintf("Found quickstart script at: %s\n", quickstartScript),

--- a/cmd/start/model_test.go
+++ b/cmd/start/model_test.go
@@ -219,6 +219,44 @@ func TestHandleDepsMissing_AutoInstallsWhenAnswerYes(t *testing.T) {
 	assert.NotNil(t, cmd)
 }
 
+func TestHandleDepsMissing_AutoInstallsWhenAnswerYesFlag(t *testing.T) {
+	m := Model{opts: Options{AnswerYes: true}}
+
+	msg := depsMissingMsg{
+		prerequisites: []tools.Prerequisite{{Name: "uv"}},
+		message:       "missing: uv",
+	}
+
+	result, cmd := m.handleDepsMissing(msg)
+
+	resultModel := result.(Model)
+	assert.False(t, resultModel.waitingToInstall)
+	assert.NotNil(t, cmd)
+}
+
+func TestHandleDepsMissing_CapturesTelemetry(t *testing.T) {
+	m := Model{}
+
+	checkResult := tools.CheckResult{
+		ValidationViolations: []string{"[uv] 'name' is required"},
+		MissingMsgs:          []string{"uv (https://example.com)"},
+		WrongVersionMsgs:     []string{"task (minimal: v3.35.0, installed: v3.32.0)"},
+	}
+
+	msg := depsMissingMsg{
+		prerequisites: []tools.Prerequisite{{Name: "uv"}},
+		message:       "missing: uv",
+		checkResult:   checkResult,
+	}
+
+	result, _ := m.handleDepsMissing(msg)
+
+	resultModel := result.(Model)
+	assert.Equal(t, checkResult.ValidationViolations, resultModel.telemetry.validationViolations)
+	assert.Equal(t, checkResult.MissingMsgs, resultModel.telemetry.missingMsgs)
+	assert.Equal(t, checkResult.WrongVersionMsgs, resultModel.telemetry.wrongVersionMsgs)
+}
+
 // --- handleInstallConfirmKey ---
 
 func TestHandleInstallConfirmKey_ConfirmKeys(t *testing.T) {
@@ -279,7 +317,7 @@ func TestHandleDepsInstallComplete_Success(t *testing.T) {
 		current: 0,
 	}
 
-	msg := depsInstallCompleteMsg{err: nil, output: "✅ All dependencies installed successfully.\n"}
+	msg := depsInstallCompleteMsg{err: nil, output: "✅ All dependencies installed successfully.\n", installed: []string{"uv"}}
 
 	result, cmd := m.handleDepsInstallComplete(msg)
 
@@ -287,6 +325,22 @@ func TestHandleDepsInstallComplete_Success(t *testing.T) {
 	assert.Equal(t, 1, resultModel.current, "should advance to next step on success")
 	assert.Equal(t, msg.output, resultModel.stepCompleteMessage)
 	assert.NotNil(t, cmd)
+}
+
+func TestHandleDepsInstallComplete_CapturesSuccessTelemetry(t *testing.T) {
+	m := Model{}
+
+	msg := depsInstallCompleteMsg{
+		err:       nil,
+		output:    "✅ All dependencies installed successfully.\n",
+		installed: []string{"uv", "task"},
+	}
+
+	result, _ := m.handleDepsInstallComplete(msg)
+
+	resultModel := result.(Model)
+	assert.Equal(t, []string{"uv", "task"}, resultModel.telemetry.installSuccess)
+	assert.Empty(t, resultModel.telemetry.installError)
 }
 
 func TestHandleDepsInstallComplete_Error(t *testing.T) {
@@ -299,6 +353,19 @@ func TestHandleDepsInstallComplete_Error(t *testing.T) {
 
 	resultModel := result.(Model)
 	assert.Equal(t, installErr, resultModel.err)
+}
+
+func TestHandleDepsInstallComplete_CapturesErrorTelemetry(t *testing.T) {
+	m := Model{}
+
+	installErr := errors.New("install failed for \"uv\" (exit code 1)")
+	msg := depsInstallCompleteMsg{err: installErr, installed: nil}
+
+	result, _ := m.handleDepsInstallComplete(msg)
+
+	resultModel := result.(Model)
+	assert.Empty(t, resultModel.telemetry.installSuccess)
+	assert.Equal(t, installErr.Error(), resultModel.telemetry.installError)
 }
 
 // --- View ---

--- a/cmd/start/model_test.go
+++ b/cmd/start/model_test.go
@@ -120,6 +120,32 @@ func setRequiredTools(t *testing.T, prereqs []tools.Prerequisite) {
 	tools.RequiredTools = prereqs
 }
 
+// --- NewStartModel ---
+
+func TestNewStartModel_CapturesYesFlag(t *testing.T) {
+	m := NewStartModel(Options{AnswerYes: true})
+
+	assert.True(t, m.telemetry.yesFlag)
+	assert.False(t, m.telemetry.nonInteractive)
+}
+
+func TestNewStartModel_CapturesNonInteractive(t *testing.T) {
+	viperx.Set("yes", true)
+	t.Cleanup(func() { viperx.Set("yes", false) })
+
+	m := NewStartModel(Options{AnswerYes: false})
+
+	assert.False(t, m.telemetry.yesFlag)
+	assert.True(t, m.telemetry.nonInteractive)
+}
+
+func TestNewStartModel_NoFlagsSet(t *testing.T) {
+	m := NewStartModel(Options{AnswerYes: false})
+
+	assert.False(t, m.telemetry.yesFlag)
+	assert.False(t, m.telemetry.nonInteractive)
+}
+
 // --- checkPrerequisites ---
 
 func TestCheckPrerequisites_AllSatisfied(t *testing.T) {

--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -32,6 +32,8 @@ import (
 // corresponding telemetry.Track* call at the command-construction site.
 var expectedTrackedCommands = []string{
 	"dr start",
+	"dr dependency check",
+	"dr dependency install",
 	"dr run",
 	"dr task",
 	"dr auth set-url",

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -114,7 +114,7 @@ Telemetry events are wired declaratively at command-construction time using a sm
 | `telemetry.TrackWith(cmd, extract)` | The command needs dynamic event properties from flags or args at firing time. |
 | `telemetry.TrackPlugin(cmd, ver)` | The command comes from a plugin. Adds `plugin_version` and sets `command_kind`. |
 
-Each helper sets a `"telemetry"` annotation on the cobra command. After RunE completes, `cobra.OnFinalize` calls `telemetry.EventFor(cmd, args)`, which returns an Amplitude event with `EventType == cmd.CommandPath()` and any properties the registered extractor produced.
+Each helper sets a `"telemetry"` annotation on the cobra command. After RunE completes, [`cobra.OnFinalize`](https://pkg.go.dev/github.com/spf13/cobra#OnFinalize) calls `telemetry.EventFor(cmd, args)`, which returns an Amplitude event with `EventType == cmd.CommandPath()` and any properties the registered extractor produced.
 
 This approach ensures:
 
@@ -139,7 +139,7 @@ PersistentPreRunE (root.go)
     ↓
 RunE / Run executes
     ↓
-cobra.OnFinalize (via cobra's deferred postRun, fires on success and error paths)
+cobra.OnFinalize (via cobra's deferred postRun, fires on success and error paths — unlike PersistentPostRunE, see [gotcha](https://www.jvt.me/posts/2024/11/29/gotcha-cobra-persistentpostrune/))
     ├─ telemetry.EventFor(cmd, args) → if tracked, client.Track(event)
     ├─ Flush telemetry (3-second timeout)
     └─ log.Stop()
@@ -147,7 +147,7 @@ cobra.OnFinalize (via cobra's deferred postRun, fires on success and error paths
 
 ### Reading RunE results in a PropExtractor
 
-Because `cobra.OnFinalize` fires after RunE, a PropExtractor can read data that RunE computed. The recommended pattern is to declare closure variables in `Cmd()` that RunE writes and the PropExtractor reads:
+Because [`cobra.OnFinalize`](https://pkg.go.dev/github.com/spf13/cobra#OnFinalize) fires after RunE on both success and error paths (unlike [`PersistentPostRunE`](https://www.jvt.me/posts/2024/11/29/gotcha-cobra-persistentpostrune/)), a PropExtractor can read data that RunE computed. The recommended pattern is to declare closure variables in `Cmd()` that RunE writes and the PropExtractor reads:
 
 ```go
 func Cmd() *cobra.Command {

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -114,12 +114,12 @@ Telemetry events are wired declaratively at command-construction time using a sm
 | `telemetry.TrackWith(cmd, extract)` | The command needs dynamic event properties from flags or args at firing time. |
 | `telemetry.TrackPlugin(cmd, ver)` | The command comes from a plugin. Adds `plugin_version` and sets `command_kind`. |
 
-Each helper sets a `"telemetry"` annotation on the cobra command. The root command's `PersistentPreRunE` calls `telemetry.EventFor(cmd, args)` which returns an Amplitude event with `EventType == cmd.CommandPath()` and any properties the registered extractor produced.
+Each helper sets a `"telemetry"` annotation on the cobra command. After RunE completes, `cobra.OnFinalize` calls `telemetry.EventFor(cmd, args)`, which returns an Amplitude event with `EventType == cmd.CommandPath()` and any properties the registered extractor produced.
 
 This approach ensures:
 
 - **Local**: Wiring lives next to the command it tracks, not in a central map.
-- **Safe**: Events fire in `PersistentPreRunE` before commands that may call `os.Exit` directly.
+- **Late-bound**: Events fire after RunE, so PropExtractors can read results computed during command execution (see [Reading RunE results in a PropExtractor](#reading-rune-results-in-a-propextractor)).
 - **Extensible**: Adding a new event requires one call where the command is built.
 - **Self-documenting**: The cobra command itself carries its telemetry intent.
 
@@ -135,13 +135,53 @@ PersistentPreRunE (root.go)
     ├─ Stamp props.CommandKind = "core" or "plugin"
     │   based on telemetry.IsPluginCommand(cmd)
     ├─ Build telemetry.Client
-    └─ telemetry.EventFor(cmd, args) → if tracked, client.Track(event)
+    └─ Register cobra.OnFinalize (closes over cmd, args, client)
     ↓
-RunE / Run executes (may call os.Exit)
+RunE / Run executes
     ↓
-PersistentPostRunE (root.go)
-    └─ Flush telemetry (3-second timeout)
+cobra.OnFinalize (via cobra's deferred postRun, fires on success and error paths)
+    ├─ telemetry.EventFor(cmd, args) → if tracked, client.Track(event)
+    ├─ Flush telemetry (3-second timeout)
+    └─ log.Stop()
 ```
+
+### Reading RunE results in a PropExtractor
+
+Because `cobra.OnFinalize` fires after RunE, a PropExtractor can read data that RunE computed. The recommended pattern is to declare closure variables in `Cmd()` that RunE writes and the PropExtractor reads:
+
+```go
+func Cmd() *cobra.Command {
+    var (
+        checkResult    tools.CheckResult
+        installSuccess []string
+        installError   string
+    )
+
+    cmd := &cobra.Command{
+        RunE: func(cmd *cobra.Command, _ []string) error {
+            checkResult = tools.CheckPrerequisites()       // written by RunE
+            installSuccess, err = dependencies.Install(…)
+            if err != nil {
+                installError = err.Error()
+                return err
+            }
+            return nil
+        },
+    }
+
+    telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+        return map[string]any{                             // read by PropExtractor
+            "validation_violations": checkResult.ValidationViolations,
+            "install_success":       installSuccess,
+            "install_error":         installError,
+        }
+    })
+
+    return cmd
+}
+```
+
+Both RunE and the PropExtractor close over the same local variables. No context keys or package-level variables are needed.
 
 ## How to add telemetry to a new command
 

--- a/internal/dependencies/installer.go
+++ b/internal/dependencies/installer.go
@@ -25,26 +25,31 @@ import (
 	"github.com/datarobot/cli/internal/tools"
 )
 
-func InstallPrerequisites(w io.Writer, prerequisites []tools.Prerequisite) error {
-	// Install prerequisites sequentially via ExecuteShLine(), stopping on the first failure
+// InstallPrerequisites installs each prerequisite sequentially. It returns the names
+// of tools successfully installed before any failure, plus the first error encountered.
+func InstallPrerequisites(w io.Writer, prerequisites []tools.Prerequisite) ([]string, error) {
+	var installed []string
+
 	for _, prerequisite := range prerequisites {
 		installCmd, err := prerequisite.PlatformInstallCommand()
 		if err != nil {
-			return err
+			return installed, err
 		}
 
 		fmt.Fprintf(w, "📦 Installing %s...\n", prerequisite.Name)
 
 		exitCode, err := ExecuteShLine(installCmd, w)
 		if err != nil {
-			return fmt.Errorf("failed to start install for %q: %w\n  command: %s", prerequisite.Name, err, installCmd)
+			return installed, fmt.Errorf("failed to start install for %q: %w\n  command: %s", prerequisite.Name, err, installCmd)
 		}
 
 		if exitCode != 0 {
-			return fmt.Errorf("install failed for %q (exit code %d)\n  Please run manually: %s\n  Or check %s", prerequisite.Name, exitCode, installCmd, prerequisite.URL)
+			return installed, fmt.Errorf("install failed for %q (exit code %d)\n  Please run manually: %s\n  Or check %s", prerequisite.Name, exitCode, installCmd, prerequisite.URL)
 		}
 
 		fmt.Fprintf(w, "✅ %s installed\n", prerequisite.Name)
+
+		installed = append(installed, prerequisite.Name)
 	}
 
 	fmt.Fprintf(w, "\n✅ All dependencies installed successfully.\n")
@@ -55,7 +60,7 @@ func InstallPrerequisites(w io.Writer, prerequisites []tools.Prerequisite) error
 		_ = state.UpdateAfterSuccessDepsCheck(repoRoot)
 	}
 
-	return nil
+	return installed, nil
 }
 
 // ExecuteShLine executes shellCmd via sh -c, streaming stdout and stderr

--- a/internal/dependencies/installer_test.go
+++ b/internal/dependencies/installer_test.go
@@ -183,7 +183,7 @@ func TestInstallPrerequisites_Empty(t *testing.T) {
 
 	var out bytes.Buffer
 
-	err := InstallPrerequisites(&out, nil)
+	_, err := InstallPrerequisites(&out, nil)
 
 	require.NoError(t, err)
 	assert.Contains(t, out.String(), "successfully")
@@ -194,7 +194,7 @@ func TestInstallPrerequisites_Success(t *testing.T) {
 
 	var out bytes.Buffer
 
-	err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "echo install-uv")})
+	_, err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "echo install-uv")})
 
 	require.NoError(t, err)
 	assert.Contains(t, out.String(), "install-uv")
@@ -204,7 +204,7 @@ func TestInstallPrerequisites_Success(t *testing.T) {
 func TestInstallPrerequisites_FailureShowsRawCommand(t *testing.T) {
 	var out bytes.Buffer
 
-	err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "exit 1")})
+	_, err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "exit 1")})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exit 1")
@@ -215,7 +215,7 @@ func TestInstallPrerequisites_NoPlatformCommand(t *testing.T) {
 
 	dep := tools.Prerequisite{Name: "uv"}
 
-	err := InstallPrerequisites(&out, []tools.Prerequisite{dep})
+	_, err := InstallPrerequisites(&out, []tools.Prerequisite{dep})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "uv")
@@ -243,7 +243,7 @@ func TestInstallPrerequisites_AbortsOnFirstFailure(t *testing.T) {
 		},
 	}
 
-	err := InstallPrerequisites(&out, deps)
+	_, err := InstallPrerequisites(&out, deps)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "uv")
@@ -255,7 +255,7 @@ func TestInstallPrerequisites_WritesStateOnSuccess(t *testing.T) {
 
 	var out bytes.Buffer
 
-	err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "echo install-uv")})
+	_, err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "echo install-uv")})
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(filepath.Join(repoRoot, ".datarobot", "cli", "state.yaml"))
@@ -273,7 +273,7 @@ func TestInstallPrerequisites_PartialFailureDoesNotWriteState(t *testing.T) {
 		prereq("ok", "echo ok"),
 	}
 
-	err := InstallPrerequisites(&out, deps)
+	_, err := InstallPrerequisites(&out, deps)
 	require.Error(t, err)
 
 	data, _ := os.ReadFile(filepath.Join(repoRoot, ".datarobot", "cli", "state.yaml"))
@@ -285,7 +285,7 @@ func TestLastSuccessDepsCheck_UpdatedByInstallPrerequisites(t *testing.T) {
 
 	var out bytes.Buffer
 
-	err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "echo install-uv")})
+	_, err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "echo install-uv")})
 	require.NoError(t, err)
 
 	data, err := os.ReadFile(filepath.Join(repoRoot, ".datarobot", "cli", "state.yaml"))

--- a/internal/dependencies/installer_test.go
+++ b/internal/dependencies/installer_test.go
@@ -183,9 +183,10 @@ func TestInstallPrerequisites_Empty(t *testing.T) {
 
 	var out bytes.Buffer
 
-	_, err := InstallPrerequisites(&out, nil)
+	installed, err := InstallPrerequisites(&out, nil)
 
 	require.NoError(t, err)
+	assert.Empty(t, installed)
 	assert.Contains(t, out.String(), "successfully")
 }
 
@@ -194,17 +195,61 @@ func TestInstallPrerequisites_Success(t *testing.T) {
 
 	var out bytes.Buffer
 
-	_, err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "echo install-uv")})
+	installed, err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "echo install-uv")})
 
 	require.NoError(t, err)
+	assert.Equal(t, []string{"uv"}, installed)
 	assert.Contains(t, out.String(), "install-uv")
 	assert.Contains(t, out.String(), "successfully")
+}
+
+func TestInstallPrerequisites_ReturnsAllInstalledNames(t *testing.T) {
+	setupFakeRepo(t)
+
+	var out bytes.Buffer
+
+	deps := []tools.Prerequisite{
+		prereq("uv", "echo install-uv"),
+		prereq("task", "echo install-task"),
+	}
+
+	installed, err := InstallPrerequisites(&out, deps)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"uv", "task"}, installed)
+}
+
+func TestInstallPrerequisites_ReturnsPartialInstalledOnFailure(t *testing.T) {
+	var out bytes.Buffer
+
+	deps := []tools.Prerequisite{
+		prereq("uv", "echo install-uv"),
+		prereq("task", "exit 1"),
+	}
+
+	installed, err := InstallPrerequisites(&out, deps)
+
+	require.Error(t, err)
+	assert.Equal(t, []string{"uv"}, installed, "should return names installed before the failure")
+	assert.Contains(t, err.Error(), "task")
+}
+
+func TestInstallPrerequisites_ReturnsEmptyWhenNoPlatformCommand(t *testing.T) {
+	var out bytes.Buffer
+
+	dep := tools.Prerequisite{Name: "uv"} // no install commands set
+
+	installed, err := InstallPrerequisites(&out, []tools.Prerequisite{dep})
+
+	require.Error(t, err)
+	assert.Empty(t, installed)
 }
 
 func TestInstallPrerequisites_FailureShowsRawCommand(t *testing.T) {
 	var out bytes.Buffer
 
-	_, err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "exit 1")})
+	installed, err := InstallPrerequisites(&out, []tools.Prerequisite{prereq("uv", "exit 1")})
+	assert.Empty(t, installed)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exit 1")

--- a/internal/telemetry/userid_test.go
+++ b/internal/telemetry/userid_test.go
@@ -419,7 +419,7 @@ func TestGetUserID_NetworkError(t *testing.T) {
 	assert.Empty(t, uid)
 }
 
-func resetTokenForTest(t *testing.T, token string) func() {
+func resetTokenForTest(_ *testing.T, token string) func() {
 	original := drapi.GetToken()
 
 	drapi.SetToken(token)

--- a/internal/tools/prerequisites.go
+++ b/internal/tools/prerequisites.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/misc/regexp2"
 	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/internal/state"
@@ -111,37 +112,46 @@ func CheckPrerequisite(name string) error {
 	return nil
 }
 
+// CheckResult holds the outcome of a CheckPrerequisites call.
+type CheckResult struct {
+	MissingTools         []Prerequisite
+	WrongVersionTools    []Prerequisite
+	MissingMsgs          []string
+	WrongVersionMsgs     []string
+	ValidationViolations []string
+}
+
 // CheckPrerequisites returns lists of missing prerequisites, wrongVersion prerequisites, and error messages to display to the user.
-func CheckPrerequisites() ([]Prerequisite, []Prerequisite, []string, []string) {
-	prerequisites, err := GetRequirements()
+func CheckPrerequisites() CheckResult {
+	prerequisites, violations, err := GetRequirements()
 	if err == nil {
 		RequiredTools = prerequisites
 	}
 
-	var (
-		missingTools      []Prerequisite
-		wrongVersionTools []Prerequisite
-		missingMsgs       []string
-		wrongVersionMsgs  []string
-	)
+	var result CheckResult
+
+	result.ValidationViolations = violations
 
 	for _, tool := range RequiredTools {
 		if !isInstalled(tool.Command) {
-			missingTools = append(missingTools, tool)
-			missingMsgs = append(missingMsgs, fmt.Sprintf("%s %s (%s)", tool.Name, tool.MinimumVersion, tool.URL))
+			result.MissingTools = append(result.MissingTools, tool)
+			result.MissingMsgs = append(result.MissingMsgs, fmt.Sprintf("%s %s (%s)", tool.Name, tool.MinimumVersion, tool.URL))
 		} else if ver, ok := isVersionInstalled(tool); !ok {
-			wrongVersionTools = append(wrongVersionTools, tool)
-			wrongVersionMsgs = append(wrongVersionMsgs, ver)
+			result.WrongVersionTools = append(result.WrongVersionTools, tool)
+			result.WrongVersionMsgs = append(result.WrongVersionMsgs, ver)
 		}
 	}
 
-	if len(missingMsgs) == 0 && len(wrongVersionMsgs) == 0 {
+	if len(result.MissingMsgs) == 0 && len(result.WrongVersionMsgs) == 0 {
 		if repoRoot, err := repo.FindRepoRoot(); err == nil {
-			_ = state.UpdateAfterSuccessDepsCheck(repoRoot)
+			err := state.UpdateAfterSuccessDepsCheck(repoRoot)
+			if err != nil {
+				log.Errorf("Failed to update state AfterSuccessDepsCheck: %v", err)
+			}
 		}
 	}
 
-	return missingTools, wrongVersionTools, missingMsgs, wrongVersionMsgs
+	return result
 }
 
 // PrerequisitesMsg formats the message to display to the user about missing/wrong-version prerequisites.

--- a/internal/tools/prerequisites_test.go
+++ b/internal/tools/prerequisites_test.go
@@ -213,12 +213,12 @@ func TestCheckPrerequisites_AllSatisfied(t *testing.T) {
 		{Name: "sh", Command: "sh"},
 	}
 
-	missing, wrongVer, missingMsgs, wrongVerMsgs := CheckPrerequisites()
+	result := CheckPrerequisites()
 
-	assert.Empty(t, missing)
-	assert.Empty(t, wrongVer)
-	assert.Empty(t, missingMsgs)
-	assert.Empty(t, wrongVerMsgs)
+	assert.Empty(t, result.MissingTools)
+	assert.Empty(t, result.WrongVersionTools)
+	assert.Empty(t, result.MissingMsgs)
+	assert.Empty(t, result.WrongVersionMsgs)
 }
 
 func TestCheckPrerequisites_MissingTool(t *testing.T) {
@@ -230,15 +230,15 @@ func TestCheckPrerequisites_MissingTool(t *testing.T) {
 		{Name: "FakeTool", Command: "nonexistent_dr_fake_tool_xyz", URL: "https://example.com"},
 	}
 
-	missing, wrongVer, missingMsgs, wrongVerMsgs := CheckPrerequisites()
+	result := CheckPrerequisites()
 
-	require.Len(t, missing, 1)
-	assert.Equal(t, "FakeTool", missing[0].Name)
-	assert.Empty(t, wrongVer)
-	assert.Len(t, missingMsgs, 1)
-	assert.Contains(t, missingMsgs[0], "FakeTool")
-	assert.Contains(t, missingMsgs[0], "https://example.com")
-	assert.Empty(t, wrongVerMsgs)
+	require.Len(t, result.MissingTools, 1)
+	assert.Equal(t, "FakeTool", result.MissingTools[0].Name)
+	assert.Empty(t, result.WrongVersionTools)
+	assert.Len(t, result.MissingMsgs, 1)
+	assert.Contains(t, result.MissingMsgs[0], "FakeTool")
+	assert.Contains(t, result.MissingMsgs[0], "https://example.com")
+	assert.Empty(t, result.WrongVersionMsgs)
 }
 
 func TestCheckPrerequisites_WrongVersion(t *testing.T) {
@@ -251,14 +251,14 @@ func TestCheckPrerequisites_WrongVersion(t *testing.T) {
 		{Name: "Echo", Command: "echo 1.0.0", MinimumVersion: "2.0.0", URL: "https://example.com"},
 	}
 
-	missing, wrongVer, missingMsgs, wrongVerMsgs := CheckPrerequisites()
+	result := CheckPrerequisites()
 
-	assert.Empty(t, missing)
-	assert.Empty(t, missingMsgs)
-	require.Len(t, wrongVer, 1)
-	assert.Equal(t, "Echo", wrongVer[0].Name)
-	assert.Len(t, wrongVerMsgs, 1)
-	assert.Contains(t, wrongVerMsgs[0], "Echo")
+	assert.Empty(t, result.MissingTools)
+	assert.Empty(t, result.MissingMsgs)
+	require.Len(t, result.WrongVersionTools, 1)
+	assert.Equal(t, "Echo", result.WrongVersionTools[0].Name)
+	assert.Len(t, result.WrongVersionMsgs, 1)
+	assert.Contains(t, result.WrongVersionMsgs[0], "Echo")
 }
 
 func TestCheckPrerequisites_Mixed(t *testing.T) {
@@ -272,14 +272,14 @@ func TestCheckPrerequisites_Mixed(t *testing.T) {
 		{Name: "Echo", Command: "echo 1.0.0", MinimumVersion: "2.0.0"},
 	}
 
-	missing, wrongVer, missingMsgs, wrongVerMsgs := CheckPrerequisites()
+	result := CheckPrerequisites()
 
-	require.Len(t, missing, 1)
-	assert.Equal(t, "FakeTool", missing[0].Name)
-	require.Len(t, wrongVer, 1)
-	assert.Equal(t, "Echo", wrongVer[0].Name)
-	assert.Len(t, missingMsgs, 1)
-	assert.Len(t, wrongVerMsgs, 1)
+	require.Len(t, result.MissingTools, 1)
+	assert.Equal(t, "FakeTool", result.MissingTools[0].Name)
+	require.Len(t, result.WrongVersionTools, 1)
+	assert.Equal(t, "Echo", result.WrongVersionTools[0].Name)
+	assert.Len(t, result.MissingMsgs, 1)
+	assert.Len(t, result.WrongVersionMsgs, 1)
 }
 
 func TestPlatformInstallCommand_CurrentPlatform(t *testing.T) {
@@ -337,10 +337,10 @@ func TestCheckPrerequisites_WritesStateWhenAllDepsSatisfied(t *testing.T) {
 
 	defer func() { RequiredTools = orig }()
 
-	_, _, missingMsgs, wrongVersionMsgs := CheckPrerequisites()
+	result := CheckPrerequisites()
 
-	assert.Empty(t, missingMsgs, "dep already present should not appear as missing")
-	assert.Empty(t, wrongVersionMsgs)
+	assert.Empty(t, result.MissingMsgs, "dep already present should not appear as missing")
+	assert.Empty(t, result.WrongVersionMsgs)
 
 	data, err := os.ReadFile(filepath.Join(repoRoot, ".datarobot", "cli", "state.yaml"))
 	require.NoError(t, err)
@@ -364,8 +364,8 @@ func TestLastSuccessDepsCheck_UpdatedByCheckPrerequisites(t *testing.T) {
 
 	defer func() { RequiredTools = orig }()
 
-	_, _, missingMsgs, _ := CheckPrerequisites()
-	require.Empty(t, missingMsgs)
+	result := CheckPrerequisites()
+	require.Empty(t, result.MissingMsgs)
 
 	data, err := os.ReadFile(filepath.Join(repoRoot, ".datarobot", "cli", "state.yaml"))
 	require.NoError(t, err)
@@ -389,8 +389,8 @@ func TestCheckPrerequisites_FailureDoesNotWriteState(t *testing.T) {
 
 	defer func() { RequiredTools = orig }()
 
-	_, _, missingMsgs, _ := CheckPrerequisites()
-	require.NotEmpty(t, missingMsgs)
+	result := CheckPrerequisites()
+	require.NotEmpty(t, result.MissingMsgs)
 
 	data, _ := os.ReadFile(filepath.Join(repoRoot, ".datarobot", "cli", "state.yaml"))
 	assert.NotContains(t, string(data), "last_success_deps_check")

--- a/internal/tools/validation.go
+++ b/internal/tools/validation.go
@@ -15,6 +15,7 @@
 package tools
 
 import (
+	"fmt"
 	"runtime"
 
 	semver "github.com/Masterminds/semver/v3"
@@ -65,58 +66,92 @@ var versionsYamlSchema = YAMLSchema{
 	Install:        installCommandsSchema,
 }
 
-// validate logs a warning if value violates the field rule.
-func (r FieldRule) validate(key, fieldName, value string) {
+// validate logs a warning if value violates the field rule and returns the violation message.
+func (r FieldRule) validate(key, fieldName, value string) string {
 	if r.Required && value == "" {
-		log.Warnf("versions.yaml [%s]: '%s' is required", key, fieldName)
+		msg := fmt.Sprintf("versions.yaml [%s]: '%s' is required", key, fieldName)
+		log.Warn(msg)
 
-		return
+		return msg
 	}
 
 	if r.Format == formatSemver && value != "" {
 		if _, err := semver.NewVersion(value); err != nil {
-			log.Warnf("versions.yaml [%s]: '%s' %q is not a valid semantic version", key, fieldName, value)
+			msg := fmt.Sprintf("versions.yaml [%s]: '%s' %q is not a valid semantic version", key, fieldName, value)
+			log.Warn(msg)
+
+			return msg
 		}
 	}
+
+	return ""
 }
 
-// Validate checks every entry in the parsed versions.yaml and logs warnings for violations.
-func (s YAMLSchema) Validate(data versionsYaml) {
+// Validate checks every entry in the parsed versions.yaml, logs warnings for violations,
+// and returns the list of violation messages.
+func (s YAMLSchema) Validate(data versionsYaml) []string {
+	var violations []string
+
 	for key, p := range data {
-		s.Name.validate(key, "name", p.Name)
-		s.MinimumVersion.validate(key, "minimum-version", p.MinimumVersion)
-		s.Command.validate(key, "command", p.Command)
-		s.URL.validate(key, "url", p.URL)
-		s.Install.validate(key, p.Install)
+		for _, v := range []string{
+			s.Name.validate(key, "name", p.Name),
+			s.MinimumVersion.validate(key, "minimum-version", p.MinimumVersion),
+			s.Command.validate(key, "command", p.Command),
+			s.URL.validate(key, "url", p.URL),
+		} {
+			if v != "" {
+				violations = append(violations, v)
+			}
+		}
+
+		violations = append(violations, s.Install.validate(key, p.Install)...)
 	}
+
+	return violations
 }
 
 // validate checks that install commands are provided
 // according to the InstallCommandsSchema rules, with special attention to the current platform.
-func (s InstallCommandsSchema) validate(key string, ic InstallCommands) {
+func (s InstallCommandsSchema) validate(key string, ic InstallCommands) []string {
 	if ic.MacOS == "" && ic.Linux == "" && ic.Windows == "" {
-		log.Warnf("versions.yaml [%s]: 'install' is not defined", key)
+		msg := fmt.Sprintf("versions.yaml [%s]: 'install' is not defined", key)
+		log.Warn(msg)
 
-		return
+		return []string{msg}
 	}
 
-	s.validatePlatform(key, "install.macos", ic.MacOS, s.MacOS, "darwin")
-	s.validatePlatform(key, "install.linux", ic.Linux, s.Linux, "linux")
-	s.validatePlatform(key, "install.windows", ic.Windows, s.Windows, "windows")
+	var violations []string
+
+	for _, v := range []string{
+		s.validatePlatform(key, "install.macos", ic.MacOS, s.MacOS, "darwin"),
+		s.validatePlatform(key, "install.linux", ic.Linux, s.Linux, "linux"),
+		s.validatePlatform(key, "install.windows", ic.Windows, s.Windows, "windows"),
+	} {
+		if v != "" {
+			violations = append(violations, v)
+		}
+	}
+
+	return violations
 }
 
 // validatePlatform logs Error if the install command for the current platform is missing and it's required, otherwise logs a warning.
-func (s InstallCommandsSchema) validatePlatform(key, fieldName, value string, rule FieldRule, goos string) {
+// Returns the violation message, or "" if no violation.
+func (s InstallCommandsSchema) validatePlatform(key, fieldName, value string, rule FieldRule, goos string) string {
 	if !rule.Required || value != "" {
-		return
+		return ""
 	}
 
 	// For now it's only warning if the install command for the current platform is missing
 	if runtime.GOOS == goos {
-		log.Errorf("versions.yaml [%s]: '%s' is required for the current platform", key, fieldName)
+		msg := fmt.Sprintf("versions.yaml [%s]: '%s' is required for the current platform", key, fieldName)
+		log.Error(msg)
 
-		return
+		return msg
 	}
 
-	log.Warnf("versions.yaml [%s]: '%s' is required", key, fieldName)
+	msg := fmt.Sprintf("versions.yaml [%s]: '%s' is required", key, fieldName)
+	log.Warn(msg)
+
+	return msg
 }

--- a/internal/tools/versions.go
+++ b/internal/tools/versions.go
@@ -65,7 +65,7 @@ func GetRequirements() ([]Prerequisite, []string, error) {
 func GetSelfRequirement() (Prerequisite, error) {
 	prerequisites, _, err := GetRequirements()
 	if err != nil {
-		return Prerequisite{}, nil
+		return Prerequisite{}, err
 	}
 
 	selfIndex := slices.IndexFunc(prerequisites, func(p Prerequisite) bool {

--- a/internal/tools/versions.go
+++ b/internal/tools/versions.go
@@ -26,30 +26,30 @@ import (
 
 type versionsYaml map[string]Prerequisite
 
-func GetRequirements() ([]Prerequisite, error) {
+func GetRequirements() ([]Prerequisite, []string, error) {
 	repoRoot, err := repo.FindRepoRoot()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if repoRoot == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	yamlFile := filepath.Join(repoRoot, ".datarobot", "cli", "versions.yaml")
 
 	data, err := os.ReadFile(yamlFile)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read versions yaml file %s: %w", yamlFile, err)
+		return nil, nil, fmt.Errorf("Failed to read versions yaml file %s: %w", yamlFile, err)
 	}
 
 	var fileParsed versionsYaml
 
 	if err = yaml.Unmarshal(data, &fileParsed); err != nil {
-		return nil, fmt.Errorf("Failed to unmarshal versions yaml file %s: %w", yamlFile, err)
+		return nil, nil, fmt.Errorf("Failed to unmarshal versions yaml file %s: %w", yamlFile, err)
 	}
 
-	versionsYamlSchema.Validate(fileParsed)
+	violations := versionsYamlSchema.Validate(fileParsed)
 
 	versions := make([]Prerequisite, 0, len(fileParsed))
 
@@ -59,11 +59,11 @@ func GetRequirements() ([]Prerequisite, error) {
 		versions = append(versions, version)
 	}
 
-	return versions, nil
+	return versions, violations, nil
 }
 
 func GetSelfRequirement() (Prerequisite, error) {
-	prerequisites, err := GetRequirements()
+	prerequisites, _, err := GetRequirements()
 	if err != nil {
 		return Prerequisite{}, nil
 	}

--- a/internal/tools/versions.go
+++ b/internal/tools/versions.go
@@ -32,10 +32,6 @@ func GetRequirements() ([]Prerequisite, []string, error) {
 		return nil, nil, err
 	}
 
-	if repoRoot == "" {
-		return nil, nil, nil
-	}
-
 	yamlFile := filepath.Join(repoRoot, ".datarobot", "cli", "versions.yaml")
 
 	data, err := os.ReadFile(yamlFile)

--- a/internal/tools/versions.go
+++ b/internal/tools/versions.go
@@ -65,7 +65,7 @@ func GetRequirements() ([]Prerequisite, []string, error) {
 func GetSelfRequirement() (Prerequisite, error) {
 	prerequisites, _, err := GetRequirements()
 	if err != nil {
-		return Prerequisite{}, err
+		return Prerequisite{}, nil
 	}
 
 	selfIndex := slices.IndexFunc(prerequisites, func(p Prerequisite) bool {


### PR DESCRIPTION
# RATIONALE

Observability: check & install event tracking:
`dr dependencies check` 
- invocation
- "missing_deps"
- "wrong_version_deps"
- versions.yaml "validation_violations"

`dr dependencies install`  && `dr start`
- invocation
- "missing_deps"
- "wrong_version_deps"
- versions.yaml "validation_violations" 
-  "install_success"
- first "install_error" (as installer stops after first error)
- "yes_flag" 
- "non_interactive" 
 

<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves core telemetry firing to `cobra.OnFinalize` and adds result-based event properties for dependency check/install/start flows, which touches root command lifecycle and dependency installation plumbing. Risk is moderate due to potential changes in when/if telemetry flush/log shutdown runs on error paths and updated return signatures for installers.
> 
> **Overview**
> Adds telemetry coverage for `dr dependency check` and `dr dependency install`, capturing missing deps, wrong-version deps, `versions.yaml` validation violations, and (for install) successful installs plus the first install error, along with `--yes`/non-interactive flags.
> 
> Updates telemetry dispatch to fire **after** command execution via `cobra.OnFinalize` so PropExtractors can read values computed in `RunE`, and ensures events/flush/log shutdown run on both success and error paths.
> 
> Refactors dependency tooling APIs to support this: `tools.CheckPrerequisites` now returns a `CheckResult` struct (including validation violations), `dependencies.InstallPrerequisites` returns the list of installed tool names (including partial progress on failure), and `start` captures these outcomes into telemetry properties. Adds/updates tests and telemetry wiring expectations, and documents the new late-bound extractor pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 121b41415294c7edbe124f472eaf0fe476888429. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->