### PR TITLE
[CFX-6248] Add `workload code codesync` to expectedWorkloadTrackedCommands in telemetry wiring test

### DIFF
--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -75,6 +75,7 @@ func TestTelemetryWiring_AllCoreCommandsTracked(t *testing.T) {
 // "workload" for the standalone subtree.
 var expectedWorkloadTrackedCommands = []string{
 	"workload code init",
+	"workload code sync",
 	"workload code versions",
 	"workload artifact get",
 	"workload artifact list",


### PR DESCRIPTION
# RATIONALE
The task said "workload code codesync", but the Cobra command is sync (Use: "sync" in codesync/cmd.go). The package/dir is codesync to avoid clashing with internal/workload/sync; the user-facing path is dr workload code sync. The wiring test walks command paths, so the entry must be "workload code sync".

## CHANGES
`cmd/telemetry_wiring_test.go`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only update to an expected command path list; no runtime or security behavior changes.
> 
> **Overview**
> Extends the workload telemetry wiring allowlist so **`dr workload code sync`** is required to carry the `telemetry` annotation, matching how other workload leaf commands are guarded in CI.
> 
> The only code change is adding `"workload code sync"` to `expectedWorkloadTrackedCommands` in `cmd/telemetry_wiring_test.go` (user-facing path `sync`, implemented under the `codesync` package).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a24f96c25598fbf0783fede31b63df033b3550c4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->