### PR TITLE
[RAPTOR-17714] feat(workload): add dr workload create/get/list/delete and artifact delete

### DIFF
--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -83,6 +83,11 @@ var expectedWorkloadTrackedCommands = []string{
 	"workload build get",
 	"workload build list",
 	"workload build logs",
+	"workload artifact delete",
+	"workload create",
+	"workload get",
+	"workload list",
+	"workload delete",
 }
 
 // TestTelemetryWiring_AllWorkloadCommandsTracked walks the workload

--- a/cmd/workload/artifact/cmd.go
+++ b/cmd/workload/artifact/cmd.go
@@ -16,6 +16,7 @@ package artifact
 
 import (
 	"github.com/datarobot/cli/cmd/workload/artifact/create"
+	"github.com/datarobot/cli/cmd/workload/artifact/del"
 	"github.com/datarobot/cli/cmd/workload/artifact/get"
 	"github.com/datarobot/cli/cmd/workload/artifact/list"
 	"github.com/spf13/cobra"
@@ -30,6 +31,7 @@ func Cmd() *cobra.Command {
 
 	cmd.AddCommand(
 		create.Cmd(),
+		del.Cmd(),
 		get.Cmd(),
 		list.Cmd(),
 	)

--- a/cmd/workload/artifact/create/cmd.go
+++ b/cmd/workload/artifact/create/cmd.go
@@ -41,10 +41,9 @@ Required fields: name, spec.containerGroups (>=1), and at least one container
 per group. Any other field accepted by the server is accepted here. JSON
 specs are sent to the Workload API verbatim, byte-for-byte. YAML specs are
 converted to JSON using standard YAML typing rules before sending: quote
-values that must stay strings (for example "0644" or "1.10"), unquoted
-dates are sent as RFC3339 timestamps, and only the first document of a
-multi-document file is read. The server validates field-level shape and
-returns a 422 with a JSON-path detail on a mismatch.
+values that must stay strings (for example "0644" or "1.10"), and unquoted
+dates are sent as RFC3339 timestamps. The server validates field-level
+shape and returns a 422 with a JSON-path detail on a mismatch.
 
 Container lifecycles:
 

--- a/cmd/workload/artifact/create/cmd.go
+++ b/cmd/workload/artifact/create/cmd.go
@@ -15,11 +15,6 @@
 package create
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"os"
-
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
@@ -37,15 +32,19 @@ func Cmd() *cobra.Command {
 		Short: "Create a workload artifact.",
 		Long: `Create a workload artifact in your DataRobot deployment infrastructure.
 
-This command reads a JSON spec from a file and POSTs it to the Workload API.
-The created artifact is returned and shown.
+This command reads a JSON or YAML spec from a file and POSTs it to the
+Workload API. The created artifact is returned and shown.
 
 By default, output is human-readable. Use --output-format json for machine-parseable output.
 
 Required fields: name, spec.containerGroups (>=1), and at least one container
-per group. All other fields are passed through to the Workload API verbatim,
-so any field accepted by the server is accepted here. The server validates
-field-level shape and returns a 422 with a JSON-path detail on a mismatch.
+per group. Any other field accepted by the server is accepted here. JSON
+specs are sent to the Workload API verbatim, byte-for-byte. YAML specs are
+converted to JSON using standard YAML typing rules before sending: quote
+values that must stay strings (for example "0644" or "1.10"), unquoted
+dates are sent as RFC3339 timestamps, and only the first document of a
+multi-document file is read. The server validates field-level shape and
+returns a 422 with a JSON-path detail on a mismatch.
 
 Container lifecycles:
 
@@ -88,11 +87,12 @@ Minimal build-from-source example (provided Dockerfile):
 
 Example:
   dr workload artifact create --spec-file spec.json
-  dr workload artifact create --spec-file spec.json --output-format json`,
+  dr workload artifact create --spec-file spec.yaml
+  dr workload artifact create --spec-file spec.yaml --output-format json`,
 		Args:    cobra.NoArgs,
 		PreRunE: auth.EnsureAuthenticatedE,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			payload, err := readSpecFile(specFile)
+			payload, err := workload.ReadSpecFile(specFile)
 			if err != nil {
 				return err
 			}
@@ -118,7 +118,7 @@ Example:
 	}
 
 	workload.AddOutputFlag(cmd, &outputFormat)
-	cmd.Flags().StringVar(&specFile, "spec-file", "", "Path to JSON spec file (required)")
+	cmd.Flags().StringVar(&specFile, "spec-file", "", "Path to JSON or YAML spec file (required)")
 	_ = cmd.MarkFlagRequired("spec-file")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
@@ -128,17 +128,4 @@ Example:
 	})
 
 	return cmd
-}
-
-func readSpecFile(path string) (json.RawMessage, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("file not found: %s", path)
-		}
-
-		return nil, err
-	}
-
-	return json.RawMessage(data), nil
 }

--- a/cmd/workload/artifact/del/cmd.go
+++ b/cmd/workload/artifact/del/cmd.go
@@ -1,0 +1,128 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package del implements the `dr workload artifact delete` verb. The
+// directory is named `del` rather than `delete` because the latter shadows
+// Go's built-in delete() function in importing files.
+package del
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/datarobot/cli/cmd/helpers"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <artifact-id>",
+		Short: "Delete a workload artifact",
+		Long: `Delete a workload artifact by id.
+
+Two server-side rules apply:
+  • Locked artifacts can never be deleted (locking is one-way).
+  • An artifact still referenced by a workload cannot be deleted; the error
+    names the blocking workload ids. Delete those first with
+    'dr workload delete <workload-id>'.
+
+Without --yes the command asks for confirmation.
+
+Example:
+  dr workload artifact delete 68b0c1d2e3f4a5b6c7d8e9f0
+  dr workload artifact delete 68b0c1d2e3f4a5b6c7d8e9f0 --yes`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			confirmed, err := confirmDelete(cmd, args[0])
+			if err != nil || !confirmed {
+				return err
+			}
+
+			if err := workload.DeleteArtifact(args[0]); err != nil {
+				return handleDeleteError(err, args[0])
+			}
+
+			fmt.Println(tui.BaseTextStyle.Render("Deleted artifact: " + args[0]))
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt.")
+
+	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
+	// flag itself is read directly from cmd.Flags() so an explicit --yes does
+	// not leak into viper.AllSettings() and persist to drconfig.yaml.
+	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+
+	telemetry.TrackWith(cmd, func(cmd *cobra.Command, args []string) map[string]any {
+		yesFlag, _ := cmd.Flags().GetBool("yes")
+
+		return map[string]any{
+			"artifact_id": telemetry.FirstArg(args),
+			"yes":         yesFlag || viperx.GetBool("yes"),
+		}
+	})
+
+	return cmd
+}
+
+func confirmDelete(cmd *cobra.Command, artifactID string) (bool, error) {
+	yesFlag, _ := cmd.Flags().GetBool("yes")
+	if yesFlag || viperx.GetBool("yes") {
+		return true, nil
+	}
+
+	if !reader.IsStdinTerminal() {
+		return false, errors.New("confirmation required: pass --yes (or set DATAROBOT_CLI_NON_INTERACTIVE=1) to delete without a prompt")
+	}
+
+	confirmed, err := helpers.Confirm(cmd.OutOrStdout(), cmd.InOrStdin(),
+		"Delete artifact "+artifactID+"? [y/N] ")
+	if err != nil {
+		return false, err
+	}
+
+	if !confirmed {
+		fmt.Println(tui.DimStyle.Render("Aborted."))
+	}
+
+	return confirmed, nil
+}
+
+// handleDeleteError converts a 404 into a friendly informational message
+// (returns nil) so the user does not see a stack-trace-style HTTP error
+// for what is effectively a no-op. Conflicts (409: locked, or referenced by
+// a workload) propagate with the server's detail intact.
+func handleDeleteError(err error, artifactID string) error {
+	var httpErr *drapi.HTTPError
+
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		fmt.Println(tui.DimStyle.Render("No artifact found with id: " + artifactID))
+
+		return nil
+	}
+
+	return err
+}

--- a/cmd/workload/artifact/del/cmd_test.go
+++ b/cmd/workload/artifact/del/cmd_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package del
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+// In tests stdin is not a terminal, so without --yes the command must stop
+// with the confirmation-required guidance before any network call.
+func TestCmd_RequiresYesWhenNonInteractive(t *testing.T) {
+	t.Setenv(reader.NonInteractiveEnv, "")
+
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"68b0c1d2e3f4a5b6c7d8e9f0"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "confirmation required")
+	assert.Contains(t, err.Error(), "--yes")
+}
+
+// Bypass works via --yes or DATAROBOT_CLI_NON_INTERACTIVE; anything else
+// requires confirmation (stdin is not a terminal under go test).
+func TestConfirmDelete_YesSources(t *testing.T) {
+	cases := []struct {
+		name          string
+		env           string
+		setYesFlag    bool
+		wantConfirmed bool
+		wantErr       bool
+	}{
+		{name: "env 1 bypasses prompt", env: "1", wantConfirmed: true},
+		{name: "env true bypasses prompt", env: "true", wantConfirmed: true},
+		{name: "empty env requires confirmation", env: "", wantErr: true},
+		{name: "env false requires confirmation", env: "false", wantErr: true},
+		{name: "yes flag bypasses prompt", env: "", setYesFlag: true, wantConfirmed: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv(reader.NonInteractiveEnv, c.env)
+
+			cmd := Cmd()
+
+			if c.setYesFlag {
+				require.NoError(t, cmd.Flags().Set("yes", "true"))
+			}
+
+			confirmed, err := confirmDelete(cmd, "art-1")
+
+			if c.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "confirmation required")
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, c.wantConfirmed, confirmed)
+		})
+	}
+}

--- a/cmd/workload/cmd.go
+++ b/cmd/workload/cmd.go
@@ -18,6 +18,10 @@ import (
 	"github.com/datarobot/cli/cmd/workload/artifact"
 	"github.com/datarobot/cli/cmd/workload/build"
 	"github.com/datarobot/cli/cmd/workload/code"
+	"github.com/datarobot/cli/cmd/workload/create"
+	"github.com/datarobot/cli/cmd/workload/del"
+	"github.com/datarobot/cli/cmd/workload/get"
+	"github.com/datarobot/cli/cmd/workload/list"
 	"github.com/datarobot/cli/internal/features"
 	"github.com/spf13/cobra"
 )
@@ -36,6 +40,13 @@ Manage and monitor workloads in your deployment infrastructure.`,
 	features.SetGate(cmd, "workload")
 
 	cmd.AddCommand(
+		// The workload itself is the primary resource: direct verbs, like
+		// `dr pipeline create|get|...`.
+		create.Cmd(),
+		del.Cmd(),
+		get.Cmd(),
+		list.Cmd(),
+		// Sub-resources keep their noun groups.
 		artifact.Cmd(),
 		build.Cmd(),
 		code.Cmd(),

--- a/cmd/workload/create/cmd.go
+++ b/cmd/workload/create/cmd.go
@@ -1,0 +1,135 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package create
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat workload.OutputFormat
+
+	var specFile string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create (deploy) a workload.",
+		Long: `Create a workload in your DataRobot deployment infrastructure.
+
+This command reads a JSON or YAML spec from a file and POSTs it to the
+Workload API. The created workload is returned and shown, including its
+stable endpoint URL. Startup is asynchronous: poll with
+'dr workload get <id>' until the status is "running", then call the
+endpoint.
+
+The spec requires name and exactly one of artifactId / artifact. Any other
+field accepted by the server is accepted here. JSON specs are sent to the
+Workload API verbatim, byte-for-byte. YAML specs are converted to JSON
+using standard YAML typing rules before sending: quote values that must
+stay strings (for example "0644" or "1.10"), unquoted dates are sent as
+RFC3339 timestamps, and only the first document of a multi-document file
+is read. The server validates field-level shape and returns a 422 with a
+JSON-path detail on a mismatch.
+
+Two flows:
+
+  1. Deploy an existing artifact (e.g. one built with 'dr workload code sync'
+     and a build):
+
+  {
+    "name": "my-app",
+    "artifactId": "68b0c1d2e3f4a5b6c7d8e9f0",
+    "runtime": {
+      "containerGroups": [{
+        "name": "default",
+        "replicaCount": 1,
+        "containers": [{
+          "name": "primary",
+          "resourceAllocation": {"cpu": 1, "memory": "512MB"}
+        }]
+      }]
+    }
+  }
+
+  2. Define a draft artifact inline and deploy it in one call:
+
+  {
+    "name": "hello-whoami",
+    "artifact": {
+      "name": "whoami-artifact",
+      "type": "service",
+      "spec": {
+        "containerGroups": [{
+          "name": "default",
+          "containers": [{
+            "name": "whoami",
+            "imageUri": "containous/whoami:latest",
+            "port": 8080,
+            "primary": true
+          }]
+        }]
+      }
+    }
+  }
+
+Example:
+  dr workload create --spec-file workload.json
+  dr workload create --spec-file workload.yaml
+  dr workload create --spec-file workload.yaml --output-format json`,
+		Args:         cobra.NoArgs,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			payload, err := workload.ReadSpecFile(specFile)
+			if err != nil {
+				return err
+			}
+
+			if err := workload.ValidateWorkloadCreateRequest(payload); err != nil {
+				return err
+			}
+
+			var wl *workload.Workload
+
+			if err := tui.RunWithSpinner("Creating workload…", func() error {
+				var createErr error
+
+				wl, createErr = workload.CreateWorkload(payload)
+
+				return createErr
+			}); err != nil {
+				return err
+			}
+
+			return workload.RenderWorkload(outputFormat, *wl)
+		},
+	}
+
+	workload.AddOutputFlag(cmd, &outputFormat)
+	cmd.Flags().StringVar(&specFile, "spec-file", "", "Path to JSON or YAML spec file (required)")
+	_ = cmd.MarkFlagRequired("spec-file")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		return map[string]any{
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/workload/create/cmd.go
+++ b/cmd/workload/create/cmd.go
@@ -42,10 +42,9 @@ The spec requires name and exactly one of artifactId / artifact. Any other
 field accepted by the server is accepted here. JSON specs are sent to the
 Workload API verbatim, byte-for-byte. YAML specs are converted to JSON
 using standard YAML typing rules before sending: quote values that must
-stay strings (for example "0644" or "1.10"), unquoted dates are sent as
-RFC3339 timestamps, and only the first document of a multi-document file
-is read. The server validates field-level shape and returns a 422 with a
-JSON-path detail on a mismatch.
+stay strings (for example "0644" or "1.10"), and unquoted dates are sent
+as RFC3339 timestamps. The server validates field-level shape and returns
+a 422 with a JSON-path detail on a mismatch.
 
 Two flows:
 

--- a/cmd/workload/create/cmd_test.go
+++ b/cmd/workload/create/cmd_test.go
@@ -15,31 +15,46 @@
 package create
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// Spec-file reading (not-found, JSON passthrough, YAML conversion) is
-// covered by internal/workload's ReadSpecFile tests.
-
-func TestCmd_RejectsArgs(t *testing.T) {
-	cmd := Cmd()
-	cmd.PreRunE = nil
-	cmd.SetArgs([]string{"--spec-file", "x.json", "unexpected-arg"})
-
-	require.Error(t, cmd.Execute())
-}
-
-func TestCmd_MissingSpecFile(t *testing.T) {
+func TestCmd_RequiresSpecFile(t *testing.T) {
 	cmd := Cmd()
 	cmd.PreRunE = nil
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `required flag(s) "spec-file" not set`)
+	assert.Contains(t, err.Error(), "spec-file")
+}
+
+func TestCmd_SpecFileNotFound(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--spec-file", "/nonexistent/workload.json"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file not found")
+}
+
+func TestCmd_InvalidSpecFailsBeforeNetwork(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spec.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"name": "wl"}`), 0o600))
+
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--spec-file", path})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one of 'artifactId'")
 }
 
 func TestCmd_InvalidOutputFormat(t *testing.T) {
@@ -50,4 +65,13 @@ func TestCmd_InvalidOutputFormat(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `invalid output format "yaml"`)
+}
+
+func TestCmd_RejectsPositionalArgs(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"unexpected", "--spec-file", "x.json"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
 }

--- a/cmd/workload/del/cmd.go
+++ b/cmd/workload/del/cmd.go
@@ -1,0 +1,130 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package del implements the `dr workload delete` verb. The directory is
+// named `del` rather than `delete` because the latter shadows Go's built-in
+// delete() function in importing files.
+package del
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/datarobot/cli/cmd/helpers"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <workload-id>",
+		Short: "Delete a workload.",
+		Long: `Delete a workload by id.
+
+Deleting a running workload is allowed: the platform stops the backing
+replicas first, then removes the workload. The artifact it was created from
+is not deleted with it; remove that separately with
+'dr workload artifact delete <artifact-id>' once no workload references it.
+
+Without --yes the command asks for confirmation.
+
+Example:
+  dr workload delete 68b0c1d2e3f4a5b6c7d8e9f0
+  dr workload delete 68b0c1d2e3f4a5b6c7d8e9f0 --yes`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			confirmed, err := confirmDelete(cmd, args[0])
+			if err != nil || !confirmed {
+				return err
+			}
+
+			if err := workload.DeleteWorkload(args[0]); err != nil {
+				return handleDeleteError(err, args[0])
+			}
+
+			fmt.Println(tui.BaseTextStyle.Render("Deleted workload: " + args[0]))
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt.")
+
+	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
+	// flag itself is read directly from cmd.Flags() so an explicit --yes does
+	// not leak into viper.AllSettings() and persist to drconfig.yaml.
+	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+
+	telemetry.TrackWith(cmd, func(cmd *cobra.Command, args []string) map[string]any {
+		yesFlag, _ := cmd.Flags().GetBool("yes")
+
+		return map[string]any{
+			"workload_id": telemetry.FirstArg(args),
+			"yes":         yesFlag || viperx.GetBool("yes"),
+		}
+	})
+
+	return cmd
+}
+
+// confirmDelete returns (true, nil) when the deletion may proceed: either
+// --yes / DATAROBOT_CLI_NON_INTERACTIVE was given, or the user confirmed
+// interactively. A declined prompt is (false, nil) so the command exits 0
+// as a no-op.
+func confirmDelete(cmd *cobra.Command, workloadID string) (bool, error) {
+	yesFlag, _ := cmd.Flags().GetBool("yes")
+	if yesFlag || viperx.GetBool("yes") {
+		return true, nil
+	}
+
+	if !reader.IsStdinTerminal() {
+		return false, errors.New("confirmation required: pass --yes (or set DATAROBOT_CLI_NON_INTERACTIVE=1) to delete without a prompt")
+	}
+
+	confirmed, err := helpers.Confirm(cmd.OutOrStdout(), cmd.InOrStdin(),
+		"Delete workload "+workloadID+"? This stops and removes a running workload. [y/N] ")
+	if err != nil {
+		return false, err
+	}
+
+	if !confirmed {
+		fmt.Println(tui.DimStyle.Render("Aborted."))
+	}
+
+	return confirmed, nil
+}
+
+// handleDeleteError converts a 404 into a friendly informational message
+// (returns nil) so the user does not see a stack-trace-style HTTP error
+// for what is effectively a no-op.
+func handleDeleteError(err error, workloadID string) error {
+	var httpErr *drapi.HTTPError
+
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		fmt.Println(tui.DimStyle.Render("No workload found with id: " + workloadID))
+
+		return nil
+	}
+
+	return err
+}

--- a/cmd/workload/del/cmd_test.go
+++ b/cmd/workload/del/cmd_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package del
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+// In tests stdin is not a terminal, so without --yes the command must stop
+// with the confirmation-required guidance before any network call.
+func TestCmd_RequiresYesWhenNonInteractive(t *testing.T) {
+	t.Setenv(reader.NonInteractiveEnv, "")
+
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"68b0c1d2e3f4a5b6c7d8e9f0"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "confirmation required")
+	assert.Contains(t, err.Error(), "--yes")
+}
+
+// Bypass works via --yes or DATAROBOT_CLI_NON_INTERACTIVE; anything else
+// requires confirmation (stdin is not a terminal under go test).
+func TestConfirmDelete_YesSources(t *testing.T) {
+	cases := []struct {
+		name          string
+		env           string
+		setYesFlag    bool
+		wantConfirmed bool
+		wantErr       bool
+	}{
+		{name: "env 1 bypasses prompt", env: "1", wantConfirmed: true},
+		{name: "env true bypasses prompt", env: "true", wantConfirmed: true},
+		{name: "empty env requires confirmation", env: "", wantErr: true},
+		{name: "env false requires confirmation", env: "false", wantErr: true},
+		{name: "yes flag bypasses prompt", env: "", setYesFlag: true, wantConfirmed: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv(reader.NonInteractiveEnv, c.env)
+
+			cmd := Cmd()
+
+			if c.setYesFlag {
+				require.NoError(t, cmd.Flags().Set("yes", "true"))
+			}
+
+			confirmed, err := confirmDelete(cmd, "wl-1")
+
+			if c.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "confirmation required")
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, c.wantConfirmed, confirmed)
+		})
+	}
+}

--- a/cmd/workload/get/cmd.go
+++ b/cmd/workload/get/cmd.go
@@ -1,0 +1,77 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat workload.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:   "get <workload-id>",
+		Short: "Display details of a workload.",
+		Long: `Display details of a single workload.
+
+This command fetches a workload by ID and shows:
+  • Name and current status
+  • Endpoint URL (stable from creation; serves traffic once running)
+  • Artifact ID, type, and importance
+  • Creation and last update timestamps
+
+Statuses progress submitted → provisioning → launching → running. Re-run
+this command until the status is "running", then call the endpoint.
+
+By default, output is human-readable. Use --output-format json for machine-parseable output.
+
+Example:
+  dr workload get 68b0c1d2e3f4a5b6c7d8e9f0
+  dr workload get 68b0c1d2e3f4a5b6c7d8e9f0 --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			var wl *workload.Workload
+
+			if err := tui.RunWithSpinner("Fetching workload…", func() error {
+				var getErr error
+
+				wl, getErr = workload.GetWorkload(args[0])
+
+				return getErr
+			}); err != nil {
+				return err
+			}
+
+			return workload.RenderWorkload(outputFormat, *wl)
+		},
+	}
+
+	workload.AddOutputFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"workload_id":   telemetry.FirstArg(args),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/workload/get/cmd_test.go
+++ b/cmd/workload/get/cmd_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package create
+package get
 
 import (
 	"testing"
@@ -21,31 +21,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Spec-file reading (not-found, JSON passthrough, YAML conversion) is
-// covered by internal/workload's ReadSpecFile tests.
-
-func TestCmd_RejectsArgs(t *testing.T) {
+func TestCmd_RequiresArg(t *testing.T) {
 	cmd := Cmd()
-	cmd.PreRunE = nil
-	cmd.SetArgs([]string{"--spec-file", "x.json", "unexpected-arg"})
-
-	require.Error(t, cmd.Execute())
-}
-
-func TestCmd_MissingSpecFile(t *testing.T) {
-	cmd := Cmd()
-	cmd.PreRunE = nil
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `required flag(s) "spec-file" not set`)
 }
 
 func TestCmd_InvalidOutputFormat(t *testing.T) {
 	cmd := Cmd()
 	cmd.PreRunE = nil
-	cmd.SetArgs([]string{"--spec-file", "x.json", "--output-format", "yaml"})
+	cmd.SetArgs([]string{"68b0c1d2e3f4a5b6c7d8e9f0", "--output-format", "yaml"})
 
 	err := cmd.Execute()
 	require.Error(t, err)

--- a/cmd/workload/list/cmd.go
+++ b/cmd/workload/list/cmd.go
@@ -1,0 +1,99 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat workload.OutputFormat
+
+	var (
+		limit    int
+		statuses []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List workloads.",
+		Long: `List workloads in your DataRobot deployment infrastructure.
+
+For each workload the listing shows:
+  • Name and current status
+  • Artifact type and importance
+  • Last update timestamp
+
+By default, output is a human-readable table. Use --output-format json for machine-parseable output.
+
+Example:
+  dr workload list
+  dr workload list --limit 10
+  dr workload list --status running
+  dr workload list --status errored --status interrupted
+  dr workload list --output-format json`,
+		Args:         cobra.NoArgs,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if limit <= 0 {
+				return fmt.Errorf("invalid --limit %d: must be positive", limit)
+			}
+
+			parsedStatuses, err := workload.ParseWorkloadStatuses(statuses)
+			if err != nil {
+				return err
+			}
+
+			var workloads []workload.Workload
+
+			if err := tui.RunWithSpinner("Fetching workloads…", func() error {
+				var listErr error
+
+				workloads, listErr = workload.ListWorkloads(limit, parsedStatuses)
+
+				return listErr
+			}); err != nil {
+				return err
+			}
+
+			return workload.RenderWorkloads(outputFormat, workloads)
+		},
+	}
+
+	workload.AddOutputFlag(cmd, &outputFormat)
+	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of workloads to return")
+	cmd.Flags().StringSliceVar(&statuses, "status", nil,
+		"Filter by status (repeatable, also accepts comma-separated values; e.g. running, errored)")
+
+	telemetry.TrackWith(cmd, func(c *cobra.Command, _ []string) map[string]any {
+		limit, _ := c.Flags().GetInt("limit")
+
+		return map[string]any{
+			"limit":         limit,
+			"output_format": string(outputFormat),
+			"status":        strings.Join(statuses, ","),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/workload/list/cmd_test.go
+++ b/cmd/workload/list/cmd_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package create
+package list
 
 import (
 	"testing"
@@ -21,31 +21,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Spec-file reading (not-found, JSON passthrough, YAML conversion) is
-// covered by internal/workload's ReadSpecFile tests.
-
 func TestCmd_RejectsArgs(t *testing.T) {
 	cmd := Cmd()
 	cmd.PreRunE = nil
-	cmd.SetArgs([]string{"--spec-file", "x.json", "unexpected-arg"})
-
-	require.Error(t, cmd.Execute())
-}
-
-func TestCmd_MissingSpecFile(t *testing.T) {
-	cmd := Cmd()
-	cmd.PreRunE = nil
-	cmd.SetArgs([]string{})
+	cmd.SetArgs([]string{"unexpected"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `required flag(s) "spec-file" not set`)
+}
+
+func TestCmd_InvalidLimit(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--limit", "0"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --limit")
+}
+
+func TestCmd_InvalidStatus(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--status", "sleeping"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid status "sleeping"`)
 }
 
 func TestCmd_InvalidOutputFormat(t *testing.T) {
 	cmd := Cmd()
 	cmd.PreRunE = nil
-	cmd.SetArgs([]string{"--spec-file", "x.json", "--output-format", "yaml"})
+	cmd.SetArgs([]string{"--output-format", "yaml"})
 
 	err := cmd.Execute()
 	require.Error(t, err)

--- a/internal/drapi/delete.go
+++ b/internal/drapi/delete.go
@@ -56,9 +56,11 @@ func Delete(url, info string, body any) (*http.Response, error) {
 	}
 
 	if !isDeleteSuccess(resp.StatusCode) {
-		resp.Body.Close()
-
-		return nil, &HTTPError{StatusCode: resp.StatusCode, URL: url}
+		// Use ErrFromResp (as Post does) so delete failures carry the
+		// server's detail: workloads DELETE replies 502 with a "please
+		// retry" hint when proton cleanup fails, and artifacts DELETE
+		// replies 409 naming the workloads that block the deletion.
+		return nil, ErrFromResp(resp, url)
 	}
 
 	return resp, err

--- a/internal/drapi/delete_test.go
+++ b/internal/drapi/delete_test.go
@@ -80,3 +80,26 @@ func TestDeleteJSON_NonSuccess(t *testing.T) {
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
 }
+
+// TestDeleteJSON_NonSuccessWithBody pins the Delete error contract: a failed
+// DELETE with a non-empty response body surfaces the server's detail in the
+// error message (via ErrFromResp, as Post does) while still unwrapping to
+// *HTTPError for status-code checks by callers such as handleDeleteError.
+func TestDeleteJSON_NonSuccessWithBody(t *testing.T) {
+	defer resetTokenForTest(t, "test-token")()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"message":"artifact is used by workloads: wl-1"}`))
+	}))
+	defer server.Close()
+
+	err := DeleteJSON(server.URL, "", nil, nil)
+	require.Error(t, err)
+
+	var httpErr *HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "artifact is used by workloads: wl-1")
+}

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -192,7 +192,7 @@ func GetPrimaryContainerImageURI(artifact Artifact) string {
 }
 
 func GetArtifact(artifactID string) (*Artifact, error) {
-	url, err := config.GetEndpointURL("/api/v2/artifacts/" + artifactID + "/")
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/")
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +288,7 @@ func CreateArtifact(payload any) (*Artifact, error) {
 }
 
 func PatchArtifactCodeRef(artifactID, catalogID, catalogVersionID string) error {
-	url, err := config.GetEndpointURL("/api/v2/artifacts/" + artifactID + "/")
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/")
 	if err != nil {
 		return err
 	}
@@ -405,6 +405,19 @@ func isPrimaryContainer(container map[string]any) bool {
 	primary, ok := container["primary"].(bool)
 
 	return ok && primary
+}
+
+// DeleteArtifact deletes a draft artifact. The server replies 409 when the
+// artifact is locked (locking is one-way; locked artifacts can never be
+// deleted) or still referenced by a workload's proton(s); the 409 detail
+// names the blocking workload IDs.
+func DeleteArtifact(artifactID string) error {
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/")
+	if err != nil {
+		return err
+	}
+
+	return drapi.DeleteJSON(url, "artifact", nil, nil)
 }
 
 func ListArtifacts(limit int, status Status) ([]Artifact, error) {

--- a/internal/workload/artifact_test.go
+++ b/internal/workload/artifact_test.go
@@ -16,8 +16,12 @@ package workload
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/datarobot/cli/internal/drapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -641,4 +645,59 @@ func TestSetPrimaryCodeRefInRawArtifact(t *testing.T) {
 			assert.Contains(t, err.Error(), c.wantSub)
 		})
 	}
+}
+
+func TestDeleteArtifact_Success(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v2/artifacts/art-1/", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	require.NoError(t, DeleteArtifact("art-1"))
+}
+
+func TestDeleteArtifact_EscapesIDInPath(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// '?' must arrive escaped inside the path segment, never as a query.
+		assert.Equal(t, "/api/v2/artifacts/art-1%3Fforce=true/", r.URL.EscapedPath())
+		assert.Empty(t, r.URL.RawQuery)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	require.NoError(t, DeleteArtifact("art-1?force=true"))
+}
+
+func TestDeleteArtifact_409PropagatesAsHTTPError(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprint(w, `{"detail":"Cannot delete artifact referenced by 1 workload(s): wl-1. Delete the workload(s) first."}`)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	err := DeleteArtifact("art-1")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "Delete the workload(s) first")
 }

--- a/internal/workload/build.go
+++ b/internal/workload/build.go
@@ -165,7 +165,7 @@ func IsBuildErrorStatus(s string) bool {
 // caller so the service layer remains a thin pass-through of the server
 // shape.
 func TriggerArtifactBuild(artifactID string) (*BuildTriggerResponse, error) {
-	url, err := config.GetEndpointURL("/api/v2/artifacts/" + artifactID + "/builds/")
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/builds/")
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func TriggerArtifactBuild(artifactID string) (*BuildTriggerResponse, error) {
 
 // GetArtifactBuild fetches a single Build by id.
 func GetArtifactBuild(artifactID, buildID string) (*Build, error) {
-	url, err := config.GetEndpointURL("/api/v2/artifacts/" + artifactID + "/builds/" + buildID)
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/builds/" + escapeID(buildID))
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func ListArtifactBuilds(artifactID string, limit int) ([]Build, error) {
 		return nil, fmt.Errorf("invalid limit %d: must be positive", limit)
 	}
 
-	endpoint := "/api/v2/artifacts/" + artifactID + "/builds/?limit=" + strconv.Itoa(limit)
+	endpoint := "/api/v2/artifacts/" + escapeID(artifactID) + "/builds/?limit=" + strconv.Itoa(limit)
 
 	pageURL, err := config.GetEndpointURL(endpoint)
 	if err != nil {
@@ -243,7 +243,7 @@ func ListArtifactBuilds(artifactID string, limit int) ([]Build, error) {
 // record cannot blank the whole tail. The original bytes for each line are
 // preserved in Raw so JSON output can pass them through unchanged.
 func GetArtifactBuildLogs(artifactID, buildID string) ([]BuildLogEntry, error) {
-	url, err := config.GetEndpointURL("/api/v2/artifacts/" + artifactID + "/builds/" + buildID + "/logs")
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/builds/" + escapeID(buildID) + "/logs")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/workload/output.go
+++ b/internal/workload/output.go
@@ -330,6 +330,115 @@ func formatLogLine(entry BuildLogEntry) string {
 	return fmt.Sprintf("[%s] %s %s", level, asctime, entry.Message)
 }
 
+func RenderWorkload(format OutputFormat, workload Workload) error {
+	if format == OutputFormatJSON {
+		return printWorkloadJSON(workload)
+	}
+
+	printWorkloadDetails(workload)
+
+	return nil
+}
+
+func RenderWorkloads(format OutputFormat, workloads []Workload) error {
+	if format == OutputFormatJSON {
+		return printWorkloadsJSON(workloads)
+	}
+
+	printWorkloadsTable(workloads)
+
+	return nil
+}
+
+func printWorkloadJSON(workload Workload) error {
+	data, err := json.MarshalIndent(NewWorkloadOutput(workload), "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+
+	return nil
+}
+
+func printWorkloadsJSON(workloads []Workload) error {
+	outputs := make([]WorkloadOutput, 0, len(workloads))
+
+	for _, w := range workloads {
+		outputs = append(outputs, NewWorkloadOutput(w))
+	}
+
+	data, err := json.MarshalIndent(outputs, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+
+	return nil
+}
+
+func printWorkloadDetails(workload Workload) {
+	endpoint := workload.Endpoint
+	if endpoint == "" {
+		endpoint = emptyValuePlaceholder
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "ID:\t%s\n", workload.ID)
+	fmt.Fprintf(w, "Name:\t%s\n", workload.Name)
+	fmt.Fprintf(w, "Status:\t%s\n", workload.Status)
+	fmt.Fprintf(w, "Endpoint:\t%s\n", endpoint)
+	fmt.Fprintf(w, "Type:\t%s\n", workload.Type)
+	fmt.Fprintf(w, "Importance:\t%s\n", workload.Importance)
+	fmt.Fprintf(w, "Artifact ID:\t%s\n", workload.ArtifactID)
+	fmt.Fprintf(w, "Created:\t%s\n", workload.CreatedAt.UTC().Format(timestampFormat))
+	fmt.Fprintf(w, "Updated:\t%s\n", workload.UpdatedAt.UTC().Format(timestampFormat))
+
+	w.Flush()
+}
+
+func printWorkloadsTable(workloads []Workload) {
+	if len(workloads) == 0 {
+		fmt.Println("No workloads found.")
+
+		return
+	}
+
+	cellStyle := tui.BaseTextStyle.Padding(0, 1)
+
+	dimStyle := tui.DimStyle.Padding(0, 1)
+
+	headers := []string{"WORKLOAD ID", "NAME", "STATUS", "TYPE", "IMPORTANCE", "UPDATED"}
+
+	updatedCol := slices.Index(headers, "UPDATED")
+
+	t := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(tui.TableBorderStyle).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return cellStyle.Bold(true)
+			}
+
+			if col == updatedCol {
+				return dimStyle
+			}
+
+			return cellStyle
+		}).
+		Headers(headers...)
+
+	for _, w := range workloads {
+		updated := w.UpdatedAt.UTC().Format(timestampFormat)
+
+		t.Row(w.ID, w.Name, w.Status, w.Type, w.Importance, updated)
+	}
+
+	fmt.Fprintln(os.Stdout, t.Render())
+}
+
 func printArtifactsTable(artifacts []Artifact) {
 	if len(artifacts) == 0 {
 		fmt.Println("No artifacts found.")

--- a/internal/workload/output_test.go
+++ b/internal/workload/output_test.go
@@ -484,3 +484,132 @@ func TestFilterLogsByLevel(t *testing.T) {
 		assert.Equal(t, entries, got)
 	})
 }
+
+func makeTestWorkload(id, name, status string) Workload {
+	return Workload{
+		ID:         id,
+		Name:       name,
+		Status:     status,
+		Type:       "service",
+		Importance: "low",
+		ArtifactID: "art-1",
+		Endpoint:   "https://app.example.com/api/v2/endpoints/workloads/" + id + "/",
+		CreatedAt:  time.Date(2026, 6, 10, 8, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 6, 10, 8, 5, 0, 0, time.UTC),
+	}
+}
+
+func TestPrintWorkloadJSON(t *testing.T) {
+	workload := makeTestWorkload("wl-1", "my-app", "running")
+
+	output := captureStdout(t, func() {
+		require.NoError(t, printWorkloadJSON(workload))
+	})
+
+	var parsed map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	assert.Equal(t, "wl-1", parsed["id"])
+	assert.Equal(t, "my-app", parsed["name"])
+	assert.Equal(t, "running", parsed["status"])
+	assert.Equal(t, "service", parsed["type"])
+	assert.Equal(t, "low", parsed["importance"])
+	assert.Equal(t, "art-1", parsed["artifactId"])
+	assert.Equal(t, "https://app.example.com/api/v2/endpoints/workloads/wl-1/", parsed["endpoint"])
+	assert.Equal(t, "2026-06-10T08:00:00Z", parsed["createdAt"])
+	assert.Equal(t, "2026-06-10T08:05:00Z", parsed["updatedAt"])
+	// The projection must not leak server-side extras.
+	assert.NotContains(t, parsed, "owners")
+	assert.NotContains(t, parsed, "permissions")
+}
+
+func TestPrintWorkloadsJSON(t *testing.T) {
+	workloads := []Workload{
+		makeTestWorkload("wl-1", "app-one", "running"),
+		makeTestWorkload("wl-2", "app-two", "errored"),
+	}
+
+	output := captureStdout(t, func() {
+		require.NoError(t, printWorkloadsJSON(workloads))
+	})
+
+	var parsed []map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	assert.Len(t, parsed, 2)
+	assert.Equal(t, "wl-1", parsed[0]["id"])
+	assert.Equal(t, "errored", parsed[1]["status"])
+}
+
+func TestPrintWorkloadsJSON_Empty(t *testing.T) {
+	output := captureStdout(t, func() {
+		require.NoError(t, printWorkloadsJSON(nil))
+	})
+
+	// A regression that emits `null` instead of a JSON array must fail here.
+	assert.JSONEq(t, `[]`, output)
+}
+
+func TestPrintWorkloadDetails(t *testing.T) {
+	workload := makeTestWorkload("wl-1", "my-app", "launching")
+
+	output := captureStdout(t, func() {
+		printWorkloadDetails(workload)
+	})
+
+	assert.Contains(t, output, "ID:")
+	assert.Contains(t, output, "wl-1")
+	assert.Contains(t, output, "Status:")
+	assert.Contains(t, output, "launching")
+	assert.Contains(t, output, "Endpoint:")
+	assert.Contains(t, output, "https://app.example.com/api/v2/endpoints/workloads/wl-1/")
+	assert.Contains(t, output, "Artifact ID:")
+	assert.Contains(t, output, "2026-06-10 08:00 UTC")
+
+	// Endpoint must come right after Status so repeated `workload get`
+	// polling reads naturally during the deploy loop.
+	statusIdx := strings.Index(output, "Status:")
+	endpointIdx := strings.Index(output, "Endpoint:")
+
+	require.GreaterOrEqual(t, statusIdx, 0)
+	assert.Greater(t, endpointIdx, statusIdx)
+}
+
+func TestPrintWorkloadDetails_EmptyEndpointPlaceholder(t *testing.T) {
+	workload := makeTestWorkload("wl-1", "my-app", "submitted")
+	workload.Endpoint = ""
+
+	output := captureStdout(t, func() {
+		printWorkloadDetails(workload)
+	})
+
+	assert.Contains(t, output, "—")
+}
+
+func TestPrintWorkloadsTable(t *testing.T) {
+	workloads := []Workload{
+		makeTestWorkload("wl-1", "app-one", "running"),
+		makeTestWorkload("wl-2", "app-two", "stopped"),
+	}
+
+	output := captureStdout(t, func() {
+		printWorkloadsTable(workloads)
+	})
+
+	assert.Contains(t, output, "WORKLOAD ID")
+	assert.Contains(t, output, "STATUS")
+	assert.Contains(t, output, "IMPORTANCE")
+	assert.Contains(t, output, "wl-1")
+	assert.Contains(t, output, "app-two")
+	assert.Contains(t, output, "running")
+	assert.Contains(t, output, "stopped")
+	assert.Contains(t, output, "2026-06-10 08:05 UTC")
+}
+
+func TestPrintWorkloadsTable_Empty(t *testing.T) {
+	output := captureStdout(t, func() {
+		printWorkloadsTable([]Workload{})
+	})
+
+	assert.Equal(t, "No workloads found.\n", output)
+}

--- a/internal/workload/spec.go
+++ b/internal/workload/spec.go
@@ -1,0 +1,56 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ReadSpecFile reads a workload or artifact spec from path and returns it as
+// a JSON payload. Valid JSON is passed through byte-for-byte; anything else
+// is parsed as YAML and converted, because the Workload API accepts only
+// JSON. Format is detected from the content, not the file extension.
+func ReadSpecFile(path string) (json.RawMessage, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("file not found: %s", path)
+		}
+
+		return nil, err
+	}
+
+	if json.Valid(data) {
+		return json.RawMessage(data), nil
+	}
+
+	var doc any
+
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("spec file %s is neither valid JSON nor valid YAML: %w", path, err)
+	}
+
+	converted, err := json.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert YAML spec %s to JSON: %w", path, err)
+	}
+
+	return json.RawMessage(converted), nil
+}

--- a/internal/workload/spec_test.go
+++ b/internal/workload/spec_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeSpec(t *testing.T, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// JSON specs must pass through byte-for-byte: the payload is the user's
+// document, not a re-serialization (key order, number formatting, and
+// whitespace all survive).
+func TestReadSpecFile_JSONPassthrough(t *testing.T) {
+	content := "{\n  \"name\": \"my-app\",\n  \"artifactId\": \"abc\",  \"replicas\": 1e2\n}"
+	path := writeSpec(t, "spec.json", content)
+
+	payload, err := ReadSpecFile(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, content, string(payload))
+}
+
+func TestReadSpecFile_YAMLConverted(t *testing.T) {
+	path := writeSpec(t, "spec.yaml", `
+name: agent-service
+importance: high
+artifact:
+  name: agent-service-artifact
+  type: service
+  spec:
+    containerGroups:
+      - name: default
+        containers:
+          - name: agent
+            imageUri: containous/whoami:latest
+            port: 8080
+            primary: true
+            environmentVars:
+              - name: LLM_API_KEY
+                required: true
+`)
+
+	payload, err := ReadSpecFile(path)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"name": "agent-service",
+		"importance": "high",
+		"artifact": {
+			"name": "agent-service-artifact",
+			"type": "service",
+			"spec": {
+				"containerGroups": [{
+					"name": "default",
+					"containers": [{
+						"name": "agent",
+						"imageUri": "containous/whoami:latest",
+						"port": 8080,
+						"primary": true,
+						"environmentVars": [{"name": "LLM_API_KEY", "required": true}]
+					}]
+				}]
+			}
+		}
+	}`, string(payload))
+}
+
+func TestReadSpecFile_InvalidBothFormats(t *testing.T) {
+	path := writeSpec(t, "spec.yaml", `{"name": [unclosed`)
+
+	_, err := ReadSpecFile(path)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "neither valid JSON nor valid YAML")
+}
+
+func TestReadSpecFile_FileNotFound(t *testing.T) {
+	_, err := ReadSpecFile(filepath.Join(t.TempDir(), "missing.yaml"))
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "file not found")
+}

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -229,6 +229,10 @@ type WorkloadList struct {
 const maxWorkloadPageSize = 100
 
 func ListWorkloads(limit int, statuses []string) ([]Workload, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("invalid limit %d: must be positive", limit)
+	}
+
 	query := url.Values{}
 	query.Set("limit", strconv.Itoa(min(limit, maxWorkloadPageSize)))
 

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -1,0 +1,283 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// Workload statuses as serialized by the server (lowercase StrEnum).
+const (
+	WorkloadStatusUnknown      = "unknown"
+	WorkloadStatusSubmitted    = "submitted"
+	WorkloadStatusProvisioning = "provisioning"
+	WorkloadStatusLaunching    = "launching"
+	WorkloadStatusRunning      = "running"
+	WorkloadStatusSuspended    = "suspended"
+	WorkloadStatusInterrupted  = "interrupted"
+	WorkloadStatusStopping     = "stopping"
+	WorkloadStatusStopped      = "stopped"
+	WorkloadStatusErrored      = "errored"
+	WorkloadStatusTerminated   = "terminated"
+)
+
+// workloadStatuses indexes every known status for flag validation.
+var workloadStatuses = map[string]struct{}{
+	WorkloadStatusUnknown:      {},
+	WorkloadStatusSubmitted:    {},
+	WorkloadStatusProvisioning: {},
+	WorkloadStatusLaunching:    {},
+	WorkloadStatusRunning:      {},
+	WorkloadStatusSuspended:    {},
+	WorkloadStatusInterrupted:  {},
+	WorkloadStatusStopping:     {},
+	WorkloadStatusStopped:      {},
+	WorkloadStatusErrored:      {},
+	WorkloadStatusTerminated:   {},
+}
+
+// ParseWorkloadStatuses lowercases and validates a list of --status values.
+func ParseWorkloadStatuses(values []string) ([]string, error) {
+	parsed := make([]string, 0, len(values))
+
+	for _, v := range values {
+		lower := strings.ToLower(strings.TrimSpace(v))
+		if lower == "" {
+			continue
+		}
+
+		if _, ok := workloadStatuses[lower]; !ok {
+			return nil, fmt.Errorf("invalid status %q: use one of %s", v, strings.Join(knownWorkloadStatuses(), ", "))
+		}
+
+		parsed = append(parsed, lower)
+	}
+
+	return parsed, nil
+}
+
+func knownWorkloadStatuses() []string {
+	// Stable, lifecycle-ordered listing for error messages and --help.
+	return []string{
+		WorkloadStatusSubmitted,
+		WorkloadStatusProvisioning,
+		WorkloadStatusLaunching,
+		WorkloadStatusRunning,
+		WorkloadStatusSuspended,
+		WorkloadStatusInterrupted,
+		WorkloadStatusStopping,
+		WorkloadStatusStopped,
+		WorkloadStatusErrored,
+		WorkloadStatusTerminated,
+		WorkloadStatusUnknown,
+	}
+}
+
+// Workload is the projection of the server's workload document the CLI
+// renders. Server-side extras (owners, permissions, creator, stats) are
+// deliberately not parsed so they cannot leak into scripted output.
+type Workload struct {
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	Status     string    `json:"status"`
+	Type       string    `json:"type"`
+	Importance string    `json:"importance"`
+	ArtifactID string    `json:"artifactId"`
+	Endpoint   string    `json:"endpoint"`
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+}
+
+// WorkloadOutput is the stable JSON shape emitted by --output-format json.
+type WorkloadOutput struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Type       string `json:"type"`
+	Importance string `json:"importance"`
+	ArtifactID string `json:"artifactId"`
+	Endpoint   string `json:"endpoint"`
+	CreatedAt  string `json:"createdAt"`
+	UpdatedAt  string `json:"updatedAt"`
+}
+
+func NewWorkloadOutput(w Workload) WorkloadOutput {
+	return WorkloadOutput{
+		ID:         w.ID,
+		Name:       w.Name,
+		Status:     w.Status,
+		Type:       w.Type,
+		Importance: w.Importance,
+		ArtifactID: w.ArtifactID,
+		Endpoint:   w.Endpoint,
+		CreatedAt:  w.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:  w.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+type workloadCreateRequest struct {
+	Name       string          `json:"name"`
+	ArtifactID string          `json:"artifactId"`
+	Artifact   json.RawMessage `json:"artifact"`
+}
+
+// ValidateWorkloadCreateRequest checks the structural invariants of a
+// user-supplied workload spec (required name, exactly one of artifactId or
+// inline artifact) and lets the server validate field-level shape. Unknown
+// fields are not rejected for the same reason as ValidateCreateRequest: the
+// server's 422 carries a JSON-path detail that's clearer than what
+// DisallowUnknownFields would produce. The original bytes are sent verbatim.
+func ValidateWorkloadCreateRequest(data []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+
+	var req workloadCreateRequest
+
+	if err := dec.Decode(&req); err != nil {
+		return fmt.Errorf("invalid spec: %w", err)
+	}
+
+	if req.Name == "" {
+		return errors.New("invalid spec: required field 'name' is missing or empty")
+	}
+
+	hasArtifactID := req.ArtifactID != ""
+	hasArtifact := len(req.Artifact) > 0 && string(req.Artifact) != "null"
+
+	if hasArtifactID == hasArtifact {
+		return errors.New("invalid spec: exactly one of 'artifactId' (existing artifact) or 'artifact' (inline definition) must be set")
+	}
+
+	return nil
+}
+
+// CreateWorkload POSTs payload to /api/v2/workloads/ and returns the parsed
+// workload. payload is typically a json.RawMessage from the spec file, sent
+// verbatim after ValidateWorkloadCreateRequest passed. The server replies
+// 201 with the full workload document inline; endpoint is present from
+// creation (it is a stable gateway URL, not a liveness signal).
+func CreateWorkload(payload any) (*Workload, error) {
+	url, err := config.GetEndpointURL("/api/v2/workloads/")
+	if err != nil {
+		return nil, err
+	}
+
+	var workload Workload
+
+	err = drapi.PostJSON(url, "workload", payload, &workload)
+	if err != nil {
+		return nil, err
+	}
+
+	return &workload, nil
+}
+
+// escapeID percent-encodes a user-supplied resource id so it always stays a
+// single URL path segment.
+func escapeID(id string) string {
+	return url.PathEscape(id)
+}
+
+func GetWorkload(workloadID string) (*Workload, error) {
+	url, err := config.GetEndpointURL("/api/v2/workloads/" + escapeID(workloadID) + "/")
+	if err != nil {
+		return nil, err
+	}
+
+	var workload Workload
+
+	err = drapi.GetJSON(url, "workload", &workload)
+	if err != nil {
+		return nil, err
+	}
+
+	return &workload, nil
+}
+
+type WorkloadList struct {
+	Data       []Workload `json:"data"`
+	Count      int        `json:"count"`
+	TotalCount int        `json:"totalCount"`
+	Next       string     `json:"next"`
+	Previous   string     `json:"previous"`
+}
+
+// maxWorkloadPageSize is the server-enforced ceiling on the list endpoint's
+// limit query param (1..100); larger values are rejected with a 422, so the
+// page size is clamped and larger totals are satisfied via next-links.
+const maxWorkloadPageSize = 100
+
+func ListWorkloads(limit int, statuses []string) ([]Workload, error) {
+	query := url.Values{}
+	query.Set("limit", strconv.Itoa(min(limit, maxWorkloadPageSize)))
+
+	for _, s := range statuses {
+		query.Add("status", s)
+	}
+
+	pageURL, err := drapi.EndpointURL("/workloads/", query)
+	if err != nil {
+		return nil, err
+	}
+
+	var all []Workload
+
+	for pageURL != "" {
+		var list WorkloadList
+
+		if err := drapi.GetJSON(pageURL, "workloads", &list); err != nil {
+			return nil, err
+		}
+
+		all = append(all, list.Data...)
+
+		if len(all) >= limit {
+			return all[:limit], nil
+		}
+
+		if list.Next == "" {
+			break
+		}
+
+		if err := drapi.AssertNextOnSameHost(list.Next); err != nil {
+			return nil, err
+		}
+
+		pageURL = list.Next
+	}
+
+	return all, nil
+}
+
+// DeleteWorkload deletes a workload. The server stops the backing proton(s)
+// first, so deleting a running workload is legal; on a proton-stop failure
+// it replies 502 with a "please retry" detail.
+func DeleteWorkload(workloadID string) error {
+	url, err := config.GetEndpointURL("/api/v2/workloads/" + escapeID(workloadID) + "/")
+	if err != nil {
+		return err
+	}
+
+	return drapi.DeleteJSON(url, "workload", nil, nil)
+}

--- a/internal/workload/workload_test.go
+++ b/internal/workload/workload_test.go
@@ -1,0 +1,413 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseWorkloadStatuses(t *testing.T) {
+	t.Run("valid values are lowercased and trimmed", func(t *testing.T) {
+		parsed, err := ParseWorkloadStatuses([]string{"Running", " stopped ", "ERRORED"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"running", "stopped", "errored"}, parsed)
+	})
+
+	t.Run("empty entries are skipped", func(t *testing.T) {
+		parsed, err := ParseWorkloadStatuses([]string{"", "running"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"running"}, parsed)
+	})
+
+	t.Run("unknown value errors", func(t *testing.T) {
+		_, err := ParseWorkloadStatuses([]string{"sleeping"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `invalid status "sleeping"`)
+		assert.Contains(t, err.Error(), WorkloadStatusRunning)
+	})
+}
+
+func TestValidateWorkloadCreateRequest(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    string
+		wantErr string
+	}{
+		{
+			name: "valid with artifactId",
+			spec: `{"name": "wl", "artifactId": "abc123", "runtime": {}}`,
+		},
+		{
+			name: "valid with inline artifact",
+			spec: `{"name": "wl", "artifact": {"name": "art", "type": "service", "spec": {}}}`,
+		},
+		{
+			name:    "missing name",
+			spec:    `{"artifactId": "abc123"}`,
+			wantErr: "required field 'name'",
+		},
+		{
+			name:    "neither artifactId nor artifact",
+			spec:    `{"name": "wl"}`,
+			wantErr: "exactly one of 'artifactId'",
+		},
+		{
+			name:    "both artifactId and artifact",
+			spec:    `{"name": "wl", "artifactId": "abc", "artifact": {"name": "art"}}`,
+			wantErr: "exactly one of 'artifactId'",
+		},
+		{
+			name: "null artifact counts as absent",
+			spec: `{"name": "wl", "artifactId": "abc", "artifact": null}`,
+		},
+		{
+			name:    "invalid JSON",
+			spec:    `{"name": `,
+			wantErr: "invalid spec",
+		},
+		{
+			name: "unknown fields pass through to the server",
+			spec: `{"name": "wl", "artifactId": "abc", "futureField": true}`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateWorkloadCreateRequest([]byte(c.spec))
+
+			if c.wantErr == "" {
+				assert.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), c.wantErr)
+		})
+	}
+}
+
+// serverWorkloadDoc is a realistic workload document including server-side
+// extras the projection must ignore (owners, permissions, runtime).
+func serverWorkloadDoc(id, name, status string) string {
+	return fmt.Sprintf(`{
+		"id": %q,
+		"name": %q,
+		"status": %q,
+		"type": "service",
+		"importance": "low",
+		"artifactId": "art-1",
+		"endpoint": "https://app.example.com/api/v2/endpoints/workloads/%s/",
+		"createdAt": "2026-06-10T08:00:00Z",
+		"updatedAt": "2026-06-10T08:05:00Z",
+		"owners": [{"id": "u-1", "email": "pii@example.com"}],
+		"permissions": ["CAN_DELETE"],
+		"runtime": {"containerGroups": []}
+	}`, id, name, status, id)
+}
+
+func assertProjection(t *testing.T, w *Workload, id, name, status string) {
+	t.Helper()
+
+	assert.Equal(t, id, w.ID)
+	assert.Equal(t, name, w.Name)
+	assert.Equal(t, status, w.Status)
+	assert.Equal(t, "service", w.Type)
+	assert.Equal(t, "low", w.Importance)
+	assert.Equal(t, "art-1", w.ArtifactID)
+	assert.Equal(t, "https://app.example.com/api/v2/endpoints/workloads/"+id+"/", w.Endpoint)
+	assert.Equal(t, time.Date(2026, 6, 10, 8, 0, 0, 0, time.UTC), w.CreatedAt.UTC())
+}
+
+func TestCreateWorkload_PostsSpecVerbatimAndParses201(t *testing.T) {
+	installSkipAuth(t)
+
+	spec := []byte(`{"name": "wl-1", "artifactId": "art-1", "futureField": {"passes": true}}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v2/workloads/", r.URL.Path)
+
+		// assert (not require) inside the handler: require calls t.FailNow,
+		// which is illegal off the test goroutine (testifylint go-require).
+		body, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		// The spec file bytes are sent verbatim, unknown fields included.
+		assert.JSONEq(t, string(spec), string(body))
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, serverWorkloadDoc("wl-id-1", "wl-1", "submitted"))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	workload, err := CreateWorkload(json.RawMessage(spec))
+	require.NoError(t, err)
+	assertProjection(t, workload, "wl-id-1", "wl-1", "submitted")
+}
+
+func TestCreateWorkload_422SurfacesServerDetail(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprint(w, `{"detail":[{"path":"artifactId","message":"Artifact not found","code":"invalid"}]}`)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := CreateWorkload(json.RawMessage(`{"name":"wl","artifactId":"missing"}`))
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusUnprocessableEntity, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "Artifact not found")
+}
+
+func TestGetWorkload_Success(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v2/workloads/wl-id-1/", r.URL.Path)
+		fmt.Fprint(w, serverWorkloadDoc("wl-id-1", "wl-1", "running"))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	workload, err := GetWorkload("wl-id-1")
+	require.NoError(t, err)
+	assertProjection(t, workload, "wl-id-1", "wl-1", "running")
+}
+
+func TestGetWorkload_EscapesIDInPath(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// '?' must arrive escaped inside the path segment, never as a query.
+		assert.Equal(t, "/api/v2/workloads/wl-1%3Fforce=true/", r.URL.EscapedPath())
+		assert.Empty(t, r.URL.RawQuery)
+		fmt.Fprint(w, serverWorkloadDoc("wl-id-1", "wl-1", "running"))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := GetWorkload("wl-1?force=true")
+	require.NoError(t, err)
+}
+
+func TestGetWorkload_404PropagatesAsHTTPError(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := GetWorkload("missing")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+}
+
+func workloadListPage(next string, docs ...string) string {
+	nextJSON := "null"
+	if next != "" {
+		nextJSON = fmt.Sprintf("%q", next)
+	}
+
+	return fmt.Sprintf(
+		`{"data": [%s], "count": %d, "totalCount": %d, "next": %s, "previous": null}`,
+		joinDocs(docs), len(docs), len(docs), nextJSON,
+	)
+}
+
+func joinDocs(docs []string) string {
+	return strings.Join(docs, ",")
+}
+
+func TestListWorkloads_SinglePageWithStatusFilter(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/workloads/", r.URL.Path)
+		assert.Equal(t, "25", r.URL.Query().Get("limit"))
+		assert.Equal(t, []string{"running", "errored"}, r.URL.Query()["status"])
+		fmt.Fprint(w, workloadListPage("", serverWorkloadDoc("wl-1", "a", "running")))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	workloads, err := ListWorkloads(25, []string{"running", "errored"})
+	require.NoError(t, err)
+	require.Len(t, workloads, 1)
+	assert.Equal(t, "wl-1", workloads[0].ID)
+}
+
+func TestListWorkloads_ClampsPageSizeToServerMax(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The server rejects limit > 100 with a 422, so the page size must
+		// be clamped even when --limit asks for more.
+		assert.Equal(t, "100", r.URL.Query().Get("limit"))
+		fmt.Fprint(w, workloadListPage("", serverWorkloadDoc("wl-1", "a", "running")))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := ListWorkloads(250, nil)
+	require.NoError(t, err)
+}
+
+func TestListWorkloads_FollowsNextAndTruncatesToLimit(t *testing.T) {
+	installSkipAuth(t)
+
+	var srvURL string
+
+	calls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+
+		switch calls {
+		case 1:
+			next := srvURL + "/api/v2/workloads/?offset=2&limit=3"
+			fmt.Fprint(w, workloadListPage(next,
+				serverWorkloadDoc("wl-1", "a", "running"),
+				serverWorkloadDoc("wl-2", "b", "running"),
+			))
+		default:
+			fmt.Fprint(w, workloadListPage("",
+				serverWorkloadDoc("wl-3", "c", "running"),
+				serverWorkloadDoc("wl-4", "d", "running"),
+			))
+		}
+	}))
+
+	defer srv.Close()
+
+	srvURL = srv.URL
+
+	installEndpoint(t, srv.URL)
+
+	workloads, err := ListWorkloads(3, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+	require.Len(t, workloads, 3)
+	assert.Equal(t, "wl-3", workloads[2].ID)
+}
+
+func TestDeleteWorkload_Success(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/api/v2/workloads/wl-1/", r.URL.Path)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	require.NoError(t, DeleteWorkload("wl-1"))
+}
+
+func TestDeleteWorkload_EscapesIDInPath(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// '/' must arrive as %2F so a traversal-looking id stays one segment.
+		assert.Equal(t, "/api/v2/workloads/..%2Fother/", r.URL.EscapedPath())
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	require.NoError(t, DeleteWorkload("../other"))
+}
+
+func TestDeleteWorkload_404PropagatesAsHTTPError(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	err := DeleteWorkload("wl-1")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+}
+
+func TestNewWorkloadOutput_FormatsTimestampsRFC3339(t *testing.T) {
+	w := Workload{
+		ID:         "wl-1",
+		Name:       "a",
+		Status:     "running",
+		Type:       "service",
+		Importance: "low",
+		ArtifactID: "art-1",
+		Endpoint:   "https://e/",
+		CreatedAt:  time.Date(2026, 6, 10, 8, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 6, 10, 8, 5, 0, 0, time.UTC),
+	}
+
+	out := NewWorkloadOutput(w)
+	assert.Equal(t, "2026-06-10T08:00:00Z", out.CreatedAt)
+	assert.Equal(t, "2026-06-10T08:05:00Z", out.UpdatedAt)
+	assert.Equal(t, "https://e/", out.Endpoint)
+}

--- a/internal/workload/workload_test.go
+++ b/internal/workload/workload_test.go
@@ -341,6 +341,14 @@ func TestListWorkloads_FollowsNextAndTruncatesToLimit(t *testing.T) {
 	assert.Equal(t, "wl-3", workloads[2].ID)
 }
 
+func TestListWorkloads_RejectsNonPositiveLimit(t *testing.T) {
+	for _, limit := range []int{0, -1} {
+		_, err := ListWorkloads(limit, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be positive")
+	}
+}
+
 func TestDeleteWorkload_Success(t *testing.T) {
 	installSkipAuth(t)
 


### PR DESCRIPTION
# RATIONALE

This completes the workload-resource leg of the `dr workload` tree. The build commands landed in #559, so users can produce artifacts but cannot yet deploy, inspect, or remove the workloads themselves from the CLI - this PR closes that loop. The workload is the plugin's primary resource, so its verbs sit at the root (`dr workload create|get|list|delete`) while `artifact`/`build`/`code` keep their noun sub-groups. Everything remains behind the `DATAROBOT_CLI_FEATURE_WORKLOAD` gate.

## CHANGES

- `dr workload create --spec-file FILE`: accepts JSON (sent byte-for-byte) or YAML (converted client-side; the API is JSON-only), POSTed after structural validation (required `name`, `artifactId` XOR inline `artifact`). Both deploy flows - existing artifact and one-shot inline draft - use the same command. `dr workload artifact create` gains the same YAML support via the shared `internal/workload.ReadSpecFile`.
- `dr workload get` / `dr workload list`: list clamps the page size to the server max (100), paginates via next links, and takes a repeatable, validated `--status` filter.
- `dr workload delete` / `dr workload artifact delete`: confirm unless `--yes`/`-y` or `DATAROBOT_CLI_NON_INTERACTIVE`; friendly 404 no-op; non-TTY stdin without `--yes` fails fast before any network call.
- `internal/drapi/delete.go`: error path now uses `ErrFromResp` (as Post does) so delete failures keep the server detail (artifact 409 names the blocking workloads, workload 502 carries the retry hint).
- Review-pass hardening: user-supplied IDs in `internal/workload` URLs are percent-encoded via a shared `escapeID` helper (9 call sites, with regression tests), create help text now describes the actual JSON-verbatim/YAML-conversion behavior, delete tests isolate `DATAROBOT_CLI_NON_INTERACTIVE` so an ambient value cannot fire a real DELETE, and the empty-list JSON test pins exact `[]` output.

## TESTING

`task lint`: 0 issues. `task test` (race + shuffle + coverage): green; if your local `.env` enables the workload gate, run `DATAROBOT_CLI_FEATURE_WORKLOAD=false task test` or the root feature-gate test fails by design. Manual: create with JSON and YAML specs, get/list/delete round-trip, all delete confirmation paths.

## NOTES

Follow-ups intentionally not here: `viperx.GetBool("yes")` truthy-set/config-fallback quirks are shared with `dependencies install`, `start`, and `dotenv` and should be fixed globally; `tui.RunWithSpinner`'s Ctrl-C and piped-stdout behavior is a pre-existing repo-wide pattern.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces deploy and destructive delete paths against live workloads/APIs; mitigated by confirmation gates, feature flag, ID escaping, and broad tests, but mistakes can stop or remove running deployments.
> 
> **Overview**
> Adds **root-level workload lifecycle commands** (`dr workload create|get|list|delete`) and **`dr workload artifact delete`**, wired into the workload command tree with telemetry coverage for the new verbs.
> 
> **Create flows** read a `--spec-file` via shared `internal/workload.ReadSpecFile` (JSON sent byte-for-byte; YAML converted to JSON). Workload create validates `name` plus exactly one of `artifactId` or inline `artifact`; artifact create now uses the same reader and documents YAML support.
> 
> **Get/list** call new workload API helpers with table/JSON rendering, list pagination (limit clamped to 100), and validated repeatable `--status` filters.
> 
> **Deletes** require confirmation unless `--yes` or `DATAROBOT_CLI_NON_INTERACTIVE`; non-TTY fails before DELETE. **404** is treated as a friendly no-op for deletes. **`drapi` DELETE failures** now use `ErrFromResp` so 409/502 bodies (blocking workloads, retry hints) surface to users. User-supplied IDs are **path-escaped** via `escapeID` across artifact/build/workload URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e45dd02fc453b9063fc515282cc15cfa70c43507. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->