### PR TITLE
[-] enhance security checks for PRs from forks and maintainers

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -6,6 +6,7 @@ concurrency:
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
 
@@ -24,6 +25,7 @@ jobs:
       go_code: ${{ steps.changes.outputs.go_code }}
       deps: ${{ steps.changes.outputs.deps }}
       install_sh: ${{ steps.changes.outputs.install_sh }}
+      github_dir: ${{ steps.changes.outputs.github_dir }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -54,6 +56,154 @@ jobs:
             install_sh:
               - 'install.sh'
               - 'smoke_test_scripts/run_install_integration_test.sh'
+            github_dir:
+              - '.github/**'
+
+  # Guards changes under `.github/` (workflows, actions, CODEOWNERS, branch-protection
+  # configs, etc.) against fork PRs and non-maintainer authors. These files control
+  # CI behavior and secret handling, so modifications from untrusted sources must be
+  # explicitly approved by a maintainer applying the `approved-workflow-changes` label.
+  #
+  # Label trust: GitHub allows triage-level users (not just maintainers) to add labels,
+  # so the guard does not trust label presence alone — it inspects the issue timeline
+  # to find who applied the label and verifies that actor has write/maintain/admin.
+  # A non-maintainer's label application is rejected and the label is auto-removed.
+  workflow-changes-guard:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.github_dir == 'true'
+    runs-on: ubuntu-latest
+    name: Guard .github/ Changes
+    permissions:
+      pull-requests: write  # needed to remove an unauthorized approval label
+      issues: read
+      contents: read
+    steps:
+      - name: Verify maintainer-authored or explicitly approved
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const isFork = pr.head.repo.full_name !== pr.base.repo.full_name;
+            const approvalLabel = 'approved-workflow-changes';
+            const maintainerPerms = ['write', 'maintain', 'admin'];
+
+            async function permissionOf(username) {
+              try {
+                const res = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username,
+                });
+
+                return res.data.permission;
+              } catch (e) {
+                console.log(`Could not resolve permission for @${username}: ${e.message}`);
+
+                return 'none';
+              }
+            }
+
+            const authorPermission = await permissionOf(pr.user.login);
+            const isAuthorMaintainer = maintainerPerms.includes(authorPermission);
+
+            // List changed files under .github/ for diagnostics.
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+            const changedGithubFiles = files
+              .filter(f => f.filename.startsWith('.github/'))
+              .map(f => `  - ${f.filename}`)
+              .join('\n');
+
+            console.log(`PR author: @${pr.user.login} (permission: ${authorPermission}, maintainer: ${isAuthorMaintainer})`);
+            console.log(`Fork PR: ${isFork}`);
+            console.log(`Changed .github/ files:\n${changedGithubFiles}`);
+
+            if (!isFork && isAuthorMaintainer) {
+              console.log('✅ Non-fork PR authored by a maintainer — allowed.');
+
+              return;
+            }
+
+            // Determine whether the approval label is present AND was applied by a maintainer.
+            // We walk the issue events timeline to find the most recent `labeled` event for
+            // our approval label and check that actor's permission. This prevents triage-level
+            // users from self-approving by applying the label themselves.
+            const events = await github.paginate(github.rest.issues.listEvents, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+
+            // Most recent `labeled`/`unlabeled` event for the approval label decides current state.
+            let labelerLogin = null;
+            let labelCurrentlyApplied = false;
+
+            for (const ev of events) {
+              if (!ev.label || ev.label.name !== approvalLabel) {
+                continue;
+              }
+
+              if (ev.event === 'labeled') {
+                labelCurrentlyApplied = true;
+                labelerLogin = ev.actor && ev.actor.login;
+              } else if (ev.event === 'unlabeled') {
+                labelCurrentlyApplied = false;
+                labelerLogin = null;
+              }
+            }
+
+            if (labelCurrentlyApplied && labelerLogin) {
+              const labelerPermission = await permissionOf(labelerLogin);
+              const isLabelerMaintainer = maintainerPerms.includes(labelerPermission);
+
+              console.log(`Approval label applied by @${labelerLogin} (permission: ${labelerPermission}, maintainer: ${isLabelerMaintainer})`);
+
+              if (isLabelerMaintainer) {
+                console.log(`✅ Changes explicitly approved via '${approvalLabel}' label by a maintainer.`);
+
+                return;
+              }
+
+              // Unauthorized application — remove the label so it can't be re-used as a bypass.
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: approvalLabel,
+                });
+
+                console.log(`Removed '${approvalLabel}' label applied by non-maintainer @${labelerLogin}.`);
+              } catch (e) {
+                console.log(`Failed to remove '${approvalLabel}' label: ${e.message}`);
+              }
+
+              core.setFailed(
+                `The '${approvalLabel}' label was applied by @${labelerLogin}, ` +
+                `who is not a maintainer (permission: \`${labelerPermission}\`). ` +
+                `The label has been removed. A user with write/maintain/admin permission ` +
+                `must re-apply it to approve these workflow changes.`
+              );
+
+              return;
+            }
+
+            const reason = isFork
+              ? `This PR comes from a fork (\`${pr.head.repo.full_name}\`)`
+              : `PR author @${pr.user.login} is not a maintainer (permission: \`${authorPermission}\`)`;
+
+            core.setFailed(
+              `Changes under \`.github/\` are restricted.\n` +
+              `${reason}, so modifications to CI workflows / actions / CODEOWNERS ` +
+              `require explicit maintainer review.\n\n` +
+              `Changed files:\n${changedGithubFiles}\n\n` +
+              `A maintainer (write/maintain/admin permission) must review these changes ` +
+              `and add the \`${approvalLabel}\` label to unblock this check.`
+            );
 
   lint:
     needs: detect-changes

