### PR TITLE
[CFX-6228][CFX-6229] sec: validate server-controlled paths in sync engine

### DIFF
--- a/internal/workload/sync/download.go
+++ b/internal/workload/sync/download.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 
 	"github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/workload/fileops"
 )
 
 // downloadFiles pulls files in parallel up to DownloadConcurrency. Each
@@ -87,6 +88,13 @@ func downloadFiles(e *Engine, catalogID, versionID string, files []FileAction) e
 // downloadOne streams the remote file to disk, hashing as it writes.
 // Empty RemoteHash skips verification (e.g. synthesized EDIT_DEL_CONFLICT).
 func downloadOne(e *Engine, catalogID, versionID string, fa FileAction) error {
+	// phase5Execute already rejected unsafe server paths up front via
+	// validateServerPaths; re-check here so the per-call-site invariant
+	// survives future refactors that might bypass the phase entry point.
+	if err := fileops.SafeRelPath(fa.Path); err != nil {
+		return fmt.Errorf("server returned unsafe download path %q: %w", fa.Path, err)
+	}
+
 	dst := filepath.Join(e.projectDir, filepath.FromSlash(fa.Path))
 
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {

--- a/internal/workload/sync/path_safety_test.go
+++ b/internal/workload/sync/path_safety_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Defense-in-depth: even if filesapi.AllFiles validates manifest entries,
+// FileAction.Path values flow through SyncPlan before reaching the
+// filesystem, so the sync engine must re-validate at the write/delete
+// site. These tests pin the rejection contract for CFX-6228 / CFX-6229.
+
+// unsafeServerPaths are the bypass classes every server-controlled-path
+// guard in this package must reject. Shared across the two call-site
+// tests so a new bypass class added here is covered at both sites.
+var unsafeServerPaths = []string{
+	"../escape",
+	"../../etc/passwd",
+	"/etc/passwd",
+	`..\windows`,
+	"",
+}
+
+func TestDownloadOne_RejectsUnsafeServerPath(t *testing.T) {
+	for _, bad := range unsafeServerPaths {
+		t.Run(bad, func(t *testing.T) {
+			// fakeFilesClient.DownloadFile returns "DownloadFile not
+			// expected" — if SafeRelPath fails first the error message
+			// is the unsafe-path wrapper, proving no remote call ran.
+			e := &Engine{projectDir: t.TempDir(), files: &fakeFilesClient{}}
+
+			err := downloadOne(e, "cid", "vid", FileAction{Path: bad})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "server returned unsafe download path")
+			assert.NotContains(t, err.Error(), "DownloadFile not expected")
+		})
+	}
+}
+
+func TestRemoveLocalDeletedFiles_RejectsUnsafeServerPath(t *testing.T) {
+	for _, bad := range unsafeServerPaths {
+		t.Run(bad, func(t *testing.T) {
+			e := &Engine{
+				projectDir: t.TempDir(),
+				plan: &SyncPlan{
+					Deletes: []FileAction{{Path: bad, Action: ActDownloadDelete}},
+				},
+			}
+
+			err := removeLocalDeletedFiles(e)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "server returned unsafe delete path")
+		})
+	}
+}
+
+func TestRemoveLocalDeletedFiles_DoesNotDeleteOutsideProjectDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// Sentinel sits in the temp dir's parent; ../sentinel would resolve
+	// to it under a naive filepath.Join, so its survival proves the
+	// SafeRelPath guard short-circuited before os.Remove.
+	sentinel := filepath.Join(filepath.Dir(dir), "sentinel-"+filepath.Base(dir))
+	require.NoError(t, os.WriteFile(sentinel, []byte("keep me"), 0o644))
+
+	t.Cleanup(func() { _ = os.Remove(sentinel) })
+
+	e := &Engine{
+		projectDir: dir,
+		plan: &SyncPlan{
+			Deletes: []FileAction{
+				{Path: "../" + filepath.Base(sentinel), Action: ActDownloadDelete},
+			},
+		},
+	}
+
+	err := removeLocalDeletedFiles(e)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server returned unsafe delete path")
+
+	_, statErr := os.Stat(sentinel)
+	require.NoError(t, statErr, "sentinel outside project dir must not have been removed")
+}
+
+// Non-ActDownloadDelete entries must be skipped without validation —
+// uploads carry locally-scanned paths that don't need this guard, and
+// running SafeRelPath on them would over-reject.
+func TestRemoveLocalDeletedFiles_IgnoresNonDownloadDeleteEntries(t *testing.T) {
+	e := &Engine{
+		projectDir: t.TempDir(),
+		plan: &SyncPlan{
+			Deletes: []FileAction{
+				{Path: "../would-be-unsafe", Action: ActUploadDelete},
+			},
+		},
+	}
+
+	require.NoError(t, removeLocalDeletedFiles(e))
+}
+
+// validateServerPaths is the up-front phase5 guard that runs before any
+// filesystem op (including Rollback.Backup). The per-call-site guards in
+// downloadOne / removeLocalDeletedFiles back it up, but this guard is the
+// one that keeps unsafe paths out of rb.Backup's stat/open/copy calls.
+
+func TestValidateServerPaths_RejectsUnsafeDownload(t *testing.T) {
+	for _, bad := range unsafeServerPaths {
+		t.Run(bad, func(t *testing.T) {
+			plan := &SyncPlan{Downloads: []FileAction{{Path: bad}}}
+
+			err := validateServerPaths(plan)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "server returned unsafe download path")
+		})
+	}
+}
+
+func TestValidateServerPaths_RejectsUnsafeConflict(t *testing.T) {
+	for _, bad := range unsafeServerPaths {
+		t.Run(bad, func(t *testing.T) {
+			plan := &SyncPlan{Conflicts: []FileAction{{Path: bad}}}
+
+			err := validateServerPaths(plan)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "server returned unsafe conflict path")
+		})
+	}
+}
+
+func TestValidateServerPaths_RejectsUnsafeDownloadDelete(t *testing.T) {
+	for _, bad := range unsafeServerPaths {
+		t.Run(bad, func(t *testing.T) {
+			plan := &SyncPlan{
+				Deletes: []FileAction{{Path: bad, Action: ActDownloadDelete}},
+			}
+
+			err := validateServerPaths(plan)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "server returned unsafe delete path")
+		})
+	}
+}
+
+// Uploads and ActUploadDelete entries carry locally-scanned paths that
+// the local walker has already validated; re-checking them here would
+// over-reject benign inputs.
+func TestValidateServerPaths_SkipsLocalDrivenEntries(t *testing.T) {
+	plan := &SyncPlan{
+		Uploads: []FileAction{{Path: "../would-be-unsafe"}},
+		Deletes: []FileAction{{Path: "../would-be-unsafe", Action: ActUploadDelete}},
+	}
+
+	require.NoError(t, validateServerPaths(plan))
+}
+
+// Phase-level regression: an unsafe path in plan.Downloads would
+// otherwise reach rb.Backup via backupDownloadTargets before any
+// per-call-site guard fired. The up-front check must short-circuit
+// before NewRollback runs, so no .wapi/.rollback dir is created and
+// no bytes outside e.projectDir are read.
+func TestPhase5Execute_RejectsUnsafePathBeforeAnyFilesystemOp(t *testing.T) {
+	dir := t.TempDir()
+
+	sentinel := filepath.Join(filepath.Dir(dir), "sentinel-"+filepath.Base(dir))
+	require.NoError(t, os.WriteFile(sentinel, []byte("keep me"), 0o644))
+
+	t.Cleanup(func() { _ = os.Remove(sentinel) })
+
+	e := &Engine{
+		projectDir: dir,
+		plan: &SyncPlan{
+			Downloads: []FileAction{
+				{Path: "../" + filepath.Base(sentinel), Action: ActDownloadAdd},
+			},
+		},
+	}
+
+	err := phase5Execute(e)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "server returned unsafe download path")
+
+	_, statErr := os.Stat(filepath.Join(dir, ".wapi", rollbackDirName))
+	assert.True(t, os.IsNotExist(statErr), "rollback dir must not be created when validation fails")
+
+	_, statErr = os.Stat(sentinel)
+	require.NoError(t, statErr, "sentinel outside project dir must be untouched")
+}

