### PR TITLE
[CFX-6370] New pre-release smoke suite for `dr-start`

### DIFF
--- a/.github/workflows/.pre-release-smoke-tests-matrix.yaml
+++ b/.github/workflows/.pre-release-smoke-tests-matrix.yaml
@@ -57,6 +57,16 @@ jobs:
           version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Node.js is the one template prerequisite the CLI cannot auto-install
+      # (no install command for it on any platform), so it must be provisioned
+      # here. uv / task / pulumi are auto-installed by `dr start --yes`.
+      # NOTE: keep this version in sync with the Agentic Starter template's
+      # required Node version (currently 24).
+      - name: Set up Node.js (template prerequisite)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/.pre-release-smoke-tests-matrix.yaml
+++ b/.github/workflows/.pre-release-smoke-tests-matrix.yaml
@@ -1,0 +1,75 @@
+name: Pre-Release Smoke Tests Matrix
+
+# Heavier, longer-running end-to-end smoke tests that gate promotion of a
+# release from pre-release to stable. Installs the freshly published binary for
+# the given version and exercises real flows (e.g. `dr start` for the Agentic
+# Starter template — regression guard).
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Released version/tag to install and verify (e.g. v1.2.3)'
+        required: true
+        type: string
+      os-matrix:
+        description: 'OS matrix for pre-release smoke tests'
+        required: false
+        type: string
+        default: '["ubuntu-latest", "macos-latest"]'
+    secrets:
+      DR_API_TOKEN:
+        required: true
+
+jobs:
+  pre-release-smoke-test:
+    strategy:
+      matrix:
+        sys:
+          - { os: ubuntu-latest, shell: bash }
+          - { os: macos-latest, shell: "zsh {0}" }
+    defaults:
+      run:
+        shell: ${{ matrix.sys.shell }}
+    runs-on: ${{ matrix.sys.os }}
+    name: Run Pre-Release Smoke Tests (${{ matrix.sys.os }})
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version }}
+
+      - name: Ubuntu - Install dependencies w/ apt-get
+        if: matrix.sys.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y expect bash-completion
+
+      - name: MacOS - Install dependencies w/ homebrew
+        if: matrix.sys.os == 'macos-latest'
+        run: |
+          brew install expect bash-completion
+
+      - name: Install yq
+        uses: dcarbone/install-yq-action@v1.3.1
+
+      - name: Install Taskfile
+        uses: arduino/setup-task@v2
+        with:
+          version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install the published DR CLI binary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          sh ./install.sh "${{ inputs.version }}"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run Pre-Release Smoke Tests
+        env:
+          DR_API_TOKEN: ${{ secrets.DR_API_TOKEN }}
+        run: |
+          task smoke-test-pre-release DR_API_TOKEN="$DR_API_TOKEN"

--- a/.github/workflows/.pre-release-smoke-tests-matrix.yaml
+++ b/.github/workflows/.pre-release-smoke-tests-matrix.yaml
@@ -49,7 +49,9 @@ jobs:
       - name: MacOS - Install dependencies w/ homebrew
         if: matrix.sys.os == 'macos-latest'
         run: |
-          brew install expect bash-completion
+          # coreutils provides `gtimeout`, which the script uses as the hard
+          # wall-clock cap on `dr start` (macOS has no native `timeout`).
+          brew install expect bash-completion coreutils
 
       - name: Install yq
         uses: dcarbone/install-yq-action@v1.3.1

--- a/.github/workflows/.pre-release-smoke-tests-matrix.yaml
+++ b/.github/workflows/.pre-release-smoke-tests-matrix.yaml
@@ -1,22 +1,17 @@
 name: Pre-Release Smoke Tests Matrix
 
 # Heavier, longer-running end-to-end smoke tests that gate promotion of a
-# release from pre-release to stable. Installs the freshly published binary for
-# the given version and exercises real flows (e.g. `dr start` for the Agentic
-# Starter template — regression guard).
+# release from pre-release to stable. Builds the CLI from the tag's source and
+# exercises real flows (e.g. `dr start` for the Agentic Starter template —
+# regression guard).
 
 on:
   workflow_call:
     inputs:
       version:
-        description: 'Released version/tag to install and verify (e.g. v1.2.3)'
+        description: 'Git ref/tag to check out and build (e.g. v1.2.3)'
         required: true
         type: string
-      os-matrix:
-        description: 'OS matrix for pre-release smoke tests'
-        required: false
-        type: string
-        default: '["ubuntu-latest", "macos-latest"]'
     secrets:
       DR_API_TOKEN:
         required: true
@@ -62,12 +57,16 @@ jobs:
           version: '3.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install the published DR CLI binary
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.4'
+
+      - name: Build and Install the DR CLI Binary
         run: |
           set -e
-          sh ./install.sh "${{ inputs.version }}"
+          task build
+          LOCAL_BINARY=./dist/dr sh install.sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run Pre-Release Smoke Tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -184,7 +184,11 @@ jobs:
 
   notify-verification-failure:
     needs: [verify-installation, pre-release-smoke-test]
