### PR TITLE
Correctly use local template for tasks if available during `dr run`

### DIFF
--- a/cmd/task/compose/cmd.go
+++ b/cmd/task/compose/cmd.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/datarobot/cli/internal/cli"
@@ -37,7 +36,7 @@ var templatePath string
 func RunE(_ *cobra.Command, _ []string) error {
 	taskfileName, ignoreTaskfile := detectExistingTaskfile()
 
-	discovery, err := createDiscovery(taskfileName)
+	discovery, err := task.NewDiscovery(taskfileName, templatePath)
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 
@@ -87,43 +86,6 @@ func RunE(_ *cobra.Command, _ []string) error {
 	fmt.Println("Added " + taskfileIgnore + " line to '.gitignore'.")
 
 	return nil
-}
-
-func createDiscovery(taskfileName string) (*task.Discovery, error) {
-	// Check for .Taskfile.template in the root directory if no template specified
-	autoTemplatePath := ".Taskfile.template"
-
-	if templatePath == "" {
-		if _, err := os.Stat(autoTemplatePath); err == nil {
-			templatePath = autoTemplatePath
-			fmt.Printf("Using auto-discovered template: %s\n", autoTemplatePath)
-		}
-	}
-
-	// If template is specified or found, use compose mode
-	if templatePath != "" {
-		absPath, err := validateTemplatePath(templatePath)
-		if err != nil {
-			return nil, fmt.Errorf("invalid template: %w", err)
-		}
-
-		return task.NewComposeDiscovery(taskfileName, absPath), nil
-	}
-
-	return task.NewTaskDiscovery(taskfileName), nil
-}
-
-func validateTemplatePath(path string) (string, error) {
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return "", fmt.Errorf("resolving template path: %w", err)
-	}
-
-	if _, err := os.Stat(absPath); os.IsNotExist(err) {
-		return "", fmt.Errorf("template file not found: %s", absPath)
-	}
-
-	return absPath, nil
 }
 
 // detectExistingTaskfile checks for existing Taskfile.yaml or Taskfile.yml

--- a/cmd/task/run/cmd.go
+++ b/cmd/task/run/cmd.go
@@ -97,7 +97,13 @@ Examples:
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			binaryName := "task"
-			discovery := task.NewTaskDiscovery("Taskfile.gen.yaml")
+
+			discovery, err := task.NewDiscovery("Taskfile.gen.yaml", "")
+			if err != nil {
+				_, _ = fmt.Fprintln(os.Stderr, err)
+
+				return cli.ErrSilent
+			}
 
 			rootTaskfile, err := discovery.Discover(opts.Dir, 2)
 			if err != nil {

--- a/internal/task/discovery.go
+++ b/internal/task/discovery.go
@@ -112,6 +112,27 @@ func NewComposeDiscovery(rootTaskfileName string, templatePath string) *Discover
 	}
 }
 
+// NewDiscovery creates the appropriate Discovery for the given taskfile name.
+// If templatePath is non-empty it is resolved to an absolute path and used as
+// the custom template. If templatePath is empty, Discover will automatically
+// check for a ".Taskfile.template" file in the project root at runtime.
+func NewDiscovery(taskfileName, templatePath string) (*Discovery, error) {
+	if templatePath == "" {
+		return NewTaskDiscovery(taskfileName), nil
+	}
+
+	absPath, err := filepath.Abs(templatePath)
+	if err != nil {
+		return nil, fmt.Errorf("resolving template path: %w", err)
+	}
+
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("template file not found: %s", absPath)
+	}
+
+	return NewComposeDiscovery(taskfileName, absPath), nil
+}
+
 func (d *Discovery) Discover(root string, maxDepth int) (string, error) {
 	// Check if .env file exists in the root directory
 	envPath := filepath.Join(root, ".datarobot")
@@ -134,6 +155,14 @@ func (d *Discovery) Discover(root string, maxDepth int) (string, error) {
 	}
 
 	rootTaskfilePath := filepath.Join(root, d.RootTaskfileName)
+
+	// Auto-detect .Taskfile.template in the project root when no explicit template is configured
+	if d.TemplatePath == "" {
+		candidate := filepath.Join(root, ".Taskfile.template")
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			d.TemplatePath = candidate
+		}
+	}
 
 	composeData, err := d.buildComposeData(root, includes)
 	if err != nil {


### PR DESCRIPTION
# RATIONALE

The wrong Taskfile.gen.yaml was getting created because it was ignoring .Taskfile.template.

## CHANGES
Look for .Taskfile.template to properly render the tasks



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to template selection for generated Taskfiles; behavior is additive and only affects projects that already ship `.Taskfile.template`.
> 
> **Overview**
> Fixes root **Taskfile** generation so **`dr run`** (and other discovery paths using `NewTaskDiscovery`) honor a project-local **`.Taskfile.template`** instead of always using the embedded default when no CLI template flag is set.
> 
> **Template resolution** is now: explicit `TemplatePath` (compose mode) → **`.Taskfile.template`** in the repo root if present → embedded `Taskfile.tmpl.yaml`. `genRootTaskfile` takes the resolved path as an argument instead of reading `d.TemplatePath` only inside the generator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34793fcb1f7baee00d39aedd7ed342c391f1df0f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->