### PR TITLE
[APP-6074] Generate tracing:start/stop and dev:stop tasks via dr task compose

### DIFF
--- a/internal/task/Taskfile.tmpl.yaml
+++ b/internal/task/Taskfile.tmpl.yaml
@@ -120,3 +120,39 @@ tasks:
       - task: {{ . }}:deploy-dev
       {{- end }}
   {{- end }}
+
+  {{- if .HasDev }}
+
+  dev:stop:
+    desc: "🛑 Stop all local dev services"
+    cmds:
+      - |
+        PIDS=$(for port in{{- range .DevPorts }} {{ .Port }}{{- end }}; do lsof -ti :$port -sTCP:LISTEN 2>/dev/null | sort -u || true; done)
+        if [[ -n "$PIDS" ]]; then
+          echo "Stopping dev services..."
+          echo "$PIDS" | xargs kill 2>/dev/null || true
+        else
+          echo "No dev services running."
+        fi
+    silent: true
+  {{- end }}
+
+  {{- if .HasTracing }}
+
+  tracing:start:
+    desc: "📡 Start the local experimentation tracing dashboard"
+    cmds:
+      - task: tracing:stop
+      {{- range .TracingComponents }}
+      - task: {{ . }}:tracing:start
+      {{- end }}
+    silent: true
+
+  tracing:stop:
+    desc: "🛑 Stop the local experimentation tracing dashboard"
+    cmds:
+      {{- range .TracingComponents }}
+      - task: {{ . }}:tracing:stop
+      {{- end }}
+    silent: true
+  {{- end }}

