### PR TITLE
[RAPTOR-17801] docs: add dr artifact and dr workload command reference

### DIFF
--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -30,19 +30,21 @@ These flags are available for all commands:
 
 ### Main commands
 
-| Command                 | Description                                         |
-|-------------------------|-----------------------------------------------------|
-| [`auth`](auth.md)       | Authenticate with DataRobot.                        |
-| `component`             | Manage template components.                         |
-| `templates`             | Manage application templates.                       |
-| [`start`](start.md)     | Run the application quickstart process.             |
-| [`run`](run.md)         | Execute application tasks.                          |
-| [`task`](task.md)       | Manage Taskfile composition and task execution.     |
-| [`dotenv`](dotenv.md)   | Manage environment variables.                       |
-| [`self`](self.md)       | CLI utility commands (update, version, completion, plugin). |
-| [`plugin`](plugins.md)  | Inspect and manage CLI plugins.                     |
-| [`pipeline`](pipeline.md) | Manage pipelines via the pipelines API (feature-gated). |
-| [`dependencies`](dependencies.md) | Check and install template dependencies (advanced). |
+| Command                           | Description                                                 |
+| --------------------------------- | ----------------------------------------------------------- |
+| [`auth`](auth.md)                 | Authenticate with DataRobot.                                |
+| `component`                       | Manage template components.                                 |
+| `templates`                       | Manage application templates.                               |
+| [`start`](start.md)               | Run the application quickstart process.                     |
+| [`run`](run.md)                   | Execute application tasks.                                  |
+| [`task`](task.md)                 | Manage Taskfile composition and task execution.             |
+| [`dotenv`](dotenv.md)             | Manage environment variables.                               |
+| [`self`](self.md)                 | CLI utility commands (update, version, completion, plugin). |
+| [`plugin`](plugins.md)            | Inspect and manage CLI plugins.                             |
+| [`pipeline`](pipeline.md)         | Manage pipelines via the pipelines API (feature-gated).     |
+| [`artifact`](artifact.md)         | Build and manage workload artifacts (feature-gated).        |
+| [`workload`](workload.md)         | Deploy and manage workloads from artifacts (feature-gated). |
+| [`dependencies`](dependencies.md) | Check and install template dependencies (advanced).         |
 
 ### Command tree
 
@@ -113,6 +115,32 @@ dr
 │   │       └── delete Delete a specific version
 │   └── task           Inspect individual pipeline tasks (source + signature)
 │       └── get        Display task source, parameters, and input payload
+├── artifact           Artifact management (feature-gated)
+│   ├── create         Create an artifact
+│   ├── get            Display details of an artifact
+│   ├── list           List artifacts
+│   ├── lock           Lock a draft artifact
+│   ├── delete         Delete an artifact
+│   ├── build          Manage artifact builds
+│   │   ├── create     Trigger a new image build
+│   │   ├── get        Get the status of a build
+│   │   ├── list       List builds for an artifact
+│   │   └── logs       Fetch build logs
+│   └── code           Manage artifact code synchronization
+│       ├── init       Link a directory to an artifact
+│       ├── sync       Push and pull code changes
+│       ├── versions   List catalog versions
+│       └── checkout   Download a version snapshot
+├── workload           Workload management (alias: wl, feature-gated)
+│   ├── create         Create (deploy) a workload
+│   ├── get            Display details of a workload
+│   ├── list           List workloads
+│   ├── delete         Delete a workload
+│   ├── start          Start a stopped workload
+│   ├── stop           Stop a workload
+│   ├── status         Show a workload's status
+│   ├── endpoint       Print a workload's endpoint URL
+│   └── logs           Show a workload's container logs
 └── self               CLI utility commands
     ├── completion     Shell completion
     │   ├── install    Install completions interactively
@@ -288,6 +316,16 @@ For detailed documentation on each command, see:
   - `schedule`&mdash;`create`/`list`/`get`/`update`/`delete` recurring (cron) runs on locked versions.
   - `environment`&mdash;`create`/`list`/`update`/`delete` named pip-package environments; `version delete` removes a specific version.
   - `task`&mdash;`get` to inspect a task's source code, function signature parameters, and (for locked versions) the latest pipeline input payload.
