### PR TITLE
[CFX-5937] expand unit tests coverage for internal/shell

### DIFF
--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -15,6 +15,7 @@
 package shell
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,4 +68,159 @@ func TestDetectShell_EnvVarFallback(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, name)
+}
+
+// TestShellFromEnvPath exercises normalizeShellName(filepath.Base(shellPath)),
+// which is the exact transformation DetectShell applies to the SHELL env var.
+// Fixture values cover Unix absolute paths, macOS Homebrew paths, bare names
+// (already resolved by the user's PATH), and PowerShell variants.
+func TestShellFromEnvPath(t *testing.T) {
+	tests := []struct {
+		shellEnv string
+		want     string
+	}{
+		// Standard Unix absolute paths
+		{shellEnv: "/bin/bash", want: "bash"},
+		{shellEnv: "/bin/sh", want: "sh"},
+		{shellEnv: "/usr/bin/bash", want: "bash"},
+		{shellEnv: "/usr/bin/zsh", want: "zsh"},
+		{shellEnv: "/usr/bin/fish", want: "fish"},
+		// macOS system paths
+		{shellEnv: "/bin/zsh", want: "zsh"},
+		// macOS Homebrew paths (Intel)
+		{shellEnv: "/usr/local/bin/bash", want: "bash"},
+		{shellEnv: "/usr/local/bin/zsh", want: "zsh"},
+		{shellEnv: "/usr/local/bin/fish", want: "fish"},
+		// macOS Homebrew paths (Apple Silicon)
+		{shellEnv: "/opt/homebrew/bin/bash", want: "bash"},
+		{shellEnv: "/opt/homebrew/bin/zsh", want: "zsh"},
+		{shellEnv: "/opt/homebrew/bin/fish", want: "fish"},
+		// Bare names — already resolved via PATH in the user's config
+		{shellEnv: "bash", want: "bash"},
+		{shellEnv: "zsh", want: "zsh"},
+		{shellEnv: "fish", want: "fish"},
+		{shellEnv: "sh", want: "sh"},
+		// PowerShell variants — pwsh must normalise to "powershell"
+		{shellEnv: "/usr/local/bin/pwsh", want: "powershell"},
+		{shellEnv: "/opt/homebrew/bin/pwsh", want: "powershell"},
+		{shellEnv: "pwsh", want: "powershell"},
+		{shellEnv: "powershell", want: "powershell"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.shellEnv, func(t *testing.T) {
+			got := normalizeShellName(filepath.Base(tt.shellEnv))
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestDetectShell_SHELLEnvFixtures calls DetectShell with SHELL set to a
+// variety of fixture values and verifies it always returns a usable, non-empty
+// name. Because parentProcessName() succeeds in the test runner the env-var
+// branch is not exercised here, but the table documents expected end-to-end
+// behaviour and guards against regressions in DetectShell's return type.
+func TestDetectShell_SHELLEnvFixtures(t *testing.T) {
+	tests := []struct {
+		shellEnv string
+	}{
+		{shellEnv: "/bin/bash"},
+		{shellEnv: "/bin/sh"},
+		{shellEnv: "/usr/bin/zsh"},
+		{shellEnv: "/usr/local/bin/fish"},
+		{shellEnv: "/usr/local/bin/pwsh"},
+		{shellEnv: "/opt/homebrew/bin/zsh"},
+		{shellEnv: "bash"},
+		{shellEnv: "zsh"},
+		{shellEnv: "fish"},
+		{shellEnv: "pwsh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.shellEnv, func(t *testing.T) {
+			t.Setenv("SHELL", tt.shellEnv)
+
+			name, err := DetectShell()
+
+			require.NoError(t, err)
+			assert.NotEmpty(t, name)
+		})
+	}
+}
+
+// TestSupportedShells verifies that the canonical shell list is complete and
+// that every entry matches the normalised form DetectShell produces.
+func TestSupportedShells(t *testing.T) {
+	supported := SupportedShells()
+
+	assert.Contains(t, supported, string(Bash))
+	assert.Contains(t, supported, string(Zsh))
+	assert.Contains(t, supported, string(Fish))
+	assert.Contains(t, supported, string(PowerShell))
+	assert.Len(t, supported, 4)
+}
+
+// TestResolveShell_SpecifiedShell verifies that an explicitly provided shell name
+// is returned unchanged without invoking detection.
+func TestResolveShell_SpecifiedShell(t *testing.T) {
+	shells := []string{"bash", "zsh", "fish", "powershell"}
+
+	for _, shell := range shells {
+		t.Run(shell, func(t *testing.T) {
+			got, err := ResolveShell(shell)
+
+			require.NoError(t, err)
+			assert.Equal(t, shell, got)
+		})
+	}
+}
+
+// TestResolveShell_AutoDetect verifies that an empty specifiedShell triggers
+// shell detection and returns a non-empty result.
+func TestResolveShell_AutoDetect(t *testing.T) {
+	got, err := ResolveShell("")
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, got)
+}
+
+// TestParentProcessNameWindows_InvalidPID verifies that an unreachable PID
+// returns an empty string. On non-Windows systems tasklist is not available,
+// so the exec will fail and the function must return "".
+func TestParentProcessNameWindows_InvalidPID(t *testing.T) {
+	got := parentProcessNameWindows(1 << 30)
+
+	assert.Empty(t, got)
+}
+
+// TestNormalizeShellName_EdgeCases extends the baseline table with variants
+// that could plausibly reach the normaliser (e.g. version-suffixed binaries,
+// mixed case, empty input).
+func TestNormalizeShellName_EdgeCases(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// Unknown shells are returned unchanged
+		{input: "sh", want: "sh"},
+		{input: "dash", want: "dash"},
+		{input: "ksh", want: "ksh"},
+		{input: "tcsh", want: "tcsh"},
+		{input: "csh", want: "csh"},
+		// Empty input round-trips as-is
+		{input: "", want: ""},
+		// Mixed-case is not normalised (OS provides canonical form)
+		{input: "Bash", want: "Bash"},
+		{input: "ZSH", want: "ZSH"},
+		// Only "pwsh" maps to "powershell"; other PowerShell names are unchanged
+		{input: "pwsh.exe", want: "pwsh.exe"},
+		{input: "powershell.exe", want: "powershell.exe"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeShellName(tt.input))
+		})
+	}
 }


### PR DESCRIPTION
# RATIONALE

expand unit tests coverage for internal/shell from 20% to 52.5% 

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

extend the coverage from 20% to 52.5%. The new tests cover:
  - ResolveShell — up to 87.5% (the only uncovered line is the DetectShell error return, which requires the test runner to have no detectable shell)
  - parentProcessNameWindows — up to 41.7% (the CSV parsing logic after a successful tasklist call remains unreachable on Linux, as expected)

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are test-only and primarily add table-driven fixtures around shell name normalization and resolution logic, with no production code modifications.
> 
> **Overview**
> Expands `internal/shell` unit tests to cover more `DetectShell`/`ResolveShell` behaviors and edge cases, including canonical `pwsh`→`powershell` normalization and `SHELL` env-var path fixtures.
> 
> Adds assertions for `SupportedShells()` contents, `ResolveShell` passthrough vs auto-detect, and a Windows `tasklist` failure case via an invalid PID to ensure `parentProcessNameWindows` safely returns an empty string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9caa5b626bfb919f84fd96749dd7a211e86a49f3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->