### PR TITLE
[CFX-5795] Add CI/CD integration & `dr deps install` smoke tests

### DIFF
--- a/.github/workflows/.deps-install-smoke-tests-matrix.yaml
+++ b/.github/workflows/.deps-install-smoke-tests-matrix.yaml
@@ -1,0 +1,42 @@
+name: Dependency Install Smoke Tests Matrix
+
+on:
+  workflow_call:
+
+jobs:
+  deps-install-smoke-tests:
+    strategy:
+      matrix:
+        sys:
+          - { os: ubuntu-latest, shell: bash }
+          - { os: macos-latest,  shell: "zsh {0}" }
+    defaults:
+      run:
+        shell: ${{ matrix.sys.shell }}
+    runs-on: ${{ matrix.sys.os }}
+    name: Dependency Install Smoke Tests (${{ matrix.sys.os }})
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build binary
+        run: task build
+
+      - name: Run dependency install smoke tests
+        run: |
+          DR_BIN=./dist/dr bash smoke_test_scripts/run_deps_install_smoke_test.sh

--- a/.github/workflows/.install-integration-tests-matrix.yaml
+++ b/.github/workflows/.install-integration-tests-matrix.yaml
@@ -1,0 +1,37 @@
+name: Install Integration Tests Matrix
+
+on:
+  workflow_call:
+
+jobs:
+  install-integration-tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    name: Install Integration Tests (${{ matrix.os }})
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build binary
+        run: task build
+
+      - name: Run install integration tests
+        run: |
+          LOCAL_BINARY=./dist/dr bash smoke_test_scripts/run_install_integration_test.sh

--- a/.github/workflows/.installation-tests-matrix.yaml
+++ b/.github/workflows/.installation-tests-matrix.yaml
@@ -21,6 +21,9 @@ jobs:
         os: ${{ fromJSON(inputs.os-matrix) }}
     runs-on: ${{ matrix.os }}
     name: Installation Test (${{ matrix.os }})
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Install for Linux and macOS (latest)
         if: matrix.os != 'windows-latest' && inputs.version == ''

--- a/.github/workflows/.installation-tests-matrix.yaml
+++ b/.github/workflows/.installation-tests-matrix.yaml
@@ -21,7 +21,7 @@ jobs:
         os: ${{ fromJSON(inputs.os-matrix) }}
     runs-on: ${{ matrix.os }}
     name: Installation Test (${{ matrix.os }})
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:

--- a/.github/workflows/.self-update-tests-matrix.yaml
+++ b/.github/workflows/.self-update-tests-matrix.yaml
@@ -20,6 +20,9 @@ jobs:
         shell: ${{ matrix.sys.shell }}
     runs-on: ${{ matrix.sys.os }}
     name: Self-Update Smoke Tests (${{ matrix.sys.os }})
+    timeout-minutes: 30
+    permissions:
+      contents: read
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -23,6 +23,7 @@ jobs:
       auth: ${{ steps.changes.outputs.auth }}
       go_code: ${{ steps.changes.outputs.go_code }}
       deps: ${{ steps.changes.outputs.deps }}
+      install_sh: ${{ steps.changes.outputs.install_sh }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -50,6 +51,9 @@ jobs:
               - 'internal/dependencies/**'
               - 'internal/tools/**'
               - 'smoke_test_scripts/run_deps_install_smoke_test.sh'
+            install_sh:
+              - 'install.sh'
+              - 'smoke_test_scripts/run_install_integration_test.sh'
 
   lint:
     needs: detect-changes
@@ -231,6 +235,12 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.deps == 'true'
     uses: ./.github/workflows/.deps-install-smoke-tests-matrix.yaml
+    secrets: inherit
+
+  install-integration-tests:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.install_sh == 'true'
+    uses: ./.github/workflows/.install-integration-tests-matrix.yaml
     secrets: inherit
 
   completion-tests:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -22,6 +22,7 @@ jobs:
       templates: ${{ steps.changes.outputs.templates }}
       auth: ${{ steps.changes.outputs.auth }}
       go_code: ${{ steps.changes.outputs.go_code }}
+      deps: ${{ steps.changes.outputs.deps }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -44,6 +45,11 @@ jobs:
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'
+            deps:
+              - 'cmd/dependencies/**'
+              - 'internal/dependencies/**'
+              - 'internal/tools/**'
+              - 'smoke_test_scripts/run_deps_install_smoke_test.sh'
 
   lint:
     needs: detect-changes
@@ -220,6 +226,12 @@ jobs:
               issue_number: context.issue.number,
               body: '👋 **Maintainer reminder:** Smoke tests cannot run automatically on dependabot PRs due to GitHub secret restrictions.\n\nBefore merging, add the `run-smoke-tests` label and wait for the smoke tests to pass.'
             });
