### PR TITLE
[RAPTOR-17792] feat(workload): add dr workload start/stop/status commands

### DIFF
--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -88,6 +88,9 @@ var expectedWorkloadTrackedCommands = []string{
 	"workload get",
 	"workload list",
 	"workload delete",
+	"workload start",
+	"workload stop",
+	"workload status",
 }
 
 // TestTelemetryWiring_AllWorkloadCommandsTracked walks the workload

--- a/cmd/workload/build/get/cmd.go
+++ b/cmd/workload/build/get/cmd.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/cmd/workload/build/internal/buildargs"
-	"github.com/datarobot/cli/cmd/workload/build/internal/pollflags"
+	"github.com/datarobot/cli/cmd/workload/internal/pollflags"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"

--- a/cmd/workload/build/trigger/cmd.go
+++ b/cmd/workload/build/trigger/cmd.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/cmd/workload/build/internal/buildargs"
-	"github.com/datarobot/cli/cmd/workload/build/internal/pollflags"
+	"github.com/datarobot/cli/cmd/workload/internal/pollflags"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"

--- a/cmd/workload/cmd.go
+++ b/cmd/workload/cmd.go
@@ -22,6 +22,9 @@ import (
 	"github.com/datarobot/cli/cmd/workload/del"
 	"github.com/datarobot/cli/cmd/workload/get"
 	"github.com/datarobot/cli/cmd/workload/list"
+	"github.com/datarobot/cli/cmd/workload/start"
+	"github.com/datarobot/cli/cmd/workload/status"
+	"github.com/datarobot/cli/cmd/workload/stop"
 	"github.com/datarobot/cli/internal/features"
 	"github.com/spf13/cobra"
 )
@@ -46,6 +49,9 @@ Manage and monitor workloads in your deployment infrastructure.`,
 		del.Cmd(),
 		get.Cmd(),
 		list.Cmd(),
+		start.Cmd(),
+		status.Cmd(),
+		stop.Cmd(),
 		// Sub-resources keep their noun groups.
 		artifact.Cmd(),
 		build.Cmd(),

--- a/cmd/workload/internal/pollflags/pollflags.go
+++ b/cmd/workload/internal/pollflags/pollflags.go
@@ -15,8 +15,9 @@
 // Package pollflags centralizes the --wait, --poll-interval, and
 // --poll-timeout flags shared between the polling workload commands
 // (`dr workload build trigger`, `dr workload build get`, and
-// `dr workload status`). Single source of truth so the commands cannot
-// drift out of sync on defaults or names.
+// `dr workload status`). Single source of truth for the flag names and
+// registration so the commands cannot drift out of sync; poll defaults
+// and the --wait help text vary per command via RegisterWithDefaults.
 
 package pollflags
 
@@ -26,6 +27,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Build-oriented defaults: container image builds are slow, so callers that
+// do not pass their own defaults poll every couple of seconds for up to half
+// an hour. Commands whose work settles faster pass tighter values via
+// RegisterWithDefaults.
 const (
 	DefaultPollInterval = 2 * time.Second
 	DefaultPollTimeout  = 30 * time.Minute
@@ -41,11 +46,22 @@ type Set struct {
 }
 
 // Register adds --wait, --poll-interval (hidden), and --poll-timeout
-// (hidden) to cmd, binding them into s. Returns s for chaining.
+// (hidden) to cmd with the build-oriented defaults and --wait help text,
+// binding them into s. Returns s for chaining.
 func Register(cmd *cobra.Command, s *Set) *Set {
-	cmd.Flags().BoolVar(&s.Wait, "wait", false, "Poll until a terminal status is reached.")
-	cmd.Flags().DurationVar(&s.Interval, "poll-interval", DefaultPollInterval, "Interval between status polls.")
-	cmd.Flags().DurationVar(&s.Timeout, "poll-timeout", DefaultPollTimeout, "Maximum time to wait before giving up.")
+	return RegisterWithDefaults(cmd, s, DefaultPollInterval, DefaultPollTimeout,
+		"Poll until the build reaches a terminal status.")
+}
+
+// RegisterWithDefaults is Register with caller-chosen interval and timeout
+// defaults plus the --wait help text, for commands whose work settles on a
+// different timescale or vocabulary than a container build (e.g.
+// `dr workload status --wait` settles in minutes, and on steady states
+// like running that are not terminal).
+func RegisterWithDefaults(cmd *cobra.Command, s *Set, interval, timeout time.Duration, waitUsage string) *Set {
+	cmd.Flags().BoolVar(&s.Wait, "wait", false, waitUsage)
+	cmd.Flags().DurationVar(&s.Interval, "poll-interval", interval, "Interval between status polls.")
+	cmd.Flags().DurationVar(&s.Timeout, "poll-timeout", timeout, "Maximum time to wait before giving up.")
 	_ = cmd.Flags().MarkHidden("poll-interval")
 	_ = cmd.Flags().MarkHidden("poll-timeout")
 

--- a/cmd/workload/internal/pollflags/pollflags.go
+++ b/cmd/workload/internal/pollflags/pollflags.go
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 // Package pollflags centralizes the --wait, --poll-interval, and
-// --poll-timeout flags shared between `dr workload build trigger` and
-// `dr workload build get`. Single source of truth so the two commands
-// cannot drift out of sync on defaults or names.
+// --poll-timeout flags shared between the polling workload commands
+// (`dr workload build trigger`, `dr workload build get`, and
+// `dr workload status`). Single source of truth so the commands cannot
+// drift out of sync on defaults or names.
 
 package pollflags
 
@@ -42,7 +43,7 @@ type Set struct {
 // Register adds --wait, --poll-interval (hidden), and --poll-timeout
 // (hidden) to cmd, binding them into s. Returns s for chaining.
 func Register(cmd *cobra.Command, s *Set) *Set {
-	cmd.Flags().BoolVar(&s.Wait, "wait", false, "Poll until the build reaches a terminal status.")
+	cmd.Flags().BoolVar(&s.Wait, "wait", false, "Poll until a terminal status is reached.")
 	cmd.Flags().DurationVar(&s.Interval, "poll-interval", DefaultPollInterval, "Interval between status polls.")
 	cmd.Flags().DurationVar(&s.Timeout, "poll-timeout", DefaultPollTimeout, "Maximum time to wait before giving up.")
 	_ = cmd.Flags().MarkHidden("poll-interval")

--- a/cmd/workload/start/cmd.go
+++ b/cmd/workload/start/cmd.go
@@ -1,0 +1,85 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package start
+
+import (
+	"fmt"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat workload.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:   "start <workload-id>",
+		Short: "Start a stopped workload.",
+		Long: `Start a stopped workload.
+
+The start is asynchronous: the server acknowledges the request and the
+workload transitions submitted → provisioning → launching → running in
+the background. Starting a workload that is already running, still
+initializing, or suspended is a no-op; the server's response message
+says so. A workload that is still stopping must finish first (the
+server replies with a conflict), and the request is rejected when it
+would exceed your concurrent workload limits.
+
+The acknowledgement message is printed on stdout. Use
+'dr workload status <workload-id> --wait' to block until the workload
+has settled.
+
+By default, output is human-readable. Use --output-format json for the
+full acknowledgement document.
+
+Example:
+  dr workload start 68b0c1d2e3f4a5b6c7d8e9f0
+  dr workload start 68b0c1d2e3f4a5b6c7d8e9f0 --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resp, err := workload.StartWorkload(args[0])
+			if err != nil {
+				return err
+			}
+
+			if err := workload.RenderWorkloadOperation(outputFormat, *resp); err != nil {
+				return err
+			}
+
+			// The follow-up hint goes to stderr so script captures of stdout
+			// stay limited to the server's acknowledgement message.
+			if outputFormat == workload.OutputFormatText {
+				fmt.Fprintln(cmd.ErrOrStderr(), "Track progress with: dr workload status "+args[0]+" --wait")
+			}
+
+			return nil
+		},
+	}
+
+	workload.AddOutputFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"workload_id":   telemetry.FirstArg(args),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/workload/start/cmd_test.go
+++ b/cmd/workload/start/cmd_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package start
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestCmd_InvalidOutputFormat(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"68b0c1d2e3f4a5b6c7d8e9f0", "--output-format", "yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid output format "yaml"`)
+}

