### PR TITLE
[CFX-6241] [SEC] P3-3: Use url.PathEscape for server-returned IDs in filesapi URL paths

### DIFF
--- a/internal/drapi/filesapi/allfiles.go
+++ b/internal/drapi/filesapi/allfiles.go
@@ -63,10 +63,11 @@ func (c *httpClient) AllFiles(catalogID, versionID string) (map[string]FileMeta,
 
 func allFilesURL(catalogID, versionID string) (string, error) {
 	if versionID != "" {
-		return drapi.EndpointURL("/files/"+catalogID+"/versions/"+versionID+"/allFiles/", nil)
+		return drapi.EndpointURL(
+			"/files/"+url.PathEscape(catalogID)+"/versions/"+url.PathEscape(versionID)+"/allFiles/", nil)
 	}
 
-	return drapi.EndpointURL("/files/"+catalogID+"/allFiles/", nil)
+	return drapi.EndpointURL("/files/"+url.PathEscape(catalogID)+"/allFiles/", nil)
 }
 
 func (c *httpClient) DownloadFile(catalogID, versionID, path string, w io.Writer) (string, int64, error) {
@@ -77,7 +78,8 @@ func (c *httpClient) DownloadFile(catalogID, versionID, path string, w io.Writer
 	q := url.Values{}
 	q.Set("fileName", path)
 
-	requestURL, err := drapi.EndpointURL("/files/"+catalogID+"/versions/"+versionID+"/file/", q)
+	requestURL, err := drapi.EndpointURL(
+		"/files/"+url.PathEscape(catalogID)+"/versions/"+url.PathEscape(versionID)+"/file/", q)
 	if err != nil {
 		return "", 0, fmt.Errorf("build download url: %w", err)
 	}
@@ -102,7 +104,7 @@ func (c *httpClient) DeleteFiles(catalogID string, paths []string) (*DeleteFiles
 		return nil, nil
 	}
 
-	requestURL, err := drapi.EndpointURL("/files/"+catalogID+"/allFiles/", nil)
+	requestURL, err := drapi.EndpointURL("/files/"+url.PathEscape(catalogID)+"/allFiles/", nil)
 	if err != nil {
 		return nil, fmt.Errorf("build delete url: %w", err)
 	}

--- a/internal/drapi/filesapi/fromfile.go
+++ b/internal/drapi/filesapi/fromfile.go
@@ -45,7 +45,7 @@ func (c *httpClient) UploadFromZipExisting(catalogID, name, overwrite string, si
 	q.Set("useArchiveContents", "true")
 	q.Set("overwrite", overwrite)
 
-	requestURL, err := drapi.EndpointURL("/files/"+catalogID+"/fromFile/", q)
+	requestURL, err := drapi.EndpointURL("/files/"+url.PathEscape(catalogID)+"/fromFile/", q)
 	if err != nil {
 		return nil, fmt.Errorf("build fromFile url: %w", err)
 	}
@@ -83,7 +83,7 @@ func uploadZipMultipart(requestURL, name string, size int64, body io.Reader) (*F
 }
 
 func (c *httpClient) PollStatus(statusID string) (*StatusResp, error) {
-	requestURL, err := drapi.EndpointURL("/status/"+statusID+"/", nil)
+	requestURL, err := drapi.EndpointURL("/status/"+url.PathEscape(statusID)+"/", nil)
 	if err != nil {
 		return nil, fmt.Errorf("build status url: %w", err)
 	}

--- a/internal/drapi/filesapi/stage.go
+++ b/internal/drapi/filesapi/stage.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/datarobot/cli/internal/drapi"
 )
@@ -38,7 +39,7 @@ func (c *httpClient) CreateCatalog() (*CatalogResp, error) {
 }
 
 func (c *httpClient) CreateStage(catalogID string) (*StageResp, error) {
-	requestURL, err := drapi.EndpointURL("/files/"+catalogID+"/stages/", nil)
+	requestURL, err := drapi.EndpointURL("/files/"+url.PathEscape(catalogID)+"/stages/", nil)
 	if err != nil {
 		return nil, fmt.Errorf("build stage url: %w", err)
 	}
@@ -53,7 +54,8 @@ func (c *httpClient) CreateStage(catalogID string) (*StageResp, error) {
 }
 
 func (c *httpClient) UploadToStage(catalogID, stageID, name string, size int64, body io.Reader) error {
-	requestURL, err := drapi.EndpointURL("/files/"+catalogID+"/stages/"+stageID+"/upload/", nil)
+	requestURL, err := drapi.EndpointURL(
+		"/files/"+url.PathEscape(catalogID)+"/stages/"+url.PathEscape(stageID)+"/upload/", nil)
 	if err != nil {
 		return fmt.Errorf("build upload url: %w", err)
 	}
@@ -80,7 +82,7 @@ func (c *httpClient) UploadToStage(catalogID, stageID, name string, size int64, 
 }
 
 func (c *httpClient) ApplyStage(catalogID, stageID, overwrite string) (*ApplyStageResp, error) {
-	requestURL, err := drapi.EndpointURL("/files/"+catalogID+"/fromStage/", nil)
+	requestURL, err := drapi.EndpointURL("/files/"+url.PathEscape(catalogID)+"/fromStage/", nil)
 	if err != nil {
 		return nil, fmt.Errorf("build apply-stage url: %w", err)
 	}

--- a/internal/drapi/filesapi/versions.go
+++ b/internal/drapi/filesapi/versions.go
@@ -36,7 +36,7 @@ func (c *httpClient) ListVersions(catalogID string, limit int) ([]CatalogVersion
 	q.Set("orderBy", "-created")
 	q.Set("limit", strconv.Itoa(versionsPageSize))
 
-	pageURL, err := drapi.EndpointURL("/files/"+catalogID+"/versions/", q)
+	pageURL, err := drapi.EndpointURL("/files/"+url.PathEscape(catalogID)+"/versions/", q)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# RATIONALE
Catalog IDs, stage IDs, and version IDs from server responses were concatenated directly into URL path strings without `url.PathEscape`. A crafted server-returned ID containing `/` or `?` could redirect HTTP requests to unintended endpoints.

## CHANGES
Wrap all server-returned ID values used in path construction with `url.PathEscape`:

```go
path := "/files/" + url.PathEscape(catalogID) + "/stages/" + url.PathEscape(stageID) + "/upload/"
```
Applied consistently across:
- `internal/drapi/filesapi/stage.go` — `catalogID`, `stageID`
- `internal/drapi/filesapi/allfiles.go` — `catalogID`, `versionID`
- `internal/drapi/filesapi/versions.go` — `catalogID`
- `internal/drapi/filesapi/fromfile.go` — `catalogID`, `statusID`
Normal IDs are unchanged by `PathEscape`; only special characters are encoded (e.g. `evil/stage` → `evil%2Fstage`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, defensive URL construction change in the files API client with no behavior change for normal IDs.
> 
> **Overview**
> **filesapi** now wraps **server-returned IDs** (`catalogID`, `versionID`, `stageID`, `statusID`) with `url.PathEscape` when they are embedded in URL path segments built for `drapi.EndpointURL`.
> 
> The change is applied across list/download/delete/all-files flows, staging and upload URLs, zip `fromFile` uploads, version listing, and status polling. IDs that are already safe are unchanged; characters like `/` or `?` in a malicious or malformed ID are encoded so they cannot break out of the intended path segment or skew which API route is hit.
> 
> `stage.go` adds the `net/url` import needed for `PathEscape`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9655a2f975b38f53edb787a2c33231d021869299. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->