### PR TITLE
Add assist plugin v0.1.29

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.29",
+          "url": "assist/assist-0.1.29.tar.xz",
+          "sha256": "f581396252189eaf057150e818f13f92b9f07e0fb1e6b372512bfc825dc6c28b",
+          "releaseDate": "2026-06-23"
+        },
+        {
           "version": "0.1.28",
           "url": "assist/assist-0.1.28.tar.xz",
           "sha256": "d8fdf16fd62ea02442f5232a369046fbd962db9bde4d400fa180758406a0ae7c",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.29 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.29
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.29
- **SHA256:** `f581396252189eaf057150e818f13f92b9f07e0fb1e6b372512bfc825dc6c28b`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Index-only metadata change with no application code; risk is limited to a wrong URL or checksum blocking installs.
> 
> **Overview**
> Registers **assist** **v0.1.29** as the newest entry in `docs/plugins/index.json`, ahead of v0.1.28. The new record points at `assist/assist-0.1.29.tar.xz` and includes its SHA256 (`f5813962…`) and release date **2026-06-23**, so `dr plugin install assist` can resolve and verify that build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2078072d87537b693735be486c09ac11790a5841. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->