### PR TITLE
[RAPTOR-17754] feat(workload): add wl alias for workload command

### DIFF
--- a/cmd/workload/cmd_test.go
+++ b/cmd/workload/cmd_test.go
@@ -15,29 +15,13 @@
 package workload
 
 import (
-	"github.com/datarobot/cli/cmd/workload/artifact"
-	"github.com/datarobot/cli/cmd/workload/code"
-	"github.com/datarobot/cli/internal/features"
-	"github.com/spf13/cobra"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func Cmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "workload",
-		Aliases: []string{"wl"},
-		GroupID: "core",
-		Short:   "🚀 Workload management commands",
-		Long: `Workload management commands for your DataRobot applications.
+func TestCmd_HasAlias(t *testing.T) {
+	cmd := Cmd()
 
-Manage and monitor workloads in your deployment infrastructure.`,
-	}
-
-	features.SetGate(cmd, "workload")
-
-	cmd.AddCommand(
-		artifact.Cmd(),
-		code.Cmd(),
-	)
-
-	return cmd
+	assert.Contains(t, cmd.Aliases, "wl")
 }


### PR DESCRIPTION
# RATIONALE

[RAPTOR-17754](https://datarobot.atlassian.net/browse/RAPTOR-17754): `dr workload` is a frequently typed command group; a short `wl` alias saves keystrokes.

## CHANGES

- Add `wl` alias to the `workload` command (behind the existing `DATAROBOT_CLI_FEATURE_WORKLOAD` gate, same as the canonical name)
- Add `TestCmd_HasAlias` test

## TESTING

- `task lint` clean, manual check: `dr wl --help` resolves to workload help, unknown command without the feature flag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI ergonomics only; no change to workload behavior, APIs, or feature-gating logic beyond registering an alias.
> 
> **Overview**
> Adds a **`wl`** shorthand so users can invoke the workload command group as `dr wl` instead of only `dr workload`, matching the pattern used elsewhere (e.g. `component` → `c`).
> 
> The alias is defined on the same Cobra command that already has the **`workload`** feature gate, so **`wl`** is gated the same way as the canonical name. A small unit test asserts **`wl`** is present in **`Aliases`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 908518de02f7a98fdf5ec3bf167b71f4ea30fb69. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->