--- a/cmd/workload/status/cmd.go
+++ b/cmd/workload/status/cmd.go
@@ -1,0 +1,120 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"fmt"
+
+	"github.com/datarobot/cli/cmd/workload/internal/pollflags"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat workload.OutputFormat
+
+	var poll pollflags.Set
+
+	cmd := &cobra.Command{
+		Use:   "status <workload-id>",
+		Short: "Show a workload's status.",
+		Long: `Show a workload's current status.
+
+Without --wait the status is fetched once and printed as a bare value
+(submitted, provisioning, launching, running, suspended, interrupted,
+stopping, stopped, errored, terminated, or unknown), making the command
+directly usable in scripts. Use 'dr workload get' for the full document.
+
+With --wait the command polls until the workload settles, i.e. leaves
+the in-flight states (submitted, provisioning, launching, stopping).
+Status transitions are reported on stderr while polling; the final
+status is printed on stdout once settled. The command exits non-zero
+when the workload settles on "errored" or the poll times out.
+
+JSON output emits one {"id", "status"} document, after settling when
+--wait is given.
+
+Example:
+  dr workload status 68b0c1d2e3f4a5b6c7d8e9f0
+  dr workload status 68b0c1d2e3f4a5b6c7d8e9f0 --wait
+  dr workload status 68b0c1d2e3f4a5b6c7d8e9f0 --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatus(cmd, args[0], outputFormat, poll)
+		},
+	}
+
+	workload.AddOutputFlag(cmd, &outputFormat)
+	pollflags.Register(cmd, &poll)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"workload_id":   telemetry.FirstArg(args),
+			"wait":          poll.Wait,
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}
+
+func runStatus(
+	cmd *cobra.Command,
+	workloadID string,
+	outputFormat workload.OutputFormat,
+	poll pollflags.Set,
+) error {
+	if !poll.Wait {
+		wl, err := workload.GetWorkload(workloadID)
+		if err != nil {
+			return err
+		}
+
+		// Printing an errored status is a correct answer, not a command
+		// failure; only --wait turns an errored settle into a non-zero exit.
+		return workload.RenderWorkloadStatus(outputFormat, *wl)
+	}
+
+	// All polling progress goes to stderr so stdout stays a single
+	// capturable status value.
+	fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for workload %s to settle...\n", workloadID)
+
+	var lastStatus string
+
+	wl, waitErr := workload.WaitForWorkloadStatus(workloadID, poll.Interval, poll.Timeout,
+		func(w *workload.Workload) {
+			if w.Status != lastStatus {
+				fmt.Fprintf(cmd.ErrOrStderr(), "  status: %s\n", w.Status)
+
+				lastStatus = w.Status
+			}
+		})
+
+	if wl == nil {
+		return waitErr
+	}
+
+	if err := workload.RenderWorkloadStatus(outputFormat, *wl); err != nil {
+		return err
+	}
+
+	// The settled status was already rendered; an errored settle or poll
+	// timeout still fails the command for script callers.
+	return waitErr
+}

--- a/cmd/workload/status/cmd.go
+++ b/cmd/workload/status/cmd.go
@@ -16,12 +16,21 @@ package status
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/datarobot/cli/cmd/workload/internal/pollflags"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/spf13/cobra"
+)
+
+const (
+	// A workload settles in minutes (or fails to), so status polls less
+	// often and gives up far sooner than the build commands' defaults,
+	// which are sized for slow container builds.
+	statusPollInterval = 5 * time.Second
+	statusPollTimeout  = 5 * time.Minute
 )
 
 func Cmd() *cobra.Command {
@@ -61,7 +70,8 @@ Example:
 	}
 
 	workload.AddOutputFlag(cmd, &outputFormat)
-	pollflags.Register(cmd, &poll)
+	pollflags.RegisterWithDefaults(cmd, &poll, statusPollInterval, statusPollTimeout,
+		"Poll until the workload settles.")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
@@ -110,11 +120,16 @@ func runStatus(
 		return waitErr
 	}
 
-	if err := workload.RenderWorkloadStatus(outputFormat, *wl); err != nil {
-		return err
+	// Only a settled status is rendered: a poll timeout hands back the last
+	// in-flight workload, and printing that on stdout would give script
+	// captures a non-final value that looks like a final one.
+	if workload.IsSettledWorkloadStatus(wl.Status) {
+		if err := workload.RenderWorkloadStatus(outputFormat, *wl); err != nil {
+			return err
+		}
 	}
 
-	// The settled status was already rendered; an errored settle or poll
-	// timeout still fails the command for script callers.
+	// An errored settle or poll timeout still fails the command for script
+	// callers.
 	return waitErr
 }

--- a/cmd/workload/status/cmd_test.go
+++ b/cmd/workload/status/cmd_test.go
@@ -64,3 +64,15 @@ func TestCmd_HidesPollFlags(t *testing.T) {
 	assert.True(t, pollIntervalFlag.Hidden)
 	assert.True(t, pollTimeoutFlag.Hidden)
 }
+
+func TestCmd_UsesStatusPollDefaults(t *testing.T) {
+	cmd := Cmd()
+
+	// Status settles in minutes, so it polls less often and times out far
+	// sooner than the build commands' 2s/30m defaults.
+	interval, _ := cmd.Flags().GetDuration("poll-interval")
+	timeout, _ := cmd.Flags().GetDuration("poll-timeout")
+
+	assert.Equal(t, statusPollInterval, interval)
+	assert.Equal(t, statusPollTimeout, timeout)
+}

--- a/cmd/workload/status/cmd_test.go
+++ b/cmd/workload/status/cmd_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestCmd_InvalidOutputFormat(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"68b0c1d2e3f4a5b6c7d8e9f0", "--output-format", "yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid output format "yaml"`)
+}
+
+func TestCmd_ParsesPollFlags(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+
+	require.NoError(t, cmd.ParseFlags([]string{"--wait", "--poll-interval", "100ms", "--poll-timeout", "30s"}))
+
+	wait, _ := cmd.Flags().GetBool("wait")
+	interval, _ := cmd.Flags().GetDuration("poll-interval")
+	timeout, _ := cmd.Flags().GetDuration("poll-timeout")
+
+	assert.True(t, wait)
+	assert.Equal(t, "100ms", interval.String())
+	assert.Equal(t, "30s", timeout.String())
+}
+
+func TestCmd_HidesPollFlags(t *testing.T) {
+	cmd := Cmd()
+	pollIntervalFlag := cmd.Flag("poll-interval")
+	pollTimeoutFlag := cmd.Flag("poll-timeout")
+
+	require.NotNil(t, pollIntervalFlag)
+	require.NotNil(t, pollTimeoutFlag)
+	assert.True(t, pollIntervalFlag.Hidden)
+	assert.True(t, pollTimeoutFlag.Hidden)
+}

