### PR TITLE
Add assist plugin v0.1.21

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.21",
+          "url": "assist/assist-0.1.21.tar.xz",
+          "sha256": "d746df38190abb936832da2a603e114f7392099e69091213596f30cd68213da0",
+          "releaseDate": "2026-05-20"
+        },
+        {
           "version": "0.1.20",
           "url": "assist/assist-0.1.20.tar.xz",
           "sha256": "36311fbea982ae7482ed36c63542066b305075125772cd3a5c2c3fa1acc4e024",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.21 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.21
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.21
- **SHA256:** `d746df38190abb936832da2a603e114f7392099e69091213596f30cd68213da0`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates a static plugin index entry to point to a new `assist` release (version/URL/hash/date) with no code-path changes.
> 
> **Overview**
> Adds `assist` plugin version `0.1.21` to `docs/plugins/index.json`, including the new tarball URL, SHA256, and release date so the CLI can discover/install the latest release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ce64d219c35dc87dfcb3c887f6223b0ac7f5780. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->