### PR TITLE
[CFX-6320] Surface install commands and resolution hint in dependency check failures

### DIFF
--- a/cmd/dependencies/check/cmd.go
+++ b/cmd/dependencies/check/cmd.go
@@ -40,7 +40,7 @@ func Cmd() *cobra.Command {
 			if len(result.MissingMsgs) > 0 || len(result.WrongVersionMsgs) > 0 {
 				cmd.SilenceUsage = true
 
-				return errors.New(tools.PrerequisitesMsg(result.MissingMsgs, result.WrongVersionMsgs))
+				return errors.New(tools.PrerequisitesMsg(result))
 			}
 
 			fmt.Fprintln(cmd.OutOrStdout(), "✅ All dependencies are already up to date.")

--- a/cmd/dependencies/install/cmd.go
+++ b/cmd/dependencies/install/cmd.go
@@ -60,7 +60,7 @@ func Cmd() *cobra.Command {
 				return nil
 			}
 
-			fmt.Fprintln(cmd.OutOrStderr(), tools.PrerequisitesMsg(checkResult.MissingMsgs, checkResult.WrongVersionMsgs))
+			fmt.Fprintln(cmd.OutOrStderr(), tools.PrerequisitesMsg(checkResult))
 
 			prerequisites := append(checkResult.MissingTools, checkResult.WrongVersionTools...)
 

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -558,7 +558,7 @@ func checkPrerequisites(m *Model) tea.Msg {
 	}
 
 	prerequisites := append(result.MissingTools, result.WrongVersionTools...)
-	message := tools.PrerequisitesMsg(result.MissingMsgs, result.WrongVersionMsgs)
+	message := tools.PrerequisitesMsg(result)
 
 	log.Debug("start: deps to install/update", "count", len(prerequisites))
 

--- a/internal/tools/prerequisites.go
+++ b/internal/tools/prerequisites.go
@@ -165,26 +165,43 @@ func CheckPrerequisites() CheckResult {
 }
 
 // PrerequisitesMsg formats the message to display to the user about missing/wrong-version prerequisites.
-func PrerequisitesMsg(missingMsgs []string, wrongVersionMsgs []string) string {
-	result := make([]string, 0)
+// It includes per-tool install commands and a resolution hint.
+func PrerequisitesMsg(result CheckResult) string {
+	parts := make([]string, 0)
 
-	if len(missingMsgs) > 0 {
-		result = append(result, "\n ❌ Missing required tools:\n")
+	if len(result.MissingTools) > 0 {
+		parts = append(parts, "\n ❌ Missing required tools:\n")
 
-		for _, msg := range missingMsgs {
-			result = append(result, "\t- "+msg)
+		for _, tool := range result.MissingTools {
+			line := fmt.Sprintf("\t- %s %s (%s)", tool.Name, tool.MinimumVersion, tool.URL)
+
+			if installCmd, err := tool.PlatformInstallCommand(); err == nil {
+				line += "\n\t  Install: " + installCmd
+			}
+
+			parts = append(parts, line)
 		}
 	}
 
-	if len(wrongVersionMsgs) > 0 {
-		result = append(result, "\n ⚠️ Wrong versions of tools:\n")
+	if len(result.WrongVersionMsgs) > 0 {
+		parts = append(parts, "\n ⚠️ Wrong versions of tools:\n")
 
-		for _, msg := range wrongVersionMsgs {
-			result = append(result, "\t- "+msg)
+		for i, msg := range result.WrongVersionMsgs {
+			line := "\t- " + strings.TrimRight(msg, "\n")
+
+			if i < len(result.WrongVersionTools) {
+				if installCmd, err := result.WrongVersionTools[i].PlatformInstallCommand(); err == nil {
+					line += "\n\t  Install: " + installCmd
+				}
+			}
+
+			parts = append(parts, line)
 		}
 	}
 
-	return strings.Join(result, "\n") + "\n"
+	parts = append(parts, "\nRun 'dr dependency install' to install missing dependencies automatically.")
+
+	return strings.Join(parts, "\n") + "\n"
 }
 
 func commandArgs(fullCommand string) (string, []string) {

--- a/internal/tools/prerequisites_test.go
+++ b/internal/tools/prerequisites_test.go
@@ -156,32 +156,68 @@ func TestSufficientSelfVersion(t *testing.T) {
 }
 
 func TestPrerequisitesMsg_BothEmpty(t *testing.T) {
-	out := PrerequisitesMsg(nil, nil)
+	out := PrerequisitesMsg(CheckResult{})
 
-	assert.Equal(t, "\n", out)
+	assert.Contains(t, out, "dr dependency install")
 }
 
 func TestPrerequisitesMsg_MissingOnly(t *testing.T) {
-	out := PrerequisitesMsg([]string{"uv 0.4.0 (https://example.com)"}, nil)
+	result := CheckResult{
+		MissingTools: []Prerequisite{
+			{Name: "uv", MinimumVersion: "0.4.0", URL: "https://example.com"},
+		},
+	}
+
+	out := PrerequisitesMsg(result)
 
 	assert.Contains(t, out, "Missing required tools")
 	assert.Contains(t, out, "uv 0.4.0")
+	assert.Contains(t, out, "https://example.com")
 	assert.NotContains(t, out, "Wrong versions")
+	assert.Contains(t, out, "dr dependency install")
+}
+
+func TestPrerequisitesMsg_MissingOnly_WithInstallCmd(t *testing.T) {
+	result := CheckResult{
+		MissingTools: []Prerequisite{
+			{
+				Name:           "uv",
+				MinimumVersion: "0.4.0",
+				URL:            "https://example.com",
+				Install:        InstallCommands{MacOS: "brew install uv", Linux: "curl -Ls https://astral.sh/uv/install.sh | sh"},
+			},
+		},
+	}
+
+	out := PrerequisitesMsg(result)
+
+	assert.Contains(t, out, "Install:")
 }
 
 func TestPrerequisitesMsg_WrongVersionOnly(t *testing.T) {
-	out := PrerequisitesMsg(nil, []string{"task (minimal: v3.35.0, installed: v3.32.0)"})
+	result := CheckResult{
+		WrongVersionTools: []Prerequisite{{Name: "task"}},
+		WrongVersionMsgs:  []string{"task (minimal: v3.35.0, installed: v3.32.0)"},
+	}
+
+	out := PrerequisitesMsg(result)
 
 	assert.Contains(t, out, "Wrong versions of tools")
 	assert.Contains(t, out, "task (minimal: v3.35.0")
 	assert.NotContains(t, out, "Missing required")
+	assert.Contains(t, out, "dr dependency install")
 }
 
 func TestPrerequisitesMsg_Both(t *testing.T) {
-	out := PrerequisitesMsg(
-		[]string{"uv 0.4.0 (https://example.com)"},
-		[]string{"task (minimal: v3.35.0, installed: v3.32.0)"},
-	)
+	result := CheckResult{
+		MissingTools: []Prerequisite{
+			{Name: "uv", MinimumVersion: "0.4.0", URL: "https://example.com"},
+		},
+		WrongVersionTools: []Prerequisite{{Name: "task"}},
+		WrongVersionMsgs:  []string{"task (minimal: v3.35.0, installed: v3.32.0)"},
+	}
+
+	out := PrerequisitesMsg(result)
 
 	assert.Contains(t, out, "Missing required tools")
 	assert.Contains(t, out, "uv 0.4.0")
@@ -190,15 +226,28 @@ func TestPrerequisitesMsg_Both(t *testing.T) {
 }
 
 func TestPrerequisitesMsg_MultipleEntries(t *testing.T) {
-	out := PrerequisitesMsg([]string{"uv", "pulumi"}, []string{"task"})
+	result := CheckResult{
+		MissingTools: []Prerequisite{
+			{Name: "uv"},
+			{Name: "pulumi"},
+		},
+		WrongVersionTools: []Prerequisite{{Name: "task"}},
+		WrongVersionMsgs:  []string{"task"},
+	}
 
-	assert.Contains(t, out, "\t- uv")
-	assert.Contains(t, out, "\t- pulumi")
-	assert.Contains(t, out, "\t- task")
+	out := PrerequisitesMsg(result)
+
+	assert.Contains(t, out, "uv")
+	assert.Contains(t, out, "pulumi")
+	assert.Contains(t, out, "task")
 }
 
 func TestPrerequisitesMsg_EndsWithNewline(t *testing.T) {
-	out := PrerequisitesMsg([]string{"uv"}, nil)
+	result := CheckResult{
+		MissingTools: []Prerequisite{{Name: "uv"}},
+	}
+
+	out := PrerequisitesMsg(result)
 
 	assert.True(t, len(out) > 0 && out[len(out)-1] == '\n')
 }


### PR DESCRIPTION
> [!NOTE]
> **This is a draft PR.** Automated investigation of [CFX-6320](https://datarobot.atlassian.net/browse/CFX-6320) showed the bug is still present in the current codebase. This PR may not be necessary if the issue is already being addressed elsewhere — please verify before merging.

# RATIONALE

During UX research (P2 session, May 2026), a junior developer hit a hard stop when `dr dependency check` reported missing dependencies but provided no guidance on how to resolve them. The error message showed tool names, required versions, and download URLs — but no install command and no pointer to `dr dependency install`.

The `Prerequisite` struct already carries platform-specific install commands (`Install.MacOS`, `Install.Linux`, `Install.Windows`) via `PlatformInstallCommand()`, but these were never surfaced to the user.

## CHANGES

- Changed `PrerequisitesMsg` to accept `CheckResult` (instead of two `[]string` slices) so it has access to the full `Prerequisite` structs
- For each missing tool, the error now includes the platform-appropriate install command (e.g. `Install: brew install uv`)
- For each wrong-version tool, same install command is appended
- A trailing hint is added: `Run 'dr dependency install' to install missing dependencies automatically.`
- Updated all three callers: `dr dependency check`, `dr dependency install`, and `dr start`
- Updated tests accordingly; added `TestPrerequisitesMsg_MissingOnly_WithInstallCmd` to cover the new install-command path

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.