### PR TITLE
[CFX-6356] Silence Amplitude SDK error logs

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -53,8 +53,10 @@ type Client struct {
 const amplitudeLogPrefix = "[amplitude] "
 
 // amplitudeLogger adapts the internal log package to Amplitude's Logger interface.
-// Amplitude's INFO logs (HTTP responses, variable additions) are demoted to DEBUG
-// when the app's log level is above INFO, keeping stderr clean by default.
+// Amplitude's INFO/WARN/ERROR logs (HTTP responses, retry exhaustion, etc.) are
+// demoted to DEBUG when the app's log level is above INFO, keeping stderr clean
+// by default — telemetry must never surface user-visible errors. They reappear
+// at INFO/WARN under --verbose/--debug for diagnostics.
 // All messages are prefixed with [amplitude] for traceability in debug log files.
 type amplitudeLogger struct{}
 
@@ -71,11 +73,19 @@ func (l *amplitudeLogger) Infof(msg string, args ...any) {
 }
 
 func (l *amplitudeLogger) Warnf(msg string, args ...any) {
-	log.Warnf(amplitudeLogPrefix+msg, args...)
+	if log.IsVerbose() {
+		log.Warnf(amplitudeLogPrefix+msg, args...)
+	} else {
+		log.Debugf(amplitudeLogPrefix+msg, args...)
+	}
 }
 
 func (l *amplitudeLogger) Errorf(msg string, args ...any) {
-	log.Errorf(amplitudeLogPrefix+msg, args...)
+	if log.IsVerbose() {
+		log.Warnf(amplitudeLogPrefix+msg, args...)
+	} else {
+		log.Debugf(amplitudeLogPrefix+msg, args...)
+	}
 }
 
 // NewClient creates a telemetry client. If IsEnabled() returns true, it initializes


### PR DESCRIPTION

### What
Demote Amplitude SDK `WARN`/`ERROR` log lines in telemetry.go to `DEBUG` by default, promoting them to `WARN` only when the user passes `--verbose` / `--debug`. Mirrors the existing demotion pattern already in place for `Infof`.

### Why
Users were seeing red, user-facing errors on stderr like:

```
ERROR [amplitude] Event reached max retry times 12: code=0, events=[…]
```

whenever Amplitude failed to deliver events (network issues, dev builds pointed at an unreachable endpoint, etc.). This directly contradicts the telemetry package contract: *"designed to never block CLI execution or cause errors visible to users."* Telemetry is best-effort and must not disturb users.

### Changes
- telemetry.go
  - `amplitudeLogger.Warnf` and `amplitudeLogger.Errorf` now log at `DEBUG` by default and `WARN` under `--verbose`/`--debug`.
  - Updated the `amplitudeLogger` doc comment to reflect the new behavior.


## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change in the telemetry adapter; no behavior change to event tracking or delivery beyond what users see in the console.
> 
> **Overview**
> **Amplitude SDK logging in `telemetry.go` is aligned with the existing `Infof` demotion pattern** so failed event delivery (retries, network issues) no longer prints user-visible `WARN`/`ERROR` lines on stderr by default.
> 
> `amplitudeLogger.Warnf` and `amplitudeLogger.Errorf` now write to **debug** unless `--verbose` / `--debug` is set; in verbose mode they surface as **warn** (including SDK errors, which are not promoted to error level). The `amplitudeLogger` comment is updated to document INFO/WARN/ERROR handling and the telemetry “never disturb users” contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d5fe70ecbb66844a50853db0a50caebe972e606. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->