--- a/cmd/workload/stop/cmd.go
+++ b/cmd/workload/stop/cmd.go
@@ -1,0 +1,83 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stop
+
+import (
+	"fmt"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat workload.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:   "stop <workload-id>",
+		Short: "Stop a workload.",
+		Long: `Stop a workload.
+
+The stop is asynchronous: the server acknowledges the request and the
+workload transitions stopping → stopped in the background. Stopping an
+already-stopped workload is a no-op; the server's response message says
+so. The workload is not deleted and can be brought back with
+'dr workload start <workload-id>'.
+
+The acknowledgement message is printed on stdout. Use
+'dr workload status <workload-id> --wait' to block until the workload
+has settled.
+
+By default, output is human-readable. Use --output-format json for the
+full acknowledgement document.
+
+Example:
+  dr workload stop 68b0c1d2e3f4a5b6c7d8e9f0
+  dr workload stop 68b0c1d2e3f4a5b6c7d8e9f0 --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resp, err := workload.StopWorkload(args[0])
+			if err != nil {
+				return err
+			}
+
+			if err := workload.RenderWorkloadOperation(outputFormat, *resp); err != nil {
+				return err
+			}
+
+			// The follow-up hint goes to stderr so script captures of stdout
+			// stay limited to the server's acknowledgement message.
+			if outputFormat == workload.OutputFormatText {
+				fmt.Fprintln(cmd.ErrOrStderr(), "Track progress with: dr workload status "+args[0]+" --wait")
+			}
+
+			return nil
+		},
+	}
+
+	workload.AddOutputFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"workload_id":   telemetry.FirstArg(args),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/workload/stop/cmd_test.go
+++ b/cmd/workload/stop/cmd_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stop
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestCmd_InvalidOutputFormat(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"68b0c1d2e3f4a5b6c7d8e9f0", "--output-format", "yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid output format "yaml"`)
+}

