### PR TITLE
[CFX-6497] chore: upgrade github-script runners to v9

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -202,7 +202,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Add label for Go code changes
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -221,7 +221,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment smoke test instructions
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({

--- a/.github/workflows/comment-commands.yaml
+++ b/.github/workflows/comment-commands.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Check if PR is from fork and commenter permissions
         id: check-fork
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -45,7 +45,7 @@ jobs:
           (contains(github.event.comment.body, '/trigger-smoke-test') ||
            contains(github.event.comment.body, '/trigger-test-smoke')) &&
           steps.check-fork.outputs.is_fork == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Add reaction
@@ -69,7 +69,7 @@ jobs:
           (contains(github.event.comment.body, '/trigger-install-test') ||
            contains(github.event.comment.body, '/trigger-test-install')) &&
           steps.check-fork.outputs.is_fork == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Add reaction
@@ -94,7 +94,7 @@ jobs:
            contains(github.event.comment.body, '/approve-fork-tests')) &&
           steps.check-fork.outputs.is_fork == 'true' &&
           steps.check-fork.outputs.is_maintainer == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Add reaction
@@ -157,7 +157,7 @@ jobs:
         if: |
           contains(github.event.comment.body, '/skip-smoke-tests') &&
           steps.check-fork.outputs.is_maintainer == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Add reaction
@@ -189,7 +189,7 @@ jobs:
         if: |
           contains(github.event.comment.body, '/skip-smoke-tests') &&
           steps.check-fork.outputs.is_maintainer == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Add reaction
@@ -214,7 +214,7 @@ jobs:
           (contains(github.event.comment.body, '/approve-smoke-tests') ||
            contains(github.event.comment.body, '/approve-fork-tests')) &&
           steps.check-fork.outputs.is_maintainer == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Add reaction

--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -23,7 +23,7 @@ jobs:
       contents: read
     steps:
       - name: Verify maintainer access
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const result = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Resolve PR commit SHA
         id: resolve
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -130,7 +130,7 @@ jobs:
     steps:
       - name: Notify smoke tests started
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Check if any changed files are under .github/
@@ -192,7 +192,7 @@ jobs:
       statuses: write
     steps:
       - name: Comment on PR with results
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const securityStatus = '${{ needs.security-scan.result }}';
@@ -225,7 +225,7 @@ jobs:
             });
 
       - name: Update Smoke Tests commit status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const securityStatus = '${{ needs.security-scan.result }}';

--- a/.github/workflows/smoke-tests-gate.yaml
+++ b/.github/workflows/smoke-tests-gate.yaml
@@ -17,7 +17,7 @@ jobs:
       statuses: write
     steps:
       - name: Set Smoke Tests status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const isFork = context.payload.pull_request.head.repo.full_name !== context.payload.pull_request.base.repo.full_name;

--- a/.github/workflows/smoke-tests-on-demand.yaml
+++ b/.github/workflows/smoke-tests-on-demand.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Check if PR is from fork
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -28,7 +28,7 @@ jobs:
 
       - name: Notify fork PR cannot use this workflow
         if: steps.check.outputs.is_fork == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({
@@ -62,7 +62,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Notify smoke tests starting
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.createComment({
@@ -107,7 +107,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment on PR with results
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const linuxStatus = '${{ needs.linux-smoke-tests.result }}';
@@ -131,7 +131,7 @@ jobs:
             });
 
       - name: Remove run-smoke-tests label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Only remove run-smoke-tests label, keep 'go' label for categorization


### PR DESCRIPTION
# RATIONALE

All of our GitHub Actions use github-script@v7, which runs on Node 20 and is deprecated. When you look at Action logs, you'll see a warning like the following:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/github-script@v7. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Ref: https://github.com/datarobot-oss/cli/actions/runs/27577081155

## CHANGES

Update all Action scripts to use `github-script@v9`.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical dependency bump in GitHub Actions with no application or secrets-handling logic changes; main risk is a rare upstream breaking change in github-script v9.
> 
> **Overview**
> Bumps **`actions/github-script`** from **v7** to **v9** everywhere it is used in CI, so those steps run on a supported Node runtime instead of deprecated Node 20.
> 
> The version change is applied across **checks** (auto-label, dependabot reminder), **comment-commands** (PR comment handlers), **fork-smoke-tests**, **smoke-tests-gate**, and **smoke-tests-on-demand**. Inline `script:` bodies and workflow behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c5f05616cb1e7e35671a5ca80dcdb1a372f142. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->