+
+- **[artifact](artifact.md)** - build and manage the container artifacts that back workloads (feature-gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`).
+  - `create` / `get` / `list` / `lock` / `delete` - the draft-to-locked artifact lifecycle.
+  - `build` - `create` / `get` / `list` / `logs` for container image builds.
+  - `code` - `init` / `sync` / `versions` / `checkout` to sync local code with an artifact via a `.wapi/` state directory.
+
+- **[workload](workload.md)** - deploy and operate workloads created from artifacts (alias `wl`; feature-gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`).
+  - `create` / `get` / `list` / `delete` - the workload lifecycle.
+  - `start` / `stop` / `status` - run-state control and status polling.
+  - `endpoint` / `logs` - print the endpoint URL and stream container logs.
 
 ## Getting help
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -317,15 +317,15 @@ For detailed documentation on each command, see:
   - `environment`&mdash;`create`/`list`/`update`/`delete` named pip-package environments; `version delete` removes a specific version.
   - `task`&mdash;`get` to inspect a task's source code, function signature parameters, and (for locked versions) the latest pipeline input payload.
 
-- **[artifact](artifact.md)** - build and manage the container artifacts that back workloads (feature-gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`).
-  - `create` / `get` / `list` / `lock` / `delete` - the draft-to-locked artifact lifecycle.
-  - `build` - `create` / `get` / `list` / `logs` for container image builds.
-  - `code` - `init` / `sync` / `versions` / `checkout` to sync local code with an artifact via a `.wapi/` state directory.
+- **[artifact](artifact.md)**&mdash;build and manage the container artifacts that back workloads (feature-gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`).
+  - `create` / `get` / `list` / `lock` / `delete`&mdash;the draft-to-locked artifact lifecycle.
+  - `build`&mdash;`create` / `get` / `list` / `logs` for container image builds.
+  - `code`&mdash;`init` / `sync` / `versions` / `checkout` to sync local code with an artifact via a `.wapi/` state directory.
 
-- **[workload](workload.md)** - deploy and operate workloads created from artifacts (alias `wl`; feature-gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`).
-  - `create` / `get` / `list` / `delete` - the workload lifecycle.
-  - `start` / `stop` / `status` - run-state control and status polling.
-  - `endpoint` / `logs` - print the endpoint URL and stream container logs.
+- **[workload](workload.md)**&mdash;deploy and operate workloads created from artifacts (alias `wl`; feature-gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`).
+  - `create` / `get` / `list` / `delete`&mdash;the workload lifecycle.
+  - `start` / `stop` / `status`&mdash;run-state control and status polling.
+  - `endpoint` / `logs`&mdash;print the endpoint URL and stream container logs.
 
 ## Getting help
 

