### PR TITLE
Revert "Correctly use local template for tasks if available during `dr run`"

### DIFF
--- a/cmd/task/compose/cmd.go
+++ b/cmd/task/compose/cmd.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/datarobot/cli/internal/cli"
@@ -36,7 +37,7 @@ var templatePath string
 func RunE(_ *cobra.Command, _ []string) error {
 	taskfileName, ignoreTaskfile := detectExistingTaskfile()
 
-	discovery, err := task.NewDiscovery(taskfileName, templatePath)
+	discovery, err := createDiscovery(taskfileName)
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, err)
 
@@ -86,6 +87,43 @@ func RunE(_ *cobra.Command, _ []string) error {
 	fmt.Println("Added " + taskfileIgnore + " line to '.gitignore'.")
 
 	return nil
+}
+
+func createDiscovery(taskfileName string) (*task.Discovery, error) {
+	// Check for .Taskfile.template in the root directory if no template specified
+	autoTemplatePath := ".Taskfile.template"
+
+	if templatePath == "" {
+		if _, err := os.Stat(autoTemplatePath); err == nil {
+			templatePath = autoTemplatePath
+			fmt.Printf("Using auto-discovered template: %s\n", autoTemplatePath)
+		}
+	}
+
+	// If template is specified or found, use compose mode
+	if templatePath != "" {
+		absPath, err := validateTemplatePath(templatePath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid template: %w", err)
+		}
+
+		return task.NewComposeDiscovery(taskfileName, absPath), nil
+	}
+
+	return task.NewTaskDiscovery(taskfileName), nil
+}
+
+func validateTemplatePath(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolving template path: %w", err)
+	}
+
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("template file not found: %s", absPath)
+	}
+
+	return absPath, nil
 }
 
 // detectExistingTaskfile checks for existing Taskfile.yaml or Taskfile.yml

--- a/cmd/task/run/cmd.go
+++ b/cmd/task/run/cmd.go
@@ -97,13 +97,7 @@ Examples:
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			binaryName := "task"
-
-			discovery, err := task.NewDiscovery("Taskfile.gen.yaml", "")
-			if err != nil {
-				_, _ = fmt.Fprintln(os.Stderr, err)
-
-				return cli.ErrSilent
-			}
+			discovery := task.NewTaskDiscovery("Taskfile.gen.yaml")
 
 			rootTaskfile, err := discovery.Discover(opts.Dir, 2)
 			if err != nil {

--- a/internal/task/discovery.go
+++ b/internal/task/discovery.go
@@ -112,27 +112,6 @@ func NewComposeDiscovery(rootTaskfileName string, templatePath string) *Discover
 	}
 }
 
-// NewDiscovery creates the appropriate Discovery for the given taskfile name.
-// If templatePath is non-empty it is resolved to an absolute path and used as
-// the custom template. If templatePath is empty, Discover will automatically
-// check for a ".Taskfile.template" file in the project root at runtime.
-func NewDiscovery(taskfileName, templatePath string) (*Discovery, error) {
-	if templatePath == "" {
-		return NewTaskDiscovery(taskfileName), nil
-	}
-
-	absPath, err := filepath.Abs(templatePath)
-	if err != nil {
-		return nil, fmt.Errorf("resolving template path: %w", err)
-	}
-
-	if _, err := os.Stat(absPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("template file not found: %s", absPath)
-	}
-
-	return NewComposeDiscovery(taskfileName, absPath), nil
-}
-
 func (d *Discovery) Discover(root string, maxDepth int) (string, error) {
 	// Check if .env file exists in the root directory
 	envPath := filepath.Join(root, ".datarobot")
@@ -155,14 +134,6 @@ func (d *Discovery) Discover(root string, maxDepth int) (string, error) {
 	}
 
 	rootTaskfilePath := filepath.Join(root, d.RootTaskfileName)
-
-	// Auto-detect .Taskfile.template in the project root when no explicit template is configured
-	if d.TemplatePath == "" {
-		candidate := filepath.Join(root, ".Taskfile.template")
-		if _, statErr := os.Stat(candidate); statErr == nil {
-			d.TemplatePath = candidate
-		}
-	}
 
 	composeData, err := d.buildComposeData(root, includes)
 	if err != nil {


### PR DESCRIPTION
Reverts datarobot-oss/cli#530

Based on Claude analysis:

The start task in `.Taskfile.template` contains:

```
start:
  cmds:
    - dr task compose        # regenerates Taskfile.gen.yaml (with the same .Taskfile.template → sets d.TemplatePath again)
    - ...
    - dr task run start      # runs "task start" → which calls dr task compose again → infinite loop
```

Here's the exact chain that creates the infinite loop:

1. `dr start` detects `task start` is available → runs `task start`
2. `task start` (from `.Taskfile.template`) runs `dr task compose`
3. `dr task compose` calls `task.NewDiscovery(taskfileName, templatePath)` → `discovery.Discover(".", 2)`
4. Inside `Discover`, the new code (added in this commit) auto-detects `.Taskfile.template` and sets `d.TemplatePath = candidate`
5. `dr task compose` regenerates `Taskfile.gen.yaml` with the same `.Taskfile.template` — the `start` task still contains dr task run start
6. `task start` then runs `dr task run start` — which runs task `start` again → back to step 2

The infinite loop is in the `.Taskfile.template` itself: the `start` task calls `dr task compose` (which picks up the template), and then `dr task run start` (which re-invokes `task start`). But the trigger is the new commit's auto-detection logic in `Discover()` that sets `d.TemplatePath` at runtime, which means the generated `Taskfile.gen.yaml` always carries a `start` task that calls back into itself via `dr task run start`.

Before this commit, `dr task compose `without an explicit --template flag would have used `NewTaskDiscovery` (no template), so the generated file would have used the built-in template — which doesn't have the `dr task run start `self-call. Now it always picks up `.Taskfile.template`, which does.

The root cause: The `.Taskfile.template`'s `start` task calls `dr task run start`, which resolves to `task start` (via the generated `Taskfile`), creating a cycle: `task start` → `dr task run start` → `task start` → ...

This was likely always latent in the template, but the commit made `dr task compose` auto-discover and use `.Taskfile.template` even when called without `--template`, so the cycle now activates during `dr start`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how generated Taskfiles are built for `dr run` vs compose, which can alter which tasks run in repos that relied on #530’s local template behavior.
> 
> **Overview**
> Reverts the unified **`task.NewDiscovery`** API and restores **split discovery paths** for compose vs run.
> 
> **`dr task compose`** again owns template selection: **`createDiscovery`** auto-picks **`.Taskfile.template`** when no **`--template`** flag is set, validates the path with **`validateTemplatePath`**, and uses **`NewComposeDiscovery`** vs **`NewTaskDiscovery`** accordingly.
> 
> **`dr run`** no longer goes through discovery that could pick a local template; it always uses **`NewTaskDiscovery("Taskfile.gen.yaml")`** and the embedded default template during **`Discover`**.
> 
> **`internal/task`** drops **`NewDiscovery`** and the runtime **`.Taskfile.template`** check inside **`Discover`**—compose mode only applies when **`TemplatePath`** is set on the discovery instance (from compose).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fff357154cf7e02edc419963fd21e01c26c4c81. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->