### PR TITLE
[CFX-6377] chore: update permissions for build-windows job in smoke test workflows

### DIFF
--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -117,6 +117,11 @@ jobs:
 
   build-windows:
     needs: [resolve-pr, security-scan]
+    # S5: caller job must grant at least the permissions the reusable workflow requests.
+    # The nested build-windows job needs contents:read (checkout) and actions:write (upload-artifact).
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/.build-windows.yaml
     with:
       go-version: '1.26.4'
@@ -172,6 +177,9 @@ jobs:
 
   linux-smoke-tests:
     needs: [resolve-pr, security-scan]
+    # S5: caller job must grant at least what the reusable workflow requests (contents:read).
+    permissions:
+      contents: read
     uses: ./.github/workflows/.smoke-tests-matrix.yaml
     with:
       go-version: '1.26.4'
@@ -182,6 +190,9 @@ jobs:
 
   windows-smoke-tests:
     needs: [resolve-pr, security-scan, build-windows]
+    # S5: caller job must grant at least what the reusable workflow requests (contents:read).
+    permissions:
+      contents: read
     uses: ./.github/workflows/.windows-smoke-test.yaml
     with:
       artifact-name: 'dr-windows-fork'

--- a/.github/workflows/smoke-tests-on-demand.yaml
+++ b/.github/workflows/smoke-tests-on-demand.yaml
@@ -79,6 +79,11 @@ jobs:
   build-windows:
     needs: check-fork
     if: needs.check-fork.outputs.is_fork == 'false'
+    # S5: caller job must grant at least what the reusable workflow requests.
+    # .build-windows.yaml needs contents:read (checkout) and actions:write (upload-artifact).
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/.build-windows.yaml
     with:
       go-version: '1.26.4'

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -23,6 +23,11 @@ permissions:
 
 jobs:
   build-windows:
+    # S5: caller job must grant at least what the reusable workflow requests.
+    # .build-windows.yaml needs contents:read (checkout) and actions:write (upload-artifact).
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/.build-windows.yaml
     with:
       go-version: '1.26.4'


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission scoping with no application or secret-handling logic changes; misconfiguration could block workflows but does not broaden runtime attack surface.
> 
> **Overview**
> Aligns smoke-test **caller jobs** with GitHub reusable-workflow rules (S5): each job that `uses:` a nested workflow now declares the minimum `permissions` that workflow needs.
> 
> **`build-windows`** callers in `smoke-tests.yaml`, `smoke-tests-on-demand.yaml`, and `fork-smoke-tests.yaml` gain `contents: read` and `actions: write` so checkout and artifact upload in `.build-windows.yaml` are allowed. On **fork** runs, where the workflow defaults to `permissions: {}`, this is required for Windows builds to succeed.
> 
> **Fork smoke tests** also set `contents: read` on **`linux-smoke-tests`** and **`windows-smoke-tests`** so those reusable matrix/windows jobs can check out code under the same deny-by-default policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5db2e7930bec37efe1cac3ed3c6e85ec3daf29c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->