### PR TITLE
[CFX-4622] Add warnings for invalid arg/subcommand

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -273,7 +273,7 @@ func setUnknownArgGuards(root *cobra.Command) {
 			return nil
 		}
 
-		return fmt.Errorf("unknown arg: %s", args[0])
+		return fmt.Errorf("unknown command: %s", args[0])
 	}
 
 	root.RunE = func(cmd *cobra.Command, _ []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -222,6 +222,10 @@ func init() {
 	// Discover and register plugin commands
 	plugin.RegisterPluginCommands(RootCmd.Command)
 
+	// Guard parent commands against unrecognised positional args.
+	// Must run after all commands (including plugins) are registered.
+	setUnknownArgGuards(RootCmd.Command)
+
 	// Override the default help command to add --all-commands flag
 	defaultHelpFunc := RootCmd.HelpFunc()
 
@@ -243,6 +247,38 @@ func init() {
 			defaultHelpFunc(cmd, args)
 		}
 	})
+}
+
+// setUnknownArgGuards walks the command tree and installs a RunE + Args validator
+// on every pure-parent command (has subcommands, no Run/RunE, no explicit Args set).
+//
+// Cobra checks !Runnable() before ValidateArgs, so a non-runnable parent silently
+// shows help for any arg. Making the command runnable lets Args fire first and
+// return a clear error; the RunE fallback shows help when no args are given.
+func setUnknownArgGuards(root *cobra.Command) {
+	for _, cmd := range root.Commands() {
+		setUnknownArgGuards(cmd)
+	}
+
+	if !root.HasSubCommands() {
+		return
+	}
+
+	if root.Args != nil || root.RunE != nil || root.Run != nil {
+		return
+	}
+
+	root.Args = func(_ *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return nil
+		}
+
+		return fmt.Errorf("unknown arg: %s", args[0])
+	}
+
+	root.RunE = func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	}
 }
 
 // initializeConfig initializes the configuration by reading from

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -94,6 +94,13 @@ func TestVersionFlag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// pflag does not reset flag values between Parse calls, so the
+			// version flag stays true after this test. Reset it so subsequent
+			// tests that execute the root command aren't affected.
+			t.Cleanup(func() {
+				_ = RootCmd.PersistentFlags().Set("version", "false")
+			})
+
 			cmd := RootCmd
 			buf := new(bytes.Buffer)
 			cmd.SetOut(buf)
@@ -187,10 +194,10 @@ func TestUnknownArgGuard(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:        "unknown arg on parent command errors",
+			name:        "unknown subcommand on parent command errors",
 			args:        []string{"self", "not-a-thing"},
 			wantErr:     true,
-			errContains: "unknown arg: not-a-thing",
+			errContains: "unknown command: not-a-thing",
 		},
 		{
 			name:    "parent command with no args shows help without error",
@@ -198,9 +205,10 @@ func TestUnknownArgGuard(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "unknown command error",
-			args:    []string{"seIf"},
-			wantErr: true,
+			name:        "unknown top-level command errors",
+			args:        []string{"not-a-command"},
+			wantErr:     true,
+			errContains: "unknown command: not-a-command",
 		},
 	}
 
@@ -243,7 +251,7 @@ func TestSetUnknownArgGuards_AppliesGuardToPureParent(t *testing.T) {
 	err := parent.Args(parent, []string{"bogus"})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown arg: bogus")
+	assert.Contains(t, err.Error(), "unknown command: bogus")
 	assert.NoError(t, parent.Args(parent, []string{}))
 }
 
@@ -264,6 +272,33 @@ func TestSetUnknownArgGuards_SkipsCommandWithRunE(t *testing.T) {
 	assert.Nil(t, parent.Args, "parent with RunE should not have Args guard installed")
 }
 
