### PR TITLE
[CFX-6052] Add template name and ID fields to telemetry properties

### DIFF
--- a/cmd/templates/setup/model.go
+++ b/cmd/templates/setup/model.go
@@ -466,7 +466,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		}
 
 		// Update state for templates setup completion
-		_ = state.UpdateAfterTemplatesSetup(repoRoot)
+		_ = state.UpdateAfterTemplatesSetup(repoRoot, m.template.Name, m.template.ID)
 
 		return m, exit
 	case exitMsg:

--- a/cmd/templates/setup/model.go
+++ b/cmd/templates/setup/model.go
@@ -437,6 +437,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 	case templateInDirMsg:
 		m.screen = dotenvScreen
 		m.list.Template = msg.template
+		m.template = msg.template
 		m.dotenv.DotenvFile = msg.dotenvFile
 		m.dotenv.NeedsPulumiLogin, m.dotenv.PulumiAlreadyLoggedIn, m.dotenv.NeedsPulumiPassphrase = dotenv.CheckPulumiSetup(filepath.Dir(msg.dotenvFile), nil)
 		m.dotenvSetupCompleted = true

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -37,6 +37,10 @@ type state struct {
 	LastDotenvSetup *time.Time `yaml:"last_dotenv_setup,omitempty"`
 	// LastSuccessDepsCheck is an ISO8601-compliant timestamp of the last successful `dr dependencies check` or `dr dependencies install` run
 	LastSuccessDepsCheck *time.Time `yaml:"last_success_deps_check,omitempty"`
+	// TemplateName is the name of the DataRobot template used to create this project
+	TemplateName string `yaml:"template_name,omitempty"`
+	// TemplateID is the stable identifier of the DataRobot template used to create this project
+	TemplateID string `yaml:"template_id,omitempty"`
 }
 
 // getStatePath determines the appropriate location for the state file.
@@ -133,7 +137,7 @@ func UpdateAfterDotenvSetup(repoRoot string) error {
 }
 
 // UpdateAfterTemplatesSetup updates the state file after a successful `dr templates setup` run.
-func UpdateAfterTemplatesSetup(repoRoot string) error {
+func UpdateAfterTemplatesSetup(repoRoot, templateName, templateID string) error {
 	// Load existing state to preserve other fields
 	existingState, err := load(repoRoot)
 	if err != nil {
@@ -142,8 +146,32 @@ func UpdateAfterTemplatesSetup(repoRoot string) error {
 
 	now := time.Now().UTC()
 	existingState.LastTemplatesSetup = &now
+	existingState.TemplateName = templateName
+	existingState.TemplateID = templateID
 
 	return existingState.update()
+}
+
+// GetTemplateName returns the template name stored in the project state file.
+// Returns an empty string if no state file exists or no template name was recorded.
+func GetTemplateName(repoRoot string) string {
+	existingState, err := load(repoRoot)
+	if err != nil {
+		return ""
+	}
+
+	return existingState.TemplateName
+}
+
+// GetTemplateInfo returns the template name and ID stored in the project state file.
+// Returns empty strings if no state file exists or no template info was recorded.
+func GetTemplateInfo(repoRoot string) (name, id string) {
+	existingState, err := load(repoRoot)
+	if err != nil {
+		return "", ""
+	}
+
+	return existingState.TemplateName, existingState.TemplateID
 }
 
 // UpdateAfterSuccessDepsCheck updates the state file after a successful `dr dependencies check` or `dr dependencies install` run.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -152,17 +152,6 @@ func UpdateAfterTemplatesSetup(repoRoot, templateName, templateID string) error 
 	return existingState.update()
 }
 
-// GetTemplateName returns the template name stored in the project state file.
-// Returns an empty string if no state file exists or no template name was recorded.
-func GetTemplateName(repoRoot string) string {
-	existingState, err := load(repoRoot)
-	if err != nil {
-		return ""
-	}
-
-	return existingState.TemplateName
-}
-
 // GetTemplateInfo returns the template name and ID stored in the project state file.
 // Returns empty strings if no state file exists or no template info was recorded.
 func GetTemplateInfo(repoRoot string) (name, id string) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/version"
 	"gopkg.in/yaml.v3"
 )
@@ -157,6 +158,8 @@ func UpdateAfterTemplatesSetup(repoRoot, templateName, templateID string) error 
 func GetTemplateInfo(repoRoot string) (name, id string) {
 	existingState, err := load(repoRoot)
 	if err != nil {
+		log.Debugf("Failed to load state for template info: %v", err)
+
 		return "", ""
 	}
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -339,4 +339,20 @@ func TestGetTemplateInfo(t *testing.T) {
 		assert.Empty(t, name)
 		assert.Empty(t, id)
 	})
+
+	t.Run("returns empty strings when state file is malformed", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		statePath := filepath.Join(tmpDir, ".datarobot", "cli", "state.yaml")
+
+		err := os.MkdirAll(filepath.Dir(statePath), 0o755)
+		require.NoError(t, err)
+
+		err = os.WriteFile(statePath, []byte("template_name: [invalid"), 0o644)
+		require.NoError(t, err)
+
+		name, id := GetTemplateInfo(tmpDir)
+
+		assert.Empty(t, name)
+		assert.Empty(t, id)
+	})
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -248,3 +248,118 @@ func TestUpdateAfterSuccessDepsCheck_PreservesOtherFields(t *testing.T) {
 	require.NotNil(t, stateAfter.LastStart)
 	assert.Equal(t, stateBefore.LastStart.Unix(), stateAfter.LastStart.Unix())
 }
