### PR TITLE
[CFX-6347] Disable telemetry key injection so it will block telemetry run.

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -17,12 +17,14 @@ builds:
       binary: "dr"
       mod_timestamp: "{{ .CommitTimestamp }}"
 
+      # Telemetry disabled pending legal approval. To re-enable, add this back
+      # to the ldflags block below:
+      #   -X "github.com/datarobot/cli/internal/telemetry.AmplitudeAPIKey={{ if index .Env "AMPLITUDE_API_KEY" }}{{ .Env.AMPLITUDE_API_KEY }}{{ end }}"
       ldflags:
         - >
           -X "github.com/datarobot/cli/internal/version.Version={{ .Tag }}"
           -X "github.com/datarobot/cli/internal/version.GitCommit={{ .ShortCommit }}"
           -X "github.com/datarobot/cli/internal/version.BuildDate={{ .CommitDate }}"
-          -X "github.com/datarobot/cli/internal/telemetry.AmplitudeAPIKey={{ if index .Env "AMPLITUDE_API_KEY" }}{{ .Env.AMPLITUDE_API_KEY }}{{ end }}"
           -X "github.com/datarobot/cli/internal/telemetry.InstallMethod=release"
 
       goarch:


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->
This pull request makes a small but important change to the `goreleaser.yaml` build configuration by temporarily disabling the inclusion of the Amplitude telemetry API key in the build process, pending legal approval. The code and comment clarify how to re-enable telemetry once approved.

* Temporarily removed the `AmplitudeAPIKey` from the `ldflags` in the build configuration, with a comment explaining this is pending legal approval and instructions for re-enabling it in the future.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only change that disables telemetry in release artifacts; no runtime logic or auth/data paths are modified.
> 
> **Overview**
> Release builds will no longer embed the Amplitude API key via GoReleaser `ldflags`, so shipped `dr` binaries keep `AmplitudeAPIKey` empty and **telemetry stays off** until legal approval (same behavior as dev builds when the key is unset).
> 
> The removed `-X` line is preserved in a comment with instructions to restore it and wire `AMPLITUDE_API_KEY` when re-enabling. Other release `ldflags` (version, git commit, build date, install method) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6204ed0ed2eeec4ff5745546c1142edd99641271. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->