### PR TITLE
[CFX-6334] `brew reinstall` instead of `brew update`. 

### DIFF
--- a/cmd/self/update/cmd.go
+++ b/cmd/self/update/cmd.go
@@ -77,16 +77,19 @@ with your default shell.
 							return err
 						}
 
-						brewUpgradeCmd := exec.Command(brewPath, "upgrade", "--cask", "dr-cli")
-						brewUpgradeCmd.Stdout = os.Stdout
-						brewUpgradeCmd.Stderr = os.Stderr
+						brewReinstallCmd := exec.Command(brewPath, "reinstall", "--cask", "dr-cli", "--force")
+						brewReinstallCmd.Stdout = os.Stdout
+						brewReinstallCmd.Stderr = os.Stderr
 
-						if err := brewUpgradeCmd.Run(); err != nil {
-							fmt.Fprintln(os.Stderr, "Error: ", err)
-							return err
+						if err := brewReinstallCmd.Run(); err == nil {
+							// Reinstall succeeded, we are done
+							return nil
 						}
-
-						return nil
+						// `brew reinstall` failed (e.g. the GitHub release was
+						// deleted and the cask download URL now returns 404).
+						// Fall through to the install script
+						fmt.Fprintf(os.Stderr, "Warning: brew reinstall --cask dr-cli failed: %v\n", err)
+						fmt.Fprintln(os.Stderr, "Falling back to install script...")
 					}
 				}
 			}

--- a/cmd/self/update/cmd.go
+++ b/cmd/self/update/cmd.go
@@ -81,15 +81,12 @@ with your default shell.
 						brewReinstallCmd.Stdout = os.Stdout
 						brewReinstallCmd.Stderr = os.Stderr
 
-						if err := brewReinstallCmd.Run(); err == nil {
-							// Reinstall succeeded, we are done
-							return nil
+						if err := brewReinstallCmd.Run(); err != nil {
+							fmt.Fprintln(os.Stderr, "Error: ", err)
+							return err
 						}
-						// `brew reinstall` failed (e.g. the GitHub release was
-						// deleted and the cask download URL now returns 404).
-						// Fall through to the install script
-						fmt.Fprintf(os.Stderr, "Warning: brew reinstall --cask dr-cli failed: %v\n", err)
-						fmt.Fprintln(os.Stderr, "Falling back to install script...")
+
+						return nil
 					}
 				}
 			}


### PR DESCRIPTION
# RATIONALE
Use `brew reinstall --cask dr-cli --force` instead of `brew update --cask dr-cli` in order to install latest available version even if the current installed version is greater than available to install via brew.

<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production CLI binaries are updated on macOS for Homebrew users, including a new fallback path that could mask brew-specific failures while still attempting a script install.
> 
> **Overview**
> On macOS with the `dr-cli` Homebrew cask installed, **`dr self update`** now runs **`brew reinstall --cask dr-cli --force`** after `brew update` instead of **`brew upgrade --cask dr-cli`**, so the CLI can be refreshed when the installed build is newer than what the cask would normally upgrade to.
> 
> If reinstall fails (e.g. broken cask download URL), the command **no longer exits with an error**; it prints a warning and **continues to the existing curl/PowerShell install script** path used for non-brew installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8908cf26d15375384b81765a78d90a28916ab9dc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->