--- a/internal/workload/sync/phase5_execute.go
+++ b/internal/workload/sync/phase5_execute.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/datarobot/cli/internal/workload/fileops"
 )
 
 // phase5Execute applies the SyncPlan in the order: disk-space check +
@@ -28,6 +30,13 @@ import (
 func phase5Execute(e *Engine) error {
 	if e.plan == nil || e.plan.IsEmpty() {
 		return nil
+	}
+
+	// Reject server-controlled traversal paths before any filesystem op
+	// runs, including Rollback.Backup which stats/reads the source path
+	// and would otherwise touch files outside e.projectDir.
+	if err := validateServerPaths(e.plan); err != nil {
+		return err
 	}
 
 	if len(e.plan.Uploads)+len(e.plan.Downloads)+len(e.plan.Deletes)+len(e.plan.Conflicts) > RollbackMaxFiles {
@@ -168,9 +177,47 @@ func removeLocalDeletedFiles(e *Engine) error {
 			continue
 		}
 
+		// phase5Execute already rejected unsafe server paths up front
+		// via validateServerPaths; re-check here so the per-call-site
+		// invariant survives future refactors that might bypass the
+		// phase entry point.
+		if err := fileops.SafeRelPath(fa.Path); err != nil {
+			return fmt.Errorf("server returned unsafe delete path %q: %w", fa.Path, err)
+		}
+
 		abs := filepath.Join(e.projectDir, filepath.FromSlash(fa.Path))
 		if err := os.Remove(abs); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("remove %s: %w", fa.Path, err)
+		}
+	}
+
+	return nil
+}
+
+// validateServerPaths rejects plan entries whose Path is server-controlled
+// and not safe to filepath.Join with e.projectDir. The local walker
+// already validates Uploads and ActUploadDelete entries, so those are
+// skipped to avoid over-rejecting benign locally-scanned paths.
+func validateServerPaths(plan *SyncPlan) error {
+	for _, fa := range plan.Downloads {
+		if err := fileops.SafeRelPath(fa.Path); err != nil {
+			return fmt.Errorf("server returned unsafe download path %q: %w", fa.Path, err)
+		}
+	}
+
+	for _, fa := range plan.Conflicts {
+		if err := fileops.SafeRelPath(fa.Path); err != nil {
+			return fmt.Errorf("server returned unsafe conflict path %q: %w", fa.Path, err)
+		}
+	}
+
+	for _, fa := range plan.Deletes {
+		if fa.Action != ActDownloadDelete {
+			continue
+		}
+
+		if err := fileops.SafeRelPath(fa.Path); err != nil {
+			return fmt.Errorf("server returned unsafe delete path %q: %w", fa.Path, err)
 		}
 	}
 


### PR DESCRIPTION
# RATIONALE

Two linked `[SEC] P1` findings from the sync-engine security review ([CFX-6228](https://datarobot.atlassian.net/browse/CFX-6228), [CFX-6229](https://datarobot.atlassian.net/browse/CFX-6229)):

- `internal/workload/sync/download.go::downloadOne` passes `FileAction.Path` (server-controlled, sourced from the `AllFiles` response) directly into `filepath.Join(e.projectDir, filepath.FromSlash(fa.Path))` and then `os.Create`. A compromised server returning `../../../etc/cron.d/evil` writes outside the project directory.
- `internal/workload/sync/phase5_execute.go::removeLocalDeletedFiles` does the same with `os.Remove`. A path of `../../../home/user/.ssh/id_rsa` deletes that file.

`filesapi.AllFiles` already validates manifest entries at the HTTP boundary, but paths flow through `SyncPlan` before reaching disk, so a per-call-site guard is required as defense in depth. `P2-4 (Rollback.Backup)` provides a third layer at the rollback path and is tracked separately.

## CHANGES

- `internal/workload/sync/download.go` - call `fileops.SafeRelPath(fa.Path)` at the top of `downloadOne`, before `filepath.Join`; return a wrapped `"server returned unsafe download path %q: %w"` error on rejection.
- `internal/workload/sync/phase5_execute.go` - call `fileops.SafeRelPath(fa.Path)` inside the `removeLocalDeletedFiles` loop, after the `ActDownloadDelete` filter and before `filepath.Join`; return a wrapped `"server returned unsafe delete path %q: %w"` error on rejection.
- `internal/workload/sync/path_safety_test.go` (new) - shared `unsafeServerPaths` slice covering five bypass classes (`../escape`, `../../etc/passwd`, `/etc/passwd`, `..\windows`, empty), table-driven tests for both call sites, a sentinel-file test that pins the no-escape-from-project-dir contract by writing a sentinel in `t.TempDir()`'s parent and asserting it survives, and a negative test confirming non-`ActDownloadDelete` entries are skipped without validation (uploads carry locally-scanned paths that would over-reject).

The wrapping style and identifier choice (`fileops.SafeRelPath`) match existing guards at `cmd/workload/code/checkout/checkout.go:290` and `internal/drapi/filesapi/allfiles.go:43,73`.

## TESTING

- `task lint` - 0 issues.
- `task test` - new tests pass under `-race`, each under 10ms; full sync package passes. (Full-repo `task test` reports one unrelated pre-existing failure in `cmd.TestWorkloadCommandNotPresentByDefault` driven by the local `.env`'s `DATAROBOT_CLI_FEATURE_WORKLOAD=true`; with that env var unset the entire suite passes.)
- Sentinel test verifies that a malicious `../` path does not result in `os.Remove` reaching outside the project directory.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tightens path handling at two filesystem call sites with existing SafeRelPath helper; behavior change is rejecting malicious paths that should never have been applied.
> 
> **Overview**
> Adds **defense-in-depth** validation so server-controlled `FileAction.Path` values cannot escape the project directory during sync.
> 
> Before writing or removing files, **`downloadOne`** and **`removeLocalDeletedFiles`** now call `fileops.SafeRelPath` and fail with clear errors (`server returned unsafe download/delete path`). Validation runs only for **`ActDownloadDelete`** deletes so upload-side delete entries (locally scanned paths) are not over-rejected.
> 
> New **`path_safety_test.go`** table-tests traversal/absolute/empty/backslash paths at both sites, uses a parent-dir **sentinel** to prove deletes never run outside the project dir, and asserts non-download-delete plan entries are skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a07bda9257e556f5ee1c6af3b128d10bd33305. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->