### PR TITLE
fix: optimize auth login script for non-interactive mode and reduce t…

### DIFF
--- a/smoke_test_scripts/expect_auth_login.exp
+++ b/smoke_test_scripts/expect_auth_login.exp
@@ -1,22 +1,49 @@
 #!/usr/local/bin/expect -f
 
-set timeout 20
+set timeout 10
 
 # Use TERM=dumb to prevent terminal color probing which causes OSC sequences
 set env(TERM) dumb
 
+# Force non-interactive mode so the CLI skips the animated Bubble Tea spinner
+# (which otherwise burns CPU redrawing every frame) and prints a single static
+# "Waiting for browser authorization…" line instead. Ctrl-C is delivered as a
+# real SIGINT, which cancels the root context and unblocks the auth wait via the
+# normal signal path (fast, deterministic exit).
+set env(DATAROBOT_CLI_NON_INTERACTIVE) 1
+
 spawn dr auth login
 
-# If we get an prompt for needed URL be sure to set it first
+# In the re-auth path the URL is already configured, so the set-url prompt never
+# appears and we go straight to the redirect URL. Handle both branches in a
+# single expect block so we don't sit through the full timeout waiting for a
+# prompt that won't show up. As soon as the auth URL is printed the CLI starts
+# waiting for browser authorization — there is no browser round-trip in tests,
+# so we interrupt immediately rather than waiting on the (unbounded) callback.
 expect {
     "Check your DataRobot login page" {
-        send -- "https://app.datarobot.com\r\n"
+        send -- "https://app.datarobot.com\r"
+        exp_continue
     }
-    timeout
+    "cliRedirect=true" {
+        # Auth URL displayed; the CLI is now waiting for browser authorization.
+        # SIGINT unblocks the wait at once (root context cancellation), so no
+        # sleep is needed before interrupting.
+        send -- "\x03"
+    }
+    timeout {
+        puts "ERROR: timed out waiting for the auth URL"
+        exit 1
+    }
 }
 
-expect "https://app.datarobot.com/account/developer-tools?cliRedirect=true"
-sleep 3
-# ctrl-c
-send -- {^C}
-expect eof
+# The process should exit promptly after the interrupt. If it somehow doesn't,
+# force it closed so the test can never hang for the full smoke-test budget.
+expect {
+    eof {}
+    timeout {
+        puts "WARN: process did not exit after interrupt; forcing close"
+        close
+        wait
+    }
+}

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -175,10 +175,55 @@ if ($config_content -match "endpoint: `"${testing_url}/api/v2`"") {
 Write-End
 
 # Test auth login
+#
+# This mirrors the bash expect test (expect_auth_login.exp): it does NOT verify a
+# live token (that is what 'dr auth check' does, and it requires a valid token +
+# reachable server). Instead it confirms that 'dr auth login' starts up and prints
+# the OAuth redirect URL, then terminates the process. PowerShell has no 'expect',
+# so we launch the command in the background, poll its output for the auth URL, and
+# kill it once seen.
 Write-Delimiter "Testing dr auth login"
-Write-InfoMsg "Testing dr auth login command (non-interactive)..."
-# Note: Full interactive testing would require a Windows expect equivalent
-dr auth check
+Write-InfoMsg "Testing dr auth login command..."
+
+$auth_out = Join-Path (Get-Location) "auth_login_stdout.txt"
+$auth_err = Join-Path (Get-Location) "auth_login_stderr.txt"
+
+$auth_proc = Start-Process -FilePath "dr" -ArgumentList "auth", "login" `
+    -RedirectStandardOutput $auth_out -RedirectStandardError $auth_err `
+    -PassThru -NoNewWindow
+
+# Poll for the auth redirect URL (same marker the bash expect script matches).
+$auth_url_shown = $false
+for ($i = 0; $i -lt 20; $i++) {
+    Start-Sleep -Milliseconds 500
+    if (Test-Path $auth_out) {
+        if ((Get-Content $auth_out -Raw) -match "cliRedirect=true") {
+            $auth_url_shown = $true
+            break
+        }
+    }
+    if ($auth_proc.HasExited) { break }
+}
+
+# No browser round-trip happens in tests, so stop the waiting process. Guard the
+# kill: the process may exit between the check and the Kill() call, which would
+# otherwise throw under $ErrorActionPreference = "Stop".
+if (-not $auth_proc.HasExited) {
+    try {
+        $auth_proc.Kill()
+        $auth_proc.WaitForExit()
+    } catch {
+        # Process already exited; nothing to clean up.
+    }
+}
+
+Remove-Item $auth_out, $auth_err -Force -ErrorAction SilentlyContinue
+
+if ($auth_url_shown) {
+    Write-SuccessMsg "Assertion passed: 'dr auth login' displayed the OAuth redirect URL."
+} else {
+    Write-ErrorMsg "Assertion failed: 'dr auth login' did not display the auth URL (cliRedirect=true)."
+}
 Write-End
 
 # Test templates (if URL is accessible)


### PR DESCRIPTION

# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->
Some expect steps waits timeouts instead of silently skip non interactive modes( browser opening links etc.) 
optimized time of smoke tests run
before
[7m 9s](https://github.com/datarobot-oss/cli/actions/runs/27963925225/usage)
after
[5m 17s](https://github.com/datarobot-oss/cli/actions/runs/27966283984/usage)

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to an Expect script; no production CLI or auth logic modified.
> 
> **Overview**
> The **`expect_auth_login.exp`** smoke script is updated so **`dr auth login`** runs faster and more reliably in CI.
> 
> It sets **`DATAROBOT_CLI_NON_INTERACTIVE=1`** so the CLI skips the Bubble Tea spinner and uses a static wait line, and lowers the expect timeout from 20s to **10s**. Auth flow handling is merged into one **`expect`** block that covers both the “set URL” prompt and the redirect URL (`cliRedirect=true`), sends **SIGINT** (`\x03`) as soon as the auth URL appears instead of sleeping and sending Ctrl-C, and fails clearly on timeout. A follow-up **`expect`** waits for **eof** or forcibly closes the process if it does not exit after interrupt, avoiding hangs on the smoke budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40295bcf2866c16290b864919cb89579b1ebb4b3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->