### PR TITLE
[RAPTOR-17799] fix(workload): drop the spinner from workload commands

### DIFF
--- a/cmd/workload/artifact/create/cmd.go
+++ b/cmd/workload/artifact/create/cmd.go
@@ -18,7 +18,6 @@ import (
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
-	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -100,15 +99,8 @@ Example:
 				return err
 			}
 
-			var artifact *workload.Artifact
-
-			if err := tui.RunWithSpinner("Creating artifact…", func() error {
-				var createErr error
-
-				artifact, createErr = workload.CreateArtifact(payload)
-
-				return createErr
-			}); err != nil {
+			artifact, err := workload.CreateArtifact(payload)
+			if err != nil {
 				return err
 			}
 

--- a/cmd/workload/artifact/get/cmd.go
+++ b/cmd/workload/artifact/get/cmd.go
@@ -18,7 +18,6 @@ import (
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
-	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -43,15 +42,8 @@ Example:
 		Args:    cobra.ExactArgs(1),
 		PreRunE: auth.EnsureAuthenticatedE,
 		RunE: func(_ *cobra.Command, args []string) error {
-			var artifact *workload.Artifact
-
-			if err := tui.RunWithSpinner("Fetching artifact…", func() error {
-				var getErr error
-
-				artifact, getErr = workload.GetArtifact(args[0])
-
-				return getErr
-			}); err != nil {
+			artifact, err := workload.GetArtifact(args[0])
+			if err != nil {
 				return err
 			}
 

--- a/cmd/workload/artifact/list/cmd.go
+++ b/cmd/workload/artifact/list/cmd.go
@@ -20,7 +20,6 @@ import (
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
-	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -55,15 +54,8 @@ Example:
 				return fmt.Errorf("invalid --limit %d: must be positive", limit)
 			}
 
-			var artifacts []workload.Artifact
-
-			if err := tui.RunWithSpinner("Fetching artifacts…", func() error {
-				var listErr error
-
-				artifacts, listErr = workload.ListArtifacts(limit, status)
-
-				return listErr
-			}); err != nil {
+			artifacts, err := workload.ListArtifacts(limit, status)
+			if err != nil {
 				return err
 			}
 

--- a/cmd/workload/code/checkout/checkout.go
+++ b/cmd/workload/code/checkout/checkout.go
@@ -32,7 +32,6 @@ import (
 	"github.com/datarobot/cli/internal/workload/fileops"
 	"github.com/datarobot/cli/internal/workload/sync"
 	"github.com/datarobot/cli/internal/workload/wapi"
-	"github.com/datarobot/cli/tui"
 )
 
 const (
@@ -77,10 +76,11 @@ func runDownload(out io.Writer, format workload.OutputFormat, dir, verArg string
 		return err
 	}
 
-	if err := tui.RunWithSpinner(
-		fmt.Sprintf("Downloading %d file(s)…", len(files)),
-		func() error { return stageAndInstall(deps.Files, pre, parent, files, totalSize, startedAt) },
-	); err != nil {
+	// Progress goes to stderr (same as `build trigger`) so stdout stays
+	// reserved for the result document.
+	fmt.Fprintf(os.Stderr, "Downloading %d file(s)…\n", len(files))
+
+	if err := stageAndInstall(deps.Files, pre, parent, files, totalSize, startedAt); err != nil {
 		return err
 	}
 

--- a/cmd/workload/create/cmd.go
+++ b/cmd/workload/create/cmd.go
@@ -18,7 +18,6 @@ import (
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
-	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -104,15 +103,8 @@ Example:
 				return err
 			}
 
-			var wl *workload.Workload
-
-			if err := tui.RunWithSpinner("Creating workload…", func() error {
-				var createErr error
-
-				wl, createErr = workload.CreateWorkload(payload)
-
-				return createErr
-			}); err != nil {
+			wl, err := workload.CreateWorkload(payload)
+			if err != nil {
 				return err
 			}
 

--- a/cmd/workload/get/cmd.go
+++ b/cmd/workload/get/cmd.go
@@ -18,7 +18,6 @@ import (
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
-	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -48,15 +47,8 @@ Example:
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			var wl *workload.Workload
-
-			if err := tui.RunWithSpinner("Fetching workload…", func() error {
-				var getErr error
-
-				wl, getErr = workload.GetWorkload(args[0])
-
-				return getErr
-			}); err != nil {
+			wl, err := workload.GetWorkload(args[0])
+			if err != nil {
 				return err
 			}
 

--- a/cmd/workload/list/cmd.go
+++ b/cmd/workload/list/cmd.go
@@ -21,7 +21,6 @@ import (
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
-	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -64,15 +63,8 @@ Example:
 				return err
 			}
 
-			var workloads []workload.Workload
-
-			if err := tui.RunWithSpinner("Fetching workloads…", func() error {
-				var listErr error
-
-				workloads, listErr = workload.ListWorkloads(limit, parsedStatuses)
-
-				return listErr
-			}); err != nil {
+			workloads, err := workload.ListWorkloads(limit, parsedStatuses)
+			if err != nil {
 				return err
 			}
 


### PR DESCRIPTION
# RATIONALE

`dr workload artifact create --output-format json | tee artifact.json` writes spinner frames and ANSI bytes into the captured file. `tui.RunWithSpinner` gates on stdin being a terminal but renders to stdout, so any pipe or command substitution with an interactive stdin captures the animation along with the data. Regression window opened with the spinner itself (CFX-6220, #525); #564's NOTES already flagged this pattern as a known repo-wide issue, now tracked as RAPTOR-17799.

The workload tree is where stdout is a machine contract (`--output-format json`, bare-value outputs), so this fixes it there by removing spinner usage outright instead of changing the shared tui component that auth/plugin commands also use: the wrapped calls are sub-second API round-trips that don't need progress UI.

## CHANGES

- Unwrap `tui.RunWithSpinner` to plain calls in: `workload artifact create/get/list`, `workload create/get/list` (6 files, mechanical).
- `workload code checkout` (the one genuinely slow operation, file downloads) keeps feedback as a plain `Downloading N file(s)…` line on stderr, following the `build trigger` precedent.

## TESTING

`task lint`: 0 issues; workload command and package tests green. With no spinner in the path, piped/captured stdout cannot receive animation bytes by construction; `| tee`, `| jq`, and `$( )` flows verified manually.

## NOTES

- `auth login` and `plugin install/update` still use the spinner. Their stdout is human text (no JSON contracts), so the corruption is cosmetic there, but RAPTOR-17799 stays open for the shared component, including its separate Ctrl-C defect (interrupt returns nil while result pointers are unfilled). A verified tui-level fix (render to stderr + ErrInterrupted) exists on a parked branch if the team prefers fixing the component.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared CLI progress helper behavior changes (TTY gating and interrupt errors) affect every command still using RunWithSpinner, though stdout capture and interrupt handling are intentional fixes.
> 
> **Overview**
> **`RunWithSpinner`** now keeps **stdout clean for piping** by rendering Bubble Tea output to **stderr** and only enabling the animated spinner when **both** stdin and stderr are TTYs (via new **`reader.IsStderrTerminal`**).
> 
> **Ctrl-C during a running spinner** no longer surfaces as success: **`ErrInterrupted`** is returned when the model quits before work finishes, using **`spinnerInterrupted`** (including wrapped **`InterruptibleModel`**). Tests cover stderr-terminal gating and interrupt detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7143601569c7edbad74779d6671c1d4aaa82c1b3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->