### PR TITLE
[RAPTOR-17714] feat(workload): add dr workload build commands

### DIFF
--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -79,6 +79,10 @@ var expectedWorkloadTrackedCommands = []string{
 	"workload artifact get",
 	"workload artifact list",
 	"workload artifact create",
+	"workload build trigger",
+	"workload build get",
+	"workload build list",
+	"workload build logs",
 }
 
 // TestTelemetryWiring_AllWorkloadCommandsTracked walks the workload

--- a/cmd/workload/build/cmd.go
+++ b/cmd/workload/build/cmd.go
@@ -12,32 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package workload
+package build
 
 import (
-	"github.com/datarobot/cli/cmd/workload/artifact"
-	"github.com/datarobot/cli/cmd/workload/build"
-	"github.com/datarobot/cli/cmd/workload/code"
-	"github.com/datarobot/cli/internal/features"
+	"github.com/datarobot/cli/cmd/workload/build/get"
+	"github.com/datarobot/cli/cmd/workload/build/list"
+	"github.com/datarobot/cli/cmd/workload/build/logs"
+	"github.com/datarobot/cli/cmd/workload/build/trigger"
 	"github.com/spf13/cobra"
 )
 
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "workload",
-		GroupID: "core",
-		Short:   "🚀 Workload management commands",
-		Long: `Workload management commands for your DataRobot applications.
+		Use:   "build",
+		Short: "Manage workload artifact builds",
+		Long: `Trigger, inspect, and read logs from container image builds for workload
+artifacts.
 
-Manage and monitor workloads in your deployment infrastructure.`,
+When run inside a directory linked via 'dr workload code init', the
+<artifact-id> argument may be omitted on every subcommand and is read from
+.wapi/config.json.`,
 	}
 
-	features.SetGate(cmd, "workload")
-
 	cmd.AddCommand(
-		artifact.Cmd(),
-		build.Cmd(),
-		code.Cmd(),
+		get.Cmd(),
+		list.Cmd(),
+		logs.Cmd(),
+		trigger.Cmd(),
 	)
 
 	return cmd

--- a/cmd/workload/build/get/cmd.go
+++ b/cmd/workload/build/get/cmd.go
@@ -1,0 +1,141 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"fmt"
+
+	"github.com/datarobot/cli/cmd/workload/build/internal/buildargs"
+	"github.com/datarobot/cli/cmd/workload/build/internal/pollflags"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat workload.OutputFormat
+
+	var poll pollflags.Set
+
+	cmd := &cobra.Command{
+		Use:   "get [<artifact-id>] <build-id>",
+		Short: "Get the status of a single build.",
+		Long: `Get a build by id.
+
+When invoked with one positional argument the artifact-id is read from
+.wapi/config.json in the current directory. When invoked with two, the
+first argument is the artifact-id and the second is the build-id.
+
+With --wait the command polls the build until it reaches a terminal
+status (COMPLETED, FAILED, CANCELLED) and prints a summary instead
+of the raw Build object. If the build is already terminal, --wait
+returns immediately.
+
+Examples:
+  dr workload build get b-xyz-456                # uses .wapi/ artifact id
+  dr workload build get art-abc-123 b-xyz-456
+  dr workload build get art-abc-123 b-xyz-456 --wait
+  dr workload build get art-abc-123 b-xyz-456 --output-format json`,
+		Args:         cobra.RangeArgs(1, 2),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGet(cmd, args, outputFormat, poll)
+		},
+	}
+
+	workload.AddOutputFlag(cmd, &outputFormat)
+	pollflags.Register(cmd, &poll)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		artifactID, buildID, _ := buildargs.ResolvePositional(args)
+
+		return map[string]any{
+			"artifact_id":   artifactID,
+			"build_id":      buildID,
+			"wait":          poll.Wait,
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}
+
+func runGet(
+	cmd *cobra.Command,
+	args []string,
+	outputFormat workload.OutputFormat,
+	poll pollflags.Set,
+) error {
+	artifactID, buildID, err := buildargs.ResolvePositional(args)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cmd.ErrOrStderr(), "Fetching build %s...\n", buildID)
+
+	build, err := workload.GetArtifactBuild(artifactID, buildID)
+	if err != nil {
+		return err
+	}
+
+	if !poll.Wait {
+		return workload.RenderBuild(outputFormat, *build)
+	}
+
+	var waitErr error
+
+	if !workload.IsTerminalBuildStatus(build.Status) {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for build %s...\n", buildID)
+
+		build, waitErr = workload.WaitForBuild(artifactID, buildID, poll.Interval, poll.Timeout, nil)
+
+		if build == nil {
+			// WaitForBuild errored before its first successful GET; render a
+			// minimal summary so the user still sees something.
+			summary := workload.BuildSummary{BuildID: buildID, Status: workload.BuildStatusCLIUnknown}
+			_ = workload.RenderBuildSummary(outputFormat, summary)
+
+			return waitErr
+		}
+	}
+
+	summary, serr := workload.BuildSummaryFor(build, workload.DefaultBuildLogTail)
+	if serr != nil {
+		_ = workload.RenderBuildSummary(outputFormat, summary)
+
+		return serr
+	}
+
+	if err := workload.RenderBuildSummary(outputFormat, summary); err != nil {
+		return err
+	}
+
+	if waitErr != nil {
+		return waitErr
+	}
+
+	// The build may have been already terminal-error on the first GET, in
+	// which case WaitForBuild was skipped and waitErr stays nil. Surface
+	// that explicitly so the process exits non-zero; hint at the logs
+	// command so the user has a one-step recovery to inspect what went
+	// wrong.
+	if workload.IsBuildErrorStatus(build.Status) {
+		return fmt.Errorf("build %s ended with status %s; run 'dr workload build logs %s' to inspect", build.ID, build.Status, build.ID)
+	}
+
+	return nil
+}