--- a/internal/workload/operations.go
+++ b/internal/workload/operations.go
@@ -15,7 +15,9 @@
 package workload
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
@@ -92,6 +94,12 @@ func IsSettledWorkloadStatus(status string) bool {
 	return false
 }
 
+// maxTransientPollErrors bounds how many consecutive transient failures
+// (5xx, 429, or network errors) WaitForWorkloadStatus tolerates before
+// giving up. The counter resets on any successful poll, so it only trips on
+// a sustained outage, not on isolated gateway blips during a long --wait.
+const maxTransientPollErrors = 5
+
 // WaitForWorkloadStatus polls GetWorkload on interval until
 // IsSettledWorkloadStatus reports the status settled or the deadline
 // expires. Settling on errored returns the final workload alongside an
@@ -99,6 +107,12 @@ func IsSettledWorkloadStatus(status string) bool {
 // waiting after stop legitimately lands on stopped) is a plain success.
 // onTick may be nil and is invoked after each successful poll for passive
 // observation, e.g. printing status transitions.
+//
+// Transient poll failures are retried rather than aborting the whole wait:
+// a single 502 over a multi-minute poll must not fail a CI deploy gate. A
+// 4xx is terminal (a 404 means the workload is gone, a 403 means auth
+// changed), and a sustained run of transient errors past
+// maxTransientPollErrors still gives up.
 func WaitForWorkloadStatus(
 	workloadID string,
 	interval, timeout time.Duration,
@@ -106,11 +120,31 @@ func WaitForWorkloadStatus(
 ) (*Workload, error) {
 	deadline := time.Now().Add(timeout)
 
+	var transientErrors int
+
 	for {
 		wl, err := GetWorkload(workloadID)
 		if err != nil {
-			return nil, fmt.Errorf("poll workload %s: %w", workloadID, err)
+			if !isTransientPollError(err) {
+				return nil, fmt.Errorf("poll workload %s: %w", workloadID, err)
+			}
+
+			transientErrors++
+
+			if transientErrors > maxTransientPollErrors {
+				return nil, fmt.Errorf("poll workload %s: %d consecutive transient errors, last: %w", workloadID, transientErrors, err)
+			}
+
+			if time.Now().After(deadline) {
+				return nil, fmt.Errorf("timeout waiting for workload %s after %s: %w", workloadID, timeout, err)
+			}
+
+			time.Sleep(interval)
+
+			continue
 		}
+
+		transientErrors = 0
 
 		if onTick != nil {
 			onTick(wl)
@@ -118,7 +152,9 @@ func WaitForWorkloadStatus(
 
 		if IsSettledWorkloadStatus(wl.Status) {
 			if wl.Status == WorkloadStatusErrored {
-				return wl, fmt.Errorf("workload %s settled with status %s; run 'dr workload events %s' to inspect", workloadID, wl.Status, workloadID)
+				// Points at `dr workload get` until the events command ships;
+				// the events PR flips this hint when the command exists.
+				return wl, fmt.Errorf("workload %s settled with status %s; run 'dr workload get %s' to inspect", workloadID, wl.Status, workloadID)
 			}
 
 			return wl, nil
@@ -130,4 +166,19 @@ func WaitForWorkloadStatus(
 
 		time.Sleep(interval)
 	}
+}
+
+// isTransientPollError reports whether a GetWorkload failure is worth
+// retrying during a poll loop: server-side 5xx and 429 rate limits, plus
+// non-HTTP errors (connection resets, timeouts). Client 4xx errors are
+// terminal -- a retry will not bring back a deleted workload or fix lost
+// auth.
+func isTransientPollError(err error) bool {
+	var httpErr *drapi.HTTPError
+
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode >= 500 || httpErr.StatusCode == http.StatusTooManyRequests
+	}
+
+	return true
 }

--- a/internal/workload/operations.go
+++ b/internal/workload/operations.go
@@ -1,0 +1,133 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// WorkloadOperationResponse is the acknowledgement returned by the
+// asynchronous lifecycle operations POST /workloads/{id}/start and /stop.
+// Status is the server's human-readable outcome message ("stopping",
+// "The proton is already running", ...), not a workload status enum value;
+// TrackVia is the API path to poll to observe the resulting transition.
+type WorkloadOperationResponse struct {
+	Status     string `json:"status"`
+	WorkloadID string `json:"workloadId"`
+	TrackVia   string `json:"trackVia"`
+}
+
+// StartWorkload requests an asynchronous start of a stopped workload. The
+// server replies 202 when the start was queued (stopped/unknown →
+// submitted) and 200 when the workload is already running, initializing,
+// or suspended (idempotent no-op); both decode into the operation
+// response. Conflicting states (409, e.g. still stopping or a restart in
+// progress), exceeded concurrency limits (403), and missing workloads
+// (404) surface as *drapi.HTTPError with the server's detail message.
+func StartWorkload(workloadID string) (*WorkloadOperationResponse, error) {
+	return postWorkloadAction(workloadID, "start")
+}
+
+// StopWorkload requests an asynchronous stop of a workload. The server
+// replies 202 when the stop was queued (status moves to stopping, then
+// stopped) and 200 when the workload is already stopped (idempotent
+// no-op); both decode into the operation response. Missing workloads
+// (404) surface as *drapi.HTTPError.
+func StopWorkload(workloadID string) (*WorkloadOperationResponse, error) {
+	return postWorkloadAction(workloadID, "stop")
+}
+
+// postWorkloadAction POSTs an empty JSON object to a workload action
+// sub-path. Action routes have no trailing slash, unlike the resource
+// route used by GetWorkload.
+func postWorkloadAction(workloadID, action string) (*WorkloadOperationResponse, error) {
+	url, err := config.GetEndpointURL("/api/v2/workloads/" + escapeID(workloadID) + "/" + action)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp WorkloadOperationResponse
+
+	if err := drapi.PostJSON(url, "workload "+action+" request", map[string]any{}, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// IsSettledWorkloadStatus reports whether status is a state the workload
+// will not leave without another action: running, stopped, suspended,
+// errored, terminated, interrupted, or unknown. In-flight states
+// (submitted, provisioning, launching, stopping) and unrecognized future
+// statuses are non-settled, so polling keeps going until the deadline
+// rather than declaring success on a status this CLI does not know.
+func IsSettledWorkloadStatus(status string) bool {
+	switch status {
+	case WorkloadStatusRunning,
+		WorkloadStatusStopped,
+		WorkloadStatusSuspended,
+		WorkloadStatusErrored,
+		WorkloadStatusTerminated,
+		WorkloadStatusInterrupted,
+		WorkloadStatusUnknown:
+		return true
+	}
+
+	return false
+}
+
+// WaitForWorkloadStatus polls GetWorkload on interval until
+// IsSettledWorkloadStatus reports the status settled or the deadline
+// expires. Settling on errored returns the final workload alongside an
+// error so callers get both pieces; any other settled status (a user
+// waiting after stop legitimately lands on stopped) is a plain success.
+// onTick may be nil and is invoked after each successful poll for passive
+// observation, e.g. printing status transitions.
+func WaitForWorkloadStatus(
+	workloadID string,
+	interval, timeout time.Duration,
+	onTick func(*Workload),
+) (*Workload, error) {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		wl, err := GetWorkload(workloadID)
+		if err != nil {
+			return nil, fmt.Errorf("poll workload %s: %w", workloadID, err)
+		}
+
+		if onTick != nil {
+			onTick(wl)
+		}
+
+		if IsSettledWorkloadStatus(wl.Status) {
+			if wl.Status == WorkloadStatusErrored {
+				return wl, fmt.Errorf("workload %s settled with status %s; run 'dr workload events %s' to inspect", workloadID, wl.Status, workloadID)
+			}
+
+			return wl, nil
+		}
+
+		if time.Now().After(deadline) {
+			return wl, fmt.Errorf("timeout waiting for workload %s after %s", workloadID, timeout)
+		}
+
+		time.Sleep(interval)
+	}
+}

--- a/internal/workload/operations_test.go
+++ b/internal/workload/operations_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func operationResponseDoc(status, workloadID string) string {
+	return fmt.Sprintf(
+		`{"status": %q, "workloadId": %q, "trackVia": "/api/v2/workloads/%s"}`,
+		status, workloadID, workloadID,
+	)
+}
+
+func TestStartWorkload_PostsEmptyBodyAndParsesResponse(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		// Action routes have no trailing slash, unlike the resource route.
+		assert.Equal(t, "/api/v2/workloads/wl-1/start", r.URL.Path)
+
+		body, _ := io.ReadAll(r.Body)
+		assert.JSONEq(t, `{}`, string(body))
+
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, operationResponseDoc("started", "wl-1"))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	resp, err := StartWorkload("wl-1")
+	require.NoError(t, err)
+	assert.Equal(t, "started", resp.Status)
+	assert.Equal(t, "wl-1", resp.WorkloadID)
+	assert.Equal(t, "/api/v2/workloads/wl-1", resp.TrackVia)
+}
+
+func TestStopWorkload_AlreadyStopped200Succeeds(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v2/workloads/wl-1/stop", r.URL.Path)
+
+		// Stopping an already-stopped workload is an idempotent no-op 200,
+		// not an error.
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, operationResponseDoc("Proton is already stopped", "wl-1"))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	resp, err := StopWorkload("wl-1")
+	require.NoError(t, err)
+	assert.Equal(t, "Proton is already stopped", resp.Status)
+}
+
+func TestStartWorkload_409SurfacesServerDetail(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprint(w, `{"detail": "The proton must be stopped before attempting to start it."}`)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := StartWorkload("wl-1")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "must be stopped before attempting to start")
+}
+
+func TestStopWorkload_404PropagatesAsHTTPError(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := StopWorkload("missing")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+}
+
+func TestStartWorkload_EscapesIDInPath(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// '?' must arrive escaped inside the path segment, never as a query.
+		assert.Equal(t, "/api/v2/workloads/wl-1%3Fforce=true/start", r.URL.EscapedPath())
+		assert.Empty(t, r.URL.RawQuery)
+
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, operationResponseDoc("started", "wl-1"))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := StartWorkload("wl-1?force=true")
+	require.NoError(t, err)
+}
+
+func TestIsSettledWorkloadStatus(t *testing.T) {
+	settled := map[string]bool{
+		WorkloadStatusUnknown:      true,
+		WorkloadStatusSubmitted:    false,
+		WorkloadStatusProvisioning: false,
+		WorkloadStatusLaunching:    false,
+		WorkloadStatusRunning:      true,
+		WorkloadStatusSuspended:    true,
+		WorkloadStatusInterrupted:  true,
+		WorkloadStatusStopping:     false,
+		WorkloadStatusStopped:      true,
+		WorkloadStatusErrored:      true,
+		WorkloadStatusTerminated:   true,
+		// Unrecognized future statuses must keep polling rather than be
+		// declared settled.
+		"future-state": false,
+	}
+
+	for status, want := range settled {
+		assert.Equalf(t, want, IsSettledWorkloadStatus(status), "status %q", status)
+	}
+}
+
+func TestWaitForWorkloadStatus_PollsUntilSettled(t *testing.T) {
+	installSkipAuth(t)
+
+	calls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+
+		status := WorkloadStatusLaunching
+		if calls >= 3 {
+			status = WorkloadStatusRunning
+		}
+
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", status))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	ticks := 0
+
+	wl, err := WaitForWorkloadStatus("wl-1", time.Millisecond, time.Minute, func(w *Workload) {
+		ticks++
+
+		require.NotNil(t, w)
+	})
+	require.NoError(t, err)
+	assert.Equal(t, WorkloadStatusRunning, wl.Status)
+	assert.Equal(t, 3, calls)
+	assert.Equal(t, 3, ticks)
+}
+
+func TestWaitForWorkloadStatus_ErroredReturnsWorkloadAndError(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", WorkloadStatusErrored))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkloadStatus("wl-1", time.Millisecond, time.Minute, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "settled with status errored")
+	assert.Contains(t, err.Error(), "dr workload events wl-1")
+	require.NotNil(t, wl)
+	assert.Equal(t, WorkloadStatusErrored, wl.Status)
+}
+
+func TestWaitForWorkloadStatus_AlreadySettledReturnsImmediately(t *testing.T) {
+	installSkipAuth(t)
+
+	calls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", WorkloadStatusStopped))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkloadStatus("wl-1", time.Millisecond, time.Minute, nil)
+	require.NoError(t, err)
+	assert.Equal(t, WorkloadStatusStopped, wl.Status)
+	assert.Equal(t, 1, calls)
+}
+
+func TestWaitForWorkloadStatus_Timeout(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", WorkloadStatusLaunching))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkloadStatus("wl-1", time.Millisecond, time.Millisecond, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout waiting for workload wl-1")
+	// The last observed workload is returned alongside the timeout so
+	// callers can still render the in-flight status.
+	require.NotNil(t, wl)
+	assert.Equal(t, WorkloadStatusLaunching, wl.Status)
+}
+
+func TestWaitForWorkloadStatus_GetErrorAborts(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkloadStatus("wl-1", time.Millisecond, time.Minute, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "poll workload wl-1")
+	assert.Nil(t, wl)
+}

--- a/internal/workload/operations_test.go
+++ b/internal/workload/operations_test.go
@@ -214,7 +214,7 @@ func TestWaitForWorkloadStatus_ErroredReturnsWorkloadAndError(t *testing.T) {
 	wl, err := WaitForWorkloadStatus("wl-1", time.Millisecond, time.Minute, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "settled with status errored")
-	assert.Contains(t, err.Error(), "dr workload events wl-1")
+	assert.Contains(t, err.Error(), "dr workload get wl-1")
 	require.NotNil(t, wl)
 	assert.Equal(t, WorkloadStatusErrored, wl.Status)
 }
@@ -260,11 +260,67 @@ func TestWaitForWorkloadStatus_Timeout(t *testing.T) {
 	assert.Equal(t, WorkloadStatusLaunching, wl.Status)
 }
 
-func TestWaitForWorkloadStatus_GetErrorAborts(t *testing.T) {
+func TestWaitForWorkloadStatus_RetriesTransientErrorThenSucceeds(t *testing.T) {
 	installSkipAuth(t)
 
+	calls := 0
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+
+		// The first two polls hit a transient gateway error; the wait must
+		// recover rather than abort on the first blip.
+		if calls <= 2 {
+			w.WriteHeader(http.StatusBadGateway)
+
+			return
+		}
+
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", WorkloadStatusRunning))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkloadStatus("wl-1", time.Millisecond, time.Minute, nil)
+	require.NoError(t, err)
+	assert.Equal(t, WorkloadStatusRunning, wl.Status)
+	assert.Equal(t, 3, calls)
+}
+
+func TestWaitForWorkloadStatus_AbortsAfterSustainedTransientErrors(t *testing.T) {
+	installSkipAuth(t)
+
+	calls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+
 		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkloadStatus("wl-1", time.Millisecond, time.Minute, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "consecutive transient errors")
+	assert.Nil(t, wl)
+	// One initial poll plus retries until the cap is exceeded.
+	assert.Equal(t, maxTransientPollErrors+1, calls)
+}
+
+func TestWaitForWorkloadStatus_4xxAbortsImmediately(t *testing.T) {
+	installSkipAuth(t)
+
+	calls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+
+		w.WriteHeader(http.StatusNotFound)
 	}))
 
 	defer srv.Close()
