### PR TITLE
Add assist plugin v0.1.27

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.27",
+          "url": "assist/assist-0.1.27.tar.xz",
+          "sha256": "a77e875ca4528261e108f578173ec75b9e2e304bb7133ae4a5c10d4a6d362ae5",
+          "releaseDate": "2026-06-09"
+        },
+        {
           "version": "0.1.26",
           "url": "assist/assist-0.1.26.tar.xz",
           "sha256": "5cd52a0e8c2fb3fd9e3136e3adc5c52b5688d5dbdd71b908421fc77aeee1d68d",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.27 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.27
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.27
- **SHA256:** `a77e875ca4528261e108f578173ec75b9e2e304bb7133ae4a5c10d4a6d362ae5`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Index-only metadata update; incorrect SHA256 or URL would affect installs but does not change application logic.
> 
> **Overview**
> Registers **assist v0.1.27** as the newest entry in `docs/plugins/index.json`, so `dr plugin install assist` can resolve and verify the updated tarball (`assist/assist-0.1.27.tar.xz` with the listed SHA256 and release date **2026-06-09**).
> 
> No CLI or plugin runtime code changes—only the published plugin catalog metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc21189d5b1d35ea94c1d0ddf9c69db341e7cbf6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->