--- a/cmd/workload/build/get/cmd_test.go
+++ b/cmd/workload/build/get/cmd_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresAtLeastOneArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestCmd_RejectsThirdArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"art-1", "b-1", "extra"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestCmd_InvalidOutputFormat(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"art-1", "b-1", "--output-format", "yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}
+
+func TestCmd_HidesPollFlags(t *testing.T) {
+	cmd := Cmd()
+
+	pollIntervalFlag := cmd.Flag("poll-interval")
+	pollTimeoutFlag := cmd.Flag("poll-timeout")
+
+	require.NotNil(t, pollIntervalFlag)
+	require.NotNil(t, pollTimeoutFlag)
+	assert.True(t, pollIntervalFlag.Hidden)
+	assert.True(t, pollTimeoutFlag.Hidden)
+}

--- a/cmd/workload/build/internal/buildargs/buildargs.go
+++ b/cmd/workload/build/internal/buildargs/buildargs.go
@@ -1,0 +1,73 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package buildargs centralizes the positional argument shape shared by
+// `dr workload build get` and `dr workload build logs`. Both accept either
+// one positional (build-id, with the artifact-id read from .wapi/config.json)
+// or two positionals (artifact-id, build-id). Keeping the dispatch in one
+// place prevents the two leaves from drifting.
+
+package buildargs
+
+import (
+	"fmt"
+
+	"github.com/datarobot/cli/internal/workload"
+)
+
+// ResolveOptional maps cobra args to a single artifactID for commands that
+// accept an optional artifact-id (0 or 1 positional).
+//
+//   - 0 args -> artifact-id is read from .wapi.
+//   - 1 arg  -> args[0]=artifact-id (overrides .wapi).
+//
+// Returns an error if .wapi is required but missing.
+func ResolveOptional(args []string) (string, error) {
+	explicit := ""
+	if len(args) == 1 {
+		explicit = args[0]
+	}
+
+	id, _, err := workload.ResolveArtifactID(explicit)
+
+	return id, err
+}
+
+// ResolvePositional maps cobra args to (artifactID, buildID).
+//
+//   - 1 arg  -> arg is the build-id; artifact-id is read from .wapi.
+//   - 2 args -> args[0]=artifact-id, args[1]=build-id (overrides .wapi).
+//
+// Returns an error if the wrong arity is given or .wapi is required but
+// missing.
+func ResolvePositional(args []string) (string, string, error) {
+	switch len(args) {
+	case 1:
+		artifactID, _, err := workload.ResolveArtifactID("")
+		if err != nil {
+			return "", "", err
+		}
+
+		return artifactID, args[0], nil
+	case 2:
+		artifactID, _, err := workload.ResolveArtifactID(args[0])
+		if err != nil {
+			return "", "", err
+		}
+
+		return artifactID, args[1], nil
+	}
+
+	return "", "", fmt.Errorf("expected 1 or 2 positional arguments, got %d", len(args))
+}

--- a/cmd/workload/build/internal/buildargs/buildargs_test.go
+++ b/cmd/workload/build/internal/buildargs/buildargs_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package buildargs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePositional_TwoArgs(t *testing.T) {
+	// With two args we never touch .wapi: the first is the artifact id,
+	// the second is the build id, and we should not error even if no
+	// .wapi project exists.
+	t.Chdir(t.TempDir())
+
+	artifactID, buildID, err := ResolvePositional([]string{"art-explicit", "b-1"})
+	require.NoError(t, err)
+	assert.Equal(t, "art-explicit", artifactID)
+	assert.Equal(t, "b-1", buildID)
+}
+
+func TestResolvePositional_OneArgNoWAPIFails(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	_, _, err := ResolvePositional([]string{"b-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no .wapi project")
+}
+
+func TestResolvePositional_WrongArity(t *testing.T) {
+	_, _, err := ResolvePositional([]string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "1 or 2 positional arguments")
+
+	_, _, err = ResolvePositional([]string{"a", "b", "c"})
+	require.Error(t, err)
+}
+
+func TestResolveOptional_ExplicitArg(t *testing.T) {
+	// With one arg we never need .wapi.
+	t.Chdir(t.TempDir())
+
+	id, err := ResolveOptional([]string{"art-explicit"})
+	require.NoError(t, err)
+	assert.Equal(t, "art-explicit", id)
+}
+
+func TestResolveOptional_NoArgsNoWAPIFails(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	_, err := ResolveOptional([]string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no .wapi project")
+}

--- a/cmd/workload/build/internal/pollflags/pollflags.go
+++ b/cmd/workload/build/internal/pollflags/pollflags.go
@@ -1,0 +1,52 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pollflags centralizes the --wait, --poll-interval, and
+// --poll-timeout flags shared between `dr workload build trigger` and
+// `dr workload build get`. Single source of truth so the two commands
+// cannot drift out of sync on defaults or names.
+
+package pollflags
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	DefaultPollInterval = 2 * time.Second
+	DefaultPollTimeout  = 30 * time.Minute
+)
+
+// Set holds the resolved values from a poll-flag triple. Callers register
+// flags with Register and then read with the accessors so the flag names
+// stay local to this package.
+type Set struct {
+	Wait     bool
+	Interval time.Duration
+	Timeout  time.Duration
+}
+
+// Register adds --wait, --poll-interval (hidden), and --poll-timeout
+// (hidden) to cmd, binding them into s. Returns s for chaining.
+func Register(cmd *cobra.Command, s *Set) *Set {
+	cmd.Flags().BoolVar(&s.Wait, "wait", false, "Poll until the build reaches a terminal status.")
+	cmd.Flags().DurationVar(&s.Interval, "poll-interval", DefaultPollInterval, "Interval between status polls.")
+	cmd.Flags().DurationVar(&s.Timeout, "poll-timeout", DefaultPollTimeout, "Maximum time to wait before giving up.")
+	_ = cmd.Flags().MarkHidden("poll-interval")
+	_ = cmd.Flags().MarkHidden("poll-timeout")
+
+	return s
+}

--- a/cmd/workload/build/list/cmd.go
+++ b/cmd/workload/build/list/cmd.go
@@ -1,0 +1,79 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"fmt"
+
+	"github.com/datarobot/cli/cmd/workload/build/internal/buildargs"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var (
+		outputFormat workload.OutputFormat
+		limit        int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list [<artifact-id>]",
+		Short: "List builds for a workload artifact.",
+		Long: `List builds in reverse-chronological order for a workload artifact.
+
+The artifact-id argument is optional when run inside a directory linked
+via 'dr workload code init'.
+
+Examples:
+  dr workload build list
+  dr workload build list art-abc-123 --limit 10
+  dr workload build list art-abc-123 --output-format json`,
+		Args:         cobra.MaximumNArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if limit <= 0 {
+				return fmt.Errorf("invalid --limit %d: must be positive", limit)
+			}
+
+			artifactID, err := buildargs.ResolveOptional(args)
+			if err != nil {
+				return err
+			}
+
+			builds, err := workload.ListArtifactBuilds(artifactID, limit)
+			if err != nil {
+				return err
+			}
+
+			return workload.RenderBuilds(outputFormat, builds)
+		},
+	}
+
+	workload.AddOutputFlag(cmd, &outputFormat)
+	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of builds to return.")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"artifact_id":   telemetry.FirstArg(args),
+			"limit":         limit,
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/workload/build/list/cmd_test.go
+++ b/cmd/workload/build/list/cmd_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_InvalidLimit(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"art-1", "--limit", "0"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "limit")
+}
+
+func TestCmd_InvalidOutputFormat(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"art-1", "--output-format", "yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}
+
+func TestCmd_RejectsExtraArgs(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"art-1", "extra"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}

--- a/cmd/workload/build/logs/cmd.go
+++ b/cmd/workload/build/logs/cmd.go
@@ -1,0 +1,102 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/datarobot/cli/cmd/workload/build/internal/buildargs"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/spf13/cobra"
+)
+
+var validLevels = map[string]bool{
+	"debug":   true,
+	"info":    true,
+	"warn":    true,
+	"warning": true,
+	"error":   true,
+}
+
+func Cmd() *cobra.Command {
+	var (
+		outputFormat workload.OutputFormat
+		level        string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "logs [<artifact-id>] <build-id>",
+		Short: "Fetch build logs.",
+		Long: `Fetch the structured log stream for a build.
+
+When invoked with one positional argument the artifact-id is read from
+.wapi/config.json in the current directory. When invoked with two, the
+first argument is the artifact-id and the second is the build-id.
+
+The server emits one structured JSON record per line; the default
+output drops records below INFO. Use --level debug to keep everything.
+
+JSON output emits a single array document so the result can be piped
+to jq directly.
+
+Examples:
+  dr workload build logs b-xyz-456
+  dr workload build logs art-abc-123 b-xyz-456
+  dr workload build logs art-abc-123 b-xyz-456 --level debug
+  dr workload build logs art-abc-123 b-xyz-456 --output-format json`,
+		Args:         cobra.RangeArgs(1, 2),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			lower := strings.ToLower(level)
+			if !validLevels[lower] {
+				return fmt.Errorf("invalid --level %q: use debug, info, warn, or error", level)
+			}
+
+			artifactID, buildID, err := buildargs.ResolvePositional(args)
+			if err != nil {
+				return err
+			}
+
+			entries, err := workload.GetArtifactBuildLogs(artifactID, buildID)
+			if err != nil {
+				return err
+			}
+
+			entries = workload.FilterLogsByLevel(entries, lower)
+
+			return workload.RenderBuildLogs(outputFormat, entries)
+		},
+	}
+
+	workload.AddOutputFlag(cmd, &outputFormat)
+	cmd.Flags().StringVar(&level, "level", "info", "Minimum log level to show (debug, info, warn, error).")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		artifactID, buildID, _ := buildargs.ResolvePositional(args)
+
+		return map[string]any{
+			"artifact_id":   artifactID,
+			"build_id":      buildID,
+			"level":         level,
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/workload/build/logs/cmd_test.go
+++ b/cmd/workload/build/logs/cmd_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresAtLeastOneArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestCmd_RejectsThirdArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"art-1", "b-1", "extra"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestCmd_InvalidLevel(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"art-1", "b-1", "--level", "trace"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --level")
+}
+
+func TestCmd_InvalidOutputFormat(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"art-1", "b-1", "--output-format", "yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}

--- a/cmd/workload/build/trigger/cmd.go
+++ b/cmd/workload/build/trigger/cmd.go
@@ -1,0 +1,160 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trigger
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/datarobot/cli/cmd/workload/build/internal/buildargs"
+	"github.com/datarobot/cli/cmd/workload/build/internal/pollflags"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat workload.OutputFormat
+
+	var poll pollflags.Set
+
+	cmd := &cobra.Command{
+		Use:   "trigger [<artifact-id>]",
+		Short: "Trigger a new image build for a workload artifact.",
+		Long: `Trigger a new container image build for a workload artifact.
+
+The artifact-id argument is optional when run inside a directory linked
+via 'dr workload code init': the id is read from .wapi/config.json.
+
+By default the command prints the new build IDs (one per line) and
+exits. With --wait it polls each build until it reaches a terminal
+status (COMPLETED, FAILED, or CANCELLED) and prints a summary with
+duration and resulting image_uri. On failure the tail of the build
+logs is dumped to stderr.
+
+JSON output emits one document:
+  - without --wait: the raw trigger response {"buildIds":[...]}.
+  - with --wait: an array of BuildSummary objects, always an array.
+
+Examples:
+  dr workload build trigger
+  dr workload build trigger art-abc-123
+  dr workload build trigger art-abc-123 --wait
+  dr workload build trigger --output-format json | jq .buildIds`,
+		Args:         cobra.MaximumNArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runTrigger(cmd, args, outputFormat, poll)
+		},
+	}
+
+	workload.AddOutputFlag(cmd, &outputFormat)
+	pollflags.Register(cmd, &poll)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"artifact_id":   telemetry.FirstArg(args),
+			"wait":          poll.Wait,
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}
+
+func runTrigger(
+	cmd *cobra.Command,
+	args []string,
+	outputFormat workload.OutputFormat,
+	poll pollflags.Set,
+) error {
+	artifactID, err := buildargs.ResolveOptional(args)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(cmd.ErrOrStderr(), "Triggering build...")
+
+	resp, err := workload.TriggerArtifactBuild(artifactID)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.BuildIDs) == 0 {
+		return errors.New("no build IDs returned by server")
+	}
+
+	if !poll.Wait {
+		// Script-capture contract: text-mode `BID=$(dr workload build
+		// trigger $ART)` gets just the IDs on stdout. JSON callers parse
+		// the trigger response document.
+		return workload.RenderBuildTrigger(outputFormat, *resp)
+	}
+
+	// With --wait the canonical stdout contract is the BuildSummary(ies)
+	// emitted after polling. Print the loose IDs to stderr so Ctrl-C
+	// users keep the handle (per RAPTOR-17387) but the captured stdout
+	// stream stays uncontaminated and `jq` works in JSON mode.
+	if outputFormat == workload.OutputFormatText {
+		for _, id := range resp.BuildIDs {
+			fmt.Fprintln(cmd.ErrOrStderr(), id)
+		}
+	}
+
+	summaries, firstWaitErr := waitForAllBuilds(cmd, artifactID, resp.BuildIDs, poll)
+
+	if err := workload.RenderBuildSummaries(outputFormat, summaries); err != nil {
+		return err
+	}
+
+	return firstWaitErr
+}
+
+func waitForAllBuilds(
+	cmd *cobra.Command,
+	artifactID string,
+	buildIDs []string,
+	poll pollflags.Set,
+) ([]workload.BuildSummary, error) {
+	summaries := make([]workload.BuildSummary, 0, len(buildIDs))
+
+	var firstWaitErr error
+
+	for _, buildID := range buildIDs {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for build %s...\n", buildID)
+
+		build, werr := workload.WaitForBuild(artifactID, buildID, poll.Interval, poll.Timeout, nil)
+		if werr != nil && firstWaitErr == nil {
+			firstWaitErr = werr
+		}
+
+		if build == nil {
+			summaries = append(summaries, workload.BuildSummary{BuildID: buildID, Status: workload.BuildStatusCLIUnknown})
+
+			continue
+		}
+
+		summary, serr := workload.BuildSummaryFor(build, workload.DefaultBuildLogTail)
+		if serr != nil && firstWaitErr == nil {
+			firstWaitErr = serr
+		}
+
+		summaries = append(summaries, summary)
+	}
+
+	return summaries, firstWaitErr
+}