+// TestSetUnknownArgGuards_RootLevelUnknownCommand verifies that a root-like
+// command (pure parent, no RunE) rejects an unrecognised first arg with the
+// expected "unknown command" message.
+//
+// Uses a fresh, isolated command tree rather than the global RootCmd to avoid
+// state pollution from cobra's package-level finalizers slice, which accumulates
+// across Execute calls in other tests and can cause RootCmd to appear non-runnable
+// by the time this assertion runs in the full test suite.
+func TestSetUnknownArgGuards_RootLevelUnknownCommand(t *testing.T) {
+	child := &cobra.Command{
+		Use:  "child",
+		RunE: func(_ *cobra.Command, _ []string) error { return nil },
+	}
+	root := &cobra.Command{Use: "root"}
+
+	root.AddCommand(child)
+
+	setUnknownArgGuards(root)
+
+	require.NotNil(t, root.Args)
+
+	err := root.Args(root, []string{"not-a-command"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command: not-a-command")
+}
+
 func TestSetUnknownArgGuards_SkipsExplicitArgs(t *testing.T) {
 	child := &cobra.Command{
 		Use:  "child",
@@ -281,7 +316,7 @@ func TestSetUnknownArgGuards_SkipsExplicitArgs(t *testing.T) {
 	err := parent.Args(parent, []string{"x"})
 
 	require.Error(t, err)
-	assert.NotContains(t, err.Error(), "unknown arg:", "explicit Args validator should not be overridden")
+	assert.NotContains(t, err.Error(), "unknown command:", "explicit Args validator should not be overridden")
 }
 
 func TestWorkloadCommandNotPresentByDefault(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/tools"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -171,6 +172,116 @@ func TestTelemetryPropExtractor_OnErrorPath(t *testing.T) {
 	missingMsgs, _ := event.EventProperties["missing_deps"].([]string)
 	assert.NotEmpty(t, missingMsgs,
 		"PropExtractor must see missing_deps populated by RunE even on the error path")
+}
+
+func TestUnknownArgGuard(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "valid subcommand passes",
+			args:    []string{"self", "version"},
+			wantErr: false,
+		},
+		{
+			name:        "unknown arg on parent command errors",
+			args:        []string{"self", "not-a-thing"},
+			wantErr:     true,
+			errContains: "unknown arg: not-a-thing",
+		},
+		{
+			name:    "parent command with no args shows help without error",
+			args:    []string{"self"},
+			wantErr: false,
+		},
+		{
+			name:    "unknown command error",
+			args:    []string{"seIf"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := RootCmd
+
+			var buf bytes.Buffer
+
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSetUnknownArgGuards_AppliesGuardToPureParent(t *testing.T) {
+	child := &cobra.Command{
+		Use:  "child",
+		RunE: func(_ *cobra.Command, _ []string) error { return nil },
+	}
+	parent := &cobra.Command{Use: "parent"}
+
+	parent.AddCommand(child)
+
+	setUnknownArgGuards(parent)
+
+	require.NotNil(t, parent.Args, "pure parent command should have Args guard installed")
+	require.NotNil(t, parent.RunE, "pure parent command should have RunE installed")
+
+	err := parent.Args(parent, []string{"bogus"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown arg: bogus")
+	assert.NoError(t, parent.Args(parent, []string{}))
+}
+
+func TestSetUnknownArgGuards_SkipsCommandWithRunE(t *testing.T) {
+	child := &cobra.Command{
+		Use:  "child",
+		RunE: func(_ *cobra.Command, _ []string) error { return nil },
+	}
+	parent := &cobra.Command{
+		Use:  "parent",
+		RunE: func(_ *cobra.Command, _ []string) error { return nil },
+	}
+
+	parent.AddCommand(child)
+
+	setUnknownArgGuards(parent)
+
+	assert.Nil(t, parent.Args, "parent with RunE should not have Args guard installed")
+}
+
+func TestSetUnknownArgGuards_SkipsExplicitArgs(t *testing.T) {
+	child := &cobra.Command{
+		Use:  "child",
+		RunE: func(_ *cobra.Command, _ []string) error { return nil },
+	}
+	parent := &cobra.Command{
+		Use:  "parent",
+		Args: cobra.NoArgs,
+	}
+
+	parent.AddCommand(child)
+
+	setUnknownArgGuards(parent)
+
+	err := parent.Args(parent, []string{"x"})
+
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "unknown arg:", "explicit Args validator should not be overridden")
 }
 
 func TestWorkloadCommandNotPresentByDefault(t *testing.T) {


### PR DESCRIPTION
# RATIONALE
Add automatic warnings when user passes invalid CLI args

Added automatic warnings when the user attempts to invoke the CLI with an invalid arg. 
Cobra is already handling flags :
```
╰─ ❯ dr self --asdf asdfh
Error: unknown flag: --asdf
```

This PR imlpements arg/subcommand error handling :
```
╰─ ❯ dr self not-a-thing
Error: unknown arg: not-a-thing
```

<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to Cobra command initialization and only affects pure-parent commands without existing `Run`/`Args` handlers, with added tests to lock in behavior.
> 
> **Overview**
> **Improves CLI feedback for invalid invocations.** After all core and plugin commands are registered, the root command now installs an `Args` + `RunE` guard on *pure-parent* commands so `dr <parent> <unknown>` returns a clear `unknown arg: ...` error instead of silently falling back to help.
> 
> Adds unit tests covering the new guard behavior and ensuring commands with existing `RunE` or explicit `Args` validators are not modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc5ca6fd2d870cc41fc154f43bccc0a0fc0d2ae9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->