### PR TITLE
[CFX-6038] fix(telemetry): demote machine ID failure from WARN to Debug

### DIFF
--- a/internal/telemetry/deviceid.go
+++ b/internal/telemetry/deviceid.go
@@ -24,9 +24,7 @@ import (
 func getMachineID() string {
 	id, err := machineid.ProtectedID("dr")
 	if err != nil {
-		// Errors at this point will cause telemetry to be less effective
-		// or to fail outright, depending on if we have user-id.
-		log.Warn("Failed to get machine ID:", err)
+		log.Debug("Failed to get machine ID:", err)
 		return ""
 	}
 


### PR DESCRIPTION
# RATIONALE

In environments where `/etc/machine-id` doesn't exist — such as DataRobot Codespaces and airgapped containers — every CLI command was printing a noisy warning to the terminal:

```
WARN  Failed to get machine ID: machineid: machineid: open /etc/machine-id: no such file or directory="missing value"
```

The failure is **expected** in these environments — no user action is possible or required. All other cache errors are logged to Debug, as well.

Thanks @asuslov for doing the testing work with .66. :)

## CHANGES

- `internal/telemetry/deviceid.go`: Downgrade `log.Warn` → `log.Debug` for the machine ID retrieval failure. The message is still visible with `--debug` for diagnostics, but no longer pollutes normal terminal output.
- Removed old comment

## RELATED

[CFX-6038](https://datarobot.atlassian.net/browse/CFX-6038)

## TESTING

- `task build` ✅
- `task lint` — 0 issues ✅
- `task test` — all pass ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes log level/comment removal when OS machine ID lookup fails; telemetry/device ID behavior is otherwise unchanged.
> 
> **Overview**
> Reduces CLI noise by demoting machine ID lookup failures in `internal/telemetry/deviceid.go` from `log.Warn` to `log.Debug`, while still returning an empty ID to trigger the existing fallback behavior. Removes the outdated warning-oriented comment in that error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1184bfba31e04d52e567468f3743f84b13e61135. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->