### PR TITLE
[CFX-6256] replace gofumpt with golangci-lint fmt

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,11 +10,11 @@ linters:
     - depguard
     - dupword
     - errname
-    # - errorlint
+    # - errorlint # disabled until we can resolve lints
     - exhaustive
-    # - godot
-    # - godox
-    # - gosec
+    # - godot # disabled until we can resolve lints
+    # - godox # disabled until we can resolve lints
+    # - gosec # disabled until we can resolve lints
     - loggercheck
     - misspell
     - nestif
@@ -26,7 +26,7 @@ linters:
     - testifylint
     - unconvert
     - usestdlibvars
-    # - wrapcheck
+    # - wrapcheck # disabled until we can resolve lints
     - wsl_v5
   settings:
     depguard:
@@ -85,6 +85,8 @@ linters:
       - builtin$
       - examples$
 formatters:
+  enable:
+    - gofumpt
   exclusions:
     generated: lax
     paths:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -93,4 +93,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
-      - ^\\.claude
+      - \.claude/.*

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -91,3 +91,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      - ^\\.claude

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -70,7 +70,7 @@ tasks:
       - echo "🧹 Checking go.mod…"
       - go mod tidy -diff
       - echo "🧹 Checking formatting…"
-      - "{{.BIN_DIR}}/gofumpt -l -d ."
+      - "{{.BIN_DIR}}/golangci-lint fmt --diff"
       - echo "🧹 Vetting…"
       - go vet ./...
       - echo "🧹 Linting…"
@@ -86,8 +86,7 @@ tasks:
       - echo "🧹 Cleaning go.mod…"
       - go mod tidy
       - echo "🧹 Formatting files…"
-      - go fmt ./...
-      - "{{.BIN_DIR}}/gofumpt -l -w ."
+      - "{{.BIN_DIR}}/golangci-lint fmt"
       - echo "🧹 Fixing lint issues…"
       - "{{.BIN_DIR}}/golangci-lint run --fix ./..."
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -33,11 +33,9 @@ tasks:
         echo "🚚 Downloading tools…"
         export GOBIN={{.BIN_DIR}}
 
-        go install mvdan.cc/gofumpt@latest
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b {{.BIN_DIR}} {{.GOLANGCI_LINT_VERSION}}
         go install github.com/goreleaser/goreleaser/v2@latest
     status:
-      - "{{.BIN_DIR}}/gofumpt --version"
       - "{{.BIN_DIR}}/golangci-lint --version"
       - "{{.BIN_DIR}}/goreleaser --version"
 
@@ -45,7 +43,6 @@ tasks:
     silent: true
     desc: "Uninstall static checkers & other binaries"
     cmds:
-      - "rm {{.BIN_DIR}}/gofumpt"
       - "rm {{.BIN_DIR}}/golangci-lint"
       - "rm {{.BIN_DIR}}/goreleaser"
 

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -356,9 +356,9 @@ Consider the following when building terminal user interfaces.
 All code must pass these tools without errors:
 
 - `go mod tidy`: Dependency management
-- `go fmt`: Basic formatting
 - `go vet`: Suspicious constructs
-- `golangci-lint`: Comprehensive linting (includes wsl, revive, staticcheck, etc.)
+- `golangci-lint run`: Comprehensive linting (includes wsl, revive, staticcheck, etc.)
+- `golangci-lint fmt`: Comprehensive formatting via gofumpt
 - `goreleaser check`: Release configuration validation
 
 **Before committing code, verify it follows [wsl](https://github.com/bombsimon/wsl?tab=readme-ov-file#wsl---whitespace-linter) (whitespace) rules.**
@@ -371,9 +371,10 @@ task lint
 
 # Individual checks
 go mod tidy
-go fmt ./...
 go vet ./...
+
 task install-tools  # Install golangci-lint
+./tmp/bin/golangci-lint fmt ./...
 ./tmp/bin/golangci-lint run ./...
 ./tmp/bin/goreleaser check
 ```

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -389,6 +389,7 @@ When upgrading the Go version in `go.mod`, you may need to update golangci-lint 
 4. Run `task lint` to verify all checks pass
 
 **Important**: golangci-lint is installed as a standalone pre-built binary (via the install script in `Taskfile.yaml`), not via `go install`. This means:
+
 - Version mismatches between your project's Go version and golangci-lint's internal Go version are handled automatically
 - The pre-built binary includes its own Go runtime, so it works with any project Go version
 - Always use `task install-tools` after updating the version variable


### PR DESCRIPTION
# RATIONALE
I kept seeing discrepancies between `task lint` in my clone of the repo, and `task lint` in CI.

Turns out that `task lint` -- specifically `gofumpt` is not that magical. It does not respect .gitignore; it only lints whatever paths are passed to it. By passing `.` it was running on the entire directory, and I've been using git worktrees so this was becoming a pain.

```log
─ ❯ task lint                                                                                                            
   🧹 Checking go.mod…                                                                                                      
   🧹 Checking formatting…                                                                                                  
   .claude/worktrees/frosty-kepler-01c387/internal/telemetry/properties.go                                                  
   diff .claude/worktrees/frosty-kepler-01c387/internal/telemetry/properties.go.orig                                        
   .claude/worktrees/frosty-kepler-01c387/internal/telemetry/properties.go                                                  
   --- .claude/worktrees/frosty-kepler-01c387/internal/telemetry/properties.go.orig                                         
   +++ .claude/worktrees/frosty-kepler-01c387/internal/telemetry/properties.go                                              
   @@ -40,16 +40,16 @@                                                                                                      
           DeviceID  string  // UUID v4, stable per installation, cached to disk                                            
           UserID    *string // DataRobot uid from GET /api/v2/account/info/, cached to disk; nil on network failure or auth
    issues                                                                                                                  
[snip]
```

Thankfully, we rely on golangci-lint, and that tool can automatically run `gofumpt` while filtering out irrelevant code via Go module loading. golangci-lint also already includes `gofumpt`, so we don't need to explicitly install it.

## CHANGES

- switch lint Tasks from calling `gofumpt` directly to calling `golangci-lint fmt`.
- configure `golangci-lint` to use only the `gofumpt` formatter ([there are others](https://golangci-lint.run/docs/formatters/configuration/), but none that are necessary right now)
- remove gofumpt as an explicit devtool dependency
- update dev-docs a bit
- add TODOs about other linters

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to developer tooling/configuration for formatting and linting, with no runtime code impact. Main risk is CI/local formatting behavior changes due to `golangci-lint fmt` and new formatter exclusions.
> 
> **Overview**
> Standardizes formatting checks/fixes on `golangci-lint fmt` (using the built-in `gofumpt` formatter) instead of invoking `gofumpt` directly, and drops `gofumpt` from the Taskfile tool install/uninstall flow.
> 
> Updates `.golangci.yaml` to enable `gofumpt` under `formatters`, add an exclusion for `^\\.claude`, and annotates several currently-disabled linters with TODO-style comments. Documentation is adjusted to reflect the new `task lint`/`task delint` and `golangci-lint fmt` workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97e8db4686c14b4ac62465e3e44bed5a0fb5c747. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->