### PR TITLE
[RAPTOR-17713] fix(workload): surface API validation errors on artifact create

### DIFF
--- a/internal/drapi/post.go
+++ b/internal/drapi/post.go
@@ -58,9 +58,7 @@ func Post(url, info string, body any) (*http.Response, error) {
 	}
 
 	if !isCreateSuccess(resp.StatusCode) {
-		resp.Body.Close()
-
-		return nil, &HTTPError{StatusCode: resp.StatusCode, URL: url}
+		return nil, ErrFromResp(resp, url)
 	}
 
 	return resp, err

--- a/internal/drapi/post_test.go
+++ b/internal/drapi/post_test.go
@@ -89,6 +89,30 @@ func TestPost_NonSuccess(t *testing.T) {
 	assert.Equal(t, http.StatusUnprocessableEntity, httpErr.StatusCode)
 }
 
+// Non-success response bodies must reach the caller so server validation
+// details (e.g. a FastAPI {"detail":[...]} envelope) survive in the error.
+func TestPost_NonSuccess_IncludesBody(t *testing.T) {
+	defer resetTokenForTest(t, "test-token")()
+
+	const validationBody = `{"detail":[{"path":"spec","message":"Field required","code":"missing"}]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(validationBody))
+	}))
+	defer server.Close()
+
+	resp, err := Post(server.URL, "", map[string]string{}) //nolint:bodyclose // resp is nil on error; Post closes it before returning
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), validationBody)
+
+	var httpErr *HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusUnprocessableEntity, httpErr.StatusCode)
+}
+
 func TestPost_Unauthorized(t *testing.T) {
 	defer resetTokenForTest(t, "test-token")()
 


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

Fixes [RAPTOR-17713](https://datarobot.atlassian.net/browse/RAPTOR-17713)

When `dr workload artifact create` submits a spec that fails server-side validation, workload-api returns 422 with a JSON-path detail explaining which field is wrong. Before this change, the CLI swallowed that body and showed the user only:

```
Error: HTTP error: 422 Unprocessable Entity (url: https://staging.../api/v2/artifacts/)
```

The response body is the only thing telling the user *what* is wrong with the spec, so an invalid submission could not be debugged without curl or browser devtools. After this change, the same failure surfaces the validation detail inline so the user can locate and fix the offending field directly from the CLI output.

## CHANGES

- `internal/drapi/post.go:60-62` - on the non-success branch, replace the bare `resp.Body.Close()` + return of an empty `*HTTPError` with `return nil, ErrFromResp(resp, url)`. `ErrFromResp` (defined in `internal/drapi/helpers.go`) reads up to 512 bytes of the body, always closes the body via `defer`, and wraps the `*HTTPError` so callers using `errors.As` still recover the typed error with its `StatusCode`. The one-line swap leaves the success path and all caller signatures untouched.
- `internal/drapi/post_test.go` - add `TestPost_NonSuccess_IncludesBody`: spins up a test server returning 422 with a representative workload-api validation body, asserts `err.Error()` contains the body bytes and `errors.As` still recovers `*HTTPError` with the expected `StatusCode`. Locks in both the new user-visible behavior and the existing typed-error contract.

## TESTING

Unit tests (fast, no network):

```bash
task lint
go test -count=1 -race -v ./internal/drapi/ -run TestPost
go test -count=1 -race ./internal/workload/... ./cmd/workload/...
```

Expected: `task lint` reports 0 issues; `TestPost_*` is 10/10 PASS including the new `TestPost_NonSuccess_IncludesBody`; workload packages green.

Staging smoke (requires `DATAROBOT_API_TOKEN` and a staging endpoint):

```bash
task build

# Unhappy path: spec missing imageUri / imageBuildConfig -> server 422
./dist/dr workload artifact create --spec-file path/to/invalid-spec.json

# Happy path: valid spec -> artifact id returned
./dist/dr workload artifact create --spec-file path/to/valid-spec.json
```

Expected unhappy-path output now includes the validation detail (this is the regression being fixed):

```
Error: HTTP error: 422 Unprocessable Entity (url: https://staging.../api/v2/artifacts/): body={"detail":[{"path":"spec.service.containerGroups.0.containers.0","message":"Value error, Either imageUri or imageBuildConfig must be provided","code":"value_error"}]}
```

Expected happy-path output is unchanged: artifact id printed (smoke run produced `6a26c219fc3c15aa5e238a83`). Smoke results captured in `tmp/test-results.md`.

## NOTES

- **Sibling verbs still discard the body.** The same close-without-read pattern lives at `internal/drapi/patch.go:58`, `internal/drapi/delete.go:58`, and `internal/drapi/get.go:96`. Deferred to a follow-up because the ticket scope is artifact create only; fixing all four in one PR would broaden the blast radius (every CLI command that PATCHes/DELETEs/GETs through `drapi`) without a reported user impact behind it yet.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to the Post error path only; success behavior and signatures are unchanged, with regression tests added.
> 
> **Overview**
> **Fixes CLI error output when `Post` gets a non-2xx response** (e.g. `dr workload artifact create` with an invalid spec).
> 
> On failed creates, `internal/drapi/post.go` no longer closes the response and returns a status-only `*HTTPError`. It now uses **`ErrFromResp`**, which reads up to 512 bytes of the response body, closes the body, and still allows **`errors.As`** to recover `*HTTPError` with the correct status code. Users see validation JSON (such as workload-api’s `{"detail":[...]}`) in the error string instead of only `HTTP error: 422 ...`.
> 
> Adds **`TestPost_NonSuccess_IncludesBody`** to lock in that behavior for a 422 with a representative validation payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd7f75c1c460045b20fbfd128e4d1faa7f93da4c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->