### PR TITLE
[CFX-6402] Bumping up the Go version to address CVEs

### DIFF
--- a/.github/documentation-style-spec.md
+++ b/.github/documentation-style-spec.md
@@ -262,7 +262,7 @@ Add periods to descriptions
 
 **Format**
 ```markdown
-✅ **Note:** The CLI requires Go 1.26.3 or later.
+✅ **Note:** The CLI requires Go 1.26.4 or later.
 
 ✅ **Important:** Never commit `.env` files to version control.
 

--- a/.github/workflows/.build-matrix.yaml
+++ b/.github/workflows/.build-matrix.yaml
@@ -12,7 +12,7 @@ on:
         description: 'Go version to use'
         required: false
         type: string
-        default: '1.26.3'
+        default: '1.26.4'
       upload-artifact:
         description: 'Whether to upload artifacts'
         required: false

--- a/.github/workflows/.build-windows.yaml
+++ b/.github/workflows/.build-windows.yaml
@@ -7,7 +7,7 @@ on:
         description: 'Go version to use'
         required: false
         type: string
-        default: '1.26.3'
+        default: '1.26.4'
       artifact-name:
         description: 'Name for the artifact'
         required: false

--- a/.github/workflows/.setup.yaml
+++ b/.github/workflows/.setup.yaml
@@ -7,7 +7,7 @@ on:
         description: 'Go version to use'
         required: false
         type: string
-        default: '1.26.3'
+        default: '1.26.4'
       install-taskfile:
         description: 'Whether to install Taskfile'
         required: false

--- a/.github/workflows/.smoke-tests-matrix.yaml
+++ b/.github/workflows/.smoke-tests-matrix.yaml
@@ -12,7 +12,7 @@ on:
         description: 'Go version to use'
         required: false
         type: string
-        default: '1.26.3'
+        default: '1.26.4'
       ref:
         description: 'Git ref to checkout (for fork PRs)'
         required: false

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,7 +11,7 @@ Builds the DR CLI binary across multiple operating systems (Linux, macOS, Window
 
 **Inputs:**
 - `os-matrix` (string, default: `["ubuntu-latest", "macos-latest", "windows-latest"]`) - OS matrix for builds
-- `go-version` (string, default: `1.26.3`) - Go version to use
+- `go-version` (string, default: `1.26.4`) - Go version to use
 - `upload-artifact` (boolean, default: `false`) - Whether to upload artifacts
 - `artifact-name-prefix` (string, default: `dr`) - Prefix for artifact names
 
@@ -21,7 +21,7 @@ jobs:
   build:
     uses: ./.github/workflows/.build-matrix.yaml
     with:
-      go-version: '1.26.3'
+      go-version: '1.26.4'
       upload-artifact: true
     secrets: inherit
 ```
@@ -30,7 +30,7 @@ jobs:
 Builds Windows binary using GoReleaser (cross-compiled from Ubuntu).
 
 **Inputs:**
-- `go-version` (string, default: `1.26.3`) - Go version to use
+- `go-version` (string, default: `1.26.4`) - Go version to use
 - `artifact-name` (string, default: `dr-windows`) - Name for the artifact
 - `ref` (string, optional) - Git ref to checkout (useful for fork PRs)
 
@@ -49,7 +49,7 @@ Runs smoke tests on Linux and macOS.
 
 **Inputs:**
 - `os-matrix` (string, default: `["ubuntu-latest", "macos-latest"]`) - OS matrix
-- `go-version` (string, default: `1.26.3`) - Go version to use
+- `go-version` (string, default: `1.26.4`) - Go version to use
 - `ref` (string, optional) - Git ref to checkout
 
 **Secrets (required):**
@@ -62,7 +62,7 @@ jobs:
   smoke-test:
     uses: ./.github/workflows/.smoke-tests-matrix.yaml
     with:
