### PR TITLE
Add assist plugin v0.1.28

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.28",
+          "url": "assist/assist-0.1.28.tar.xz",
+          "sha256": "d8fdf16fd62ea02442f5232a369046fbd962db9bde4d400fa180758406a0ae7c",
+          "releaseDate": "2026-06-12"
+        },
+        {
           "version": "0.1.27",
           "url": "assist/assist-0.1.27.tar.xz",
           "sha256": "a77e875ca4528261e108f578173ec75b9e2e304bb7133ae4a5c10d4a6d362ae5",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.28 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.28
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.28
- **SHA256:** `d8fdf16fd62ea02442f5232a369046fbd962db9bde4d400fa180758406a0ae7c`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only catalog metadata with no application logic changes; install behavior depends on the published artifact matching the listed SHA256.
> 
> **Overview**
> Registers **assist v0.1.28** as the newest entry in `docs/plugins/index.json`, so `dr plugin install assist` can resolve the latest tarball (`assist/assist-0.1.28.tar.xz`) with checksum `d8fdf16f…` and release date **2026-06-12**. Older assist versions are unchanged; only the index ordering is updated by prepending the new version block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 010db9171d9b1d8fd822c94c371a331e7fed2eb2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->