-    if: failure()
+    # Use always() + explicit result checks so the alert fires when EITHER gate
+    # fails. A bare failure() is unreliable here: when verify-installation fails,
+    # pre-release-smoke-test is skipped, and the skipped dependency can cause this
+    # job to be skipped too — silencing installation-only failures.
+    if: always() && (needs.verify-installation.result == 'failure' || needs.pre-release-smoke-test.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack of Verification Failure

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,8 +95,16 @@ jobs:
       version: ${{ github.ref_name }}
     secrets: inherit
 
-  promote-release:
+  pre-release-smoke-test:
     needs: verify-installation
+    uses: ./.github/workflows/.pre-release-smoke-tests-matrix.yaml
+    with:
+      version: ${{ github.ref_name }}
+    secrets:
+      DR_API_TOKEN: ${{ secrets.DR_API_TOKEN }}
+
+  promote-release:
+    needs: [verify-installation, pre-release-smoke-test]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -175,11 +183,11 @@ jobs:
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   notify-verification-failure:
-    needs: verify-installation
+    needs: [verify-installation, pre-release-smoke-test]
     if: failure()
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Slack of Installation Failure
+      - name: Notify Slack of Verification Failure
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload: |
@@ -197,7 +205,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Release was published but *installation verification failed*. The release remains marked as a pre-release."
+                    "text": "Release was published but *installation verification or pre-release smoke tests failed*. The release remains marked as a pre-release."
                   }
                 },
                 {

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -155,6 +155,11 @@ tasks:
     cmds:
       - ./smoke_test_scripts/run_smoke_test.sh {{if .DR_API_TOKEN}}{{.DR_API_TOKEN}}{{else}}$DR_API_TOKEN{{end}}
 
+  smoke-test-pre-release:
+    desc: "Run pre-release smoke tests (heavier end-to-end; gates release promotion)"
+    cmds:
+      - ./smoke_test_scripts/run_pre_release_smoke_test.sh {{if .DR_API_TOKEN}}{{.DR_API_TOKEN}}{{else}}$DR_API_TOKEN{{end}}
+
   smoke-test-self-update:
     desc: "Run self-update smoke tests"
     cmds:

--- a/smoke_test_scripts/COVERAGE.md
+++ b/smoke_test_scripts/COVERAGE.md
@@ -10,6 +10,7 @@ This document tracks what is covered by smoke tests across all platforms. Use it
 | `windows/run_smoke_test.ps1` | Windows | `task smoke-test-windows` |
 | `run_plugin_update_smoke_test.sh` | Unix | `task smoke-test` |
 | `run_self_update_smoke_test.sh` | Unix (macOS for brew tests) | manual / CI |
+| `run_pre_release_smoke_test.sh` | Unix (Linux / macOS) | `task smoke-test-pre-release` (gates release promotion) |
 
 ---
 
@@ -50,6 +51,10 @@ Legend: ✅ Covered · ⚠️ Partial · ❌ Not covered · ⏭️ Intentionally
 | **Dotenv** | | | |
 | `dr dotenv setup` inside template directory | ✅ | ⏭️ | |
 | `DATAROBOT_ENDPOINT` preserved in `.env` | ✅ | ⏭️ | |
+| **Start (`dr start`)** — `run_pre_release_smoke_test.sh` | | | |
+| Clone Agentic Starter (`datarobot-agent-application`) | ✅ | ⏭️ | Pre-release suite; skipped on Windows (no `expect`) |
+| `dr start` reaches start-command execution, no hang/loop | ✅ | ⏭️ | Regression guard; bounded run + hard `timeout` |
+| `dr start` resolves start command exactly once (no loop) | ✅ | ⏭️ | Asserted via `$HOME/.dr-tui-debug.log` step count |
 | **Plugin Auto-Update** (`run_plugin_update_smoke_test.sh`) | | | |
 | Install plugin at pinned version | ✅ | ❌ | |
 | Auto-update prompt appears on plugin run | ✅ | ❌ | |
@@ -68,7 +73,7 @@ Legend: ✅ Covered · ⚠️ Partial · ❌ Not covered · ⏭️ Intentionally
 ## Known Gaps
 
 ### Windows
-- No interactive testing (no `expect` equivalent): `dr auth setURL`, `dr auth login`, `dr templates setup`, `dr dotenv setup`, and all plugin-update flows are untested or manually simulated.
+- No interactive testing (no `expect` equivalent): `dr auth setURL`, `dr auth login`, `dr templates setup`, `dr dotenv setup`, `dr start`, and all plugin-update flows are untested or manually simulated.
 - `datarobot` alias is not verified.
 - Plugin auto-update and self-update flows are not covered.
 - Shell detection only covers PowerShell (not cmd.exe in the main suite; covered by a standalone `.bat` script).

--- a/smoke_test_scripts/expect_start.exp
+++ b/smoke_test_scripts/expect_start.exp
@@ -1,0 +1,102 @@
+#!/usr/local/bin/expect -f
+
+# Bounded `dr start` smoke test.
+#
+# Regression guard: CLI 0.2.69/0.2.70 went into an infinite loop on
+# `dr start` for the Agentic Starter (datarobot-agent-application) template and
+# completely broke the quickstart flow. No pre-release test caught it.
+#
+# This script runs `dr start` non-interactively under a PTY and verifies it
+# reaches the "execute the template start command" stage WITHOUT hanging or
+# looping. As soon as the start command is invoked, we stop the process so the
+# template's app/server is never fully booted (the "bounded" approach): we only
+# assert that `dr start`'s discovery + resolution completed correctly and once.
+#
+# Detection of the failure mode is layered:
+#   * inactivity `timeout` here -> a stalled flow that never reaches execution.
+#   * a hard wall-clock `timeout` wrapped around this script in
+#     run_pre_release_smoke_test.sh -> a busy loop that keeps emitting output
+#     (never hits inactivity timeout).
+#   * a bounded "start: execute step" / "execute_script=true" assertion against
+#     the $HOME/.dr-tui-debug.log file in run_pre_release_smoke_test.sh ->
+#     repetition loops.
+
+# Inactivity timeout. Generous so a slow (but healthy) dependency auto-install
+# does not false-fail; a true hang trips this, while a busy loop is caught by the
+# hard wall-clock timeout wrapped around this script in run_pre_release_smoke_test.sh.
+set timeout 240
+
+# Use TERM=dumb to prevent terminal color probing which causes OSC sequences.
+set env(TERM) dumb
+
+set config $env(DATAROBOT_CLI_CONFIG)
+
+# --yes        : non-interactive (auto-install deps, auto-run start script)
+# --debug      : emit step logs to $HOME/.dr-tui-debug.log even while the TUI runs
+spawn dr start --yes --debug --config $config
+
+# Walk the quickstart flow. We loop because intermediate prompts/screens may
+# appear before the start command is reached.
+set reached_execution 0
+set saw_error 0
+
+expect {
+    -re {Running 'task start'} {
+        puts "\nOK: dr start reached 'task start' execution."
+        set reached_execution 1
+    }
+    "Found quickstart script at:" {
+        puts "\nOK: dr start found and is executing a quickstart script."
+        set reached_execution 1
+    }
+    "No start command or quickstart script found" {
+        # Flow completed (no loop) but the template exposed no start command.
+        # Unexpected for the Agentic Starter template - surface it.
+        puts "\nERROR: dr start found no start command for this template."
+        exit 3
+    }
+    -re {update it now|Press 'y' or ENTER to confirm} {
+        # Self-update prompt. Decline so the quickstart flow continues.
+        puts "Self-update prompt detected - declining to continue start flow."
+        send -- "n"
+        exp_continue
+    }
+    "Press 'y' or ENTER to install" {
+        # Should not appear with --yes, but proceed if it does.
+        puts "Dependency install prompt detected - accepting."
+        send -- "y"
+        exp_continue
+    }
+    -re {Error: } {
+        # The flow surfaced an error and quit. This is a terminal state (no
+        # infinite loop), but indicates the start flow did not succeed.
+        puts "\nERROR: dr start exited with an error before reaching execution."
+        set saw_error 1
+    }
+    timeout {
+        puts "\nERROR: Timeout waiting for dr start to reach the start command."
+        puts "       This may indicate an infinite-loop / hang regression."
+        exit 1
+    }
+    eof {
+        puts "\nERROR: dr start exited before reaching the start command."
+        exit 4
+    }
+}
+
+# Stop the process immediately once execution is reached so we never fully boot
+# the template's application/server (bounded run). Ctrl-C is handled globally by
+# the TUI's interruptible model; closing the PTY guarantees teardown.
+send -- "\003"
+catch {close}
+catch {wait}
+
+if {$saw_error} {
+    exit 2
+}
+
+if {$reached_execution} {
+    exit 0
+}
+
+exit 5

--- a/smoke_test_scripts/expect_start.exp
+++ b/smoke_test_scripts/expect_start.exp
@@ -41,13 +41,23 @@ set reached_execution 0
 set saw_error 0
 
 expect {
-    -re {Running 'task start'} {
-        puts "\nOK: dr start reached 'task start' execution."
+    "Choose your agentic framework" {
+        # Success signal: dr start -> task start -> the Agentic Starter quickstart
+        # actually launched and reached its first interactive prompt. A loop/hang
+        # regression could never get this far.
+        puts "\nOK: agentic starter quickstart reached the framework selection prompt."
         set reached_execution 1
     }
+    -re {Running 'task start'} {
+        # dr resolved to running `task start`; keep reading until the task itself
+        # produces output / a prompt (the real proof that execution happened).
+        puts "dr start is launching 'task start'..."
+        exp_continue
+    }
     "Found quickstart script at:" {
-        puts "\nOK: dr start found and is executing a quickstart script."
-        set reached_execution 1
+        # dr resolved to a quickstart script; keep reading until it runs.
+        puts "dr start found a quickstart script; waiting for it to run..."
+        exp_continue
     }
     "No start command or quickstart script found" {
         # Flow completed (no loop) but the template exposed no start command.
@@ -74,12 +84,12 @@ expect {
         set saw_error 1
     }
     timeout {
-        puts "\nERROR: Timeout waiting for dr start to reach the start command."
+        puts "\nERROR: Timeout waiting for the start command to actually run."
         puts "       This may indicate an infinite-loop / hang regression."
         exit 1
     }
     eof {
-        puts "\nERROR: dr start exited before reaching the start command."
+        puts "\nERROR: dr start exited before the start command produced output."
         exit 4
     }
 }

--- a/smoke_test_scripts/expect_templates_setup_agentic.exp
+++ b/smoke_test_scripts/expect_templates_setup_agentic.exp
@@ -143,3 +143,8 @@ if {!$already_finished} {
 }
 
 expect eof
+
+# Propagate the spawned `dr templates setup` exit status so the caller can
+# detect a non-zero exit (e.g. the wizard erroring out) even when EOF is reached.
+catch wait result
+exit [lindex $result 3]

--- a/smoke_test_scripts/expect_templates_setup_agentic.exp
+++ b/smoke_test_scripts/expect_templates_setup_agentic.exp
@@ -51,94 +51,46 @@ sleep 1
 expect "datarobot-agent-application"
 send -- "\r\n"
 
-# Phase 0: Handle Pulumi setup if it appears before the dotenv wizard.
-# The Pulumi State Backend Selection screen may appear before the wizard if the
-# template includes PULUMI_CONFIG_PASSPHRASE and Pulumi is installed but not
-# logged in on the runner.
+# Drive whatever setup screens appear after selecting the template, accepting
+# defaults / auto-generating throughout, until the wizard offers to finish.
+# These screens (Pulumi state-backend selection, the Pulumi passphrase prompt,
+# the dotenv variable wizard, multi-select component lists) can appear in
+# different orders depending on the template and runner state, so we respond to
+# whichever prompt shows up rather than assuming a fixed sequence. `exp_continue`
+# keeps the same expect running after each match; only "enter to finish", EOF, or
+# a timeout ends the loop.
+set timeout 360
 expect {
     "Pulumi State Backend Selection" {
-        puts "Pulumi setup screen detected - selecting Login locally"
-
-        # "Login locally" is the first option, already highlighted — press enter
-        send -- "\r\n"
-
-        # After local login, a passphrase prompt may appear
-        set timeout 60
-        expect {
-            "PULUMI_CONFIG_PASSPHRASE" {
-                puts "Passphrase prompt appeared - accepting auto-generate"
-                # Press enter/y to auto-generate passphrase
-                send -- "\r\n"
-            }
-            "Variable:" {
-                # Pulumi completed without passphrase, wizard started directly
-                puts "Pulumi done, wizard started"
-                send -- "\r\n"
-            }
-            "Skipped" {
-                # Pulumi done, prompts auto-skipped
-                puts "Pulumi done, prompts auto-skipped"
-            }
-            timeout {
-                puts "ERROR: Timeout after Pulumi login"
-                exit 1
-            }
-        }
+        puts "Pulumi backend selection - choosing 'Login locally'"
+        send -- "\r"
+        exp_continue
+    }
+    -re {generate passphrase|PULUMI_CONFIG_PASSPHRASE} {
+        puts "Pulumi passphrase prompt - auto-generating"
+        send -- "\r"
+        exp_continue
+    }
+    "space to toggle" {
+        puts "Multi-select list - accepting defaults"
+        send -- "\r"
+        exp_continue
     }
     "Variable:" {
-        # No Pulumi setup needed — wizard started directly
-        send -- "\r\n"
-    }
-    "Skipped" {
-        # No Pulumi setup needed — prompts auto-skipped
-    }
-    timeout {
-        puts "ERROR: Timeout waiting for wizard or Pulumi setup"
-        exit 1
-    }
-}
-
-# Phase 1: Wait for the wizard to actually start ("Variable:" is wizard-only text)
-# or for the wizard to auto-complete all prompts ("Skipped"), mirroring the
-# transient-screen handling in expect_templates_setup.exp.
-set already_finished 0
-set timeout 60
-expect {
-    "Variable:" {
-        send -- "\r\n"
-    }
-    "Skipped" {
+        puts "Wizard variable prompt - accepting default"
+        send -- "\r"
+        exp_continue
     }
     "enter to finish" {
-        send -- "\r\n"
-        set already_finished 1
+        puts "Wizard complete - finishing"
+        send -- "\r"
+    }
+    eof {
+        # Setup process exited on its own.
     }
     timeout {
-        puts "ERROR: Timeout waiting for wizard to start"
+        puts "ERROR: Timeout waiting for the setup wizard to progress"
         exit 1
-    }
-}
-
-# Phase 2: Handle remaining wizard prompts, then exit the menu.
-if {!$already_finished} {
-    set done 0
-    while {!$done} {
-        expect {
-            "space to toggle" {
-                send -- "\r\n"
-            }
-            "Variable:" {
-                send -- "\r\n"
-            }
-            "enter to finish" {
-                send -- "\r\n"
-                set done 1
-            }
-            timeout {
-                puts "ERROR: Timeout waiting for next variable prompt or menu"
-                exit 1
-            }
-        }
     }
 }
 

--- a/smoke_test_scripts/expect_templates_setup_agentic.exp
+++ b/smoke_test_scripts/expect_templates_setup_agentic.exp
@@ -1,0 +1,145 @@
+#!/usr/local/bin/expect -f
+
+# Clone the "Agentic Starter" template (repo: datarobot-agent-application) via
+# `dr templates setup`. This mirrors expect_templates_setup.exp but targets the
+# agent application template so that the subsequent `dr start` smoke test
+# (expect_start.exp).
+
+set timeout 60
+
+# Use TERM=dumb to prevent terminal color probing which causes OSC sequences
+set env(TERM) dumb
+
+# Debug: Print the config path
+puts "DATAROBOT_CLI_CONFIG: $env(DATAROBOT_CLI_CONFIG)"
+
+spawn dr templates setup --config $env(DATAROBOT_CLI_CONFIG)
+
+# Handle potential authentication prompt with longer timeout
+set timeout 10
+expect {
+    "to connect your DataRobot credentials" {
+        # Auth prompt appeared - this means token validation failed
+        puts "\nERROR: Authentication required - token may be invalid or config not found"
+        puts "Config path: $env(DATAROBOT_CLI_CONFIG)"
+        exit 1
+    }
+    "more" {
+        # Template list appeared - continue normally
+        puts "Template list loaded successfully"
+    }
+    timeout {
+        puts "ERROR: Timeout waiting for template list or auth prompt"
+        exit 1
+    }
+}
+
+set timeout 360
+
+# Filter the list down to the Agentic Starter template
+send -- {/}
+
+expect "Filter"
+send -- "Agentic\n"
+
+sleep 1
+expect "Agentic Starter"
+send -- "\r\n"
+
+# Accept the default clone directory (datarobot-agent-application)
+sleep 1
+expect "datarobot-agent-application"
+send -- "\r\n"
+
+# Phase 0: Handle Pulumi setup if it appears before the dotenv wizard.
+# The Pulumi State Backend Selection screen may appear before the wizard if the
+# template includes PULUMI_CONFIG_PASSPHRASE and Pulumi is installed but not
+# logged in on the runner.
+expect {
+    "Pulumi State Backend Selection" {
+        puts "Pulumi setup screen detected - selecting Login locally"
+
+        # "Login locally" is the first option, already highlighted — press enter
+        send -- "\r\n"
+
+        # After local login, a passphrase prompt may appear
+        set timeout 60
+        expect {
+            "PULUMI_CONFIG_PASSPHRASE" {
+                puts "Passphrase prompt appeared - accepting auto-generate"
+                # Press enter/y to auto-generate passphrase
+                send -- "\r\n"
+            }
+            "Variable:" {
+                # Pulumi completed without passphrase, wizard started directly
+                puts "Pulumi done, wizard started"
+                send -- "\r\n"
+            }
+            "Skipped" {
+                # Pulumi done, prompts auto-skipped
+                puts "Pulumi done, prompts auto-skipped"
+            }
+            timeout {
+                puts "ERROR: Timeout after Pulumi login"
+                exit 1
+            }
+        }
+    }
+    "Variable:" {
+        # No Pulumi setup needed — wizard started directly
+        send -- "\r\n"
+    }
+    "Skipped" {
+        # No Pulumi setup needed — prompts auto-skipped
+    }
+    timeout {
+        puts "ERROR: Timeout waiting for wizard or Pulumi setup"
+        exit 1
+    }
+}
+
+# Phase 1: Wait for the wizard to actually start ("Variable:" is wizard-only text)
+# or for the wizard to auto-complete all prompts ("Skipped"), mirroring the
+# transient-screen handling in expect_templates_setup.exp.
+set already_finished 0
+set timeout 60
+expect {
+    "Variable:" {
+        send -- "\r\n"
+    }
+    "Skipped" {
+    }
+    "enter to finish" {
+        send -- "\r\n"
+        set already_finished 1
+    }
+    timeout {
+        puts "ERROR: Timeout waiting for wizard to start"
+        exit 1
+    }
+}
+
+# Phase 2: Handle remaining wizard prompts, then exit the menu.
+if {!$already_finished} {
+    set done 0
+    while {!$done} {
+        expect {
+            "space to toggle" {
+                send -- "\r\n"
+            }
+            "Variable:" {
+                send -- "\r\n"
+            }
+            "enter to finish" {
+                send -- "\r\n"
+                set done 1
+            }
+            timeout {
+                puts "ERROR: Timeout waiting for next variable prompt or menu"
+                exit 1
+            }
+        }
+    }
+}
+
+expect eof

--- a/smoke_test_scripts/run_pre_release_smoke_test.sh
+++ b/smoke_test_scripts/run_pre_release_smoke_test.sh
@@ -19,6 +19,18 @@ if [[ -z "$DR_API_TOKEN" ]]; then
   exit 1
 fi
 
+# Preflight: required tooling. Failing here with a clear message beats a cryptic
+# downstream failure (e.g. a missing `yq` silently leaves the endpoint unset, so
+# `dr templates setup` shows the URL picker instead of the template list).
+for _tool in dr expect yq wget; do
+  if ! command -v "$_tool" >/dev/null 2>&1; then
+    echo "❌ Required tool '$_tool' not found on PATH."
+    echo "   Local setup: build & install the CLI ('task build' && 'LOCAL_BINARY=./dist/dr sh install.sh'),"
+    echo "   then install deps (macOS: 'brew install expect yq coreutils wget')."
+    exit 1
+  fi
+done
+
 export TERM="dumb"
 
 # Timing helpers

--- a/smoke_test_scripts/run_pre_release_smoke_test.sh
+++ b/smoke_test_scripts/run_pre_release_smoke_test.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+# Pre-release smoke tests.
+#
+# These are heavier, longer-running end-to-end tests that we do NOT want to run
+# on every PR / in the fast smoke suite (run_smoke_test.sh). They are intended
+# to gate promotion of a release from pre-release to stable. Add future
+# slow/expensive end-to-end checks here rather than to run_smoke_test.sh.
+#
+# Currently covers:
+#   * dr start flow for the Agentic Starter (datarobot-agent-application)
+#     template — regression guard (infinite loop on `dr start`).
+
+# Be sure to get DR_API_TOKEN from args
+args=("$@")
+DR_API_TOKEN=${args[0]}
+if [[ -z "$DR_API_TOKEN" ]]; then
+  echo "❌ The variable 'DR_API_TOKEN' must be supplied as arg."
+  exit 1
+fi
+
+export TERM="dumb"
+
+# Timing helpers
+SCRIPT_START=$(date +%s)
+TEST_TIMINGS=""
+
+start_timer() {
+    TEST_NAME="$1"
+    TEST_START=$(date +%s)
+    echo ""
+    echo "▶ $TEST_NAME"
+}
+
+stop_timer() {
+    local elapsed=$(( $(date +%s) - TEST_START ))
+    echo "  ⏱  ${TEST_NAME}: ${elapsed}s"
+    TEST_TIMINGS="${TEST_TIMINGS}  ${elapsed}s\t${TEST_NAME}\n"
+}
+
+# Used throughout testing
+testing_url="https://app.datarobot.com"
+
+# Determine if we can access URL
+wget -q --spider "$testing_url"
+if [ $? -eq 0 ]; then
+    url_accessible=1
+else
+    url_accessible=0
+fi
+
+# Using `DATAROBOT_CLI_CONFIG` to be sure we can save/update config file in GitHub Action runners
+testing_dr_cli_config_dir="$(pwd)/.config/datarobot/"
+mkdir -p "$testing_dr_cli_config_dir"
+export DATAROBOT_CLI_CONFIG="${testing_dr_cli_config_dir}drconfig.yaml"
+touch "$DATAROBOT_CLI_CONFIG"
+cat "$(pwd)/smoke_test_scripts/assets/example_config.yaml" > "$DATAROBOT_CLI_CONFIG"
+
+# Set API token and endpoint in our ephemeral config file. Unlike the fast smoke
+# suite (which sets the endpoint interactively via `dr auth setURL`), this script
+# is non-interactive end-to-end, so we write both keys directly.
+yq -i ".token = \"$DR_API_TOKEN\"" "$DATAROBOT_CLI_CONFIG"
+yq -i ".endpoint = \"${testing_url}/api/v2\"" "$DATAROBOT_CLI_CONFIG"
+
+start_timer "dr start flow (Agentic Starter template)"
+if [ "$url_accessible" -eq 0 ]; then
+  echo "ℹ️ URL (${testing_url}) is not accessible so skipping 'dr start' Agentic Starter test."
+  stop_timer
+else
+  # Regression guard: CLI 0.2.69/0.2.70 went into an infinite loop on
+  # `dr start` for the Agentic Starter (datarobot-agent-application) template and
+  # completely broke the quickstart flow, but no pre-release test caught it.
+  # This test clones that template and runs `dr start`, asserting it reaches the
+  # start-command execution stage without hanging or looping.
+
+  AGENTIC_DIR="./datarobot-agent-application"
+
+  # Clean any leftover clone from a previous run.
+  rm -rf "$AGENTIC_DIR"
+
+  # 1. Clone the Agentic Starter template.
+  expect ./smoke_test_scripts/expect_templates_setup_agentic.exp
+  if [ ! -d "$AGENTIC_DIR" ]; then
+    echo "❌ Assertion failed: Agentic Starter directory ($AGENTIC_DIR) does not exist after setup."
+    exit 1
+  fi
+  echo "✅ Agentic Starter template cloned to $AGENTIC_DIR."
+
+  # 2. Run `dr start` from inside the cloned template.
+  #    Reset the debug log so step counts reflect only this invocation. A busy
+  #    infinite loop keeps emitting output and would never trip expect's
+  #    inactivity timeout, so a hard wall-clock `timeout` is the catch-all for
+  #    the hang/loop.
+  DEBUG_LOG="$HOME/.dr-tui-debug.log"
+  : > "$DEBUG_LOG" 2>/dev/null || true
+
+  cd "$AGENTIC_DIR"
+
+  START_TIMEOUT=360
+  if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout" # macOS via coreutils
+  else
+    TIMEOUT_BIN=""
+  fi
+
+  if [ -n "$TIMEOUT_BIN" ]; then
+    "$TIMEOUT_BIN" "$START_TIMEOUT" expect ../smoke_test_scripts/expect_start.exp
+    start_rc=$?
+  else
+    echo "ℹ️ 'timeout' not available - running without a hard wall-clock cap."
+    expect ../smoke_test_scripts/expect_start.exp
+    start_rc=$?
+  fi
+
+  if [ "$start_rc" -eq 124 ]; then
+    echo "❌ Assertion failed: 'dr start' exceeded ${START_TIMEOUT}s (hard timeout) - likely an infinite loop / hang."
+    cd ..
+    rm -rf "$AGENTIC_DIR"
+    exit 1
+  fi
+  if [ "$start_rc" -ne 0 ]; then
+    echo "❌ Assertion failed: 'dr start' bounded run failed (expect exit code: $start_rc)."
+    echo "   --- tail of $DEBUG_LOG ---"
+    tail -n 40 "$DEBUG_LOG" 2>/dev/null || echo "   (no debug log)"
+    cd ..
+    rm -rf "$AGENTIC_DIR"
+    exit 1
+  fi
+  echo "✅ 'dr start' reached the start-command execution stage without hanging."
+
+  # 3. Confirm via the debug log that discovery resolved to executing the start
+  #    command, and that the step machine ran a bounded number of times.
+  if [ -f "$DEBUG_LOG" ]; then
+    if grep -q "execute_script=true" "$DEBUG_LOG"; then
+      echo "✅ Assertion passed: 'dr start' resolved to executing the template start command (execute_script=true)."
+    else
+      echo "❌ Assertion failed: 'dr start' never reached start-command execution (no execute_script=true in debug log)."
+      tail -n 40 "$DEBUG_LOG" 2>/dev/null
+      cd ..
+      rm -rf "$AGENTIC_DIR"
+      exit 1
+    fi
+
+    # A healthy run logs "start: execute step" once per step (5 steps). A loop
+    # would repeat these far beyond the step count. Allow generous headroom.
+    step_runs=$(grep -c "start: execute step" "$DEBUG_LOG" 2>/dev/null)
+    [ -z "$step_runs" ] && step_runs=0
+    echo "ℹ️ 'start: execute step' log lines: ${step_runs}"
+    if [ "$step_runs" -gt 20 ]; then
+      echo "❌ Assertion failed: 'dr start' executed steps ${step_runs} times (> 20) - indicates an infinite loop."
+      cd ..
+      rm -rf "$AGENTIC_DIR"
+      exit 1
+    fi
+  else
+    echo "ℹ️ Debug log ($DEBUG_LOG) not found - skipping debug-log assertions."
+  fi
+
+  # Clean up the cloned template.
+  cd ..
+  rm -rf "$AGENTIC_DIR"
+  stop_timer
+fi
+
+# Print timing summary
+TOTAL_ELAPSED=$(( $(date +%s) - SCRIPT_START ))
+echo ""
+echo "══════════════════════════════════════"
+echo "  Pre-Release Smoke Test Timing Summary"
+echo "══════════════════════════════════════"
+printf "$TEST_TIMINGS"
+echo "──────────────────────────────────────"
+echo "  Total: ${TOTAL_ELAPSED}s"
+echo "══════════════════════════════════════"

--- a/smoke_test_scripts/run_pre_release_smoke_test.sh
+++ b/smoke_test_scripts/run_pre_release_smoke_test.sh
@@ -64,8 +64,12 @@ yq -i ".endpoint = \"${testing_url}/api/v2\"" "$DATAROBOT_CLI_CONFIG"
 
 start_timer "dr start flow (Agentic Starter template)"
 if [ "$url_accessible" -eq 0 ]; then
-  echo "ℹ️ URL (${testing_url}) is not accessible so skipping 'dr start' Agentic Starter test."
+  # This is a release gate: if we cannot reach the endpoint we CANNOT verify the
+  # `dr start` regression guard, so we must fail rather than skip. Skipping here
+  # would let a release be promoted without the check ever running.
+  echo "❌ URL (${testing_url}) is not accessible - cannot run the 'dr start' pre-release gate. Failing instead of skipping."
   stop_timer
+  exit 1
 else
   # Regression guard: CLI 0.2.69/0.2.70 went into an infinite loop on
   # `dr start` for the Agentic Starter (datarobot-agent-application) template and
@@ -102,17 +106,16 @@ else
   elif command -v gtimeout >/dev/null 2>&1; then
     TIMEOUT_BIN="gtimeout" # macOS via coreutils
   else
-    TIMEOUT_BIN=""
+    # The hard wall-clock cap is the primary busy-loop detector for this gate, so
+    # we refuse to run uncapped. On macOS install GNU coreutils for `gtimeout`.
+    echo "❌ Neither 'timeout' nor 'gtimeout' is available - cannot enforce the wall-clock cap this gate requires. Install GNU coreutils (e.g. 'brew install coreutils')."
+    cd ..
+    rm -rf "$AGENTIC_DIR"
+    exit 1
   fi
 
-  if [ -n "$TIMEOUT_BIN" ]; then
-    "$TIMEOUT_BIN" "$START_TIMEOUT" expect ../smoke_test_scripts/expect_start.exp
-    start_rc=$?
-  else
-    echo "ℹ️ 'timeout' not available - running without a hard wall-clock cap."
-    expect ../smoke_test_scripts/expect_start.exp
-    start_rc=$?
-  fi
+  "$TIMEOUT_BIN" "$START_TIMEOUT" expect ../smoke_test_scripts/expect_start.exp
+  start_rc=$?
 
   if [ "$start_rc" -eq 124 ]; then
     echo "❌ Assertion failed: 'dr start' exceeded ${START_TIMEOUT}s (hard timeout) - likely an infinite loop / hang."
@@ -132,30 +135,35 @@ else
 
   # 3. Confirm via the debug log that discovery resolved to executing the start
   #    command, and that the step machine ran a bounded number of times.
-  if [ -f "$DEBUG_LOG" ]; then
-    if grep -q "execute_script=true" "$DEBUG_LOG"; then
-      echo "✅ Assertion passed: 'dr start' resolved to executing the template start command (execute_script=true)."
-    else
-      echo "❌ Assertion failed: 'dr start' never reached start-command execution (no execute_script=true in debug log)."
-      tail -n 40 "$DEBUG_LOG" 2>/dev/null
-      cd ..
-      rm -rf "$AGENTIC_DIR"
-      exit 1
-    fi
+  #    The log-based checks ARE the regression guard, so a missing log is a hard
+  #    failure for this gate - never a silent skip.
+  if [ ! -f "$DEBUG_LOG" ]; then
+    echo "❌ Assertion failed: debug log ($DEBUG_LOG) not found - cannot run the log-based regression assertions. Failing instead of skipping."
+    cd ..
+    rm -rf "$AGENTIC_DIR"
+    exit 1
+  fi
 
-    # A healthy run logs "start: execute step" once per step (5 steps). A loop
-    # would repeat these far beyond the step count. Allow generous headroom.
-    step_runs=$(grep -c "start: execute step" "$DEBUG_LOG" 2>/dev/null)
-    [ -z "$step_runs" ] && step_runs=0
-    echo "ℹ️ 'start: execute step' log lines: ${step_runs}"
-    if [ "$step_runs" -gt 20 ]; then
-      echo "❌ Assertion failed: 'dr start' executed steps ${step_runs} times (> 20) - indicates an infinite loop."
-      cd ..
-      rm -rf "$AGENTIC_DIR"
-      exit 1
-    fi
+  if grep -q "execute_script=true" "$DEBUG_LOG"; then
+    echo "✅ Assertion passed: 'dr start' resolved to executing the template start command (execute_script=true)."
   else
-    echo "ℹ️ Debug log ($DEBUG_LOG) not found - skipping debug-log assertions."
+    echo "❌ Assertion failed: 'dr start' never reached start-command execution (no execute_script=true in debug log)."
+    tail -n 40 "$DEBUG_LOG" 2>/dev/null
+    cd ..
+    rm -rf "$AGENTIC_DIR"
+    exit 1
+  fi
+
+  # A healthy run logs "start: execute step" once per step (5 steps). A loop
+  # would repeat these far beyond the step count. Allow generous headroom.
+  step_runs=$(grep -c "start: execute step" "$DEBUG_LOG" 2>/dev/null)
+  [ -z "$step_runs" ] && step_runs=0
+  echo "ℹ️ 'start: execute step' log lines: ${step_runs}"
+  if [ "$step_runs" -gt 20 ]; then
+    echo "❌ Assertion failed: 'dr start' executed steps ${step_runs} times (> 20) - indicates an infinite loop."
+    cd ..
+    rm -rf "$AGENTIC_DIR"
+    exit 1
   fi
 
   # Clean up the cloned template.

--- a/smoke_test_scripts/run_pre_release_smoke_test.sh
+++ b/smoke_test_scripts/run_pre_release_smoke_test.sh
@@ -109,14 +109,7 @@ else
     echo "❌ Assertion failed: Agentic Starter directory ($AGENTIC_DIR) does not exist after setup."
     exit 1
   fi
-  # Guard against an exit-0-but-incomplete clone: the dotenv wizard writes a
-  # .env as part of setup, so its absence means setup did not finish even if the
-  # directory and a zero exit code are present.
-  if [ ! -f "$AGENTIC_DIR/.env" ]; then
-    echo "❌ Assertion failed: setup left no .env in $AGENTIC_DIR - incomplete clone/setup."
-    rm -rf "$AGENTIC_DIR"
-    exit 1
-  fi
+
   echo "✅ Agentic Starter template cloned and set up in $AGENTIC_DIR."
 
   # 2. Run `dr start` from inside the cloned template.

--- a/smoke_test_scripts/run_pre_release_smoke_test.sh
+++ b/smoke_test_scripts/run_pre_release_smoke_test.sh
@@ -109,7 +109,15 @@ else
     echo "❌ Assertion failed: Agentic Starter directory ($AGENTIC_DIR) does not exist after setup."
     exit 1
   fi
-  echo "✅ Agentic Starter template cloned to $AGENTIC_DIR."
+  # Guard against an exit-0-but-incomplete clone: the dotenv wizard writes a
+  # .env as part of setup, so its absence means setup did not finish even if the
+  # directory and a zero exit code are present.
+  if [ ! -f "$AGENTIC_DIR/.env" ]; then
+    echo "❌ Assertion failed: setup left no .env in $AGENTIC_DIR - incomplete clone/setup."
+    rm -rf "$AGENTIC_DIR"
+    exit 1
+  fi
+  echo "✅ Agentic Starter template cloned and set up in $AGENTIC_DIR."
 
   # 2. Run `dr start` from inside the cloned template.
   #    Reset the debug log so step counts reflect only this invocation. A busy

--- a/smoke_test_scripts/run_pre_release_smoke_test.sh
+++ b/smoke_test_scripts/run_pre_release_smoke_test.sh
@@ -82,8 +82,17 @@ else
   # Clean any leftover clone from a previous run.
   rm -rf "$AGENTIC_DIR"
 
-  # 1. Clone the Agentic Starter template.
+  # 1. Clone the Agentic Starter template. Check the expect exit status first: a
+  #    failed setup (timeout, wizard error, non-zero `dr templates setup`) can
+  #    still leave a partial directory behind, so directory existence alone is
+  #    not enough to call the clone successful.
   expect ./smoke_test_scripts/expect_templates_setup_agentic.exp
+  setup_rc=$?
+  if [ "$setup_rc" -ne 0 ]; then
+    echo "❌ Assertion failed: 'dr templates setup' (Agentic Starter) failed (expect exit code: $setup_rc)."
+    rm -rf "$AGENTIC_DIR"
+    exit 1
+  fi
   if [ ! -d "$AGENTIC_DIR" ]; then
     echo "❌ Assertion failed: Agentic Starter directory ($AGENTIC_DIR) does not exist after setup."
     exit 1

--- a/smoke_test_scripts/run_smoke_test.sh
+++ b/smoke_test_scripts/run_smoke_test.sh
@@ -207,6 +207,10 @@ else
   stop_timer
 fi
 
+# NOTE: The heavier `dr start` (Agentic Starter) end-to-end test lives in the
+# pre-release suite (run_pre_release_smoke_test.sh / `task smoke-test-pre-release`)
+# to keep this fast suite quick. See smoke_test_scripts/COVERAGE.md.
+
 # Print timing summary
 TOTAL_ELAPSED=$(( $(date +%s) - SCRIPT_START ))
 echo ""


### PR DESCRIPTION

# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->
A recent CLI release shipped a bug that completely broke the dr start flow (an infinite loop) for the Agentic Starter (datarobot-agent-application) template. No pre-release test exercised dr start, so the regression went out undetected.
This PR adds a dr start end-to-end regression guard and introduces a dedicated pre-release smoke test suite to house heavier checks like it — kept out of the fast per-PR suite — and wires that suite into the release pipeline so a broken dr start blocks promotion to stable.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

#### New pre-release smoke suite

`smoke_test_scripts/run_pre_release_smoke_test.sh` — self-contained heavier end-to-end suite (own token/config/endpoint/timing setup). Future slow checks go here, not in run_smoke_test.sh.
Taskfile.yaml — new task smoke-test-pre-release target.

#### `dr start` regression test (the actual guard)

`expect_templates_setup_agentic.exp` — clones the Agentic Starter template via dr templates setup (filters "Agentic Starter", dir datarobot-agent-application).
`expect_start.exp` — runs dr start --yes --debug under a PTY and asserts it reaches the start-command execution stage, then stops before the app actually boots (bounded run). Fails on inactivity timeout.
The suite wraps the run in a hard wall-clock timeout (catches busy loops) and, via $HOME/.dr-tui-debug.log, asserts the flow resolved to executing the start command (execute_script=true) and ran the step machine a bounded number of times (catches repetition loops). Three layered detectors for hang / busy-loop / repetition.

Fast suite stays fast

Removed the heavy dr start block from run_smoke_test.sh (left a pointer comment).

#### CI: gate release promotion

`.github/workflows/.pre-release-smoke-tests-matrix.yaml` (new reusable workflow) — installs the freshly published binary for the tag and runs task smoke-test-pre-release on Ubuntu + macOS.
`.github/workflows/release.yaml` — new pre-release-smoke-test job (needs verify-installation); promote-release now needs [verify-installation, pre-release-smoke-test]; failure notification covers it. Flow is now release → verify-installation → pre-release-smoke-test → promote-release. A failure keeps the release marked pre-release.

#### Docs

smoke_test_scripts/COVERAGE.md — added the new script row and dr start coverage rows.

<img width="883" height="435" alt="image" src="https://github.com/user-attachments/assets/37fb2636-82bb-415f-be35-5e672c26f3c6" />

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflows, Task targets, and smoke-test scripts; no application CLI logic is modified, though release promotion now depends on live API/network and `DR_API_TOKEN` in CI.
> 
> **Overview**
> Adds a **heavier pre-release smoke suite** (separate from the fast PR `run_smoke_test.sh` path) with a **`dr start` regression guard** for the Agentic Starter template: clone via `expect_templates_setup_agentic.exp`, bounded `dr start --yes --debug` via `expect_start.exp`, plus wall-clock `timeout`/`gtimeout` and assertions on `$HOME/.dr-tui-debug.log` (`execute_script=true`, bounded `start: execute step` count) to catch hangs and infinite loops.
> 
> **Release pipeline** now runs `verify-installation` → **`pre-release-smoke-test`** (new reusable `.pre-release-smoke-tests-matrix.yaml` on Ubuntu/macOS, published binary + `task smoke-test-pre-release`) before **`promote-release`**; Slack failure notification uses `always()` so installation-only failures still alert. `Taskfile.yaml` adds `smoke-test-pre-release`; `COVERAGE.md` documents the new coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ae834a03a7870cd6916ccac97b9e2929610ee75. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->