### PR TITLE
[CFX-6498] fix(ci): validate fork smoke dispatch initiator permissions

### DIFF
--- a/.github/workflows/comment-commands.yaml
+++ b/.github/workflows/comment-commands.yaml
@@ -113,6 +113,7 @@ jobs:
               ref: 'main',
               inputs: {
                 pr_number: context.issue.number.toString(),
+                triggering_actor: context.actor,
               }
             });
 

--- a/.github/workflows/comment-commands.yaml
+++ b/.github/workflows/comment-commands.yaml
@@ -113,7 +113,7 @@ jobs:
               ref: 'main',
               inputs: {
                 pr_number: context.issue.number.toString(),
-                triggering_actor: context.actor,
+                approver: context.actor,
               }
             });
 

--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
       approver:
-        description: 'Auto-filled by CI (leave empty for manual runs)'
+        description: 'Username of maintainer approving this test. Auto-filled by CI (leave empty for manual runs)'
         required: false
         type: string
 

--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
       approver:
-        description: 'Auto-filled by /approve-smoke-tests, leave empty for manual runs'
+        description: 'Auto-filled by CI (leave empty for manual runs)'
         required: false
         type: string
 

--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -14,6 +14,10 @@ on:
         description: 'Exact commit SHA from the fork PR to test (leave empty to use PR head)'
         required: false
         type: string
+      triggering_actor:
+        description: 'Username of the maintainer who approved dispatch (for workflow-to-workflow dispatches)'
+        required: false
+        type: string
 
 jobs:
   check-permissions:
@@ -26,21 +30,24 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const triggeringActor = '${{ inputs.triggering_actor }}'.trim();
+            const actorToCheck = triggeringActor || context.actor;
+
             const result = await github.rest.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              username: context.actor,
+              username: actorToCheck,
             });
             const allowed = ['write', 'maintain', 'admin'];
             const permission = result.data.permission;
             if (!allowed.includes(permission)) {
               core.setFailed(
-                `@${context.actor} has permission '${permission}' — ` +
+                `@${actorToCheck} has permission '${permission}' — ` +
                 `maintainer access (write/maintain/admin) is required to run fork smoke tests.`
               );
               return;
             }
-            console.log(`@${context.actor} has permission '${permission}' — proceeding.`);
+            console.log(`@${actorToCheck} has permission '${permission}' — proceeding.`);
 
   resolve-pr:
     needs: [check-permissions]

--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -14,8 +14,8 @@ on:
         description: 'Exact commit SHA from the fork PR to test (leave empty to use PR head)'
         required: false
         type: string
-      triggering_actor:
-        description: 'Username of the maintainer who approved dispatch (for workflow-to-workflow dispatches)'
+      approver:
+        description: 'Auto-filled by /approve-smoke-tests, leave empty for manual runs'
         required: false
         type: string
 
@@ -30,8 +30,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const triggeringActor = '${{ inputs.triggering_actor }}'.trim();
-            const actorToCheck = triggeringActor || context.actor;
+            const approver = '${{ inputs.approver }}'.trim();
+            const actorToCheck = approver || context.actor;
 
             const result = await github.rest.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- pass the maintainer username from comment-commands into fork-smoke-tests as `approver`
- validate collaborator permission against `approver` when provided, with fallback to context.actor
- keep manual dispatch behavior unchanged while fixing workflow-dispatch runs from main

## Testing
- Fork PR Smoke Tests (Manual Dispatch) -- I did this by using my maintainer privileges to push my fork directly to datarobot-oss/cli, then executing the Action using that new branch and this PR. You can see an example run here https://github.com/datarobot-oss/cli/actions/runs/27580999167

## UI
Adding the new `approver` field to dispatch creates a new field in the GitHub Actions UI. I set the description to remind us that we don't need to normally set this.

### Before
<img width="406" height="424" alt="image" src="https://github.com/user-attachments/assets/1c70b988-4066-4ae7-adb2-b5e86633b3f5" />

### After
<img width="364" height="472" alt="image" src="https://github.com/user-attachments/assets/1dbe8785-fd9e-4aec-9551-a68b3059e196" />