--- a/cmd/workload/build/trigger/cmd_test.go
+++ b/cmd/workload/build/trigger/cmd_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trigger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RejectsExtraArgs(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"art-1", "extra"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestCmd_InvalidOutputFormat(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"art-1", "--output-format", "yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}
+
+func TestCmd_ParsesPollFlags(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+
+	require.NoError(t, cmd.ParseFlags([]string{"--wait", "--poll-interval", "100ms", "--poll-timeout", "30s"}))
+
+	wait, _ := cmd.Flags().GetBool("wait")
+	interval, _ := cmd.Flags().GetDuration("poll-interval")
+	timeout, _ := cmd.Flags().GetDuration("poll-timeout")
+
+	assert.True(t, wait)
+	assert.Equal(t, "100ms", interval.String())
+	assert.Equal(t, "30s", timeout.String())
+}
+
+func TestCmd_HidesPollFlags(t *testing.T) {
+	cmd := Cmd()
+	pollIntervalFlag := cmd.Flag("poll-interval")
+	pollTimeoutFlag := cmd.Flag("poll-timeout")
+
+	require.NotNil(t, pollIntervalFlag)
+	require.NotNil(t, pollTimeoutFlag)
+	assert.True(t, pollIntervalFlag.Hidden)
+	assert.True(t, pollTimeoutFlag.Hidden)
+}

--- a/internal/drapi/post.go
+++ b/internal/drapi/post.go
@@ -64,8 +64,17 @@ func Post(url, info string, body any) (*http.Response, error) {
 	return resp, err
 }
 
+// isCreateSuccess permits 200 OK and 201 Created (synchronous create) plus
+// 202 Accepted for async triggers such as POST /artifacts/{id}/builds/, which
+// return the trigger response body alongside the accepted status. Mirrors the
+// 202 acceptance already present in isDeleteSuccess.
 func isCreateSuccess(code int) bool {
-	return code == http.StatusOK || code == http.StatusCreated
+	switch code {
+	case http.StatusOK, http.StatusCreated, http.StatusAccepted:
+		return true
+	}
+
+	return false
 }
 
 // restoreRequestBody re-arms req.Body after RedactedReqInfo (which dumps and

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -65,6 +65,10 @@ type ContainerGroup struct {
 
 type Container struct {
 	ImageBuildConfig *ImageBuildConfig `json:"imageBuildConfig,omitempty"`
+	// ImageURI is the resolved container image reference. Server-managed:
+	// before a successful build this is the placeholder from create; after
+	// build COMPLETED it points at the produced image.
+	ImageURI string `json:"imageUri,omitempty"`
 	// *bool so an absent value round-trips as nil and omitempty drops it
 	// on marshal, instead of re-asserting `false` back to the server.
 	Primary *bool `json:"primary,omitempty"`
@@ -158,6 +162,33 @@ func codeRefFromContainer(container Container) *DatarobotCodeRef {
 	}
 
 	return container.ImageBuildConfig.CodeRef.Datarobot
+}
+
+// GetPrimaryContainerImageURI returns the imageUri of the primary container
+// (the one flagged "primary": true), falling back to
+// containerGroups[0].containers[0] when no primary is marked. Mirrors
+// ExtractCodeRef's selection semantics so reads and writes target the same
+// container after a build updates the spec server-side.
+func GetPrimaryContainerImageURI(artifact Artifact) string {
+	for _, group := range artifact.Spec.ContainerGroups {
+		for _, container := range group.Containers {
+			if container.Primary == nil || !*container.Primary {
+				continue
+			}
+
+			return container.ImageURI
+		}
+	}
+
+	if len(artifact.Spec.ContainerGroups) == 0 {
+		return ""
+	}
+
+	if len(artifact.Spec.ContainerGroups[0].Containers) == 0 {
+		return ""
+	}
+
+	return artifact.Spec.ContainerGroups[0].Containers[0].ImageURI
 }
 
 func GetArtifact(artifactID string) (*Artifact, error) {

--- a/internal/workload/artifact_test.go
+++ b/internal/workload/artifact_test.go
@@ -431,6 +431,50 @@ func TestValidateCreateRequest_Errors(t *testing.T) {
 	}
 }
 
+func TestGetPrimaryContainerImageURI(t *testing.T) {
+	primary := true
+	notPrimary := false
+
+	t.Run("returns primary container imageUri", func(t *testing.T) {
+		artifact := Artifact{
+			Spec: Spec{
+				ContainerGroups: []ContainerGroup{
+					{Containers: []Container{
+						{Primary: &notPrimary, ImageURI: "side-image:1"},
+						{Primary: &primary, ImageURI: "primary-image:1"},
+					}},
+				},
+			},
+		}
+		assert.Equal(t, "primary-image:1", GetPrimaryContainerImageURI(artifact))
+	})
+
+	t.Run("falls back to [0][0] when no primary marked", func(t *testing.T) {
+		artifact := Artifact{
+			Spec: Spec{
+				ContainerGroups: []ContainerGroup{
+					{Containers: []Container{
+						{ImageURI: "first-image:1"},
+						{ImageURI: "second-image:1"},
+					}},
+				},
+			},
+		}
+		assert.Equal(t, "first-image:1", GetPrimaryContainerImageURI(artifact))
+	})
+
+	t.Run("empty when no container groups", func(t *testing.T) {
+		assert.Empty(t, GetPrimaryContainerImageURI(Artifact{}))
+	})
+
+	t.Run("empty when group has no containers", func(t *testing.T) {
+		artifact := Artifact{
+			Spec: Spec{ContainerGroups: []ContainerGroup{{}}},
+		}
+		assert.Empty(t, GetPrimaryContainerImageURI(artifact))
+	})
+}
+
 func TestSetPrimaryCodeRefInRawArtifact(t *testing.T) {
 	t.Run("OverwritesPrimaryCodeRef_LeavesSidecarsAlone", func(t *testing.T) {
 		// Sidecar at [0], primary at [1]. Only the primary repoints, and its

--- a/internal/workload/build.go
+++ b/internal/workload/build.go
@@ -1,0 +1,404 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/log"
+)
+
+// Build statuses are server-side enum values (UPPERCASE). All five were
+// observed live during smoke against staging.
+const (
+	BuildStatusPending    = "PENDING"
+	BuildStatusInProgress = "IN_PROGRESS"
+	BuildStatusCompleted  = "COMPLETED"
+	BuildStatusFailed     = "FAILED"
+	BuildStatusCancelled  = "CANCELLED"
+)
+
+// BuildStatusCLIUnknown is a CLI-side sentinel for "the server never gave
+// us a Build object" (e.g. the very first poll errored out). It is never
+// emitted by the server and intentionally lives outside the server-status
+// const block so it cannot be confused for a real enum value.
+const BuildStatusCLIUnknown = "UNKNOWN"
+
+// Default tail length used by BuildSummaryFor when a build ends in an error
+// status. Kept conservative to keep `--wait` summaries reasonable in stderr.
+const DefaultBuildLogTail = 50
+
+// BuildTriggerResponse is the body returned by POST /artifacts/{id}/builds/.
+// Field name is per the C2W tutorial; first smoke POST verifies casing.
+type BuildTriggerResponse struct {
+	BuildIDs []string `json:"buildIds"`
+}
+
+// Build is the per-build resource the platform owns. UPDATEs from
+// PENDING -> IN_PROGRESS -> {COMPLETED|FAILED|CANCELLED}; the user-facing
+// duration is UpdatedAt - CreatedAt.
+type Build struct {
+	ID         string    `json:"id"`
+	Name       string    `json:"name,omitempty"`
+	ArtifactID string    `json:"artifactId"`
+	Status     string    `json:"status"`
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+}
+
+// BuildList is the paginated envelope returned by GET /artifacts/{id}/builds/.
+type BuildList struct {
+	Data       []Build `json:"data"`
+	Count      int     `json:"count"`
+	TotalCount int     `json:"totalCount"`
+	Next       string  `json:"next"`
+	Previous   string  `json:"previous"`
+}
+
+// BuildLogEntry is one record from the JSONL log stream. Decoded fields are
+// the ones we read for filtering and human rendering; Raw is the verbatim
+// source line so JSON output can pass through every server field unchanged.
+type BuildLogEntry struct {
+	Asctime   string          `json:"asctime"`
+	Levelname string          `json:"levelname"`
+	Name      string          `json:"name,omitempty"`
+	Message   string          `json:"message"`
+	BuildID   string          `json:"build_id,omitempty"`
+	Raw       json.RawMessage `json:"-"`
+}
+
+// MarshalJSON emits the verbatim source line when Raw is set so renderers
+// preserve every server field; falls back to the named fields otherwise.
+func (e BuildLogEntry) MarshalJSON() ([]byte, error) {
+	if len(e.Raw) > 0 {
+		return e.Raw, nil
+	}
+
+	type plain BuildLogEntry
+
+	return json.Marshal(plain(e))
+}
+
+// BuildOutput is the JSON projection of Build we emit to users. Mirrors
+// ArtifactOutput's role: a deliberate, narrow shape so server-side
+// additions (verbose internals, creator PII like email/userhash) do not
+// leak into our scripted output contract.
+type BuildOutput struct {
+	ID         string `json:"id"`
+	Name       string `json:"name,omitempty"`
+	ArtifactID string `json:"artifactId"`
+	Status     string `json:"status"`
+	CreatedAt  string `json:"createdAt"`
+	UpdatedAt  string `json:"updatedAt"`
+}
+
+// NewBuildOutput projects a Build into its user-facing JSON shape.
+func NewBuildOutput(b Build) BuildOutput {
+	return BuildOutput{
+		ID:         b.ID,
+		Name:       b.Name,
+		ArtifactID: b.ArtifactID,
+		Status:     b.Status,
+		CreatedAt:  b.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:  b.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// BuildSummary is the JSON document RenderBuildSummary emits for `--wait`
+// and the same shape used to assemble the human one-liner in text mode.
+// LogTail is NOT omitempty: a stable JSON shape lets consumers `jq` it
+// uniformly whether or not logs were fetched successfully.
+type BuildSummary struct {
+	BuildID         string          `json:"buildId"`
+	Status          string          `json:"status"`
+	DurationSeconds int64           `json:"durationSeconds"`
+	ImageURI        string          `json:"imageUri"`
+	LogTail         []BuildLogEntry `json:"logTail"`
+}
+
+// IsTerminalBuildStatus reports whether s is a state from which the build
+// will not progress further (COMPLETED, FAILED, CANCELLED). Unknown statuses
+// are treated as non-terminal so polling keeps going rather than declaring
+// success on a status the server added without telling us.
+func IsTerminalBuildStatus(s string) bool {
+	switch s {
+	case BuildStatusCompleted, BuildStatusFailed, BuildStatusCancelled:
+		return true
+	}
+
+	return false
+}
+
+// IsBuildErrorStatus reports whether s is a terminal failure.
+func IsBuildErrorStatus(s string) bool {
+	switch s {
+	case BuildStatusFailed, BuildStatusCancelled:
+		return true
+	}
+
+	return false
+}
+
+// TriggerArtifactBuild POSTs an empty body to /artifacts/{id}/builds/ and
+// returns the trigger response. The defensive empty-slice check is in the
+// caller so the service layer remains a thin pass-through of the server
+// shape.
+func TriggerArtifactBuild(artifactID string) (*BuildTriggerResponse, error) {
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + artifactID + "/builds/")
+	if err != nil {
+		return nil, err
+	}
+
+	var resp BuildTriggerResponse
+
+	if err := drapi.PostJSON(url, "build", map[string]any{}, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// GetArtifactBuild fetches a single Build by id.
+func GetArtifactBuild(artifactID, buildID string) (*Build, error) {
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + artifactID + "/builds/" + buildID)
+	if err != nil {
+		return nil, err
+	}
+
+	var build Build
+
+	if err := drapi.GetJSON(url, "build", &build); err != nil {
+		return nil, err
+	}
+
+	return &build, nil
+}
+
+// ListArtifactBuilds returns up to limit Builds for the artifact, walking
+// pagination the same way ListArtifacts does.
+func ListArtifactBuilds(artifactID string, limit int) ([]Build, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("invalid limit %d: must be positive", limit)
+	}
+
+	endpoint := "/api/v2/artifacts/" + artifactID + "/builds/?limit=" + strconv.Itoa(limit)
+
+	pageURL, err := config.GetEndpointURL(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	var all []Build
+
+	for pageURL != "" {
+		var list BuildList
+
+		if err := drapi.GetJSON(pageURL, "builds", &list); err != nil {
+			return nil, err
+		}
+
+		all = append(all, list.Data...)
+
+		if len(all) >= limit {
+			return all[:limit], nil
+		}
+
+		if list.Next == "" {
+			break
+		}
+
+		if err := drapi.AssertNextOnSameHost(list.Next); err != nil {
+			return nil, err
+		}
+
+		pageURL = list.Next
+	}
+
+	return all, nil
+}
+
+// GetArtifactBuildLogs returns parsed log entries for a build. The endpoint
+// emits newline-delimited JSON; we tolerate malformed lines so a single bad
+// record cannot blank the whole tail. The original bytes for each line are
+// preserved in Raw so JSON output can pass them through unchanged.
+func GetArtifactBuildLogs(artifactID, buildID string) ([]BuildLogEntry, error) {
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + artifactID + "/builds/" + buildID + "/logs")
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := drapi.Get(url, "build logs")
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	return parseBuildLogs(resp.Body)
+}
+
+func parseBuildLogs(r io.Reader) ([]BuildLogEntry, error) {
+	scanner := bufio.NewScanner(r)
+	// Each line can be a multi-KB structured log; bump the buffer past the
+	// 64KiB default to accommodate verbose entries without truncation.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var entries []BuildLogEntry
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(strings.TrimSpace(string(line))) == 0 {
+			continue
+		}
+
+		var entry BuildLogEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			// Skip malformed lines rather than fail the whole fetch;
+			// log payloads regularly include non-JSON tail lines from
+			// the underlying buildkit pipe.
+			continue
+		}
+
+		entry.Raw = append(json.RawMessage(nil), line...)
+		entries = append(entries, entry)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read build logs: %w", err)
+	}
+
+	return entries, nil
+}
+
+// WaitForBuild polls GetArtifactBuild on interval until IsTerminalBuildStatus
+// returns true or deadline expires. On terminal error status it returns the
+// final Build alongside an error so callers get both pieces. onTick may be
+// nil and is invoked after each poll for debug-only observation (Bubble Tea
+// cannot redraw the spinner label from inside fn(), so this is a passive
+// seam in PR 1).
+func WaitForBuild(
+	artifactID, buildID string,
+	interval, timeout time.Duration,
+	onTick func(*Build),
+) (*Build, error) {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		build, err := GetArtifactBuild(artifactID, buildID)
+		if err != nil {
+			return nil, fmt.Errorf("poll build %s: %w", buildID, err)
+		}
+
+		if onTick != nil {
+			onTick(build)
+		}
+
+		if IsTerminalBuildStatus(build.Status) {
+			if IsBuildErrorStatus(build.Status) {
+				return build, fmt.Errorf("build %s ended with status %s; run 'dr workload build logs %s' to inspect", buildID, build.Status, buildID)
+			}
+
+			return build, nil
+		}
+
+		if time.Now().After(deadline) {
+			return build, fmt.Errorf("timeout waiting for build %s after %s", buildID, timeout)
+		}
+
+		time.Sleep(interval)
+	}
+}
+
+// BuildSummaryFor composes the terminal-state summary RenderBuildSummary
+// renders. Duration comes from the Build timestamps; ImageURI is fetched
+// from the parent artifact's primary container only on COMPLETED (the
+// server only updates imageUri on a successful build); for any other
+// status -- FAILED, CANCELLED, or a still-PENDING/IN_PROGRESS build
+// returned alongside a timeout error -- we skip the artifact fetch so a
+// stale imageUri from a prior successful build cannot leak into the
+// current build's summary. On error status we additionally pull the log
+// tail so the user has something to act on.
+func BuildSummaryFor(build *Build, tailLen int) (BuildSummary, error) {
+	if build == nil {
+		return BuildSummary{}, errors.New("nil build")
+	}
+
+	summary := BuildSummary{
+		BuildID:         build.ID,
+		Status:          build.Status,
+		DurationSeconds: buildDurationSeconds(*build),
+	}
+
+	if build.Status != BuildStatusCompleted {
+		if IsBuildErrorStatus(build.Status) {
+			logs, lerr := GetArtifactBuildLogs(build.ArtifactID, build.ID)
+			if lerr != nil {
+				// Surface the fetch error via debug logging rather than
+				// failing the whole summary -- the user still benefits
+				// from seeing the build's terminal state even when the
+				// build-service logs endpoint is unavailable (which is
+				// common right after a CANCELLED build, when the logs
+				// have been garbage-collected).
+				log.Debug("BuildSummaryFor: log tail fetch failed", "build_id", build.ID, "err", lerr)
+			} else {
+				summary.LogTail = lastN(logs, tailLen)
+			}
+		}
+
+		return summary, nil
+	}
+
+	artifact, err := GetArtifact(build.ArtifactID)
+	if err != nil {
+		// Surface the partial summary so callers can still render
+		// duration and status even when the artifact fetch fails.
+		// ImageURI stays empty in that case.
+		return summary, fmt.Errorf("fetch parent artifact for build %s: %w", build.ID, err)
+	}
+
+	summary.ImageURI = GetPrimaryContainerImageURI(*artifact)
+
+	return summary, nil
+}
+
+func buildDurationSeconds(build Build) int64 {
+	if build.UpdatedAt.IsZero() || build.CreatedAt.IsZero() {
+		return 0
+	}
+
+	d := build.UpdatedAt.Sub(build.CreatedAt)
+	if d < 0 {
+		return 0
+	}
+
+	return int64(d.Seconds())
+}
+
+func lastN(entries []BuildLogEntry, n int) []BuildLogEntry {
+	if n <= 0 || len(entries) <= n {
+		return entries
+	}
+
+	return entries[len(entries)-n:]
+}

--- a/internal/workload/build_test.go
+++ b/internal/workload/build_test.go
@@ -1,0 +1,631 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTerminalBuildStatus(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{BuildStatusPending, false},
+		{BuildStatusInProgress, false},
+		{BuildStatusCompleted, true},
+		{BuildStatusFailed, true},
+		{BuildStatusCancelled, true},
+		{"UNKNOWN", false},
+		{"", false},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, IsTerminalBuildStatus(c.status), "status %q", c.status)
+	}
+}
+
+func TestIsBuildErrorStatus(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{BuildStatusCompleted, false},
+		{BuildStatusFailed, true},
+		{BuildStatusCancelled, true},
+		{BuildStatusPending, false},
+		{"WHATEVER", false},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, IsBuildErrorStatus(c.status), "status %q", c.status)
+	}
+}
+
+func TestBuildDurationSeconds(t *testing.T) {
+	zero := time.Time{}
+
+	start := time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		b    Build
+		want int64
+	}{
+		{"zero updatedAt", Build{CreatedAt: start, UpdatedAt: zero}, 0},
+		{"zero createdAt", Build{CreatedAt: zero, UpdatedAt: start}, 0},
+		{"normal", Build{CreatedAt: start, UpdatedAt: start.Add(12 * time.Second)}, 12},
+		{"updatedAt before createdAt", Build{CreatedAt: start.Add(time.Second), UpdatedAt: start}, 0},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, buildDurationSeconds(c.b))
+		})
+	}
+}
+
+func TestLastN(t *testing.T) {
+	mk := func(n int) []BuildLogEntry {
+		out := make([]BuildLogEntry, n)
+		for i := range out {
+			out[i] = BuildLogEntry{Message: fmt.Sprintf("m-%d", i)}
+		}
+
+		return out
+	}
+
+	t.Run("returns all when len <= n", func(t *testing.T) {
+		assert.Len(t, lastN(mk(3), 5), 3)
+	})
+
+	t.Run("trims to last n", func(t *testing.T) {
+		got := lastN(mk(10), 3)
+		require.Len(t, got, 3)
+		assert.Equal(t, "m-7", got[0].Message)
+		assert.Equal(t, "m-9", got[2].Message)
+	})
+
+	t.Run("returns input when n <= 0", func(t *testing.T) {
+		in := mk(4)
+		assert.Equal(t, in, lastN(in, 0))
+		assert.Equal(t, in, lastN(in, -1))
+	})
+}
+
+func TestParseBuildLogs(t *testing.T) {
+	t.Run("valid JSONL passthrough", func(t *testing.T) {
+		body := `{"asctime":"2026-06-09 10:00:00","levelname":"INFO","name":"image-builder","message":"start","build_id":"b-1"}
+{"asctime":"2026-06-09 10:00:01","levelname":"DEBUG","name":"image-builder","message":"detail","build_id":"b-1"}
+`
+		entries, err := parseBuildLogs(strings.NewReader(body))
+		require.NoError(t, err)
+		require.Len(t, entries, 2)
+		assert.Equal(t, "INFO", entries[0].Levelname)
+		assert.Equal(t, "start", entries[0].Message)
+		assert.Equal(t, "b-1", entries[0].BuildID)
+		assert.NotEmpty(t, entries[0].Raw, "raw bytes preserved for passthrough")
+	})
+
+	t.Run("malformed lines are skipped", func(t *testing.T) {
+		body := `{"levelname":"INFO","message":"ok"}
+not-json-garbage
+{"levelname":"ERROR","message":"bad"}
+`
+		entries, err := parseBuildLogs(strings.NewReader(body))
+		require.NoError(t, err)
+		require.Len(t, entries, 2)
+		assert.Equal(t, "ok", entries[0].Message)
+		assert.Equal(t, "bad", entries[1].Message)
+	})
+
+	t.Run("empty body returns empty slice", func(t *testing.T) {
+		entries, err := parseBuildLogs(strings.NewReader(""))
+		require.NoError(t, err)
+		assert.Empty(t, entries)
+	})
+
+	t.Run("blank lines are skipped", func(t *testing.T) {
+		body := "\n\n{\"levelname\":\"INFO\",\"message\":\"x\"}\n\n"
+		entries, err := parseBuildLogs(strings.NewReader(body))
+		require.NoError(t, err)
+		assert.Len(t, entries, 1)
+	})
+}
+
+func TestBuildLogEntry_MarshalJSON_PassesThroughRaw(t *testing.T) {
+	entry := BuildLogEntry{
+		Asctime:   "later", // would disagree with Raw to prove passthrough wins
+		Levelname: "INFO",
+		Message:   "decoded",
+		Raw:       json.RawMessage(`{"original":"untouched","levelname":"INFO"}`),
+	}
+
+	out, err := json.Marshal(entry)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"original":"untouched","levelname":"INFO"}`, string(out))
+}
+
+func TestBuildLogEntry_MarshalJSON_FallsBackToFields(t *testing.T) {
+	entry := BuildLogEntry{
+		Asctime:   "2026-06-09",
+		Levelname: "INFO",
+		Message:   "decoded",
+	}
+
+	out, err := json.Marshal(entry)
+	require.NoError(t, err)
+
+	var got map[string]any
+
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, "INFO", got["levelname"])
+	assert.Equal(t, "decoded", got["message"])
+	assert.NotContains(t, got, "Raw")
+	assert.NotContains(t, got, "raw")
+}
+
+func TestTriggerArtifactBuild_PostsEmptyBodyAndDecodes(t *testing.T) {
+	installSkipAuth(t)
+
+	var (
+		gotPath   string
+		gotMethod string
+		gotBody   []byte
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotBody, _ = io.ReadAll(r.Body)
+
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"buildIds":["b-1","b-2"]}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	resp, err := TriggerArtifactBuild("art-1")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, []string{"b-1", "b-2"}, resp.BuildIDs)
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v2/artifacts/art-1/builds/", gotPath)
+	assert.JSONEq(t, `{}`, string(gotBody))
+}
+
+func TestTriggerArtifactBuild_PropagatesValidationError(t *testing.T) {
+	installSkipAuth(t)
+
+	const detail = `{"detail":[{"path":"id","message":"Artifact not found","code":"not_found"}]}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(detail))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := TriggerArtifactBuild("art-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Artifact not found", "validation body must reach caller (0ae2527 regression)")
+}
+
+func TestGetArtifactBuild_Decodes(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/artifacts/art-1/builds/b-1", r.URL.Path)
+
+		_, _ = w.Write([]byte(`{
+			"id":"b-1",
+			"name":"my build",
+			"artifactId":"art-1",
+			"status":"COMPLETED",
+			"createdAt":"2026-06-09T10:00:00Z",
+			"updatedAt":"2026-06-09T10:00:12Z"
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	build, err := GetArtifactBuild("art-1", "b-1")
+	require.NoError(t, err)
+	assert.Equal(t, "b-1", build.ID)
+	assert.Equal(t, BuildStatusCompleted, build.Status)
+	assert.Equal(t, int64(12), buildDurationSeconds(*build))
+}
+
+func TestGetArtifactBuild_NotFound(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := GetArtifactBuild("art-1", "b-missing")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+}
+
+func TestListArtifactBuilds_PaginatesAndCaps(t *testing.T) {
+	installSkipAuth(t)
+
+	var (
+		hits    int32
+		nextURL string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		page := atomic.AddInt32(&hits, 1)
+
+		assert.Equal(t, "/api/v2/artifacts/art-1/builds/", r.URL.Path)
+
+		switch page {
+		case 1:
+			body := fmt.Sprintf(`{
+				"data": [
+					{"id":"b-1","artifactId":"art-1","status":"COMPLETED"},
+					{"id":"b-2","artifactId":"art-1","status":"COMPLETED"}
+				],
+				"count": 2, "totalCount": 5,
+				"next": "%s/api/v2/artifacts/art-1/builds/?limit=5&offset=2",
+				"previous": null
+			}`, nextURL)
+			_, _ = w.Write([]byte(body))
+		case 2:
+			body := `{
+				"data": [
+					{"id":"b-3","artifactId":"art-1","status":"COMPLETED"},
+					{"id":"b-4","artifactId":"art-1","status":"COMPLETED"},
+					{"id":"b-5","artifactId":"art-1","status":"COMPLETED"}
+				],
+				"count": 3, "totalCount": 5,
+				"next": "",
+				"previous": null
+			}`
+			_, _ = w.Write([]byte(body))
+		}
+	}))
+
+	defer srv.Close()
+
+	nextURL = srv.URL
+
+	installEndpoint(t, srv.URL)
+
+	builds, err := ListArtifactBuilds("art-1", 5)
+	require.NoError(t, err)
+	require.Len(t, builds, 5)
+	assert.Equal(t, "b-5", builds[4].ID)
+}
+
+func TestListArtifactBuilds_RespectsLimitCap(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{"id":"b-1","artifactId":"art-1","status":"COMPLETED"},
+				{"id":"b-2","artifactId":"art-1","status":"COMPLETED"},
+				{"id":"b-3","artifactId":"art-1","status":"COMPLETED"}
+			],
+			"count": 3, "totalCount": 100, "next": "", "previous": null
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	builds, err := ListArtifactBuilds("art-1", 2)
+	require.NoError(t, err)
+	assert.Len(t, builds, 2)
+}
+
+func TestListArtifactBuilds_InvalidLimit(t *testing.T) {
+	_, err := ListArtifactBuilds("art-1", 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "limit")
+}
+
+func TestGetArtifactBuildLogs_ParsesJSONL(t *testing.T) {
+	installSkipAuth(t)
+
+	body := `{"asctime":"2026-06-09 10:00:00","levelname":"INFO","name":"image-builder","message":"line-1","build_id":"b-1"}
+{"asctime":"2026-06-09 10:00:01","levelname":"DEBUG","name":"image-builder","message":"line-2","build_id":"b-1"}
+`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/artifacts/art-1/builds/b-1/logs", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	entries, err := GetArtifactBuildLogs("art-1", "b-1")
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "INFO", entries[0].Levelname)
+	assert.Equal(t, "line-2", entries[1].Message)
+}
+
+func TestWaitForBuild_TerminalCompletedReturnsNil(t *testing.T) {
+	installSkipAuth(t)
+
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		page := atomic.AddInt32(&hits, 1)
+
+		status := BuildStatusInProgress
+		if page >= 2 {
+			status = BuildStatusCompleted
+		}
+
+		fmt.Fprintf(w, `{
+			"id":"b-1","artifactId":"art-1","status":"%s",
+			"createdAt":"2026-06-09T10:00:00Z",
+			"updatedAt":"2026-06-09T10:00:08Z"
+		}`, status)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	var ticks int
+
+	build, err := WaitForBuild("art-1", "b-1", time.Millisecond, time.Second, func(*Build) {
+		ticks++
+	})
+	require.NoError(t, err)
+	assert.Equal(t, BuildStatusCompleted, build.Status)
+	assert.GreaterOrEqual(t, ticks, 2)
+}
+
+func TestWaitForBuild_FailedReturnsError(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"id":"b-1","artifactId":"art-1","status":"FAILED",
+			"createdAt":"2026-06-09T10:00:00Z",
+			"updatedAt":"2026-06-09T10:00:08Z"
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	build, err := WaitForBuild("art-1", "b-1", time.Millisecond, time.Second, nil)
+	require.Error(t, err)
+	require.NotNil(t, build, "FAILED returns final Build alongside error")
+	assert.Equal(t, BuildStatusFailed, build.Status)
+	assert.Contains(t, err.Error(), "FAILED")
+}
+
+func TestWaitForBuild_Timeout(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"id":"b-1","artifactId":"art-1","status":"PENDING",
+			"createdAt":"2026-06-09T10:00:00Z",
+			"updatedAt":"2026-06-09T10:00:00Z"
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := WaitForBuild("art-1", "b-1", 5*time.Millisecond, 25*time.Millisecond, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+}
+
+func TestBuildSummaryFor_SuccessSkipsLogs(t *testing.T) {
+	installSkipAuth(t)
+
+	var logsHit bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/logs") {
+			logsHit = true
+
+			return
+		}
+
+		_, _ = w.Write([]byte(`{
+			"id":"art-1","name":"a","status":"draft",
+			"spec":{"containerGroups":[{"containers":[{"primary":true,"imageUri":"ecr/img:tag"}]}]},
+			"createdAt":"2026-06-09T10:00:00Z","updatedAt":"2026-06-09T10:00:00Z"
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	build := &Build{
+		ID:         "b-1",
+		ArtifactID: "art-1",
+		Status:     BuildStatusCompleted,
+		CreatedAt:  time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 6, 9, 10, 0, 12, 0, time.UTC),
+	}
+
+	summary, err := BuildSummaryFor(build, DefaultBuildLogTail)
+	require.NoError(t, err)
+	assert.Equal(t, "b-1", summary.BuildID)
+	assert.Equal(t, BuildStatusCompleted, summary.Status)
+	assert.Equal(t, int64(12), summary.DurationSeconds)
+	assert.Equal(t, "ecr/img:tag", summary.ImageURI)
+	assert.Empty(t, summary.LogTail)
+	assert.False(t, logsHit, "logs endpoint must not be hit on success")
+}
+
+func TestBuildSummaryFor_FailureFetchesLogs(t *testing.T) {
+	installSkipAuth(t)
+
+	logBody := `{"levelname":"INFO","message":"start"}
+{"levelname":"ERROR","message":"boom"}
+`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/logs") {
+			_, _ = w.Write([]byte(logBody))
+
+			return
+		}
+
+		_, _ = w.Write([]byte(`{
+			"id":"art-1","name":"a","status":"draft",
+			"spec":{"containerGroups":[{"containers":[{"primary":true,"imageUri":""}]}]},
+			"createdAt":"2026-06-09T10:00:00Z","updatedAt":"2026-06-09T10:00:00Z"
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	build := &Build{
+		ID:         "b-1",
+		ArtifactID: "art-1",
+		Status:     BuildStatusFailed,
+		CreatedAt:  time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 6, 9, 10, 0, 9, 0, time.UTC),
+	}
+
+	summary, err := BuildSummaryFor(build, 1)
+	require.NoError(t, err)
+	assert.Equal(t, int64(9), summary.DurationSeconds)
+	assert.Empty(t, summary.ImageURI)
+	require.Len(t, summary.LogTail, 1)
+	assert.Equal(t, "boom", summary.LogTail[0].Message)
+}
+
+func TestBuildSummaryFor_NilBuild(t *testing.T) {
+	_, err := BuildSummaryFor(nil, DefaultBuildLogTail)
+	require.Error(t, err)
+}
+
+// TestBuildSummaryFor_TimeoutLeavesImageEmpty guards the non-terminal-on-
+// timeout case: WaitForBuild returns the last-polled IN_PROGRESS build
+// alongside a timeout error. BuildSummaryFor must NOT load the artifact
+// (which would leak a stale imageUri from a prior successful build) and
+// must NOT fetch logs (IN_PROGRESS is not an error status).
+func TestBuildSummaryFor_TimeoutLeavesImageEmpty(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("BuildSummaryFor must not hit any endpoint when status is not COMPLETED and not an error (hit: %s)", r.URL.Path)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	build := &Build{
+		ID:         "b-1",
+		ArtifactID: "art-1",
+		Status:     BuildStatusInProgress,
+		CreatedAt:  time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 6, 9, 10, 10, 0, 0, time.UTC),
+	}
+
+	summary, err := BuildSummaryFor(build, DefaultBuildLogTail)
+	require.NoError(t, err)
+	assert.Equal(t, BuildStatusInProgress, summary.Status)
+	assert.Equal(t, int64(600), summary.DurationSeconds)
+	assert.Empty(t, summary.ImageURI, "non-terminal status must not leak a prior build's imageUri")
+	assert.Empty(t, summary.LogTail, "non-error status must not fetch logs")
+}
+
+// TestBuildSummaryFor_FailureLogFetch502 reproduces the live CANCELLED-build
+// smoke case: the build-service garbage-collected the log records and the
+// /logs endpoint 502s. BuildSummaryFor must NOT propagate the log-fetch
+// failure as an error; the summary stays valuable (duration + status) and
+// LogTail is left nil so the caller can render the partial info.
+func TestBuildSummaryFor_FailureLogFetch502(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/logs") {
+			// Match the staging shape: 502 with a JSON detail body.
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(`{"detail":"Failed to retrieve build logs"}`))
+
+			return
+		}
+
+		// The skip-artifact-on-error branch must NOT hit this handler at
+		// all for FAILED/CANCELLED builds; assert by failing if it does.
+		t.Errorf("BuildSummaryFor must not fetch the parent artifact on error status (hit: %s)", r.URL.Path)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	build := &Build{
+		ID:         "b-1",
+		ArtifactID: "art-1",
+		Status:     BuildStatusCancelled,
+		CreatedAt:  time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 6, 9, 10, 24, 8, 0, time.UTC),
+	}
+
+	summary, err := BuildSummaryFor(build, DefaultBuildLogTail)
+	require.NoError(t, err, "log-fetch 502 must not fail the summary")
+	assert.Equal(t, "b-1", summary.BuildID)
+	assert.Equal(t, BuildStatusCancelled, summary.Status)
+	assert.Equal(t, int64(1448), summary.DurationSeconds)
+	assert.Empty(t, summary.ImageURI, "imageUri must not be set on error-status builds")
+	assert.Nil(t, summary.LogTail, "LogTail stays nil so callers can detect 'no logs available'")
+}

--- a/internal/workload/output.go
+++ b/internal/workload/output.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/charmbracelet/lipgloss"
@@ -98,6 +99,235 @@ func printArtifactDetails(artifact Artifact) {
 	fmt.Fprintf(w, "Updated:\t%s\n", artifact.UpdatedAt.UTC().Format(timestampFormat))
 
 	w.Flush()
+}
+
+// Build log levels in ascending severity. Used by FilterLogsByLevel to drop
+// records below the requested threshold; ordering mirrors the python logging
+// numeric levels but compared by name (the server emits "DEBUG", "INFO",
+// "WARNING"/"WARN", "ERROR", "CRITICAL"). Unknown levels are passed through.
+var buildLogLevelRank = map[string]int{
+	"DEBUG":    10,
+	"INFO":     20,
+	"WARN":     30,
+	"WARNING":  30,
+	"ERROR":    40,
+	"CRITICAL": 50,
+}
+
+// FilterLogsByLevel returns the subset of entries whose Levelname is at or
+// above the given minimum. The threshold is matched case-insensitively;
+// "info" drops DEBUG, "debug" keeps everything, an unknown threshold passes
+// the input through unchanged so users can opt out of filtering with a
+// nonsense value if desired.
+func FilterLogsByLevel(entries []BuildLogEntry, minLevel string) []BuildLogEntry {
+	threshold, ok := buildLogLevelRank[strings.ToUpper(minLevel)]
+	if !ok {
+		return entries
+	}
+
+	out := make([]BuildLogEntry, 0, len(entries))
+
+	for _, e := range entries {
+		rank, known := buildLogLevelRank[strings.ToUpper(e.Levelname)]
+		if !known {
+			out = append(out, e)
+
+			continue
+		}
+
+		if rank >= threshold {
+			out = append(out, e)
+		}
+	}
+
+	return out
+}
+
+func RenderBuild(format OutputFormat, build Build) error {
+	if format == OutputFormatJSON {
+		return printJSON(NewBuildOutput(build))
+	}
+
+	printBuildDetails(build)
+
+	return nil
+}
+
+func RenderBuilds(format OutputFormat, builds []Build) error {
+	if format == OutputFormatJSON {
+		outputs := make([]BuildOutput, 0, len(builds))
+
+		for _, b := range builds {
+			outputs = append(outputs, NewBuildOutput(b))
+		}
+
+		return printJSON(outputs)
+	}
+
+	printBuildsTable(builds)
+
+	return nil
+}
+
+func RenderBuildTrigger(format OutputFormat, resp BuildTriggerResponse) error {
+	if format == OutputFormatJSON {
+		return printJSON(resp)
+	}
+
+	for _, id := range resp.BuildIDs {
+		fmt.Println(id)
+	}
+
+	return nil
+}
+
+// RenderBuildSummaries emits a list of summaries. Text mode walks each one
+// through RenderBuildSummary; JSON mode emits the whole slice as one array
+// document so `--wait` scripts always get a single `jq`-able value even
+// when multiple build IDs were triggered.
+func RenderBuildSummaries(format OutputFormat, summaries []BuildSummary) error {
+	if format == OutputFormatJSON {
+		return printJSON(summaries)
+	}
+
+	for _, s := range summaries {
+		if err := RenderBuildSummary(format, s); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// RenderBuildSummary renders the terminal-state summary for `--wait`.
+// In text mode the human one-liner goes to stdout; the failure log tail
+// (when present) goes to stderr so stdout stays clean for script callers
+// reading both build ID and summary line. JSON mode emits one document on
+// stdout including the LogTail in-document.
+func RenderBuildSummary(format OutputFormat, summary BuildSummary) error {
+	if format == OutputFormatJSON {
+		return printJSON(summary)
+	}
+
+	dur := fmt.Sprintf("%ds", summary.DurationSeconds)
+
+	if summary.ImageURI != "" {
+		fmt.Printf("Build %s: %s in %s (image: %s)\n", summary.BuildID, summary.Status, dur, summary.ImageURI)
+	} else {
+		fmt.Printf("Build %s: %s in %s\n", summary.BuildID, summary.Status, dur)
+	}
+
+	if len(summary.LogTail) > 0 {
+		fmt.Fprintf(os.Stderr, "--- last %d log lines ---\n", len(summary.LogTail))
+
+		for _, entry := range summary.LogTail {
+			fmt.Fprintln(os.Stderr, formatLogLine(entry))
+		}
+	}
+
+	return nil
+}
+
+func RenderBuildLogs(format OutputFormat, entries []BuildLogEntry) error {
+	if format == OutputFormatJSON {
+		return printJSON(entries)
+	}
+
+	for _, entry := range entries {
+		fmt.Println(formatLogLine(entry))
+	}
+
+	return nil
+}
+
+func printJSON(v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+
+	return nil
+}
+
+func printBuildDetails(build Build) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "ID:\t%s\n", build.ID)
+
+	if build.Name != "" {
+		fmt.Fprintf(w, "Name:\t%s\n", build.Name)
+	}
+
+	fmt.Fprintf(w, "Artifact ID:\t%s\n", build.ArtifactID)
+	fmt.Fprintf(w, "Status:\t%s\n", build.Status)
+	fmt.Fprintf(w, "Created:\t%s\n", build.CreatedAt.UTC().Format(timestampFormat))
+	fmt.Fprintf(w, "Updated:\t%s\n", build.UpdatedAt.UTC().Format(timestampFormat))
+
+	w.Flush()
+}
+
+func printBuildsTable(builds []Build) {
+	if len(builds) == 0 {
+		fmt.Println("No builds found.")
+
+		return
+	}
+
+	cellStyle := tui.BaseTextStyle.Padding(0, 1)
+	dimStyle := tui.DimStyle.Padding(0, 1)
+
+	headers := []string{"BUILD ID", "NAME", "ARTIFACT ID", "STATUS", "CREATED", "UPDATED"}
+	updatedCol := slices.Index(headers, "UPDATED")
+
+	t := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(tui.TableBorderStyle).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return cellStyle.Bold(true)
+			}
+
+			if col == updatedCol {
+				return dimStyle
+			}
+
+			return cellStyle
+		}).
+		Headers(headers...)
+
+	for _, b := range builds {
+		name := b.Name
+		if name == "" {
+			name = emptyValuePlaceholder
+		}
+
+		t.Row(
+			b.ID,
+			name,
+			b.ArtifactID,
+			b.Status,
+			b.CreatedAt.UTC().Format(timestampFormat),
+			b.UpdatedAt.UTC().Format(timestampFormat),
+		)
+	}
+
+	fmt.Fprintln(os.Stdout, t.Render())
+}
+
+func formatLogLine(entry BuildLogEntry) string {
+	level := entry.Levelname
+	if level == "" {
+		level = "?"
+	}
+
+	asctime := entry.Asctime
+	if asctime == "" {
+		return fmt.Sprintf("[%s] %s", level, entry.Message)
+	}
+
+	return fmt.Sprintf("[%s] %s %s", level, asctime, entry.Message)
 }
 
 func printArtifactsTable(artifacts []Artifact) {

--- a/internal/workload/output_test.go
+++ b/internal/workload/output_test.go
@@ -213,3 +213,274 @@ func TestPrintArtifactsTable_Empty(t *testing.T) {
 
 	assert.Equal(t, "No artifacts found.\n", output)
 }
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stderr
+
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	fn()
+
+	w.Close()
+
+	os.Stderr = old
+
+	var buf bytes.Buffer
+
+	_, _ = io.Copy(&buf, r)
+
+	return buf.String()
+}
+
+func makeTestBuild(id, status string) Build {
+	return Build{
+		ID:         id,
+		Name:       "image build",
+		ArtifactID: "art-1",
+		Status:     status,
+		CreatedAt:  time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 6, 9, 10, 0, 12, 0, time.UTC),
+	}
+}
+
+func TestRenderBuild_Text(t *testing.T) {
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderBuild(OutputFormatText, makeTestBuild("b-1", BuildStatusCompleted)))
+	})
+
+	assert.Contains(t, out, "ID:")
+	assert.Contains(t, out, "b-1")
+	assert.Contains(t, out, "Status:")
+	assert.Contains(t, out, BuildStatusCompleted)
+}
+
+func TestRenderBuild_JSON(t *testing.T) {
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderBuild(OutputFormatJSON, makeTestBuild("b-1", BuildStatusCompleted)))
+	})
+
+	var got map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "b-1", got["id"])
+	assert.Equal(t, BuildStatusCompleted, got["status"])
+}
+
+func TestRenderBuilds_TextTable(t *testing.T) {
+	builds := []Build{makeTestBuild("b-1", BuildStatusCompleted), makeTestBuild("b-2", BuildStatusFailed)}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderBuilds(OutputFormatText, builds))
+	})
+
+	assert.Contains(t, out, "BUILD ID")
+	assert.Contains(t, out, "b-1")
+	assert.Contains(t, out, "b-2")
+	assert.Contains(t, out, BuildStatusFailed)
+}
+
+func TestRenderBuilds_TextEmpty(t *testing.T) {
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderBuilds(OutputFormatText, nil))
+	})
+
+	assert.Equal(t, "No builds found.\n", out)
+}
+
+func TestRenderBuilds_JSONAlwaysArray(t *testing.T) {
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderBuilds(OutputFormatJSON, []Build{makeTestBuild("b-1", BuildStatusCompleted)}))
+	})
+
+	var got []map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "b-1", got[0]["id"])
+}
+
+func TestRenderBuildTrigger_TextOneIDPerLine(t *testing.T) {
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderBuildTrigger(OutputFormatText, BuildTriggerResponse{BuildIDs: []string{"b-1", "b-2"}}))
+	})
+
+	assert.Equal(t, "b-1\nb-2\n", out, "exact one-id-per-line format is the BID=$(...) script contract")
+}
+
+func TestRenderBuildTrigger_JSONPassthrough(t *testing.T) {
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderBuildTrigger(OutputFormatJSON, BuildTriggerResponse{BuildIDs: []string{"b-1"}}))
+	})
+
+	var got map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	ids, ok := got["buildIds"].([]any)
+	require.True(t, ok)
+	require.Len(t, ids, 1)
+	assert.Equal(t, "b-1", ids[0])
+}
+
+func TestRenderBuildSummary_TextSuccessIncludesImage(t *testing.T) {
+	summary := BuildSummary{
+		BuildID:         "b-1",
+		Status:          BuildStatusCompleted,
+		DurationSeconds: 12,
+		ImageURI:        "ecr/img:tag",
+	}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderBuildSummary(OutputFormatText, summary))
+	})
+
+	assert.Equal(t, "Build b-1: COMPLETED in 12s (image: ecr/img:tag)\n", out)
+}
+
+func TestRenderBuildSummary_TextSuccessWithoutImageURI(t *testing.T) {
+	summary := BuildSummary{
+		BuildID:         "b-1",
+		Status:          BuildStatusCompleted,
+		DurationSeconds: 12,
+	}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderBuildSummary(OutputFormatText, summary))
+	})
+
+	assert.Equal(t, "Build b-1: COMPLETED in 12s\n", out)
+}
+
+func TestRenderBuildSummary_TextFailureDumpsTailToStderr(t *testing.T) {
+	summary := BuildSummary{
+		BuildID:         "b-1",
+		Status:          BuildStatusFailed,
+		DurationSeconds: 9,
+		LogTail: []BuildLogEntry{
+			{Levelname: "INFO", Asctime: "t1", Message: "start"},
+			{Levelname: "ERROR", Asctime: "t2", Message: "boom"},
+		},
+	}
+
+	var (
+		stdoutOut string
+		stderrOut string
+	)
+
+	stderrOut = captureStderr(t, func() {
+		stdoutOut = captureStdout(t, func() {
+			require.NoError(t, RenderBuildSummary(OutputFormatText, summary))
+		})
+	})
+
+	assert.Equal(t, "Build b-1: FAILED in 9s\n", stdoutOut, "summary line stays on stdout")
+	assert.Contains(t, stderrOut, "last 2 log lines")
+	assert.Contains(t, stderrOut, "start")
+	assert.Contains(t, stderrOut, "boom")
+}
+
+func TestRenderBuildSummary_JSONIncludesTail(t *testing.T) {
+	summary := BuildSummary{
+		BuildID:         "b-1",
+		Status:          BuildStatusFailed,
+		DurationSeconds: 9,
+		LogTail: []BuildLogEntry{
+			{Levelname: "ERROR", Message: "boom"},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderBuildSummary(OutputFormatJSON, summary))
+	})
+
+	var got map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, BuildStatusFailed, got["status"])
+	assert.InEpsilon(t, float64(9), got["durationSeconds"], 0.001)
+
+	tail, ok := got["logTail"].([]any)
+	require.True(t, ok)
+	require.Len(t, tail, 1)
+}
+
+func TestRenderBuildLogs_TextFormat(t *testing.T) {
+	entries := []BuildLogEntry{
+		{Levelname: "INFO", Asctime: "t1", Message: "started"},
+		{Levelname: "ERROR", Asctime: "t2", Message: "broke"},
+	}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderBuildLogs(OutputFormatText, entries))
+	})
+
+	assert.Contains(t, out, "[INFO] t1 started")
+	assert.Contains(t, out, "[ERROR] t2 broke")
+}
+
+func TestRenderBuildLogs_JSONPassthroughPreservesRaw(t *testing.T) {
+	entries := []BuildLogEntry{
+		{
+			Levelname: "INFO",
+			Message:   "decoded",
+			Raw:       json.RawMessage(`{"levelname":"INFO","extra":"server-field","message":"raw"}`),
+		},
+	}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderBuildLogs(OutputFormatJSON, entries))
+	})
+
+	var got []map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "server-field", got[0]["extra"], "raw bytes must pass through unchanged")
+	assert.Equal(t, "raw", got[0]["message"])
+}
+
+func TestFilterLogsByLevel(t *testing.T) {
+	entries := []BuildLogEntry{
+		{Levelname: "DEBUG", Message: "d"},
+		{Levelname: "INFO", Message: "i"},
+		{Levelname: "WARNING", Message: "w"},
+		{Levelname: "ERROR", Message: "e"},
+		{Levelname: "UNKNOWN", Message: "u"},
+	}
+
+	t.Run("info drops DEBUG and keeps unknown", func(t *testing.T) {
+		got := FilterLogsByLevel(entries, "info")
+
+		msgs := make([]string, 0, len(got))
+
+		for _, e := range got {
+			msgs = append(msgs, e.Message)
+		}
+
+		assert.ElementsMatch(t, []string{"i", "w", "e", "u"}, msgs)
+	})
+
+	t.Run("debug keeps everything", func(t *testing.T) {
+		got := FilterLogsByLevel(entries, "debug")
+		assert.Len(t, got, len(entries))
+	})
+
+	t.Run("error keeps only ERROR and unknown", func(t *testing.T) {
+		got := FilterLogsByLevel(entries, "error")
+
+		msgs := make([]string, 0, len(got))
+
+		for _, e := range got {
+			msgs = append(msgs, e.Message)
+		}
+
+		assert.ElementsMatch(t, []string{"e", "u"}, msgs)
+	})
+
+	t.Run("unknown threshold is pass-through", func(t *testing.T) {
+		got := FilterLogsByLevel(entries, "nonsense")
+		assert.Equal(t, entries, got)
+	})
+}

--- a/internal/workload/resolveart.go
+++ b/internal/workload/resolveart.go
@@ -1,0 +1,64 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/datarobot/cli/internal/workload/wapi"
+)
+
+const (
+	ArtifactIDSourceExplicit = "explicit"
+	ArtifactIDSourceWAPI     = "wapi"
+)
+
+// ResolveArtifactID returns the artifact id to operate on. When explicit is
+// non-empty it is returned verbatim with source "explicit". Otherwise the
+// current working directory is searched for a .wapi/config.json (the same
+// project-linked sync state managed by 'dr workload code init/sync') and the
+// id is read from there with source "wapi".
+//
+// Returns a user-facing error when neither source provides one so callers can
+// surface the .wapi-init hint without further wrapping.
+func ResolveArtifactID(explicit string) (string, string, error) {
+	if explicit != "" {
+		return explicit, ArtifactIDSourceExplicit, nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", "", fmt.Errorf("resolve current directory: %w", err)
+	}
+
+	absDir, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve %s: %w", cwd, err)
+	}
+
+	cfg, err := wapi.LoadConfig(absDir)
+	if err != nil {
+		if errors.Is(err, wapi.ErrNotInitialized) {
+			return "", "", fmt.Errorf("artifact id not provided and no .wapi project in %s. Run 'dr workload code init <artifact-id>' or pass the id explicitly", absDir)
+		}
+
+		return "", "", fmt.Errorf("read .wapi/config.json: %w", err)
+	}
+
+	return cfg.ArtifactID, ArtifactIDSourceWAPI, nil
+}

--- a/internal/workload/resolveart_test.go
+++ b/internal/workload/resolveart_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const validResolveConfig = `{
+	"artifactId": "art-from-wapi-000000000",
+	"catalogId": null,
+	"lastSyncedVersionId": null,
+	"createdAt": "2026-04-01T08:00:00Z",
+	"cliVersion": "v0.0.0-test"
+}`
+
+func writeWAPIConfig(t *testing.T, dir, body string) {
+	t.Helper()
+
+	wapiDir := filepath.Join(dir, ".wapi")
+	require.NoError(t, os.MkdirAll(wapiDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(wapiDir, "config.json"), []byte(body), 0o600))
+}
+
+func TestResolveArtifactID_ExplicitWinsOverWAPI(t *testing.T) {
+	dir := t.TempDir()
+
+	writeWAPIConfig(t, dir, validResolveConfig)
+	t.Chdir(dir)
+
+	id, source, err := ResolveArtifactID("art-explicit")
+	require.NoError(t, err)
+	assert.Equal(t, "art-explicit", id)
+	assert.Equal(t, ArtifactIDSourceExplicit, source)
+}
+
+func TestResolveArtifactID_FromWAPIWhenExplicitEmpty(t *testing.T) {
+	dir := t.TempDir()
+
+	writeWAPIConfig(t, dir, validResolveConfig)
+	t.Chdir(dir)
+
+	id, source, err := ResolveArtifactID("")
+	require.NoError(t, err)
+	assert.Equal(t, "art-from-wapi-000000000", id)
+	assert.Equal(t, ArtifactIDSourceWAPI, source)
+}
+
+func TestResolveArtifactID_NotInitializedHasUserHint(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Chdir(dir)
+
+	_, _, err := ResolveArtifactID("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no .wapi project")
+	assert.Contains(t, err.Error(), "dr workload code init")
+}
+
+func TestResolveArtifactID_CorruptConfigPropagates(t *testing.T) {
+	dir := t.TempDir()
+
+	writeWAPIConfig(t, dir, "{ this is not json")
+	t.Chdir(dir)
+
+	_, _, err := ResolveArtifactID("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), ".wapi/config.json")
+}

--- a/internal/workload/testhelpers_test.go
+++ b/internal/workload/testhelpers_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+)
+
+// installSkipAuth configures viper so drapi.AuthorizeRequest does not
+// attempt to verify a token over the network. Mirrors the helper in
+// internal/pipeline/transport_test.go.
+func installSkipAuth(t *testing.T) {
+	t.Helper()
+
+	prevSkip := viperx.GetBool("skip_auth")
+	prevTok := viperx.GetString(config.DataRobotAPIKey)
+
+	viperx.Set("skip_auth", true)
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+
+	t.Cleanup(func() {
+		viperx.Set("skip_auth", prevSkip)
+		viperx.Set(config.DataRobotAPIKey, prevTok)
+	})
+}
+
+// installEndpoint redirects config.GetEndpointURL("/...") to point at the
+// given httptest server URL for the duration of the test.
+func installEndpoint(t *testing.T, url string) {
+	t.Helper()
+
+	prev := viperx.GetString(config.DataRobotURL)
+
+	viperx.Set(config.DataRobotURL, url)
+
+	t.Cleanup(func() {
+		viperx.Set(config.DataRobotURL, prev)
+	})
+}


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

Before this PR, the `dr workload` CLI supported `artifact create` but had no way to trigger an artifact build, watch one to completion, list past builds, or read build logs. Users had to drop into `curl` against `POST /artifacts/<id>/builds/` and `GET /artifacts/<id>/builds/<bid>` for everything build-related.

This PR adds a `dr workload build` command tree that covers all of those operations from the CLI.

## CHANGES

- New parent command `dr workload build` registered as a sibling of `artifact` and `code` under `workload`.
- Four leaf commands:
  - `build trigger [<art-id>]`: POSTs an empty body to `/api/v2/artifacts/<id>/builds/`. Defensive empty-`buildIds` error. `--wait` polls each returned build to terminal status and renders a `BuildSummary` (duration + `imageUri` on success; log tail to stderr on `FAILED` / `CANCELLED`).
  - `build list [<art-id>]`: paginated build history with `--limit` (default 100). Table shows the server-supplied build NAME column.
  - `build get [<art-id>] <build-id>`: single Build detail; `--wait` polls if non-terminal, exits non-zero on terminal error status with an explicit error message.
  - `build logs [<art-id>] <build-id>`: JSONL log stream parsed and rendered as `[LEVEL] asctime message`. `--level debug|info|warn|error` filter (default `info`); JSON output emits a single array document and preserves verbatim server fields via a `Raw` passthrough.
- `<art-id>` is optional on every subcommand: when omitted, `workload.ResolveArtifactID` reads it from `.wapi/config.json` in the current directory. From inside a `.wapi/`-linked project, single-positional invocations like `build get $BID` and `build logs $BID` just work.
- Shared helpers in `cmd/workload/build/internal/`:
  - `pollflags`: single source of truth for `--wait` / `--poll-interval` / `--poll-timeout` (defaults: 2s, 30m; the two poll flags are `MarkHidden`).
  - `buildargs`: shared `ResolvePositional` for the `[<art-id>] <build-id>` shape consumed by `get` and `logs`.
- `BuildOutput` projection on JSON output: only `{id, name, artifactId, status, createdAt, updatedAt}` reach scripted consumers; the server-side `creator` block (email / userhash) is never exposed. Mirrors how `ArtifactOutput` shields the artifact JSON.
- `BuildSummary.LogTail` has a stable shape: the JSON tag drops `omitempty`, so `jq '.logTail | length'` works the same whether the log endpoint returned successfully or 502'd.
- `BuildSummaryFor` on `FAILED` / `CANCELLED` builds skips the parent-artifact fetch so a stale `imageUri` (from a previous successful build) is not surfaced as if it belonged to the failed build. Log-fetch failures are demoted to `log.Debug` so they show with `--debug` but do not blow up the summary.
- Progress text is plain stderr output: `Triggering build...`, `Fetching build X...`, `Waiting for build X...`. All progress goes to `cmd.ErrOrStderr()`; results go to `cmd.OutOrStdout()`. The `BID=$(dr workload build trigger)` script-capture contract is preserved.
- New `BuildStatusUnknown = "UNKNOWN"` CLI-side sentinel for the rare case where `WaitForBuild` returns no Build before erroring.
- One-line `drapi` change: `isCreateSuccess` now also accepts HTTP 202 alongside 200/201 (matches the 202 acceptance already present in `isDeleteSuccess`), so the `POST /builds/` endpoint's 202 Accepted response can be decoded normally.
- ~2,640 lines added across 23 files, roughly 50/50 production code and tests. New `httptest` coverage on every service-layer function (`TriggerArtifactBuild`, `GetArtifactBuild`, `ListArtifactBuilds`, `GetArtifactBuildLogs`, `WaitForBuild`, `BuildSummaryFor` success and 502-log-fetch paths).

## TESTING

- `task delint && task lint && task test && task build` clean. The only test failure observed is a pre-existing `internal/plugin/TestGetManifestValid` flake (reproduces on `main` at `0ae2527`).
- Live smoke against `staging.datarobot.com` against an artifact with a Python + uv project:
  - Every server status enum string verified live: `PENDING`, `IN_PROGRESS`, `COMPLETED`, `FAILED`, `CANCELLED`.
  - `BID=$(./dist/dr workload build trigger)` captures only the 24-char hex build id; no progress contamination.
  - `build list / get / logs` from inside a `.wapi/` directory all resolve the artifact id implicitly.
  - `build get $BID --wait` on a `CANCELLED` build exits 1 and dumps the last 50 log lines to stderr; the JSON form emits a single document with `imageUri: ""` and `logTail` present.
  - `build logs $BID --level error` filters down to a single `[ERROR]` line.
  - Server validation errors (e.g. triggering on an artifact whose code lacks `pyproject.toml + uv.lock`) surface verbatim as `HTTP 422 ... body={"detail":"... cannot detect any runtime."}`.
- Full smoke trace recorded in `tmp/test-results.md`.

## NOTES

- One file outside `internal/workload/*` was touched: `internal/drapi/post.go` (one-line `isCreateSuccess` expansion to accept 202). The change mirrors `isDeleteSuccess` and is required by the build trigger endpoint's contract; documented inline.
- The "skip fetch parent artifact on error status" branch in `BuildSummaryFor` is a client-side workaround for the server leaving a stale `imageUri` on non-`COMPLETED` builds. The comment flags it as removable once the server returns `""` itself; worth filing a `workload-api` ticket.

---

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new surface against authenticated workload APIs and a shared `drapi` POST success rule (202), but behavior is additive with broad httptest coverage and no auth/data-model changes.
> 
> **Overview**
> Adds **`dr workload build`** under `workload` so users can trigger container image builds, list history, inspect status, and read logs without raw API calls.
> 
> **CLI:** `trigger`, `list`, `get`, and `logs` support optional artifact id from **`.wapi/config.json`** (same pattern as `code init`). Shared **`pollflags`** (`--wait`, hidden poll interval/timeout) and **`buildargs`** keep `get`/`logs` positional shapes aligned. **`--wait`** on `trigger`/`get` polls to terminal status, prints a **`BuildSummary`** (duration, `imageUri` on success; log tail to stderr on failure), and exits non-zero on failed/cancelled builds.
> 
> **Library:** New **`internal/workload/build.go`** wraps artifact build REST endpoints (trigger, get, list, logs JSONL, **`WaitForBuild`**, **`BuildSummaryFor`**). **`ResolveArtifactID`** centralizes explicit vs `.wapi` id resolution. **`Container.ImageURI`** and **`GetPrimaryContainerImageURI`** support post-build image display. Output helpers add narrowed **`BuildOutput`**, tables, log level filtering, and script-friendly trigger output (one build id per line).
> 
> **API client:** **`isCreateSuccess`** in **`internal/drapi/post.go`** now treats **HTTP 202** as success so async **`POST .../builds/`** responses decode correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 977f64f499e2b40c71c06db410406acd99b466a0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->