### PR TITLE
Add assist plugin v0.1.26

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.26",
+          "url": "assist/assist-0.1.26.tar.xz",
+          "sha256": "5cd52a0e8c2fb3fd9e3136e3adc5c52b5688d5dbdd71b908421fc77aeee1d68d",
+          "releaseDate": "2026-06-05"
+        },
+        {
           "version": "0.1.25",
           "url": "assist/assist-0.1.25.tar.xz",
           "sha256": "285c9f211fa7a49d0b65daebbfb6a788578c056528d8063cbfbad62479d3d3f1",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.26 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.26
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.26
- **SHA256:** `5cd52a0e8c2fb3fd9e3136e3adc5c52b5688d5dbdd71b908421fc77aeee1d68d`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Index-only metadata update with no runtime code changes; install behavior depends on correct SHA256 and artifact hosting.
> 
> **Overview**
> Registers **assist v0.1.26** as the newest entry in `docs/plugins/index.json`, so `dr plugin install assist` can resolve and verify that release (tarball URL, SHA256, release date **2026-06-05**).
> 
> No application or CLI logic changes—only the published plugin catalog metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 842fca1316d2b509824e9e079ba664398b4a5a5e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->