-      go-version: '1.26.3'
+      go-version: '1.26.4'
     secrets:
       DR_API_TOKEN: ${{ secrets.DR_API_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -114,7 +114,7 @@ jobs:
 Basic environment setup (checkout, Go, Taskfile, caching).
 
 **Inputs:**
-- `go-version` (string, default: `1.26.3`) - Go version to use
+- `go-version` (string, default: `1.26.4`) - Go version to use
 - `install-taskfile` (boolean, default: `true`) - Whether to install Taskfile
 - `setup-cache` (boolean, default: `false`) - Whether to setup Go cache
 

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
@@ -106,7 +106,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: Install Taskfile
         uses: arduino/setup-task@v2
@@ -167,7 +167,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: Install Envdoc
         run: |
@@ -188,7 +188,7 @@ jobs:
     if: needs.detect-changes.outputs.go_code == 'true' || needs.detect-changes.outputs.completion == 'true'
     uses: ./.github/workflows/.build-matrix.yaml
     with:
-      go-version: '1.26.3'
+      go-version: '1.26.4'
       upload-artifact: true
       artifact-name-prefix: 'dr'
     secrets: inherit

--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -102,7 +102,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: Install gosec
         run: go install github.com/securego/gosec/v2/cmd/gosec@latest
@@ -115,7 +115,7 @@ jobs:
     needs: [resolve-pr, security-scan]
     uses: ./.github/workflows/.build-windows.yaml
     with:
-      go-version: '1.26.3'
+      go-version: '1.26.4'
       artifact-name: 'dr-windows-fork'
       ref: ${{ needs.resolve-pr.outputs.sha }}
     secrets: inherit
@@ -170,7 +170,7 @@ jobs:
     needs: [resolve-pr, security-scan]
     uses: ./.github/workflows/.smoke-tests-matrix.yaml
     with:
-      go-version: '1.26.3'
+      go-version: '1.26.4'
       ref: ${{ needs.resolve-pr.outputs.sha }}
     secrets: inherit
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.3'
+          go-version: '1.26.4'
 
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -59,7 +59,7 @@ jobs:
   #     - name: Set up Go
   #       uses: actions/setup-go@v5
   #       with:
-  #         go-version: '1.26.3'
+  #         go-version: '1.26.4'
 
   #     - name: Install gosec
   #       run: go install github.com/securego/gosec/v2/cmd/gosec@latest
@@ -110,7 +110,7 @@ jobs:
   #     - name: Set up Go
   #       uses: actions/setup-go@v5
   #       with:
-  #         go-version: '1.26.3'
+  #         go-version: '1.26.4'
 
   #     - name: Install govulncheck
   #       run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/smoke-tests-on-demand.yaml
+++ b/.github/workflows/smoke-tests-on-demand.yaml
@@ -77,7 +77,7 @@ jobs:
     if: needs.check-fork.outputs.is_fork == 'false'
     uses: ./.github/workflows/.build-windows.yaml
     with:
-      go-version: '1.26.3'
+      go-version: '1.26.4'
       artifact-name: 'dr-windows'
     secrets: inherit
 
@@ -86,7 +86,7 @@ jobs:
     if: needs.check-fork.outputs.is_fork == 'false'
     uses: ./.github/workflows/.smoke-tests-matrix.yaml
     with:
-      go-version: '1.26.3'
+      go-version: '1.26.4'
     secrets:
       DR_API_TOKEN: ${{ secrets.DR_API_TOKEN }}
 

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -21,14 +21,14 @@ jobs:
   build-windows:
     uses: ./.github/workflows/.build-windows.yaml
     with:
-      go-version: '1.26.3'
+      go-version: '1.26.4'
       artifact-name: 'dr-windows'
     secrets: inherit
 
   smoke-test:
     uses: ./.github/workflows/.smoke-tests-matrix.yaml
     with:
-      go-version: '1.26.3'
+      go-version: '1.26.4'
     secrets:
       DR_API_TOKEN: ${{ secrets.DR_API_TOKEN }}
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: 1.26.3
+  go: 1.26.4
 linters:
   enable:
     - asasalint

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ If you would like to build and install from source, you can do so by following t
 
 #### Prerequisites
 
-- Go 1.26.3 or later (for building from source)
+- Go 1.26.4 or later (for building from source)
 - Git
 - [Task](https://taskfile.dev/) (for development and task running)
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -64,7 +64,7 @@ See [Building](building.md) for detailed workflow documentation.
 
 Before you begin development:
 
-- **Go 1.26.3 or later**&mdash;required for building the CLI.
+- **Go 1.26.4 or later**&mdash;required for building the CLI.
 - **Git**&mdash;version control.
 - **Task**&mdash;task runner for development commands.
 - **golangci-lint**&mdash;installed automatically via `task dev-init`.

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -18,7 +18,7 @@ This guide outlines how to build, test, and develop with the DataRobot CLI.
 
 ### Prerequisites
 
-- [Go 1.26.3+](https://golang.org/dl/)
+- [Go 1.26.4+](https://golang.org/dl/)
 - Git version control
 - [Task](https://taskfile.dev/installation/) (The task runner)
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -6,7 +6,7 @@ This page outlines how to set up your development environment to build and devel
 
 ## Prerequisites
 
-- [Go 1.26.3](https://golang.org/dl/)
+- [Go 1.26.4](https://golang.org/dl/)
 - Git for version control
 - [Task](https://taskfile.dev/installation/) (A task runner)
 

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -98,7 +98,7 @@ These map to Amplitude's built-in fields and power native segmentation (version 
 | -------------------- | ------------------------------------------------------------------------- |
 | `install_method`     | Set at build time via ldflags (`release`, `source`, etc.)                 |
 | `os_arch`            | CPU architecture from `runtime.GOARCH`                                    |
-| `go_version`         | Go runtime version (e.g. `go1.26.3`) from `runtime.Version()`             |
+| `go_version`         | Go runtime version (e.g. `go1.26.4`) from `runtime.Version()`             |
 | `environment`        | `US`, `EU`, `JP`, or `custom` — derived from endpoint URL                 |
 | `datarobot_instance` | Base URL of the configured DataRobot instance                             |
 | `template_name`      | Best-effort from `.datarobot/answers/` in the current repo                |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datarobot/cli
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level Go bump with no application logic changes; CI and docs stay aligned on a single version.
> 
> **Overview**
> Bumps the project **Go toolchain from 1.26.3 to 1.26.4** to address CVEs (CFX-6402).
> 
> The `go` directive in **`go.mod`** is updated, and **`.golangci.yaml`** `run.go` matches the new version. **GitHub Actions** reusable workflows (`.build-matrix`, `.build-windows`, `.setup`, `.smoke-tests-matrix`) and entry workflows (`checks`, `release`, `smoke-tests`, `fork-smoke-tests`, `smoke-tests-on-demand`, commented blocks in `security-scan`) now default to or pin **1.26.4** for `actions/setup-go`. **Docs** (`README`, development guides, workflow README, documentation style example, telemetry `go_version` example) state the new minimum Go version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 541e6d643eec83f2a707031548600a28041c8181. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->