### PR TITLE
[CFX-6189] fix flaky unit test for plugin discovery

### DIFF
--- a/docs/development/plugins.md
+++ b/docs/development/plugins.md
@@ -34,6 +34,16 @@ Plugins are deduplicated by `manifest.name` (not by filename). If multiple binar
   - Set to `0s` to disable plugin discovery entirely.
 - Manifest retrieval is bounded by `plugin.manifest_timeout_ms` (default `500ms`).
 
+#### Testing notes
+
+The default `500ms` timeout is occasionally exceeded under heavy test load (e.g. `task test` with `-race`).
+Test suites that exercise plugin discovery should:
+
+1. Call `viperx.Reset()` in `SetupTest`/`TearDownTest` to prevent config-file or env-var
+   values from leaking into the manifest timeout.
+2. Set a generous test-specific timeout before discovering:
+   `viperx.Set("plugin.manifest_timeout_ms", 5000)` (5 seconds).
+
 ## Manifest protocol
 
 To be recognized as a plugin, the executable **must** respond to the special argument:

--- a/internal/plugin/discover_test.go
+++ b/internal/plugin/discover_test.go
@@ -67,6 +67,8 @@ func (s *DiscoverTestSuite) SetupTest() {
 	s.tempDir, err = os.MkdirTemp("", "plugin-discover-test")
 	s.Require().NoError(err)
 
+	// Reset viper and raise the manifest timeout so subprocess calls
+	// do not fail under the heavy load of -race / -shuffle test runs.
 	viperx.Reset()
 	viperx.Set("plugin.manifest_timeout_ms", 5000)
 }
@@ -76,6 +78,7 @@ func (s *DiscoverTestSuite) TearDownTest() {
 		_ = os.RemoveAll(s.tempDir)
 	}
 
+	// Clear any test-specific viper state so it does not leak to other suites.
 	viperx.Reset()
 }
 
