### PR TITLE
Add assist plugin v0.1.25

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.25",
+          "url": "assist/assist-0.1.25.tar.xz",
+          "sha256": "285c9f211fa7a49d0b65daebbfb6a788578c056528d8063cbfbad62479d3d3f1",
+          "releaseDate": "2026-06-04"
+        },
+        {
           "version": "0.1.24",
           "url": "assist/assist-0.1.24.tar.xz",
           "sha256": "5d8e37c4d5f9f3f7900c01f4805d70817bbdf77c80e67701c64f3f28a0cea011",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.25 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.25
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.25
- **SHA256:** `285c9f211fa7a49d0b65daebbfb6a788578c056528d8063cbfbad62479d3d3f1`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only index update with pinned SHA256; no application or security logic changes.
> 
> **Overview**
> Registers **assist v0.1.25** as the newest entry in `docs/plugins/index.json`, prepended to the existing `assist` version list with tarball URL, SHA256, and release date **2026-06-04**.
> 
> No other plugins or index structure are modified; clients that read the first listed version will treat **0.1.25** as the latest installable release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 578c3bc8e3abb3a4d65348920dda7073d64975fa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->