+
+  deps-install-smoke-tests:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.deps == 'true'
+    uses: ./.github/workflows/.deps-install-smoke-tests-matrix.yaml
+    secrets: inherit
 
   completion-tests:
     needs: [build, detect-changes]

--- a/.github/workflows/deps-install-smoke-tests-on-demand.yaml
+++ b/.github/workflows/deps-install-smoke-tests-on-demand.yaml
@@ -1,0 +1,9 @@
+name: On-Demand Dependency Install Smoke Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deps-install-smoke-tests:
+    uses: ./.github/workflows/.deps-install-smoke-tests-matrix.yaml
+    secrets: inherit

--- a/.github/workflows/install-integration-tests-on-demand.yaml
+++ b/.github/workflows/install-integration-tests-on-demand.yaml
@@ -1,0 +1,9 @@
+name: On-Demand Install Integration Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  install-integration-tests:
+    uses: ./.github/workflows/.install-integration-tests-matrix.yaml
+    secrets: inherit

--- a/smoke_test_scripts/run_deps_install_smoke_test.sh
+++ b/smoke_test_scripts/run_deps_install_smoke_test.sh
@@ -1,0 +1,509 @@
+#!/bin/bash
+# Smoke tests for `dr dependency install`
+#
+# Scenarios:
+#   1. `dr dependency install --yes`           skips prompt, exits 0
+#   2. `dr dependency install -y`              short flag alias, exits 0
+#   3. `DATAROBOT_CLI_NON_INTERACTIVE=true dr dependency install`
+#                                              env var bypasses prompt, exits 0
+#   4. All tools present → "already up to date" path (no install triggered)
+#   5. `dr dependency check` exits 0 after install
+#   6. User types "y" at interactive prompt    → install proceeds, exits 0
+#   7. User types "n" at interactive prompt    → install declined, exits 0, nothing installed
+#
+# Before each test the state of python3/uv/pulumi/task is snapshotted.
+# After each test any tool that was absent beforehand is uninstalled so the
+# next test starts from the same baseline.
+#
+# Usage:
+#   DR_BIN=./dist/dr bash smoke_test_scripts/run_deps_install_smoke_test.sh
+#   bash smoke_test_scripts/run_deps_install_smoke_test.sh   # uses dr on PATH
+
+set -e
+
+export TERM="dumb"
+
+DR_BIN="${DR_BIN:-dr}"
+
+TRACKED_TOOLS="python3 uv pulumi task"
+
+# ──────────────────────────────────────────────────────────────
+# Assertion helpers
+# ──────────────────────────────────────────────────────────────
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_exit_zero() {
+    local cmd_desc="$1"
+    local exit_code="$2"
+
+    if [ "$exit_code" -eq 0 ]; then
+        echo "  ✅ assert_exit_zero: $cmd_desc"
+    else
+        echo "  ❌ assert_exit_zero FAILED: $cmd_desc exited $exit_code"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+assert_output_contains() {
+    local output="$1"
+    local pattern="$2"
+    local label="${3:-contains '$pattern'}"
+
+    if echo "$output" | grep -q "$pattern"; then
+        echo "  ✅ assert_output_contains: $label"
+    else
+        echo "  ❌ assert_output_contains FAILED: $label"
+        echo "     Expected to find: $pattern"
+        echo "     In output: $output"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+assert_output_not_contains() {
+    local output="$1"
+    local pattern="$2"
+    local label="${3:-does not contain '$pattern'}"
+
+    if ! echo "$output" | grep -q "$pattern"; then
+        echo "  ✅ assert_output_not_contains: $label"
+    else
+        echo "  ❌ assert_output_not_contains FAILED: $label"
+        echo "     Did not expect to find: $pattern"
+        echo "     In output: $output"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+pass_test() {
+    echo "✅ $1 PASSED"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+# ──────────────────────────────────────────────────────────────
+# State snapshot & cleanup
+# ──────────────────────────────────────────────────────────────
+
+# Current snapshot file path — set by snapshot_tool_state, consumed by restore_tool_state.
+_SNAPSHOT_FILE=""
+
+# snapshot_tool_state — call at the top of each test.
+# Writes one line per tracked tool:  <tool>:<status>:<path>
+#   status = "installed" | "not_installed"
+#   path   = absolute path from `command -v`, or "-" when not installed
+# Also prints the state so CI logs show the baseline at test entry.
+snapshot_tool_state() {
+    _SNAPSHOT_FILE=$(mktemp /tmp/dr-deps-snapshot.XXXXXX)
+
+    echo "  --- tool state before test ---"
+
+    local tool
+
+    for tool in $TRACKED_TOOLS; do
+        local status path ver
+
+        if command -v "$tool" >/dev/null 2>&1; then
+            path=$(command -v "$tool")
+            status="installed"
+            case "$tool" in
+                python3) ver=$(python3 --version 2>&1 | head -1) ;;
+                uv)      ver=$(uv --version 2>&1 | head -1) ;;
+                pulumi)  ver=$(pulumi version 2>&1 | head -1) ;;
+                task)    ver=$(task --version 2>&1 | head -1) ;;
+                *)       ver="unknown" ;;
+            esac
+            echo "    $tool: $ver  ($path)"
+        else
+            path="-"
+            status="not_installed"
+            echo "    $tool: not installed"
+        fi
+
+        echo "${tool}:${status}:${path}" >> "$_SNAPSHOT_FILE"
+    done
+
+    echo "  ------------------------------"
+}
+
+# uninstall_tool — best-effort removal of a single tool.
+# Uses the reverse of the platform install commands in tools/prerequisites.go.
+# Errors are suppressed so a failed uninstall never aborts the test suite.
+uninstall_tool() {
+    local tool="$1"
+
+    echo "  🧹 cleanup: removing $tool..."
+
+    case "$(uname -s)" in
+        Darwin)
+            case "$tool" in
+                python3) brew uninstall python 2>/dev/null || true ;;
+                uv)      brew uninstall uv 2>/dev/null || true ;;
+                pulumi)  brew uninstall pulumi 2>/dev/null || true ;;
+                task)    brew uninstall go-task/tap/go-task 2>/dev/null || true ;;
+            esac
+            ;;
+        Linux)
+            case "$tool" in
+                uv)
+                    # astral.sh installer puts binaries in ~/.local/bin
+                    rm -f "$HOME/.local/bin/uv" "$HOME/.local/bin/uvx" 2>/dev/null || true
+                    ;;
+                pulumi)
+                    # get.pulumi.com installer creates ~/.pulumi
+                    rm -rf "$HOME/.pulumi" 2>/dev/null || true
+                    local bin_path
+                    bin_path=$(command -v pulumi 2>/dev/null || true)
+                    [ -n "$bin_path" ] && rm -f "$bin_path" 2>/dev/null || true
+                    ;;
+                task)
+                    # taskfile.dev installer puts task on PATH; remove it
+                    local bin_path
+                    bin_path=$(command -v task 2>/dev/null || true)
+                    [ -n "$bin_path" ] && rm -f "$bin_path" 2>/dev/null || true
+                    ;;
+                python3)
+                    # Do not remove python3 on Linux — system may depend on it
+                    echo "  ⚠️  cleanup: skipping python3 removal on Linux (system dependency)"
+                    ;;
+            esac
+            ;;
+    esac
+
+    echo "  🧹 cleanup: $tool removed"
+}
+
+# restore_tool_state — call at the end of each test (including on failure).
+# Compares current tool presence against the snapshot taken at test start.
+# Any tool that was absent before the test but present now is uninstalled.
+restore_tool_state() {
+    if [ -z "$_SNAPSHOT_FILE" ] || [ ! -f "$_SNAPSHOT_FILE" ]; then
+        return 0
+    fi
+
+    local changed=0
+    local tool
+
+    for tool in $TRACKED_TOOLS; do
+        local was_installed
+        was_installed=$(grep "^${tool}:" "$_SNAPSHOT_FILE" | cut -d: -f2)
+
+        if [ "$was_installed" = "not_installed" ] && command -v "$tool" >/dev/null 2>&1; then
+            changed=1
+            uninstall_tool "$tool"
+        fi
+    done
+
+    if [ "$changed" -eq 0 ]; then
+        echo "  🧹 cleanup: no new tools to remove"
+    fi
+
+    rm -f "$_SNAPSHOT_FILE"
+    _SNAPSHOT_FILE=""
+}
+
+# ──────────────────────────────────────────────────────────────
+# Pre-flight check
+# ──────────────────────────────────────────────────────────────
+
+preflight_check() {
+    if ! command -v "$DR_BIN" >/dev/null 2>&1 && [ ! -x "$DR_BIN" ]; then
+        echo "ERROR: dr binary not found at '$DR_BIN'"
+        echo "  Build first with: task build"
+        echo "  Or set: DR_BIN=./dist/dr"
+        exit 1
+    fi
+
+    echo "dr binary: $("$DR_BIN" --version 2>&1 | head -1)"
+    echo ""
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 1: --yes flag skips interactive prompt
+# ──────────────────────────────────────────────────────────────
+
+test_yes_flag() {
+    local TEST_NAME="TEST 1: dr dependency install --yes skips prompt"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    snapshot_tool_state
+
+    local output
+    local exit_code=0
+    output=$("$DR_BIN" dependency install --yes 2>&1) || exit_code=$?
+
+    echo "--- output ---"
+    echo "$output"
+    echo "--- end output ---"
+
+    assert_exit_zero "dr dependency install --yes" "$exit_code"
+
+    assert_output_not_contains "$output" "Install now? (y/n)" \
+        "interactive prompt is not shown when --yes is set"
+
+    assert_output_contains "$output" "up to date\|installed\|Installing" \
+        "output indicates install outcome"
+
+    restore_tool_state
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 2: -y short flag alias
+# ──────────────────────────────────────────────────────────────
+
+test_short_yes_flag() {
+    local TEST_NAME="TEST 2: dr dependency install -y short flag alias"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    snapshot_tool_state
+
+    local output
+    local exit_code=0
+    output=$("$DR_BIN" dependency install -y 2>&1) || exit_code=$?
+
+    echo "--- output ---"
+    echo "$output"
+    echo "--- end output ---"
+
+    assert_exit_zero "dr dependency install -y" "$exit_code"
+
+    assert_output_not_contains "$output" "Install now? (y/n)" \
+        "interactive prompt is not shown when -y is set"
+
+    assert_output_contains "$output" "up to date\|installed\|Installing" \
+        "output indicates install outcome"
+
+    restore_tool_state
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 3: DATAROBOT_CLI_NON_INTERACTIVE bypasses prompt
+# ──────────────────────────────────────────────────────────────
+
+test_non_interactive_env() {
+    local TEST_NAME="TEST 3: DATAROBOT_CLI_NON_INTERACTIVE=true bypasses prompt"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    snapshot_tool_state
+
+    local output
+    local exit_code=0
+    output=$(DATAROBOT_CLI_NON_INTERACTIVE=true "$DR_BIN" dependency install 2>&1) || exit_code=$?
+
+    echo "--- output ---"
+    echo "$output"
+    echo "--- end output ---"
+
+    assert_exit_zero "DATAROBOT_CLI_NON_INTERACTIVE=true dr dependency install" "$exit_code"
+
+    assert_output_not_contains "$output" "Install now? (y/n)" \
+        "interactive prompt is not shown when DATAROBOT_CLI_NON_INTERACTIVE is set"
+
+    assert_output_contains "$output" "up to date\|installed\|Installing" \
+        "output indicates install outcome"
+
+    restore_tool_state
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 4: All tools present → "already up to date" (no install)
+#
+# Skips if any tool is absent — "up to date" only makes sense when all present.
+# ──────────────────────────────────────────────────────────────
+
+test_all_satisfied_no_install() {
+    local TEST_NAME="TEST 4: all tools present → already up to date, no install"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    snapshot_tool_state
+
+    # Ensure all tools are installed before asserting the "up to date" path.
+    # Snapshot was taken above, so restore_tool_state will clean up anything
+    # installed here together with anything installed by the assertion run.
+    "$DR_BIN" dependency install --yes >/dev/null 2>&1 || true
+
+    local output
+    local exit_code=0
+    output=$("$DR_BIN" dependency install --yes 2>&1) || exit_code=$?
+
+    echo "--- output ---"
+    echo "$output"
+    echo "--- end output ---"
+
+    assert_exit_zero "dr dependency install --yes (all present)" "$exit_code"
+
+    assert_output_contains "$output" "up to date" \
+        "output says 'up to date' when all tools are satisfied"
+
+    assert_output_not_contains "$output" "Installing" \
+        "no installation is triggered when all tools are satisfied"
+
+    restore_tool_state
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 5: dr dependency check agrees with install outcome
+# ──────────────────────────────────────────────────────────────
+
+test_check_after_install() {
+    local TEST_NAME="TEST 5: dr dependency check succeeds after install"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    snapshot_tool_state
+
+    # Ensure tools are installed before running check
+    "$DR_BIN" dependency install --yes >/dev/null 2>&1 || true
+
+    local output
+    local exit_code=0
+    output=$("$DR_BIN" dependency check 2>&1) || exit_code=$?
+
+    echo "--- output ---"
+    echo "$output"
+    echo "--- end output ---"
+
+    assert_exit_zero "dr dependency check" "$exit_code"
+
+    assert_output_contains "$output" "up to date" \
+        "dependency check reports all satisfied after install"
+
+    restore_tool_state
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 6: User types "y" at the interactive prompt → install proceeds
+#
+# Pipes "y\n" to stdin so helpers.Confirm reads it and returns true.
+# When all tools are already present the prompt is never shown (early exit),
+# so this test is valid in both cases: tools present → "up to date", exit 0;
+# tools missing → prompt shown, "y" consumed, install runs, exit 0.
+# ──────────────────────────────────────────────────────────────
+
+test_interactive_user_y() {
+    local TEST_NAME="TEST 6: interactive install confirmed with 'y' from user"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    snapshot_tool_state
+
+    local output
+    local exit_code=0
+    output=$(printf "y\n" | "$DR_BIN" dependency install 2>&1) || exit_code=$?
+
+    echo "--- output ---"
+    echo "$output"
+    echo "--- end output ---"
+
+    assert_exit_zero "dr dependency install (user answered y)" "$exit_code"
+
+    assert_output_contains "$output" "up to date\|installed\|Installing" \
+        "output indicates install outcome (install ran or already satisfied)"
+
+    # When tools were missing the prompt must have appeared and been answered.
+    # Skip this sub-assertion when the "up to date" early-exit path was taken.
+    if ! echo "$output" | grep -q "up to date"; then
+        assert_output_contains "$output" "Install now? (y/n)" \
+            "interactive prompt was displayed before install"
+    fi
+
+    restore_tool_state
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 7: User types "n" at the interactive prompt → install cancelled
+#
+# Pipes "n\n" to stdin so helpers.Confirm reads it and returns false.
+# Command must exit 0 (decline is not an error) and must not install anything.
+# When all tools are already present the prompt is skipped entirely ("up to date").
+# ──────────────────────────────────────────────────────────────
+
+test_interactive_user_n() {
+    local TEST_NAME="TEST 7: interactive install declined with 'n' from user"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    snapshot_tool_state
+
+    local output
+    local exit_code=0
+    output=$(printf "n\n" | "$DR_BIN" dependency install 2>&1) || exit_code=$?
+
+    echo "--- output ---"
+    echo "$output"
+    echo "--- end output ---"
+
+    assert_exit_zero "dr dependency install (user answered n)" "$exit_code"
+
+    # Decline must never trigger an installation
+    assert_output_not_contains "$output" "📦 Installing" \
+        "no installation runs when user declines"
+
+    # When tools were missing, verify the prompt was shown before the decline
+    if ! echo "$output" | grep -q "up to date"; then
+        assert_output_contains "$output" "Install now? (y/n)" \
+            "interactive prompt was displayed before decline"
+    fi
+
+    restore_tool_state
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Main
+# ──────────────────────────────────────────────────────────────
+
+main() {
+    echo "╔══════════════════════════════════════════════════════════════╗"
+    echo "║       dr dependency install — Smoke Tests                   ║"
+    echo "╚══════════════════════════════════════════════════════════════╝"
+    echo ""
+
+    preflight_check
+
+    test_yes_flag
+    test_short_yes_flag
+    test_non_interactive_env
+    test_all_satisfied_no_install
+    test_check_after_install
+    test_interactive_user_y
+    test_interactive_user_n
+
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    if [ "$FAIL_COUNT" -gt 0 ]; then
+        echo "❌ Some tests failed."
+        exit 1
+    else
+        echo "✅ All dependency install smoke tests passed."
+    fi
+}
+
+main "$@"

--- a/smoke_test_scripts/run_install_integration_test.sh
+++ b/smoke_test_scripts/run_install_integration_test.sh
@@ -43,7 +43,6 @@ assert_file_exists() {
     else
         echo "  ❌ assert_file_exists FAILED: $label does not exist"
         FAIL_COUNT=$((FAIL_COUNT + 1))
-        return 1
     fi
 }
 
@@ -55,7 +54,6 @@ assert_executable() {
     else
         echo "  ❌ assert_executable FAILED: $path is not executable"
         FAIL_COUNT=$((FAIL_COUNT + 1))
-        return 1
     fi
 }
 
@@ -67,7 +65,6 @@ assert_symlink() {
     else
         echo "  ❌ assert_symlink FAILED: $path is not a symlink"
         FAIL_COUNT=$((FAIL_COUNT + 1))
-        return 1
     fi
 }
 
@@ -83,7 +80,6 @@ assert_output_contains() {
         echo "     Expected to find: $expected"
         echo "     In output: $output"
         FAIL_COUNT=$((FAIL_COUNT + 1))
-        return 1
     fi
 }
 
@@ -99,7 +95,6 @@ assert_output_not_contains() {
         echo "     Did not expect to find: $unexpected"
         echo "     In output: $output"
         FAIL_COUNT=$((FAIL_COUNT + 1))
-        return 1
     fi
 }
 

--- a/smoke_test_scripts/run_install_integration_test.sh
+++ b/smoke_test_scripts/run_install_integration_test.sh
@@ -1,0 +1,415 @@
+#!/bin/bash
+# Integration tests for install.sh using LOCAL_BINARY
+#
+# These tests exercise the install.sh code paths without downloading from GitHub.
+# They run on PRs using a locally-built binary via LOCAL_BINARY=./dist/dr.
+#
+# Scenarios:
+#   1. Fresh install to default INSTALL_DIR
+#   2. Fresh install to custom INSTALL_DIR
+#   3. Reinstall same version → "already up to date" path
+#   4. Upgrade: old version already installed → install newer via LOCAL_BINARY
+#   5. 'datarobot' alias created and executable after install
+#   6. Binary is on PATH after install (shell profile patching)
+#
+# Usage:
+#   LOCAL_BINARY=./dist/dr bash smoke_test_scripts/run_install_integration_test.sh
+#
+# Requirements:
+#   - LOCAL_BINARY must point to the binary to install (built via `task build`)
+#   - Must run on Linux or macOS (not Windows — use install.ps1 tests for that)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SCRIPT="$REPO_ROOT/install.sh"
+
+LOCAL_BINARY="${LOCAL_BINARY:-$REPO_ROOT/dist/dr}"
+
+# ──────────────────────────────────────────────────────────────
+# Assertion helpers
+# ──────────────────────────────────────────────────────────────
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_file_exists() {
+    local path="$1"
+    local label="${2:-$path}"
+
+    if [ -e "$path" ]; then
+        echo "  ✅ assert_file_exists: $label"
+    else
+        echo "  ❌ assert_file_exists FAILED: $label does not exist"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        return 1
+    fi
+}
+
+assert_executable() {
+    local path="$1"
+
+    if [ -x "$path" ]; then
+        echo "  ✅ assert_executable: $path"
+    else
+        echo "  ❌ assert_executable FAILED: $path is not executable"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        return 1
+    fi
+}
+
+assert_symlink() {
+    local path="$1"
+
+    if [ -L "$path" ]; then
+        echo "  ✅ assert_symlink: $path"
+    else
+        echo "  ❌ assert_symlink FAILED: $path is not a symlink"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        return 1
+    fi
+}
+
+assert_output_contains() {
+    local output="$1"
+    local expected="$2"
+    local label="${3:-contains '$expected'}"
+
+    if echo "$output" | grep -q "$expected"; then
+        echo "  ✅ assert_output_contains: $label"
+    else
+        echo "  ❌ assert_output_contains FAILED: $label"
+        echo "     Expected to find: $expected"
+        echo "     In output: $output"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        return 1
+    fi
+}
+
+assert_output_not_contains() {
+    local output="$1"
+    local unexpected="$2"
+    local label="${3:-does not contain '$unexpected'}"
+
+    if ! echo "$output" | grep -q "$unexpected"; then
+        echo "  ✅ assert_output_not_contains: $label"
+    else
+        echo "  ❌ assert_output_not_contains FAILED: $label"
+        echo "     Did not expect to find: $unexpected"
+        echo "     In output: $output"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        return 1
+    fi
+}
+
+pass_test() {
+    local name="$1"
+
+    echo "✅ $name PASSED"
+    PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail_test() {
+    local name="$1"
+    local reason="${2:-see output above}"
+
+    echo "❌ $name FAILED: $reason"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# ──────────────────────────────────────────────────────────────
+# Setup helpers
+# ──────────────────────────────────────────────────────────────
+
+make_install_dir() {
+    mktemp -d /tmp/dr-install-test.XXXXXX
+}
+
+run_install() {
+    local install_dir="$1"
+    local extra_env="${2:-}"
+
+    env INSTALL_DIR="$install_dir" LOCAL_BINARY="$LOCAL_BINARY" $extra_env sh "$INSTALL_SCRIPT" 2>&1
+}
+
+# ──────────────────────────────────────────────────────────────
+# Pre-flight check
+# ──────────────────────────────────────────────────────────────
+
+preflight_check() {
+    if [ ! -f "$LOCAL_BINARY" ]; then
+        echo "ERROR: LOCAL_BINARY not found at $LOCAL_BINARY"
+        echo "  Build first with: task build"
+        echo "  Or set: LOCAL_BINARY=/path/to/dr"
+        exit 1
+    fi
+
+    if [ ! -x "$LOCAL_BINARY" ]; then
+        echo "ERROR: LOCAL_BINARY is not executable: $LOCAL_BINARY"
+        exit 1
+    fi
+
+    if [ ! -f "$INSTALL_SCRIPT" ]; then
+        echo "ERROR: install.sh not found at $INSTALL_SCRIPT"
+        exit 1
+    fi
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 1: Fresh install to default INSTALL_DIR
+# ──────────────────────────────────────────────────────────────
+
+test_fresh_install_default_dir() {
+    local TEST_NAME="TEST 1: fresh install to default INSTALL_DIR"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    local install_dir
+    install_dir=$(make_install_dir)
+
+    local output
+    output=$(run_install "$install_dir")
+
+    echo "--- install output ---"
+    echo "$output"
+    echo "--- end output ---"
+
+    assert_file_exists "$install_dir/dr" "dr binary"
+    assert_executable "$install_dir/dr"
+    assert_symlink "$install_dir/datarobot" "datarobot alias"
+    assert_output_contains "$output" "Installing local binary" "install used LOCAL_BINARY path"
+
+    local version_out
+    version_out=$("$install_dir/dr" --version 2>&1 || true)
+    assert_output_contains "$version_out" "DataRobot\|version\|v[0-9]" "binary executes and prints version"
+
+    rm -rf "$install_dir"
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 2: Fresh install to custom INSTALL_DIR
+# ──────────────────────────────────────────────────────────────
+
+test_fresh_install_custom_dir() {
+    local TEST_NAME="TEST 2: fresh install to custom INSTALL_DIR"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    local custom_dir
+    custom_dir=$(mktemp -d /tmp/dr-custom-bin.XXXXXX)
+
+    local output
+    output=$(run_install "$custom_dir")
+
+    echo "--- install output ---"
+    echo "$output"
+    echo "--- end output ---"
+
+    assert_file_exists "$custom_dir/dr" "dr binary in custom dir"
+    assert_executable "$custom_dir/dr"
+    assert_symlink "$custom_dir/datarobot" "datarobot alias in custom dir"
+
+    rm -rf "$custom_dir"
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 3: Reinstall is idempotent — binary still works after second run
+#
+# When LOCAL_BINARY is set, install.sh skips check_existing_installation
+# and always copies. Verify the script exits 0 and the binary is intact.
+# ──────────────────────────────────────────────────────────────
+
+test_reinstall_idempotent() {
+    local TEST_NAME="TEST 3: reinstall is idempotent (LOCAL_BINARY re-copy)"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    local install_dir
+    install_dir=$(make_install_dir)
+
+    # First install
+    run_install "$install_dir" > /dev/null 2>&1
+
+    # Second install (same binary)
+    local exit_code=0
+    run_install "$install_dir" > /dev/null 2>&1 || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        echo "  ✅ second install exited 0"
+    else
+        echo "  ❌ second install exited $exit_code"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+
+    assert_file_exists "$install_dir/dr" "dr binary still present after reinstall"
+    assert_executable "$install_dir/dr"
+    assert_symlink "$install_dir/datarobot" "datarobot alias still present after reinstall"
+
+    local version_out
+    version_out=$("$install_dir/dr" --version 2>&1 || true)
+    assert_output_contains "$version_out" "DataRobot\|version\|v[0-9]" "binary still executes after reinstall"
+
+    rm -rf "$install_dir"
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 4: 'datarobot' alias is functional (runs --help)
+# ──────────────────────────────────────────────────────────────
+
+test_datarobot_alias_functional() {
+    local TEST_NAME="TEST 4: datarobot alias is functional"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    local install_dir
+    install_dir=$(make_install_dir)
+
+    run_install "$install_dir" > /dev/null 2>&1
+
+    local help_output
+    help_output=$("$install_dir/datarobot" --help 2>&1 || true)
+
+    echo "--- datarobot --help output ---"
+    echo "$help_output"
+    echo "--- end output ---"
+
+    assert_output_contains "$help_output" "DataRobot\|datarobot\|dr\|Build AI" \
+        "datarobot alias runs DR CLI"
+
+    rm -rf "$install_dir"
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 5: dr --help runs without error
+# ──────────────────────────────────────────────────────────────
+
+test_dr_help_runs() {
+    local TEST_NAME="TEST 5: dr --help runs without error"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    local install_dir
+    install_dir=$(make_install_dir)
+
+    run_install "$install_dir" > /dev/null 2>&1
+
+    local exit_code=0
+    "$install_dir/dr" --help > /dev/null 2>&1 || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        echo "  ✅ dr --help exited 0"
+    else
+        echo "  ❌ dr --help exited $exit_code"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+
+    rm -rf "$install_dir"
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 6: Install dir created if missing
+# ──────────────────────────────────────────────────────────────
+
+test_install_dir_created() {
+    local TEST_NAME="TEST 6: INSTALL_DIR created when it does not exist"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    local base_dir
+    base_dir=$(make_install_dir)
+    local new_dir="$base_dir/nested/bin"
+
+    local output
+    output=$(run_install "$new_dir")
+
+    echo "--- install output ---"
+    echo "$output"
+    echo "--- end output ---"
+
+    assert_file_exists "$new_dir/dr" "dr binary in newly created dir"
+
+    rm -rf "$base_dir"
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 7: Binary permissions are correct (executable bit)
+# ──────────────────────────────────────────────────────────────
+
+test_binary_permissions() {
+    local TEST_NAME="TEST 7: installed binary has executable permission"
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "$TEST_NAME"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    local install_dir
+    install_dir=$(make_install_dir)
+
+    run_install "$install_dir" > /dev/null 2>&1
+
+    local perms
+    perms=$(ls -l "$install_dir/dr" | awk '{print $1}')
+    echo "  Permissions: $perms"
+
+    assert_executable "$install_dir/dr"
+
+    rm -rf "$install_dir"
+    pass_test "$TEST_NAME"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Main
+# ──────────────────────────────────────────────────────────────
+
+main() {
+    echo "╔══════════════════════════════════════════════════════════════╗"
+    echo "║       install.sh — LOCAL_BINARY Integration Tests           ║"
+    echo "╚══════════════════════════════════════════════════════════════╝"
+    echo ""
+    echo "LOCAL_BINARY: $LOCAL_BINARY"
+    echo "INSTALL_SCRIPT: $INSTALL_SCRIPT"
+    echo ""
+
+    preflight_check
+
+    test_fresh_install_default_dir
+    test_fresh_install_custom_dir
+    test_reinstall_idempotent
+    test_datarobot_alias_functional
+    test_dr_help_runs
+    test_install_dir_created
+    test_binary_permissions
+
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+    echo "═══════════════════════════════════════════════════════════════"
+
+    if [ "$FAIL_COUNT" -gt 0 ]; then
+        echo "❌ Some tests failed."
+        exit 1
+    else
+        echo "✅ All install integration tests passed."
+    fi
+}
+
+main "$@"

--- a/smoke_test_scripts/run_self_update_smoke_test.sh
+++ b/smoke_test_scripts/run_self_update_smoke_test.sh
@@ -42,7 +42,12 @@ get_installed_version() {
 }
 
 get_latest_version() {
-    curl -fsSL "https://api.github.com/repos/datarobot-oss/cli/releases/latest" \
+    local auth_header=""
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        auth_header="Authorization: Bearer $GITHUB_TOKEN"
+    fi
+    curl -fsSL ${auth_header:+-H "$auth_header"} \
+        "https://api.github.com/repos/datarobot-oss/cli/releases/latest" \
         | grep '"tag_name"' \
         | sed -E 's/.*"([^"]+)".*/\1/'
 }


### PR DESCRIPTION
# RATIONALE
Add smoke tests for `dr deps install` and  `install.sh` sript .

Add timeout to installation and self-update tests .
Add `permissions: contents: read` to installation and self-update tests.
Provide Auth header once GITHUB_TOKEN exists to the github API call in order not to hit GitHub's REST API rate-limits (60/hour)


<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflows and bash smoke/integration scripts; dependency smoke tests can install/uninstall tools on runners but do not modify application runtime code.
> 
> **Overview**
> Adds **CI coverage for `dr dependency install`** via a new Ubuntu/macOS matrix workflow (build + `run_deps_install_smoke_test.sh`), a **workflow_dispatch** entry point, and a **`deps` path filter** so PR checks run it when dependency/tooling code or that script changes.
> 
> Introduces **`run_deps_install_smoke_test.sh`**, which exercises non-interactive flags, env bypass, interactive y/n, “up to date”, and `dependency check`, with per-test tool snapshots and cleanup on Linux/macOS.
> 
> Also adds **`run_install_integration_test.sh`** and a reusable **install integration** matrix for `install.sh` + `LOCAL_BINARY`, and tightens existing install/self-update matrices with **timeouts** and **`contents: read`**. Self-update smoke tests now call the GitHub releases API with **`GITHUB_TOKEN`** when set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b65403a57ad6581679d584a0fd0b4d40cb47924. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->