### PR TITLE
[CFX-6497] chore: upgrade action/checkout runners to v6

### DIFF
--- a/.github/workflows/.build-matrix.yaml
+++ b/.github/workflows/.build-matrix.yaml
@@ -33,7 +33,7 @@ jobs:
     name: (${{ matrix.os }})
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Taskfile
         uses: arduino/setup-task@v2

--- a/.github/workflows/.build-windows.yaml
+++ b/.github/workflows/.build-windows.yaml
@@ -24,7 +24,7 @@ jobs:
     name: Build Windows Binary with GoReleaser
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/.deps-install-smoke-tests-matrix.yaml
+++ b/.github/workflows/.deps-install-smoke-tests-matrix.yaml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/.install-integration-tests-matrix.yaml
+++ b/.github/workflows/.install-integration-tests-matrix.yaml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/.self-update-tests-matrix.yaml
+++ b/.github/workflows/.self-update-tests-matrix.yaml
@@ -27,7 +27,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Debug brew environment (macOS only)
         if: runner.os == 'macOS' && inputs.debug_brew

--- a/.github/workflows/.setup.yaml
+++ b/.github/workflows/.setup.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/.smoke-tests-matrix.yaml
+++ b/.github/workflows/.smoke-tests-matrix.yaml
@@ -36,7 +36,7 @@ jobs:
     name: Run Smoke Tests (${{ matrix.sys.os }})
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/.windows-smoke-test.yaml
+++ b/.github/workflows/.windows-smoke-test.yaml
@@ -22,7 +22,7 @@ jobs:
     name: Run Windows Smoke Tests
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -26,7 +26,7 @@ jobs:
       install_sh: ${{ steps.changes.outputs.install_sh }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect file changes
         uses: dorny/paths-filter@v3
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check License Header
         uses: apache/skywalking-eyes/header@main
@@ -156,7 +156,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Taskfile
         uses: arduino/setup-task@v2
@@ -250,7 +250,7 @@ jobs:
     name: Test Completions
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download Binary
         uses: actions/download-artifact@v4

--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -78,7 +78,7 @@ jobs:
     name: Security Scan
     steps:
       - name: Checkout PR code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.resolve-pr.outputs.sha }}
           fetch-depth: 0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Promote release if stable version
         env:

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -20,7 +20,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 #v0.35.0
@@ -54,7 +54,7 @@ jobs:
   #     security-events: write
   #   steps:
   #     - name: Checkout Code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
 
   #     - name: Set up Go
   #       uses: actions/setup-go@v5
@@ -89,7 +89,7 @@ jobs:
   #     pull-requests: write
   #   steps:
   #     - name: Checkout Code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
 
   #     - name: Dependency Review
   #       uses: actions/dependency-review-action@v4
@@ -105,7 +105,7 @@ jobs:
   #     security-events: write
   #   steps:
   #     - name: Checkout Code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
 
   #     - name: Set up Go
   #       uses: actions/setup-go@v5

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:


### PR DESCRIPTION
# RATIONALE

Similar to #573 and `github-script@v7`, our GitHub Actions use `actions/checkout@v4` which runs on Node 20, which is deprecated. When you look at Action logs, you'll see a warning like the following:

> [Check Caller Permissions](https://github.com/datarobot-oss/cli/actions/runs/27579538041/job/81536192801#step:3:2)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/github-script@v7. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

https://github.com/datarobot-oss/cli/actions/runs/27579538041

## CHANGES

Update all Action scripts to use `actions/checkout@v6`.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical dependency bump in CI only; no application code or checkout behavior changes beyond the action version.
> 
> **Overview**
> Bumps **`actions/checkout`** from **v4** to **v6** everywhere it appears in GitHub Actions workflows (reusable matrices, PR checks, release, security scan, fork smoke tests, and static Pages deploy), including commented-out checkout steps in `security-scan.yaml`.
> 
> This aligns checkout with GitHub’s move off Node 20 for Actions and clears the deprecation warnings tied to older checkout versions. Step inputs (`ref`, `fetch-depth`, etc.) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11ac28c6c44ffdbe02dfdfa06338402d30a9a0b8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->