+
+func TestUpdateAfterTemplatesSetup(t *testing.T) {
+	t.Run("saves template name, ID and timestamp", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
+		err := os.MkdirAll(localStateDir, 0o755)
+		require.NoError(t, err)
+
+		beforeUpdate := time.Now().UTC()
+
+		err = UpdateAfterTemplatesSetup(tmpDir, "my-awesome-template", "tmpl-abc123")
+		require.NoError(t, err)
+
+		afterUpdate := time.Now().UTC()
+
+		loadedState, err := load(tmpDir)
+		require.NoError(t, err)
+
+		assert.Equal(t, "my-awesome-template", loadedState.TemplateName)
+		assert.Equal(t, "tmpl-abc123", loadedState.TemplateID)
+		assert.NotEmpty(t, loadedState.CLIVersion)
+		require.NotNil(t, loadedState.LastTemplatesSetup)
+		assert.True(t, loadedState.LastTemplatesSetup.After(beforeUpdate) || loadedState.LastTemplatesSetup.Equal(beforeUpdate))
+		assert.True(t, loadedState.LastTemplatesSetup.Before(afterUpdate) || loadedState.LastTemplatesSetup.Equal(afterUpdate))
+	})
+
+	t.Run("preserves other fields when updating", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
+		err := os.MkdirAll(localStateDir, 0o755)
+		require.NoError(t, err)
+
+		err = UpdateAfterSuccessfulRun(tmpDir)
+		require.NoError(t, err)
+
+		stateBefore, err := load(tmpDir)
+		require.NoError(t, err)
+		require.NotNil(t, stateBefore.LastStart)
+
+		err = UpdateAfterTemplatesSetup(tmpDir, "preserved-template", "tmpl-xyz999")
+		require.NoError(t, err)
+
+		stateAfter, err := load(tmpDir)
+		require.NoError(t, err)
+
+		assert.Equal(t, "preserved-template", stateAfter.TemplateName)
+		assert.Equal(t, "tmpl-xyz999", stateAfter.TemplateID)
+		require.NotNil(t, stateAfter.LastStart)
+		assert.Equal(t, stateBefore.LastStart.Unix(), stateAfter.LastStart.Unix())
+	})
+}
+
+func TestGetTemplateName(t *testing.T) {
+	t.Run("returns template name when state exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
+		err := os.MkdirAll(localStateDir, 0o755)
+		require.NoError(t, err)
+
+		err = UpdateAfterTemplatesSetup(tmpDir, "cool-template", "tmpl-cool1")
+		require.NoError(t, err)
+
+		name := GetTemplateName(tmpDir)
+
+		assert.Equal(t, "cool-template", name)
+	})
+
+	t.Run("returns empty string when no state file exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		name := GetTemplateName(tmpDir)
+
+		assert.Empty(t, name)
+	})
+
+	t.Run("returns empty string when template name not set", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
+		err := os.MkdirAll(localStateDir, 0o755)
+		require.NoError(t, err)
+
+		err = UpdateAfterSuccessfulRun(tmpDir)
+		require.NoError(t, err)
+
+		name := GetTemplateName(tmpDir)
+
+		assert.Empty(t, name)
+	})
+}
+
+func TestGetTemplateInfo(t *testing.T) {
+	t.Run("returns both name and ID when state exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
+		err := os.MkdirAll(localStateDir, 0o755)
+		require.NoError(t, err)
+
+		err = UpdateAfterTemplatesSetup(tmpDir, "my-template", "tmpl-id-001")
+		require.NoError(t, err)
+
+		name, id := GetTemplateInfo(tmpDir)
+
+		assert.Equal(t, "my-template", name)
+		assert.Equal(t, "tmpl-id-001", id)
+	})
+
+	t.Run("returns empty strings when no state file exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		name, id := GetTemplateInfo(tmpDir)
+
+		assert.Empty(t, name)
+		assert.Empty(t, id)
+	})
+}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -300,44 +300,6 @@ func TestUpdateAfterTemplatesSetup(t *testing.T) {
 	})
 }
 
