### PR TITLE
[CFX-6449] feat(plugins): support install from local file or URL

### DIFF
--- a/cmd/plugin/install/cmd.go
+++ b/cmd/plugin/install/cmd.go
@@ -29,6 +29,8 @@ var (
 	registryURL       string
 	listPlugins       bool
 	listVersions      bool
+	filePath          string
+	pluginURL         string
 )
 
 func Cmd() *cobra.Command {
@@ -43,12 +45,17 @@ Use --version to specify a version constraint:
   - Caret (compatible): ^1.2.3 (any 1.x.x >= 1.2.3)
   - Tilde (patch-level): ~1.2.3 (any 1.2.x >= 1.2.3)
   - Minimum: >=1.0.0
-  - Latest: latest (default)`,
+  - Latest: latest (default)
+
+Use --file to install directly from a local .tar.xz archive instead of the registry.
+Use --url to install directly from an HTTP/HTTPS URL instead of the registry.`,
 		Example: `  dr plugin install assist
   dr plugin install assist --version 0.1.6
   dr plugin install assist --version "^0.1.0"
   dr plugin install assist --versions
-  dr plugin install --list`,
+  dr plugin install --list
+  dr plugin install assist --file ./assist-0.2.0.tar.xz
+  dr plugin install assist --url https://example.com/assist-0.2.0.tar.xz`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: runInstall,
 	}
@@ -57,9 +64,13 @@ Use --version to specify a version constraint:
 	cmd.Flags().BoolVar(&listVersions, "versions", false, "List available versions for a plugin")
 	cmd.Flags().StringVar(&registryURL, "registry-url", plugin.PluginRegistryURL, "URL of the plugin registry")
 	cmd.Flags().BoolVar(&listPlugins, "list", false, "List available plugins from the registry")
+	cmd.Flags().StringVar(&filePath, "file", "", "Install from a local .tar.xz archive instead of the registry")
+	cmd.Flags().StringVar(&pluginURL, "url", "", "Install from an HTTP/HTTPS URL instead of the registry")
 
 	// Mark mutually exclusive flags
