### PR TITLE
Add assist plugin v0.1.24

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.24",
+          "url": "assist/assist-0.1.24.tar.xz",
+          "sha256": "5d8e37c4d5f9f3f7900c01f4805d70817bbdf77c80e67701c64f3f28a0cea011",
+          "releaseDate": "2026-06-02"
+        },
+        {
           "version": "0.1.23",
           "url": "assist/assist-0.1.23.tar.xz",
           "sha256": "a1c7d30fd184565bb6219daffbc811a35939e6d65e6efa2b660e46f82b14d4a2",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.24 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.24
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.24
- **SHA256:** `5d8e37c4d5f9f3f7900c01f4805d70817bbdf77c80e67701c64f3f28a0cea011`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only index update; no application or security logic changes.
> 
> **Overview**
> Registers **assist** **0.1.24** as the newest entry in `docs/plugins/index.json`, with tarball URL `assist/assist-0.1.24.tar.xz`, pinned SHA256, and release date **2026-06-02**, so `dr plugin install assist` can resolve the latest version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 365872db502e6bca935a1b24306176cfe8bd664d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->