### PR TITLE
[CFX-6128] Add more DEBUG logs for `dr  dependencies ...`

### DIFF
--- a/cmd/dependencies/check/cmd.go
+++ b/cmd/dependencies/check/cmd.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/tools"
 	"github.com/spf13/cobra"
@@ -30,7 +31,11 @@ func Cmd() *cobra.Command {
 		Use:   "check",
 		Short: "✅ Check template dependencies",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			log.Debug("deps: check start")
+
 			result = tools.CheckPrerequisites()
+
+			log.Debug("deps: check result", "missing", len(result.MissingMsgs), "wrong_version", len(result.WrongVersionMsgs))
 
 			if len(result.MissingMsgs) > 0 || len(result.WrongVersionMsgs) > 0 {
 				cmd.SilenceUsage = true

--- a/cmd/dependencies/install/cmd.go
+++ b/cmd/dependencies/install/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/datarobot/cli/cmd/helpers"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/dependencies"
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/tools"
 	"github.com/spf13/cobra"
@@ -47,7 +48,11 @@ func Cmd() *cobra.Command {
 			yesFlag = opts.Yes
 			nonInteractive = viperx.GetBool("yes")
 
+			log.Debug("deps: install start", "yes", yesFlag, "non_interactive", nonInteractive)
+
 			checkResult = tools.CheckPrerequisites()
+
+			log.Debug("deps: install check result", "missing", len(checkResult.MissingMsgs), "wrong_version", len(checkResult.WrongVersionMsgs))
 
 			if len(checkResult.MissingMsgs) == 0 && len(checkResult.WrongVersionMsgs) == 0 {
 				fmt.Fprintln(cmd.OutOrStdout(), "✅ All dependencies are already up to date.")
@@ -68,9 +73,13 @@ func Cmd() *cobra.Command {
 				}
 
 				if !yes {
+					log.Debug("deps: install declined by user")
+
 					return nil
 				}
 			}
+
+			log.Debug("deps: proceeding with install", "count", len(prerequisites))
 
 			var err error
 
@@ -81,6 +90,8 @@ func Cmd() *cobra.Command {
 
 				return err
 			}
+
+			log.Debug("deps: install complete", "installed", installSuccess)
 
 			return nil
 		},

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -219,6 +219,8 @@ func (m Model) execSelfUpdate() tea.Cmd {
 }
 
 func (m Model) execInstallDeps() tea.Cmd {
+	log.Debug("start: installing deps", "count", len(m.depsToInstall))
+
 	return func() tea.Msg {
 		var buf bytes.Buffer
 
@@ -344,7 +346,11 @@ func (m Model) handleDepsMissing(msg depsMissingMsg) (tea.Model, tea.Cmd) {
 	m.telemetry.missingMsgs = msg.checkResult.MissingMsgs
 	m.telemetry.wrongVersionMsgs = msg.checkResult.WrongVersionMsgs
 
-	if m.opts.AnswerYes || viperx.GetBool("yes") {
+	autoInstall := m.opts.AnswerYes || viperx.GetBool("yes")
+
+	log.Debug("start: handling missing deps", "count", len(msg.prerequisites), "auto_install", autoInstall)
+
+	if autoInstall {
 		return m, m.execInstallDeps()
 	}
 
@@ -354,6 +360,8 @@ func (m Model) handleDepsMissing(msg depsMissingMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleDepsInstallComplete(msg depsInstallCompleteMsg) (tea.Model, tea.Cmd) {
+	log.Debug("start: deps install complete", "installed", msg.installed, "err", msg.err)
+
 	m.telemetry.installSuccess = msg.installed
 
 	if msg.err != nil {
@@ -409,11 +417,15 @@ func (m Model) handleWaitingToExecuteKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) handleInstallConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "y", "Y", "enter":
+		log.Debug("start: user confirmed deps install")
+
 		m.waitingToInstall = false
 		m.stepCompleteMessage = ""
 
 		return m, m.execInstallDeps()
 	case "n", "N", "q", "esc":
+		log.Debug("start: user cancelled deps install")
+
 		m.err = errors.New("Installation cancelled. Run 'dr dependencies install' to install missing dependencies.")
 
 		return m, tea.Quit
@@ -532,10 +544,14 @@ func checkSelfVersion(_ *Model) tea.Msg {
 
 func checkPrerequisites(m *Model) tea.Msg {
 	if m.repoRoot != "" && state.HasRecentSuccessDepsCheck(m.repoRoot) {
+		log.Debug("start: deps check skipped", "reason", "recent_success")
+
 		return stepCompleteMsg{message: "Recent successful dependency check detected, skipping prerequisites check...\n"}
 	}
 
 	result := tools.CheckPrerequisites()
+
+	log.Debug("start: deps check result", "missing", len(result.MissingMsgs), "wrong_version", len(result.WrongVersionMsgs))
 
 	if len(result.MissingMsgs) == 0 && len(result.WrongVersionMsgs) == 0 {
 		return stepCompleteMsg{}
@@ -543,6 +559,8 @@ func checkPrerequisites(m *Model) tea.Msg {
 
 	prerequisites := append(result.MissingTools, result.WrongVersionTools...)
 	message := tools.PrerequisitesMsg(result.MissingMsgs, result.WrongVersionMsgs)
+
+	log.Debug("start: deps to install/update", "count", len(prerequisites))
 
 	return depsMissingMsg{
 		prerequisites: prerequisites,

--- a/internal/dependencies/installer.go
+++ b/internal/dependencies/installer.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os/exec"
 
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/internal/state"
 	"github.com/datarobot/cli/internal/tools"
@@ -28,36 +29,53 @@ import (
 // InstallPrerequisites installs each prerequisite sequentially. It returns the names
 // of tools successfully installed before any failure, plus the first error encountered.
 func InstallPrerequisites(w io.Writer, prerequisites []tools.Prerequisite) ([]string, error) {
+	log.Debug("deps: installing prerequisites", "count", len(prerequisites))
+
 	var installed []string
 
 	for _, prerequisite := range prerequisites {
 		installCmd, err := prerequisite.PlatformInstallCommand()
 		if err != nil {
+			log.Debug("deps: no install command", "name", prerequisite.Name, "err", err)
+
 			return installed, err
 		}
+
+		log.Debug("deps: running install", "name", prerequisite.Name, "cmd", installCmd)
 
 		fmt.Fprintf(w, "📦 Installing %s...\n", prerequisite.Name)
 
 		exitCode, err := ExecuteShLine(installCmd, w)
 		if err != nil {
+			log.Debug("deps: install failed to start", "name", prerequisite.Name, "err", err)
+
 			return installed, fmt.Errorf("failed to start install for %q: %w\n  command: %s", prerequisite.Name, err, installCmd)
 		}
 
 		if exitCode != 0 {
+			log.Debug("deps: install exited non-zero", "name", prerequisite.Name, "exit_code", exitCode)
+
 			return installed, fmt.Errorf("install failed for %q (exit code %d)\n  Please run manually: %s\n  Or check %s", prerequisite.Name, exitCode, installCmd, prerequisite.URL)
 		}
+
+		log.Debug("deps: tool installed", "name", prerequisite.Name)
 
 		fmt.Fprintf(w, "✅ %s installed\n", prerequisite.Name)
 
 		installed = append(installed, prerequisite.Name)
 	}
 
+	log.Debug("deps: all prerequisites installed", "count", len(installed))
+
 	fmt.Fprintf(w, "\n✅ All dependencies installed successfully.\n")
 
 	// Update state after successful installs.
 	// Executed only after all installs succeed to avoid state inconsistency if an install fails.
 	if repoRoot, err := repo.FindRepoRoot(); err == nil {
-		_ = state.UpdateAfterSuccessDepsCheck(repoRoot)
+		err := state.UpdateAfterSuccessDepsCheck(repoRoot)
+		if err != nil {
+			log.Errorf("Failed to update state AfterSuccessDepsCheck: %v", err)
+		}
 	}
 
 	return installed, nil

--- a/internal/tools/prerequisites.go
+++ b/internal/tools/prerequisites.go
@@ -128,21 +128,31 @@ func CheckPrerequisites() CheckResult {
 		RequiredTools = prerequisites
 	}
 
+	log.Debug("deps: checking prerequisites", "count", len(RequiredTools))
+
 	var result CheckResult
 
 	result.ValidationViolations = violations
 
 	for _, tool := range RequiredTools {
 		if !isInstalled(tool.Command) {
+			log.Debug("deps: tool missing", "name", tool.Name)
+
 			result.MissingTools = append(result.MissingTools, tool)
 			result.MissingMsgs = append(result.MissingMsgs, fmt.Sprintf("%s %s (%s)", tool.Name, tool.MinimumVersion, tool.URL))
 		} else if ver, ok := isVersionInstalled(tool); !ok {
+			log.Debug("deps: tool wrong version", "name", tool.Name, "msg", ver)
+
 			result.WrongVersionTools = append(result.WrongVersionTools, tool)
 			result.WrongVersionMsgs = append(result.WrongVersionMsgs, ver)
+		} else {
+			log.Debug("deps: tool ok", "name", tool.Name)
 		}
 	}
 
 	if len(result.MissingMsgs) == 0 && len(result.WrongVersionMsgs) == 0 {
+		log.Debug("deps: all prerequisites satisfied")
+
 		if repoRoot, err := repo.FindRepoRoot(); err == nil {
 			err := state.UpdateAfterSuccessDepsCheck(repoRoot)
 			if err != nil {


### PR DESCRIPTION
# RATIONALE
Improve logging of the `dr dependencies` and `dr start` commands, specifically around dependencies.
<img width="830" height="175" alt="Screenshot 2026-05-21 at 15 52 47" src="https://github.com/user-attachments/assets/eda70a1a-fb6c-49fe-a7dd-cb71cbca0da6" />

<img width="812" height="276" alt="Screenshot 2026-05-21 at 15 51 58" src="https://github.com/user-attachments/assets/1e4e1234-846f-4693-a0b8-44c06969f1cd" />

<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds `log.Debug` instrumentation around prerequisite checking/installation and `dr start` dependency prompts, with only a small behavior change to log (not ignore) state update failures after installs.
> 
> **Overview**
> Adds richer **DEBUG-level observability** for `dr dependencies check`, `dr dependencies install`, and the `dr start` prerequisite flow (start/end events, counts of missing/wrong-version tools, auto-install vs prompt decisions, and user confirm/cancel actions).
> 
> Also instruments the installer and prerequisite checker to log per-tool outcomes and install command execution, and now surfaces failures from `state.UpdateAfterSuccessDepsCheck` as an error log instead of silently ignoring them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78029518745ac29a52d0727971537cdfd7a81a5b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->