-	cmd.MarkFlagsMutuallyExclusive("list", "versions", "version")
+	cmd.MarkFlagsMutuallyExclusive("list", "versions", "version", "file", "url")
+	cmd.MarkFlagsMutuallyExclusive("file", "registry-url")
+	cmd.MarkFlagsMutuallyExclusive("url", "registry-url")
 
 	telemetry.TrackWith(cmd, func(c *cobra.Command, args []string) map[string]any {
 		ver, _ := c.Flags().GetString("version")
@@ -74,6 +85,18 @@ Use --version to specify a version constraint:
 }
 
 func runInstall(_ *cobra.Command, args []string) error {
+	if filePath != "" {
+		return runInstallFromFile(args)
+	}
+
+	if pluginURL != "" {
+		return runInstallFromURL(args)
+	}
+
+	return runInstallFromRegistry(args)
+}
+
+func runInstallFromRegistry(args []string) error {
 	finalRegistryURL := shared.NormalizeRegistryURL(registryURL)
 
 	var (
@@ -150,6 +173,70 @@ func runInstall(_ *cobra.Command, args []string) error {
 	fmt.Println(tui.SuccessStyle.Render("✓ Successfully installed " + pluginEntry.Name + " " + version.Version))
 	fmt.Println()
 	fmt.Printf("Run `dr %s --help` to get started.\n", pluginEntry.Name)
+
+	return nil
+}
+
+func runInstallFromFile(args []string) error {
+	name := ""
+	if len(args) > 0 {
+		name = args[0]
+	}
+
+	fmt.Println()
+	fmt.Println(tui.SubTitleStyle.Render("Installing Plugin"))
+
+	var resolvedName string
+
+	if err := tui.RunWithSpinner(
+		fmt.Sprintf("Installing plugin from %s…", filePath),
+		func() error {
+			var err error
+
+			resolvedName, err = plugin.InstallPluginFromFile(filePath, name)
+
+			return err
+		},
+	); err != nil {
+		return fmt.Errorf("failed to install plugin: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Println(tui.SuccessStyle.Render("✓ Successfully installed " + resolvedName + " (local)"))
+	fmt.Println()
+	fmt.Printf("Run `dr %s --help` to get started.\n", resolvedName)
+
+	return nil
+}
+
+func runInstallFromURL(args []string) error {
+	name := ""
+	if len(args) > 0 {
+		name = args[0]
+	}
+
+	fmt.Println()
+	fmt.Println(tui.SubTitleStyle.Render("Installing Plugin"))
+
+	var resolvedName string
+
+	if err := tui.RunWithSpinner(
+		fmt.Sprintf("Installing plugin from %s…", pluginURL),
+		func() error {
+			var err error
+
+			resolvedName, err = plugin.InstallPluginFromURL(pluginURL, name)
+
+			return err
+		},
+	); err != nil {
+		return fmt.Errorf("failed to install plugin: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Println(tui.SuccessStyle.Render("✓ Successfully installed " + resolvedName))
+	fmt.Println()
+	fmt.Printf("Run `dr %s --help` to get started.\n", resolvedName)
 
 	return nil
 }

--- a/docs/commands/plugins.md
+++ b/docs/commands/plugins.md
@@ -12,9 +12,13 @@ dr plugin install PLUGIN_NAME --version "^1.0.0"
 dr plugin install --list
 dr plugin install PLUGIN_NAME --versions
 dr plugin install --list --registry-url http://localhost:8000/plugins
+dr plugin install PLUGIN_NAME --file ./plugin-0.2.0.tar.xz
+dr plugin install --file ./plugin-0.2.0.tar.xz
+dr plugin install PLUGIN_NAME --url https://example.com/plugin-0.2.0.tar.xz
+dr plugin install --url https://example.com/plugin-0.2.0.tar.xz
 ```
 
-Installs a plugin from the remote plugin registry.
+Installs a plugin from the remote plugin registry, a local archive, or an HTTP/HTTPS URL.
 
 When you run the command without arguments, it displays the list of available plugins (equivalent to `--list`).
 
@@ -29,6 +33,14 @@ When you run the command without arguments, it displays the list of available pl
 - `--registry-url`&mdash;URL of the plugin registry (default: `https://cli.datarobot.com/plugins/index.json`).
 - `--versions`&mdash;list available versions for a specific plugin.
 - `--list`&mdash;list available plugins from the registry without installing.
+- `--file`&mdash;install from a local `.tar.xz` archive instead of the registry.
+- `--url`&mdash;install from an HTTP/HTTPS URL instead of the registry.
+
+`--file` and `--url` are mutually exclusive with each other and with `--version`, `--versions`, `--list`, and `--registry-url`.
+
+When no plugin name argument is given with `--file` or `--url`, the name is read from `manifest.json` inside the archive. You can pass an explicit name as the first argument to override this.
+
+> **Note:** URL installs bypass registry checksum verification. Only install from URLs you trust.
 
 ### Examples
 
@@ -55,6 +67,18 @@ dr plugin install assist --version "^0.1.0"
 
 # Install from custom registry.
 dr plugin install assist --registry-url http://127.0.0.1:8000/cli/dev-docs/plugins
+
+# Install from a local archive (name read from manifest.json inside the archive).
+dr plugin install --file ./assist-0.2.0.tar.xz
+
+# Install from a local archive with an explicit plugin name.
+dr plugin install assist --file ./assist-0.2.0.tar.xz
+
+# Install from an HTTP/HTTPS URL (name read from manifest.json inside the archive).
+dr plugin install --url https://example.com/assist-0.2.0.tar.xz
+
+# Install from an HTTP/HTTPS URL with an explicit plugin name.
+dr plugin install assist --url https://example.com/assist-0.2.0.tar.xz
 ```
 
 ## dr plugin uninstall

--- a/internal/plugin/install_from_test.go
+++ b/internal/plugin/install_from_test.go
@@ -1,0 +1,262 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadNameFromArchive tests name extraction from .tar.xz archives.
+func TestReadNameFromArchive(t *testing.T) {
+	t.Run("valid archive returns manifest name", func(t *testing.T) {
+		archivePath := createTestPluginArchive(t, "my-plugin", "1.0.0", true)
+		defer os.Remove(archivePath)
+
+		name, err := readNameFromArchive(archivePath)
+
+		require.NoError(t, err)
+		assert.Equal(t, "my-plugin", name)
+	})
+
+	t.Run("archive missing manifest.json returns error", func(t *testing.T) {
+		archivePath := createTestPluginArchive(t, "broken", "1.0.0", false)
+		defer os.Remove(archivePath)
+
+		_, err := readNameFromArchive(archivePath)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "manifest.json")
+	})
+
+	t.Run("non-existent file returns error", func(t *testing.T) {
+		_, err := readNameFromArchive("/does/not/exist.tar.xz")
+
+		require.Error(t, err)
+	})
+}
+
+// TestInstallPluginFromFile tests installation from a local archive.
+func TestInstallPluginFromFile(t *testing.T) {
+	const pluginName = "test-install-from-file"
+
+	defer func() { _ = UninstallPlugin(pluginName) }()
+
+	t.Run("explicit name installs successfully", func(t *testing.T) {
+		archivePath := createTestPluginArchive(t, pluginName, "1.0.0", true)
+		defer os.Remove(archivePath)
+
+		resolvedName, err := InstallPluginFromFile(archivePath, pluginName)
+
+		require.NoError(t, err)
+		assert.Equal(t, pluginName, resolvedName)
+		require.NoError(t, ValidatePlugin(pluginName))
+	})
+
+	t.Run("no name reads from manifest", func(t *testing.T) {
+		archivePath := createTestPluginArchive(t, pluginName, "1.1.0", true)
+		defer os.Remove(archivePath)
+
+		resolvedName, err := InstallPluginFromFile(archivePath, "")
+
+		require.NoError(t, err)
+		assert.Equal(t, pluginName, resolvedName)
+		require.NoError(t, ValidatePlugin(pluginName))
+	})
+
+	t.Run("no name and no manifest returns error", func(t *testing.T) {
+		archivePath := createTestPluginArchive(t, pluginName, "1.0.0", false)
+		defer os.Remove(archivePath)
+
+		_, err := InstallPluginFromFile(archivePath, "")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "plugin name")
+	})
+
+	t.Run("non-existent file returns error", func(t *testing.T) {
+		_, err := InstallPluginFromFile("/does/not/exist.tar.xz", pluginName)
+
+		require.Error(t, err)
+	})
+
+	t.Run("metadata records local source", func(t *testing.T) {
+		archivePath := createTestPluginArchive(t, pluginName, "2.0.0", true)
+		defer os.Remove(archivePath)
+
+		_, err := InstallPluginFromFile(archivePath, pluginName)
+		require.NoError(t, err)
+
+		managedDir, err := ManagedPluginsDir()
+		require.NoError(t, err)
+
+		metaPath := filepath.Join(managedDir, pluginName, ".installed.json")
+		assert.FileExists(t, metaPath)
+
+		plugins, err := GetInstalledPlugins()
+		require.NoError(t, err)
+
+		var found bool
+
+		for _, p := range plugins {
+			if p.Name == pluginName {
+				found = true
+
+				assert.Equal(t, "local", p.Version)
+				assert.NotEmpty(t, p.Source)
+			}
+		}
+
+		assert.True(t, found, "installed plugin should appear in list")
+	})
+}
+
+// TestInstallPluginFromURL tests installation from an HTTP URL.
+func TestInstallPluginFromURL(t *testing.T) {
+	const pluginName = "test-install-from-url"
+
+	defer func() { _ = UninstallPlugin(pluginName) }()
+
+	t.Run("explicit name installs successfully", func(t *testing.T) {
+		archivePath := createTestPluginArchive(t, pluginName, "1.0.0", true)
+		defer os.Remove(archivePath)
+
+		srv := serveFile(t, archivePath)
+		defer srv.Close()
+
+		resolvedName, err := InstallPluginFromURL(srv.URL+"/plugin.tar.xz", pluginName)
+
+		require.NoError(t, err)
+		assert.Equal(t, pluginName, resolvedName)
+		require.NoError(t, ValidatePlugin(pluginName))
+	})
+
+	t.Run("no name reads from manifest", func(t *testing.T) {
+		archivePath := createTestPluginArchive(t, pluginName, "1.1.0", true)
+		defer os.Remove(archivePath)
+
+		srv := serveFile(t, archivePath)
+		defer srv.Close()
+
+		resolvedName, err := InstallPluginFromURL(srv.URL+"/plugin.tar.xz", "")
+
+		require.NoError(t, err)
+		assert.Equal(t, pluginName, resolvedName)
+		require.NoError(t, ValidatePlugin(pluginName))
+	})
+
+	t.Run("no name and no manifest returns error", func(t *testing.T) {
+		archivePath := createTestPluginArchive(t, pluginName, "1.0.0", false)
+		defer os.Remove(archivePath)
+
+		srv := serveFile(t, archivePath)
+		defer srv.Close()
+
+		_, err := InstallPluginFromURL(srv.URL+"/plugin.tar.xz", "")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "plugin name")
+	})
+
+	t.Run("404 response returns error", func(t *testing.T) {
+		srv := httptest.NewServer(http.NotFoundHandler())
+		defer srv.Close()
+
+		_, err := InstallPluginFromURL(srv.URL+"/missing.tar.xz", pluginName)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "404")
+	})
+
+	t.Run("metadata records source URL", func(t *testing.T) {
+		archivePath := createTestPluginArchive(t, pluginName, "2.0.0", true)
+		defer os.Remove(archivePath)
+
+		srv := serveFile(t, archivePath)
+		defer srv.Close()
+
+		pluginURL := srv.URL + "/plugin.tar.xz"
+
+		_, err := InstallPluginFromURL(pluginURL, pluginName)
+		require.NoError(t, err)
+
+		plugins, err := GetInstalledPlugins()
+		require.NoError(t, err)
+
+		for _, p := range plugins {
+			if p.Name == pluginName {
+				assert.Equal(t, pluginURL, p.Source)
+			}
+		}
+	})
+}
+
+// TestInstallPathTraversal verifies that unsafe plugin names are rejected before any
+// filesystem operation, preventing directory traversal via --file, --url, or a
+// crafted manifest.json.
+func TestInstallPathTraversal(t *testing.T) {
+	unsafe := []string{"../../etc/passwd", "../escape", "/absolute", "foo/bar", ".."}
+
+	t.Run("InstallPluginFromFile rejects unsafe explicit name", func(t *testing.T) {
+		archivePath := createTestPluginArchive(t, "safe", "1.0.0", true)
+		defer os.Remove(archivePath)
+
+		for _, name := range unsafe {
+			_, err := InstallPluginFromFile(archivePath, name)
+
+			require.Errorf(t, err, "expected error for name %q", name)
+		}
+	})
+
+	t.Run("InstallPluginFromURL rejects unsafe explicit name", func(t *testing.T) {
+		archivePath := createTestPluginArchive(t, "safe", "1.0.0", true)
+		defer os.Remove(archivePath)
+
+		srv := serveFile(t, archivePath)
+		defer srv.Close()
+
+		for _, name := range unsafe {
+			_, err := InstallPluginFromURL(srv.URL+"/plugin.tar.xz", name)
+
+			require.Errorf(t, err, "expected error for name %q", name)
+		}
+	})
+
+	t.Run("InstallPluginFromFile rejects unsafe name from manifest", func(t *testing.T) {
+		for _, name := range unsafe {
+			archivePath := createTestPluginArchive(t, name, "1.0.0", true)
+			defer os.Remove(archivePath)
+
+			_, err := InstallPluginFromFile(archivePath, "")
+
+			require.Errorf(t, err, "expected error for manifest name %q", name)
+		}
+	})
+}
+
+// serveFile starts a test HTTP server that serves a single file for all requests.
+func serveFile(t *testing.T, path string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, path)
+	}))
+}

--- a/internal/plugin/remote.go
+++ b/internal/plugin/remote.go
@@ -170,6 +170,112 @@ func findBestMatch(versions []RegistryVersion, constraint *semver.Constraints) (
 	return &versions[candidateIndexes[bestIdx]], nil
 }
 
+// InstallPluginFromURL downloads and installs a plugin from an arbitrary HTTP/HTTPS URL.
+// No SHA256 checksum is required since the URL comes directly from the user.
+// If name is empty, the plugin name is read from manifest.json inside the archive.
+// Returns the resolved plugin name.
+func InstallPluginFromURL(url, name string) (string, error) {
+	archivePath, err := downloadHTTP(url)
+	if err != nil {
+		return "", fmt.Errorf("failed to download plugin: %w", err)
+	}
+
+	defer os.Remove(archivePath)
+
+	if name == "" {
+		name, err = readNameFromArchive(archivePath)
+		if err != nil {
+			return "", fmt.Errorf("could not determine plugin name: %w\nUse: dr plugin install <name> --url ...", err)
+		}
+	}
+
+	pluginDir, err := preparePluginDirectory(name)
+	if err != nil {
+		return "", err
+	}
+
+	entry := RegistryPlugin{Name: name}
+
+	version := RegistryVersion{
+		Version: "local",
+		URL:     url,
+	}
+
+	return name, installPluginFromArchive(archivePath, pluginDir, entry, version)
+}
+
+// InstallPluginFromFile installs a plugin from a local .tar.xz archive.
+// If name is empty, the plugin name is read from manifest.json inside the archive.
+// Returns the resolved plugin name.
+func InstallPluginFromFile(filePath, name string) (string, error) {
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve file path: %w", err)
+	}
+
+	if _, err := os.Stat(absPath); err != nil {
+		return "", fmt.Errorf("file not found: %w", err)
+	}
+
+	if name == "" {
+		name, err = readNameFromArchive(absPath)
+		if err != nil {
+			return "", fmt.Errorf("could not determine plugin name: %w\nUse: dr plugin install <name> --file ...", err)
+		}
+	}
+
+	pluginDir, err := preparePluginDirectory(name)
+	if err != nil {
+		return "", err
+	}
+
+	entry := RegistryPlugin{Name: name}
+
+	version := RegistryVersion{
+		Version: "local",
+		URL:     absPath,
+	}
+
+	return name, installPluginFromArchive(absPath, pluginDir, entry, version)
+}
+
+// readNameFromArchive extracts a .tar.xz archive to a temp directory, reads the
+// plugin name from manifest.json, and cleans up. Used when the caller has not
+// supplied an explicit plugin name.
+func readNameFromArchive(archivePath string) (string, error) {
+	tmpDir, err := os.MkdirTemp("", "dr-plugin-probe-*")
+	if err != nil {
+		return "", err
+	}
+
+	defer os.RemoveAll(tmpDir)
+
+	if err := extractTarXz(archivePath, tmpDir); err != nil {
+		return "", fmt.Errorf("failed to read archive: %w", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "manifest.json"))
+	if err != nil {
+		return "", fmt.Errorf("manifest.json not found in archive: %w", err)
+	}
+
+	var manifest BasicPluginManifest
+
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return "", fmt.Errorf("failed to parse manifest.json: %w", err)
+	}
+
+	if manifest.Name == "" {
+		return "", errors.New("manifest.json is missing the 'name' field")
+	}
+
+	if err := validatePluginName(manifest.Name); err != nil {
+		return "", fmt.Errorf("manifest.json contains unsafe plugin name: %w", err)
+	}
+
+	return manifest.Name, nil
+}
+
 // InstallPlugin downloads and installs a plugin
 func InstallPlugin(pluginEntry RegistryPlugin, version RegistryVersion, baseURL string) error {
 	pluginDir, err := preparePluginDirectory(pluginEntry.Name)
@@ -187,6 +293,10 @@ func InstallPlugin(pluginEntry RegistryPlugin, version RegistryVersion, baseURL 
 }
 
 func preparePluginDirectory(name string) (string, error) {
+	if err := validatePluginName(name); err != nil {
+		return "", err
+	}
+
 	managedDir, err := ManagedPluginsDir()
 	if err != nil {
 		return "", fmt.Errorf("Failed to get plugins directory: %w", err)

--- a/internal/plugin/validation.go
+++ b/internal/plugin/validation.go
@@ -23,10 +23,25 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/datarobot/cli/internal/log"
 	"github.com/google/go-cmp/cmp"
 )
+
+// validatePluginName checks that name is a safe single-segment identifier with no path separators.
+// This prevents path traversal attacks when name is used to construct a filesystem path.
+func validatePluginName(name string) error {
+	if name == "" {
+		return errors.New("plugin name must not be empty")
+	}
+
+	if strings.ContainsAny(name, `/\`) || name == ".." || name == "." {
+		return fmt.Errorf("plugin name %q must not contain path separators or be a relative reference", name)
+	}
+
+	return nil
+}
 
 // ValidatePluginScript validates that a plugin script outputs a manifest matching the expected manifest.
 // All fields must match exactly, including Scripts and MinCLIVersion for managed plugins.

--- a/internal/plugin/validation_test.go
+++ b/internal/plugin/validation_test.go
@@ -25,6 +25,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidatePluginName(t *testing.T) {
+	valid := []string{
+		"assist",
+		"my-plugin",
+		"plugin_v2",
+		"dr-apps",
+	}
+
+	for _, name := range valid {
+		t.Run("valid/"+name, func(t *testing.T) {
+			assert.NoError(t, validatePluginName(name))
+		})
+	}
+
+	invalid := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"dotdot", ".."},
+		{"dot", "."},
+		{"unix traversal", "../../etc/passwd"},
+		{"unix separator", "foo/bar"},
+		{"windows separator", `foo\bar`},
+		{"leading slash", "/absolute"},
+	}
+
+	for _, tt := range invalid {
+		t.Run("invalid/"+tt.name, func(t *testing.T) {
+			err := validatePluginName(tt.input)
+
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestValidateManifests_Matching(t *testing.T) {
 	manifest := PluginManifest{
 		BasicPluginManifest: BasicPluginManifest{


### PR DESCRIPTION
## Summary

- Adds `--file <path>` flag to `dr plugin install` to install from a local `.tar.xz` archive
- Adds `--url <url>` flag to install from an arbitrary HTTP/HTTPS URL, bypassing the registry
- Both flags infer the plugin name from `manifest.json` inside the archive when no name arg is given; explicit `<name>` arg still works as an override
- `--file` and `--url` are mutually exclusive with `--version`, `--versions`, `--list`, and `--registry-url` (enforced by cobra)

Closes [CFX-6449](https://datarobot.atlassian.net/browse/CFX-6449)

## Test plan

- [ ] `dr plugin install assist --file ./assist-0.2.0.tar.xz` installs from local archive with explicit name
- [ ] `dr plugin install --file ./assist-0.2.0.tar.xz` installs from local archive, name read from manifest
- [ ] `dr plugin install assist --url https://example.com/assist-0.2.0.tar.xz` installs from URL with explicit name
- [ ] `dr plugin install --url https://example.com/assist-0.2.0.tar.xz` installs from URL, name read from manifest
- [ ] Combining `--file` or `--url` with `--version`, `--versions`, `--list`, or `--registry-url` produces a clear error
- [ ] Unit tests pass: `go test ./internal/plugin/...`


```
(.venv) anton.suslov@asuslov-me-M1Y7Y:~/workspace$ dr --version
DataRobot CLI version: v0.2.71-20-g024c35bb1611e45-dirty
(.venv) anton.suslov@asuslov-me-M1Y7Y:~/workspace$ dr plugins list
Discovered Plugins
──────────────────
╭────────┬─────────┬───────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────╮
│ NAME   │ VERSION │ DESCRIPTION                                       │ PATH                                                              │
├────────┼─────────┼───────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
│ assist │ 0.1.25  │ AI agent design, coding, and deployment assistant │ /Users/anton.suslov/.config/datarobot/plugins/assist/dr-assist.sh │
╰────────┴─────────┴───────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────╯
(.venv) anton.suslov@asuslov-me-M1Y7Y:~/workspace$ dr plugin install --url https://cli.datarobot.com/plugins/xp/xp-1.2.0.tar.xz

Installing Plugin
─────────────────

✓ Successfully installed xp

Run `dr xp --help` to get started.
(.venv) anton.suslov@asuslov-me-M1Y7Y:~/workspace$ dr plugins list
Discovered Plugins
──────────────────
╭────────┬─────────┬────────────────────────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────╮
│ NAME   │ VERSION │ DESCRIPTION                                                                                │ PATH                                                                   │
├────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
│ assist │ 0.1.25  │ AI agent design, coding, and deployment assistant                                          │ /Users/anton.suslov/.config/datarobot/plugins/assist/dr-assist.sh      │
│ xp     │ 1.2.0   │ A local experimentation dashboard for DataRobot users to visualize and compare agent runs. │ /Users/anton.suslov/.config/datarobot/plugins/xp/dr-experimentation.sh │
╰────────┴─────────┴────────────────────────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────╯
(.venv) anton.suslov@asuslov-me-M1Y7Y:~/workspace$ curl -L -O https://cli.datarobot.com/plugins/assist/assist-0.1.27.tar.xz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 37.8M  100 37.8M    0     0  15.7M      0  0:00:02  0:00:02 --:--:-- 15.7M
(.venv) anton.suslov@asuslov-me-M1Y7Y:~/workspace$ dr plugin install --file assist-0.1.27.tar.xz 

Installing Plugin
─────────────────

✓ Successfully installed assist (local)

Run `dr assist --help` to get started.
(.venv) anton.suslov@asuslov-me-M1Y7Y:~/workspace$ dr plugins list
Discovered Plugins
──────────────────
╭────────┬─────────┬────────────────────────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────╮
│ NAME   │ VERSION │ DESCRIPTION                                                                                │ PATH                                                                   │
├────────┼─────────┼────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
│ assist │ 0.1.27  │ AI agent design, coding, and deployment assistant                                          │ /Users/anton.suslov/.config/datarobot/plugins/assist/dr-assist.sh      │
│ xp     │ 1.2.0   │ A local experimentation dashboard for DataRobot users to visualize and compare agent runs. │ /Users/anton.suslov/.config/datarobot/plugins/xp/dr-experimentation.sh │
╰────────┴─────────┴────────────────────────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────╯
```
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> URL installs bypass registry checksum verification, so users can install arbitrary archives from untrusted URLs; otherwise the change reuses existing extract/install paths with solid test coverage.
> 
> **Overview**
> Adds **off-registry** plugin installation to `dr plugin install` via **`--file`** (local `.tar.xz`) and **`--url`** (HTTP/HTTPS). When no plugin name is passed, the name is inferred from **`manifest.json`** in the archive; an optional positional name still overrides.
> 
> The install command routes to new handlers that call **`InstallPluginFromFile`** / **`InstallPluginFromURL`**, which reuse existing archive extraction and metadata writing. These paths record version **`local`** and store the file path or URL as **source**, and **URL installs do not require registry SHA256 checksums** (unlike registry downloads). **`--file`**, **`--url`**, and registry-oriented flags (**`--version`**, **`--list`**, **`--registry-url`**, etc.) are **mutually exclusive**.
> 
> Unit tests cover manifest name probing, file/URL install success and failure cases, and installed metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3761fc2272f6bec8e21512b1e0b8c08642507fdb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->