@@ -275,4 +331,6 @@ func TestWaitForWorkloadStatus_GetErrorAborts(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "poll workload wl-1")
 	assert.Nil(t, wl)
+	// A 4xx is terminal: a deleted workload is not coming back.
+	assert.Equal(t, 1, calls)
 }

--- a/internal/workload/output.go
+++ b/internal/workload/output.go
@@ -485,3 +485,30 @@ func printArtifactsTable(artifacts []Artifact) {
 
 	fmt.Fprintln(os.Stdout, t.Render())
 }
+
+// RenderWorkloadOperation renders the acknowledgement of an asynchronous
+// start/stop request. Text mode prints the server's human-readable outcome
+// message; JSON mode emits the full operation response document so scripts
+// keep the workloadId and trackVia handles.
+func RenderWorkloadOperation(format OutputFormat, resp WorkloadOperationResponse) error {
+	if format == OutputFormatJSON {
+		return printJSON(resp)
+	}
+
+	fmt.Println(resp.Status)
+
+	return nil
+}
+
+// RenderWorkloadStatus renders just the workload's status. Text mode prints
+// the bare status value so `dr workload status <id>` is directly usable in
+// scripts (symmetric with `dr workload endpoint` printing the bare URL).
+func RenderWorkloadStatus(format OutputFormat, workload Workload) error {
+	if format == OutputFormatJSON {
+		return printJSON(WorkloadStatusOutput{ID: workload.ID, Status: workload.Status})
+	}
+
+	fmt.Println(workload.Status)
+
+	return nil
+}