@@ -159,7 +162,8 @@ func (s *DiscoverTestSuite) TestDiscoverInDirDeduplicatesByManifestName() {
 	seen := make(map[string]bool)
 	plugins, errs := discoverInDir(s.tempDir, seen)
 
-	// Log any errors for debugging
+	// Log manifest-fetch errors so future test failures show *why* discovery
+	// returned zero plugins instead of only asserting *that* it did.
 	for _, err := range errs {
 		log.Debug("Deduplication test manifest error", "error", err)
 	}

--- a/internal/plugin/discover_test.go
+++ b/internal/plugin/discover_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/log"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -65,12 +66,17 @@ func (s *DiscoverTestSuite) SetupTest() {
 
 	s.tempDir, err = os.MkdirTemp("", "plugin-discover-test")
 	s.Require().NoError(err)
+
+	viperx.Reset()
+	viperx.Set("plugin.manifest_timeout_ms", 5000)
 }
 
 func (s *DiscoverTestSuite) TearDownTest() {
 	if s.tempDir != "" {
 		_ = os.RemoveAll(s.tempDir)
 	}
+
+	viperx.Reset()
 }
 
 func (s *DiscoverTestSuite) TestDiscoverInDirEmptyDirectory() {
@@ -144,11 +150,6 @@ func (s *DiscoverTestSuite) TestDiscoverInDirHandlesDuplicates() {
 	s.Empty(plugins)
 }
 
-// TODO: This test is flaky under `go test -shuffle=on` / parallel execution
-// in the broader `task test` run, but passes cleanly when run in isolation.
-// Suspected: shared filesystem state between sub-tests in the suite, or
-// enumeration-order sensitivity in the manifest-name dedup logic.
-// Unrelated to the envbuilder/dotenv changes that surfaced this observation.
 func (s *DiscoverTestSuite) TestDiscoverInDirDeduplicatesByManifestName() {
 	// Two different binary names, same manifest name
 	manifest := `{"name":"shared-name","version":"1.0.0","description":"Test"}`
@@ -157,6 +158,11 @@ func (s *DiscoverTestSuite) TestDiscoverInDirDeduplicatesByManifestName() {
 
 	seen := make(map[string]bool)
 	plugins, errs := discoverInDir(s.tempDir, seen)
+
+	// Log any errors for debugging
+	for _, err := range errs {
+		log.Debug("Deduplication test manifest error", "error", err)
+	}
 
 	// Only one should be registered (first one wins based on directory order)
 	s.Require().Len(plugins, 1, "Expected exactly one plugin when two share the same manifest name")


### PR DESCRIPTION
# RATIONALE

```log
   -test.shuffle 1779130453895286000
   --- FAIL: TestDiscoverTestSuite (1.71s)
       --- FAIL: TestDiscoverTestSuite/TestDiscoverInDirDeduplicatesByManifestName (1.00s)
           discover_test.go:162:
                   Error Trace:    /Users/aj.alon/workspace/cli/internal/plugin/discover_test.go:162
                                                           /Users/aj.alon/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.3.darwin-arm64/src/runtime/asm_arm64.s:1447
                   Error:          "[]" should have 1 item(s), but has 0
                   Test:           TestDiscoverTestSuite/TestDiscoverInDirDeduplicatesByManifestName
                   Messages:       Expected exactly one plugin when two share the same manifest name
   FAIL
   coverage: 62.5% of statements
   FAIL    http://github.com/datarobot/cli/internal/plugin         9.617s
```

I kept seeing failures for `TestDiscoverInDirDeduplicatesByManifestName` during normal `task test` execution.

With a little help from Kimi 2.6, I found that the subprocess calls to `getManifest()` were timing out at 500ms each, hence the `1.00s` failed test duration. Because the subprocess calls were timing out, the test was finding 0 discovered plugins, not 1.

Normally `getManifest()` times out after 500ms, but @chasdr added the ability to override this via viper configuration. The test suite is a great place to exercise that little bit of functionality.

Kimi 2.6:
> Under heavy test load with the race detector, subprocess execution (`exec.CommandContext`) is slow enough that `500ms` is marginal for even a trivial `/bin/sh` script. Additionally, `DiscoverTestSuite` never called `viperx.Reset()`, so `plugin.manifest_timeout_ms` could be influenced by config-file or env-var values left by prior tests or `root.go::init()`.

## HISTORY

PR #326 -- Chas adds plugin support
PR #367 -- I noticed this and tweaked the tests for better logging
PR #463 -- I noticed this again, did a little digging, added a note

## CHANGES

- **`internal/plugin/discover_test.go`**
  - `DiscoverTestSuite.SetupTest`: Reset viper state and raise `plugin.manifest_timeout_ms` to `5000` so subprocess calls do not fail under `-race` load
  - `DiscoverTestSuite.TearDownTest`: Reset viper state to prevent leakage to other suites
  - `TestDiscoverInDirDeduplicatesByManifestName`: Log manifest-fetch errors before asserting, so future failures reveal *why* discovery returned zero plugins

- **`docs/development/plugins.md`**
  - Added "Testing notes" under the "Timeouts" section documenting the viperx reset pattern and generous timeout recommendation for test suites

## TESTING

- `go test -race -shuffle=on -count=5 ./internal/plugin/...` passes consistently
- `task lint` clean


# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to tests and developer documentation, with no production plugin discovery behavior modified.
> 
> **Overview**
> Stabilizes `internal/plugin/discover_test.go` by resetting `viperx` state per test, bumping `plugin.manifest_timeout_ms` to 5s for discovery suite runs, and logging manifest-fetch errors in the deduplication test to aid debugging.
> 
> Adds **testing guidance** to `docs/development/plugins.md` recommending `viperx.Reset()` and a larger `plugin.manifest_timeout_ms` when exercising plugin discovery under `-race`/heavy load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 391898beccbcf667165dcf469b9d69f527ff83df. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->