### PR TITLE
Add assist plugin v0.1.23

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.23",
+          "url": "assist/assist-0.1.23.tar.xz",
+          "sha256": "a1c7d30fd184565bb6219daffbc811a35939e6d65e6efa2b660e46f82b14d4a2",
+          "releaseDate": "2026-05-28"
+        },
+        {
           "version": "0.1.21",
           "url": "assist/assist-0.1.21.tar.xz",
           "sha256": "d746df38190abb936832da2a603e114f7392099e69091213596f30cd68213da0",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.23 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.23
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.23
- **SHA256:** `a1c7d30fd184565bb6219daffbc811a35939e6d65e6efa2b660e46f82b14d4a2`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only metadata update with no application or security logic changes.
> 
> **Overview**
> Registers **assist** `0.1.23` as the newest entry in `docs/plugins/index.json`, so `dr plugin install assist` can resolve and verify that release (tarball URL, SHA256, release date `2026-05-28`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d065dbda16b40c70eb1374362ddbebb75476c71. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->