--- a/internal/workload/output_test.go
+++ b/internal/workload/output_test.go
@@ -613,3 +613,50 @@ func TestPrintWorkloadsTable_Empty(t *testing.T) {
 
 	assert.Equal(t, "No workloads found.\n", output)
 }
+
+func TestRenderWorkloadOperation_TextPrintsServerMessage(t *testing.T) {
+	resp := WorkloadOperationResponse{
+		Status:     "Proton is already stopped",
+		WorkloadID: "wl-1",
+		TrackVia:   "/api/v2/workloads/wl-1",
+	}
+
+	output := captureStdout(t, func() {
+		require.NoError(t, RenderWorkloadOperation(OutputFormatText, resp))
+	})
+
+	assert.Equal(t, "Proton is already stopped\n", output)
+}
+
+func TestRenderWorkloadOperation_JSON(t *testing.T) {
+	resp := WorkloadOperationResponse{
+		Status:     "started",
+		WorkloadID: "wl-1",
+		TrackVia:   "/api/v2/workloads/wl-1",
+	}
+
+	output := captureStdout(t, func() {
+		require.NoError(t, RenderWorkloadOperation(OutputFormatJSON, resp))
+	})
+
+	assert.JSONEq(t,
+		`{"status": "started", "workloadId": "wl-1", "trackVia": "/api/v2/workloads/wl-1"}`,
+		output)
+}
+
+func TestRenderWorkloadStatus_TextBare(t *testing.T) {
+	output := captureStdout(t, func() {
+		require.NoError(t, RenderWorkloadStatus(OutputFormatText, makeTestWorkload("wl-1", "a", "running")))
+	})
+
+	// The bare status value is the script-capture contract.
+	assert.Equal(t, "running\n", output)
+}
+
+func TestRenderWorkloadStatus_JSONShape(t *testing.T) {
+	output := captureStdout(t, func() {
+		require.NoError(t, RenderWorkloadStatus(OutputFormatJSON, makeTestWorkload("wl-1", "a", "errored")))
+	})
+
+	assert.JSONEq(t, `{"id": "wl-1", "status": "errored"}`, output)
+}

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -137,6 +137,14 @@ func NewWorkloadOutput(w Workload) WorkloadOutput {
 	}
 }
 
