### PR TITLE
[RAPTOR-17794] feat(workload): add dr workload artifact lock command

### DIFF
--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -85,6 +85,7 @@ var expectedWorkloadTrackedCommands = []string{
 	"workload build list",
 	"workload build logs",
 	"workload artifact delete",
+	"workload artifact lock",
 	"workload create",
 	"workload get",
 	"workload list",

--- a/cmd/workload/artifact/lock/cmd.go
+++ b/cmd/workload/artifact/lock/cmd.go
@@ -1,0 +1,69 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lock
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat workload.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:   "lock <artifact-id>",
+		Short: "Lock a draft workload artifact",
+		Long: `Promote a draft workload artifact to locked and show the result.
+
+Locking is one-way: a locked artifact's name, description, and spec become
+immutable, it gets a version number, and it can never be deleted or
+unlocked. Locking an already locked artifact is rejected.
+
+Before locking, the server validates build completeness: every container
+built from source (imageBuildConfig) must have its code uploaded and an
+image build completed; otherwise the lock is rejected with an error naming
+what is missing.
+
+By default, output is human-readable. Use --output-format json for machine-parseable output.
+
+Example:
+  dr workload artifact lock 68b0c1d2e3f4a5b6c7d8e9f0
+  dr workload artifact lock 68b0c1d2e3f4a5b6c7d8e9f0 --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			artifact, err := workload.LockArtifact(args[0])
+			if err != nil {
+				return err
+			}
+
+			return workload.RenderArtifact(outputFormat, *artifact)
+		},
+	}
+
+	workload.AddOutputFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"artifact_id":   telemetry.FirstArg(args),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/workload/artifact/lock/cmd_test.go
+++ b/cmd/workload/artifact/lock/cmd_test.go
@@ -12,31 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package artifact
+package lock
 
 import (
-	"github.com/datarobot/cli/cmd/workload/artifact/create"
-	"github.com/datarobot/cli/cmd/workload/artifact/del"
-	"github.com/datarobot/cli/cmd/workload/artifact/get"
-	"github.com/datarobot/cli/cmd/workload/artifact/list"
-	"github.com/datarobot/cli/cmd/workload/artifact/lock"
-	"github.com/spf13/cobra"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func Cmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "artifact",
-		Short: "Manage workload artifacts",
-		Long:  `Manage workload artifacts in your DataRobot deployment infrastructure.`,
-	}
+func TestCmd_RequiresArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.SetArgs([]string{})
 
-	cmd.AddCommand(
-		create.Cmd(),
-		del.Cmd(),
-		get.Cmd(),
-		list.Cmd(),
-		lock.Cmd(),
-	)
+	err := cmd.Execute()
+	require.Error(t, err)
+}
 
-	return cmd
+func TestCmd_InvalidOutputFormat(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"art-abc-123", "--output-format", "yaml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid output format "yaml"`)
 }

--- a/internal/drapi/patch.go
+++ b/internal/drapi/patch.go
@@ -56,9 +56,11 @@ func Patch(url, info string, body any) (*http.Response, error) {
 	}
 
 	if !isPatchSuccess(resp.StatusCode) {
-		resp.Body.Close()
-
-		return nil, &HTTPError{StatusCode: resp.StatusCode, URL: url}
+		// Use ErrFromResp (as Post and Delete do) so patch failures carry
+		// the server's detail: artifacts PATCH replies 403 when the
+		// artifact is locked and 422 naming the incomplete build piece
+		// when a lock is rejected.
+		return nil, ErrFromResp(resp, url)
 	}
 
 	return resp, err

--- a/internal/drapi/patch.go
+++ b/internal/drapi/patch.go
@@ -57,9 +57,7 @@ func Patch(url, info string, body any) (*http.Response, error) {
 
 	if !isPatchSuccess(resp.StatusCode) {
 		// Use ErrFromResp (as Post and Delete do) so patch failures carry
-		// the server's detail: artifacts PATCH replies 403 when the
-		// artifact is locked and 422 naming the incomplete build piece
-		// when a lock is rejected.
+		// the server's error detail instead of a bare status code.
 		return nil, ErrFromResp(resp, url)
 	}
 

--- a/internal/drapi/patch_test.go
+++ b/internal/drapi/patch_test.go
@@ -63,14 +63,13 @@ func TestPatchJSON_200WithBody(t *testing.T) {
 }
 
 // TestPatchJSON_ErrorCarriesBodyDetail pins Patch to ErrFromResp on failure
-// so the server's detail (e.g. why an artifact lock was rejected) reaches
-// the user instead of a bare status code.
+// so the server's error detail reaches the user instead of a bare status code.
 func TestPatchJSON_ErrorCarriesBodyDetail(t *testing.T) {
 	defer resetTokenForTest(t, "test-token")()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"detail":"Cannot update artifact: artifact is locked"}`))
+		_, _ = w.Write([]byte(`{"detail":"resource is immutable"}`))
 	}))
 	defer server.Close()
 
@@ -81,5 +80,5 @@ func TestPatchJSON_ErrorCarriesBodyDetail(t *testing.T) {
 
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusForbidden, httpErr.StatusCode)
-	assert.Contains(t, err.Error(), "artifact is locked")
+	assert.Contains(t, err.Error(), "resource is immutable")
 }

--- a/internal/drapi/patch_test.go
+++ b/internal/drapi/patch_test.go
@@ -61,3 +61,25 @@ func TestPatchJSON_200WithBody(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "xyz", out.ID)
 }
+
+// TestPatchJSON_ErrorCarriesBodyDetail pins Patch to ErrFromResp on failure
+// so the server's detail (e.g. why an artifact lock was rejected) reaches
+// the user instead of a bare status code.
+func TestPatchJSON_ErrorCarriesBodyDetail(t *testing.T) {
+	defer resetTokenForTest(t, "test-token")()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"Cannot update artifact: artifact is locked"}`))
+	}))
+	defer server.Close()
+
+	err := PatchJSON(server.URL, "", map[string]string{"k": "v"}, nil)
+	require.Error(t, err)
+
+	var httpErr *HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusForbidden, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "artifact is locked")
+}

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -407,6 +407,29 @@ func isPrimaryContainer(container map[string]any) bool {
 	return ok && primary
 }
 