-func TestGetTemplateName(t *testing.T) {
-	t.Run("returns template name when state exists", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
-		err := os.MkdirAll(localStateDir, 0o755)
-		require.NoError(t, err)
-
-		err = UpdateAfterTemplatesSetup(tmpDir, "cool-template", "tmpl-cool1")
-		require.NoError(t, err)
-
-		name := GetTemplateName(tmpDir)
-
-		assert.Equal(t, "cool-template", name)
-	})
-
-	t.Run("returns empty string when no state file exists", func(t *testing.T) {
-		tmpDir := t.TempDir()
-
-		name := GetTemplateName(tmpDir)
-
-		assert.Empty(t, name)
-	})
-
-	t.Run("returns empty string when template name not set", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
-		err := os.MkdirAll(localStateDir, 0o755)
-		require.NoError(t, err)
-
-		err = UpdateAfterSuccessfulRun(tmpDir)
-		require.NoError(t, err)
-
-		name := GetTemplateName(tmpDir)
-
-		assert.Empty(t, name)
-	})
-}
-
 func TestGetTemplateInfo(t *testing.T) {
 	t.Run("returns both name and ID when state exists", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -356,6 +318,21 @@ func TestGetTemplateInfo(t *testing.T) {
 
 	t.Run("returns empty strings when no state file exists", func(t *testing.T) {
 		tmpDir := t.TempDir()
+
+		name, id := GetTemplateInfo(tmpDir)
+
+		assert.Empty(t, name)
+		assert.Empty(t, id)
+	})
+
+	t.Run("returns empty strings when template info not set", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		localStateDir := filepath.Join(tmpDir, ".datarobot", "cli")
+		err := os.MkdirAll(localStateDir, 0o755)
+		require.NoError(t, err)
+
+		err = UpdateAfterSuccessfulRun(tmpDir)
+		require.NoError(t, err)
 
 		name, id := GetTemplateInfo(tmpDir)
 

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -22,7 +22,9 @@ import (
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/internal/shell"
+	"github.com/datarobot/cli/internal/state"
 	"github.com/datarobot/cli/internal/version"
 )
 
@@ -52,6 +54,8 @@ type CommonProperties struct {
 	CommandKind       string  // "core" or "plugin", set by the root command after dispatch
 	OrganizationID    *string // DataRobot org ID from GET /api/v2/account/info/, cached to disk; nil on network failure or auth issues
 	TenantID          *string // DataRobot tenant ID from GET /api/v2/account/info/, cached to disk; nil if unavailable (legit absent for legacy/system accounts)
+	TemplateName      *string // Name of the DataRobot template used to create this project; nil when not inside a template project
+	TemplateID        *string // Stable ID of the DataRobot template used to create this project; nil when not inside a template project
 }
 
 // DetectShell returns the name of the shell the CLI is running from.
@@ -102,6 +106,20 @@ func CollectCommonProperties() *CommonProperties {
 		}
 	}
 
+	// Read template info from project state if running inside a template project
+	repoRoot, err := repo.FindRepoRoot()
+	if err == nil {
+		name, id := state.GetTemplateInfo(repoRoot)
+
+		if name != "" {
+			props.TemplateName = &name
+		}
+
+		if id != "" {
+			props.TemplateID = &id
+		}
+	}
+
 	return props
 }
 
@@ -124,6 +142,14 @@ func (p *CommonProperties) AsMap() map[string]any {
 
 	if p.TenantID != nil {
 		m["tenant_id"] = *p.TenantID
+	}
+
+	if p.TemplateName != nil {
+		m["template_name"] = *p.TemplateName
+	}
+
+	if p.TemplateID != nil {
+		m["template_id"] = *p.TemplateID
 	}
 
 	return m

--- a/internal/telemetry/properties_test.go
+++ b/internal/telemetry/properties_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -80,6 +81,29 @@ func TestCommonPropertiesAsMap(t *testing.T) {
 	// session_id, user_id, and device_id are top-level Amplitude fields, not event properties
 	assert.NotContains(t, m, "session_id")
 	assert.NotContains(t, m, "user_id")
+	// template_name is absent when not set
+	assert.NotContains(t, m, "template_name")
+}
+
+func TestCommonPropertiesAsMap_IncludesTemplateName(t *testing.T) {
+	props := &CommonProperties{
+		TemplateName: ptrString("my-template"),
+		TemplateID:   ptrString("tmpl-abc123"),
+	}
+
+	m := props.AsMap()
+
+	assert.Equal(t, "my-template", m["template_name"])
+	assert.Equal(t, "tmpl-abc123", m["template_id"])
+}
+
+func TestCommonPropertiesAsMap_OmitsTemplateNameWhenNil(t *testing.T) {
+	props := &CommonProperties{}
+
+	m := props.AsMap()
+
+	assert.NotContains(t, m, "template_name")
+	assert.NotContains(t, m, "template_id")
 }
 
 func TestGetOrCreateDeviceID_CreatesAndPersists(t *testing.T) {
@@ -323,4 +347,71 @@ func TestDetectShell_ReturnsNonEmpty(t *testing.T) {
 
 	assert.NotEmpty(t, shell)
 	assert.NotEqual(t, "unknown", shell)
+}
+
+func TestCollectCommonProperties_TemplateNameFromState(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Resolve symlinks (important for macOS where /var -> /private/var)
+	tmpDir, err := filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, err)
+
+	// Create .datarobot/answers to satisfy repo detection
+	answersDir := filepath.Join(tmpDir, ".datarobot", "answers")
+	err = os.MkdirAll(answersDir, 0o755)
+	require.NoError(t, err)
+
+	// Write state with template name and ID
+	err = state.UpdateAfterTemplatesSetup(tmpDir, "telemetry-test-template", "tmpl-tst-001")
+	require.NoError(t, err)
+
+	// Change to temp dir so FindRepoRoot() finds it
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, os.Chdir(originalWd))
+	}()
+
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
+
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	props := CollectCommonProperties()
+
+	require.NotNil(t, props.TemplateName)
+	assert.Equal(t, "telemetry-test-template", *props.TemplateName)
+	require.NotNil(t, props.TemplateID)
+	assert.Equal(t, "tmpl-tst-001", *props.TemplateID)
+
+	m := props.AsMap()
+
+	assert.Equal(t, "telemetry-test-template", m["template_name"])
+	assert.Equal(t, "tmpl-tst-001", m["template_id"])
+}
+
+func TestCollectCommonProperties_TemplateNameNilOutsideProject(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// No .datarobot directory — not a template project
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+
+	defer func() {
+		require.NoError(t, os.Chdir(originalWd))
+	}()
+
+	err = os.Chdir(tmpDir)
+	require.NoError(t, err)
+
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	props := CollectCommonProperties()
+
+	assert.Nil(t, props.TemplateName)
+
+	m := props.AsMap()
+
+	assert.NotContains(t, m, "template_name")
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -235,3 +235,50 @@ func TestAmplitudeLogger_DoesNotPanic(t *testing.T) {
 	logger.Warnf("test %s", "message")
 	logger.Errorf("test %s", "message")
 }
+
+func TestTrack_TemplateFieldsInEventProperties(t *testing.T) {
+	originalAPIKey := AmplitudeAPIKey
+
+	defer func() { AmplitudeAPIKey = originalAPIKey }()
+
+	AmplitudeAPIKey = ""
+
+	props := &CommonProperties{
+		TemplateName: ptrString("my-template"),
+		TemplateID:   ptrString("tmpl-abc123"),
+	}
+
+	client := NewClient(props)
+
+	var captured types.Event
+
+	// Intercept the event by inspecting EventProperties after Track merges them.
+	// Since amp is nil (dev mode), Track only logs — we validate via AsMap directly.
+	eventProps := client.props.AsMap()
+
+	// Simulate Track merge: common props are the base, event-specific props override.
+	captured.EventProperties = eventProps
+
+	assert.Equal(t, "my-template", captured.EventProperties["template_name"])
+	assert.Equal(t, "tmpl-abc123", captured.EventProperties["template_id"])
+}
+
+func TestTrack_TemplateFieldsAbsentWhenNotInProject(t *testing.T) {
+	originalAPIKey := AmplitudeAPIKey
+
+	defer func() { AmplitudeAPIKey = originalAPIKey }()
+
+	AmplitudeAPIKey = ""
+
+	props := &CommonProperties{
+		CLIVersion: "v1.0.0",
+		// TemplateName and TemplateID intentionally nil
+	}
+
+	client := NewClient(props)
+
+	eventProps := client.props.AsMap()
+
+	assert.NotContains(t, eventProps, "template_name")
+	assert.NotContains(t, eventProps, "template_id")
+}


### PR DESCRIPTION
Enhance telemetry properties by including template name and ID fields, allowing better tracking of projects created from templates. Update state management to store this information and ensure tests validate the new functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the persisted project `state.yaml` schema and threads new fields into telemetry generation, which could affect analytics consistency and state upgrade behavior.
> 
> **Overview**
> Adds template provenance to telemetry by **persisting template `name`/`id` in project state** after `dr templates setup`, and then **reading that state at startup** to populate new `template_name`/`template_id` common event properties.
> 
> Updates the templates setup flow to pass the selected template into `state.UpdateAfterTemplatesSetup`, extends `internal/state` with the new fields plus `GetTemplateInfo`, and expands unit tests to cover state persistence and telemetry property inclusion/omission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e4f42c30066b199ae5a4185e60ecf49f1176097. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->