### PR TITLE
[CFX-6220] add loading spinners to blocking CLI commands

### DIFF
--- a/cmd/auth/login/cmd.go
+++ b/cmd/auth/login/cmd.go
@@ -79,6 +79,8 @@ func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop
 
 	var key string
 
+	auth.PrintAuthInstructions(auth.AuthCallbackURL(datarobotHost))
+
 	err = tui.RunWithSpinner("Waiting for browser authorization…", func() error {
 		var waitErr error
 

--- a/cmd/auth/login/cmd.go
+++ b/cmd/auth/login/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -76,7 +77,15 @@ func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop
 	// Clear existing token and get new one
 	viperx.Set(config.DataRobotAPIKey, "")
 
-	key, err := auth.WaitForAPIKeyCallback(cmd.Context(), datarobotHost)
+	var key string
+
+	err = tui.RunWithSpinner("Waiting for browser authorization…", func() error {
+		var waitErr error
+
+		key, waitErr = auth.WaitForAPIKeyCallback(cmd.Context(), datarobotHost)
+
+		return waitErr
+	})
 	if err != nil {
 		log.Error(err)
 

--- a/cmd/component/shared/addModel.go
+++ b/cmd/component/shared/addModel.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/datarobot/cli/internal/copier"
@@ -46,6 +47,7 @@ const (
 type AddModel struct {
 	screen   addScreens
 	list     list.Model
+	spinner  spinner.Model
 	width    int
 	height   int
 	errorMsg string
@@ -53,8 +55,13 @@ type AddModel struct {
 }
 
 func NewAddModel() AddModel {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = tui.InfoStyle
+
 	return AddModel{
-		screen: addLoadingScreen,
+		screen:  addLoadingScreen,
+		spinner: s,
 	}
 }
 
@@ -149,7 +156,7 @@ func (am AddModel) loadComponents() tea.Cmd {
 }
 
 func (am AddModel) Init() tea.Cmd {
-	return tea.Batch(am.loadComponents(), tea.WindowSize())
+	return tea.Batch(am.loadComponents(), am.spinner.Tick, tea.WindowSize())
 }
 
 func (am AddModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
@@ -158,6 +165,14 @@ func (am AddModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		if msg.MsgID == errMsgID {
 			am.errorMsg = ""
 			return am, nil
+		}
+	case spinner.TickMsg:
+		if am.screen == addLoadingScreen {
+			var cmd tea.Cmd
+
+			am.spinner, cmd = am.spinner.Update(msg)
+
+			return am, cmd
 		}
 	case tea.WindowSizeMsg:
 		am.width = msg.Width
@@ -230,7 +245,7 @@ func (am AddModel) View() string {
 func (am AddModel) addLoadingScreenView() string {
 	var sb strings.Builder
 
-	sb.WriteString("Loading components...")
+	sb.WriteString(tui.InfoStyle.Render(am.spinner.View()+" ") + "Loading components…")
 
 	return sb.String()
 }

--- a/cmd/component/shared/updateModel.go
+++ b/cmd/component/shared/updateModel.go
@@ -22,6 +22,7 @@ import (
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -107,6 +108,7 @@ type UpdateModel struct {
 	viewport    viewport.Model
 	help        help.Model
 	keys        detailKeyMap
+	spinner     spinner.Model
 	ready       bool
 	ExitMessage string
 	updateFlags copier.UpdateFlags
@@ -193,16 +195,21 @@ func NewUpdateComponentModel(updateFlags copier.UpdateFlags) UpdateModel {
 	h.Styles.ShortKey = lipgloss.NewStyle().Foreground(tui.DrPurple)
 	h.Styles.ShortDesc = lipgloss.NewStyle().Foreground(tui.DimStyle.GetForeground())
 
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = tui.InfoStyle
+
 	return UpdateModel{
 		screen:      listScreen,
 		help:        h,
 		keys:        newDetailKeys(),
 		updateFlags: updateFlags,
+		spinner:     s,
 	}
 }
 
 func (m UpdateModel) Init() tea.Cmd {
-	return tea.Batch(m.loadComponents(), tea.WindowSize())
+	return tea.Batch(m.loadComponents(), m.spinner.Tick, tea.WindowSize())
 }
 
 func (m UpdateModel) loadComponents() tea.Cmd {
@@ -243,6 +250,14 @@ func (m UpdateModel) showComponentInfo() tea.Cmd {
 
 func (m UpdateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop
 	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		if len(m.list.Items()) == 0 {
+			var cmd tea.Cmd
+
+			m.spinner, cmd = m.spinner.Update(msg)
+
+			return m, cmd
+		}
 	case componentsLoadedMsg:
 		m.list = msg.list
 
@@ -415,6 +430,13 @@ func (m UpdateModel) viewListScreen() string {
 		sb.WriteString("\n")
 		sb.WriteString(tui.DimStyle.Render("Press any key to exit"))
 		sb.WriteString("\n")
+
+		return sb.String()
+	}
+
+	// Show spinner while components are loading
+	if len(m.list.Items()) == 0 {
+		sb.WriteString(tui.InfoStyle.Render(m.spinner.View()+" ") + "Loading components…")
 
 		return sb.String()
 	}

--- a/cmd/component/shared/updateModel.go
+++ b/cmd/component/shared/updateModel.go
@@ -105,10 +105,12 @@ type UpdateModel struct {
 	infoMessage string
 	screen      screens
 	list        list.Model // This list holds the components
+	width       int
 	viewport    viewport.Model
 	help        help.Model
 	keys        detailKeyMap
 	spinner     spinner.Model
+	updating    bool
 	ready       bool
 	ExitMessage string
 	updateFlags copier.UpdateFlags
@@ -161,6 +163,8 @@ func (m UpdateModel) unselectComponent(itemToUnselect ListItem, err error) (Upda
 	}
 
 	if count <= 1 {
+		m.updating = false
+
 		return m, tea.Quit
 	}
 
@@ -250,8 +254,11 @@ func (m UpdateModel) showComponentInfo() tea.Cmd {
 
 func (m UpdateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop
 	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+
 	case spinner.TickMsg:
-		if len(m.list.Items()) == 0 {
+		if len(m.list.Items()) == 0 || m.updating {
 			var cmd tea.Cmd
 
 			m.spinner, cmd = m.spinner.Update(msg)
@@ -268,11 +275,33 @@ func (m UpdateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop
 
 		return m, tea.WindowSize()
 	case updateCompleteMsg:
+		if msg.err != nil {
+			m.infoMessage = "Failed to update " + msg.item.component.ComponentDetails.Name
+		} else {
+			m.infoMessage = "Updated " + msg.item.component.ComponentDetails.Name
+		}
+
 		return m.unselectComponent(msg.item, msg.err)
 	}
 
 	switch m.screen {
 	case listScreen:
+		if m.updating {
+			switch msg := msg.(type) {
+			case tea.WindowSizeMsg:
+				if len(m.list.Items()) > 0 {
+					newListModel, cmd := m.list.Update(msg)
+					m.list = newListModel
+
+					return m, cmd
+				}
+
+				return m, nil
+			}
+
+			return m, nil
+		}
+
 		// IMPT: Since we're using a custom item & respective delegate
 		// we need to account for filtering here and allow list to handle updating
 		if m.list.FilterState() == list.Filtering {
@@ -331,9 +360,12 @@ func (m UpdateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop
 						cmdsToRun = append(cmdsToRun, updateComponent(listItem, m.updateFlags))
 					}
 
+					m.updating = true
+					m.infoMessage = "Updating selected components..."
+
 					cmd := tea.Sequence(cmdsToRun...)
 
-					return m, cmd
+					return m, tea.Batch(m.spinner.Tick, cmd)
 				}
 			default:
 				// If we have an error allow any keypress to exit screen/quit
@@ -437,6 +469,14 @@ func (m UpdateModel) viewListScreen() string {
 	// Show spinner while components are loading
 	if len(m.list.Items()) == 0 {
 		sb.WriteString(tui.InfoStyle.Render(m.spinner.View()+" ") + "Loading components…")
+
+		return sb.String()
+	}
+
+	if m.updating {
+		sb.WriteString(tui.WelcomeStyle.Render("Available Components for Recipe Agent Template:"))
+		sb.WriteString("\n\n")
+		sb.WriteString(tui.RenderStatusBar(m.width, m.spinner, "Updating selected components...", true))
 
 		return sb.String()
 	}

--- a/cmd/dotenv/promptModel.go
+++ b/cmd/dotenv/promptModel.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -39,6 +40,8 @@ type promptModel struct {
 	list       list.Model
 	Values     []string
 	successCmd tea.Cmd
+	loading    bool
+	spinner    spinner.Model
 }
 
 var (
@@ -56,7 +59,13 @@ const (
 	errMsgTimeout        = "⏳ Request timed out. Please check your network connection and try again."
 	errMsgNoLLMs         = "🤷 No available LLMs found. Please contact support for assistance."
 	errMsgContactSupport = "👥 Please try again or contact support if the issue persists."
+	loadingLLMsMsg       = "Fetching available LLMs from DataRobot..."
 )
+
+type llmCatalogLoadedMsg struct {
+	llms *drapi.LLMList
+	err  error
+}
 
 type item envbuilder.PromptOption
 
@@ -105,7 +114,7 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 
 func newPromptModel(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptModel, tea.Cmd) {
 	if prompt.Type == "llmgw_catalog" {
-		return newLLMListPrompt(prompt, successCmd)
+		return newLLMListPromptAsync(prompt, successCmd)
 	}
 
 	if len(prompt.Options) == 0 {
@@ -113,6 +122,29 @@ func newPromptModel(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptMod
 	}
 
 	return newListPrompt(prompt, successCmd)
+}
+
+func newLLMListPromptAsync(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptModel, tea.Cmd) {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = tui.InfoStyle
+
+	pm := promptModel{
+		prompt:     prompt,
+		successCmd: successCmd,
+		loading:    true,
+		spinner:    s,
+	}
+
+	return pm, tea.Batch(pm.spinner.Tick, loadLLMCatalogCmd())
+}
+
+func loadLLMCatalogCmd() tea.Cmd {
+	return func() tea.Msg {
+		llms, err := drapi.GetLLMs()
+
+		return llmCatalogLoadedMsg{llms: llms, err: err}
+	}
 }
 
 func newTextInputPrompt(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptModel, tea.Cmd) {
@@ -193,39 +225,55 @@ func llmsToPromptOptions(llms []drapi.LLM) []envbuilder.PromptOption {
 func newLLMListPrompt(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptModel, tea.Cmd) {
 	llms, err := drapi.GetLLMs()
 	if err != nil {
-		log.Errorf("Error retrieving LLMs: %s", err.Error())
+		return llmErrorPrompt(prompt, successCmd, err), nil
+	}
 
-		var (
-			netErr     net.Error
-			httpErr    *drapi.HTTPError
-			statusCode int
-		)
+	return llmListPromptFromCatalog(prompt, successCmd, llms)
+}
 
-		helpMsg := errMsgPrefix
+func llmErrorPrompt(prompt envbuilder.UserPrompt, successCmd tea.Cmd, err error) promptModel {
+	log.Errorf("Error retrieving LLMs: %s", err.Error())
 
-		// Check if the error is a network timeout or an HTTP error to provide more specific feedback
-		// Treat net.Error.Timeout() as an HTTP 408 Request Timeout for user-friendly messaging
-		if errors.As(err, &netErr) && netErr.Timeout() {
-			statusCode = http.StatusRequestTimeout
-		} else if errors.As(err, &httpErr) {
-			statusCode = httpErr.StatusCode
-		}
+	var (
+		netErr     net.Error
+		httpErr    *drapi.HTTPError
+		statusCode int
+	)
 
-		switch statusCode {
-		case http.StatusUnauthorized, http.StatusForbidden:
-			helpMsg += errMsgAuthFailed
-		case http.StatusNotFound:
-			helpMsg += errMsgNotFound
-		case http.StatusRequestTimeout, http.StatusGatewayTimeout:
-			helpMsg += errMsgTimeout
-		default:
-			helpMsg += err.Error() + "\n\n" + errMsgContactSupport
-		}
+	helpMsg := errMsgPrefix
 
+	// Check if the error is a network timeout or an HTTP error to provide more specific feedback
+	// Treat net.Error.Timeout() as an HTTP 408 Request Timeout for user-friendly messaging
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		statusCode = http.StatusRequestTimeout
+	} else if errors.As(err, &httpErr) {
+		statusCode = httpErr.StatusCode
+	}
+
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		helpMsg += errMsgAuthFailed
+	case http.StatusNotFound:
+		helpMsg += errMsgNotFound
+	case http.StatusRequestTimeout, http.StatusGatewayTimeout:
+		helpMsg += errMsgTimeout
+	default:
+		helpMsg += err.Error() + "\n\n" + errMsgContactSupport
+	}
+
+	errPrompt := prompt
+	errPrompt.Type = typeError
+	errPrompt.Help = helpMsg
+
+	return promptModel{prompt: errPrompt, successCmd: successCmd}
+}
+
+
+func llmListPromptFromCatalog(prompt envbuilder.UserPrompt, successCmd tea.Cmd, llms *drapi.LLMList) (promptModel, tea.Cmd) {
+	if llms == nil {
 		errPrompt := prompt
 		errPrompt.Type = typeError
-
-		errPrompt.Help = helpMsg
+		errPrompt.Help = errMsgPrefix + errMsgContactSupport
 
 		return promptModel{prompt: errPrompt, successCmd: successCmd}, nil
 	}
@@ -273,6 +321,31 @@ func (pm promptModel) GetValues() []string {
 }
 
 func (pm promptModel) Update(msg tea.Msg) (promptModel, tea.Cmd) {
+	if pm.loading {
+		switch msg := msg.(type) {
+		case llmCatalogLoadedMsg:
+			if msg.err != nil {
+				errorPrompt := llmErrorPrompt(pm.prompt, pm.successCmd, msg.err)
+				errorPrompt.loading = false
+
+				return errorPrompt, nil
+			}
+
+			nextPrompt, cmd := llmListPromptFromCatalog(pm.prompt, pm.successCmd, msg.llms)
+			nextPrompt.loading = false
+
+			return nextPrompt, cmd
+		case spinner.TickMsg:
+			var cmd tea.Cmd
+
+			pm.spinner, cmd = pm.spinner.Update(msg)
+
+			return pm, cmd
+		}
+
+		return pm, nil
+	}
+
 	if len(pm.prompt.Options) > 0 {
 		switch msg := msg.(type) {
 		case tea.KeyMsg:
@@ -357,6 +430,14 @@ func (pm promptModel) View() string {
 
 	sb.Write([]byte(tui.SubTitleStyle.Render(fmt.Sprintf("Variable: %v", pm.prompt.Env))))
 	sb.WriteString("\n\n")
+
+	if pm.loading {
+		sb.WriteString(tui.InfoStyle.Render(pm.spinner.View() + " " + loadingLLMsMsg))
+		sb.WriteString("\n\n")
+		sb.WriteString(tui.DimStyle.Render("ctrl-p back to previous"))
+
+		return sb.String()
+	}
 
 	if pm.prompt.Type.String() == typeError {
 		sb.WriteString(tui.ErrorStyle.Render(pm.prompt.Help))

--- a/cmd/dotenv/promptModel.go
+++ b/cmd/dotenv/promptModel.go
@@ -268,7 +268,6 @@ func llmErrorPrompt(prompt envbuilder.UserPrompt, successCmd tea.Cmd, err error)
 	return promptModel{prompt: errPrompt, successCmd: successCmd}
 }
 
-
 func llmListPromptFromCatalog(prompt envbuilder.UserPrompt, successCmd tea.Cmd, llms *drapi.LLMList) (promptModel, tea.Cmd) {
 	if llms == nil {
 		errPrompt := prompt
@@ -320,7 +319,7 @@ func (pm promptModel) GetValues() []string {
 	return []string{current.FilterValue()}
 }
 
-func (pm promptModel) Update(msg tea.Msg) (promptModel, tea.Cmd) {
+func (pm promptModel) Update(msg tea.Msg) (promptModel, tea.Cmd) { //nolint:cyclop
 	if pm.loading {
 		switch msg := msg.(type) {
 		case llmCatalogLoadedMsg:

--- a/cmd/dotenv/promptModel_test.go
+++ b/cmd/dotenv/promptModel_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
@@ -169,6 +170,65 @@ func TestNewLLMListPrompt_Success(t *testing.T) {
 
 	require.NotContains(t, pm.prompt.Type.String(), "error")
 	assert.Len(t, pm.list.Items(), 2)
+}
+
+func TestNewLLMListPromptAsync_LoadingState(t *testing.T) {
+	prompt := envbuilder.UserPrompt{Type: "llmgw_catalog", Env: "LLM_VAR"}
+
+	pm, cmd := newLLMListPromptAsync(prompt, nil)
+
+	assert.True(t, pm.loading)
+	assert.NotNil(t, cmd)
+}
+
+func TestPromptModel_UpdateLLMCatalogLoadedMsg_Success(t *testing.T) {
+	pm, _ := newLLMListPromptAsync(envbuilder.UserPrompt{Type: "llmgw_catalog", Env: "LLM_VAR"}, nil)
+
+	updated, cmd := pm.Update(llmCatalogLoadedMsg{llms: &drapi.LLMList{
+		LLMs: []drapi.LLM{
+			{LlmID: "1", Name: "GPT-4o", Provider: "azure", Model: "gpt-4o", IsActive: true},
+		},
+		Count: 1, TotalCount: 1,
+	}})
+
+	assert.False(t, updated.loading)
+	assert.NotContains(t, updated.prompt.Type.String(), "error")
+	assert.Len(t, updated.list.Items(), 1)
+	assert.NotNil(t, cmd)
+}
+
+func TestPromptModel_UpdateLLMCatalogLoadedMsg_Error(t *testing.T) {
+	pm, _ := newLLMListPromptAsync(envbuilder.UserPrompt{Type: "llmgw_catalog", Env: "LLM_VAR"}, nil)
+
+	updated, cmd := pm.Update(llmCatalogLoadedMsg{err: &drapi.HTTPError{StatusCode: http.StatusUnauthorized}})
+
+	assert.False(t, updated.loading)
+	assert.Contains(t, updated.prompt.Type.String(), "error")
+	assert.Contains(t, updated.prompt.Help, "Authentication failed")
+	assert.Nil(t, cmd)
+}
+
+func TestPromptModel_UpdateLLMCatalogSpinnerTick(t *testing.T) {
+	pm, _ := newLLMListPromptAsync(envbuilder.UserPrompt{Type: "llmgw_catalog", Env: "LLM_VAR"}, nil)
+
+	updated, cmd := pm.Update(spinner.TickMsg{})
+
+	assert.True(t, updated.loading)
+	assert.NotNil(t, cmd)
+}
+
+func TestPromptModelView_LoadingState(t *testing.T) {
+	pm := promptModel{
+		prompt: envbuilder.UserPrompt{Type: "llmgw_catalog", Env: "LLM_VAR", Help: "help text"},
+		loading: true,
+		spinner: spinner.New(),
+	}
+
+	view := pm.View()
+
+	assert.Contains(t, view, "LLM_VAR")
+	assert.Contains(t, view, "Fetching available LLMs from DataRobot")
+	assert.Contains(t, view, "ctrl-p back to previous")
 }
 
 // TestPromptModelView_ErrorType verifies that when the prompt type contains "error",

--- a/cmd/dotenv/promptModel_test.go
+++ b/cmd/dotenv/promptModel_test.go
@@ -219,7 +219,7 @@ func TestPromptModel_UpdateLLMCatalogSpinnerTick(t *testing.T) {
 
 func TestPromptModelView_LoadingState(t *testing.T) {
 	pm := promptModel{
-		prompt: envbuilder.UserPrompt{Type: "llmgw_catalog", Env: "LLM_VAR", Help: "help text"},
+		prompt:  envbuilder.UserPrompt{Type: "llmgw_catalog", Env: "LLM_VAR", Help: "help text"},
 		loading: true,
 		spinner: spinner.New(),
 	}

--- a/cmd/plugin/discovery.go
+++ b/cmd/plugin/discovery.go
@@ -206,11 +206,18 @@ func askYesNo() bool {
 
 // performPluginUpdate runs the backup → install → validate cycle for a plugin update.
 func performPluginUpdate(result *internalPlugin.UpdateCheckResult) {
-	shared.RunPluginUpdate(
+	err := shared.RunPluginUpdate(
 		result.PluginName,
 		result.InstalledVersion,
 		result.RegistryPlugin,
 		*result.LatestVersion,
 		result.BaseURL,
 	)
+	if err != nil {
+		fmt.Println(tui.ErrorStyle.Render(fmt.Sprintf("✗ Failed to update %s: %v", result.PluginName, err)))
+
+		return
+	}
+
+	fmt.Println(tui.SuccessStyle.Render("✓ Updated " + result.PluginName + " to " + result.LatestVersion.Version))
 }

--- a/cmd/plugin/install/cmd.go
+++ b/cmd/plugin/install/cmd.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/cmd/plugin/shared"
-	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/plugin"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/tui"
@@ -76,11 +75,22 @@ Use --version to specify a version constraint:
 
 func runInstall(_ *cobra.Command, args []string) error {
 	finalRegistryURL := shared.NormalizeRegistryURL(registryURL)
-	if viperx.GetBool("verbose") {
-		fmt.Printf("Fetching plugin registry from %s...\n", finalRegistryURL)
-	}
 
-	registry, baseURL, err := plugin.FetchRegistry(finalRegistryURL)
+	var (
+		registry *plugin.PluginRegistry
+		baseURL  string
+	)
+
+	err := tui.RunWithSpinner(
+		fmt.Sprintf("Fetching plugin registry from %s…", finalRegistryURL),
+		func() error {
+			var fetchErr error
+
+			registry, baseURL, fetchErr = plugin.FetchRegistry(finalRegistryURL)
+
+			return fetchErr
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("failed to fetch plugin registry: %w", err)
 	}
@@ -129,10 +139,10 @@ func runInstall(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to resolve version: %w", err)
 	}
 
-	fmt.Printf("Installing %s version %s...\n", pluginEntry.Name, version.Version)
-	fmt.Printf("Downloading from: %s/%s\n", baseURL, version.URL)
-
-	if err := plugin.InstallPlugin(pluginEntry, *version, baseURL); err != nil {
+	if err := tui.RunWithSpinner(
+		fmt.Sprintf("Installing %s %s…", pluginEntry.Name, version.Version),
+		func() error { return plugin.InstallPlugin(pluginEntry, *version, baseURL) },
+	); err != nil {
 		return fmt.Errorf("failed to install plugin: %w", err)
 	}
 

--- a/cmd/plugin/shared/helpers.go
+++ b/cmd/plugin/shared/helpers.go
@@ -15,10 +15,10 @@
 package shared
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/datarobot/cli/internal/plugin"
-	"github.com/datarobot/cli/tui"
 )
 
 // NormalizeRegistryURL ensures the URL ends with index.json
@@ -35,45 +35,48 @@ func NormalizeRegistryURL(url string) string {
 }
 
 // RunPluginUpdate performs the backup → install → validate → rollback cycle
-// for upgrading a managed plugin. It prints styled status messages and returns
-// true only when the update succeeds and validation passes.
-func RunPluginUpdate(pluginName, fromVersion string, entry plugin.RegistryPlugin, version plugin.RegistryVersion, baseURL string) bool {
-	fmt.Printf("Updating %s from %s to %s...\n", pluginName, fromVersion, version.Version)
-
+// for upgrading a managed plugin. It returns nil only when the update succeeds
+// and validation passes.
+func RunPluginUpdate(pluginName, _ string, entry plugin.RegistryPlugin, version plugin.RegistryVersion, baseURL string) error {
 	backupPath, err := plugin.BackupPlugin(pluginName)
 	if err != nil {
-		fmt.Println(tui.ErrorStyle.Render(fmt.Sprintf("✗ Failed to backup %s: %v", pluginName, err)))
-
-		return false
+		return fmt.Errorf("backup %s: %w", pluginName, err)
 	}
+
 	defer plugin.CleanupBackup(backupPath)
 
 	if err := plugin.InstallPlugin(entry, version, baseURL); err != nil {
-		fmt.Println(tui.ErrorStyle.Render(fmt.Sprintf("✗ Failed to update %s: %v", pluginName, err)))
-		rollbackPlugin(pluginName, backupPath)
+		rollbackErr := rollbackPlugin(pluginName, backupPath)
+		if rollbackErr != nil {
+			return errors.Join(
+				fmt.Errorf("install %s: %w", pluginName, err),
+				rollbackErr,
+			)
+		}
 
-		return false
+		return fmt.Errorf("install %s: %w", pluginName, err)
 	}
 
 	if err := plugin.ValidatePlugin(pluginName); err != nil {
-		fmt.Println(tui.ErrorStyle.Render(fmt.Sprintf("✗ Plugin validation failed: %v", err)))
-		rollbackPlugin(pluginName, backupPath)
+		rollbackErr := rollbackPlugin(pluginName, backupPath)
+		if rollbackErr != nil {
+			return errors.Join(
+				fmt.Errorf("validate %s: %w", pluginName, err),
+				rollbackErr,
+			)
+		}
 
-		return false
+		return fmt.Errorf("validate %s: %w", pluginName, err)
 	}
 
-	fmt.Println(tui.SuccessStyle.Render("✓ Updated " + pluginName + " to " + version.Version))
-
-	return true
+	return nil
 }
 
-// rollbackPlugin attempts to restore a plugin from its backup, printing the outcome.
-func rollbackPlugin(pluginName, backupPath string) {
-	fmt.Println("Rolling back to previous version...")
-
+// rollbackPlugin attempts to restore a plugin from its backup.
+func rollbackPlugin(pluginName, backupPath string) error {
 	if restoreErr := plugin.RestorePlugin(pluginName, backupPath); restoreErr != nil {
-		fmt.Println(tui.ErrorStyle.Render(fmt.Sprintf("✗ Failed to restore backup: %v", restoreErr)))
-	} else {
-		fmt.Println(tui.SuccessStyle.Render("✓ Restored previous version"))
+		return fmt.Errorf("restore backup for %s: %w", pluginName, restoreErr)
 	}
+
+	return nil
 }

--- a/cmd/plugin/update/cmd.go
+++ b/cmd/plugin/update/cmd.go
@@ -166,9 +166,18 @@ func updateSinglePlugin(p plugin.InstalledPlugin, registry *plugin.PluginRegistr
 		return false
 	}
 
-	if !shared.RunPluginUpdate(p.Name, p.Version, pluginEntry, *latestVersion, baseURL) {
+	if err := tui.RunWithSpinner(
+		fmt.Sprintf("Updating %s from %s to %s…", p.Name, p.Version, latestVersion.Version),
+		func() error {
+			return shared.RunPluginUpdate(p.Name, p.Version, pluginEntry, *latestVersion, baseURL)
+		},
+	); err != nil {
+		fmt.Println(tui.ErrorStyle.Render(fmt.Sprintf("✗ Failed to update %s: %v", p.Name, err)))
+
 		return false
 	}
+
+	fmt.Println(tui.SuccessStyle.Render("✓ Updated " + p.Name + " to " + latestVersion.Version))
 
 	fmt.Println()
 

--- a/cmd/plugin/update/cmd.go
+++ b/cmd/plugin/update/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/datarobot/cli/internal/plugin"
 	"github.com/datarobot/cli/internal/state"
 	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -74,9 +75,21 @@ func runUpdate(_ *cobra.Command, args []string) error {
 
 	finalRegistryURL := shared.NormalizeRegistryURL(registryURL)
 
-	fmt.Printf("Fetching plugin registry from %s...\n", finalRegistryURL)
+	var (
+		registry *plugin.PluginRegistry
+		baseURL  string
+	)
 
-	registry, baseURL, err := plugin.FetchRegistry(finalRegistryURL)
+	err = tui.RunWithSpinner(
+		fmt.Sprintf("Fetching plugin registry from %s…", finalRegistryURL),
+		func() error {
+			var fetchErr error
+
+			registry, baseURL, fetchErr = plugin.FetchRegistry(finalRegistryURL)
+
+			return fetchErr
+		},
+	)
 	if err != nil {
 		return fmt.Errorf("failed to fetch plugin registry: %w", err)
 	}

--- a/cmd/workload/artifact/create/cmd.go
+++ b/cmd/workload/artifact/create/cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -100,8 +101,15 @@ Example:
 				return err
 			}
 
-			artifact, err := workload.CreateArtifact(payload)
-			if err != nil {
+			var artifact *workload.Artifact
+
+			if err := tui.RunWithSpinner("Creating artifact…", func() error {
+				var createErr error
+
+				artifact, createErr = workload.CreateArtifact(payload)
+
+				return createErr
+			}); err != nil {
 				return err
 			}
 

--- a/cmd/workload/artifact/get/cmd.go
+++ b/cmd/workload/artifact/get/cmd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -42,8 +43,15 @@ Example:
 		Args:    cobra.ExactArgs(1),
 		PreRunE: auth.EnsureAuthenticatedE,
 		RunE: func(_ *cobra.Command, args []string) error {
-			artifact, err := workload.GetArtifact(args[0])
-			if err != nil {
+			var artifact *workload.Artifact
+
+			if err := tui.RunWithSpinner("Fetching artifact…", func() error {
+				var getErr error
+
+				artifact, getErr = workload.GetArtifact(args[0])
+
+				return getErr
+			}); err != nil {
 				return err
 			}
 

--- a/cmd/workload/artifact/list/cmd.go
+++ b/cmd/workload/artifact/list/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -54,8 +55,15 @@ Example:
 				return fmt.Errorf("invalid --limit %d: must be positive", limit)
 			}
 
-			artifacts, err := workload.ListArtifacts(limit, status)
-			if err != nil {
+			var artifacts []workload.Artifact
+
+			if err := tui.RunWithSpinner("Fetching artifacts…", func() error {
+				var listErr error
+
+				artifacts, listErr = workload.ListArtifacts(limit, status)
+
+				return listErr
+			}); err != nil {
 				return err
 			}
 

--- a/cmd/workload/code/checkout/checkout.go
+++ b/cmd/workload/code/checkout/checkout.go
@@ -32,6 +32,7 @@ import (
 	"github.com/datarobot/cli/internal/workload/fileops"
 	"github.com/datarobot/cli/internal/workload/sync"
 	"github.com/datarobot/cli/internal/workload/wapi"
+	"github.com/datarobot/cli/tui"
 )
 
 const (
@@ -76,7 +77,10 @@ func runDownload(out io.Writer, format workload.OutputFormat, dir, verArg string
 		return err
 	}
 
-	if err := stageAndInstall(deps.Files, pre, parent, files, totalSize, startedAt); err != nil {
+	if err := tui.RunWithSpinner(
+		fmt.Sprintf("Downloading %d file(s)…", len(files)),
+		func() error { return stageAndInstall(deps.Files, pre, parent, files, totalSize, startedAt) },
+	); err != nil {
 		return err
 	}
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -37,6 +37,20 @@ import (
 // This can be overridden in tests to mock the browser-based authentication flow.
 var APIKeyCallbackFunc = WaitForAPIKeyCallback
 
+// AuthCallbackURL returns the DataRobot URL the user must visit to authorize the CLI.
+func AuthCallbackURL(datarobotHost string) string {
+	return datarobotHost + "/account/developer-tools?cliRedirect=true"
+}
+
+// PrintAuthInstructions prints the message instructing the user to visit the
+// given auth URL. It must be called before any TUI/bubbletea program starts
+// rendering, otherwise the output will be garbled or hidden.
+func PrintAuthInstructions(authURL string) {
+	fmt.Println("\n\nPlease visit this link to connect your DataRobot credentials to the CLI")
+	fmt.Println("(If you're prompted to log in, you may need to re-enter this URL):")
+	fmt.Printf("%s\n\n", authURL)
+}
+
 // ErrEnvCredentialsNotSet is returned when environment credentials are not fully configured.
 var ErrEnvCredentialsNotSet = errors.New("environment credentials not set")
 
@@ -165,6 +179,8 @@ func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
 	// Auto-retrieve new credentials without prompting
 	viperx.Set(config.DataRobotAPIKey, "")
 
+	PrintAuthInstructions(AuthCallbackURL(datarobotHost))
+
 	key, err := APIKeyCallbackFunc(ctx, datarobotHost)
 	if err != nil {
 		log.Error("Failed to retrieve API key.", "error", err)
@@ -218,11 +234,7 @@ func WaitForAPIKeyCallback(ctx context.Context, datarobotHost string) (string, e
 	}
 
 	// Start the server in a goroutine
-	authURL := datarobotHost + "/account/developer-tools?cliRedirect=true"
-
-	fmt.Println("\n\nPlease visit this link to connect your DataRobot credentials to the CLI")
-	fmt.Println("(If you're prompted to log in, you may need to re-enter this URL):")
-	fmt.Printf("%s\n\n", authURL)
+	authURL := AuthCallbackURL(datarobotHost)
 
 	go func() {
 		open.Open(authURL)
@@ -246,11 +258,11 @@ func WaitForAPIKeyCallback(ctx context.Context, datarobotHost string) (string, e
 			return "", errors.New("Interrupt request received.")
 		}
 
-		fmt.Println("Successfully consumed API key from API request")
+		log.Debug("Successfully consumed API key from API request")
 
 		return apiKey, nil
 	case <-ctx.Done():
-		fmt.Println("\nCtrl-C received, exiting...")
+		log.Debug("Ctrl-C received, exiting auth wait")
 		return "", errors.New("Interrupt request received.")
 	}
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -218,13 +218,13 @@ func WaitForAPIKeyCallback(ctx context.Context, datarobotHost string) (string, e
 	}
 
 	// Start the server in a goroutine
+	authURL := datarobotHost + "/account/developer-tools?cliRedirect=true"
+
+	fmt.Println("\n\nPlease visit this link to connect your DataRobot credentials to the CLI")
+	fmt.Println("(If you're prompted to log in, you may need to re-enter this URL):")
+	fmt.Printf("%s\n\n", authURL)
+
 	go func() {
-		authURL := datarobotHost + "/account/developer-tools?cliRedirect=true"
-
-		fmt.Println("\n\nPlease visit this link to connect your DataRobot credentials to the CLI")
-		fmt.Println("(If you're prompted to log in, you may need to re-enter this URL):")
-		fmt.Printf("%s\n\n", authURL)
-
 		open.Open(authURL)
 
 		err := server.Serve(listen)

--- a/internal/misc/reader/reader.go
+++ b/internal/misc/reader/reader.go
@@ -79,3 +79,20 @@ func AskYesNo() bool {
 func IsStdinTerminal() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
+
+// NonInteractiveEnv is the env var users set to force non-interactive mode
+// (e.g. Agent Assist). It is also bound to the viper "yes" key in commands
+// that support a --yes flag.
+const NonInteractiveEnv = "DATAROBOT_CLI_NON_INTERACTIVE"
+
+// IsNonInteractive reports whether DATAROBOT_CLI_NON_INTERACTIVE is set to a
+// truthy value. Callers should use this to skip animations, prompts, and other
+// interactive UI when running under automation.
+func IsNonInteractive() bool {
+	switch os.Getenv(NonInteractiveEnv) {
+	case "1", "t", "T", "true", "TRUE", "True", "y", "Y", "yes", "YES", "Yes":
+		return true
+	}
+
+	return false
+}

--- a/internal/misc/reader/reader_test.go
+++ b/internal/misc/reader/reader_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNonInteractive(t *testing.T) {
+	cases := map[string]bool{
+		"":      false,
+		"true":  true,
+		"TRUE":  true,
+		"True":  true,
+		"1":     true,
+		"yes":   true,
+		"y":     true,
+		"false": false,
+		"0":     false,
+		"no":    false,
+		"foo":   false,
+	}
+
+	for value, want := range cases {
+		t.Setenv(NonInteractiveEnv, value)
+		assert.Equalf(t, want, IsNonInteractive(), "value=%q", value)
+	}
+}

--- a/tui/spinner.go
+++ b/tui/spinner.go
@@ -1,0 +1,90 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tui
+
+import (
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type spinnerModel struct {
+	spinner spinner.Model
+	label   string
+	fn      func() error
+	done    bool
+}
+
+type spinnerDoneMsg struct{ err error }
+
+func (m spinnerModel) Init() tea.Cmd {
+	return tea.Batch(
+		m.spinner.Tick,
+		func() tea.Msg {
+			return spinnerDoneMsg{err: m.fn()}
+		},
+	)
+}
+
+func (m spinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case spinnerDoneMsg:
+		m.done = true
+
+		return m, tea.Quit
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+
+		m.spinner, cmd = m.spinner.Update(msg)
+
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m spinnerModel) View() string {
+	if m.done {
+		return ""
+	}
+
+	return InfoStyle.Render(m.spinner.View()+" ") + m.label + "\n"
+}
+
+// RunWithSpinner runs fn in the background while showing an animated spinner
+// with the given label. Returns the error from fn, if any.
+func RunWithSpinner(label string, fn func() error) error {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = InfoStyle
+
+	var fnErr error
+
+	m := spinnerModel{
+		spinner: s,
+		label:   label,
+		fn: func() error {
+			fnErr = fn()
+
+			return fnErr
+		},
+	}
+
+	_, err := Run(m)
+	if err != nil {
+		return err
+	}
+
+	return fnErr
+}

--- a/tui/spinner.go
+++ b/tui/spinner.go
@@ -23,20 +23,6 @@ import (
 	"github.com/datarobot/cli/internal/misc/reader"
 )
 
-// nonInteractiveEnv mirrors the DATAROBOT_CLI_NON_INTERACTIVE env var used
-// elsewhere (bound to the viper "yes" key). When set to a truthy value, the
-// spinner skips animation and just runs fn synchronously.
-const nonInteractiveEnv = "DATAROBOT_CLI_NON_INTERACTIVE"
-
-func isNonInteractiveEnv() bool {
-	switch os.Getenv(nonInteractiveEnv) {
-	case "1", "t", "T", "true", "TRUE", "True", "y", "Y", "yes", "YES", "Yes":
-		return true
-	}
-
-	return false
-}
-
 type spinnerModel struct {
 	spinner spinner.Model
 	label   string
@@ -87,7 +73,7 @@ func RunWithSpinner(label string, fn func() error) error {
 		return fn()
 	}
 
-	if isNonInteractiveEnv() {
+	if reader.IsNonInteractive() {
 		fmt.Fprintln(os.Stderr, InfoStyle.Render("• ")+label)
 
 		return fn()

--- a/tui/spinner.go
+++ b/tui/spinner.go
@@ -15,10 +15,27 @@
 package tui
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/internal/misc/reader"
 )
+
+// nonInteractiveEnv mirrors the DATAROBOT_CLI_NON_INTERACTIVE env var used
+// elsewhere (bound to the viper "yes" key). When set to a truthy value, the
+// spinner skips animation and just runs fn synchronously.
+const nonInteractiveEnv = "DATAROBOT_CLI_NON_INTERACTIVE"
+
+func isNonInteractiveEnv() bool {
+	switch os.Getenv(nonInteractiveEnv) {
+	case "1", "t", "T", "true", "TRUE", "True", "y", "Y", "yes", "YES", "Yes":
+		return true
+	}
+
+	return false
+}
 
 type spinnerModel struct {
 	spinner spinner.Model
@@ -67,6 +84,12 @@ func (m spinnerModel) View() string {
 // with the given label. Returns the error from fn, if any.
 func RunWithSpinner(label string, fn func() error) error {
 	if !reader.IsStdinTerminal() {
+		return fn()
+	}
+
+	if isNonInteractiveEnv() {
+		fmt.Fprintln(os.Stderr, InfoStyle.Render("• ")+label)
+
 		return fn()
 	}
 

--- a/tui/spinner.go
+++ b/tui/spinner.go
@@ -17,6 +17,7 @@ package tui
 import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/internal/misc/reader"
 )
 
 type spinnerModel struct {
@@ -65,6 +66,10 @@ func (m spinnerModel) View() string {
 // RunWithSpinner runs fn in the background while showing an animated spinner
 // with the given label. Returns the error from fn, if any.
 func RunWithSpinner(label string, fn func() error) error {
+	if !reader.IsStdinTerminal() {
+		return fn()
+	}
+
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = InfoStyle

--- a/tui/spinner_test.go
+++ b/tui/spinner_test.go
@@ -106,6 +106,35 @@ func TestRunWithSpinner_ErrorPath(t *testing.T) {
 	assert.ErrorIs(t, err, want)
 }
 
+func TestRunWithSpinner_NonInteractiveEnv_SkipsTUI(t *testing.T) {
+	t.Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "true")
+
+	called := false
+
+	err := RunWithSpinner("test label", func() error {
+		called = true
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestIsNonInteractiveEnv(t *testing.T) {
+	t.Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "")
+	assert.False(t, isNonInteractiveEnv())
+
+	t.Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "true")
+	assert.True(t, isNonInteractiveEnv())
+
+	t.Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "1")
+	assert.True(t, isNonInteractiveEnv())
+
+	t.Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "false")
+	assert.False(t, isNonInteractiveEnv())
+}
+
 func TestRunWithSpinner_LabelRendered(t *testing.T) {
 	s := spinner.New()
 	s.Spinner = spinner.Dot

--- a/tui/spinner_test.go
+++ b/tui/spinner_test.go
@@ -121,20 +121,6 @@ func TestRunWithSpinner_NonInteractiveEnv_SkipsTUI(t *testing.T) {
 	assert.True(t, called)
 }
 
-func TestIsNonInteractiveEnv(t *testing.T) {
-	t.Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "")
-	assert.False(t, isNonInteractiveEnv())
-
-	t.Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "true")
-	assert.True(t, isNonInteractiveEnv())
-
-	t.Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "1")
-	assert.True(t, isNonInteractiveEnv())
-
-	t.Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "false")
-	assert.False(t, isNonInteractiveEnv())
-}
-
 func TestRunWithSpinner_LabelRendered(t *testing.T) {
 	s := spinner.New()
 	s.Spinner = spinner.Dot

--- a/tui/spinner_test.go
+++ b/tui/spinner_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tui
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpinnerModel_ViewShowsLabelWhileRunning(t *testing.T) {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = InfoStyle
+
+	m := spinnerModel{
+		spinner: s,
+		label:   "Loading…",
+	}
+
+	view := m.View()
+
+	assert.Contains(t, view, "Loading…")
+}
+
+func TestSpinnerModel_ViewEmptyWhenDone(t *testing.T) {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	m := spinnerModel{
+		spinner: s,
+		label:   "Loading…",
+		done:    true,
+	}
+
+	assert.Empty(t, m.View())
+}
+
+func TestSpinnerModel_UpdateOnDoneMsg(t *testing.T) {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	m := spinnerModel{
+		spinner: s,
+		label:   "Loading…",
+	}
+
+	updated, cmd := m.Update(spinnerDoneMsg{err: nil})
+
+	assert.True(t, updated.(spinnerModel).done)
+	assert.NotNil(t, cmd) // tea.Quit
+}
+
+func TestSpinnerModel_UpdateOnDoneMsgWithError(t *testing.T) {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	m := spinnerModel{
+		spinner: s,
+		label:   "Loading…",
+	}
+
+	sentErr := errors.New("something failed")
+
+	updated, _ := m.Update(spinnerDoneMsg{err: sentErr})
+
+	assert.True(t, updated.(spinnerModel).done)
+}
+
+func TestRunWithSpinner_SuccessPath(t *testing.T) {
+	called := false
+
+	err := RunWithSpinner("test label", func() error {
+		called = true
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestRunWithSpinner_ErrorPath(t *testing.T) {
+	want := errors.New("fn error")
+
+	err := RunWithSpinner("test label", func() error {
+		return want
+	})
+
+	assert.ErrorIs(t, err, want)
+}
+
+func TestRunWithSpinner_LabelRendered(t *testing.T) {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = InfoStyle
+
+	m := spinnerModel{
+		spinner: s,
+		label:   "my special label",
+	}
+
+	view := m.View()
+
+	assert.Contains(t, view, "my special label")
+}
+
+func TestSpinnerModel_InitReturnsBatch(t *testing.T) {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	m := spinnerModel{
+		spinner: s,
+		label:   "Loading…",
+		fn:      func() error { return nil },
+	}
+
+	cmd := m.Init()
+
+	assert.NotNil(t, cmd)
+
+	// Execute the batch to drain msgs (just verifies it doesn't panic)
+	msgs := cmd()
+	_ = msgs
+}
+
+func TestSpinnerModel_UpdateTickMsg(t *testing.T) {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	m := spinnerModel{
+		spinner: s,
+		label:   "Loading…",
+	}
+
+	tickMsg := spinner.TickMsg{}
+
+	updated, cmd := m.Update(tickMsg)
+
+	assert.NotNil(t, updated)
+	assert.NotNil(t, cmd) // next tick
+}
+
+func TestSpinnerModel_UpdateUnknownMsg(t *testing.T) {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	type unknownMsg struct{}
+
+	m := spinnerModel{
+		spinner: s,
+		label:   "Loading…",
+	}
+
+	updated, cmd := m.Update(unknownMsg{})
+
+	assert.NotNil(t, updated)
+	assert.Nil(t, cmd)
+}
+
+func TestSpinnerModel_UpdateReturnsSelf(t *testing.T) {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	m := spinnerModel{
+		spinner: s,
+		label:   "Loading…",
+	}
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	_, ok := updated.(spinnerModel)
+
+	assert.True(t, ok)
+}


### PR DESCRIPTION
- Add tui.RunWithSpinner helper (tui/spinner.go) with unit tests
- Apply spinner to plugin install/update (FetchRegistry + InstallPlugin)
- Apply spinner to auth login (WaitForAPIKeyCallback)
- Apply spinner to workload artifact create/get/list
- Apply spinner to workload code checkout (stageAndInstall)
- Thread spinner into component add/update TUI loading screens


https://github.com/user-attachments/assets/8ca8cb9f-89ed-4675-bc89-13cf1205bbbf



# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 49df52a74ef244c6b4b34a9be88e7d975aac2fbe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->