--- a/internal/task/discovery.go
+++ b/internal/task/discovery.go
@@ -63,6 +63,8 @@ type taskfileTmplData struct {
 	DeployComponents    []string
 	HasDeployDev        bool
 	DeployDevComponents []string
+	HasTracing          bool
+	TracingComponents   []string
 }
 
 var (
@@ -314,6 +316,7 @@ func (d *Discovery) buildComposeData(root string, includes []componentInclude) (
 		DevComponents:       []string{},
 		DeployComponents:    []string{},
 		DeployDevComponents: []string{},
+		TracingComponents:   []string{},
 		DevPorts:            d.loadDevPorts(root),
 	}
 
@@ -358,10 +361,11 @@ func (d *Discovery) checkAndAddTask(data *taskfileTmplData, task Task, component
 		"uninstall":  {&data.UninstallComponents, &data.HasUninstall},
 		"test":       {&data.TestComponents, &data.HasTest},
 		"dev":        {&data.DevComponents, &data.HasDev},
-		"deploy":     {&data.DeployComponents, &data.HasDeploy},
-		"up":         {&data.DeployComponents, &data.HasDeploy},
-		"deploy-dev": {&data.DeployDevComponents, &data.HasDeployDev},
-		"up-dev":     {&data.DeployDevComponents, &data.HasDeployDev},
+		"deploy":         {&data.DeployComponents, &data.HasDeploy},
+		"up":             {&data.DeployComponents, &data.HasDeploy},
+		"deploy-dev":     {&data.DeployDevComponents, &data.HasDeployDev},
+		"up-dev":         {&data.DeployDevComponents, &data.HasDeployDev},
+		"tracing:start":  {&data.TracingComponents, &data.HasTracing},
 	}
 
 	// Check task name

--- a/internal/task/discovery.go
+++ b/internal/task/discovery.go
@@ -355,17 +355,17 @@ func (d *Discovery) checkAndAddTask(data *taskfileTmplData, task Task, component
 		components *[]string
 		hasFlag    *bool
 	}{
-		"start":      {&data.StartComponents, &data.HasStart},
-		"lint":       {&data.LintComponents, &data.HasLint},
-		"install":    {&data.InstallComponents, &data.HasInstall},
-		"uninstall":  {&data.UninstallComponents, &data.HasUninstall},
-		"test":       {&data.TestComponents, &data.HasTest},
-		"dev":        {&data.DevComponents, &data.HasDev},
-		"deploy":         {&data.DeployComponents, &data.HasDeploy},
-		"up":             {&data.DeployComponents, &data.HasDeploy},
-		"deploy-dev":     {&data.DeployDevComponents, &data.HasDeployDev},
-		"up-dev":         {&data.DeployDevComponents, &data.HasDeployDev},
-		"tracing:start":  {&data.TracingComponents, &data.HasTracing},
+		"start":         {&data.StartComponents, &data.HasStart},
+		"lint":          {&data.LintComponents, &data.HasLint},
+		"install":       {&data.InstallComponents, &data.HasInstall},
+		"uninstall":     {&data.UninstallComponents, &data.HasUninstall},
+		"test":          {&data.TestComponents, &data.HasTest},
+		"dev":           {&data.DevComponents, &data.HasDev},
+		"deploy":        {&data.DeployComponents, &data.HasDeploy},
+		"up":            {&data.DeployComponents, &data.HasDeploy},
+		"deploy-dev":    {&data.DeployDevComponents, &data.HasDeployDev},
+		"up-dev":        {&data.DeployDevComponents, &data.HasDeployDev},
+		"tracing:start": {&data.TracingComponents, &data.HasTracing},
 	}
 
 	// Check task name

--- a/internal/task/discovery_test.go
+++ b/internal/task/discovery_test.go
@@ -152,6 +152,31 @@ func (suite *DiscoveryTestSuite) TestFindComponentsRespectsMaxDepth() {
 	suite.Equal("shallow", includes[0].Name)
 }
 
+func (suite *DiscoveryTestSuite) TestCheckAndAddTaskRecognizesTracingStart() {
+	discovery := &Discovery{}
+	data := taskfileTmplData{
+		TracingComponents: []string{},
+	}
+
+	discovery.checkAndAddTask(&data, Task{Name: "tracing:start"}, "infra")
+
+	suite.True(data.HasTracing)
+	suite.Equal([]string{"infra"}, data.TracingComponents)
+}
+
+func (suite *DiscoveryTestSuite) TestCheckAndAddTaskDeduplicatesTracingComponents() {
+	discovery := &Discovery{}
+	data := taskfileTmplData{
+		TracingComponents: []string{},
+	}
+
+	discovery.checkAndAddTask(&data, Task{Name: "tracing:start"}, "infra")
+	discovery.checkAndAddTask(&data, Task{Name: "tracing:start"}, "infra")
+
+	suite.True(data.HasTracing)
+	suite.Len(data.TracingComponents, 1)
+}
+
 func (suite *DiscoveryTestSuite) TestFindComponentsSkipsHiddenDirs() {
 	discovery := &Discovery{
 		RootTaskfileName: "Taskfile.yaml",

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -40,16 +40,16 @@ type CommonProperties struct {
 	DeviceID  string  // UUID v4, stable per installation, cached to disk
 	UserID    *string // DataRobot uid from GET /api/v2/account/info/, cached to disk; nil on network failure or auth issues
 	// event properties
-	CLIVersion        string // CLI version from version.Version (ldflags)
-	InstallMethod     string // Build distribution method (ldflags)
-	OSName            string // human-readable OS name from runtime.GOOS
-	OSArch            string // CPU architecture from runtime.GOARCH
-	OSVersion         string // OS release version string, detected at startup
-	Language          string // user language from LANG env var (e.g. "en_US")
-	GoVersion         string // Go runtime version (e.g. "go1.26.2")
-	Shell             string // Name of the user's shell (e.g. "zsh", "bash", "powershell")
-	DataRobotInstance string // Base URL of configured DataRobot instance
-	CommandKind       string // "core" or "plugin", set by the root command after dispatch
+	CLIVersion        string  // CLI version from version.Version (ldflags)
+	InstallMethod     string  // Build distribution method (ldflags)
+	OSName            string  // human-readable OS name from runtime.GOOS
+	OSArch            string  // CPU architecture from runtime.GOARCH
+	OSVersion         string  // OS release version string, detected at startup
+	Language          string  // user language from LANG env var (e.g. "en_US")
+	GoVersion         string  // Go runtime version (e.g. "go1.26.2")
+	Shell             string  // Name of the user's shell (e.g. "zsh", "bash", "powershell")
+	DataRobotInstance string  // Base URL of configured DataRobot instance
+	CommandKind       string  // "core" or "plugin", set by the root command after dispatch
 	OrganizationID    *string // DataRobot org ID from GET /api/v2/account/info/, cached to disk; nil on network failure or auth issues
 	TenantID          *string // DataRobot tenant ID from GET /api/v2/account/info/, cached to disk; nil if unavailable (legit absent for legacy/system accounts)
 }


### PR DESCRIPTION
## CHANGES

- Discover tracing:start task in component Taskfiles and aggregate into TracingComponents; generate root-level tracing:start and tracing:stop tasks that delegate to the infra component's tracing tasks
- Generate dev:stop task from DevPorts (.taskfile-data.yaml) when dev components are present, killing processes by port with deduplication
- Add tests for tracing:start discovery and deduplication


## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes generated Taskfile behavior by adding process-killing `dev:stop` logic and new `tracing:start/stop` aggregation, which could impact local developer workflows if ports/components are misconfigured.
> 
> **Overview**
> Adds support for composing *tracing dashboard* tasks: discovery now recognizes `tracing:start` in component Taskfiles, aggregates matching components, and the root `Taskfile` template emits `tracing:start`/`tracing:stop` tasks that delegate to those components.
> 
> When any dev components exist, the generated root Taskfile now also includes `dev:stop`, which attempts to stop local dev services by finding listeners on the configured `.DevPorts` and killing the associated PIDs. Coverage is updated with tests to ensure `tracing:start` discovery and component de-duplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2bbd22b69d18845fc00f98c4ea35fa3f0722857. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->