+// WorkloadStatusOutput is the stable JSON shape emitted by
+// `dr workload status --output-format json`; the full document stays the
+// domain of `dr workload get`.
+type WorkloadStatusOutput struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
 type workloadCreateRequest struct {
 	Name       string          `json:"name"`
 	ArtifactID string          `json:"artifactId"`


### PR DESCRIPTION
# RATIONALE

RAPTOR-17792, part 1 of 2. #564 lets users deploy, inspect, and remove workloads, but there is still no lifecycle control: once a workload runs, stopping or restarting it means leaving the CLI. This adds the lifecycle verbs so Tutorial 5 (code-to-workload) can run end to end in scripts. Part 2 adds the read-only inspectors (`endpoint`, `events`). Everything stays behind the `DATAROBOT_CLI_FEATURE_WORKLOAD` gate.

## CHANGES

- `dr workload stop <id>` / `dr workload start <id>`: POST the async lifecycle actions. Stdout carries the server's acknowledgement message (idempotent no-op messages included); the "track progress with status --wait" hint goes to stderr so `MSG=$(dr workload stop X)` stays clean. `--output-format json` emits the full `{status, workloadId, trackVia}` document. Start's 409 (must be stopped first) and 403 (concurrency limits) surface with the server detail.
- `dr workload status <id>`: prints the bare status value (script-capture contract, symmetric with `endpoint` in part 2); JSON mode prints `{id, status}`. The full document remains `dr workload get`'s job.
- `status --wait`: polls until the workload leaves the in-flight states (submitted, provisioning, launching, stopping), printing transition lines to stderr. Exits non-zero only when it settles on `errored` (with a hint to `dr workload events`) or the poll times out; `stopped`/`suspended`/`terminated` are legitimate settle states ("wait until settled", not "wait until running").
- `cmd/workload/build/internal/pollflags` moves to `cmd/workload/internal/pollflags` (own commit): `status` needs the same `--wait`/`--poll-interval`/`--poll-timeout` triple but Go internal visibility blocked the import from outside `build/`. Help text de-build-ified; no behavior change.
- Client layer: `StartWorkload`/`StopWorkload` (empty-body POSTs, no trailing slash on action routes) and `WaitForWorkloadStatus` + `IsSettledWorkloadStatus` mirroring `WaitForBuild`; unrecognized future statuses keep polling rather than being declared settled.

## TESTING

`task lint`: 0 issues. `task test` (race + shuffle): green, with the usual `DATAROBOT_CLI_FEATURE_WORKLOAD=false` caveat if your local `.env` enables the gate. Unit coverage: httptest-backed client tests (paths, empty body, 200 no-op, 409/404 detail passthrough, ID escaping, poll-until-settled / already-settled / errored / timeout / GET-abort), renderer contracts (bare status text, JSON shapes), command arg/flag validation.

## NOTES

Part 2 (endpoint/events) is stacked on this branch and opens after this merges. 

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New commands drive real start/stop API actions and script-facing exit semantics on `status --wait`; changes are isolated to the workload feature gate with solid httptest coverage.
> 
> **Overview**
> Adds **workload lifecycle control** to the CLI: `dr workload start`, `stop`, and `status` are wired into the workload command tree (behind the existing feature gate), with telemetry expectations updated for all three.
> 
> **Start/stop** POST async `/start` and `/stop` actions via new `StartWorkload` / `StopWorkload` client helpers. Stdout carries the server acknowledgement (text) or full `{status, workloadId, trackVia}` (JSON); progress hints go to stderr so shell captures stay clean. HTTP 409/403/404 details pass through from the API.
> 
> **Status** prints a **bare status** on stdout for scripting (JSON: `{id, status}`). With **`--wait`**, it polls until the workload leaves in-flight states using shared `WaitForWorkloadStatus` / `IsSettledWorkloadStatus` (mirroring build wait behavior). Polling progress goes to stderr; exit is non-zero only when settling on `errored` or on poll timeout.
> 
> **`pollflags`** moves from `cmd/workload/build/internal` to `cmd/workload/internal` so `status` can share `--wait` / `--poll-interval` / `--poll-timeout` with build commands; build imports are updated and `--wait` help text is generalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff49f7ee9fbd79525b9562bc0f3fc74bfed96c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->