--- a/.github/workflows/smoke-tests-gate-status.yaml
+++ b/.github/workflows/smoke-tests-gate-status.yaml
@@ -1,0 +1,88 @@
+name: Smoke Tests Gate Status
+
+# Companion to `Smoke Tests Gate`. Runs via `workflow_run` so it executes from the
+# default branch with a writable token (NOT `pull_request_target`, which is risky
+# because it runs PR-supplied workflow files with secret access). This workflow only
+# reads a small artifact produced by the gate job — it never checks out or executes
+# PR code.
+#
+# Sets the required "Smoke Tests" commit status:
+# - Non-fork PRs: `success` (smoke tests may be run optionally via labels/commands).
+# - Fork PRs:     `failure` — blocks merge until a maintainer runs
+#                 `/approve-smoke-tests` or `/skip-smoke-tests`.
+on:
+  workflow_run:
+    workflows: ['Smoke Tests Gate']
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  set-status:
+    runs-on: ubuntu-latest
+    # Skip status updates if the gate run itself was cancelled / failed in a way that
+    # produced no artifact — `success`/`failure` from the gate are both fine because
+    # the gate's only job is to upload metadata.
+    if: github.event.workflow_run.conclusion != 'cancelled'
+    permissions:
+      actions: read       # download artifact from the triggering run
+      statuses: write     # post the required commit status
+    steps:
+      - name: Download gate info artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: smoke-tests-gate-info
+          path: gate-info
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load gate info
+        id: load
+        run: |
+          if [ ! -f gate-info/pr.env ]; then
+            echo "::error::gate-info/pr.env not found in artifact"
+            exit 1
+          fi
+
+          # shellcheck disable=SC2002
+          cat gate-info/pr.env | tee -a "$GITHUB_OUTPUT"
+
+      - name: Set Smoke Tests commit status
+        uses: actions/github-script@v7
+        env:
+          SHA: ${{ steps.load.outputs.sha }}
+          IS_FORK: ${{ steps.load.outputs.is_fork }}
+          PR_NUMBER: ${{ steps.load.outputs.pr_number }}
+        with:
+          script: |
+            const sha = process.env.SHA;
+            const isFork = process.env.IS_FORK === 'true';
+            const prNumber = process.env.PR_NUMBER;
+
+            if (!sha) {
+              core.setFailed('Missing SHA from gate artifact.');
+              return;
+            }
+
+            if (isFork) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: 'failure',
+                context: 'Smoke Tests',
+                description: 'Fork PR — maintainer must run /approve-smoke-tests or /skip-smoke-tests',
+              });
+              console.log(`Set Smoke Tests → failure for fork PR #${prNumber} @ ${sha} (blocks merge until maintainer action).`);
+            } else {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: 'success',
+                context: 'Smoke Tests',
+                description: 'Non-fork PR — use /trigger-smoke-test or labels to run smoke tests',
+              });
+              console.log(`Set Smoke Tests → success for PR #${prNumber} @ ${sha}`);
+            }

--- a/.github/workflows/smoke-tests-gate.yaml
+++ b/.github/workflows/smoke-tests-gate.yaml
@@ -1,13 +1,14 @@
 name: Smoke Tests Gate
 
-# Sets the required "Smoke Tests" commit status for all PRs targeting main.
-# - Non-fork PRs: auto-succeed (smoke tests can be run optionally via labels/commands).
-# - Fork PRs: an explicit `failure` status is posted to block merge until a maintainer
-#   runs (/approve-smoke-tests) or skips (/skip-smoke-tests) tests. Uses
-#   `pull_request_target` so the workflow runs with a token that can write statuses
-#   (the job only reads PR metadata and posts a status — it does NOT check out PR code).
+# Records the PR head SHA + fork status so the companion `Smoke Tests Gate Status`
+# workflow (triggered via `workflow_run`) can post the required "Smoke Tests" commit
+# status with a writable token.
+#
+# We deliberately use `pull_request` (NOT `pull_request_target`) here so this workflow
+# runs with a read-only token and no secrets exposed to fork PR code. The status
+# write happens in the companion workflow, which runs from the default branch.
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     branches:
       - main
