### PR TITLE
[YOLO] fix workflows

### DIFF
--- a/.github/workflows/comment-commands.yaml
+++ b/.github/workflows/comment-commands.yaml
@@ -29,13 +29,13 @@ jobs:
             const isFork = pr.data.head.repo.full_name !== context.repo.owner + '/' + context.repo.repo;
             core.setOutput('is_fork', isFork);
 
-            // Check if commenter is a maintainer (write or admin permission)
+            // Check if commenter is a maintainer (write/maintain/admin permission)
             const permission = await github.rest.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner,
               repo: context.repo.repo,
               username: context.actor
             });
-            const isMaintainer = ['write', 'admin'].includes(permission.data.permission);
+            const isMaintainer = ['write', 'maintain', 'admin'].includes(permission.data.permission);
             core.setOutput('is_maintainer', isMaintainer);
 
             return { isFork, isMaintainer };
@@ -206,7 +206,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: '❌ **Insufficient permissions**\n\n' +
-                    'Only maintainers with write or admin access can skip smoke tests.'
+                    'Only maintainers with write/maintain/admin access can skip smoke tests.'
             });
 
       - name: Handle unauthorized fork smoke test attempt
@@ -231,6 +231,6 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: '❌ **Insufficient permissions**\n\n' +
-                    'Only maintainers with write or admin access can approve fork PRs for smoke tests.\n\n' +
+                    'Only maintainers with write/maintain/admin access can approve fork PRs for smoke tests.\n\n' +
                     'Please wait for a maintainer to review and approve.'
             });

--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -16,7 +16,33 @@ on:
         type: string
 
 jobs:
+  check-permissions:
+    runs-on: ubuntu-latest
+    name: Check Caller Permissions
+    permissions:
+      contents: read
+    steps:
+      - name: Verify maintainer access
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const result = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+            const allowed = ['write', 'maintain', 'admin'];
+            const permission = result.data.permission;
+            if (!allowed.includes(permission)) {
+              core.setFailed(
+                `@${context.actor} has permission '${permission}' — ` +
+                `maintainer access (write/maintain/admin) is required to run fork smoke tests.`
+              );
+            }
+            console.log(`@${context.actor} has permission '${permission}' — proceeding.`);
+
   resolve-pr:
+    needs: [check-permissions]
     runs-on: ubuntu-latest
     name: Resolve PR Details
     outputs:
@@ -95,12 +121,14 @@ jobs:
 
   notify-start:
     needs: [resolve-pr, security-scan]
+    if: needs.resolve-pr.outputs.is_fork == 'true'
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      pull-requests: write
       issues: write
     steps:
       - name: Notify smoke tests started
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -38,6 +38,7 @@ jobs:
                 `@${context.actor} has permission '${permission}' — ` +
                 `maintainer access (write/maintain/admin) is required to run fork smoke tests.`
               );
+              return;
             }
             console.log(`@${context.actor} has permission '${permission}' — proceeding.`);
 


### PR DESCRIPTION

# RATIONALE

The GitHub Actions permission check for maintainers was incomplete — the `maintain` repository role was not included in the allowed permissions list, meaning contributors with `maintain` access (a valid GitHub collaborator level between `write` and `admin`) were incorrectly denied access to trigger/approve smoke tests.

## CHANGES

**comment-commands.yaml**
- Updated the `isMaintainer` permission check to include `'maintain'` alongside `'write'` and `'admin'`
- Updated user-facing error messages in PR comments to reflect the full set of accepted permission levels (`write/maintain/admin`)

**fork-smoke-tests.yaml**
- Added a new `check-permissions` job that runs before `resolve-pr`, verifying the caller has `write`, `maintain`, or `admin` access before the workflow proceeds
- Made `resolve-pr` depend on `check-permissions` via `needs`
- Added `if: needs.resolve-pr.outputs.is_fork == 'true'` guard to the `notify-start` job so it only runs for fork PRs
- Upgraded `notify-start` permissions from `pull-requests: read` to `pull-requests: write` (required to post comments)
- Added `continue-on-error: true` to the notify step to prevent a notification failure from blocking the workflow
## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GitHub Actions workflows that can run with repository secrets; while changes are small and permission-tightening, mistakes could affect who can trigger privileged CI or whether notifications run as expected.
> 
> **Overview**
> Fixes maintainer permission checks for comment-driven smoke-test controls by treating GitHub’s `maintain` role as authorized (alongside `write`/`admin`) and updates the user-facing denial messages accordingly.
> 
> Hardens the fork smoke-test `workflow_dispatch` path by adding an upfront permission-gating job, making downstream jobs depend on it, and tightening notification behavior (only notify for fork PRs, grant `pull-requests: write` for commenting, and don’t fail the workflow if the start-notification comment fails).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110dbaadb448d8eb6a5cfafe90b9c0ae5336fa71. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->