### PR TITLE
[CMPT-6045] feat(pipeline): add dr pipeline task get with stable task IDs

### DIFF
--- a/cmd/pipeline/cmd.go
+++ b/cmd/pipeline/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/datarobot/cli/cmd/pipeline/lock"
 	"github.com/datarobot/cli/cmd/pipeline/run"
 	"github.com/datarobot/cli/cmd/pipeline/schedule"
+	"github.com/datarobot/cli/cmd/pipeline/task"
 	"github.com/datarobot/cli/cmd/pipeline/update"
 	"github.com/datarobot/cli/cmd/pipeline/version"
 	"github.com/datarobot/cli/internal/features"
@@ -59,6 +60,7 @@ input payloads, runs, and recurring schedules.`,
 		input.Cmd(),
 		schedule.Cmd(),
 		environment.Cmd(),
+		task.Cmd(),
 	)
 
 	return cmd

--- a/cmd/pipeline/graph/cmd.go
+++ b/cmd/pipeline/graph/cmd.go
@@ -128,10 +128,16 @@ func printGraphHuman(g pipeline.Graph) {
 
 	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
-	fmt.Fprintln(writer, "  ID\tTYPE\tNAME")
+	fmt.Fprintln(writer, "  ID\tTYPE\tNAME\tTASK ID")
 
 	for _, n := range g.Nodes {
-		fmt.Fprintf(writer, "  %d\t%s\t%s\n", n.ID, n.Type, n.Name)
+		taskID := "—"
+
+		if n.TaskID != nil {
+			taskID = *n.TaskID
+		}
+
+		fmt.Fprintf(writer, "  %d\t%s\t%s\t%s\n", n.ID, n.Type, n.Name, taskID)
 	}
 
 	_ = writer.Flush()

--- a/cmd/pipeline/graph/cmd.go
+++ b/cmd/pipeline/graph/cmd.go
@@ -134,7 +134,7 @@ func printGraphHuman(g pipeline.Graph) {
 		taskID := "—"
 
 		if n.TaskID != nil {
-			taskID = *n.TaskID
+			taskID = strconv.Itoa(*n.TaskID)
 		}
 
 		fmt.Fprintf(writer, "  %d\t%s\t%s\t%s\n", n.ID, n.Type, n.Name, taskID)

--- a/cmd/pipeline/task/cmd.go
+++ b/cmd/pipeline/task/cmd.go
@@ -1,0 +1,39 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"github.com/datarobot/cli/cmd/pipeline/task/get"
+	"github.com/spf13/cobra"
+)
+
+// Cmd returns the parent command for `dr pipeline task`.
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "task",
+		Short: "Inspect pipeline tasks",
+		Long: `Inspect individual tasks (@task-decorated functions) within a pipeline.
+
+Task IDs are stable identifiers minted when a pipeline is uploaded. They
+appear in the TASK ID column of ` + "`dr pipeline graph`" + ` and can be
+used to fetch source code, function signature, and pipeline input values.`,
+	}
+
+	cmd.AddCommand(
+		get.Cmd(),
+	)
+
+	return cmd
+}

--- a/cmd/pipeline/task/get/cmd.go
+++ b/cmd/pipeline/task/get/cmd.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/datarobot/cli/cmd/pipeline/scopeflag"
 	"github.com/datarobot/cli/internal/auth"
@@ -40,7 +41,8 @@ func Cmd() *cobra.Command {
 		Long: `Display the source code, function signature, and (for locked versions)
 the latest pipeline input payload for a single task.
 
-Task IDs are returned by the pipeline graph command in the TASK ID column.
+Task IDs are small sequential numbers (1, 2, 3, ...) scoped to the pipeline,
+returned by the pipeline graph command in the TASK ID column.
 
 Scope is selected from the --scope/--version flags:
   - no flags                   -> draft task
@@ -49,9 +51,9 @@ Scope is selected from the --scope/--version flags:
   - --scope=locked --version=N -> locked task for version N
 
 Example:
-  dr pipeline task get --pipeline <id> <task-id>
-  dr pipeline task get --pipeline <id> --version=2 <task-id>
-  dr pipeline task get --pipeline <id> <task-id> --output-format json`,
+  dr pipeline task get --pipeline <id> 1
+  dr pipeline task get --pipeline <id> --version=2 1
+  dr pipeline task get --pipeline <id> 1 --output-format json`,
 		Args:         cobra.ExactArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
@@ -60,12 +62,17 @@ Example:
 				return errors.New("--pipeline is required")
 			}
 
+			taskID, err := strconv.Atoi(args[0])
+			if err != nil || taskID < 1 {
+				return fmt.Errorf("task-id must be a positive number (e.g. 1), got %q", args[0])
+			}
+
 			scope, version, err := flags.Resolve(cmd)
 			if err != nil {
 				return err
 			}
 
-			result, err := pipeline.GetTask(flags.PipelineID, scope, version, args[0])
+			result, err := pipeline.GetTask(flags.PipelineID, scope, version, taskID)
 			if err != nil {
 				return handleTaskNotFoundError(err, args[0])
 			}

