### PR TITLE
[CFX-5936] - add unit tests for internal/log

### DIFF
--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charmbracelet/log"
+	"github.com/datarobot/cli/internal/config/viperx"
+	drlog "github.com/datarobot/cli/internal/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const debugLogFile = ".dr-tui-debug.log"
+
+// startLogger redirects HOME to a temp dir, calls Start(), and registers
+// Stop + viperx.Reset in cleanup so global state is restored after each test.
+func startLogger(t *testing.T) string {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+
+	t.Setenv("HOME", tmpDir)
+	t.Cleanup(func() {
+		drlog.Stop()
+		viperx.Reset()
+	})
+
+	drlog.Start()
+
+	return tmpDir
+}
+
+// TestStart verifies that Start() picks up the right log level and verbosity
+// for the debug, verbose, and default configurations, and that the log file
+// is always created.
+func TestStart(t *testing.T) {
+	cases := []struct {
+		name        string
+		debug       bool
+		verbose     bool
+		wantLevel   log.Level
+		wantVerbose bool
+	}{
+		{"debug", true, false, log.DebugLevel, true},
+		{"verbose", false, true, log.InfoLevel, true},
+		{"default", false, false, log.InfoLevel, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			viperx.Set("debug", tc.debug)
+			viperx.Set("verbose", tc.verbose)
+
+			tmpDir := startLogger(t)
+
+			assert.Equal(t, tc.wantLevel, drlog.GetLevel())
+			assert.Equal(t, tc.wantVerbose, drlog.IsVerbose())
+			assert.FileExists(t, filepath.Join(tmpDir, debugLogFile))
+		})
+	}
+}
+
+// TestLog_WritesToFile exercises every public logging function and confirms
+// their output reaches the log file. It also covers the stderrLogger == nil
+// branch in Log/Logf by calling StopStderr mid-test.
+func TestLog_WritesToFile(t *testing.T) {
+	viperx.Set("debug", true)
+
+	tmpDir := startLogger(t)
+
+	drlog.Debug("debug msg")
+	drlog.Debugf("debugf %s", "val")
+	drlog.Info("info msg")
+	drlog.Infof("infof %s", "val")
+	drlog.Warn("warn msg")
+	drlog.Warnf("warnf %s", "val")
+	drlog.Error("error msg")
+	drlog.Errorf("errorf %s", "val")
+	drlog.Print("print msg")
+	drlog.Printf("printf %s", "val")
+	drlog.Log(log.DebugLevel, "log msg", "k", "v")
+	drlog.Logf(log.DebugLevel, "logf %s", "val")
+
+	content, err := os.ReadFile(filepath.Join(tmpDir, debugLogFile))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "debug msg")
+	assert.Contains(t, string(content), "info msg")
+	assert.Contains(t, string(content), "warn msg")
+	assert.Contains(t, string(content), "error msg")
+	assert.Contains(t, string(content), "logf val")
+
+	// Cover the stderrLogger == nil branch in Log and Logf.
+	drlog.StopStderr()
+	drlog.Debug("after stderr stopped")
+	drlog.Logf(log.InfoLevel, "logf after stop")
+}

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/datarobot/cli/internal/config/viperx"
 	drlog "github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,8 +35,7 @@ func startLogger(t *testing.T) string {
 	t.Helper()
 
 	tmpDir := t.TempDir()
-
-	t.Setenv("HOME", tmpDir)
+	testutil.SetTestHomeDir(t, tmpDir)
 	t.Cleanup(func() {
 		drlog.Stop()
 		viperx.Reset()


### PR DESCRIPTION
# RATIONALE
expand unit tests coverage for internal/log from 0% to 86.4% of statements
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
`‎internal/log/logger_test.go` includes:
  - TestStart — verifies that Start() correctly sets log level and verbosity across three configurations (debug, verbose, default), and that the debug log file is always created in $HOME/.dr-tui-debug.log.
  - TestLog_WritesToFile — calls every public logging function (Debug, Info, Warn, Error, Print, Log, Logf, etc.) in debug mode and asserts their output appears in the log file. It also exercises the stderrLogger == nil branch by calling StopStderr() mid-test and confirming the remaining calls don't panic.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds tests only and does not modify runtime logging behavior; risk is limited to potential test flakiness due to filesystem/home-dir assumptions.
> 
> **Overview**
> Adds new unit tests for `internal/log` to validate `Start()` sets the expected log level/verbosity for `debug`/`verbose`/default configs and that the debug log file is created in `$HOME`.
> 
> Extends coverage by exercising all public logging helpers to ensure messages are written to the log file, and explicitly covers the `stderrLogger == nil` path by calling `StopStderr()` mid-test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1ef5375d3ebf8badf126fce7837bd12222fe47f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->