### PR TITLE
[CFX-6255]Add support detection for CLI-supported shells and tests

### DIFF
--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -81,23 +81,8 @@ func DetectShell() (string, error) {
 		}
 	}
 
-	// Shell-specific version variables are exported by the shell and inherited
-	// by every subprocess, including package-manager installers (brew → ruby).
-	// Check them before $SHELL because they reflect the active session shell
-	// rather than the login shell recorded in /etc/passwd.
-	if os.Getenv("ZSH_VERSION") != "" {
-		return string(Zsh), nil
-	}
-
-	if os.Getenv("BASH_VERSION") != "" {
-		return string(Bash), nil
-	}
-
-	if os.Getenv("FISH_VERSION") != "" {
-		return string(Fish), nil
-	}
-
-	// Try SHELL environment variable last (Unix/macOS login shell path).
+	// $SHELL is a real environment variable that is inherited by all
+	// subprocesses, including package-manager installers (brew → ruby → dr).
 	if shellPath := os.Getenv("SHELL"); shellPath != "" {
 		return normalizeShellName(filepath.Base(shellPath)), nil
 	}

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -59,13 +59,45 @@ func normalizeShellName(name string) string {
 	return name
 }
 
-func DetectShell() (string, error) {
-	// Prefer the parent process name — accurate even after `exec sh` or similar.
-	if name := parentProcessName(); name != "" {
-		return normalizeShellName(name), nil
+// isSupportedShell reports whether name is one of the shells the CLI supports
+// for completion installation. Only normalized names should be passed.
+func isSupportedShell(name string) bool {
+	for _, s := range SupportedShells() {
+		if name == s {
+			return true
+		}
 	}
 
-	// Try SHELL environment variable next (Unix/macOS).
+	return false
+}
+
+func DetectShell() (string, error) {
+	// Prefer the parent process name — accurate for normal interactive use.
+	// Only trust it when it resolves to a shell the CLI actually supports;
+	// non-shell parents (e.g. Homebrew's Ruby interpreter) must fall through.
+	if name := parentProcessName(); name != "" {
+		if normalized := normalizeShellName(name); isSupportedShell(normalized) {
+			return normalized, nil
+		}
+	}
+
+	// Shell-specific version variables are exported by the shell and inherited
+	// by every subprocess, including package-manager installers (brew → ruby).
+	// Check them before $SHELL because they reflect the active session shell
+	// rather than the login shell recorded in /etc/passwd.
+	if os.Getenv("ZSH_VERSION") != "" {
+		return string(Zsh), nil
+	}
+
+	if os.Getenv("BASH_VERSION") != "" {
+		return string(Bash), nil
+	}
+
+	if os.Getenv("FISH_VERSION") != "" {
+		return string(Fish), nil
+	}
+
+	// Try SHELL environment variable last (Unix/macOS login shell path).
 	if shellPath := os.Getenv("SHELL"); shellPath != "" {
 		return normalizeShellName(filepath.Base(shellPath)), nil
 	}

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/tui"
 )
 
@@ -84,6 +85,8 @@ func DetectShell() (string, error) {
 	// $SHELL is a real environment variable that is inherited by all
 	// subprocesses, including package-manager installers (brew → ruby → dr).
 	if shellPath := os.Getenv("SHELL"); shellPath != "" {
+		log.Debug("Parent process name did not match a supported shell; falling back to $SHELL", "SHELL", shellPath)
+
 		return normalizeShellName(filepath.Base(shellPath)), nil
 	}
 

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -116,6 +116,11 @@ func TestShellFromEnvPath(t *testing.T) {
 	}
 }
 
+// TestDetectShell_ShellVersionEnvVars intentionally omitted: ZSH_VERSION,
+// BASH_VERSION, and FISH_VERSION are shell-only parameters, not environment
+// variables — they are never inherited by subprocesses and cannot be used for
+// detection. The $SHELL env var is the correct fallback (see DetectShell).
+
 func TestIsSupportedShell(t *testing.T) {
 	tests := []struct {
 		name string
@@ -135,40 +140,6 @@ func TestIsSupportedShell(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, isSupportedShell(tt.name))
-		})
-	}
-}
-
-// TestDetectShell_ShellVersionEnvVars verifies that shell-specific version
-// variables ($ZSH_VERSION, $BASH_VERSION, $FISH_VERSION) are used when the
-// parent process is not a supported shell — the scenario that occurs when dr
-// is invoked by a package-manager installer such as Homebrew (parent = ruby).
-func TestDetectShell_ShellVersionEnvVars(t *testing.T) {
-	tests := []struct {
-		envKey string
-		want   string
-	}{
-		{envKey: "ZSH_VERSION", want: "zsh"},
-		{envKey: "BASH_VERSION", want: "bash"},
-		{envKey: "FISH_VERSION", want: "fish"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.envKey, func(t *testing.T) {
-			// Clear competing env vars so only the one under test is set.
-			t.Setenv("ZSH_VERSION", "")
-			t.Setenv("BASH_VERSION", "")
-			t.Setenv("FISH_VERSION", "")
-			t.Setenv("SHELL", "")
-			t.Setenv(tt.envKey, "5.0")
-
-			// parentProcessName() returns the test-runner process (e.g. "go",
-			// "task") which is not a supported shell, so detection must fall
-			// through to the version-env-var branch.
-			name, err := DetectShell()
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, name)
 		})
 	}
 }

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -116,6 +116,63 @@ func TestShellFromEnvPath(t *testing.T) {
 	}
 }
 