--- a/docs/commands/artifact.md
+++ b/docs/commands/artifact.md
@@ -1,0 +1,226 @@
+# `dr artifact` - Artifact management
+
+Build and manage the container artifacts that back your DataRobot workloads. An artifact bundles one or more container images, built from your code or pulled from a registry, into a spec that a workload can later run. The `dr artifact` group is a thin wrapper over the Workload API: each subcommand maps to a single operation on an artifact, its builds, or its code.
+
+## Synopsis
+
+```bash
+dr artifact <command> [subcommand] [flags]
+```
+
+## Description
+
+An **artifact** is a versioned container spec made up of one or more container groups. Every artifact moves through a one-way lifecycle:
+
+- `create` registers a **draft** from a JSON or YAML spec.
+- `code` and `build` fill in the container images (see below).
+- `lock` promotes the draft to **locked**. A locked artifact gets a version number, its name and spec become immutable, and it can no longer be deleted or unlocked.
+
+Each container in the spec is one of two kinds:
+
+- **Prebuilt**: set `imageUri` to an existing image. There is nothing to build.
+- **Built from source**: set `imageBuildConfig`, push your code with `dr artifact code sync`, and produce an image with `dr artifact build create`. The Dockerfile is either one you provide (`./Dockerfile`) or one the server generates from a base environment.
+
+The `code` subcommands keep a local directory in sync with an artifact's source. They store a `.wapi/` state directory at the project root, much like `.git/`: local work happens in the project root while `.wapi/` records the remote binding and last-synced state. Once a directory is linked with `dr artifact code init`, the `build` and `code` subcommands read the artifact id from `.wapi/config.json`, so you can leave it off.
+
+A locked, fully built artifact is what you hand to `dr workload create` to deploy. See [`dr workload`](workload.md).
+
+> [!NOTE]
+> The `artifact` command is currently behind a feature gate. Enable it by exporting `DATAROBOT_CLI_FEATURE_WORKLOAD=true` before running any `dr artifact` subcommand. See [Feature gates](../development/feature-gates.md) for details.
+>
+> **First time?** If you're new to the CLI, start with the [Quick start](../../README.md#quick-start) for step-by-step setup instructions.
+
+## Quick start
+
+```bash
+# Register a draft artifact from a spec file
+dr artifact create --spec-file spec.yaml
+
+# Link the current directory to it, then push your code
+dr artifact code init <artifact-id>
+dr artifact code sync
+
+# Build the container image and wait for it to finish
+dr artifact build create --wait
+
+# Lock the artifact once the build succeeds
+dr artifact lock <artifact-id>
+```
+
+## Command groups
+
+| Command               | Endpoint                               | Purpose                                                                    |
+| --------------------- | -------------------------------------- | -------------------------------------------------------------------------- |
+| `dr artifact create`  | `POST   /api/v2/artifacts/`            | Register a draft artifact from a JSON/YAML spec.                           |
+| `dr artifact get`     | `GET    /api/v2/artifacts/{id}/`       | Show a single artifact.                                                    |
+| `dr artifact list`    | `GET    /api/v2/artifacts/`            | List artifacts, optionally filtered by status.                             |
+| `dr artifact lock`    | `PATCH  /api/v2/artifacts/{id}/`       | Promote a draft to locked (immutable).                                     |
+| `dr artifact delete`  | `DELETE /api/v2/artifacts/{id}/`       | Delete an artifact.                                                        |
+| `dr artifact build …` | `…/artifacts/{id}/builds[/{build-id}]` | Trigger, inspect, and read logs from image builds.                         |
+| `dr artifact code …`  | DataRobot catalog (Files API)          | Sync local code with an artifact (`init`, `sync`, `versions`, `checkout`). |
+
+## Subcommands
+
+### `create`
+
+Register a new draft artifact from a JSON or YAML spec file. The spec needs a `name` and at least one container group with at least one container. JSON is sent to the server byte-for-byte; YAML is converted to JSON first, so quote any value that must stay a string (for example `"0644"`). On a shape mismatch the server returns a `422` naming the offending JSON path.
+
+```bash
+dr artifact create --spec-file <path> [--output-format text|json]
+```
+
+**Flags:**
+
+- `--spec-file <path>`: path to the JSON or YAML spec (required).
+- `--output-format <text|json>`: output format. Defaults to `text`.
+
+**Example:**
+
+```yaml
+# spec.yaml - a single prebuilt container
+name: my-agent
+spec:
+  containerGroups:
+    - containers:
+        - imageUri: nginx:latest
+          port: 8080
+          primary: true
+```
+
+```bash
+dr artifact create --spec-file spec.yaml
+```
+
+To build from source instead of using a prebuilt image, replace the container's `imageUri` with an `imageBuildConfig`:
+
+```yaml
+name: my-agent
+spec:
+  containerGroups:
+    - containers:
+        - primary: true
+          port: 8080
+          imageBuildConfig:
+            dockerfile:
+              source: provided   # build from ./Dockerfile in your synced code
+```
+
+### `get`
+
+Show a single artifact: its name, status, code reference, and timestamps.
+
+```bash
+dr artifact get <artifact-id> [--output-format text|json]
+```
+
+### `list`
+
+List artifacts, most useful with a status filter.
+
+```bash
+dr artifact list [--status draft|locked] [--limit N] [--output-format text|json]
+```
+
+**Flags:**
+
+- `--status <draft|locked>`: only show artifacts in this status.
+- `--limit <N>`: maximum number to return. Defaults to `100`.
+- `--output-format <text|json>`: output format. Defaults to `text`.
+
+### `lock`
+
+Promote a draft artifact to locked. Before locking, the server checks that every container built from source has its code uploaded and an image build completed; otherwise the lock is rejected and the error names what is missing. Locking is one-way.
+
+```bash
+dr artifact lock <artifact-id> [--output-format text|json]
+```
+
+### `delete`
+
+Delete an artifact by id. Locked artifacts cannot be deleted, and an artifact still referenced by a workload cannot be deleted either (the error names the blocking workloads, so delete those first). You are asked to confirm unless `--yes` is set.
+
+```bash
+dr artifact delete <artifact-id> [--yes]
+```
+
+**Flags:**
+
+- `--yes`, `-y`: skip the confirmation prompt. Also honored via `DATAROBOT_CLI_NON_INTERACTIVE=1`.
+
+### `build`
+
+Trigger and inspect container image builds for an artifact. Inside a linked directory the `<artifact-id>` argument can be omitted; it is read from `.wapi/config.json`.
+
+```bash
+dr artifact build create [<artifact-id>] [--wait]             # trigger a build
+dr artifact build list   [<artifact-id>] [--limit N]          # list builds, newest first
+dr artifact build get    [<artifact-id>] <build-id> [--wait]  # show one build
+dr artifact build logs   [<artifact-id>] <build-id> [--level debug|info|warn|error]
+```
+
+`build create` prints the new build id(s) and returns right away. With `--wait` it polls until each build reaches a terminal status (`COMPLETED`, `FAILED`, or `CANCELLED`), prints a summary with the duration and resulting image, and on failure dumps the tail of the build log. `build logs` shows one structured record per line and hides anything below `info` unless you lower `--level`.
+
+### `code`
+
+Synchronize a local project directory with an artifact's source code. Run `init` once to link a directory, then `sync` to push and pull changes.
+
+```bash
+dr artifact code init     [<artifact-id>] [--dir <path>] [--yes]
+dr artifact code sync     [--dir <path>] [--dry-run | --diff] [--yes]
+dr artifact code versions [--dir <path>] [--limit N]
+dr artifact code checkout [<ver>] [--dir <path>] [--clean]
+```
+
+- `init` creates the `.wapi/` state directory and binds it to an existing draft artifact. The artifact must already exist (`dr artifact create` or the DataRobot UI); these commands manage an artifact's code, not its lifecycle.
+- `sync` computes a three-way diff against the last synced state and applies it in one versioned step. Conflicts resolve to the remote copy, and your version is kept as a `*.LOCAL.<timestamp>` file. Preview with `--dry-run`, or use `--diff` to also see per-file diffs. Both exit before any remote write.
+- `versions` lists the artifact's catalog versions, marking the one the artifact currently points at (`*`) and noting the one you last synced.
+- `checkout` downloads a version into `.wapi/.checkouts/<version-id>/` for read-only inspection; your working directory is left untouched. `--clean` removes checkout directories instead of downloading.
+
+## Shared flags
+
+### `--output-format`
+
+Every subcommand that prints a resource accepts `--output-format json` for machine-parseable output. The default, `text`, is human-readable.
+
+### `--yes`
+
+Commands that prompt (`delete`, `code init`, `code sync`, `code checkout`) accept `--yes` / `-y` to skip the prompt. Setting `DATAROBOT_CLI_NON_INTERACTIVE=1` does the same, and prompts are skipped automatically when stdin is not a terminal.
+
+### Global options
+
+All [global flags](README.md#global-flags) are available, notably `--debug` for protocol-level tracing.
+
+## Examples
+
+### Build and lock an artifact from source
+
+```bash
+dr artifact create --spec-file spec.yaml   # prints the new artifact id
+dr artifact code init <artifact-id>
+dr artifact code sync                       # upload your code
+dr artifact build create --wait             # build the image, wait for it
+dr artifact lock <artifact-id>              # freeze it for deployment
+```
+
+### Inspect builds and logs
+
+```bash
+dr artifact build list <artifact-id>
+dr artifact build get  <artifact-id> <build-id> --wait
+dr artifact build logs <artifact-id> <build-id> --level debug
+```
+
+## Error handling
+
+| Status | Cause                                                                                                             |
+| ------ | ----------------------------------------------------------------------------------------------------------------- |
+| `404`  | The artifact, build, or version does not exist.                                                                   |
+| `409`  | Tried to delete a locked artifact, delete one still referenced by a workload, or lock an already-locked artifact. |
+| `422`  | The spec failed server validation; the response names the offending JSON path.                                    |
+
+## See also
+
+- [`dr workload`](workload.md): deploy a locked artifact as a running workload.
+- [Authentication](auth.md): how `dr auth login` and `--skip-auth` interact.
+- [Configuration](../user-guide/configuration.md): config file and environment-variable precedence.
+- [Feature gates](../development/feature-gates.md): turning `DATAROBOT_CLI_FEATURE_WORKLOAD` on and off.

--- a/docs/commands/workload.md
+++ b/docs/commands/workload.md
@@ -1,0 +1,217 @@
+# `dr workload` - Workload management
+
+Deploy and operate workloads on your DataRobot infrastructure. A workload is a running deployment created from an artifact; once it is running it serves traffic on a stable endpoint URL. The `dr workload` group is a thin wrapper over the Workload API, with one subcommand per operation. It is also available under the alias `wl`.
+
+## Synopsis
+
+```bash
+dr workload <command> [flags]
+dr wl <command> [flags]
+```
+
+## Description
+
+A **workload** runs the containers defined by an [artifact](artifact.md). You create one from a spec that either references an existing `artifactId` or defines a draft `artifact` inline.
+
+Startup is asynchronous. A workload moves through `submitted → provisioning → launching → running`; other states include `suspended`, `interrupted`, `stopping`, `stopped`, `errored`, and `terminated`. After `create`, poll `dr workload status <id>` (or `dr workload get`) until the status is `running`, then call its endpoint.
+
+`start` and `stop` are asynchronous and idempotent too: stopping keeps the workload so it can be started again later, and the artifact it was created from is never removed along with it.
+
+> [!NOTE]
+> The `workload` command is currently behind a feature gate. Enable it by exporting `DATAROBOT_CLI_FEATURE_WORKLOAD=true` before running any `dr workload` subcommand. See [Feature gates](../development/feature-gates.md) for details.
+>
+> **First time?** If you're new to the CLI, start with the [Quick start](../../README.md#quick-start) for step-by-step setup instructions.
+
+## Quick start
+
+```bash
+# Deploy a workload from a spec file
+dr workload create --spec-file workload.yaml
+
+# Watch it come up
+dr workload status <workload-id>
+
+# Once running, grab its endpoint and call it
+curl "$(dr workload endpoint <workload-id>)health"
+
+# Tail the logs
+dr workload logs <workload-id> --follow
+```
+
+## Command groups
+
+| Command                | Endpoint                                  | Purpose                                        |
+| ---------------------- | ----------------------------------------- | ---------------------------------------------- |
+| `dr workload create`   | `POST   /api/v2/workloads/`               | Deploy a workload from a spec.                 |
+| `dr workload get`      | `GET    /api/v2/workloads/{id}/`          | Show a single workload.                        |
+| `dr workload list`     | `GET    /api/v2/workloads/`               | List workloads, optionally filtered by status. |
+| `dr workload delete`   | `DELETE /api/v2/workloads/{id}/`          | Delete a workload.                             |
+| `dr workload start`    | `POST   /api/v2/workloads/{id}/start`     | Start a stopped workload.                      |
+| `dr workload stop`     | `POST   /api/v2/workloads/{id}/stop`      | Stop a running workload.                       |
+| `dr workload status`   | `GET    /api/v2/workloads/{id}/`          | Print the bare status value.                   |
+| `dr workload endpoint` | `GET    /api/v2/workloads/{id}/`          | Print the endpoint URL.                        |
+| `dr workload logs`     | `GET    /api/v2/otel/workload/{id}/logs/` | Show a workload's container logs.              |
+
+## Subcommands
+
+### `create`
+
+Deploy a workload from a JSON or YAML spec file. The spec needs a `name` and exactly one of `artifactId` (an existing artifact) or an inline `artifact` object. JSON is sent to the server byte-for-byte; YAML is converted to JSON first. Startup is asynchronous, and the response includes the stable endpoint URL.
+
+```bash
+dr workload create --spec-file <path> [--output-format text|json]
+```
+
+**Flags:**
+
+- `--spec-file <path>`: path to the JSON or YAML spec (required).
+- `--output-format <text|json>`: output format. Defaults to `text`.
+
+**Example:**
+
+```yaml
+# workload.yaml - deploy an existing artifact
+name: my-app
+artifactId: 68b0c1d2e3f4a5b6c7d8e9f0
+runtime:
+  containerGroups:
+    - name: default
+      replicaCount: 1
+      containers:
+        - name: primary
+          resourceAllocation:
+            cpu: 1
+            memory: 512MB
+```
+
+```bash
+dr workload create --spec-file workload.yaml
+```
+
+To define the artifact in the same call instead of referencing one, replace `artifactId` with an inline `artifact:` object; the draft artifact is created and deployed together.
+
+### `get`
+
+Show a single workload: name, status, endpoint, artifact, and timestamps.
+
+```bash
+dr workload get <workload-id> [--output-format text|json]
+```
+
+### `list`
+
+List workloads, optionally filtered by status.
+
+```bash
+dr workload list [--status <status>] [--limit N] [--output-format text|json]
+```
+
+**Flags:**
+
+- `--status <status>`: filter by status. Repeatable, and also accepts comma-separated values (for example `--status running --status errored`).
+- `--limit <N>`: maximum number to return. Defaults to `100`.
+- `--output-format <text|json>`: output format. Defaults to `text`.
+
+### `delete`
+
+Delete a workload by id. A running workload is stopped first and then removed. The artifact it was created from is not deleted. You are asked to confirm unless `--yes` is set.
+
+```bash
+dr workload delete <workload-id> [--yes]
+```
+
+**Flags:**
+
+- `--yes`, `-y`: skip the confirmation prompt. Also honored via `DATAROBOT_CLI_NON_INTERACTIVE=1`.
+
+### `start` / `stop`
+
+Start a stopped workload, or stop a running one. Both are asynchronous: the server acknowledges the request and the workload transitions in the background. Each is a no-op if the workload is already in the target state.
+
+```bash
+dr workload start <workload-id> [--output-format text|json]
+dr workload stop  <workload-id> [--output-format text|json]
+```
+
+### `status`
+
+Print a workload's current status as a bare value (for example `running`), so it drops straight into scripts. An `errored` status is a valid answer, so the command still exits `0`. Use `dr workload get` for the full document.
+
+```bash
+dr workload status <workload-id> [--output-format text|json]
+```
+
+### `endpoint`
+
+Print only the workload's endpoint URL and nothing else, so it composes directly in scripts. The URL ends with a trailing slash, so append sub-paths without a leading slash of their own:
+
+```bash
+curl "$(dr workload endpoint <workload-id>)health"
+```
+
+The command fails when the workload has no endpoint URL yet.
+
+### `logs`
+
+Show the application logs from a workload's containers. By default it prints the most recent `--limit` lines oldest-first, like `kubectl logs --tail`. Use `--level` to drop everything below a severity, and `--follow` (`-f`) to keep streaming new lines as they arrive (Ctrl-C to stop).
+
+```bash
+dr workload logs <workload-id> [--limit N] [--level <level>] [--follow] [--output-format text|json]
+```
+
+**Flags:**
+
+- `--limit <N>`: number of recent lines to fetch. Defaults to `100`.
+- `--level <level>`: minimum level to show (`debug`, `info`, `warn`, `warning`, `error`, `critical`). Empty keeps every line.
+- `--follow`, `-f`: stream new lines as they arrive.
+- `--output-format <text|json>`: output format. Defaults to `text`. With `--follow`, JSON is emitted as one object per line (JSON Lines).
+
+## Shared flags
+
+### `--output-format`
+
+Every subcommand accepts `--output-format json` for machine-parseable output. The default, `text`, is human-readable. `status` and `endpoint` print a single bare value by default so they slot straight into scripts.
+
+### `--yes`
+
+`delete` prompts for confirmation unless you pass `--yes` / `-y` (or set `DATAROBOT_CLI_NON_INTERACTIVE=1`). The prompt is skipped automatically when stdin is not a terminal.
+
+### Global options
+
+All [global flags](README.md#global-flags) are available, notably `--debug` for protocol-level tracing.
+
+## Examples
+
+### Deploy, watch, and call a workload
+
+```bash
+dr workload create --spec-file workload.yaml   # prints the new workload id
+dr workload status <workload-id>               # repeat until "running"
+curl "$(dr workload endpoint <workload-id>)health"
+```
+
+### Operate a workload
+
+```bash
+dr workload list --status running
+dr workload logs   <workload-id> --follow
+dr workload stop   <workload-id>
+dr workload start  <workload-id>
+dr workload delete <workload-id>
+```
+
+## Error handling
+
+| Status | Cause                                                                                                       |
+| ------ | ----------------------------------------------------------------------------------------------------------- |
+| `403`  | Starting the workload would exceed your concurrent workload limits.                                         |
+| `404`  | The workload does not exist.                                                                                |
+| `409`  | The workload must finish its current transition first (for example a `start` while it is still `stopping`). |
+| `422`  | The spec failed server validation; the response names the offending JSON path.                              |
+
+## See also
+
+- [`dr artifact`](artifact.md): build and lock the artifact a workload runs.
+- [Authentication](auth.md): how `dr auth login` and `--skip-auth` interact.
+- [Configuration](../user-guide/configuration.md): config file and environment-variable precedence.
+- [Feature gates](../development/feature-gates.md): turning `DATAROBOT_CLI_FEATURE_WORKLOAD` on and off.


### PR DESCRIPTION
# RATIONALE

The `dr artifact` and `dr workload` command groups had no user-facing documentation. This adds their command-reference pages so users can discover and use them.

## CHANGES

- Add `docs/commands/artifact.md`: reference for the `dr artifact` group: the draft-to-locked lifecycle (`create` / `get` / `list` / `lock` / `delete`), `build` (`create` / `get` / `list` / `logs`), and `code` (`init` / `sync` / `versions` / `checkout`, backed by the `.wapi/` state dir).
- Add `docs/commands/workload.md`: reference for the `dr workload` group (`create` / `get` / `list` / `delete` / `start` / `stop` / `status` / `endpoint` / `logs`), including the async status lifecycle and the artifact-to-workload relationship.
- Both pages follow the existing `pipeline.md` structure: synopsis, description, command-groups table with endpoints, per-subcommand usage and flags, examples, and an error-handling table.
- Link both from `docs/commands/README.md` (main commands table, command tree, and command details).
- The pages are left out of the `mkdocs.yml` nav while both groups remain gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD`.

## TESTING

- `markdownlint-cli2` reports no errors on the two new pages.
- `mkdocs build` succeeds; all cross-links resolve and the pages render.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or CLI behavior impact.
> 
> **Overview**
> Adds user-facing command reference for the feature-gated **`dr artifact`** and **`dr workload`** (alias **`wl`**) groups, which previously had no dedicated docs.
> 
> **`docs/commands/artifact.md`** documents the draft→locked artifact lifecycle, **`build`** subcommands, and **`code`** sync via **`.wapi/`**, aligned with the existing **`pipeline.md`** layout (synopsis, API mapping tables, flags, examples, HTTP error table).
> 
> **`docs/commands/workload.md`** covers deploy/operate flows (async status, **`endpoint`** / **`logs`** for scripting), with the same structure.
> 
> **`docs/commands/README.md`** is updated to list both commands in the main table, expand the command tree, and add command-details bullets; the main commands table formatting is widened for alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee5fef165d322b5313a8a183f82312818394a34. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->