--- a/cmd/pipeline/task/get/cmd.go
+++ b/cmd/pipeline/task/get/cmd.go
@@ -1,0 +1,104 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/datarobot/cli/cmd/pipeline/scopeflag"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/pipeline"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var (
+		flags        scopeflag.Flags
+		outputFormat pipeline.OutputFormat
+	)
+
+	cmd := &cobra.Command{
+		Use:   "get <task-id>",
+		Short: "Display details of a pipeline task",
+		Long: `Display the source code, function signature, and (for locked versions)
+the latest pipeline input payload for a single task.
+
+Task IDs are returned by the pipeline graph command in the TASK ID column.
+
+Scope is selected from the --scope/--version flags:
+  - no flags                   -> draft task
+  - --version=N                -> locked task for version N (scope auto-set)
+  - --scope=draft              -> draft task
+  - --scope=locked --version=N -> locked task for version N
+
+Example:
+  dr pipeline task get --pipeline <id> <task-id>
+  dr pipeline task get --pipeline <id> --version=2 <task-id>
+  dr pipeline task get --pipeline <id> <task-id> --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if flags.PipelineID == "" {
+				return errors.New("--pipeline is required")
+			}
+
+			scope, version, err := flags.Resolve(cmd)
+			if err != nil {
+				return err
+			}
+
+			result, err := pipeline.GetTask(flags.PipelineID, scope, version, args[0])
+			if err != nil {
+				return handleTaskNotFoundError(err, args[0])
+			}
+
+			return pipeline.RenderTask(outputFormat, *result)
+		},
+	}
+
+	flags.Bind(cmd)
+	_ = cmd.MarkFlagRequired("pipeline")
+	pipeline.AddOutputFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"pipeline_id":   flags.PipelineID,
+			"task_id":       telemetry.FirstArg(args),
+			"scope":         flags.Scope,
+			"version":       flags.Version,
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}
+
+func handleTaskNotFoundError(err error, taskID string) error {
+	var httpErr *drapi.HTTPError
+
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		fmt.Println(tui.DimStyle.Render("Task not found: " + taskID))
+
+		return nil
+	}
+
+	return err
+}

--- a/cmd/pipeline/task/get/cmd_test.go
+++ b/cmd/pipeline/task/get/cmd_test.go
@@ -39,7 +39,7 @@ func TestCmd_Name(t *testing.T) {
 }
 
 func TestCmd_RejectsMissingPipeline(t *testing.T) {
-	err := runCmd(t, "t-1")
+	err := runCmd(t, "1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pipeline")
 }
@@ -49,14 +49,26 @@ func TestCmd_RequiresPositional(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCmd_RejectsNonNumericTaskID(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p", "abc123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task-id must be a positive number")
+}
+
+func TestCmd_RejectsZeroTaskID(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task-id must be a positive number")
+}
+
 func TestCmd_RejectsBadScopeCombo(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p", "--scope", "locked", "t-1")
+	err := runCmd(t, "--pipeline", "p", "--scope", "locked", "1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--version")
 }
 
 func TestCmd_RejectsInvalidOutputFormat(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p", "--output-format", "yaml", "t-1")
+	err := runCmd(t, "--pipeline", "p", "--output-format", "yaml", "1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid output format")
 }

--- a/cmd/pipeline/task/get/cmd_test.go
+++ b/cmd/pipeline/task/get/cmd_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runCmd(t *testing.T, args ...string) error {
+	t.Helper()
+
+	cmd := Cmd()
+	cmd.SetArgs(args)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.PreRunE = nil
+
+	return cmd.Execute()
+}
+
+func TestCmd_Name(t *testing.T) {
+	assert.Equal(t, "get", Cmd().Name())
+}
+
+func TestCmd_RejectsMissingPipeline(t *testing.T) {
+	err := runCmd(t, "t-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pipeline")
+}
+
+func TestCmd_RequiresPositional(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p")
+	require.Error(t, err)
+}
+
+func TestCmd_RejectsBadScopeCombo(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p", "--scope", "locked", "t-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--version")
+}
+
+func TestCmd_RejectsInvalidOutputFormat(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p", "--output-format", "yaml", "t-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -104,13 +104,15 @@ dr
 │   │   ├── get        Display a single schedule
 │   │   ├── update     Change cron expression / timezone
 │   │   └── delete     Delete a schedule
-│   └── environment    Manage named, versioned pip-package environments
-│       ├── create     Register a new environment with an initial version
-│       ├── list       List registered environments
-│       ├── update     Append a new version to an environment
-│       ├── delete     Soft-delete the latest active version of an environment
-│       └── version    Manage environment versions
-│           └── delete Delete a specific version
+│   ├── environment    Manage named, versioned pip-package environments
+│   │   ├── create     Register a new environment with an initial version
+│   │   ├── list       List registered environments
+│   │   ├── update     Append a new version to an environment
+│   │   ├── delete     Soft-delete the latest active version of an environment
+│   │   └── version    Manage environment versions
+│   │       └── delete Delete a specific version
+│   └── task           Inspect individual pipeline tasks (source + signature)
+│       └── get        Display task source, parameters, and input payload
 └── self               CLI utility commands
     ├── completion     Shell completion
     │   ├── install    Install completions interactively
@@ -285,6 +287,7 @@ For detailed documentation on each command, see:
   - `input`&mdash;`create`/`list`/`get`/`update`/`delete` JSON payloads used by runs.
   - `schedule`&mdash;`create`/`list`/`get`/`update`/`delete` recurring (cron) runs on locked versions.
   - `environment`&mdash;`create`/`list`/`update`/`delete` named pip-package environments; `version delete` removes a specific version.
+  - `task`&mdash;`get` to inspect a task's source code, function signature parameters, and (for locked versions) the latest pipeline input payload.
 
 ## Getting help
 

--- a/docs/commands/pipeline.md
+++ b/docs/commands/pipeline.md
@@ -22,7 +22,9 @@ top-level `dr pipeline` subcommand operates on one of four resources:
 - pipeline **runs** — concrete executions on Covalent,
 - pipeline **schedules** — recurring runs on a cron expression,
 - pipeline **environments** — named, immutable-versioned bags of pip
-  packages that pipelines can be built against.
+  packages that pipelines can be built against,
+- pipeline **tasks** — source code, function signature, and input payload
+  for individual `@task`-decorated functions.
 
 Versions are created automatically:
 
@@ -82,6 +84,7 @@ dr pipeline lock <pipeline-id>
 | `dr pipeline input …`   | `…/inputs` and `…/inputs/{input_id}` | Manage JSON payloads for runs.                   |
 | `dr pipeline schedule …` | `…/versions/{ver}/schedules`        | Manage recurring (cron) runs on locked versions. |
 | `dr pipeline environment …` | `/pipelines/environments[/{id}]` | Manage named, versioned pip-package environments. |
+| `dr pipeline task …`        | `…/tasks/{task_id}` (draft or locked) | Inspect individual task source, signature, and inputs. |
 
 ## Subcommands
 
@@ -243,11 +246,13 @@ dr pipeline version get  --pipeline <id> <version-id>     [--output-format json]
 ### `graph`
 
 Display the pipeline/task DAG as either a JSON payload or a human-readable summary.
+The human table includes a **TASK ID** column showing the stable identifier for each
+task node (populated once CMPT-6040 is deployed; `—` for legacy pipelines).
 
 ```bash
 dr pipeline graph --pipeline <id>                       # draft graph
 dr pipeline graph --pipeline <id> --version=N           # locked-version graph
-dr pipeline graph --pipeline <id> --output-format json
+dr pipeline graph --pipeline <id> --output-format json  # includes taskId on each node
 ```
 
 ## Shared flags
@@ -302,6 +307,19 @@ dr pipeline delete <pipeline-id>
 dr pipeline version list --pipeline <pipeline-id>
 dr pipeline version get  --pipeline <pipeline-id> 2
 dr pipeline graph        --pipeline <pipeline-id> --version=2 --output-format json
+```
+
+### Inspect a task
+
+```bash
+# 1. Find task IDs via the graph (TASK ID column)
+dr pipeline graph --pipeline <pipeline-id>
+
+# 2. View source + signature for a draft task
+dr pipeline task get --pipeline <pipeline-id> <task-id>
+
+# 3. View the same task on a locked version (includes input payload)
+dr pipeline task get --pipeline <pipeline-id> --version=2 <task-id>
 ```
 
 ### `input`
@@ -370,6 +388,25 @@ dr pipeline environment version delete --environment <environment-id> <version>
 immutable version. `environment delete` soft-deletes the latest active version (cascading
 to the parent if no active versions remain). `environment version delete` targets a
 specific version by its integer number.
+
+### `task`
+
+Inspect individual `@task`-decorated functions within a pipeline. Task IDs are stable
+24-char identifiers minted when a pipeline is uploaded; they appear in the **TASK ID**
+column of `dr pipeline graph` and are preserved across re-uploads and across the
+draft-to-locked transition.
+
+```bash
+dr pipeline task get --pipeline <id> <task-id>                   # draft — source + params, inputs=null
+dr pipeline task get --pipeline <id> --version=N <task-id>       # locked — source + params + latest VALID input payload
+dr pipeline task get --pipeline <id> <task-id> --output-format json
+```
+
+`task get` returns the task's Python source string, its `@task` function signature
+parameters (name + optional type annotation), and — for locked versions — the full
+payload from the latest `VALID` `PipelineInput` record for that version.
+
+If the task ID is not found, the command prints `Task not found: <task-id>` and exits 0.
 
 ## Error handling
 

--- a/docs/commands/pipelines-reference.md
+++ b/docs/commands/pipelines-reference.md
@@ -131,6 +131,17 @@ Schedules are **locked-only** — every verb requires both `--pipeline` and `--v
 
 ---
 
+## Tasks (`dr pipeline task …`)
+
+Task IDs are stable identifiers minted when a pipeline is uploaded. They appear in the
+TASK ID column of `dr pipeline graph` and can be used to inspect individual tasks.
+
+| Command | API endpoint | Usage | Inputs |
+|---|---|---|---|
+| `dr pipeline task get` | `GET /pipelines/{id}/tasks/{task_id}` (draft) <br> `GET /pipelines/{id}/versions/{ver}/tasks/{task_id}` (locked) | `dr pipeline task get --pipeline <id> <task-id>` <br> `dr pipeline task get --pipeline <id> --version=2 <task-id>` <br> `dr pipeline task get --pipeline <id> <task-id> --output-format json` | **Positional:** `<task-id>` (required). **Flags:** `--pipeline <id>` (required), `--scope`, `--version`, `--output-format json`. |
+
+---
+
 ## Environments (`dr pipeline environment …`)
 
 | Command | API endpoint | Usage | Inputs |
@@ -180,3 +191,5 @@ Schedules are **locked-only** — every verb requires both `--pipeline` and `--v
 | `PATCH /pipelines/environments/{id}` | `dr pipeline environment update` |
 | `DELETE /pipelines/environments/{id}` | `dr pipeline environment delete` |
 | `DELETE /pipelines/environments/{id}/versions/{n}` | `dr pipeline environment version delete` |
+| `GET /pipelines/{id}/tasks/{task_id}` | `dr pipeline task get` (draft) |
+| `GET /pipelines/{id}/versions/{ver}/tasks/{task_id}` | `dr pipeline task get` (locked) |

--- a/internal/pipeline/task.go
+++ b/internal/pipeline/task.go
@@ -23,7 +23,10 @@
 // payload. The same draft/locked URL split is used as for inputs and runs.
 package pipeline
 
-import "net/http"
+import (
+	"net/http"
+	"strconv"
+)
 
 // TaskParameter mirrors TaskParameter from the pipelines-api schema.
 // It holds a single parameter from a @task function signature.
@@ -34,11 +37,13 @@ type TaskParameter struct {
 
 // PipelineTask mirrors TaskResponse from the pipelines-api.
 // The wire-level "id" is stored as TaskID to match the CLI vocabulary used
-// across other pipeline resource types (InputID, RunID, etc.).
+// across other pipeline resource types (InputID, RunID, etc.). Task IDs are
+// small sequential integers (1-based) scoped per pipeline — the same shape
+// as version numbers.
 // ResourceBundle and TaskGroupID are null until the executor AST-extraction
 // and task-grouping features land (pipelines-api CMPT-6040).
 type PipelineTask struct {
-	TaskID         string          `json:"id"`
+	TaskID         int             `json:"id"`
 	PipelineID     string          `json:"pipelineId"`
 	VersionID      *int            `json:"versionId,omitempty"`
 	Name           string          `json:"name"`
@@ -52,8 +57,8 @@ type PipelineTask struct {
 // GetTask fetches per-task detail from the pipelines-api. For draft scope
 // the response always has Inputs=nil; for locked scope Inputs is the latest
 // VALID pipeline input payload or nil if none exists.
-func GetTask(pipelineID string, scope Scope, version *int, taskID string) (*PipelineTask, error) {
-	endpoint, err := EndpointFor(pipelineID, scope, version, "tasks/"+taskID)
+func GetTask(pipelineID string, scope Scope, version *int, taskID int) (*PipelineTask, error) {
+	endpoint, err := EndpointFor(pipelineID, scope, version, "tasks/"+strconv.Itoa(taskID))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pipeline/task.go
+++ b/internal/pipeline/task.go
@@ -1,0 +1,65 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// task.go wraps the pipeline task-detail endpoints added in pipelines-api
+// CMPT-6040:
+//
+//	GET /api/v2/pipelines/{pipeline_id}/tasks/{task_id}
+//	GET /api/v2/pipelines/{pipeline_id}/versions/{version_id}/tasks/{task_id}
+//
+// These endpoints return the per-task source code, function signature
+// parameters, and (for locked versions) the latest VALID pipeline input
+// payload. The same draft/locked URL split is used as for inputs and runs.
+package pipeline
+
+import "net/http"
+
+// TaskParameter mirrors TaskParameter from the pipelines-api schema.
+// It holds a single parameter from a @task function signature.
+type TaskParameter struct {
+	Name       string  `json:"name"`
+	Annotation *string `json:"annotation,omitempty"`
+}
+
+// PipelineTask mirrors TaskResponse from the pipelines-api.
+// The wire-level "id" is stored as TaskID to match the CLI vocabulary used
+// across other pipeline resource types (InputID, RunID, etc.).
+type PipelineTask struct {
+	TaskID     string          `json:"id"`
+	PipelineID string          `json:"pipelineId"`
+	VersionID  *int            `json:"versionId,omitempty"`
+	Name       string          `json:"name"`
+	Parameters []TaskParameter `json:"parameters"`
+	Inputs     map[string]any  `json:"inputs,omitempty"`
+	Source     string          `json:"source"`
+}
+
+// GetTask fetches per-task detail from the pipelines-api. For draft scope
+// the response always has Inputs=nil; for locked scope Inputs is the latest
+// VALID pipeline input payload or nil if none exists.
+func GetTask(pipelineID string, scope Scope, version *int, taskID string) (*PipelineTask, error) {
+	endpoint, err := EndpointFor(pipelineID, scope, version, "tasks/"+taskID)
+	if err != nil {
+		return nil, err
+	}
+
+	var task PipelineTask
+
+	err = doJSON(http.MethodGet, endpoint, nil, "task", &task)
+	if err != nil {
+		return nil, err
+	}
+
+	return &task, nil
+}

--- a/internal/pipeline/task.go
+++ b/internal/pipeline/task.go
@@ -35,14 +35,18 @@ type TaskParameter struct {
 // PipelineTask mirrors TaskResponse from the pipelines-api.
 // The wire-level "id" is stored as TaskID to match the CLI vocabulary used
 // across other pipeline resource types (InputID, RunID, etc.).
+// ResourceBundle and TaskGroupID are null until the executor AST-extraction
+// and task-grouping features land (pipelines-api CMPT-6040).
 type PipelineTask struct {
-	TaskID     string          `json:"id"`
-	PipelineID string          `json:"pipelineId"`
-	VersionID  *int            `json:"versionId,omitempty"`
-	Name       string          `json:"name"`
-	Parameters []TaskParameter `json:"parameters"`
-	Inputs     map[string]any  `json:"inputs,omitempty"`
-	Source     string          `json:"source"`
+	TaskID         string          `json:"id"`
+	PipelineID     string          `json:"pipelineId"`
+	VersionID      *int            `json:"versionId,omitempty"`
+	Name           string          `json:"name"`
+	Parameters     []TaskParameter `json:"parameters"`
+	Inputs         map[string]any  `json:"inputs,omitempty"`
+	Source         string          `json:"source"`
+	ResourceBundle map[string]any  `json:"resourceBundle,omitempty"`
+	TaskGroupID    *int            `json:"taskGroupId,omitempty"`
 }
 
 // GetTask fetches per-task detail from the pipelines-api. For draft scope

--- a/internal/pipeline/task_output.go
+++ b/internal/pipeline/task_output.go
@@ -35,7 +35,7 @@ type taskParamJSON struct {
 // taskJSON is the CLI-facing DTO used for `--output-format json`. It remaps
 // camelCase wire keys to snake_case to match the other pipeline output DTOs.
 type taskJSON struct {
-	TaskID         string          `json:"task_id"`
+	TaskID         int             `json:"task_id"`
 	PipelineID     string          `json:"pipeline_id"`
 	VersionID      *int            `json:"version_id,omitempty"`
 	Name           string          `json:"name"`
@@ -101,7 +101,7 @@ func PrintTaskHuman(t PipelineTask) {
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
-	fmt.Fprintf(w, "Task ID:\t%s\n", t.TaskID)
+	fmt.Fprintf(w, "Task ID:\t%d\n", t.TaskID)
 	fmt.Fprintf(w, "Pipeline ID:\t%s\n", t.PipelineID)
 	fmt.Fprintf(w, "Scope:\t%s\n", scope)
 	fmt.Fprintf(w, "Version:\t%s\n", versionDisplay)

--- a/internal/pipeline/task_output.go
+++ b/internal/pipeline/task_output.go
@@ -1,0 +1,136 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// task_output.go holds the rendering helpers for dr pipeline task verbs.
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/datarobot/cli/tui"
+)
+
+// taskParamJSON is the CLI-facing shape for a single task parameter.
+type taskParamJSON struct {
+	Name       string  `json:"name"`
+	Annotation *string `json:"annotation,omitempty"`
+}
+
+// taskJSON is the CLI-facing DTO used for `--output-format json`. It remaps
+// camelCase wire keys to snake_case to match the other pipeline output DTOs.
+type taskJSON struct {
+	TaskID     string          `json:"task_id"`
+	PipelineID string          `json:"pipeline_id"`
+	VersionID  *int            `json:"version_id,omitempty"`
+	Name       string          `json:"name"`
+	Parameters []taskParamJSON `json:"parameters"`
+	Inputs     map[string]any  `json:"inputs,omitempty"`
+	Source     string          `json:"source"`
+}
+
+func toTaskJSON(t PipelineTask) taskJSON {
+	params := make([]taskParamJSON, len(t.Parameters))
+
+	for i, p := range t.Parameters {
+		params[i] = taskParamJSON(p)
+	}
+
+	return taskJSON{
+		TaskID:     t.TaskID,
+		PipelineID: t.PipelineID,
+		VersionID:  t.VersionID,
+		Name:       t.Name,
+		Parameters: params,
+		Inputs:     t.Inputs,
+		Source:     t.Source,
+	}
+}
+
+// RenderTask routes a single task to JSON or human output.
+func RenderTask(format OutputFormat, t PipelineTask) error {
+	if format == OutputFormatJSON {
+		return PrintTaskJSON(t)
+	}
+
+	PrintTaskHuman(t)
+
+	return nil
+}
+
+// PrintTaskJSON marshals a task as indented JSON using CLI-vocabulary keys.
+func PrintTaskJSON(t PipelineTask) error {
+	data, err := json.MarshalIndent(toTaskJSON(t), "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+
+	return nil
+}
+
+// PrintTaskHuman renders a single task in a human-friendly tabwriter form.
+func PrintTaskHuman(t PipelineTask) {
+	scope := "draft"
+	versionDisplay := emptyValuePlaceholder
+
+	if t.VersionID != nil {
+		scope = "locked"
+		versionDisplay = strconv.Itoa(*t.VersionID)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "Task ID:\t%s\n", t.TaskID)
+	fmt.Fprintf(w, "Pipeline ID:\t%s\n", t.PipelineID)
+	fmt.Fprintf(w, "Scope:\t%s\n", scope)
+	fmt.Fprintf(w, "Version:\t%s\n", versionDisplay)
+	fmt.Fprintf(w, "Name:\t%s\n", t.Name)
+
+	w.Flush()
+
+	if len(t.Parameters) > 0 {
+		fmt.Println()
+		fmt.Println(tui.BaseTextStyle.Render("Parameters:"))
+
+		for _, p := range t.Parameters {
+			ann := emptyValuePlaceholder
+
+			if p.Annotation != nil {
+				ann = *p.Annotation
+			}
+
+			fmt.Printf("  %s: %s\n", p.Name, ann)
+		}
+	}
+
+	if t.Inputs != nil {
+		fmt.Println()
+		fmt.Println(tui.BaseTextStyle.Render("Inputs:"))
+
+		data, err := json.MarshalIndent(t.Inputs, "  ", "  ")
+		if err == nil {
+			fmt.Println("  " + strings.TrimPrefix(string(data), "  "))
+		}
+	}
+
+	fmt.Println()
+	fmt.Println(tui.BaseTextStyle.Render("Source:"))
+	fmt.Println(t.Source)
+}

--- a/internal/pipeline/task_output.go
+++ b/internal/pipeline/task_output.go
@@ -35,13 +35,15 @@ type taskParamJSON struct {
 // taskJSON is the CLI-facing DTO used for `--output-format json`. It remaps
 // camelCase wire keys to snake_case to match the other pipeline output DTOs.
 type taskJSON struct {
-	TaskID     string          `json:"task_id"`
-	PipelineID string          `json:"pipeline_id"`
-	VersionID  *int            `json:"version_id,omitempty"`
-	Name       string          `json:"name"`
-	Parameters []taskParamJSON `json:"parameters"`
-	Inputs     map[string]any  `json:"inputs,omitempty"`
-	Source     string          `json:"source"`
+	TaskID         string          `json:"task_id"`
+	PipelineID     string          `json:"pipeline_id"`
+	VersionID      *int            `json:"version_id,omitempty"`
+	Name           string          `json:"name"`
+	Parameters     []taskParamJSON `json:"parameters"`
+	Inputs         map[string]any  `json:"inputs,omitempty"`
+	Source         string          `json:"source"`
+	ResourceBundle map[string]any  `json:"resource_bundle,omitempty"`
+	TaskGroupID    *int            `json:"task_group_id,omitempty"`
 }
 
 func toTaskJSON(t PipelineTask) taskJSON {
@@ -52,13 +54,15 @@ func toTaskJSON(t PipelineTask) taskJSON {
 	}
 
 	return taskJSON{
-		TaskID:     t.TaskID,
-		PipelineID: t.PipelineID,
-		VersionID:  t.VersionID,
-		Name:       t.Name,
-		Parameters: params,
-		Inputs:     t.Inputs,
-		Source:     t.Source,
+		TaskID:         t.TaskID,
+		PipelineID:     t.PipelineID,
+		VersionID:      t.VersionID,
+		Name:           t.Name,
+		Parameters:     params,
+		Inputs:         t.Inputs,
+		Source:         t.Source,
+		ResourceBundle: t.ResourceBundle,
+		TaskGroupID:    t.TaskGroupID,
 	}
 }
 

--- a/internal/pipeline/task_output_test.go
+++ b/internal/pipeline/task_output_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sampleTask() PipelineTask {
+	ver := 2
+	ann := "int"
+
+	return PipelineTask{
+		TaskID:     "t-1",
+		PipelineID: "p-1",
+		VersionID:  &ver,
+		Name:       "add",
+		Parameters: []TaskParameter{
+			{Name: "x", Annotation: &ann},
+			{Name: "y", Annotation: &ann},
+		},
+		Inputs: map[string]any{"a": float64(100)},
+		Source: "def add(x: int, y: int) -> int:\n    return x + y",
+	}
+}
+
+// ── toTaskJSON ───────────────────────────────────────────────────────────────
+
+func TestToTaskJSON_RemapsWireFields(t *testing.T) {
+	j := toTaskJSON(sampleTask())
+
+	assert.Equal(t, "t-1", j.TaskID)
+	assert.Equal(t, "p-1", j.PipelineID)
+	require.NotNil(t, j.VersionID)
+	assert.Equal(t, 2, *j.VersionID)
+	assert.Equal(t, "add", j.Name)
+	require.Len(t, j.Parameters, 2)
+	assert.Equal(t, "x", j.Parameters[0].Name)
+}
+
+func TestToTaskJSON_DraftScope(t *testing.T) {
+	tk := sampleTask()
+	tk.VersionID = nil
+	tk.Inputs = nil
+
+	j := toTaskJSON(tk)
+
+	assert.Nil(t, j.VersionID)
+	assert.Nil(t, j.Inputs)
+}
+
+func TestToTaskJSON_JSONKeysUseCliVocabulary(t *testing.T) {
+	data, err := json.Marshal(toTaskJSON(sampleTask()))
+	require.NoError(t, err)
+
+	var raw map[string]any
+
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	assert.Contains(t, raw, "task_id")
+	assert.Contains(t, raw, "pipeline_id")
+	assert.Contains(t, raw, "version_id")
+	assert.NotContains(t, raw, "id", "wire 'id' must not appear in CLI output")
+	assert.NotContains(t, raw, "pipelineId")
+	assert.NotContains(t, raw, "versionId")
+}
+
+// ── RenderTask ───────────────────────────────────────────────────────────────
+
+func TestRenderTask_JSON(t *testing.T) {
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderTask(OutputFormatJSON, sampleTask()))
+	})
+
+	var parsed map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(out), &parsed))
+	assert.Equal(t, "t-1", parsed["task_id"])
+	assert.Equal(t, "add", parsed["name"])
+}
+
+func TestRenderTask_Human(t *testing.T) {
+	out := captureStdout(t, func() { PrintTaskHuman(sampleTask()) })
+
+	assert.Contains(t, out, "t-1")
+	assert.Contains(t, out, "locked")
+	assert.Contains(t, out, "add")
+	assert.Contains(t, out, "x")
+	assert.Contains(t, out, "def add")
+}
+
+func TestPrintTaskHuman_DraftNoInputs(t *testing.T) {
+	tk := sampleTask()
+	tk.VersionID = nil
+	tk.Inputs = nil
+
+	out := captureStdout(t, func() { PrintTaskHuman(tk) })
+
+	assert.Contains(t, out, "draft")
+	assert.NotContains(t, out, "Inputs:")
+}

--- a/internal/pipeline/task_output_test.go
+++ b/internal/pipeline/task_output_test.go
@@ -93,6 +93,7 @@ func TestRenderTask_JSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(out), &parsed))
 	assert.Equal(t, "t-1", parsed["task_id"])
 	assert.Equal(t, "add", parsed["name"])
+	assert.Equal(t, "def add(x: int, y: int) -> int:\n    return x + y", parsed["source"])
 }
 
 func TestRenderTask_Human(t *testing.T) {

--- a/internal/pipeline/task_output_test.go
+++ b/internal/pipeline/task_output_test.go
@@ -79,6 +79,37 @@ func TestToTaskJSON_JSONKeysUseCliVocabulary(t *testing.T) {
 	assert.NotContains(t, raw, "id", "wire 'id' must not appear in CLI output")
 	assert.NotContains(t, raw, "pipelineId")
 	assert.NotContains(t, raw, "versionId")
+	assert.NotContains(t, raw, "resourceBundle", "camelCase wire key must not appear in CLI output")
+	assert.NotContains(t, raw, "taskGroupId", "camelCase wire key must not appear in CLI output")
+}
+
+func TestToTaskJSON_NewFieldsOmittedWhenNil(t *testing.T) {
+	tk := sampleTask()
+	tk.ResourceBundle = nil
+	tk.TaskGroupID = nil
+
+	data, err := json.Marshal(toTaskJSON(tk))
+	require.NoError(t, err)
+
+	var raw map[string]any
+
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.NotContains(t, raw, "resource_bundle", "omitempty: nil ResourceBundle must be absent")
+	assert.NotContains(t, raw, "task_group_id", "omitempty: nil TaskGroupID must be absent")
+}
+
+func TestToTaskJSON_NewFieldsPassedThrough(t *testing.T) {
+	grp := 7
+	tk := sampleTask()
+	tk.ResourceBundle = map[string]any{"cpu": "2", "memory": "4Gi"}
+	tk.TaskGroupID = &grp
+
+	j := toTaskJSON(tk)
+
+	require.NotNil(t, j.ResourceBundle)
+	assert.Equal(t, "2", j.ResourceBundle["cpu"])
+	require.NotNil(t, j.TaskGroupID)
+	assert.Equal(t, 7, *j.TaskGroupID)
 }
 
 // ── RenderTask ───────────────────────────────────────────────────────────────

--- a/internal/pipeline/task_output_test.go
+++ b/internal/pipeline/task_output_test.go
@@ -27,7 +27,7 @@ func sampleTask() PipelineTask {
 	ann := "int"
 
 	return PipelineTask{
-		TaskID:     "t-1",
+		TaskID:     1,
 		PipelineID: "p-1",
 		VersionID:  &ver,
 		Name:       "add",
@@ -45,7 +45,7 @@ func sampleTask() PipelineTask {
 func TestToTaskJSON_RemapsWireFields(t *testing.T) {
 	j := toTaskJSON(sampleTask())
 
-	assert.Equal(t, "t-1", j.TaskID)
+	assert.Equal(t, 1, j.TaskID)
 	assert.Equal(t, "p-1", j.PipelineID)
 	require.NotNil(t, j.VersionID)
 	assert.Equal(t, 2, *j.VersionID)
@@ -122,7 +122,7 @@ func TestRenderTask_JSON(t *testing.T) {
 	var parsed map[string]any
 
 	require.NoError(t, json.Unmarshal([]byte(out), &parsed))
-	assert.Equal(t, "t-1", parsed["task_id"])
+	assert.EqualValues(t, 1, parsed["task_id"])
 	assert.Equal(t, "add", parsed["name"])
 	assert.Equal(t, "def add(x: int, y: int) -> int:\n    return x + y", parsed["source"])
 }
@@ -130,7 +130,7 @@ func TestRenderTask_JSON(t *testing.T) {
 func TestRenderTask_Human(t *testing.T) {
 	out := captureStdout(t, func() { PrintTaskHuman(sampleTask()) })
 
-	assert.Contains(t, out, "t-1")
+	assert.Contains(t, out, "Task ID:")
 	assert.Contains(t, out, "locked")
 	assert.Contains(t, out, "add")
 	assert.Contains(t, out, "x")

--- a/internal/pipeline/task_test.go
+++ b/internal/pipeline/task_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTask_DraftURLShape(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v2/pipelines/p-1/tasks/t-1", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"t-1",
+			"pipelineId":"p-1",
+			"versionId":null,
+			"name":"add",
+			"parameters":[{"name":"x","annotation":"int"},{"name":"y","annotation":"int"}],
+			"inputs":null,
+			"source":"def add(x: int, y: int) -> int:\n    return x + y"
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	got, err := GetTask("p-1", ScopeDraft, nil, "t-1")
+	require.NoError(t, err)
+	assert.Equal(t, "t-1", got.TaskID)
+	assert.Equal(t, "p-1", got.PipelineID)
+	assert.Nil(t, got.VersionID)
+	assert.Equal(t, "add", got.Name)
+	require.Len(t, got.Parameters, 2)
+	assert.Equal(t, "x", got.Parameters[0].Name)
+	require.NotNil(t, got.Parameters[0].Annotation)
+	assert.Equal(t, "int", *got.Parameters[0].Annotation)
+	assert.Nil(t, got.Inputs)
+}
+
+func TestGetTask_LockedURLShape(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v2/pipelines/p-1/versions/2/tasks/t-1", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"t-1",
+			"pipelineId":"p-1",
+			"versionId":2,
+			"name":"add",
+			"parameters":[{"name":"x","annotation":"int"}],
+			"inputs":{"a":100,"b":200},
+			"source":"def add(x: int) -> int:\n    return x"
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	v := 2
+	got, err := GetTask("p-1", ScopeLocked, &v, "t-1")
+	require.NoError(t, err)
+	assert.Equal(t, "t-1", got.TaskID)
+	require.NotNil(t, got.VersionID)
+	assert.Equal(t, 2, *got.VersionID)
+	assert.NotNil(t, got.Inputs)
+	assert.InEpsilon(t, float64(100), got.Inputs["a"], 1e-9)
+}
+
+func TestGetTask_404ReturnsHTTPError(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"task not found"}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := GetTask("p-1", ScopeDraft, nil, "t-missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 404")
+}
+
+func TestGetTask_ParameterNilAnnotation(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"t-1",
+			"pipelineId":"p-1",
+			"name":"fn",
+			"parameters":[{"name":"x"}],
+			"source":"def fn(x):\n    pass"
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	got, err := GetTask("p-1", ScopeDraft, nil, "t-1")
+	require.NoError(t, err)
+	require.Len(t, got.Parameters, 1)
+	assert.Nil(t, got.Parameters[0].Annotation)
+}

--- a/internal/pipeline/task_test.go
+++ b/internal/pipeline/task_test.go
@@ -28,11 +28,11 @@ func TestGetTask_DraftURLShape(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v2/pipelines/p-1/tasks/t-1", r.URL.Path)
+		assert.Equal(t, "/api/v2/pipelines/p-1/tasks/1", r.URL.Path)
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
-			"id":"t-1",
+			"id":1,
 			"pipelineId":"p-1",
 			"versionId":null,
 			"name":"add",
@@ -48,9 +48,9 @@ func TestGetTask_DraftURLShape(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	got, err := GetTask("p-1", ScopeDraft, nil, "t-1")
+	got, err := GetTask("p-1", ScopeDraft, nil, 1)
 	require.NoError(t, err)
-	assert.Equal(t, "t-1", got.TaskID)
+	assert.Equal(t, 1, got.TaskID)
 	assert.Equal(t, "p-1", got.PipelineID)
 	assert.Nil(t, got.VersionID)
 	assert.Equal(t, "add", got.Name)
@@ -68,11 +68,11 @@ func TestGetTask_LockedURLShape(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/v2/pipelines/p-1/versions/2/tasks/t-1", r.URL.Path)
+		assert.Equal(t, "/api/v2/pipelines/p-1/versions/2/tasks/1", r.URL.Path)
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
-			"id":"t-1",
+			"id":1,
 			"pipelineId":"p-1",
 			"versionId":2,
 			"name":"add",
@@ -89,9 +89,9 @@ func TestGetTask_LockedURLShape(t *testing.T) {
 	installEndpoint(t, srv.URL)
 
 	v := 2
-	got, err := GetTask("p-1", ScopeLocked, &v, "t-1")
+	got, err := GetTask("p-1", ScopeLocked, &v, 1)
 	require.NoError(t, err)
-	assert.Equal(t, "t-1", got.TaskID)
+	assert.Equal(t, 1, got.TaskID)
 	require.NotNil(t, got.VersionID)
 	assert.Equal(t, 2, *got.VersionID)
 	assert.NotNil(t, got.Inputs)
@@ -110,7 +110,7 @@ func TestGetTask_404ReturnsHTTPError(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	_, err := GetTask("p-1", ScopeDraft, nil, "t-missing")
+	_, err := GetTask("p-1", ScopeDraft, nil, 404)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HTTP 404")
 }
@@ -121,7 +121,7 @@ func TestGetTask_ParameterNilAnnotation(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
-			"id":"t-1",
+			"id":1,
 			"pipelineId":"p-1",
 			"name":"fn",
 			"parameters":[{"name":"x"}],
@@ -133,7 +133,7 @@ func TestGetTask_ParameterNilAnnotation(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	got, err := GetTask("p-1", ScopeDraft, nil, "t-1")
+	got, err := GetTask("p-1", ScopeDraft, nil, 1)
 	require.NoError(t, err)
 	require.Len(t, got.Parameters, 1)
 	assert.Nil(t, got.Parameters[0].Annotation)

--- a/internal/pipeline/task_test.go
+++ b/internal/pipeline/task_test.go
@@ -38,7 +38,9 @@ func TestGetTask_DraftURLShape(t *testing.T) {
 			"name":"add",
 			"parameters":[{"name":"x","annotation":"int"},{"name":"y","annotation":"int"}],
 			"inputs":null,
-			"source":"def add(x: int, y: int) -> int:\n    return x + y"
+			"source":"def add(x: int, y: int) -> int:\n    return x + y",
+			"resourceBundle":null,
+			"taskGroupId":null
 		}`))
 	}))
 
@@ -57,6 +59,8 @@ func TestGetTask_DraftURLShape(t *testing.T) {
 	require.NotNil(t, got.Parameters[0].Annotation)
 	assert.Equal(t, "int", *got.Parameters[0].Annotation)
 	assert.Nil(t, got.Inputs)
+	assert.Nil(t, got.ResourceBundle)
+	assert.Nil(t, got.TaskGroupID)
 }
 
 func TestGetTask_LockedURLShape(t *testing.T) {
@@ -74,7 +78,9 @@ func TestGetTask_LockedURLShape(t *testing.T) {
 			"name":"add",
 			"parameters":[{"name":"x","annotation":"int"}],
 			"inputs":{"a":100,"b":200},
-			"source":"def add(x: int) -> int:\n    return x"
+			"source":"def add(x: int) -> int:\n    return x",
+			"resourceBundle":null,
+			"taskGroupId":null
 		}`))
 	}))
 

--- a/internal/pipeline/version.go
+++ b/internal/pipeline/version.go
@@ -43,7 +43,7 @@ type GraphNode struct {
 	Source         *string `json:"source,omitempty"`
 	ResourceBundle any     `json:"resourceBundle,omitempty"`
 	TaskGroupID    any     `json:"taskGroupId,omitempty"`
-	TaskID         *string `json:"taskId,omitempty"`
+	TaskID         *int    `json:"taskId,omitempty"`
 }
 
 // GraphEdge mirrors PipelineGraphEdge. Source and Target are integer node IDs.

--- a/internal/pipeline/version.go
+++ b/internal/pipeline/version.go
@@ -43,6 +43,7 @@ type GraphNode struct {
 	Source         *string `json:"source,omitempty"`
 	ResourceBundle any     `json:"resourceBundle,omitempty"`
 	TaskGroupID    any     `json:"taskGroupId,omitempty"`
+	TaskID         *string `json:"taskId,omitempty"`
 }
 
 // GraphEdge mirrors PipelineGraphEdge. Source and Target are integer node IDs.


### PR DESCRIPTION
# RATIONALE

pipelines-api PR #56 (CMPT-6040) introduces stable per-task identifiers and two new GET endpoints:

```
GET /api/v2/pipelines/{pipeline_id}/tasks/{task_id}
GET /api/v2/pipelines/{pipeline_id}/versions/{version_id}/tasks/{task_id}
```

Each endpoint returns the task's Python source code, `@task` function signature parameters, pipeline ID/version, and (for locked versions) the latest VALID pipeline input payload.

The graph endpoint also gains an additive `taskId` field on each node so users can discover task IDs without a separate API call.

## CHANGES

### New: `dr pipeline task get <task-id>`

```
dr pipeline task get --pipeline <id> <task-id>
dr pipeline task get --pipeline <id> --version=2 <task-id>
dr pipeline task get --pipeline <id> <task-id> --output-format json
```

- Draft scope: returns source + parameters, `inputs` is null
- Locked scope: returns source + parameters + latest VALID pipeline input payload
- `--pipeline` is required; `--scope`/`--version` follow the shared draft/locked rules
- 404 renders a friendly "Task not found: \<id\>" message (nil return, not error)
- Telemetry tracks `pipeline_id`, `task_id`, `scope`, `version`, `output_format`

### Updated: `dr pipeline graph`

- `GraphNode` gains `TaskID *string \`json:"taskId,omitempty"\`` — additive, non-breaking
- Human table now shows a **TASK ID** column (prints `—` for legacy pipelines that pre-date CMPT-6040)

### Files

| File | Change |
|---|---|
| `internal/pipeline/task.go` | `PipelineTask`, `TaskParameter` types + `GetTask()` for both URL shapes |
| `internal/pipeline/task_output.go` | `RenderTask`, `PrintTaskJSON` (snake_case DTO), `PrintTaskHuman` |
| `internal/pipeline/task_test.go` | HTTP round-trip tests (draft URL, locked URL, 404, nil annotation) |
| `internal/pipeline/task_output_test.go` | JSON remapping + human render tests |
| `cmd/pipeline/task/get/cmd.go` | `dr pipeline task get` command |
| `cmd/pipeline/task/get/cmd_test.go` | Flag-validation tests |
| `cmd/pipeline/task/cmd.go` | Parent `task` subcommand |
| `cmd/pipeline/cmd.go` | Register `task.Cmd()` |
| `internal/pipeline/version.go` | Add `TaskID *string` to `GraphNode` |
| `cmd/pipeline/graph/cmd.go` | Show TASK ID column in human output |
| `docs/commands/pipelines-reference.md` | Add Tasks section + 2 endpoint lookup rows |

## TESTING

- `go test ./internal/pipeline/... ./cmd/pipeline/task/...` — all pass
- `task lint` — 0 issues
- `task test` — full suite passes

## RELATED

- pipelines-api PR #56 (CMPT-6040): https://github.com/datarobot/pipelines-api/pull/56
- JIRA: CMPT-6040, CMPT-6045

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CLI and additive graph field; behavior mirrors existing pipeline GET patterns with tests.
> 
> **Overview**
> Adds **`dr pipeline task get`** so users can inspect a single @task by stable ID (source, signature parameters, and for locked versions the latest valid input payload), using the same draft/locked `--scope` / `--version` rules as other pipeline reads. JSON output remaps API fields to snake_case CLI keys; **404** prints a friendly message instead of failing.
> 
> **`dr pipeline graph`** human output now includes a **TASK ID** column (em dash when missing on older pipelines); `GraphNode` unmarshals the new optional `taskId` from the API. Command reference docs list the new task endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a67592e2631338e337c144e9f4cdb092813d141. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->