+func TestIsSupportedShell(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "bash", want: true},
+		{name: "zsh", want: true},
+		{name: "fish", want: true},
+		{name: "powershell", want: true},
+		{name: "ruby", want: false},
+		{name: "python", want: false},
+		{name: "sh", want: false},
+		{name: "node", want: false},
+		{name: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSupportedShell(tt.name))
+		})
+	}
+}
+
+// TestDetectShell_ShellVersionEnvVars verifies that shell-specific version
+// variables ($ZSH_VERSION, $BASH_VERSION, $FISH_VERSION) are used when the
+// parent process is not a supported shell — the scenario that occurs when dr
+// is invoked by a package-manager installer such as Homebrew (parent = ruby).
+func TestDetectShell_ShellVersionEnvVars(t *testing.T) {
+	tests := []struct {
+		envKey string
+		want   string
+	}{
+		{envKey: "ZSH_VERSION", want: "zsh"},
+		{envKey: "BASH_VERSION", want: "bash"},
+		{envKey: "FISH_VERSION", want: "fish"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.envKey, func(t *testing.T) {
+			// Clear competing env vars so only the one under test is set.
+			t.Setenv("ZSH_VERSION", "")
+			t.Setenv("BASH_VERSION", "")
+			t.Setenv("FISH_VERSION", "")
+			t.Setenv("SHELL", "")
+			t.Setenv(tt.envKey, "5.0")
+
+			// parentProcessName() returns the test-runner process (e.g. "go",
+			// "task") which is not a supported shell, so detection must fall
+			// through to the version-env-var branch.
+			name, err := DetectShell()
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, name)
+		})
+	}
+}
+
 // TestDetectShell_SHELLEnvFixtures calls DetectShell with SHELL set to a
 // variety of fixture values and verifies it always returns a usable, non-empty
 // name. Because parentProcessName() succeeds in the test runner the env-var


### PR DESCRIPTION
---

# RATIONALE

When `dr` is installed via Homebrew, the cask post-install hook runs inside Homebrew's Ruby interpreter. `DetectShell()` called `parentProcessName()` first, which ran `ps -p <ppid> -o comm=` and got back `ruby`. Since `ruby` passed through `normalizeShellName()` unchanged and returned with no error, the `$SHELL` fallback was never reached — causing `dr self completion install` to fail immediately with:

```
Error: Unsupported shell: ruby.
```

install.sh was unaffected because it reads `$SHELL` directly.

## CHANGES

**shell.go**
- Added `isSupportedShell(name string) bool` — checks a normalized name against `SupportedShells()` (`bash`, `zsh`, `fish`, `powershell`)
- `DetectShell()` now only returns the parent process name if `isSupportedShell()` passes; non-shell parents (ruby, python, node, etc.) fall through to the `$SHELL` fallback
- Updated comment on the `$SHELL` branch to clarify it is a real environment variable that IS inherited through the full subprocess chain (brew → ruby → `dr`)

**shell_test.go**
- Added `TestIsSupportedShell` — verifies supported shells return true, and non-shells (`ruby`, `sh`, `node`, `""`) return false
- Added a tombstone comment explaining why `ZSH_VERSION`/`BASH_VERSION`/`FISH_VERSION` were considered and rejected (they are shell-only parameters, not environment variables, and are never inherited by subprocesses)

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shell-detection behavior used for completion installation; mis-detection could affect install UX across environments (notably package-manager invocations), but scope is limited and covered by new tests.
> 
> **Overview**
> **Refines shell detection for completion install.** `DetectShell` now normalizes the parent process name and only accepts it if it’s one of the CLI’s supported shells, avoiding false positives when launched by non-shell parents (e.g. package managers).
> 
> Adds `isSupportedShell` plus tests to validate supported-shell filtering, and documents that shell-only version parameters (e.g. `ZSH_VERSION`) are intentionally not used since they aren’t inherited like `$SHELL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc2e72fd0dae8ac673cffca670d83b43ba646b15. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->