+// LockArtifact promotes a draft artifact to locked via PATCH {"status": "locked"}
+// and returns the updated artifact (status locked, version assigned). Locking is
+// one-way. The server replies 403 when the artifact is already locked, 404 when
+// it does not exist, and 422 when a source-built container is incomplete (missing
+// codeRef or unbuilt imageUri); the error detail names the missing piece.
+func LockArtifact(artifactID string) (*Artifact, error) {
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/")
+	if err != nil {
+		return nil, err
+	}
+
+	body := map[string]string{"status": ArtifactStatusLocked}
+
+	var artifact Artifact
+
+	err = drapi.PatchJSON(url, "artifact", body, &artifact)
+	if err != nil {
+		return nil, err
+	}
+
+	return &artifact, nil
+}
+
 // DeleteArtifact deletes a draft artifact. The server replies 409 when the
 // artifact is locked (locking is one-way; locked artifacts can never be
 // deleted) or still referenced by a workload's proton(s); the 409 detail

--- a/internal/workload/artifact_test.go
+++ b/internal/workload/artifact_test.go
@@ -701,3 +701,92 @@ func TestDeleteArtifact_409PropagatesAsHTTPError(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
 	assert.Contains(t, err.Error(), "Delete the workload(s) first")
 }
+
+func TestLockArtifact_SendsStatusLocked(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/api/v2/artifacts/art-1/", r.URL.Path)
+
+		var body map[string]any
+
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, map[string]any{"status": "locked"}, body)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"art-1","name":"my-agent","status":"locked"}`)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	artifact, err := LockArtifact("art-1")
+	require.NoError(t, err)
+	assert.Equal(t, "art-1", artifact.ID)
+	assert.Equal(t, "locked", artifact.Status)
+}
+
+func TestLockArtifact_EscapesIDInPath(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// '?' must arrive escaped inside the path segment, never as a query.
+		assert.Equal(t, "/api/v2/artifacts/art-1%3Fforce=true/", r.URL.EscapedPath())
+		assert.Empty(t, r.URL.RawQuery)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"art-1","status":"locked"}`)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := LockArtifact("art-1?force=true")
+	require.NoError(t, err)
+}
+
+func TestLockArtifact_422PropagatesDetail(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprint(w, `{"detail":"Cannot lock artifact: imageBuildConfig is set but imageUri is not populated. Trigger and complete an image build before locking."}`)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := LockArtifact("art-1")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusUnprocessableEntity, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "complete an image build before locking")
+}
+
+func TestLockArtifact_403AlreadyLockedPropagatesAsHTTPError(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Cannot update artifact: artifact is locked"}`)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := LockArtifact("art-1")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusForbidden, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "artifact is locked")
+}


### PR DESCRIPTION
# RATIONALE

[RAPTOR-17794](https://datarobot.atlassian.net/browse/RAPTOR-17794): workload artifacts are created as drafts and must be locked to finalize them - locking freezes name/description/spec, assigns a version number, and is one-way (locked artifacts can never be unlocked or deleted). The CLI had no verb for this step; this PR adds `dr workload artifact lock <artifact-id>`.

## CHANGES

- New `dr workload artifact lock <artifact-id>` command (feature-gated under `workload` like the rest of the group): PATCHes `/api/v2/artifacts/{id}/` with `{"status": "locked"}` and renders the updated artifact (`--output-format text|json`).
- `internal/workload`: new `LockArtifact(artifactID)` helper.
- `internal/drapi`: `Patch` now wraps failures with `ErrFromResp` (as `Post` and `Delete` already do) so the server's detail reaches the user - e.g. 403 `"Cannot update artifact: artifact is locked"` and the 422 build-completeness remediation (`"...Upload source code and PATCH the codeRef before locking."`). Previously PATCH failures surfaced as bare status codes.
- Telemetry: command tracked via `TrackWith`; added to `expectedWorkloadTrackedCommands` in the wiring test.

## TESTING

- `task lint`: 0 issues; `DATAROBOT_CLI_FEATURE_WORKLOAD=false task test`: all packages pass (race detector on).
- Unit tests: request shape (`{"status":"locked"}`, PATCH, escaped ID path), 403/422 detail propagation, command arg/flag validation, drapi error-detail pinning test.
- Manual smoke against staging: lock draft → `locked` + server-assigned `version=1`; re-lock → exit 1 with 403 detail; lock artifact with `imageBuildConfig` but no codeRef → exit 1 with 422 remediation text; nonexistent id → 404; delete locked → 409. All smoke artifacts cleaned up.