@@ -18,34 +19,26 @@ permissions:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
     steps:
-      - name: Set Smoke Tests status
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const isFork = context.payload.pull_request.head.repo.full_name !== context.payload.pull_request.base.repo.full_name;
-            const sha = context.payload.pull_request.head.sha;
+      - name: Record PR metadata for status workflow
+        run: |
+          mkdir -p gate-info
+          IS_FORK="false"
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]; then
+            IS_FORK="true"
+          fi
+          {
+            echo "sha=${{ github.event.pull_request.head.sha }}"
+            echo "pr_number=${{ github.event.pull_request.number }}"
+            echo "is_fork=${IS_FORK}"
+          } > gate-info/pr.env
 
-            if (isFork) {
-              await github.rest.repos.createCommitStatus({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                sha,
-                state: 'failure',
-                context: 'Smoke Tests',
-                description: 'Fork PR — maintainer must run /approve-smoke-tests or /skip-smoke-tests',
-              });
-              console.log(`Set Smoke Tests → failure for fork PR ${sha} (blocks merge until maintainer action).`);
-            } else {
-              await github.rest.repos.createCommitStatus({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                sha,
-                state: 'success',
-                context: 'Smoke Tests',
-                description: 'Non-fork PR — use /trigger-smoke-test or labels to run smoke tests',
-              });
-              console.log(`Set Smoke Tests → success for ${sha}`);
-            }
+          echo "Recorded gate info:"
+          cat gate-info/pr.env
+
+      - name: Upload gate info
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-tests-gate-info
+          path: gate-info/
+          retention-days: 1

--- a/.github/workflows/smoke-tests-gate.yaml
+++ b/.github/workflows/smoke-tests-gate.yaml
@@ -2,13 +2,18 @@ name: Smoke Tests Gate
 
 # Sets the required "Smoke Tests" commit status for all PRs targeting main.
 # - Non-fork PRs: auto-succeed (smoke tests can be run optionally via labels/commands).
-# - Fork PRs: no status is set here (read-only token). The missing required check blocks
-#   merge. A maintainer must run (/approve-smoke-tests) or skip (/skip-smoke-tests) tests.
+# - Fork PRs: an explicit `failure` status is posted to block merge until a maintainer
+#   runs (/approve-smoke-tests) or skips (/skip-smoke-tests) tests. Uses
+#   `pull_request_target` so the workflow runs with a token that can write statuses
+#   (the job only reads PR metadata and posts a status — it does NOT check out PR code).
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     branches:
       - main
+
+permissions:
+  contents: read
 
 jobs:
   gate:
@@ -24,9 +29,15 @@ jobs:
             const sha = context.payload.pull_request.head.sha;
 
             if (isFork) {
-              console.log('Fork PR detected — skipping status creation (read-only token).');
-              console.log('The missing required "Smoke Tests" check will block merge.');
-              console.log('Maintainers: use /approve-smoke-tests to run tests, or /skip-smoke-tests to bypass.');
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: 'failure',
+                context: 'Smoke Tests',
+                description: 'Fork PR — maintainer must run /approve-smoke-tests or /skip-smoke-tests',
+              });
+              console.log(`Set Smoke Tests → failure for fork PR ${sha} (blocks merge until maintainer action).`);
             } else {
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,


### PR DESCRIPTION

# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->
This pull request introduces significant improvements to GitHub workflow security and PR validation, especially around changes to workflow files and smoke test gating for forked PRs. The main enhancements include a new approval guard for `.github/` changes, a split and hardened smoke test gating process, and expanded PR event triggers.

**Security and workflow protections:**

* Added a new `workflow-changes-guard` job in `.github/workflows/checks.yaml` that blocks PRs modifying `.github/` files (workflows, actions, CODEOWNERS, etc.) unless the PR is authored by a maintainer or explicitly approved by a maintainer via the `approved-workflow-changes` label. This job verifies label application permissions and auto-removes unauthorized labels.
* Expanded the `pull_request` trigger types in `.github/workflows/checks.yaml` to include label events, ensuring workflow protections respond to label changes (such as approval labels).

**Smoke test gating improvements:**

* Refactored the smoke test gating into two workflows:
  * `.github/workflows/smoke-tests-gate.yaml` now only records PR metadata (SHA, fork status) as an artifact, using a read-only token and exposing no secrets to fork PR code.
  * New `.github/workflows/smoke-tests-gate-status.yaml` workflow (triggered by `workflow_run`) reads the artifact and sets the required "Smoke Tests" commit status with a writable token, ensuring fork PRs are blocked until a maintainer intervenes.

**Workflow detection enhancements:**

* Updated the change detection logic in `.github/workflows/checks.yaml` to track changes under `.github/` and pass this information to jobs for conditional execution.

These changes significantly strengthen CI/CD security by preventing untrusted workflow modifications and ensuring that smoke tests are properly gated for forked PRs.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
