### PR TITLE
[CMPT-6415]: propagate pipelines-api latest changes

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -160,22 +160,6 @@ tasks:
     cmds:
       - ./smoke_test_scripts/run_pre_release_smoke_test.sh {{if .DR_API_TOKEN}}{{.DR_API_TOKEN}}{{else}}$DR_API_TOKEN{{end}}
 
-  demo-pipelines:
-    desc: "End-to-end demo of every dr pipelines command. Defaults to interactive (keypress per step); pass DELAY=N or `-- --delay=N` for auto-advance. Set SKIP_SCHEDULES=true or SKIP_ENVIRONMENTS=true to skip steps that require k8s/Covalent."
-    deps: [build]
-    vars:
-      DEMO_DIR: '{{default "/Users/sunnypal.sharma/Desktop/tests/pipelines-api" .DEMO_DIR}}'
-      DELAY_FLAG: '{{if .DELAY}}--delay={{.DELAY}}{{end}}'
-    env:
-      DATAROBOT_CLI_FEATURE_PIPELINE: "true"
-      # DATAROBOT_CLI_ENDPOINT: "http://localhost:8100/api/v2"
-      # DATAROBOT_CLI_TOKEN: "local"
-      # DATAROBOT_CLI_SKIP_AUTH: "true"
-      DEMO_SKIP_SCHEDULES: '{{if eq .SKIP_SCHEDULES "false"}}false{{else}}true{{end}}'
-      DEMO_SKIP_IMAGES: '{{if eq .SKIP_IMAGES "false"}}false{{else}}true{{end}}'
-    cmds:
-      - DR_BIN="$PWD/dist/dr" DEMO_DIR="{{.DEMO_DIR}}" bash "{{.DEMO_DIR}}/demo.sh" {{.DELAY_FLAG}} {{.CLI_ARGS}} 2>&1 | tee output.txt
-
   smoke-test-self-update:
     desc: "Run self-update smoke tests"
     cmds:
@@ -199,8 +183,8 @@ tasks:
     cmds:
       - echo "📚 Starting documentation server…"
       - uv sync
-      - echo "🌐 Open http://localhost:8001 in your browser"
-      - uv run mkdocs serve --dev-addr localhost:8001
+      - echo "🌐 Open http://localhost:8000 in your browser"
+      - uv run mkdocs serve
 
   copyright:
     silent: true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -160,6 +160,22 @@ tasks:
     cmds:
       - ./smoke_test_scripts/run_pre_release_smoke_test.sh {{if .DR_API_TOKEN}}{{.DR_API_TOKEN}}{{else}}$DR_API_TOKEN{{end}}
 
+  demo-pipelines:
+    desc: "End-to-end demo of every dr pipelines command. Defaults to interactive (keypress per step); pass DELAY=N or `-- --delay=N` for auto-advance. Set SKIP_SCHEDULES=true or SKIP_ENVIRONMENTS=true to skip steps that require k8s/Covalent."
+    deps: [build]
+    vars:
+      DEMO_DIR: '{{default "/Users/sunnypal.sharma/Desktop/tests/pipelines-api" .DEMO_DIR}}'
+      DELAY_FLAG: '{{if .DELAY}}--delay={{.DELAY}}{{end}}'
+    env:
+      DATAROBOT_CLI_FEATURE_PIPELINE: "true"
+      # DATAROBOT_CLI_ENDPOINT: "http://localhost:8100/api/v2"
+      # DATAROBOT_CLI_TOKEN: "local"
+      # DATAROBOT_CLI_SKIP_AUTH: "true"
+      DEMO_SKIP_SCHEDULES: '{{if eq .SKIP_SCHEDULES "false"}}false{{else}}true{{end}}'
+      DEMO_SKIP_IMAGES: '{{if eq .SKIP_IMAGES "false"}}false{{else}}true{{end}}'
+    cmds:
+      - DR_BIN="$PWD/dist/dr" DEMO_DIR="{{.DEMO_DIR}}" bash "{{.DEMO_DIR}}/demo.sh" {{.DELAY_FLAG}} {{.CLI_ARGS}} 2>&1 | tee output.txt
+
   smoke-test-self-update:
     desc: "Run self-update smoke tests"
     cmds:
@@ -183,8 +199,8 @@ tasks:
     cmds:
       - echo "📚 Starting documentation server…"
       - uv sync
-      - echo "🌐 Open http://localhost:8000 in your browser"
-      - uv run mkdocs serve
+      - echo "🌐 Open http://localhost:8001 in your browser"
+      - uv run mkdocs serve --dev-addr localhost:8001
 
   copyright:
     silent: true

--- a/cmd/pipeline/cmd.go
+++ b/cmd/pipeline/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/datarobot/cli/cmd/pipeline/lock"
 	"github.com/datarobot/cli/cmd/pipeline/run"
 	"github.com/datarobot/cli/cmd/pipeline/schedule"
+	"github.com/datarobot/cli/cmd/pipeline/source"
 	"github.com/datarobot/cli/cmd/pipeline/task"
 	"github.com/datarobot/cli/cmd/pipeline/update"
 	"github.com/datarobot/cli/cmd/pipeline/version"
@@ -60,6 +61,7 @@ input payloads, runs, and recurring schedules.`,
 		input.Cmd(),
 		schedule.Cmd(),
 		image.Cmd(),
+		source.Cmd(),
 		task.Cmd(),
 	)
 

--- a/cmd/pipeline/create/cmd.go
+++ b/cmd/pipeline/create/cmd.go
@@ -32,6 +32,7 @@ func Cmd() *cobra.Command {
 		description  string
 		name         string
 		mode         string
+		imageID      string
 		outputFormat outputformat.OutputFormat
 		fromFile     string
 	)
@@ -52,6 +53,7 @@ Example:
   dr pipeline create ./my_pipeline.py
   dr pipeline create --from-file=./my_pipeline.py
   dr pipeline create ./my_pipeline.py --name "My Pipeline" --description "First draft" --mode draft
+  dr pipeline create ./my_pipeline.py --image <image-id>
   dr pipeline create --from-file=./my_pipeline.py --output-format json`,
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
@@ -74,7 +76,7 @@ Example:
 				return err
 			}
 
-			result, err := pipeline.CreatePipeline(filePath, description, name, mode)
+			result, err := pipeline.CreatePipeline(filePath, description, name, mode, imageID)
 			if err != nil {
 				return err
 			}
@@ -88,6 +90,7 @@ Example:
 	cmd.Flags().StringVar(&description, "description", "", "Optional description for the pipeline")
 	cmd.Flags().StringVar(&name, "name", "", "Optional human-readable display name; defaults to the title-cased @pipeline function name")
 	cmd.Flags().StringVar(&mode, "mode", "", "Pipeline mode: draft or locked")
+	cmd.Flags().StringVar(&imageID, "image", "", "Execution image ID to associate with this pipeline")
 	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to the Python file to upload, e.g. --from-file=./my_pipeline.py (alternative to the positional argument)")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {

--- a/cmd/pipeline/image/cmd.go
+++ b/cmd/pipeline/image/cmd.go
@@ -17,6 +17,7 @@ package image
 import (
 	"github.com/datarobot/cli/cmd/pipeline/image/create"
 	"github.com/datarobot/cli/cmd/pipeline/image/del"
+	"github.com/datarobot/cli/cmd/pipeline/image/get"
 	"github.com/datarobot/cli/cmd/pipeline/image/list"
 	"github.com/datarobot/cli/cmd/pipeline/image/update"
 	"github.com/datarobot/cli/cmd/pipeline/image/version"
@@ -42,6 +43,7 @@ deleted individually with ` + "`image version delete`" + `.`,
 
 	cmd.AddCommand(
 		create.Cmd(),
+		get.Cmd(),
 		list.Cmd(),
 		update.Cmd(),
 		del.Cmd(),

--- a/cmd/pipeline/image/cmd.go
+++ b/cmd/pipeline/image/cmd.go
@@ -25,7 +25,7 @@ import (
 
 // Cmd returns the parent command for `dr pipeline image`. It groups the
 // lifecycle verbs that operate on pipeline execution images (named,
-// immutable-versioned bags of pip packages).
+// immutable-versioned execution environments).
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "image",
@@ -33,10 +33,10 @@ func Cmd() *cobra.Command {
 		Short:   "Manage pipeline execution images",
 		Long: `Manage pipeline execution images.
 
-Images are named, immutable-versioned bags of pip packages that
-pipelines can be built against. Each ` + "`update`" + ` adds packages by
-creating a new version; older versions can be deleted individually with
-` + "`image version delete`" + `.`,
+Images are named, immutable-versioned execution environments backed by
+pip packages that pipelines can be built against. Each ` + "`update`" + ` creates
+a new version with a complete replacement definition; older versions can be
+deleted individually with ` + "`image version delete`" + `.`,
 	}
 
 	cmd.AddCommand(

--- a/cmd/pipeline/image/cmd.go
+++ b/cmd/pipeline/image/cmd.go
@@ -34,7 +34,8 @@ func Cmd() *cobra.Command {
 		Long: `Manage pipeline execution images.
 
 Images are named, immutable-versioned execution environments backed by
-pip packages that pipelines can be built against. Each ` + "`update`" + ` creates
+pip packages, conda packages, a base Docker image, and optional NVIDIA GPU
+support. Pipelines can be built against them. Each ` + "`update`" + ` creates
 a new version with a complete replacement definition; older versions can be
 deleted individually with ` + "`image version delete`" + `.`,
 	}

--- a/cmd/pipeline/image/create/cmd.go
+++ b/cmd/pipeline/image/create/cmd.go
@@ -26,10 +26,14 @@ import (
 
 func Cmd() *cobra.Command {
 	var (
-		name         string
-		description  string
-		rawPackages  []string
-		outputFormat outputformat.OutputFormat
+		name          string
+		description   string
+		rawPackages   []string
+		rawConda      []string
+		rawCondaChans []string
+		baseImage     string
+		nvidia        bool
+		outputFormat  outputformat.OutputFormat
 	)
 
 	cmd := &cobra.Command{
@@ -38,12 +42,15 @@ func Cmd() *cobra.Command {
 		Long: `Create a new pipeline execution image.
 
 A new image is registered with an initial version (v1) containing the
-supplied pip packages. The image may be referenced by pipelines once
+supplied package definition. The image may be referenced by pipelines once
 its first version reaches the READY state.
+
+At least one of --package (pip) or --conda must be provided.
 
 Example:
   dr pipeline image create --name ml-base --package numpy --package pandas
-  dr pipeline image create --name ml-base --package numpy,pandas==2.0 --description "training base" --output-format json`,
+  dr pipeline image create --name ml-base --conda scipy --conda numpy --base-image python:3.12
+  dr pipeline image create --name gpu-base --package torch --nvidia --output-format json`,
 		Args:         cobra.NoArgs,
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
@@ -54,12 +61,18 @@ Example:
 				return errors.New("--name is required")
 			}
 
-			packages, err := pipeline.NormalizePackages(rawPackages)
-			if err != nil {
-				return err
+			pip := pipeline.NormalizePackageList(rawPackages)
+			conda := pipeline.BuildCondaValue(rawConda, rawCondaChans)
+
+			if len(pip) == 0 && conda == nil {
+				return errors.New("at least one of --package (pip) or --conda is required")
 			}
 
-			result, err := pipeline.CreateImage(name, description, packages)
+			if conda != nil && len(conda.Deps) == 0 {
+				return errors.New("--conda-channel requires at least one --conda package")
+			}
+
+			result, err := pipeline.CreateImage(name, description, pip, conda, baseImage, nvidia)
 			if err != nil {
 				return err
 			}
@@ -74,6 +87,10 @@ Example:
 	_ = cmd.MarkFlagRequired("name")
 	cmd.Flags().StringVar(&description, "description", "", "Optional description")
 	cmd.Flags().StringSliceVar(&rawPackages, "package", nil, "Pip package spec (repeatable, also accepts comma-separated values)")
+	cmd.Flags().StringSliceVar(&rawConda, "conda", nil, "Conda package spec (repeatable)")
+	cmd.Flags().StringSliceVar(&rawCondaChans, "conda-channel", nil, "Conda channel (repeatable; if set, sends a structured CondaSpec)")
+	cmd.Flags().StringVar(&baseImage, "base-image", "", "Docker base image URI (e.g. python:3.12)")
+	cmd.Flags().BoolVar(&nvidia, "nvidia", false, "Enable NVIDIA GPU support")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/image/get/cmd.go
+++ b/cmd/pipeline/image/get/cmd.go
@@ -1,0 +1,78 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/pipeline"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:   "get <image-id>",
+		Short: "Fetch details of a pipeline execution image",
+		Long: `Fetch the full detail of a pipeline execution image, including all versions
+and their build status.
+
+By default, output is human-readable. Use --output-format json for machine-parseable output.
+
+Example:
+  dr pipeline image get img-507f1f77bcf86cd799439011
+  dr pipeline image get img-507f1f77bcf86cd799439011 --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		RunE: func(_ *cobra.Command, args []string) error {
+			imageID := args[0]
+
+			img, err := pipeline.GetImage(imageID)
+			if err != nil {
+				var httpErr *drapi.HTTPError
+
+				if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+					fmt.Println(tui.DimStyle.Render("No image found: " + imageID))
+
+					return nil
+				}
+
+				return err
+			}
+
+			return pipeline.RenderImage(outputFormat, *img)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"image_id":      telemetry.FirstArg(args),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/pipeline/image/get/cmd.go
+++ b/cmd/pipeline/image/get/cmd.go
@@ -45,7 +45,9 @@ Example:
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		PreRunE:      auth.EnsureAuthenticatedE,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
 			imageID := args[0]
 
 			img, err := pipeline.GetImage(imageID)

--- a/cmd/pipeline/image/get/cmd_test.go
+++ b/cmd/pipeline/image/get/cmd_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runCmd(t *testing.T, args ...string) error {
+	t.Helper()
+
+	cmd := Cmd()
+	cmd.SetArgs(args)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.PreRunE = nil
+
+	return cmd.Execute()
+}
+
+func TestCmd_RequiresImageArg(t *testing.T) {
+	err := runCmd(t)
+	require.Error(t, err)
+}
+
+func TestCmd_RejectsInvalidOutputFormat(t *testing.T) {
+	err := runCmd(t, "--output-format", "yaml", "img-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}
+
+func TestCmd_HasExpectedFlags(t *testing.T) {
+	cmd := Cmd()
+	assert.NotNil(t, cmd.Flags().Lookup("output-format"), "expected --output-format flag")
+}
+
+func TestCmd_RejectsExtraArgs(t *testing.T) {
+	err := runCmd(t, "img-1", "img-2")
+	require.Error(t, err)
+}

--- a/cmd/pipeline/image/update/cmd.go
+++ b/cmd/pipeline/image/update/cmd.go
@@ -15,6 +15,8 @@
 package update
 
 import (
+	"errors"
+
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
@@ -24,35 +26,47 @@ import (
 
 func Cmd() *cobra.Command {
 	var (
-		rawPackages  []string
-		outputFormat outputformat.OutputFormat
+		rawPackages   []string
+		rawConda      []string
+		rawCondaChans []string
+		baseImage     string
+		nvidia        bool
+		outputFormat  outputformat.OutputFormat
 	)
 
 	cmd := &cobra.Command{
 		Use:   "update <image-id>",
 		Short: "Add a new version to a pipeline execution image",
-		Long: `Update a pipeline execution image by creating a new version with the supplied pip packages.
+		Long: `Update a pipeline execution image by creating a new version with the supplied definition.
 
-Each update creates a new immutable version. The supplied packages become
-the complete pip list for that version — existing packages are not carried
-over automatically. To add a package, include all desired packages in the
-new version's list.
+Each update creates a new immutable version. The supplied definition becomes
+the complete spec for that version — existing packages are not carried over
+automatically. To add a package, include all desired packages in the new version.
+
+At least one of --package (pip) or --conda must be provided.
 
 Example:
   dr pipeline image update img-123 --package scikit-learn
-  dr pipeline image update img-123 --package "scikit-learn==1.5,torch" --output-format json`,
+  dr pipeline image update img-123 --conda scipy --conda numpy
+  dr pipeline image update img-123 --package torch --nvidia --output-format json`,
 		Args:         cobra.ExactArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			packages, err := pipeline.NormalizePackages(rawPackages)
-			if err != nil {
-				return err
+			pip := pipeline.NormalizePackageList(rawPackages)
+			conda := pipeline.BuildCondaValue(rawConda, rawCondaChans)
+
+			if len(pip) == 0 && conda == nil {
+				return errors.New("at least one of --package (pip) or --conda is required")
 			}
 
-			result, err := pipeline.UpdateImage(args[0], packages)
+			if conda != nil && len(conda.Deps) == 0 {
+				return errors.New("--conda-channel requires at least one --conda package")
+			}
+
+			result, err := pipeline.UpdateImage(args[0], pip, conda, baseImage, nvidia)
 			if err != nil {
 				return err
 			}
@@ -64,6 +78,10 @@ Example:
 	outputformat.AddFlag(cmd, &outputFormat)
 
 	cmd.Flags().StringSliceVar(&rawPackages, "package", nil, "Pip package spec (repeatable, also accepts comma-separated values)")
+	cmd.Flags().StringSliceVar(&rawConda, "conda", nil, "Conda package spec (repeatable)")
+	cmd.Flags().StringSliceVar(&rawCondaChans, "conda-channel", nil, "Conda channel (repeatable; if set, sends a structured CondaSpec)")
+	cmd.Flags().StringVar(&baseImage, "base-image", "", "Docker base image URI (e.g. python:3.12)")
+	cmd.Flags().BoolVar(&nvidia, "nvidia", false, "Enable NVIDIA GPU support")
 
 	telemetry.TrackWith(cmd, func(c *cobra.Command, args []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/image/update/cmd.go
+++ b/cmd/pipeline/image/update/cmd.go
@@ -31,10 +31,12 @@ func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update <image-id>",
 		Short: "Add a new version to a pipeline execution image",
-		Long: `Update a pipeline execution image by appending packages.
+		Long: `Update a pipeline execution image by creating a new version with the supplied pip packages.
 
-Updating creates a new immutable version of the image containing the
-supplied pip packages. Existing versions are unchanged.
+Each update creates a new immutable version. The supplied packages become
+the complete pip list for that version — existing packages are not carried
+over automatically. To add a package, include all desired packages in the
+new version's list.
 
 Example:
   dr pipeline image update img-123 --package scikit-learn

--- a/cmd/pipeline/image/version/cmd.go
+++ b/cmd/pipeline/image/version/cmd.go
@@ -16,19 +16,21 @@ package version
 
 import (
 	"github.com/datarobot/cli/cmd/pipeline/image/version/del"
+	"github.com/datarobot/cli/cmd/pipeline/image/version/logs"
 	"github.com/spf13/cobra"
 )
 
 // Cmd returns the parent command for `dr pipeline image version`.
-// Currently only delete is exposed; the pipelines-api does not surface
-// per-version GET endpoints.
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Manage versions of a pipeline execution image",
 	}
 
-	cmd.AddCommand(del.Cmd())
+	cmd.AddCommand(
+		del.Cmd(),
+		logs.Cmd(),
+	)
 
 	return cmd
 }

--- a/cmd/pipeline/image/version/cmd_test.go
+++ b/cmd/pipeline/image/version/cmd_test.go
@@ -33,3 +33,17 @@ func TestCmd_RegistersDelete(t *testing.T) {
 
 	assert.True(t, found, "missing delete subcommand")
 }
+
+func TestCmd_RegistersLogs(t *testing.T) {
+	cmd := Cmd()
+
+	found := false
+
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "logs" {
+			found = true
+		}
+	}
+
+	assert.True(t, found, "missing logs subcommand")
+}

--- a/cmd/pipeline/image/version/logs/cmd.go
+++ b/cmd/pipeline/image/version/logs/cmd.go
@@ -1,0 +1,84 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/pipeline"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var imageID string
+
+	cmd := &cobra.Command{
+		Use:   "logs <version>",
+		Short: "Fetch build logs for a specific pipeline execution image version",
+		Long: `Fetch the raw build log output for a specific pipeline execution image version.
+
+Logs are available once the build has completed (status READY or ERROR).
+
+Example:
+  dr pipeline image version logs --image img-507f1f77bcf86cd799439011 1`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		RunE: func(_ *cobra.Command, args []string) error {
+			version, err := strconv.Atoi(args[0])
+			if err != nil || version <= 0 {
+				return fmt.Errorf("invalid version: %q (expected a positive integer)", args[0])
+			}
+
+			resp, err := pipeline.GetImageBuildLogs(imageID, version)
+			if err != nil {
+				var httpErr *drapi.HTTPError
+
+				if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+					fmt.Println(tui.DimStyle.Render(
+						fmt.Sprintf("No image version found: %s v%d", imageID, version),
+					))
+
+					return nil
+				}
+
+				return err
+			}
+
+			fmt.Print(resp.Logs)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&imageID, "image", "", "Image ID (required)")
+	_ = cmd.MarkFlagRequired("image")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"image_id": imageID,
+			"version":  telemetry.FirstArg(args),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/pipeline/image/version/logs/cmd_test.go
+++ b/cmd/pipeline/image/version/logs/cmd_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runCmd(t *testing.T, args ...string) error {
+	t.Helper()
+
+	cmd := Cmd()
+	cmd.SetArgs(args)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.PreRunE = nil
+
+	return cmd.Execute()
+}
+
+func TestCmd_RequiresImageFlag(t *testing.T) {
+	err := runCmd(t, "1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image")
+}
+
+func TestCmd_RequiresVersionArg(t *testing.T) {
+	err := runCmd(t, "--image", "img-1")
+	require.Error(t, err)
+}
+
+func TestCmd_RejectsNonIntegerVersion(t *testing.T) {
+	err := runCmd(t, "--image", "img-1", "notanumber")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid version")
+}
+
+func TestCmd_RejectsZeroVersion(t *testing.T) {
+	err := runCmd(t, "--image", "img-1", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid version")
+}
+
+func TestCmd_HasExpectedFlags(t *testing.T) {
+	cmd := Cmd()
+	assert.NotNil(t, cmd.Flags().Lookup("image"), "expected --image flag")
+}

--- a/cmd/pipeline/list/cmd.go
+++ b/cmd/pipeline/list/cmd.go
@@ -27,6 +27,7 @@ import (
 func Cmd() *cobra.Command {
 	var (
 		mode         string
+		search       string
 		offset       int
 		limit        int
 		outputFormat outputformat.OutputFormat
@@ -42,6 +43,7 @@ By default, output is human-readable. Use --output-format json for machine-parse
 Example:
   dr pipeline list
   dr pipeline list --mode draft
+  dr pipeline list --search "my-pipeline"
   dr pipeline list --offset 0 --limit 50 --output-format json`,
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
@@ -53,7 +55,7 @@ Example:
 				return fmt.Errorf("invalid mode: %s (supported: draft, locked)", mode)
 			}
 
-			list, err := pipeline.ListPipelines(mode, offset, limit)
+			list, err := pipeline.ListPipelines(mode, search, offset, limit)
 			if err != nil {
 				return err
 			}
@@ -65,6 +67,7 @@ Example:
 	outputformat.AddFlag(cmd, &outputFormat)
 
 	cmd.Flags().StringVar(&mode, "mode", "", "Pipeline mode: draft or locked")
+	cmd.Flags().StringVar(&search, "search", "", "Filter pipelines by name substring")
 	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
 	cmd.Flags().IntVar(&limit, "limit", 50, "Pagination limit (1-200)")
 

--- a/cmd/pipeline/run/cmd.go
+++ b/cmd/pipeline/run/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/datarobot/cli/cmd/pipeline/run/get"
 	"github.com/datarobot/cli/cmd/pipeline/run/list"
 	"github.com/datarobot/cli/cmd/pipeline/run/status"
+	"github.com/datarobot/cli/cmd/pipeline/run/task"
 	"github.com/spf13/cobra"
 )
 
@@ -43,6 +44,7 @@ When --version is supplied, the locked scope is selected automatically.`,
 		get.Cmd(),
 		status.Cmd(),
 		cancel.Cmd(),
+		task.Cmd(),
 	)
 
 	return cmd

--- a/cmd/pipeline/run/create/cmd.go
+++ b/cmd/pipeline/run/create/cmd.go
@@ -69,7 +69,8 @@ Example:
 	_ = cmd.MarkFlagRequired("pipeline")
 	cmd.Flags().StringVar(&inputID, "input", "", "Input ID to trigger the run with")
 	_ = cmd.MarkFlagRequired("input")
-	cmd.Flags().StringVar(&imageID, "image", "", "Override the pipeline's linked execution image for this run")
+	cmd.Flags().StringVar(&imageID, "image", "", "Execution image ID for this run")
+	_ = cmd.MarkFlagRequired("image")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/run/task/cmd.go
+++ b/cmd/pipeline/run/task/cmd.go
@@ -1,0 +1,44 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"github.com/datarobot/cli/cmd/pipeline/run/task/get"
+	"github.com/datarobot/cli/cmd/pipeline/run/task/list"
+	"github.com/datarobot/cli/cmd/pipeline/run/task/logs"
+	"github.com/datarobot/cli/cmd/pipeline/run/task/result"
+	"github.com/spf13/cobra"
+)
+
+// Cmd returns the parent command for `dr pipeline run task`.
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "task",
+		Short: "Inspect individual task executions within a run",
+		Long: `Inspect the per-@task execution records within a pipeline run.
+
+Each @task function in a pipeline becomes an electron; these subcommands
+expose the lifecycle, logs, and return value of individual electrons.`,
+	}
+
+	cmd.AddCommand(
+		list.Cmd(),
+		get.Cmd(),
+		logs.Cmd(),
+		result.Cmd(),
+	)
+
+	return cmd
+}

--- a/cmd/pipeline/run/task/cmd_test.go
+++ b/cmd/pipeline/run/task/cmd_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package run
+package task
 
 import (
 	"testing"
@@ -24,12 +24,10 @@ func TestCmd_RegistersAllVerbs(t *testing.T) {
 	cmd := Cmd()
 
 	want := map[string]bool{
-		"create": false,
 		"list":   false,
 		"get":    false,
-		"status": false,
-		"cancel": false,
-		"task":   false,
+		"logs":   false,
+		"result": false,
 	}
 
 	for _, sub := range cmd.Commands() {

--- a/cmd/pipeline/run/task/get/cmd.go
+++ b/cmd/pipeline/run/task/get/cmd.go
@@ -1,0 +1,161 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/pipeline"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var (
+		pipelineID   string
+		runID        string
+		outputFormat outputformat.OutputFormat
+	)
+
+	cmd := &cobra.Command{
+		Use:   "get <task-id>",
+		Short: "Get a single task execution record",
+		Long: `Display the lifecycle status of a single @task electron within a run.
+
+<task-id> is the sequential task number (1, 2, 3, …) as returned by
+"dr pipeline run task list".
+
+Example:
+  dr pipeline run task get --pipeline <id> --run <run-id> 1
+  dr pipeline run task get --pipeline <id> --run <run-id> 2 --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			taskID, err := parseTaskID(args[0])
+			if err != nil {
+				return err
+			}
+
+			task, err := pipeline.GetTaskExecution(pipelineID, runID, taskID)
+			if err != nil {
+				return handleNotFound(err, args[0])
+			}
+
+			return renderTask(outputFormat, task)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	cmd.Flags().StringVar(&pipelineID, "pipeline", "", "Pipeline ID")
+	_ = cmd.MarkFlagRequired("pipeline")
+	cmd.Flags().StringVar(&runID, "run", "", "Run (dispatch) ID")
+	_ = cmd.MarkFlagRequired("run")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"pipeline_id":   pipelineID,
+			"run_id":        runID,
+			"task_id":       telemetry.FirstArg(args),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}
+
+func parseTaskID(s string) (int, error) {
+	id, err := strconv.Atoi(s)
+	if err != nil || id <= 0 {
+		return 0, fmt.Errorf("invalid task-id %q: must be a positive integer", s)
+	}
+
+	return id, nil
+}
+
+func renderTask(format outputformat.OutputFormat, task *pipeline.TaskExecution) error {
+	if format == outputformat.OutputFormatJSON {
+		data, err := json.MarshalIndent(task, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(data))
+
+		return nil
+	}
+
+	printTaskHuman(task)
+
+	return nil
+}
+
+func printTaskHuman(task *pipeline.TaskExecution) {
+	taskIDStr := "-"
+	if task.TaskID != nil {
+		taskIDStr = strconv.Itoa(*task.TaskID)
+	}
+
+	startedStr := "-"
+	if task.StartedAt != nil {
+		startedStr = task.StartedAt.UTC().Format("2006-01-02 15:04:05")
+	}
+
+	completedStr := "-"
+	if task.CompletedAt != nil {
+		completedStr = task.CompletedAt.UTC().Format("2006-01-02 15:04:05")
+	}
+
+	errorStr := "-"
+	if task.ErrorDetail != nil {
+		errorStr = *task.ErrorDetail
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "Task ID:\t%s\n", taskIDStr)
+	fmt.Fprintf(w, "Name:\t%s\n", task.Name)
+	fmt.Fprintf(w, "Status:\t%s\n", task.Status)
+	fmt.Fprintf(w, "Started:\t%s\n", startedStr)
+	fmt.Fprintf(w, "Completed:\t%s\n", completedStr)
+	fmt.Fprintf(w, "Error:\t%s\n", errorStr)
+
+	w.Flush()
+}
+
+func handleNotFound(err error, taskID string) error {
+	var httpErr *drapi.HTTPError
+
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		fmt.Println(tui.DimStyle.Render("No task execution found with id: " + taskID))
+
+		return nil
+	}
+
+	return err
+}

--- a/cmd/pipeline/run/task/get/cmd_test.go
+++ b/cmd/pipeline/run/task/get/cmd_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package create
+package get
 
 import (
 	"io"
@@ -34,40 +34,55 @@ func runCmd(t *testing.T, args ...string) error {
 	return cmd.Execute()
 }
 
-func TestCmd_RejectsInvalidOutput(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p", "--input", "in-1", "--image", "img-1", "--output-format", "yaml")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid output format")
-}
-
 func TestCmd_RejectsMissingPipeline(t *testing.T) {
-	err := runCmd(t, "--input", "in-1", "--image", "img-1")
+	err := runCmd(t, "--run", "d-1", "1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pipeline")
 }
 
-func TestCmd_RejectsMissingInput(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p", "--image", "img-1")
+func TestCmd_RejectsMissingRun(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1", "1")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "input")
+	assert.Contains(t, err.Error(), "run")
 }
 
-func TestCmd_RejectsMissingImage(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p", "--input", "in-1")
+func TestCmd_RequiresPositionalArg(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1", "--run", "d-1")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "image")
 }
 
-func TestCmd_RejectsBadScopeCombo(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p", "--input", "in-1", "--image", "img-1", "--scope", "draft", "--version", "2")
+func TestCmd_RejectsNonIntegerTaskID(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1", "--run", "d-1", "notanumber")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "draft cannot be combined")
+	assert.Contains(t, err.Error(), "invalid task-id")
+}
+
+func TestCmd_RejectsZeroTaskID(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1", "--run", "d-1", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid task-id")
+}
+
+func TestParseTaskID_Valid(t *testing.T) {
+	id, err := parseTaskID("3")
+	require.NoError(t, err)
+	assert.Equal(t, 3, id)
+}
+
+func TestParseTaskID_RejectsZero(t *testing.T) {
+	_, err := parseTaskID("0")
+	require.Error(t, err)
+}
+
+func TestParseTaskID_RejectsNonInteger(t *testing.T) {
+	_, err := parseTaskID("abc")
+	require.Error(t, err)
 }
 
 func TestCmd_HasExpectedFlags(t *testing.T) {
 	cmd := Cmd()
 
-	for _, name := range []string{"pipeline", "scope", "version", "input", "image", "output-format"} {
+	for _, name := range []string{"pipeline", "run", "output-format"} {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }

--- a/cmd/pipeline/run/task/list/cmd.go
+++ b/cmd/pipeline/run/task/list/cmd.go
@@ -1,0 +1,149 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"slices"
+	"strconv"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/pipeline"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var (
+		pipelineID   string
+		runID        string
+		outputFormat outputformat.OutputFormat
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List task executions for a run",
+		Long: `List per-@task execution records for a pipeline run.
+
+Returns an empty list when the run has not yet received any task callbacks
+(dispatch still in PENDING or PREPARING state).
+
+Example:
+  dr pipeline run task list --pipeline <id> --run <run-id>
+  dr pipeline run task list --pipeline <id> --run <run-id> --output-format json`,
+		Args:         cobra.NoArgs,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			tasks, err := pipeline.ListTaskExecutions(pipelineID, runID)
+			if err != nil {
+				return err
+			}
+
+			return renderTaskList(outputFormat, tasks)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	cmd.Flags().StringVar(&pipelineID, "pipeline", "", "Pipeline ID")
+	_ = cmd.MarkFlagRequired("pipeline")
+	cmd.Flags().StringVar(&runID, "run", "", "Run (dispatch) ID")
+	_ = cmd.MarkFlagRequired("run")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		return map[string]any{
+			"pipeline_id":   pipelineID,
+			"run_id":        runID,
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}
+
+func renderTaskList(format outputformat.OutputFormat, tasks []pipeline.TaskExecution) error {
+	if format == outputformat.OutputFormatJSON {
+		data, err := json.MarshalIndent(tasks, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(data))
+
+		return nil
+	}
+
+	if len(tasks) == 0 {
+		fmt.Println(tui.DimStyle.Render("No task executions recorded yet"))
+
+		return nil
+	}
+
+	cellStyle := tui.BaseTextStyle.Padding(0, 1)
+
+	dimStyle := tui.DimStyle.Padding(0, 1)
+
+	headers := []string{"TASK ID", "NAME", "STATUS", "STARTED", "COMPLETED"}
+
+	completedCol := slices.Index(headers, "COMPLETED")
+
+	t := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(tui.TableBorderStyle).
+		StyleFunc(func(row, col int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return cellStyle.Bold(true)
+			}
+
+			if col == completedCol {
+				return dimStyle
+			}
+
+			return cellStyle
+		}).
+		Headers(headers...)
+
+	for _, task := range tasks {
+		taskIDStr := "-"
+		if task.TaskID != nil {
+			taskIDStr = strconv.Itoa(*task.TaskID)
+		}
+
+		startedStr := "-"
+		if task.StartedAt != nil {
+			startedStr = task.StartedAt.UTC().Format("2006-01-02 15:04:05")
+		}
+
+		completedStr := "-"
+		if task.CompletedAt != nil {
+			completedStr = task.CompletedAt.UTC().Format("2006-01-02 15:04:05")
+		}
+
+		t.Row(taskIDStr, task.Name, task.Status, startedStr, completedStr)
+	}
+
+	fmt.Fprintln(os.Stdout, t.Render())
+
+	return nil
+}

--- a/cmd/pipeline/run/task/list/cmd_test.go
+++ b/cmd/pipeline/run/task/list/cmd_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package del
+package list
 
 import (
 	"io"
@@ -35,22 +35,21 @@ func runCmd(t *testing.T, args ...string) error {
 }
 
 func TestCmd_RejectsMissingPipeline(t *testing.T) {
-	err := runCmd(t, "s-1")
+	err := runCmd(t, "--run", "d-1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pipeline")
 }
 
-func TestCmd_RequiresPositional(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p")
+func TestCmd_RejectsMissingRun(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1")
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "run")
 }
 
 func TestCmd_HasExpectedFlags(t *testing.T) {
 	cmd := Cmd()
-	assert.NotNil(t, cmd.Flags().Lookup("pipeline"), "expected --pipeline flag")
-	assert.Nil(t, cmd.Flags().Lookup("version"), "unexpected --version flag after removal")
-}
 
-func TestCmd_Name(t *testing.T) {
-	assert.Equal(t, "delete", Cmd().Name())
+	for _, name := range []string{"pipeline", "run", "output-format"} {
+		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
+	}
 }

--- a/cmd/pipeline/run/task/logs/cmd.go
+++ b/cmd/pipeline/run/task/logs/cmd.go
@@ -1,0 +1,149 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logs
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/pipeline"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var (
+		pipelineID   string
+		runID        string
+		stream       string
+		tailLines    int
+		verbosity    string
+		outputFormat outputformat.OutputFormat
+	)
+
+	cmd := &cobra.Command{
+		Use:   "logs <task-id>",
+		Short: "Fetch logs for a task execution",
+		Long: `Fetch logs for an individual @task electron in a run.
+
+Without --stream: reads live K8s pod logs (stops working ~60s after the
+job terminates when kubelet GC's the pod).
+
+With --stream stdout or --stream stderr: reads the durable S3-uploaded
+log captured by the electron runner at process exit. Use this for
+post-mortem debugging after the pod has been GC'd.
+
+Example:
+  dr pipeline run task logs --pipeline <id> --run <run-id> 1
+  dr pipeline run task logs --pipeline <id> --run <run-id> 1 --stream stdout
+  dr pipeline run task logs --pipeline <id> --run <run-id> 1 --tail 100 --verbosity all`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			taskID, err := strconv.Atoi(args[0])
+			if err != nil || taskID <= 0 {
+				return fmt.Errorf("invalid task-id %q: must be a positive integer", args[0])
+			}
+
+			if stream != "" && stream != "stdout" && stream != "stderr" {
+				return fmt.Errorf("--stream must be stdout or stderr (got %q)", stream)
+			}
+
+			if stream != "" {
+				return fetchDurableLog(pipelineID, runID, taskID, stream, verbosity, outputFormat)
+			}
+
+			var tail *int
+
+			if cmd.Flags().Changed("tail") {
+				tail = &tailLines
+			}
+
+			return fetchLiveLogs(pipelineID, runID, taskID, tail, verbosity, outputFormat)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	cmd.Flags().StringVar(&pipelineID, "pipeline", "", "Pipeline ID")
+	_ = cmd.MarkFlagRequired("pipeline")
+	cmd.Flags().StringVar(&runID, "run", "", "Run (dispatch) ID")
+	_ = cmd.MarkFlagRequired("run")
+	cmd.Flags().StringVar(&stream, "stream", "", "Read durable S3 log: stdout or stderr")
+	cmd.Flags().IntVar(&tailLines, "tail", 0, "Limit to last N lines (live logs only)")
+	cmd.Flags().StringVar(&verbosity, "verbosity", "", "Log verbosity: user (default) or all")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"pipeline_id":   pipelineID,
+			"run_id":        runID,
+			"task_id":       telemetry.FirstArg(args),
+			"stream":        stream,
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}
+
+func fetchLiveLogs(pipelineID, runID string, taskID int, tailLines *int, verbosity string, format outputformat.OutputFormat) error {
+	logs, err := pipeline.GetTaskLogs(pipelineID, runID, taskID, tailLines, verbosity)
+	if err != nil {
+		return err
+	}
+
+	if format == outputformat.OutputFormatJSON {
+		data, err := json.MarshalIndent(logs, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(data))
+
+		return nil
+	}
+
+	fmt.Print(logs.Logs)
+
+	return nil
+}
+
+func fetchDurableLog(pipelineID, runID string, taskID int, stream, verbosity string, format outputformat.OutputFormat) error {
+	log, err := pipeline.GetTaskDurableLog(pipelineID, runID, taskID, stream, verbosity)
+	if err != nil {
+		return err
+	}
+
+	if format == outputformat.OutputFormatJSON {
+		data, err := json.MarshalIndent(log, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(data))
+
+		return nil
+	}
+
+	fmt.Print(log.Content)
+
+	return nil
+}

--- a/cmd/pipeline/run/task/logs/cmd_test.go
+++ b/cmd/pipeline/run/task/logs/cmd_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package del
+package logs
 
 import (
 	"io"
@@ -35,22 +35,38 @@ func runCmd(t *testing.T, args ...string) error {
 }
 
 func TestCmd_RejectsMissingPipeline(t *testing.T) {
-	err := runCmd(t, "s-1")
+	err := runCmd(t, "--run", "d-1", "1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pipeline")
 }
 
-func TestCmd_RequiresPositional(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p")
+func TestCmd_RejectsMissingRun(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1", "1")
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "run")
+}
+
+func TestCmd_RequiresPositionalArg(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1", "--run", "d-1")
+	require.Error(t, err)
+}
+
+func TestCmd_RejectsNonIntegerTaskID(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1", "--run", "d-1", "foo")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid task-id")
+}
+
+func TestCmd_RejectsInvalidStream(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1", "--run", "d-1", "--stream", "both", "1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--stream")
 }
 
 func TestCmd_HasExpectedFlags(t *testing.T) {
 	cmd := Cmd()
-	assert.NotNil(t, cmd.Flags().Lookup("pipeline"), "expected --pipeline flag")
-	assert.Nil(t, cmd.Flags().Lookup("version"), "unexpected --version flag after removal")
-}
 
-func TestCmd_Name(t *testing.T) {
-	assert.Equal(t, "delete", Cmd().Name())
+	for _, name := range []string{"pipeline", "run", "stream", "tail", "verbosity"} {
+		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
+	}
 }

--- a/cmd/pipeline/run/task/result/cmd.go
+++ b/cmd/pipeline/run/task/result/cmd.go
@@ -1,0 +1,127 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package result
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/pipeline"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var (
+		pipelineID   string
+		runID        string
+		outputFormat outputformat.OutputFormat
+	)
+
+	cmd := &cobra.Command{
+		Use:   "result <task-id>",
+		Short: "Get the presigned URL for a completed task's result",
+		Long: `Return the presigned S3 URL for a completed @task electron's result blob.
+
+The result is a cloudpickle payload. Download the URL directly from S3
+and decode with cloudpickle.loads(). pipelines-api never proxies the bytes.
+
+Returns 409 when the task has not yet reached COMPLETED state.
+
+Example:
+  dr pipeline run task result --pipeline <id> --run <run-id> 1
+  dr pipeline run task result --pipeline <id> --run <run-id> 1 --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			taskID, err := strconv.Atoi(args[0])
+			if err != nil || taskID <= 0 {
+				return fmt.Errorf("invalid task-id %q: must be a positive integer", args[0])
+			}
+
+			res, err := pipeline.GetTaskResult(pipelineID, runID, taskID)
+			if err != nil {
+				return err
+			}
+
+			return renderResult(outputFormat, res)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	cmd.Flags().StringVar(&pipelineID, "pipeline", "", "Pipeline ID")
+	_ = cmd.MarkFlagRequired("pipeline")
+	cmd.Flags().StringVar(&runID, "run", "", "Run (dispatch) ID")
+	_ = cmd.MarkFlagRequired("run")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"pipeline_id":   pipelineID,
+			"run_id":        runID,
+			"task_id":       telemetry.FirstArg(args),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}
+
+func renderResult(format outputformat.OutputFormat, res *pipeline.TaskExecutionResult) error {
+	if format == outputformat.OutputFormatJSON {
+		data, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(data))
+
+		return nil
+	}
+
+	printResultHuman(res)
+
+	return nil
+}
+
+func printResultHuman(res *pipeline.TaskExecutionResult) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "URL:\t%s\n", res.URL)
+	fmt.Fprintf(w, "Expires In:\t%ds\n", res.ExpiresIn)
+	fmt.Fprintf(w, "Content Type:\t%s\n", res.ContentType)
+
+	if res.ValueAvailable {
+		valueStr := fmt.Sprintf("%v", res.Value)
+		fmt.Fprintf(w, "Value Preview:\t%s\n", valueStr)
+	} else {
+		reason := "unavailable"
+		if res.ValueUnavailableReason != nil {
+			reason = *res.ValueUnavailableReason
+		}
+
+		fmt.Fprintf(w, "Value Preview:\t(not available: %s)\n", reason)
+	}
+
+	w.Flush()
+}

--- a/cmd/pipeline/run/task/result/cmd_test.go
+++ b/cmd/pipeline/run/task/result/cmd_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package del
+package result
 
 import (
 	"io"
@@ -35,22 +35,38 @@ func runCmd(t *testing.T, args ...string) error {
 }
 
 func TestCmd_RejectsMissingPipeline(t *testing.T) {
-	err := runCmd(t, "s-1")
+	err := runCmd(t, "--run", "d-1", "1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pipeline")
 }
 
-func TestCmd_RequiresPositional(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p")
+func TestCmd_RejectsMissingRun(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1", "1")
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "run")
+}
+
+func TestCmd_RequiresPositionalArg(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1", "--run", "d-1")
+	require.Error(t, err)
+}
+
+func TestCmd_RejectsNonIntegerTaskID(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1", "--run", "d-1", "notanumber")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid task-id")
+}
+
+func TestCmd_RejectsZeroTaskID(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1", "--run", "d-1", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid task-id")
 }
 
 func TestCmd_HasExpectedFlags(t *testing.T) {
 	cmd := Cmd()
-	assert.NotNil(t, cmd.Flags().Lookup("pipeline"), "expected --pipeline flag")
-	assert.Nil(t, cmd.Flags().Lookup("version"), "unexpected --version flag after removal")
-}
 
-func TestCmd_Name(t *testing.T) {
-	assert.Equal(t, "delete", Cmd().Name())
+	for _, name := range []string{"pipeline", "run", "output-format"} {
+		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
+	}
 }

--- a/cmd/pipeline/schedule/create/cmd.go
+++ b/cmd/pipeline/schedule/create/cmd.go
@@ -30,6 +30,8 @@ func Cmd() *cobra.Command {
 		version      int
 		cron         string
 		inputID      string
+		imageID      string
+		imageVersion int
 		timezone     string
 		outputFormat outputformat.OutputFormat
 	)
@@ -39,9 +41,12 @@ func Cmd() *cobra.Command {
 		Short: "Create a recurring schedule for a locked pipeline version",
 		Long: `Register a cron-style schedule that triggers a run on a fixed cadence.
 
+The schedule snapshots the pipeline version, input, and image at creation time
+so that every future run uses the same reproducibility tuple.
+
 Example:
-  dr pipeline schedule create --pipeline <id> --version=2 --cron "0 * * * *" --input <input-id>
-  dr pipeline schedule create --pipeline <id> --version=2 --cron "0 9 * * *" --input <input-id> --timezone America/Los_Angeles`,
+  dr pipeline schedule create --pipeline <id> --version=2 --cron "0 * * * *" --input <input-id> --image <image-id> --image-version 1
+  dr pipeline schedule create --pipeline <id> --version=2 --cron "0 9 * * *" --input <input-id> --image <image-id> --image-version 1 --timezone America/Los_Angeles`,
 		Args:         cobra.NoArgs,
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
@@ -52,13 +57,20 @@ Example:
 				return errors.New("--version is required and must be > 0")
 			}
 
-			body := pipeline.ScheduleCreateRequest{
-				CronExpression:  cron,
-				PipelineInputID: inputID,
-				Timezone:        timezone,
+			if imageVersion <= 0 {
+				return errors.New("--image-version is required and must be > 0")
 			}
 
-			result, err := pipeline.CreateSchedule(pipelineID, version, body)
+			body := pipeline.ScheduleCreateRequest{
+				CronExpression:    cron,
+				PipelineVersionID: version,
+				PipelineInputID:   inputID,
+				ImageID:           imageID,
+				ImageVersion:      imageVersion,
+				Timezone:          timezone,
+			}
+
+			result, err := pipeline.CreateSchedule(pipelineID, body)
 			if err != nil {
 				return err
 			}
@@ -71,12 +83,16 @@ Example:
 
 	cmd.Flags().StringVar(&pipelineID, "pipeline", "", "Pipeline ID")
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().IntVar(&version, "version", 0, "Locked pipeline version")
+	cmd.Flags().IntVar(&version, "version", 0, "Locked pipeline version to schedule")
 	_ = cmd.MarkFlagRequired("version")
 	cmd.Flags().StringVar(&cron, "cron", "", "Cron expression, e.g. \"0 * * * *\"")
 	_ = cmd.MarkFlagRequired("cron")
 	cmd.Flags().StringVar(&inputID, "input", "", "Input ID to run on each tick")
 	_ = cmd.MarkFlagRequired("input")
+	cmd.Flags().StringVar(&imageID, "image", "", "Image ID to run the schedule with")
+	_ = cmd.MarkFlagRequired("image")
+	cmd.Flags().IntVar(&imageVersion, "image-version", 0, "Image version to run the schedule with")
+	_ = cmd.MarkFlagRequired("image-version")
 	cmd.Flags().StringVar(&timezone, "timezone", "", "IANA timezone name (default UTC)")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {

--- a/cmd/pipeline/schedule/create/cmd_test.go
+++ b/cmd/pipeline/schedule/create/cmd_test.go
@@ -38,6 +38,7 @@ func TestCmd_RejectsInvalidOutput(t *testing.T) {
 	err := runCmd(t,
 		"--pipeline", "p", "--version", "2",
 		"--cron", "0 * * * *", "--input", "in-1",
+		"--image", "img-1", "--image-version", "1",
 		"--output-format", "yaml",
 	)
 	require.Error(t, err)
@@ -45,33 +46,63 @@ func TestCmd_RejectsInvalidOutput(t *testing.T) {
 }
 
 func TestCmd_RejectsMissingPipeline(t *testing.T) {
-	err := runCmd(t, "--version", "2", "--cron", "0 * * * *", "--input", "in-1")
+	err := runCmd(t,
+		"--version", "2", "--cron", "0 * * * *",
+		"--input", "in-1", "--image", "img-1", "--image-version", "1",
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pipeline")
 }
 
 func TestCmd_RejectsMissingVersion(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p", "--cron", "0 * * * *", "--input", "in-1")
+	err := runCmd(t,
+		"--pipeline", "p", "--cron", "0 * * * *",
+		"--input", "in-1", "--image", "img-1", "--image-version", "1",
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "version")
 }
 
 func TestCmd_RejectsMissingCron(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p", "--version", "2", "--input", "in-1")
+	err := runCmd(t,
+		"--pipeline", "p", "--version", "2",
+		"--input", "in-1", "--image", "img-1", "--image-version", "1",
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cron")
 }
 
 func TestCmd_RejectsMissingInput(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p", "--version", "2", "--cron", "0 * * * *")
+	err := runCmd(t,
+		"--pipeline", "p", "--version", "2",
+		"--cron", "0 * * * *", "--image", "img-1", "--image-version", "1",
+	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "input")
+}
+
+func TestCmd_RejectsMissingImage(t *testing.T) {
+	err := runCmd(t,
+		"--pipeline", "p", "--version", "2",
+		"--cron", "0 * * * *", "--input", "in-1", "--image-version", "1",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image")
+}
+
+func TestCmd_RejectsMissingImageVersion(t *testing.T) {
+	err := runCmd(t,
+		"--pipeline", "p", "--version", "2",
+		"--cron", "0 * * * *", "--input", "in-1", "--image", "img-1",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "image-version")
 }
 
 func TestCmd_HasExpectedFlags(t *testing.T) {
 	cmd := Cmd()
 
-	for _, name := range []string{"pipeline", "version", "cron", "input", "timezone", "output-format"} {
+	for _, name := range []string{"pipeline", "version", "cron", "input", "image", "image-version", "timezone", "output-format"} {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }

--- a/cmd/pipeline/schedule/del/cmd.go
+++ b/cmd/pipeline/schedule/del/cmd.go
@@ -32,27 +32,20 @@ import (
 )
 
 func Cmd() *cobra.Command {
-	var (
-		pipelineID string
-		version    int
-	)
+	var pipelineID string
 
 	cmd := &cobra.Command{
 		Use:   "delete <schedule-id>",
 		Short: "Delete a pipeline schedule",
-		Long: `Delete a recurring schedule from a locked pipeline version.
+		Long: `Delete a recurring schedule from a pipeline.
 
 Example:
-  dr pipeline schedule delete --pipeline <id> --version=2 <schedule-id>`,
+  dr pipeline schedule delete --pipeline <id> <schedule-id>`,
 		Args:         cobra.ExactArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if version <= 0 {
-				return errors.New("--version is required and must be > 0")
-			}
-
-			err := pipeline.DeleteSchedule(pipelineID, version, args[0])
+			err := pipeline.DeleteSchedule(pipelineID, args[0])
 			if err != nil {
 				return handleDeleteError(err, args[0])
 			}
@@ -65,14 +58,11 @@ Example:
 
 	cmd.Flags().StringVar(&pipelineID, "pipeline", "", "Pipeline ID")
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().IntVar(&version, "version", 0, "Locked pipeline version")
-	_ = cmd.MarkFlagRequired("version")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
 			"pipeline_id": pipelineID,
 			"schedule_id": telemetry.FirstArg(args),
-			"version":     version,
 		}
 	})
 

--- a/cmd/pipeline/schedule/get/cmd.go
+++ b/cmd/pipeline/schedule/get/cmd.go
@@ -31,7 +31,6 @@ import (
 func Cmd() *cobra.Command {
 	var (
 		pipelineID   string
-		version      int
 		outputFormat outputformat.OutputFormat
 	)
 
@@ -41,19 +40,15 @@ func Cmd() *cobra.Command {
 		Long: `Display the cron expression, timezone, and lifecycle status of a schedule.
 
 Example:
-  dr pipeline schedule get --pipeline <id> --version=2 <schedule-id>
-  dr pipeline schedule get --pipeline <id> --version=2 <schedule-id> --output-format json`,
+  dr pipeline schedule get --pipeline <id> <schedule-id>
+  dr pipeline schedule get --pipeline <id> <schedule-id> --output-format json`,
 		Args:         cobra.ExactArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			if version <= 0 {
-				return errors.New("--version is required and must be > 0")
-			}
-
-			result, err := pipeline.GetSchedule(pipelineID, version, args[0])
+			result, err := pipeline.GetSchedule(pipelineID, args[0])
 			if err != nil {
 				return handleGetError(err, args[0])
 			}
@@ -66,14 +61,11 @@ Example:
 
 	cmd.Flags().StringVar(&pipelineID, "pipeline", "", "Pipeline ID")
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().IntVar(&version, "version", 0, "Locked pipeline version")
-	_ = cmd.MarkFlagRequired("version")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
 			"pipeline_id":   pipelineID,
 			"schedule_id":   telemetry.FirstArg(args),
-			"version":       version,
 			"output_format": string(outputFormat),
 		}
 	})

--- a/cmd/pipeline/schedule/get/cmd_test.go
+++ b/cmd/pipeline/schedule/get/cmd_test.go
@@ -38,26 +38,30 @@ func runCmd(t *testing.T, args ...string) error {
 }
 
 func TestCmd_RejectsInvalidOutput(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p", "--version", "2", "--output-format", "yaml", "s-1")
+	err := runCmd(t, "--pipeline", "p", "--output-format", "yaml", "s-1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid output format")
 }
 
 func TestCmd_RejectsMissingPipeline(t *testing.T) {
-	err := runCmd(t, "--version", "2", "s-1")
+	err := runCmd(t, "s-1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pipeline")
 }
 
-func TestCmd_RejectsMissingVersion(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p", "s-1")
+func TestCmd_RequiresPositional(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "version")
 }
 
-func TestCmd_RequiresPositional(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p", "--version", "2")
-	require.Error(t, err)
+func TestCmd_HasExpectedFlags(t *testing.T) {
+	cmd := Cmd()
+
+	for _, name := range []string{"pipeline", "output-format"} {
+		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
+	}
+
+	assert.Nil(t, cmd.Flags().Lookup("version"), "unexpected --version flag after removal")
 }
 
 func TestHandleGetError_404IsSuppressed(t *testing.T) {

--- a/cmd/pipeline/schedule/list/cmd.go
+++ b/cmd/pipeline/schedule/list/cmd.go
@@ -15,8 +15,6 @@
 package list
 
 import (
-	"errors"
-
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
@@ -27,7 +25,6 @@ import (
 func Cmd() *cobra.Command {
 	var (
 		pipelineID   string
-		version      int
 		offset       int
 		limit        int
 		outputFormat outputformat.OutputFormat
@@ -35,23 +32,19 @@ func Cmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List schedules for a locked pipeline version",
-		Long: `List recurring schedules attached to a locked pipeline version.
+		Short: "List all schedules for a pipeline",
+		Long: `List recurring schedules attached to a pipeline across all versions.
 
 Example:
-  dr pipeline schedule list --pipeline <id> --version=2
-  dr pipeline schedule list --pipeline <id> --version=2 --output-format json`,
+  dr pipeline schedule list --pipeline <id>
+  dr pipeline schedule list --pipeline <id> --output-format json`,
 		Args:         cobra.NoArgs,
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			if version <= 0 {
-				return errors.New("--version is required and must be > 0")
-			}
-
-			items, err := pipeline.ListSchedules(pipelineID, version, offset, limit)
+			items, err := pipeline.ListSchedules(pipelineID, offset, limit)
 			if err != nil {
 				return err
 			}
@@ -64,15 +57,12 @@ Example:
 
 	cmd.Flags().StringVar(&pipelineID, "pipeline", "", "Pipeline ID")
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().IntVar(&version, "version", 0, "Locked pipeline version")
-	_ = cmd.MarkFlagRequired("version")
 	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
 	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of schedules to return")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
 			"pipeline_id":   pipelineID,
-			"version":       version,
 			"offset":        offset,
 			"limit":         limit,
 			"output_format": string(outputFormat),

--- a/cmd/pipeline/schedule/list/cmd_test.go
+++ b/cmd/pipeline/schedule/list/cmd_test.go
@@ -35,27 +35,23 @@ func runCmd(t *testing.T, args ...string) error {
 }
 
 func TestCmd_RejectsInvalidOutput(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p", "--version", "2", "--output-format", "yaml")
+	err := runCmd(t, "--pipeline", "p", "--output-format", "yaml")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid output format")
 }
 
 func TestCmd_RejectsMissingPipeline(t *testing.T) {
-	err := runCmd(t, "--version", "2")
+	err := runCmd(t)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pipeline")
-}
-
-func TestCmd_RejectsMissingVersion(t *testing.T) {
-	err := runCmd(t, "--pipeline", "p")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "version")
 }
 
 func TestCmd_HasExpectedFlags(t *testing.T) {
 	cmd := Cmd()
 
-	for _, name := range []string{"pipeline", "version", "offset", "limit", "output-format"} {
+	for _, name := range []string{"pipeline", "offset", "limit", "output-format"} {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
+
+	assert.Nil(t, cmd.Flags().Lookup("version"), "unexpected --version flag after removal")
 }

--- a/cmd/pipeline/schedule/update/cmd.go
+++ b/cmd/pipeline/schedule/update/cmd.go
@@ -27,7 +27,6 @@ import (
 func Cmd() *cobra.Command {
 	var (
 		pipelineID   string
-		version      int
 		cron         string
 		timezone     string
 		outputFormat outputformat.OutputFormat
@@ -42,20 +41,20 @@ At least one of --cron or --timezone must be supplied; otherwise the
 command sends an empty patch which the API treats as a no-op.
 
 Example:
-  dr pipeline schedule update --pipeline <id> --version=2 <schedule-id> --cron "*/15 * * * *"
-  dr pipeline schedule update --pipeline <id> --version=2 <schedule-id> --timezone Europe/Berlin`,
+  dr pipeline schedule update --pipeline <id> <schedule-id> --cron "*/15 * * * *"
+  dr pipeline schedule update --pipeline <id> <schedule-id> --timezone Europe/Berlin`,
 		Args:         cobra.ExactArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			body, err := buildUpdateBody(cmd, pipelineID, version, cron, timezone)
+			body, err := buildUpdateBody(cmd, cron, timezone)
 			if err != nil {
 				return err
 			}
 
-			result, err := pipeline.UpdateSchedule(pipelineID, version, args[0], body)
+			result, err := pipeline.UpdateSchedule(pipelineID, args[0], body)
 			if err != nil {
 				return err
 			}
@@ -68,8 +67,6 @@ Example:
 
 	cmd.Flags().StringVar(&pipelineID, "pipeline", "", "Pipeline ID")
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().IntVar(&version, "version", 0, "Locked pipeline version")
-	_ = cmd.MarkFlagRequired("version")
 	cmd.Flags().StringVar(&cron, "cron", "", "New cron expression")
 	cmd.Flags().StringVar(&timezone, "timezone", "", "New IANA timezone name")
 
@@ -77,7 +74,6 @@ Example:
 		return map[string]any{
 			"pipeline_id":   pipelineID,
 			"schedule_id":   telemetry.FirstArg(args),
-			"version":       version,
 			"output_format": string(outputFormat),
 		}
 	})
@@ -85,13 +81,8 @@ Example:
 	return cmd
 }
 
-// buildUpdateBody validates the flag set and assembles the PATCH body. It is
-// extracted from RunE to keep the cobra command's cyclomatic complexity low.
-func buildUpdateBody(cmd *cobra.Command, _ string, version int, cron, timezone string) (pipeline.ScheduleUpdateRequest, error) {
-	if version <= 0 {
-		return pipeline.ScheduleUpdateRequest{}, errors.New("--version is required and must be > 0")
-	}
-
+// buildUpdateBody validates the flag set and assembles the PATCH body.
+func buildUpdateBody(cmd *cobra.Command, cron, timezone string) (pipeline.ScheduleUpdateRequest, error) {
 	cronChanged := cmd.Flags().Changed("cron")
 	tzChanged := cmd.Flags().Changed("timezone")
 

--- a/cmd/pipeline/schedule/update/cmd_test.go
+++ b/cmd/pipeline/schedule/update/cmd_test.go
@@ -27,9 +27,9 @@ func TestBuildUpdateBody_RejectsEmptyCron(t *testing.T) {
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 
-	require.NoError(t, cmd.ParseFlags([]string{"--pipeline=p", "--version=2", "--cron="}))
+	require.NoError(t, cmd.ParseFlags([]string{"--pipeline=p", "--cron="}))
 
-	_, err := buildUpdateBody(cmd, "p", 2, "", "")
+	_, err := buildUpdateBody(cmd, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--cron must not be empty")
 }
@@ -39,9 +39,9 @@ func TestBuildUpdateBody_RejectsEmptyTimezone(t *testing.T) {
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 
-	require.NoError(t, cmd.ParseFlags([]string{"--pipeline=p", "--version=2", "--timezone="}))
+	require.NoError(t, cmd.ParseFlags([]string{"--pipeline=p", "--timezone="}))
 
-	_, err := buildUpdateBody(cmd, "p", 2, "", "")
+	_, err := buildUpdateBody(cmd, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--timezone must not be empty")
 }
@@ -51,9 +51,9 @@ func TestBuildUpdateBody_RequiresAtLeastOneField(t *testing.T) {
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 
-	require.NoError(t, cmd.ParseFlags([]string{"--pipeline=p", "--version=2"}))
+	require.NoError(t, cmd.ParseFlags([]string{"--pipeline=p"}))
 
-	_, err := buildUpdateBody(cmd, "p", 2, "", "")
+	_, err := buildUpdateBody(cmd, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "at least one of --cron")
 }
@@ -64,12 +64,12 @@ func TestBuildUpdateBody_PicksUpChangedFlags(t *testing.T) {
 	cmd.SetErr(io.Discard)
 
 	require.NoError(t, cmd.ParseFlags([]string{
-		"--pipeline=p", "--version=2",
+		"--pipeline=p",
 		"--cron=*/5 * * * *",
 		"--timezone=America/Los_Angeles",
 	}))
 
-	body, err := buildUpdateBody(cmd, "p", 2, "*/5 * * * *", "America/Los_Angeles")
+	body, err := buildUpdateBody(cmd, "*/5 * * * *", "America/Los_Angeles")
 	require.NoError(t, err)
 	require.NotNil(t, body.CronExpression)
 	require.NotNil(t, body.Timezone)
@@ -84,32 +84,20 @@ func TestBuildUpdateBody_SkipsUnchangedFlags(t *testing.T) {
 
 	// only --cron supplied; --timezone untouched
 	require.NoError(t, cmd.ParseFlags([]string{
-		"--pipeline=p", "--version=2",
+		"--pipeline=p",
 		"--cron=0 0 * * *",
 	}))
 
-	body, err := buildUpdateBody(cmd, "p", 2, "0 0 * * *", "")
+	body, err := buildUpdateBody(cmd, "0 0 * * *", "")
 	require.NoError(t, err)
 	require.NotNil(t, body.CronExpression)
 	assert.Equal(t, "0 0 * * *", *body.CronExpression)
 	assert.Nil(t, body.Timezone, "untouched --timezone should not be sent")
 }
 
-func TestBuildUpdateBody_RejectsZeroVersion(t *testing.T) {
-	cmd := Cmd()
-	cmd.SetOut(io.Discard)
-	cmd.SetErr(io.Discard)
-
-	require.NoError(t, cmd.ParseFlags([]string{"--pipeline=p", "--cron=0 0 * * *"}))
-
-	_, err := buildUpdateBody(cmd, "p", 0, "0 0 * * *", "")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--version")
-}
-
 func TestCmd_RejectsInvalidOutput(t *testing.T) {
 	cmd := Cmd()
-	cmd.SetArgs([]string{"sched-id", "--pipeline=p", "--version=2", "--cron=0 0 * * *", "--output-format=yaml"})
+	cmd.SetArgs([]string{"sched-id", "--pipeline=p", "--cron=0 0 * * *", "--output-format=yaml"})
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)
 	cmd.PreRunE = nil
@@ -117,4 +105,14 @@ func TestCmd_RejectsInvalidOutput(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid output format")
+}
+
+func TestCmd_HasExpectedFlags(t *testing.T) {
+	cmd := Cmd()
+
+	for _, name := range []string{"pipeline", "cron", "timezone", "output-format"} {
+		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
+	}
+
+	assert.Nil(t, cmd.Flags().Lookup("version"), "unexpected --version flag after removal")
 }

--- a/cmd/pipeline/source/cmd.go
+++ b/cmd/pipeline/source/cmd.go
@@ -64,7 +64,7 @@ Example:
 
 			result, err := pipeline.GetPipelineSource(flags.PipelineID, scope, version)
 			if err != nil {
-				return handleSourceError(err, flags.PipelineID)
+				return handleSourceError(err, flags.PipelineID, outputFormat)
 			}
 
 			if outputFormat == outputformat.OutputFormatJSON {
@@ -92,10 +92,14 @@ Example:
 	return cmd
 }
 
-func handleSourceError(err error, pipelineID string) error {
+func handleSourceError(err error, pipelineID string, format outputformat.OutputFormat) error {
 	var httpErr *drapi.HTTPError
 
 	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		if format == outputformat.OutputFormatJSON {
+			return err
+		}
+
 		fmt.Println(tui.DimStyle.Render("No source available for pipeline: " + pipelineID))
 
 		return nil

--- a/cmd/pipeline/source/cmd.go
+++ b/cmd/pipeline/source/cmd.go
@@ -12,37 +12,45 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package create
+package source
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
 	"github.com/datarobot/cli/cmd/pipeline/scopeflag"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
 func Cmd() *cobra.Command {
 	var (
 		flags        scopeflag.Flags
-		inputID      string
-		imageID      string
 		outputFormat outputformat.OutputFormat
 	)
 
 	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Trigger a pipeline run",
-		Long: `Trigger a new run (single execution) of a pipeline.
+		Use:   "source",
+		Short: "Display the source code of a pipeline",
+		Long: `Display the full source.py content of a pipeline.
 
-The run is created in PENDING state. Use ` + "`dr pipeline run get`" + `
-or ` + "`dr pipeline run status`" + ` to follow its progress.
+Scope is selected from the --scope/--version flags:
+  - no flags                   -> draft source (latest version)
+  - --version=N                -> locked source for version N (scope auto-set)
+  - --scope=draft              -> draft source
+  - --scope=locked --version=N -> locked source for version N
 
 Example:
-  dr pipeline run create --pipeline <id> --input <input-id>
-  dr pipeline run create --pipeline <id> --input <input-id> --image <image-id>
-  dr pipeline run create --pipeline <id> --version=2 --input <input-id> --output-format json`,
+  dr pipeline source --pipeline <id>
+  dr pipeline source --pipeline <id> --version=2
+  dr pipeline source --pipeline <id> --output-format json`,
 		Args:         cobra.NoArgs,
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
@@ -54,12 +62,18 @@ Example:
 				return err
 			}
 
-			result, err := pipeline.CreateRun(flags.PipelineID, scope, version, inputID, imageID)
+			result, err := pipeline.GetPipelineSource(flags.PipelineID, scope, version)
 			if err != nil {
-				return err
+				return handleSourceError(err, flags.PipelineID)
 			}
 
-			return pipeline.RenderRun(outputFormat, *result)
+			if outputFormat == outputformat.OutputFormatJSON {
+				return printSourceJSON(*result)
+			}
+
+			fmt.Print(result.Source)
+
+			return nil
 		},
 	}
 
@@ -67,18 +81,36 @@ Example:
 
 	flags.Bind(cmd)
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().StringVar(&inputID, "input", "", "Input ID to trigger the run with")
-	_ = cmd.MarkFlagRequired("input")
-	cmd.Flags().StringVar(&imageID, "image", "", "Override the pipeline's linked execution image for this run")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
 			"pipeline_id":   flags.PipelineID,
-			"scope":         flags.Scope,
-			"version":       flags.Version,
 			"output_format": string(outputFormat),
 		}
 	})
 
 	return cmd
+}
+
+func handleSourceError(err error, pipelineID string) error {
+	var httpErr *drapi.HTTPError
+
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		fmt.Println(tui.DimStyle.Render("No source available for pipeline: " + pipelineID))
+
+		return nil
+	}
+
+	return err
+}
+
+func printSourceJSON(s pipeline.PipelineSourceResponse) error {
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+
+	return nil
 }

--- a/cmd/pipeline/source/cmd_test.go
+++ b/cmd/pipeline/source/cmd_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runCmd(t *testing.T, args ...string) error {
+	t.Helper()
+
+	cmd := Cmd()
+	cmd.SetArgs(args)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.PreRunE = nil
+
+	return cmd.Execute()
+}
+
+func TestCmd_RequiresPipelineFlag(t *testing.T) {
+	err := runCmd(t)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pipeline")
+}
+
+func TestCmd_RejectsInvalidOutputFormat(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p-1", "--output-format", "yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}
+
+func TestCmd_HasExpectedFlags(t *testing.T) {
+	cmd := Cmd()
+
+	for _, name := range []string{"pipeline", "output-format", "scope", "version"} {
+		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag to be registered", name)
+	}
+}
+
+func TestHandleSourceError_TextFormat_404_PrintsMessageAndReturnsNil(t *testing.T) {
+	err := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "/test", Detail: "not found"}
+
+	result := handleSourceError(err, "p-123", outputformat.OutputFormatText)
+
+	assert.NoError(t, result)
+}
+
+func TestHandleSourceError_JSONFormat_404_ReturnsError(t *testing.T) {
+	err := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "/test", Detail: "not found"}
+
+	result := handleSourceError(err, "p-123", outputformat.OutputFormatJSON)
+
+	require.Error(t, result)
+	assert.Equal(t, err, result)
+}
+
+func TestHandleSourceError_NonNotFound_AlwaysReturnsError(t *testing.T) {
+	for _, format := range []outputformat.OutputFormat{outputformat.OutputFormatText, outputformat.OutputFormatJSON} {
+		t.Run(string(format), func(t *testing.T) {
+			err := &drapi.HTTPError{StatusCode: http.StatusInternalServerError, URL: "/test", Detail: "boom"}
+
+			result := handleSourceError(err, "p-123", format)
+
+			require.Error(t, result)
+		})
+	}
+}
+
+func TestHandleSourceError_NonHTTPError_AlwaysReturnsError(t *testing.T) {
+	plain := errors.New("connection refused")
+
+	for _, format := range []outputformat.OutputFormat{outputformat.OutputFormatText, outputformat.OutputFormatJSON} {
+		t.Run(string(format), func(t *testing.T) {
+			result := handleSourceError(plain, "p-123", format)
+
+			require.Error(t, result)
+			assert.Equal(t, plain, result)
+		})
+	}
+}

--- a/cmd/pipeline/update/cmd.go
+++ b/cmd/pipeline/update/cmd.go
@@ -15,7 +15,8 @@
 package update
 
 import (
-	"github.com/datarobot/cli/cmd/pipeline/fileutil"
+	"errors"
+
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
@@ -26,28 +27,30 @@ import (
 func Cmd() *cobra.Command {
 	var (
 		imageID      string
+		name         string
+		description  string
 		outputFormat outputformat.OutputFormat
 		fromFile     string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "update <pipeline-id> [<file>]",
-		Short: "Re-upload a Python file to update a draft pipeline.",
-		Long: `Update an existing draft pipeline by re-uploading a Python file.
+		Short: "Update a draft pipeline's file, name, description, or image.",
+		Long: `Update an existing draft pipeline. Supports metadata-only updates
+(name/description/image) without re-uploading the source file.
 
-A new version is appended to the pipeline. The pipeline name encoded in the
-uploaded file must match the existing pipeline name. Locked pipelines cannot
-be updated.
+When a .py file is provided (positional or --from-file), a new version is
+appended. The pipeline name encoded in the uploaded file must match the
+existing pipeline name. Locked pipelines cannot be updated.
 
-The path to the Python file can be supplied either as a positional argument
-or via the --from-file=<path> flag. Exactly one of the two must be provided.
-
-By default, output is human-readable. Use --output-format json for machine-parseable output.
+At least one of --file, --name, --description, or --image must be supplied.
 
 Example:
   dr pipeline update 507f1f77bcf86cd799439011 ./my_pipeline.py
-  dr pipeline update 507f1f77bcf86cd799439011 --from-file=./my_pipeline.py
-  dr pipeline update 507f1f77bcf86cd799439011 --image <image-id> --from-file=./my_pipeline.py
+  dr pipeline update 507f1f77bcf86cd799439011 --name "My Pipeline"
+  dr pipeline update 507f1f77bcf86cd799439011 --description "Trains a model"
+  dr pipeline update 507f1f77bcf86cd799439011 --image <image-id>
+  dr pipeline update 507f1f77bcf86cd799439011 --name "New Name" --description "New desc"
   dr pipeline update 507f1f77bcf86cd799439011 --from-file=./my_pipeline.py --output-format json`,
 		Args:         cobra.RangeArgs(1, 2),
 		SilenceUsage: true,
@@ -57,12 +60,16 @@ Example:
 
 			pipelineID := args[0]
 
-			filePath, err := fileutil.ResolveFilePath(args[1:], fromFile)
+			filePath, err := resolveOptionalFilePath(args[1:], fromFile)
 			if err != nil {
 				return err
 			}
 
-			result, err := pipeline.UpdatePipeline(pipelineID, filePath, imageID)
+			if filePath == "" && name == "" && description == "" && imageID == "" {
+				return errors.New("at least one of a file, --name, --description, or --image must be specified")
+			}
+
+			result, err := pipeline.UpdatePipeline(pipelineID, filePath, imageID, name, description)
 			if err != nil {
 				return err
 			}
@@ -74,7 +81,9 @@ Example:
 	outputformat.AddFlag(cmd, &outputFormat)
 
 	cmd.Flags().StringVar(&imageID, "image", "", "Execution image ID to associate with this pipeline")
-	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to the Python file to upload, e.g. --from-file=./my_pipeline.py (alternative to the positional argument)")
+	cmd.Flags().StringVar(&name, "name", "", "New display name for the pipeline")
+	cmd.Flags().StringVar(&description, "description", "", "New description for the pipeline")
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to the Python file to upload (alternative to the positional argument)")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
@@ -84,4 +93,23 @@ Example:
 	})
 
 	return cmd
+}
+
+// resolveOptionalFilePath returns the file path from the positional arg or --from-file.
+// Returns ("", nil) when neither is provided (metadata-only update).
+func resolveOptionalFilePath(args []string, fromFile string) (string, error) {
+	positional := ""
+	if len(args) > 0 {
+		positional = args[0]
+	}
+
+	if positional != "" && fromFile != "" {
+		return "", errors.New("specify the file either as a positional argument or via --from-file, not both")
+	}
+
+	if positional != "" {
+		return positional, nil
+	}
+
+	return fromFile, nil
 }

--- a/cmd/pipeline/update/cmd.go
+++ b/cmd/pipeline/update/cmd.go
@@ -25,6 +25,7 @@ import (
 
 func Cmd() *cobra.Command {
 	var (
+		imageID      string
 		outputFormat outputformat.OutputFormat
 		fromFile     string
 	)
@@ -46,6 +47,7 @@ By default, output is human-readable. Use --output-format json for machine-parse
 Example:
   dr pipeline update 507f1f77bcf86cd799439011 ./my_pipeline.py
   dr pipeline update 507f1f77bcf86cd799439011 --from-file=./my_pipeline.py
+  dr pipeline update 507f1f77bcf86cd799439011 --image <image-id> --from-file=./my_pipeline.py
   dr pipeline update 507f1f77bcf86cd799439011 --from-file=./my_pipeline.py --output-format json`,
 		Args:         cobra.RangeArgs(1, 2),
 		SilenceUsage: true,
@@ -60,7 +62,7 @@ Example:
 				return err
 			}
 
-			result, err := pipeline.UpdatePipeline(pipelineID, filePath)
+			result, err := pipeline.UpdatePipeline(pipelineID, filePath, imageID)
 			if err != nil {
 				return err
 			}
@@ -71,6 +73,7 @@ Example:
 
 	outputformat.AddFlag(cmd, &outputFormat)
 
+	cmd.Flags().StringVar(&imageID, "image", "", "Execution image ID to associate with this pipeline")
 	cmd.Flags().StringVar(&fromFile, "from-file", "", "Path to the Python file to upload, e.g. --from-file=./my_pipeline.py (alternative to the positional argument)")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {

--- a/cmd/pipeline/update/cmd.go
+++ b/cmd/pipeline/update/cmd.go
@@ -43,7 +43,7 @@ When a .py file is provided (positional or --from-file), a new version is
 appended. The pipeline name encoded in the uploaded file must match the
 existing pipeline name. Locked pipelines cannot be updated.
 
-At least one of --file, --name, --description, or --image must be supplied.
+At least one of a source file (positional argument or --from-file), --name, --description, or --image must be supplied.
 
 Example:
   dr pipeline update 507f1f77bcf86cd799439011 ./my_pipeline.py

--- a/cmd/pipeline/update/cmd_test.go
+++ b/cmd/pipeline/update/cmd_test.go
@@ -93,7 +93,7 @@ func TestCmd_RequiresPipelineID(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestCmd_RequiresFilePath(t *testing.T) {
+func TestCmd_RequiresAtLeastOneChange(t *testing.T) {
 	cmd := Cmd()
 	cmd.SetArgs([]string{"some-id"})
 	cmd.SetOut(io.Discard)
@@ -102,7 +102,7 @@ func TestCmd_RequiresFilePath(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "a file path is required")
+	assert.Contains(t, err.Error(), "at least one of")
 }
 
 func TestCmd_RejectsBothPositionalAndFromFile(t *testing.T) {
@@ -132,9 +132,36 @@ func TestCmd_RejectsInvalidOutput(t *testing.T) {
 func TestCmd_HasExpectedFlags(t *testing.T) {
 	cmd := Cmd()
 
-	for _, name := range []string{"output-format", "from-file"} {
+	for _, name := range []string{"output-format", "from-file", "name", "description", "image"} {
 		flag := cmd.Flags().Lookup(name)
 		assert.NotNilf(t, flag, "expected --%s flag to be registered", name)
+	}
+}
+
+func TestCmd_AcceptsNameOnlyUpdate(t *testing.T) {
+	cmd := Cmd()
+	cmd.SetArgs([]string{"some-id", "--name", "New Name"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.PreRunE = nil
+
+	// Will fail trying to reach the API, but should not fail validation.
+	err := cmd.Execute()
+	if err != nil {
+		assert.NotContains(t, err.Error(), "at least one of")
+	}
+}
+
+func TestCmd_AcceptsDescriptionOnlyUpdate(t *testing.T) {
+	cmd := Cmd()
+	cmd.SetArgs([]string{"some-id", "--description", "New desc"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.PreRunE = nil
+
+	err := cmd.Execute()
+	if err != nil {
+		assert.NotContains(t, err.Error(), "at least one of")
 	}
 }
 

--- a/docs/commands/pipeline.md
+++ b/docs/commands/pipeline.md
@@ -21,8 +21,9 @@ top-level `dr pipeline` subcommand operates on one of four resources:
 - pipeline **inputs** — JSON payloads supplied to a run,
 - pipeline **runs** — concrete executions on Covalent,
 - pipeline **schedules** — recurring runs on a cron expression,
-- pipeline **images** — named, immutable-versioned bags of pip
-  packages that pipelines can be built against,
+- pipeline **images** — named, immutable-versioned execution environments (pip
+  packages, conda packages, base image, NVIDIA GPU support) that pipelines can
+  be built against,
 - pipeline **tasks** — source code, function signature, and input payload
   for individual `@task`-decorated functions.
 
@@ -80,6 +81,7 @@ dr pipeline lock <pipeline-id>
 | `dr pipeline lock`      | `PATCH  /api/v2/pipelines/{id}/mode` | Promote a draft to locked mode.                  |
 | `dr pipeline version …` | `…/versions[/{ver}]`                 | Inspect pipeline versions.                       |
 | `dr pipeline graph`     | `…/graph` (draft or locked)          | Render the pipeline/task DAG.                    |
+| `dr pipeline source`    | `…/source` (draft or locked)         | Retrieve the pipeline's Python source code.      |
 | `dr pipeline run …`     | `…/dispatches` and `…/{id}`          | Trigger, inspect, and cancel runs.               |
 | `dr pipeline input …`   | `…/inputs` and `…/inputs/{input_id}` | Manage JSON payloads for runs.                   |
 | `dr pipeline schedule …` | `…/versions/{ver}/schedules`        | Manage recurring (cron) runs on locked versions. |
@@ -113,6 +115,8 @@ dr pipeline create --from-file=<file> [flags]
 - `--description <text>` — optional human-readable description stored on
   the pipeline.
 - `--mode <draft|locked>` — pipeline lifecycle mode. Defaults to `draft`.
+- `--image <image-id>` — optional execution image to associate with the
+  pipeline. The pipeline's runs will use this image's environment.
 - `--output-format <json>` — emit machine-parseable JSON instead of the
   human-readable summary.
 
@@ -136,6 +140,20 @@ Status:       READY
 Mode:         draft
 Tasks:        create_vector_database, ingest_confluence_files, setup_credential_and_datastore
 Created:      2026-04-28T11:43:00Z
+```
+
+When `--image` is supplied, an `Image ID:` row is shown in the response.
+
+```bash
+$ dr pipeline create ./confluence_to_vdb.py --image 683c000000000000000000ab
+Pipeline ID:  683c2a1b4f8e1a2b3c4d5e6f
+Name:         confluence_to_vdb
+Version:      1
+Status:       READY
+Mode:         draft
+Tasks:        create_vector_database, ingest_confluence_files, setup_credential_and_datastore
+Image ID:     683c000000000000000000ab
+Created:      2026-04-28T11:42:28Z
 ```
 
 ### `list`
@@ -198,6 +216,10 @@ Versions (3):
   v3       READY   3.12    2026-04-28T12:25:11Z  create_vector_database
 ```
 
+When a pipeline has a linked execution image, an `Image:` row is shown
+(format: `<imageId> (v<n>, <status>)`). When an `inputSetTemplate` is set,
+an `Input template:` section is printed below the header block.
+
 If the pipeline doesn't exist, `get` prints
 `No pipeline found with id: <id>` and exits 0.
 
@@ -220,6 +242,8 @@ dr pipeline update <pipeline-id> --from-file=<file> [flags]
 **Flags:**
 
 - `--from-file <path>` — alternative to the positional file argument.
+- `--image <image-id>` — optional execution image to associate with the
+  pipeline.
 - `--output-format <json>` — emit machine-parseable JSON.
 
 ### `delete`
@@ -267,6 +291,23 @@ dr pipeline graph --pipeline <id> --version=N           # locked-version graph
 dr pipeline graph --pipeline <id> --output-format json  # includes taskId on each node
 ```
 
+### `source`
+
+Retrieve the Python source file of a pipeline as uploaded.
+
+```bash
+dr pipeline source --pipeline <id>                       # draft source
+dr pipeline source --pipeline <id> --version=N           # locked-version source
+dr pipeline source --pipeline <id> --output-format json  # returns {"source": "..."}
+```
+
+**Flags:**
+
+- `--pipeline <id>` — pipeline ObjectId (required).
+- `--scope <draft|locked>` — scope selector. Default `draft`.
+- `--version <n>` — locked version number; implies `--scope=locked`.
+- `--output-format <json>` — emit the source wrapped in a JSON object.
+
 ## Shared flags
 
 ### `--from-file` / positional file
@@ -313,12 +354,14 @@ dr pipeline lock   <pipeline-id>
 dr pipeline delete <pipeline-id>
 ```
 
-### Inspect versions and graph
+### Inspect versions, graph, and source
 
 ```bash
 dr pipeline version list --pipeline <pipeline-id>
 dr pipeline version get  --pipeline <pipeline-id> 2
 dr pipeline graph        --pipeline <pipeline-id> --version=2 --output-format json
+dr pipeline source       --pipeline <pipeline-id>             # draft source
+dr pipeline source       --pipeline <pipeline-id> --version=2 # locked version source
 ```
 
 ### Inspect a task
@@ -371,11 +414,15 @@ Trigger, inspect, and cancel pipeline executions.
 ```bash
 dr pipeline run create --pipeline <id> --input <input-id>              # draft
 dr pipeline run create --pipeline <id> --version=N --input <input-id>  # locked
+dr pipeline run create --pipeline <id> --input <input-id> --image <img-id>  # override image
 dr pipeline run list   --pipeline <id> [--scope|--version]
 dr pipeline run get    --pipeline <id> <run-id> [--scope|--version]
 dr pipeline run status --pipeline <id> <run-id> [--scope|--version]
 dr pipeline run cancel --pipeline <id> <run-id> [--scope|--version]
 ```
+
+`run create` accepts an optional `--image <image-id>` flag to override the
+execution image linked to the pipeline for this specific run.
 
 `run status` is a lighter-weight call intended for polling — returns just
 the run ID, status, and Covalent dispatch ID.
@@ -384,22 +431,44 @@ the run ID, status, and Covalent dispatch ID.
 
 ### `image`
 
-Manage pipeline execution images — named, immutable-versioned bags of pip packages
-that pipelines can be built against. Each `update` appends a new version; individual
-older versions can be removed with `image version delete`.
+Manage pipeline execution images — named, immutable-versioned environments (pip
+packages, conda packages, base Docker image, NVIDIA GPU support) that pipelines
+can be built against. Each `update` appends a new version; individual older versions
+can be removed with `image version delete`.
 
 ```bash
+# pip-only image
 dr pipeline image create --name <name> --package <pkg> [--package <pkg> …] [--description <text>] [--output-format json]
+
+# conda image (channels optional; --conda-channel requires at least one --conda)
+dr pipeline image create --name <name> --conda <pkg> [--conda <pkg> …] [--conda-channel <ch>]
+
+# combined pip + conda + base image + nvidia
+dr pipeline image create --name gpu-base --package torch --conda scipy \
+    --base-image nvcr.io/nvidia/pytorch:24.01-py3 --nvidia
+
 dr pipeline image list   [--offset N] [--limit N] [--output-format json]
 dr pipeline image update <image-id> --package <pkg> [--package <pkg> …] [--output-format json]
+dr pipeline image update <image-id> --conda <pkg> [--conda-channel <ch>] [--base-image <uri>] [--nvidia]
 dr pipeline image delete <image-id>
 dr pipeline image version delete --image <image-id> <version>
 ```
 
-`image create` registers a new image; `image update` appends a new
-immutable version. `image delete` soft-deletes the latest active version (cascading
-to the parent if no active versions remain). `image version delete` targets a
-specific version by its integer number.
+`image create` registers a new image with an initial version (v1). At least one of
+`--package` (pip) or `--conda` must be supplied; `--conda-channel` requires at
+least one `--conda` package. `image update` appends a new immutable version with
+the supplied definition — all fields must be re-specified since the server does not
+carry over the previous version's packages. `image delete` soft-deletes the latest
+active version (cascading to the parent if no active versions remain).
+`image version delete` targets a specific version by its integer number.
+
+**`image create` / `image update` flags:**
+
+- `--package <spec>` — pip package spec (repeatable, also accepts comma-separated values).
+- `--conda <spec>` — conda package spec (repeatable).
+- `--conda-channel <channel>` — conda channel (repeatable); requires at least one `--conda`.
+- `--base-image <uri>` — Docker base image URI (e.g. `python:3.12`).
+- `--nvidia` — enable NVIDIA GPU support.
 
 ### `task`
 

--- a/docs/commands/pipeline.md
+++ b/docs/commands/pipeline.md
@@ -116,7 +116,8 @@ dr pipeline create --from-file=<file> [flags]
   the pipeline.
 - `--mode <draft|locked>` — pipeline lifecycle mode. Defaults to `draft`.
 - `--image <image-id>` — optional execution image to associate with the
-  pipeline. The pipeline's runs will use this image's environment.
+  pipeline. The pipeline's runs will use this image's environment. Image IDs
+  are obtained from `dr pipeline image create` or `dr pipeline image list`.
 - `--output-format <json>` — emit machine-parseable JSON instead of the
   human-readable summary.
 
@@ -242,8 +243,10 @@ dr pipeline update <pipeline-id> --from-file=<file> [flags]
 **Flags:**
 
 - `--from-file <path>` — alternative to the positional file argument.
-- `--image <image-id>` — optional execution image to associate with the
-  pipeline.
+- `--name <text>` — new display name for the pipeline.
+- `--description <text>` — new description for the pipeline.
+- `--image <image-id>` — execution image to associate with the pipeline.
+  Image IDs are obtained from `dr pipeline image create` or `dr pipeline image list`.
 - `--output-format <json>` — emit machine-parseable JSON.
 
 ### `delete`
@@ -412,17 +415,17 @@ dr pipeline schedule delete --pipeline <id> --version=N <schedule-id>
 Trigger, inspect, and cancel pipeline executions.
 
 ```bash
-dr pipeline run create --pipeline <id> --input <input-id>              # draft
-dr pipeline run create --pipeline <id> --version=N --input <input-id>  # locked
-dr pipeline run create --pipeline <id> --input <input-id> --image <img-id>  # override image
+dr pipeline run create --pipeline <id> --input <input-id> --image <img-id>              # draft
+dr pipeline run create --pipeline <id> --version=N --input <input-id> --image <img-id>  # locked
 dr pipeline run list   --pipeline <id> [--scope|--version]
 dr pipeline run get    --pipeline <id> <run-id> [--scope|--version]
 dr pipeline run status --pipeline <id> <run-id> [--scope|--version]
 dr pipeline run cancel --pipeline <id> <run-id> [--scope|--version]
 ```
 
-`run create` accepts an optional `--image <image-id>` flag to override the
-execution image linked to the pipeline for this specific run.
+`run create` requires `--image <image-id>` — the execution image to use for
+this run. Image IDs are obtained from `dr pipeline image create` or
+`dr pipeline image list`.
 
 `run status` is a lighter-weight call intended for polling — returns just
 the run ID, status, and Covalent dispatch ID.

--- a/docs/commands/pipelines-reference.md
+++ b/docs/commands/pipelines-reference.md
@@ -24,10 +24,10 @@ accepts.
 
 | Command | API endpoint | Usage | Inputs |
 |---|---|---|---|
-| `dr pipeline create` | `POST /pipelines` | `dr pipeline create ./my_pipeline.py` <br> `dr pipeline create --from-file=./my_pipeline.py` <br> `dr pipeline create ./my_pipeline.py --name "My Pipeline" --description "First draft" --mode draft` <br> `dr pipeline create --from-file=./my_pipeline.py --output-format json` | **Positional:** `<file>` (Python file; mutually exclusive with `--from-file`). <br> **Flags:** `--from-file=<path>`, `--name <text>` (optional display name; defaults to title-cased `@pipeline` function name), `--description <text>`, `--mode draft\|locked`, `--output-format json`. |
+| `dr pipeline create` | `POST /pipelines` | `dr pipeline create ./my_pipeline.py` <br> `dr pipeline create --from-file=./my_pipeline.py` <br> `dr pipeline create ./my_pipeline.py --name "My Pipeline" --description "First draft" --mode draft` <br> `dr pipeline create ./my_pipeline.py --image <img-id>` <br> `dr pipeline create --from-file=./my_pipeline.py --output-format json` | **Positional:** `<file>` (Python file; mutually exclusive with `--from-file`). <br> **Flags:** `--from-file=<path>`, `--name <text>` (optional display name; defaults to title-cased `@pipeline` function name), `--description <text>`, `--mode draft\|locked`, `--image <image-id>` (optional), `--output-format json`. |
 | `dr pipeline list` | `GET /pipelines` | `dr pipeline list` <br> `dr pipeline list --mode draft` <br> `dr pipeline list --offset 50 --limit 10 --output-format json` | **Flags:** `--mode draft\|locked`, `--offset <n>`, `--limit <n>`, `--output-format json`. |
 | `dr pipeline get` | `GET /pipelines/{pipeline_id}` | `dr pipeline get <pipeline-id>` <br> `dr pipeline get <pipeline-id> --output-format json` | **Positional:** `<pipeline-id>` (required). <br> **Flags:** `--output-format json`. |
-| `dr pipeline update` | `PATCH /pipelines/{pipeline_id}` | `dr pipeline update <pipeline-id> ./my_pipeline.py` <br> `dr pipeline update <pipeline-id> --from-file=./my_pipeline.py` | **Positional:** `<pipeline-id>` (required), `<file>` (mutually exclusive with `--from-file`). <br> **Flags:** `--from-file=<path>`, `--output-format json`. |
+| `dr pipeline update` | `PATCH /pipelines/{pipeline_id}` | `dr pipeline update <pipeline-id> ./my_pipeline.py` <br> `dr pipeline update <pipeline-id> --from-file=./my_pipeline.py` <br> `dr pipeline update <pipeline-id> ./my_pipeline.py --image <img-id>` | **Positional:** `<pipeline-id>` (required), `<file>` (mutually exclusive with `--from-file`). <br> **Flags:** `--from-file=<path>`, `--image <image-id>` (optional), `--output-format json`. |
 | `dr pipeline delete` | `DELETE /pipelines/{pipeline_id}` | `dr pipeline delete <pipeline-id>` | **Positional:** `<pipeline-id>` (required). |
 | `dr pipeline lock` | `PATCH /pipelines/{pipeline_id}/mode` | `dr pipeline lock <pipeline-id>` <br> `dr pipeline lock <pipeline-id> --output-format json` | **Positional:** `<pipeline-id>` (required). <br> **Flags:** `--output-format json`. |
 
@@ -40,6 +40,18 @@ accepts.
 | `dr pipeline version list` | `GET /pipelines/{pipeline_id}/versions` | `dr pipeline version list --pipeline <id>` <br> `dr pipeline version list --pipeline <id> --offset 10 --limit 5 --output-format json` | **Flags:** `--pipeline <id>` (required), `--offset <n>`, `--limit <n>`, `--output-format json`. |
 | `dr pipeline version get` | `GET /pipelines/{pipeline_id}/versions/{version_id}` | `dr pipeline version get --pipeline <id> 2` <br> `dr pipeline version get --pipeline <id> 2 --output-format json` | **Positional:** `<version-id>` (positive integer, required). <br> **Flags:** `--pipeline <id>` (required), `--output-format json`. |
 | `dr pipeline graph` | `GET /pipelines/{pipeline_id}/graph` (draft) <br> `GET /pipelines/{pipeline_id}/versions/{version_id}/graph` (locked) | `dr pipeline graph --pipeline <id>` (draft) <br> `dr pipeline graph --pipeline <id> --version=2` (locked) <br> `dr pipeline graph --pipeline <id> --version=2 --output-format json` | **Flags:** `--pipeline <id>` (required), `--scope draft\|locked`, `--version <n>`, `--output-format json`. |
+
+---
+
+## Source (`dr pipeline source`)
+
+Retrieve the Python source file of a pipeline as originally uploaded.
+
+| Command | API endpoint | Usage | Inputs |
+|---|---|---|---|
+| `dr pipeline source` | `GET /pipelines/{id}/source` (draft) <br> `GET /pipelines/{id}/versions/{ver}/source` (locked) | `dr pipeline source --pipeline <id>` <br> `dr pipeline source --pipeline <id> --version=2` <br> `dr pipeline source --pipeline <id> --output-format json` | **Flags:** `--pipeline <id>` (required), `--scope draft\|locked`, `--version <n>`, `--output-format json`. |
+
+Human output prints the source verbatim. JSON output wraps it: `{"source": "..."}`.
 
 ---
 
@@ -109,7 +121,7 @@ term `dispatches` / `dispatch_id`, but the CLI's `--output-format json` remaps t
 
 | Command | API endpoint | Usage | Inputs |
 |---|---|---|---|
-| `dr pipeline run create` | `POST /pipelines/{id}/dispatches` (draft) <br> `POST /pipelines/{id}/versions/{ver}/dispatches` (locked) | `dr pipeline run create --pipeline <id> --input <input-id>` <br> `dr pipeline run create --pipeline <id> --version=2 --input <input-id> --output-format json` | **Flags:** `--pipeline <id>` (required), `--input <input-id>` (required), `--scope`, `--version`, `--output-format json`. |
+| `dr pipeline run create` | `POST /pipelines/{id}/dispatches` (draft) <br> `POST /pipelines/{id}/versions/{ver}/dispatches` (locked) | `dr pipeline run create --pipeline <id> --input <input-id>` <br> `dr pipeline run create --pipeline <id> --version=2 --input <input-id> --output-format json` <br> `dr pipeline run create --pipeline <id> --input <input-id> --image <img-id>` | **Flags:** `--pipeline <id>` (required), `--input <input-id>` (required), `--scope`, `--version`, `--image <image-id>` (optional; overrides the pipeline's linked image for this run), `--output-format json`. |
 | `dr pipeline run list` | `GET /pipelines/{id}/dispatches` (draft) <br> `GET /pipelines/{id}/versions/{ver}/dispatches` (locked) | `dr pipeline run list --pipeline <id>` <br> `dr pipeline run list --pipeline <id> --version=2 --output-format json` | **Flags:** `--pipeline <id>` (required), `--scope`, `--version`, `--offset <n>`, `--limit <n>`, `--output-format json`. |
 | `dr pipeline run get` | `GET /pipelines/{id}/dispatches/{dispatch_id}` (draft) <br> `GET /pipelines/{id}/versions/{ver}/dispatches/{dispatch_id}` (locked) | `dr pipeline run get --pipeline <id> <run-id>` | **Positional:** `<run-id>` (required). **Flags:** `--pipeline <id>` (required), `--scope`, `--version`, `--output-format json`. |
 | `dr pipeline run status` | `GET /pipelines/{id}/dispatches/{dispatch_id}/status` (draft) <br> `GET /pipelines/{id}/versions/{ver}/dispatches/{dispatch_id}/status` (locked) | `dr pipeline run status --pipeline <id> <run-id>` | **Positional:** `<run-id>` (required). **Flags:** `--pipeline <id>` (required), `--scope`, `--version`, `--output-format json`. |
@@ -146,9 +158,9 @@ TASK ID column of `dr pipeline graph` and can be used to inspect individual task
 
 | Command | API endpoint | Usage | Inputs |
 |---|---|---|---|
-| `dr pipeline image create` | `POST /pipelines/images` | `dr pipeline image create --name ml-base --package numpy --package pandas` <br> `dr pipeline image create --name ml-base --package numpy,pandas==2.0 --description "base" --output-format json` | **Flags:** `--name <name>` (required), `--package <spec>` (repeatable / comma-separated), `--description <text>`, `--output-format json`. |
+| `dr pipeline image create` | `POST /pipelines/images` | `dr pipeline image create --name ml-base --package numpy --package pandas` <br> `dr pipeline image create --name ml-base --conda scipy --conda numpy --base-image python:3.12` <br> `dr pipeline image create --name gpu-base --package torch --nvidia --output-format json` | **Flags:** `--name <name>` (required), `--package <spec>` (repeatable / comma-separated), `--conda <spec>` (repeatable), `--conda-channel <channel>` (repeatable; requires `--conda`), `--base-image <uri>`, `--nvidia`, `--description <text>`, `--output-format json`. At least one of `--package` or `--conda` required. |
 | `dr pipeline image list` | `GET /pipelines/images` | `dr pipeline image list` <br> `dr pipeline image list --offset 50 --limit 10 --output-format json` | **Flags:** `--offset <n>`, `--limit <n>`, `--output-format json`. |
-| `dr pipeline image update` | `PATCH /pipelines/images/{id}` | `dr pipeline image update <img-id> --package scikit-learn` | **Positional:** `<image-id>` (required). **Flags:** `--package <spec>` (repeatable / comma-separated), `--output-format json`. |
+| `dr pipeline image update` | `PATCH /pipelines/images/{id}` | `dr pipeline image update <img-id> --package scikit-learn` <br> `dr pipeline image update <img-id> --conda scipy --base-image python:3.12` <br> `dr pipeline image update <img-id> --package torch --nvidia` | **Positional:** `<image-id>` (required). **Flags:** `--package <spec>` (repeatable / comma-separated), `--conda <spec>` (repeatable), `--conda-channel <channel>` (repeatable; requires `--conda`), `--base-image <uri>`, `--nvidia`, `--output-format json`. At least one of `--package` or `--conda` required. All fields must be re-specified on each update (no carry-over from previous version). |
 | `dr pipeline image delete` | `DELETE /pipelines/images/{id}` | `dr pipeline image delete <img-id>` | **Positional:** `<image-id>` (required). |
 | `dr pipeline image version delete` | `DELETE /pipelines/images/{id}/versions/{n}` | `dr pipeline image version delete --image <img-id> <version>` | **Positional:** `<version>` (integer, required). **Flags:** `--image <img-id>` (required). |
 
@@ -168,6 +180,8 @@ TASK ID column of `dr pipeline graph` and can be used to inspect individual task
 | `GET /pipelines/{id}/versions/{ver}` | `dr pipeline version get` |
 | `GET /pipelines/{id}/graph` | `dr pipeline graph` (draft) |
 | `GET /pipelines/{id}/versions/{ver}/graph` | `dr pipeline graph` (locked) |
+| `GET /pipelines/{id}/source` | `dr pipeline source` (draft) |
+| `GET /pipelines/{id}/versions/{ver}/source` | `dr pipeline source` (locked) |
 | `POST /pipelines/{id}/dispatches` | `dr pipeline run create` (draft) |
 | `GET /pipelines/{id}/dispatches` | `dr pipeline run list` (draft) |
 | `GET /pipelines/{id}/dispatches/{dispatch_id}` | `dr pipeline run get` (draft) |

--- a/internal/pipeline/image.go
+++ b/internal/pipeline/image.go
@@ -22,9 +22,11 @@
 //
 //	POST   /api/v2/pipelines/images
 //	GET    /api/v2/pipelines/images
+//	GET    /api/v2/pipelines/images/{id}
 //	PATCH  /api/v2/pipelines/images/{id}              (replacement -> new version)
 //	DELETE /api/v2/pipelines/images/{id}              (soft-deletes latest version, cascades parent)
 //	DELETE /api/v2/pipelines/images/{id}/versions/{n} (soft-deletes a specific version)
+//	GET    /api/v2/pipelines/images/{id}/versions/{n}/logs
 package pipeline
 
 import (
@@ -101,11 +103,15 @@ const (
 // ImageDefinition mirrors PipelineImageDefinition — the canonical
 // definition stored on a PipelineImageVersion row and round-tripped
 // verbatim on every read.
+//
+// JSON tags match the response wire format: "packages" and "pythonBaseImage".
+// Request structs (ImageCreateRequest, ImageUpdateRequest) use the "pip" /
+// "baseImage" aliases accepted by the API's backward-compat validator.
 type ImageDefinition struct {
 	Name      string      `json:"name"`
-	Pip       []string    `json:"pip"`
+	Pip       []string    `json:"packages"`
 	Conda     *CondaValue `json:"conda,omitempty"`
-	BaseImage *string     `json:"baseImage,omitempty"`
+	BaseImage *string     `json:"pythonBaseImage,omitempty"`
 	Nvidia    bool        `json:"nvidia"`
 }
 
@@ -115,6 +121,7 @@ type ImageVersion struct {
 	Definition  ImageDefinition `json:"definition"`
 	Status      ImageStatus     `json:"status"`
 	ErrorDetail *string         `json:"errorDetail,omitempty"`
+	ImageURI    *string         `json:"imageUri,omitempty"`
 	CreatedAt   time.Time       `json:"createdAt"`
 	UpdatedAt   time.Time       `json:"updatedAt"`
 }
@@ -230,6 +237,48 @@ func ListImages(offset, limit int) ([]ImageSummary, error) {
 	return page.Data, nil
 }
 
+// ImageLogsResponse mirrors PipelineImageLogsResponse from the API.
+type ImageLogsResponse struct {
+	Logs string `json:"logs"`
+}
+
+// GetImage fetches a single image by ID from GET /api/v2/pipelines/images/{image_id}.
+func GetImage(imageID string) (*Image, error) {
+	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/images/" + imageID)
+	if err != nil {
+		return nil, err
+	}
+
+	var result Image
+
+	err = doJSON(http.MethodGet, endpoint, nil, "get image", &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// GetImageBuildLogs fetches build logs for a specific image version from
+// GET /api/v2/pipelines/images/{image_id}/versions/{version_id}/logs.
+func GetImageBuildLogs(imageID string, version int) (*ImageLogsResponse, error) {
+	endpoint, err := config.GetEndpointURL(
+		"/api/v2/pipelines/images/" + imageID + "/versions/" + strconv.Itoa(version) + "/logs",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var result ImageLogsResponse
+
+	err = doJSON(http.MethodGet, endpoint, nil, "image build logs", &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
 // UpdateImage PATCHes an image with a new complete definition, creating a
 // new immutable version. The supplied definition is a full replacement.
 // The response includes the full Image with all versions ordered newest-first.
@@ -245,9 +294,8 @@ func UpdateImage(imageID string, pip []string, conda *CondaValue, baseImage stri
 	// Fetch the current image to resolve its canonical name — required by
 	// the update request body even though the server overrides it with the
 	// stored name anyway.
-	var current Image
-
-	if err = doJSON(http.MethodGet, endpoint, nil, "get image for update", &current); err != nil {
+	current, err := GetImage(imageID)
+	if err != nil {
 		return nil, err
 	}
 

--- a/internal/pipeline/image.go
+++ b/internal/pipeline/image.go
@@ -16,8 +16,8 @@
 // execution-image endpoints described under the
 // `pipeline-execution-images` tag of the pipelines-api OpenAPI spec.
 //
-// Images are named, immutable-versioned execution environments backed by
-// pip packages. They live at the top of the pipelines namespace (not
+// Images are named, immutable-versioned execution environments (pip/conda
+// packages, base image, NVIDIA GPU support). They live at the top of the pipelines namespace (not
 // nested under a specific pipeline) and have their own lifecycle:
 //
 //	POST   /api/v2/pipelines/images
@@ -74,6 +74,7 @@ func (c *CondaValue) UnmarshalJSON(data []byte) error {
 	var deps []string
 
 	if err := json.Unmarshal(data, &deps); err == nil {
+		c.Channels = nil
 		c.Deps = deps
 
 		return nil

--- a/internal/pipeline/image.go
+++ b/internal/pipeline/image.go
@@ -28,6 +28,7 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -39,6 +40,57 @@ import (
 // ImageStatus mirrors PipelineImageStatus in the API.
 type ImageStatus string
 
+// CondaSpec mirrors CondaSpec from the pipelines-api: a structured conda
+// definition with explicit channels and dependencies lists.
+type CondaSpec struct {
+	Channels     []string `json:"channels"`
+	Dependencies []string `json:"dependencies"`
+}
+
+// CondaValue holds a conda definition that serialises as either a plain
+// package list (when Channels is empty) or a CondaSpec object (when
+// Channels is provided). Matches the anyOf[[]string, CondaSpec] schema.
+type CondaValue struct {
+	Deps     []string
+	Channels []string
+}
+
+// MarshalJSON renders a plain []string when no channels are set, or a
+// CondaSpec object when channels are provided.
+func (c CondaValue) MarshalJSON() ([]byte, error) {
+	if len(c.Channels) > 0 {
+		return json.Marshal(CondaSpec{
+			Channels:     c.Channels,
+			Dependencies: c.Deps,
+		})
+	}
+
+	return json.Marshal(c.Deps)
+}
+
+// UnmarshalJSON accepts both the string-array form and the CondaSpec
+// object form returned by the pipelines-api.
+func (c *CondaValue) UnmarshalJSON(data []byte) error {
+	var deps []string
+
+	if err := json.Unmarshal(data, &deps); err == nil {
+		c.Deps = deps
+
+		return nil
+	}
+
+	var spec CondaSpec
+
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return err
+	}
+
+	c.Channels = spec.Channels
+	c.Deps = spec.Dependencies
+
+	return nil
+}
+
 const (
 	ImageStatusCreating ImageStatus = "CREATING"
 	ImageStatusReady    ImageStatus = "READY"
@@ -49,10 +101,11 @@ const (
 // definition stored on a PipelineImageVersion row and round-tripped
 // verbatim on every read.
 type ImageDefinition struct {
-	Name      string   `json:"name"`
-	Pip       []string `json:"pip"`
-	BaseImage *string  `json:"baseImage,omitempty"`
-	Nvidia    bool     `json:"nvidia"`
+	Name      string      `json:"name"`
+	Pip       []string    `json:"pip"`
+	Conda     *CondaValue `json:"conda,omitempty"`
+	BaseImage *string     `json:"baseImage,omitempty"`
+	Nvidia    bool        `json:"nvidia"`
 }
 
 // ImageVersion mirrors PipelineImageVersionResponse.
@@ -89,35 +142,50 @@ type ImageSummary struct {
 
 // ImageCreateRequest mirrors PipelineImageCreateRequest.
 type ImageCreateRequest struct {
-	Name        string   `json:"name"`
-	Description *string  `json:"description,omitempty"`
-	Pip         []string `json:"pip"`
+	Name        string      `json:"name"`
+	Description *string     `json:"description,omitempty"`
+	Pip         []string    `json:"pip,omitempty"`
+	Conda       *CondaValue `json:"conda,omitempty"`
+	BaseImage   *string     `json:"baseImage,omitempty"`
+	Nvidia      bool        `json:"nvidia,omitempty"`
 }
 
 // ImageUpdateRequest mirrors PipelineImageUpdateRequest.
 // Name is required by the API; the server overrides it with the parent
 // image's canonical name so all versions share the same name.
 type ImageUpdateRequest struct {
-	Name string   `json:"name"`
-	Pip  []string `json:"pip"`
+	Name      string      `json:"name"`
+	Pip       []string    `json:"pip,omitempty"`
+	Conda     *CondaValue `json:"conda,omitempty"`
+	BaseImage *string     `json:"baseImage,omitempty"`
+	Nvidia    bool        `json:"nvidia,omitempty"`
 }
 
-// CreateImage POSTs a new image with an initial set of pip packages.
-// The API returns 201 with the full Image payload (a single CREATING
-// version is returned immediately; READY status is reached
-// asynchronously by the covalent build).
-func CreateImage(name, description string, packages []string) (*Image, error) {
+// CreateImage POSTs a new image. The API returns 201 with the full Image
+// payload (a single CREATING version is returned immediately; READY status
+// is reached asynchronously by the covalent build).
+func CreateImage(name, description string, pip []string, conda *CondaValue, baseImage string, nvidia bool) (*Image, error) {
 	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/images")
 	if err != nil {
 		return nil, err
 	}
 
 	body := ImageCreateRequest{
-		Name: name,
-		Pip:  packages,
+		Name:  name,
+		Pip:   pip,
+		Conda: conda,
 	}
+
 	if description != "" {
 		body.Description = &description
+	}
+
+	if baseImage != "" {
+		body.BaseImage = &baseImage
+	}
+
+	if nvidia {
+		body.Nvidia = true
 	}
 
 	var result Image
@@ -162,13 +230,12 @@ func ListImages(offset, limit int) ([]ImageSummary, error) {
 }
 
 // UpdateImage PATCHes an image with a new complete definition, creating a
-// new immutable version. The packages list is a full replacement — not an
-// append — of the previous version's pip list. The response includes the
-// full Image with all versions ordered newest-first.
+// new immutable version. The supplied definition is a full replacement.
+// The response includes the full Image with all versions ordered newest-first.
 //
 // The API requires the image name in the body; UpdateImage fetches it
 // first so callers only need to supply the image ID.
-func UpdateImage(imageID string, packages []string) (*Image, error) {
+func UpdateImage(imageID string, pip []string, conda *CondaValue, baseImage string, nvidia bool) (*Image, error) {
 	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/images/" + imageID)
 	if err != nil {
 		return nil, err
@@ -178,13 +245,23 @@ func UpdateImage(imageID string, packages []string) (*Image, error) {
 	// the update request body even though the server overrides it with the
 	// stored name anyway.
 	var current Image
+
 	if err = doJSON(http.MethodGet, endpoint, nil, "get image for update", &current); err != nil {
 		return nil, err
 	}
 
 	body := ImageUpdateRequest{
-		Name: current.Name,
-		Pip:  packages,
+		Name:  current.Name,
+		Pip:   pip,
+		Conda: conda,
+	}
+
+	if baseImage != "" {
+		body.BaseImage = &baseImage
+	}
+
+	if nvidia {
+		body.Nvidia = true
 	}
 
 	var result Image

--- a/internal/pipeline/image.go
+++ b/internal/pipeline/image.go
@@ -16,14 +16,13 @@
 // execution-image endpoints described under the
 // `pipeline-execution-images` tag of the pipelines-api OpenAPI spec.
 //
-// Images are named, immutable-versioned bags of pip packages that
-// pipelines can be built against. They live at the top of the pipelines
-// namespace (not nested under a specific pipeline) and have their own
-// lifecycle:
+// Images are named, immutable-versioned execution environments backed by
+// pip packages. They live at the top of the pipelines namespace (not
+// nested under a specific pipeline) and have their own lifecycle:
 //
 //	POST   /api/v2/pipelines/images
 //	GET    /api/v2/pipelines/images
-//	PATCH  /api/v2/pipelines/images/{id}              (adds packages -> new version)
+//	PATCH  /api/v2/pipelines/images/{id}              (replacement -> new version)
 //	DELETE /api/v2/pipelines/images/{id}              (soft-deletes latest version, cascades parent)
 //	DELETE /api/v2/pipelines/images/{id}/versions/{n} (soft-deletes a specific version)
 package pipeline
@@ -46,14 +45,24 @@ const (
 	ImageStatusError    ImageStatus = "ERROR"
 )
 
+// ImageDefinition mirrors PipelineImageDefinition — the canonical
+// definition stored on a PipelineImageVersion row and round-tripped
+// verbatim on every read.
+type ImageDefinition struct {
+	Name      string   `json:"name"`
+	Pip       []string `json:"pip"`
+	BaseImage *string  `json:"baseImage,omitempty"`
+	Nvidia    bool     `json:"nvidia"`
+}
+
 // ImageVersion mirrors PipelineImageVersionResponse.
 type ImageVersion struct {
-	Version     int         `json:"version"`
-	Packages    []string    `json:"packages"`
-	Status      ImageStatus `json:"status"`
-	ErrorDetail *string     `json:"errorDetail,omitempty"`
-	CreatedAt   time.Time   `json:"createdAt"`
-	UpdatedAt   time.Time   `json:"updatedAt"`
+	Version     int             `json:"version"`
+	Definition  ImageDefinition `json:"definition"`
+	Status      ImageStatus     `json:"status"`
+	ErrorDetail *string         `json:"errorDetail,omitempty"`
+	CreatedAt   time.Time       `json:"createdAt"`
+	UpdatedAt   time.Time       `json:"updatedAt"`
 }
 
 // Image mirrors PipelineImageResponse (full detail).
@@ -82,12 +91,15 @@ type ImageSummary struct {
 type ImageCreateRequest struct {
 	Name        string   `json:"name"`
 	Description *string  `json:"description,omitempty"`
-	Packages    []string `json:"packages"`
+	Pip         []string `json:"pip"`
 }
 
 // ImageUpdateRequest mirrors PipelineImageUpdateRequest.
+// Name is required by the API; the server overrides it with the parent
+// image's canonical name so all versions share the same name.
 type ImageUpdateRequest struct {
-	Packages []string `json:"packages"`
+	Name string   `json:"name"`
+	Pip  []string `json:"pip"`
 }
 
 // CreateImage POSTs a new image with an initial set of pip packages.
@@ -101,8 +113,8 @@ func CreateImage(name, description string, packages []string) (*Image, error) {
 	}
 
 	body := ImageCreateRequest{
-		Name:     name,
-		Packages: packages,
+		Name: name,
+		Pip:  packages,
 	}
 	if description != "" {
 		body.Description = &description
@@ -149,16 +161,31 @@ func ListImages(offset, limit int) ([]ImageSummary, error) {
 	return page.Data, nil
 }
 
-// UpdateImage PATCHes an image with additional packages, creating a new
-// immutable version. The response includes the full Image with all
-// versions ordered newest-first.
+// UpdateImage PATCHes an image with a new complete definition, creating a
+// new immutable version. The packages list is a full replacement — not an
+// append — of the previous version's pip list. The response includes the
+// full Image with all versions ordered newest-first.
+//
+// The API requires the image name in the body; UpdateImage fetches it
+// first so callers only need to supply the image ID.
 func UpdateImage(imageID string, packages []string) (*Image, error) {
 	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/images/" + imageID)
 	if err != nil {
 		return nil, err
 	}
 
-	body := ImageUpdateRequest{Packages: packages}
+	// Fetch the current image to resolve its canonical name — required by
+	// the update request body even though the server overrides it with the
+	// stored name anyway.
+	var current Image
+	if err = doJSON(http.MethodGet, endpoint, nil, "get image for update", &current); err != nil {
+		return nil, err
+	}
+
+	body := ImageUpdateRequest{
+		Name: current.Name,
+		Pip:  packages,
+	}
 
 	var result Image
 

--- a/internal/pipeline/image.go
+++ b/internal/pipeline/image.go
@@ -31,12 +31,15 @@ package pipeline
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/log"
 )
 
 // ImageStatus mirrors PipelineImageStatus in the API.
@@ -296,6 +299,12 @@ func UpdateImage(imageID string, pip []string, conda *CondaValue, baseImage stri
 	// stored name anyway.
 	current, err := GetImage(imageID)
 	if err != nil {
+		var httpErr *drapi.HTTPError
+
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			log.Warnf("image not found during update: %s", imageID)
+		}
+
 		return nil, err
 	}
 

--- a/internal/pipeline/image_output.go
+++ b/internal/pipeline/image_output.go
@@ -42,6 +42,7 @@ type imageVersionJSON struct {
 	Nvidia      bool     `json:"nvidia,omitempty"`
 	Status      string   `json:"status"`
 	ErrorDetail *string  `json:"error_detail,omitempty"`
+	ImageURI    *string  `json:"image_uri,omitempty"`
 	CreatedAt   string   `json:"created_at"`
 	UpdatedAt   string   `json:"updated_at"`
 }
@@ -79,6 +80,7 @@ func toImageJSON(img Image) imageJSON {
 			Nvidia:      v.Definition.Nvidia,
 			Status:      string(v.Status),
 			ErrorDetail: v.ErrorDetail,
+			ImageURI:    v.ImageURI,
 			CreatedAt:   v.CreatedAt.UTC().Format(time.RFC3339),
 			UpdatedAt:   v.UpdatedAt.UTC().Format(time.RFC3339),
 		}

--- a/internal/pipeline/image_output.go
+++ b/internal/pipeline/image_output.go
@@ -19,7 +19,6 @@ package pipeline
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -37,7 +36,10 @@ import (
 // imageVersionJSON is the DTO for a single ImageVersion in JSON output.
 type imageVersionJSON struct {
 	Version     int      `json:"version"`
-	Pip         []string `json:"pip"`
+	Pip         []string `json:"pip,omitempty"`
+	Conda       any      `json:"conda,omitempty"`
+	BaseImage   *string  `json:"base_image,omitempty"`
+	Nvidia      bool     `json:"nvidia,omitempty"`
 	Status      string   `json:"status"`
 	ErrorDetail *string  `json:"error_detail,omitempty"`
 	CreatedAt   string   `json:"created_at"`
@@ -70,14 +72,22 @@ func toImageJSON(img Image) imageJSON {
 	versions := make([]imageVersionJSON, len(img.Versions))
 
 	for i, v := range img.Versions {
-		versions[i] = imageVersionJSON{
+		ver := imageVersionJSON{
 			Version:     v.Version,
 			Pip:         v.Definition.Pip,
+			BaseImage:   v.Definition.BaseImage,
+			Nvidia:      v.Definition.Nvidia,
 			Status:      string(v.Status),
 			ErrorDetail: v.ErrorDetail,
 			CreatedAt:   v.CreatedAt.UTC().Format(time.RFC3339),
 			UpdatedAt:   v.UpdatedAt.UTC().Format(time.RFC3339),
 		}
+
+		if v.Definition.Conda != nil {
+			ver.Conda = v.Definition.Conda
+		}
+
+		versions[i] = ver
 	}
 
 	return imageJSON{
@@ -156,7 +166,11 @@ func PrintImageHuman(img Image) {
 
 	w.Flush()
 
-	if len(img.Versions) == 0 {
+	printImageVersionsHuman(img.Versions)
+}
+
+func printImageVersionsHuman(versions []ImageVersion) {
+	if len(versions) == 0 {
 		return
 	}
 
@@ -167,7 +181,7 @@ func PrintImageHuman(img Image) {
 
 	dimStyle := tui.DimStyle.Padding(0, 1)
 
-	headers := []string{"VERSION", "STATUS", "PACKAGES", "UPDATED"}
+	headers := []string{"VERSION", "STATUS", "PIP", "CONDA", "BASE IMAGE", "UPDATED"}
 
 	updatedCol := slices.Index(headers, "UPDATED")
 
@@ -187,11 +201,23 @@ func PrintImageHuman(img Image) {
 		}).
 		Headers(headers...)
 
-	for _, ver := range img.Versions {
+	for _, ver := range versions {
+		baseImageStr := emptyValuePlaceholder
+		if ver.Definition.BaseImage != nil && *ver.Definition.BaseImage != "" {
+			baseImageStr = *ver.Definition.BaseImage
+		}
+
+		condaStr := emptyValuePlaceholder
+		if ver.Definition.Conda != nil && len(ver.Definition.Conda.Deps) > 0 {
+			condaStr = joinPackages(ver.Definition.Conda.Deps)
+		}
+
 		t.Row(
 			fmt.Sprintf("v%d", ver.Version),
 			string(ver.Status),
 			joinPackages(ver.Definition.Pip),
+			condaStr,
+			baseImageStr,
 			ver.UpdatedAt.UTC().Format(timestampFormat),
 		)
 	}
@@ -276,10 +302,14 @@ func joinPackages(packages []string) string {
 	return joined[:maxLen-3] + "..."
 }
 
-// NormalizePackages takes the raw slice from a cobra StringSliceVar and
-// returns a cleaned list. It returns an error when the resulting list is
-// empty so callers can surface a friendly validation message.
-func NormalizePackages(raw []string) ([]string, error) {
+// NormalizePackageList normalises a raw StringSliceVar into a trimmed,
+// comma-split list. Unlike NormalizePackages it returns nil (not an error)
+// when the input is empty, for use in commands where pip is optional.
+func NormalizePackageList(raw []string) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+
 	out := make([]string, 0, len(raw))
 
 	for _, entry := range raw {
@@ -291,9 +321,22 @@ func NormalizePackages(raw []string) ([]string, error) {
 		}
 	}
 
-	if len(out) == 0 {
-		return nil, errors.New("at least one package is required (use --package)")
+	return out
+}
+
+// BuildCondaValue converts raw --conda and --conda-channel flag slices
+// into a *CondaValue suitable for image requests. Returns nil when both
+// slices are empty so the caller can omit the field.
+func BuildCondaValue(rawDeps, rawChannels []string) *CondaValue {
+	deps := NormalizePackageList(rawDeps)
+	channels := NormalizePackageList(rawChannels)
+
+	if len(deps) == 0 && len(channels) == 0 {
+		return nil
 	}
 
-	return out, nil
+	return &CondaValue{
+		Deps:     deps,
+		Channels: channels,
+	}
 }

--- a/internal/pipeline/image_output.go
+++ b/internal/pipeline/image_output.go
@@ -83,7 +83,7 @@ func toImageJSON(img Image) imageJSON {
 			UpdatedAt:   v.UpdatedAt.UTC().Format(time.RFC3339),
 		}
 
-		if v.Definition.Conda != nil {
+		if v.Definition.Conda != nil && (len(v.Definition.Conda.Deps) > 0 || len(v.Definition.Conda.Channels) > 0) {
 			ver.Conda = v.Definition.Conda
 		}
 

--- a/internal/pipeline/image_output.go
+++ b/internal/pipeline/image_output.go
@@ -307,7 +307,7 @@ func formatCondaCell(conda *CondaValue) string {
 		return depPart
 	}
 
-	if depPart == "" {
+	if depPart == "" || depPart == emptyValuePlaceholder {
 		return chanPart
 	}
 
@@ -319,6 +319,10 @@ func formatCondaCell(conda *CondaValue) string {
 // table stays readable in a typical terminal.
 func joinPackages(packages []string) string {
 	const maxLen = 60
+
+	if len(packages) == 0 {
+		return emptyValuePlaceholder
+	}
 
 	joined := strings.Join(packages, ",")
 	if len(joined) <= maxLen {

--- a/internal/pipeline/image_output.go
+++ b/internal/pipeline/image_output.go
@@ -37,7 +37,7 @@ import (
 // imageVersionJSON is the DTO for a single ImageVersion in JSON output.
 type imageVersionJSON struct {
 	Version     int      `json:"version"`
-	Packages    []string `json:"packages"`
+	Pip         []string `json:"pip"`
 	Status      string   `json:"status"`
 	ErrorDetail *string  `json:"error_detail,omitempty"`
 	CreatedAt   string   `json:"created_at"`
@@ -72,7 +72,7 @@ func toImageJSON(img Image) imageJSON {
 	for i, v := range img.Versions {
 		versions[i] = imageVersionJSON{
 			Version:     v.Version,
-			Packages:    v.Packages,
+			Pip:         v.Definition.Pip,
 			Status:      string(v.Status),
 			ErrorDetail: v.ErrorDetail,
 			CreatedAt:   v.CreatedAt.UTC().Format(time.RFC3339),
@@ -191,7 +191,7 @@ func PrintImageHuman(img Image) {
 		t.Row(
 			fmt.Sprintf("v%d", ver.Version),
 			string(ver.Status),
-			joinPackages(ver.Packages),
+			joinPackages(ver.Definition.Pip),
 			ver.UpdatedAt.UTC().Format(timestampFormat),
 		)
 	}

--- a/internal/pipeline/image_output.go
+++ b/internal/pipeline/image_output.go
@@ -208,8 +208,8 @@ func printImageVersionsHuman(versions []ImageVersion) {
 		}
 
 		condaStr := emptyValuePlaceholder
-		if ver.Definition.Conda != nil && len(ver.Definition.Conda.Deps) > 0 {
-			condaStr = joinPackages(ver.Definition.Conda.Deps)
+		if ver.Definition.Conda != nil && (len(ver.Definition.Conda.Deps) > 0 || len(ver.Definition.Conda.Channels) > 0) {
+			condaStr = formatCondaCell(ver.Definition.Conda)
 		}
 
 		t.Row(
@@ -286,6 +286,32 @@ func PrintImageListHuman(items []ImageSummary) {
 	}
 
 	fmt.Fprintln(os.Stdout, t.Render())
+}
+
+// formatCondaCell renders a CondaValue for the human-readable versions table.
+// When channels are present they are shown as a bracketed prefix so the user
+// can see the full structured spec, not just the dependency list.
+//
+//	plain list form:        "scipy, numpy"
+//	CondaSpec (no deps):    "[conda-forge]"
+//	CondaSpec (with deps):  "[conda-forge] scipy, numpy"
+func formatCondaCell(conda *CondaValue) string {
+	chanPart := ""
+	if len(conda.Channels) > 0 {
+		chanPart = "[" + strings.Join(conda.Channels, ",") + "]"
+	}
+
+	depPart := joinPackages(conda.Deps)
+
+	if chanPart == "" {
+		return depPart
+	}
+
+	if depPart == "" {
+		return chanPart
+	}
+
+	return chanPart + " " + depPart
 }
 
 // joinPackages collapses a package slice into a single comma-separated

--- a/internal/pipeline/image_output_test.go
+++ b/internal/pipeline/image_output_test.go
@@ -149,6 +149,43 @@ func TestPrintImageHuman_HidesCondaWhenEmpty(t *testing.T) {
 	assert.Contains(t, out, emptyValuePlaceholder, "conda cell should show placeholder when no conda packages")
 }
 
+// --- imageJSON includes imageUri ---
+
+func TestPrintImageJSON_ImageURIIncluded(t *testing.T) {
+	imageURI := "registry.example.com/img-1:v2"
+	img := Image{
+		ImageID:       "img-1",
+		Name:          "ml-base",
+		LatestVersion: 1,
+		CreatedAt:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		Versions: []ImageVersion{
+			{
+				Version:  1,
+				Status:   ImageStatusReady,
+				ImageURI: &imageURI,
+				Definition: ImageDefinition{
+					Name: "ml-base",
+					Pip:  []string{"numpy"},
+				},
+				CreatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderImage(outputformat.OutputFormatJSON, img))
+	})
+
+	var parsed map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(out), &parsed))
+	versions := parsed["versions"].([]any)
+	got := versions[0].(map[string]any)["image_uri"]
+	assert.Equal(t, imageURI, got)
+}
+
 // --- imageJSON preserves conda channels ---
 
 func TestPrintImageJSON_CondaChannelsPreserved(t *testing.T) {

--- a/internal/pipeline/image_output_test.go
+++ b/internal/pipeline/image_output_test.go
@@ -1,0 +1,186 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- CondaValue JSON codec ---
+
+func TestCondaValue_MarshalJSON_PlainList(t *testing.T) {
+	c := CondaValue{Deps: []string{"scipy", "numpy"}}
+
+	b, err := json.Marshal(c)
+	require.NoError(t, err)
+	assert.JSONEq(t, `["scipy","numpy"]`, string(b))
+}
+
+func TestCondaValue_MarshalJSON_WithChannels(t *testing.T) {
+	c := CondaValue{
+		Channels: []string{"conda-forge", "defaults"},
+		Deps:     []string{"numpy=1.21.*"},
+	}
+
+	b, err := json.Marshal(c)
+	require.NoError(t, err)
+
+	var got CondaSpec
+
+	require.NoError(t, json.Unmarshal(b, &got))
+	assert.Equal(t, []string{"conda-forge", "defaults"}, got.Channels)
+	assert.Equal(t, []string{"numpy=1.21.*"}, got.Dependencies)
+}
+
+func TestCondaValue_UnmarshalJSON_PlainList(t *testing.T) {
+	var c CondaValue
+
+	require.NoError(t, json.Unmarshal([]byte(`["scipy","numpy"]`), &c))
+	assert.Equal(t, []string{"scipy", "numpy"}, c.Deps)
+	assert.Empty(t, c.Channels)
+}
+
+func TestCondaValue_UnmarshalJSON_CondaSpec(t *testing.T) {
+	var c CondaValue
+
+	raw := `{"channels":["conda-forge"],"dependencies":["numpy=1.21.*","xarray=0.15.1"]}`
+	require.NoError(t, json.Unmarshal([]byte(raw), &c))
+	assert.Equal(t, []string{"conda-forge"}, c.Channels)
+	assert.Equal(t, []string{"numpy=1.21.*", "xarray=0.15.1"}, c.Deps)
+}
+
+// --- formatCondaCell ---
+
+func TestFormatCondaCell_PlainDeps(t *testing.T) {
+	c := &CondaValue{Deps: []string{"scipy", "numpy"}}
+
+	assert.Equal(t, "scipy,numpy", formatCondaCell(c))
+}
+
+func TestFormatCondaCell_ChannelsOnly(t *testing.T) {
+	c := &CondaValue{Channels: []string{"conda-forge"}}
+
+	assert.Equal(t, "[conda-forge]", formatCondaCell(c))
+}
+
+func TestFormatCondaCell_ChannelsAndDeps(t *testing.T) {
+	c := &CondaValue{
+		Channels: []string{"conda-forge", "defaults"},
+		Deps:     []string{"numpy=1.21.*"},
+	}
+
+	assert.Equal(t, "[conda-forge,defaults] numpy=1.21.*", formatCondaCell(c))
+}
+
+// --- image human output includes conda channels ---
+
+func TestPrintImageHuman_ShowsCondaChannels(t *testing.T) {
+	baseImage := "python:3.12"
+	img := Image{
+		ImageID:       "img-1",
+		Name:          "ml-base",
+		LatestVersion: 1,
+		CreatedAt:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		Versions: []ImageVersion{
+			{
+				Version: 1,
+				Status:  ImageStatusReady,
+				Definition: ImageDefinition{
+					Name:      "ml-base",
+					Pip:       []string{"torch"},
+					Conda:     &CondaValue{Channels: []string{"conda-forge"}, Deps: []string{"scipy"}},
+					BaseImage: &baseImage,
+					Nvidia:    true,
+				},
+				CreatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	out := captureStdout(t, func() { PrintImageHuman(img) })
+
+	assert.Contains(t, out, "[conda-forge]", "channels must appear in human output")
+	assert.Contains(t, out, "scipy", "dependencies must appear in human output")
+}
+
+func TestPrintImageHuman_HidesCondaWhenEmpty(t *testing.T) {
+	img := Image{
+		ImageID:       "img-2",
+		Name:          "pip-only",
+		LatestVersion: 1,
+		CreatedAt:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		Versions: []ImageVersion{
+			{
+				Version: 1,
+				Status:  ImageStatusReady,
+				Definition: ImageDefinition{
+					Name: "pip-only",
+					Pip:  []string{"numpy"},
+				},
+				CreatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	out := captureStdout(t, func() { PrintImageHuman(img) })
+
+	assert.Contains(t, out, emptyValuePlaceholder, "conda cell should show placeholder when no conda packages")
+}
+
+// --- imageJSON preserves conda channels ---
+
+func TestPrintImageJSON_CondaChannelsPreserved(t *testing.T) {
+	img := Image{
+		ImageID:       "img-1",
+		Name:          "ml-base",
+		LatestVersion: 1,
+		CreatedAt:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		Versions: []ImageVersion{
+			{
+				Version: 1,
+				Status:  ImageStatusReady,
+				Definition: ImageDefinition{
+					Name:  "ml-base",
+					Conda: &CondaValue{Channels: []string{"conda-forge"}, Deps: []string{"scipy"}},
+				},
+				CreatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderImage(outputformat.OutputFormatJSON, img))
+	})
+
+	var parsed map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(out), &parsed))
+	versions := parsed["versions"].([]any)
+	conda := versions[0].(map[string]any)["conda"].(map[string]any)
+	assert.Equal(t, []any{"conda-forge"}, conda["channels"])
+	assert.Equal(t, []any{"scipy"}, conda["dependencies"])
+}

--- a/internal/pipeline/image_test.go
+++ b/internal/pipeline/image_test.go
@@ -41,7 +41,7 @@ func TestCreateImage_PostsBody(t *testing.T) {
 			assert.Equal(t, "for testing", *body.Description)
 		}
 
-		assert.Equal(t, []string{"numpy", "pandas==2.0"}, body.Packages)
+		assert.Equal(t, []string{"numpy", "pandas==2.0"}, body.Pip)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
@@ -50,7 +50,7 @@ func TestCreateImage_PostsBody(t *testing.T) {
 			"name":"ml-base",
 			"description":"for testing",
 			"latestVersion":1,
-			"versions":[{"version":1,"packages":["numpy","pandas==2.0"],"status":"CREATING","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"}],
+			"versions":[{"version":1,"definition":{"name":"ml-base","pip":["numpy","pandas==2.0"],"nvidia":false},"status":"CREATING","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"}],
 			"createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"
 		}`))
 	}))
@@ -136,24 +136,40 @@ func TestListImages_OmitsZeroPagination(t *testing.T) {
 func TestUpdateImage_PatchesBody(t *testing.T) {
 	installSkipAuth(t)
 
+	// UpdateImage does a GET first to resolve the canonical name, then PATCHes.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPatch, r.Method)
 		assert.Equal(t, "/api/v2/pipelines/images/img-1", r.URL.Path)
 
-		var body ImageUpdateRequest
-
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		assert.Equal(t, []string{"scikit-learn"}, body.Packages)
-
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"id":"img-1","name":"ml-base","latestVersion":2,
-			"versions":[
-				{"version":2,"packages":["scikit-learn"],"status":"CREATING","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"},
-				{"version":1,"packages":["numpy"],"status":"READY","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"}
-			],
-			"createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"
-		}`))
+
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{
+				"id":"img-1","name":"ml-base","latestVersion":1,
+				"versions":[
+					{"version":1,"definition":{"name":"ml-base","pip":["numpy"],"nvidia":false},"status":"READY","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"}
+				],
+				"createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"
+			}`))
+		case http.MethodPatch:
+			var body ImageUpdateRequest
+
+			assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "ml-base", body.Name)
+			assert.Equal(t, []string{"scikit-learn"}, body.Pip)
+
+			_, _ = w.Write([]byte(`{
+				"id":"img-1","name":"ml-base","latestVersion":2,
+				"versions":[
+					{"version":2,"definition":{"name":"ml-base","pip":["scikit-learn"],"nvidia":false},"status":"CREATING","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"},
+					{"version":1,"definition":{"name":"ml-base","pip":["numpy"],"nvidia":false},"status":"READY","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"}
+				],
+				"createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"
+			}`))
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
 	}))
 
 	defer srv.Close()
@@ -165,6 +181,7 @@ func TestUpdateImage_PatchesBody(t *testing.T) {
 	assert.Equal(t, 2, got.LatestVersion)
 	require.Len(t, got.Versions, 2)
 	assert.Equal(t, 2, got.Versions[0].Version)
+	assert.Equal(t, []string{"scikit-learn"}, got.Versions[0].Definition.Pip)
 }
 
 func TestDeleteImage_HitsCorrectURL(t *testing.T) {

--- a/internal/pipeline/image_test.go
+++ b/internal/pipeline/image_test.go
@@ -59,7 +59,7 @@ func TestCreateImage_PostsBody(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	got, err := CreateImage("ml-base", "for testing", []string{"numpy", "pandas==2.0"})
+	got, err := CreateImage("ml-base", "for testing", []string{"numpy", "pandas==2.0"}, nil, "", false)
 	require.NoError(t, err)
 	assert.Equal(t, "img-1", got.ImageID)
 	assert.Equal(t, 1, got.LatestVersion)
@@ -86,7 +86,7 @@ func TestCreateImage_OmitsEmptyDescription(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	_, err := CreateImage("x", "", []string{"numpy"})
+	_, err := CreateImage("x", "", []string{"numpy"}, nil, "", false)
 	require.NoError(t, err)
 }
 
@@ -176,7 +176,7 @@ func TestUpdateImage_PatchesBody(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	got, err := UpdateImage("img-1", []string{"scikit-learn"})
+	got, err := UpdateImage("img-1", []string{"scikit-learn"}, nil, "", false)
 	require.NoError(t, err)
 	assert.Equal(t, 2, got.LatestVersion)
 	require.Len(t, got.Versions, 2)

--- a/internal/pipeline/image_test.go
+++ b/internal/pipeline/image_test.go
@@ -50,7 +50,7 @@ func TestCreateImage_PostsBody(t *testing.T) {
 			"name":"ml-base",
 			"description":"for testing",
 			"latestVersion":1,
-			"versions":[{"version":1,"definition":{"name":"ml-base","pip":["numpy","pandas==2.0"],"nvidia":false},"status":"CREATING","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"}],
+			"versions":[{"version":1,"definition":{"name":"ml-base","packages":["numpy","pandas==2.0"],"nvidia":false},"status":"CREATING","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"}],
 			"createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"
 		}`))
 	}))
@@ -147,7 +147,7 @@ func TestUpdateImage_PatchesBody(t *testing.T) {
 			_, _ = w.Write([]byte(`{
 				"id":"img-1","name":"ml-base","latestVersion":1,
 				"versions":[
-					{"version":1,"definition":{"name":"ml-base","pip":["numpy"],"nvidia":false},"status":"READY","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"}
+					{"version":1,"definition":{"name":"ml-base","packages":["numpy"],"nvidia":false},"status":"READY","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"}
 				],
 				"createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"
 			}`))
@@ -161,8 +161,8 @@ func TestUpdateImage_PatchesBody(t *testing.T) {
 			_, _ = w.Write([]byte(`{
 				"id":"img-1","name":"ml-base","latestVersion":2,
 				"versions":[
-					{"version":2,"definition":{"name":"ml-base","pip":["scikit-learn"],"nvidia":false},"status":"CREATING","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"},
-					{"version":1,"definition":{"name":"ml-base","pip":["numpy"],"nvidia":false},"status":"READY","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"}
+					{"version":2,"definition":{"name":"ml-base","packages":["scikit-learn"],"nvidia":false},"status":"CREATING","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"},
+					{"version":1,"definition":{"name":"ml-base","packages":["numpy"],"nvidia":false},"status":"READY","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"}
 				],
 				"createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"
 			}`))
@@ -230,6 +230,147 @@ func TestDeleteImage_PropagatesNotFound(t *testing.T) {
 	installEndpoint(t, srv.URL)
 
 	err := DeleteImage("nope")
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+}
+
+func TestGetImage_ReturnsFullDetail(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v2/pipelines/images/img-1", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"img-1",
+			"name":"ml-base",
+			"description":"test image",
+			"latestVersion":2,
+			"versions":[
+				{"version":2,"definition":{"name":"ml-base","packages":["scikit-learn"],"pythonBaseImage":"python:3.12","nvidia":false},"status":"READY","imageUri":"registry.example.com/img-1:v2","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"},
+				{"version":1,"definition":{"name":"ml-base","packages":["numpy"],"nvidia":false},"status":"READY","createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"}
+			],
+			"createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	got, err := GetImage("img-1")
+	require.NoError(t, err)
+	assert.Equal(t, "img-1", got.ImageID)
+	assert.Equal(t, "ml-base", got.Name)
+	assert.Equal(t, 2, got.LatestVersion)
+	require.Len(t, got.Versions, 2)
+
+	v2 := got.Versions[0]
+	assert.Equal(t, []string{"scikit-learn"}, v2.Definition.Pip)
+
+	if assert.NotNil(t, v2.Definition.BaseImage) {
+		assert.Equal(t, "python:3.12", *v2.Definition.BaseImage)
+	}
+
+	if assert.NotNil(t, v2.ImageURI) {
+		assert.Equal(t, "registry.example.com/img-1:v2", *v2.ImageURI)
+	}
+}
+
+func TestGetImage_DefinitionUsesCanonicalKeys(t *testing.T) {
+	installSkipAuth(t)
+
+	// Verifies the read-path JSON tag fix: API returns "packages" and
+	// "pythonBaseImage" (camelCase aliases), not the old "pip"/"baseImage".
+	baseImage := "my-registry/python:3.11"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"img-2","name":"base","latestVersion":1,
+			"versions":[{
+				"version":1,
+				"definition":{"name":"base","packages":["torch","transformers"],"pythonBaseImage":"my-registry/python:3.11","nvidia":true},
+				"status":"READY",
+				"createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"
+			}],
+			"createdAt":"2026-04-29T10:00:00Z","updatedAt":"2026-04-29T10:00:00Z"
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	got, err := GetImage("img-2")
+	require.NoError(t, err)
+	require.Len(t, got.Versions, 1)
+
+	def := got.Versions[0].Definition
+	assert.Equal(t, []string{"torch", "transformers"}, def.Pip, "packages key must unmarshal into Pip field")
+
+	if assert.NotNil(t, def.BaseImage, "pythonBaseImage key must unmarshal into BaseImage field") {
+		assert.Equal(t, baseImage, *def.BaseImage)
+	}
+
+	assert.True(t, def.Nvidia)
+}
+
+func TestGetImage_PropagatesNotFound(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := GetImage("missing")
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+}
+
+func TestGetImageBuildLogs_ReturnsLogs(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v2/pipelines/images/img-1/versions/2/logs", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"logs":"Step 1/5: FROM python:3.12\nStep 2/5: RUN pip install numpy\nBuild complete."}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	got, err := GetImageBuildLogs("img-1", 2)
+	require.NoError(t, err)
+	assert.Contains(t, got.Logs, "Step 1/5")
+	assert.Contains(t, got.Logs, "Build complete.")
+}
+
+func TestGetImageBuildLogs_PropagatesNotFound(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := GetImageBuildLogs("nope", 1)
 
 	var httpErr *drapi.HTTPError
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -52,19 +52,32 @@ type PipelineVersion struct {
 	CreatedAt      time.Time      `json:"createdAt"`
 }
 
+// LinkedImageBlock mirrors LinkedImageBlock from the pipelines-api:
+// a snapshot of the execution image bound to a pipeline.
+type LinkedImageBlock struct {
+	ImageID     string  `json:"imageId"`
+	Name        string  `json:"name"`
+	Version     int     `json:"version"`
+	Status      string  `json:"status"`
+	ErrorDetail *string `json:"errorDetail,omitempty"`
+}
+
 // Pipeline mirrors PipelineDetailResponse from the pipelines-api.
 type Pipeline struct {
-	PipelineID     string            `json:"id"`
-	Name           string            `json:"name"`
-	Description    string            `json:"description,omitempty"`
-	Mode           string            `json:"mode"`
-	IsActive       bool              `json:"isActive"`
-	TaskNames      []string          `json:"taskNames,omitempty"`
-	PythonVersion  string            `json:"pythonVersion,omitempty"`
-	ResourceBundle map[string]any    `json:"resourceBundle,omitempty"`
-	CreatedAt      time.Time         `json:"createdAt"`
-	UpdatedAt      time.Time         `json:"updatedAt"`
-	Versions       []PipelineVersion `json:"versions"`
+	PipelineID       string            `json:"id"`
+	Name             string            `json:"name"`
+	Description      string            `json:"description,omitempty"`
+	Mode             string            `json:"mode"`
+	IsActive         bool              `json:"isActive"`
+	TaskNames        []string          `json:"taskNames,omitempty"`
+	InputSetTemplate *string           `json:"inputSetTemplate,omitempty"`
+	ImageID          *string           `json:"imageId,omitempty"`
+	LinkedImage      *LinkedImageBlock `json:"linkedImage,omitempty"`
+	PythonVersion    string            `json:"pythonVersion,omitempty"`
+	ResourceBundle   map[string]any    `json:"resourceBundle,omitempty"`
+	CreatedAt        time.Time         `json:"createdAt"`
+	UpdatedAt        time.Time         `json:"updatedAt"`
+	Versions         []PipelineVersion `json:"versions"`
 }
 
 // CreateResponse mirrors PipelineCreateResponse from the pipelines-api.
@@ -76,6 +89,7 @@ type CreateResponse struct {
 	Status     string    `json:"status"`
 	Mode       string    `json:"mode"`
 	TaskNames  []string  `json:"taskNames,omitempty"`
+	ImageID    *string   `json:"imageId,omitempty"`
 	CreatedAt  time.Time `json:"createdAt"`
 }
 
@@ -92,7 +106,7 @@ type ListItem struct {
 }
 
 // CreatePipeline uploads a Python file to POST /api/v2/pipelines.
-func CreatePipeline(filePath, description, name, mode string) (*CreateResponse, error) {
+func CreatePipeline(filePath, description, name, mode, imageID string) (*CreateResponse, error) {
 	endpoint, err := config.GetEndpointURL("/api/v2/pipelines")
 	if err != nil {
 		return nil, err
@@ -109,6 +123,10 @@ func CreatePipeline(filePath, description, name, mode string) (*CreateResponse, 
 
 	if mode != "" {
 		fields["mode"] = mode
+	}
+
+	if imageID != "" {
+		fields["image_id"] = imageID
 	}
 
 	var result CreateResponse
@@ -173,15 +191,21 @@ func GetPipeline(pipelineID string) (*Pipeline, error) {
 }
 
 // UpdatePipeline re-uploads a Python file to PATCH /api/v2/pipelines/{pipeline_id}.
-func UpdatePipeline(pipelineID, filePath string) (*CreateResponse, error) {
+func UpdatePipeline(pipelineID, filePath, imageID string) (*CreateResponse, error) {
 	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + pipelineID)
 	if err != nil {
 		return nil, err
 	}
 
+	fields := map[string]string{}
+
+	if imageID != "" {
+		fields["image_id"] = imageID
+	}
+
 	var result CreateResponse
 
-	err = doMultipart(http.MethodPatch, endpoint, filePath, nil, "update pipeline", &result)
+	err = doMultipart(http.MethodPatch, endpoint, filePath, fields, "update pipeline", &result)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -83,14 +83,15 @@ type Pipeline struct {
 // CreateResponse mirrors PipelineCreateResponse from the pipelines-api.
 // It is also returned by PATCH /pipelines/{id}.
 type CreateResponse struct {
-	PipelineID string    `json:"id"`
-	Name       string    `json:"name"`
-	Version    int       `json:"version"`
-	Status     string    `json:"status"`
-	Mode       string    `json:"mode"`
-	TaskNames  []string  `json:"taskNames,omitempty"`
-	ImageID    *string   `json:"imageId,omitempty"`
-	CreatedAt  time.Time `json:"createdAt"`
+	PipelineID  string    `json:"id"`
+	Name        string    `json:"name"`
+	Description *string   `json:"description,omitempty"`
+	Version     int       `json:"version"`
+	Status      string    `json:"status"`
+	Mode        string    `json:"mode"`
+	TaskNames   []string  `json:"taskNames,omitempty"`
+	ImageID     *string   `json:"imageId,omitempty"`
+	CreatedAt   time.Time `json:"createdAt"`
 }
 
 // ListItem mirrors PipelineListItem from the pipelines-api.
@@ -140,7 +141,7 @@ func CreatePipeline(filePath, description, name, mode, imageID string) (*CreateR
 }
 
 // ListPipelines fetches a paginated list of pipelines from GET /api/v2/pipelines.
-func ListPipelines(mode string, offset, limit int) (*DataPage[ListItem], error) {
+func ListPipelines(mode, search string, offset, limit int) (*DataPage[ListItem], error) {
 	endpoint, err := config.GetEndpointURL("/api/v2/pipelines")
 	if err != nil {
 		return nil, err
@@ -149,6 +150,10 @@ func ListPipelines(mode string, offset, limit int) (*DataPage[ListItem], error) 
 	query := url.Values{}
 	if mode != "" {
 		query.Set("mode", mode)
+	}
+
+	if search != "" {
+		query.Set("search", search)
 	}
 
 	if offset > 0 {
@@ -190,8 +195,9 @@ func GetPipeline(pipelineID string) (*Pipeline, error) {
 	return &pipeline, nil
 }
 
-// UpdatePipeline re-uploads a Python file to PATCH /api/v2/pipelines/{pipeline_id}.
-func UpdatePipeline(pipelineID, filePath, imageID string) (*CreateResponse, error) {
+// UpdatePipeline patches a draft pipeline. filePath is optional (empty = no file
+// re-upload); name, description, and imageID are each no-op when empty.
+func UpdatePipeline(pipelineID, filePath, imageID, name, description string) (*CreateResponse, error) {
 	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + pipelineID)
 	if err != nil {
 		return nil, err
@@ -201,6 +207,14 @@ func UpdatePipeline(pipelineID, filePath, imageID string) (*CreateResponse, erro
 
 	if imageID != "" {
 		fields["image_id"] = imageID
+	}
+
+	if name != "" {
+		fields["name"] = name
+	}
+
+	if description != "" {
+		fields["description"] = description
 	}
 
 	var result CreateResponse
@@ -319,38 +333,40 @@ func decodeHTTPError(resp *http.Response, endpoint string) error {
 	return &drapi.HTTPError{StatusCode: resp.StatusCode, URL: endpoint, Detail: detail}
 }
 
-// buildMultipartBody constructs a multipart/form-data body containing the named
-// file plus the given form fields.
+// buildMultipartBody constructs a multipart/form-data body. filePath is optional;
+// when empty, no file part is included (metadata-only update).
 func buildMultipartBody(filePath string, fields map[string]string) (*bytes.Buffer, string, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return nil, "", fmt.Errorf("open %s: %w", filePath, err)
-	}
-
-	defer file.Close()
-
 	var body bytes.Buffer
 
 	writer := multipart.NewWriter(&body)
 
-	part, err := writer.CreateFormFile("file", filepath.Base(filePath))
-	if err != nil {
-		return nil, "", err
-	}
+	if filePath != "" {
+		file, err := os.Open(filePath)
+		if err != nil {
+			return nil, "", fmt.Errorf("open %s: %w", filePath, err)
+		}
 
-	_, err = io.Copy(part, file)
-	if err != nil {
-		return nil, "", err
-	}
+		defer file.Close()
 
-	for key, value := range fields {
-		err = writer.WriteField(key, value)
+		part, err := writer.CreateFormFile("file", filepath.Base(filePath))
+		if err != nil {
+			return nil, "", err
+		}
+
+		_, err = io.Copy(part, file)
 		if err != nil {
 			return nil, "", err
 		}
 	}
 
-	err = writer.Close()
+	for key, value := range fields {
+		err := writer.WriteField(key, value)
+		if err != nil {
+			return nil, "", err
+		}
+	}
+
+	err := writer.Close()
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/pipeline/pipeline_output.go
+++ b/internal/pipeline/pipeline_output.go
@@ -159,17 +159,41 @@ func printPipelineHuman(p Pipeline) {
 	fmt.Fprintf(w, "Description:\t%s\n", description)
 	fmt.Fprintf(w, "Mode:\t%s\n", p.Mode)
 	fmt.Fprintf(w, "Active:\t%t\n", p.IsActive)
+	printLinkedImageLine(w, p)
 	fmt.Fprintf(w, "Created:\t%s\n", p.CreatedAt.UTC().Format(timestampFormat))
 	fmt.Fprintf(w, "Updated:\t%s\n", p.UpdatedAt.UTC().Format(timestampFormat))
 
 	w.Flush()
 
-	if len(p.Versions) == 0 {
+	printInputTemplateSectionIfPresent(p)
+	printPipelineVersionsHuman(p.Versions)
+}
+
+func printLinkedImageLine(w *tabwriter.Writer, p Pipeline) {
+	if p.LinkedImage != nil {
+		fmt.Fprintf(w, "Image:\t%s (v%d, %s)\n", p.LinkedImage.ImageID, p.LinkedImage.Version, p.LinkedImage.Status)
+	} else if p.ImageID != nil && *p.ImageID != "" {
+		fmt.Fprintf(w, "Image ID:\t%s\n", *p.ImageID)
+	}
+}
+
+func printInputTemplateSectionIfPresent(p Pipeline) {
+	if p.InputSetTemplate == nil {
 		return
 	}
 
 	fmt.Println()
-	fmt.Println(tui.BaseTextStyle.Render(fmt.Sprintf("Versions (%d):", len(p.Versions))))
+	fmt.Println(tui.BaseTextStyle.Render("Input template:"))
+	fmt.Println(tui.DimStyle.Render(*p.InputSetTemplate))
+}
+
+func printPipelineVersionsHuman(versions []PipelineVersion) {
+	if len(versions) == 0 {
+		return
+	}
+
+	fmt.Println()
+	fmt.Println(tui.BaseTextStyle.Render(fmt.Sprintf("Versions (%d):", len(versions))))
 
 	cellStyle := tui.BaseTextStyle.Padding(0, 1)
 
@@ -195,7 +219,7 @@ func printPipelineHuman(p Pipeline) {
 		}).
 		Headers(headers...)
 
-	for _, ver := range p.Versions {
+	for _, ver := range versions {
 		tasks := emptyValuePlaceholder
 		if len(ver.TaskNames) > 0 {
 			tasks = strings.Join(ver.TaskNames, ", ")
@@ -217,7 +241,7 @@ func printPipelineHuman(p Pipeline) {
 
 	fmt.Fprintln(os.Stdout, t.Render())
 
-	for _, ver := range p.Versions {
+	for _, ver := range versions {
 		if ver.ErrorDetail == "" {
 			continue
 		}
@@ -240,6 +264,11 @@ func printCreateResponseHuman(result CreateResponse) {
 	fmt.Fprintf(w, "Status:\t%s\n", result.Status)
 	fmt.Fprintf(w, "Mode:\t%s\n", result.Mode)
 	fmt.Fprintf(w, "Tasks:\t%s\n", tasks)
+
+	if result.ImageID != nil && *result.ImageID != "" {
+		fmt.Fprintf(w, "Image ID:\t%s\n", *result.ImageID)
+	}
+
 	fmt.Fprintf(w, "Created:\t%s\n", result.CreatedAt.UTC().Format(timestampFormat))
 
 	w.Flush()

--- a/internal/pipeline/pipeline_output.go
+++ b/internal/pipeline/pipeline_output.go
@@ -260,6 +260,11 @@ func printCreateResponseHuman(result CreateResponse) {
 
 	fmt.Fprintf(w, "Pipeline ID:\t%s\n", result.PipelineID)
 	fmt.Fprintf(w, "Name:\t%s\n", result.Name)
+
+	if result.Description != nil && *result.Description != "" {
+		fmt.Fprintf(w, "Description:\t%s\n", *result.Description)
+	}
+
 	fmt.Fprintf(w, "Version:\t%d\n", result.Version)
 	fmt.Fprintf(w, "Status:\t%s\n", result.Status)
 	fmt.Fprintf(w, "Mode:\t%s\n", result.Mode)

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -46,6 +46,8 @@ type Run struct {
 	PipelineID         string    `json:"pipelineId"`
 	VersionID          *int      `json:"versionId,omitempty"`
 	InputID            string    `json:"inputId"`
+	ImageID            *string   `json:"imageId,omitempty"`
+	ImageVersion       *int      `json:"imageVersion,omitempty"`
 	CovalentDispatchID string    `json:"covalentDispatchId,omitempty"`
 	TriggeredBy        string    `json:"triggeredBy"`
 	Status             string    `json:"status"`
@@ -64,18 +66,23 @@ type RunStatus struct {
 
 // RunCreateRequest mirrors PipelineDispatchCreateRequest.
 type RunCreateRequest struct {
-	InputID string `json:"inputId"`
+	InputID string  `json:"inputId"`
+	ImageID *string `json:"imageId,omitempty"`
 }
 
 // CreateRun starts a new run for the given input. Returns the
 // freshly-created Run (status PENDING).
-func CreateRun(pipelineID string, scope Scope, version *int, inputID string) (*Run, error) {
+func CreateRun(pipelineID string, scope Scope, version *int, inputID, imageID string) (*Run, error) {
 	endpoint, err := EndpointFor(pipelineID, scope, version, "dispatches")
 	if err != nil {
 		return nil, err
 	}
 
 	body := RunCreateRequest{InputID: inputID}
+
+	if imageID != "" {
+		body.ImageID = &imageID
+	}
 
 	var result Run
 

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -33,6 +33,7 @@ import (
 // Run lifecycle states (mirrors PipelineDispatchStatus on the wire).
 const (
 	RunStatusPending   = "PENDING"
+	RunStatusPreparing = "PREPARING"
 	RunStatusRunning   = "RUNNING"
 	RunStatusCompleted = "COMPLETED"
 	RunStatusFailed    = "FAILED"

--- a/internal/pipeline/run_output.go
+++ b/internal/pipeline/run_output.go
@@ -40,6 +40,8 @@ type runJSON struct {
 	PipelineID    string `json:"pipeline_id"`
 	VersionID     *int   `json:"version_id,omitempty"`
 	InputID       string `json:"input_id"`
+	ImageID       string `json:"image_id,omitempty"`
+	ImageVersion  *int   `json:"image_version,omitempty"`
 	CovalentRunID string `json:"covalent_run_id,omitempty"`
 	TriggeredBy   string `json:"triggered_by"`
 	Status        string `json:"status"`
@@ -49,11 +51,12 @@ type runJSON struct {
 }
 
 func toRunJSON(r Run) runJSON {
-	return runJSON{
+	j := runJSON{
 		RunID:         r.RunID,
 		PipelineID:    r.PipelineID,
 		VersionID:     r.VersionID,
 		InputID:       r.InputID,
+		ImageVersion:  r.ImageVersion,
 		CovalentRunID: r.CovalentDispatchID,
 		TriggeredBy:   r.TriggeredBy,
 		Status:        r.Status,
@@ -61,6 +64,12 @@ func toRunJSON(r Run) runJSON {
 		CreatedAt:     r.CreatedAt.UTC().Format(time.RFC3339),
 		UpdatedAt:     r.UpdatedAt.UTC().Format(time.RFC3339),
 	}
+
+	if r.ImageID != nil {
+		j.ImageID = *r.ImageID
+	}
+
+	return j
 }
 
 // runStatusJSON mirrors RunStatus with CLI-vocabulary keys.
@@ -145,6 +154,16 @@ func PrintRunHuman(r Run) {
 	fmt.Fprintf(w, "Scope:\t%s\n", scope)
 	fmt.Fprintf(w, "Version:\t%s\n", versionDisplay)
 	fmt.Fprintf(w, "Input ID:\t%s\n", r.InputID)
+
+	if r.ImageID != nil && *r.ImageID != "" {
+		imageVersionStr := emptyValuePlaceholder
+		if r.ImageVersion != nil {
+			imageVersionStr = "v" + strconv.Itoa(*r.ImageVersion)
+		}
+
+		fmt.Fprintf(w, "Image ID:\t%s (%s)\n", *r.ImageID, imageVersionStr)
+	}
+
 	fmt.Fprintf(w, "Status:\t%s\n", r.Status)
 	fmt.Fprintf(w, "Triggered By:\t%s\n", r.TriggeredBy)
 	fmt.Fprintf(w, "Covalent Run:\t%s\n", covalent)

--- a/internal/pipeline/run_task.go
+++ b/internal/pipeline/run_task.go
@@ -1,0 +1,189 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// run_task.go wraps the per-task execution endpoints under
+// /api/v2/pipelines/{pid}/dispatches/{did}/tasks/...
+// These endpoints expose the lifecycle, logs, and result of individual
+// @task electrons within a dispatch (run).
+
+package pipeline
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/datarobot/cli/internal/config"
+)
+
+// TaskExecution mirrors TaskExecutionResponse.
+type TaskExecution struct {
+	TaskID      *int       `json:"taskId,omitempty"`
+	Name        string     `json:"name"`
+	Status      string     `json:"status"`
+	StartedAt   *time.Time `json:"startedAt,omitempty"`
+	CompletedAt *time.Time `json:"completedAt,omitempty"`
+	ErrorDetail *string    `json:"errorDetail,omitempty"`
+}
+
+// TaskExecutionLogs mirrors TaskExecutionLogsResponse (live K8s pod logs).
+type TaskExecutionLogs struct {
+	Logs              string `json:"logs"`
+	FilteredLineCount int    `json:"filteredLineCount"`
+}
+
+// TaskExecutionDurableLog mirrors TaskExecutionDurableLogResponse
+// (S3-uploaded log content read back inline).
+type TaskExecutionDurableLog struct {
+	Content           string `json:"content"`
+	ContentType       string `json:"contentType"`
+	TotalBytes        int    `json:"totalBytes"`
+	Truncated         bool   `json:"truncated"`
+	FilteredLineCount int    `json:"filteredLineCount"`
+}
+
+// TaskExecutionResult mirrors TaskExecutionResultResponse (presigned S3 URL
+// for the task's cloudpickle result blob).
+type TaskExecutionResult struct {
+	URL                    string  `json:"url"`
+	ExpiresIn              int     `json:"expiresIn"`
+	ContentType            string  `json:"contentType"`
+	Value                  any     `json:"value,omitempty"`
+	ValueAvailable         bool    `json:"valueAvailable"`
+	ValueUnavailableReason *string `json:"valueUnavailableReason,omitempty"`
+}
+
+func taskBase(pipelineID, runID string) (string, error) {
+	return config.GetEndpointURL(
+		"/api/v2/pipelines/" + pipelineID + "/dispatches/" + runID + "/tasks",
+	)
+}
+
+// ListTaskExecutions returns all task execution records for a run.
+func ListTaskExecutions(pipelineID, runID string) ([]TaskExecution, error) {
+	endpoint, err := taskBase(pipelineID, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	var tasks []TaskExecution
+
+	err = doJSON(http.MethodGet, endpoint, nil, "task executions", &tasks)
+	if err != nil {
+		return nil, err
+	}
+
+	return tasks, nil
+}
+
+// GetTaskExecution fetches a single task execution by its sequential task ID.
+func GetTaskExecution(pipelineID, runID string, taskID int) (*TaskExecution, error) {
+	base, err := taskBase(pipelineID, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := base + "/" + strconv.Itoa(taskID)
+
+	var task TaskExecution
+
+	err = doJSON(http.MethodGet, endpoint, nil, "task execution", &task)
+	if err != nil {
+		return nil, err
+	}
+
+	return &task, nil
+}
+
+// GetTaskLogs reads live K8s pod logs for a task. tailLines limits the number
+// of trailing lines returned (nil = no limit). verbosity is "user" or "all".
+func GetTaskLogs(pipelineID, runID string, taskID int, tailLines *int, verbosity string) (*TaskExecutionLogs, error) {
+	base, err := taskBase(pipelineID, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	query := url.Values{}
+	if tailLines != nil {
+		query.Set("tail_lines", strconv.Itoa(*tailLines))
+	}
+
+	if verbosity != "" {
+		query.Set("verbosity", verbosity)
+	}
+
+	endpoint := base + "/" + strconv.Itoa(taskID) + "/logs"
+
+	if encoded := query.Encode(); encoded != "" {
+		endpoint = endpoint + "?" + encoded
+	}
+
+	var logs TaskExecutionLogs
+
+	err = doJSON(http.MethodGet, endpoint, nil, "task logs", &logs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &logs, nil
+}
+
+// GetTaskDurableLog reads the S3-uploaded log for a task. stream must be
+// "stdout" or "stderr". verbosity is "user" or "all".
+func GetTaskDurableLog(pipelineID, runID string, taskID int, stream, verbosity string) (*TaskExecutionDurableLog, error) {
+	base, err := taskBase(pipelineID, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	query := url.Values{}
+	if verbosity != "" {
+		query.Set("verbosity", verbosity)
+	}
+
+	endpoint := base + "/" + strconv.Itoa(taskID) + "/logs/" + stream
+
+	if encoded := query.Encode(); encoded != "" {
+		endpoint = endpoint + "?" + encoded
+	}
+
+	var log TaskExecutionDurableLog
+
+	err = doJSON(http.MethodGet, endpoint, nil, "task durable log", &log)
+	if err != nil {
+		return nil, err
+	}
+
+	return &log, nil
+}
+
+// GetTaskResult returns the presigned S3 URL for a completed task's result.
+func GetTaskResult(pipelineID, runID string, taskID int) (*TaskExecutionResult, error) {
+	base, err := taskBase(pipelineID, runID)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := base + "/" + strconv.Itoa(taskID) + "/result"
+
+	var result TaskExecutionResult
+
+	err = doJSON(http.MethodGet, endpoint, nil, "task result", &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/internal/pipeline/run_task.go
+++ b/internal/pipeline/run_task.go
@@ -20,12 +20,12 @@
 package pipeline
 
 import (
-	"net/http"
 	"net/url"
 	"strconv"
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
 )
 
 // TaskExecution mirrors TaskExecutionResponse.
@@ -80,7 +80,7 @@ func ListTaskExecutions(pipelineID, runID string) ([]TaskExecution, error) {
 
 	var tasks []TaskExecution
 
-	err = doJSON(http.MethodGet, endpoint, nil, "task executions", &tasks)
+	err = drapi.GetJSON(endpoint, "task executions", &tasks)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func GetTaskExecution(pipelineID, runID string, taskID int) (*TaskExecution, err
 
 	var task TaskExecution
 
-	err = doJSON(http.MethodGet, endpoint, nil, "task execution", &task)
+	err = drapi.GetJSON(endpoint, "task execution", &task)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func GetTaskLogs(pipelineID, runID string, taskID int, tailLines *int, verbosity
 
 	var logs TaskExecutionLogs
 
-	err = doJSON(http.MethodGet, endpoint, nil, "task logs", &logs)
+	err = drapi.GetJSON(endpoint, "task logs", &logs)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func GetTaskDurableLog(pipelineID, runID string, taskID int, stream, verbosity s
 
 	var log TaskExecutionDurableLog
 
-	err = doJSON(http.MethodGet, endpoint, nil, "task durable log", &log)
+	err = drapi.GetJSON(endpoint, "task durable log", &log)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func GetTaskResult(pipelineID, runID string, taskID int) (*TaskExecutionResult, 
 
 	var result TaskExecutionResult
 
-	err = doJSON(http.MethodGet, endpoint, nil, "task result", &result)
+	err = drapi.GetJSON(endpoint, "task result", &result)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pipeline/run_task_test.go
+++ b/internal/pipeline/run_task_test.go
@@ -1,0 +1,199 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListTaskExecutions_URLAndDecode(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v2/pipelines/p-1/dispatches/d-1/tasks", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"taskId":1,"name":"load_data","status":"COMPLETED"},
+			{"taskId":2,"name":"train_model","status":"RUNNING"}
+		]`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	tasks, err := ListTaskExecutions("p-1", "d-1")
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	assert.Equal(t, "load_data", tasks[0].Name)
+	assert.Equal(t, "COMPLETED", tasks[0].Status)
+	require.NotNil(t, tasks[0].TaskID)
+	assert.Equal(t, 1, *tasks[0].TaskID)
+}
+
+func TestGetTaskExecution_URLAndDecode(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v2/pipelines/p-1/dispatches/d-1/tasks/2", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"taskId":2,"name":"train_model","status":"FAILED","errorDetail":"OOM"}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	task, err := GetTaskExecution("p-1", "d-1", 2)
+	require.NoError(t, err)
+	assert.Equal(t, "train_model", task.Name)
+	assert.Equal(t, "FAILED", task.Status)
+	require.NotNil(t, task.ErrorDetail)
+	assert.Equal(t, "OOM", *task.ErrorDetail)
+}
+
+func TestGetTaskLogs_URLQueryAndDecode(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/pipelines/p-1/dispatches/d-1/tasks/1/logs", r.URL.Path)
+		assert.Equal(t, "50", r.URL.Query().Get("tail_lines"))
+		assert.Equal(t, "all", r.URL.Query().Get("verbosity"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"logs":"hello from task\n","filteredLineCount":0}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	tail := 50
+	logs, err := GetTaskLogs("p-1", "d-1", 1, &tail, "all")
+	require.NoError(t, err)
+	assert.Equal(t, "hello from task\n", logs.Logs)
+	assert.Equal(t, 0, logs.FilteredLineCount)
+}
+
+func TestGetTaskLogs_NoQueryParamsWhenAbsent(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/pipelines/p-1/dispatches/d-1/tasks/1/logs", r.URL.Path)
+		assert.Empty(t, r.URL.Query().Get("tail_lines"))
+		assert.Empty(t, r.URL.Query().Get("verbosity"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"logs":"","filteredLineCount":0}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := GetTaskLogs("p-1", "d-1", 1, nil, "")
+	require.NoError(t, err)
+}
+
+func TestGetTaskDurableLog_URLAndDecode(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/pipelines/p-1/dispatches/d-1/tasks/3/logs/stdout", r.URL.Path)
+		assert.Equal(t, "user", r.URL.Query().Get("verbosity"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"content":"task output\n","contentType":"text/plain","totalBytes":12,"truncated":false,"filteredLineCount":2}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	log, err := GetTaskDurableLog("p-1", "d-1", 3, "stdout", "user")
+	require.NoError(t, err)
+	assert.Equal(t, "task output\n", log.Content)
+	assert.Equal(t, 12, log.TotalBytes)
+	assert.False(t, log.Truncated)
+	assert.Equal(t, 2, log.FilteredLineCount)
+}
+
+func TestGetTaskResult_URLAndDecode(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/pipelines/p-1/dispatches/d-1/tasks/1/result", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"url":"https://s3.example.com/result.tobj?sig=abc",
+			"expiresIn":900,
+			"contentType":"application/octet-stream",
+			"value":42,
+			"valueAvailable":true
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	res, err := GetTaskResult("p-1", "d-1", 1)
+	require.NoError(t, err)
+	assert.Equal(t, "https://s3.example.com/result.tobj?sig=abc", res.URL)
+	assert.Equal(t, 900, res.ExpiresIn)
+	assert.True(t, res.ValueAvailable)
+}
+
+func TestGetTaskResult_ValueUnavailable(t *testing.T) {
+	installSkipAuth(t)
+
+	reason := "not_json_serializable"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		resp := TaskExecutionResult{
+			URL:                    "https://s3.example.com/result.tobj",
+			ExpiresIn:              900,
+			ContentType:            "application/octet-stream",
+			ValueAvailable:         false,
+			ValueUnavailableReason: &reason,
+		}
+
+		data, _ := json.Marshal(resp)
+		_, _ = w.Write(data)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	res, err := GetTaskResult("p-1", "d-1", 1)
+	require.NoError(t, err)
+	assert.False(t, res.ValueAvailable)
+	require.NotNil(t, res.ValueUnavailableReason)
+	assert.Equal(t, "not_json_serializable", *res.ValueUnavailableReason)
+}

--- a/internal/pipeline/run_test.go
+++ b/internal/pipeline/run_test.go
@@ -44,7 +44,7 @@ func TestCreateRun_DraftURLAndBody(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	got, err := CreateRun("p-1", ScopeDraft, nil, "in-1")
+	got, err := CreateRun("p-1", ScopeDraft, nil, "in-1", "")
 	require.NoError(t, err)
 	assert.Equal(t, "d-1", got.RunID)
 	assert.Equal(t, RunStatusPending, got.Status)
@@ -65,7 +65,7 @@ func TestCreateRun_LockedURL(t *testing.T) {
 	installEndpoint(t, srv.URL)
 
 	v := 2
-	got, err := CreateRun("p-1", ScopeLocked, &v, "in-1")
+	got, err := CreateRun("p-1", ScopeLocked, &v, "in-1", "")
 	require.NoError(t, err)
 	require.NotNil(t, got.VersionID)
 	assert.Equal(t, 2, *got.VersionID)

--- a/internal/pipeline/schedule.go
+++ b/internal/pipeline/schedule.go
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 // schedule.go wraps the pipeline schedule endpoints described in
-// pipelines-api/.../controllers/pipeline_schedule.py. Schedules are only
-// valid for locked pipeline versions, so the URL always carries a
-// /versions/{ver} segment and there is no Scope parameter on this side.
+// pipelines-api/.../controllers/pipeline_schedule.py. Schedules live
+// directly under a pipeline (not a specific version) in the API URL; the
+// locked pipeline version is captured in the CREATE request body instead.
 
 package pipeline
 
@@ -24,6 +24,8 @@ import (
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/datarobot/cli/internal/config"
 )
 
 // ScheduleStatus mirrors PipelineScheduleStatus in the pipelines-api enums.
@@ -40,6 +42,8 @@ type Schedule struct {
 	ScheduleID     string         `json:"id"`
 	PipelineID     string         `json:"pipelineId"`
 	Version        int            `json:"version"`
+	ImageID        string         `json:"imageId"`
+	ImageVersion   int            `json:"imageVersion"`
 	CronExpression string         `json:"cronExpression"`
 	Timezone       string         `json:"timezone"`
 	Status         ScheduleStatus `json:"status"`
@@ -49,9 +53,12 @@ type Schedule struct {
 
 // ScheduleCreateRequest mirrors PipelineScheduleCreateRequest.
 type ScheduleCreateRequest struct {
-	CronExpression  string `json:"cron_expression"`
-	PipelineInputID string `json:"pipeline_input_id"`
-	Timezone        string `json:"timezone,omitempty"`
+	CronExpression    string `json:"cron_expression"`
+	PipelineVersionID int    `json:"pipeline_version_id"`
+	PipelineInputID   string `json:"pipeline_input_id"`
+	ImageID           string `json:"image_id"`
+	ImageVersion      int    `json:"image_version"`
+	Timezone          string `json:"timezone,omitempty"`
 }
 
 // ScheduleUpdateRequest mirrors PipelineScheduleUpdateRequest. Both fields
@@ -61,9 +68,13 @@ type ScheduleUpdateRequest struct {
 	Timezone       *string `json:"timezone,omitempty"`
 }
 
-// CreateSchedule registers a new recurring run for a locked version.
-func CreateSchedule(pipelineID string, version int, body ScheduleCreateRequest) (*Schedule, error) {
-	endpoint, err := EndpointFor(pipelineID, ScopeLocked, &version, "schedules")
+func scheduleBase(pipelineID string) (string, error) {
+	return config.GetEndpointURL("/api/v2/pipelines/" + pipelineID + "/schedules")
+}
+
+// CreateSchedule registers a new recurring run for a locked pipeline version.
+func CreateSchedule(pipelineID string, body ScheduleCreateRequest) (*Schedule, error) {
+	endpoint, err := scheduleBase(pipelineID)
 	if err != nil {
 		return nil, err
 	}
@@ -78,9 +89,9 @@ func CreateSchedule(pipelineID string, version int, body ScheduleCreateRequest) 
 	return &result, nil
 }
 
-// ListSchedules returns a paginated list of schedules for a locked version.
-func ListSchedules(pipelineID string, version, offset, limit int) ([]Schedule, error) {
-	endpoint, err := EndpointFor(pipelineID, ScopeLocked, &version, "schedules")
+// ListSchedules returns a paginated list of all schedules for a pipeline.
+func ListSchedules(pipelineID string, offset, limit int) ([]Schedule, error) {
+	endpoint, err := scheduleBase(pipelineID)
 	if err != nil {
 		return nil, err
 	}
@@ -109,11 +120,13 @@ func ListSchedules(pipelineID string, version, offset, limit int) ([]Schedule, e
 }
 
 // GetSchedule fetches a single schedule by id.
-func GetSchedule(pipelineID string, version int, scheduleID string) (*Schedule, error) {
-	endpoint, err := EndpointFor(pipelineID, ScopeLocked, &version, "schedules/"+scheduleID)
+func GetSchedule(pipelineID, scheduleID string) (*Schedule, error) {
+	endpoint, err := scheduleBase(pipelineID)
 	if err != nil {
 		return nil, err
 	}
+
+	endpoint = endpoint + "/" + scheduleID
 
 	var schedule Schedule
 
@@ -126,11 +139,13 @@ func GetSchedule(pipelineID string, version int, scheduleID string) (*Schedule, 
 }
 
 // UpdateSchedule patches a schedule's cron expression and/or timezone.
-func UpdateSchedule(pipelineID string, version int, scheduleID string, body ScheduleUpdateRequest) (*Schedule, error) {
-	endpoint, err := EndpointFor(pipelineID, ScopeLocked, &version, "schedules/"+scheduleID)
+func UpdateSchedule(pipelineID, scheduleID string, body ScheduleUpdateRequest) (*Schedule, error) {
+	endpoint, err := scheduleBase(pipelineID)
 	if err != nil {
 		return nil, err
 	}
+
+	endpoint = endpoint + "/" + scheduleID
 
 	var result Schedule
 
@@ -143,11 +158,11 @@ func UpdateSchedule(pipelineID string, version int, scheduleID string, body Sche
 }
 
 // DeleteSchedule removes a schedule.
-func DeleteSchedule(pipelineID string, version int, scheduleID string) error {
-	endpoint, err := EndpointFor(pipelineID, ScopeLocked, &version, "schedules/"+scheduleID)
+func DeleteSchedule(pipelineID, scheduleID string) error {
+	endpoint, err := scheduleBase(pipelineID)
 	if err != nil {
 		return err
 	}
 
-	return doDelete(endpoint, "delete schedule")
+	return doDelete(endpoint+"/"+scheduleID, "delete schedule")
 }

--- a/internal/pipeline/schedule_output.go
+++ b/internal/pipeline/schedule_output.go
@@ -35,6 +35,8 @@ type scheduleJSON struct {
 	ScheduleID     string `json:"schedule_id"`
 	PipelineID     string `json:"pipeline_id"`
 	Version        int    `json:"version"`
+	ImageID        string `json:"image_id"`
+	ImageVersion   int    `json:"image_version"`
 	CronExpression string `json:"cron_expression"`
 	Timezone       string `json:"timezone"`
 	Status         string `json:"status"`
@@ -47,6 +49,8 @@ func toScheduleJSON(s Schedule) scheduleJSON {
 		ScheduleID:     s.ScheduleID,
 		PipelineID:     s.PipelineID,
 		Version:        s.Version,
+		ImageID:        s.ImageID,
+		ImageVersion:   s.ImageVersion,
 		CronExpression: s.CronExpression,
 		Timezone:       s.Timezone,
 		Status:         string(s.Status),
@@ -96,6 +100,8 @@ func PrintScheduleHuman(s Schedule) {
 	fmt.Fprintf(w, "Schedule ID:\t%s\n", s.ScheduleID)
 	fmt.Fprintf(w, "Pipeline ID:\t%s\n", s.PipelineID)
 	fmt.Fprintf(w, "Version:\tv%d\n", s.Version)
+	fmt.Fprintf(w, "Image ID:\t%s\n", s.ImageID)
+	fmt.Fprintf(w, "Image Version:\tv%d\n", s.ImageVersion)
 	fmt.Fprintf(w, "Cron:\t%s\n", s.CronExpression)
 	fmt.Fprintf(w, "Timezone:\t%s\n", s.Timezone)
 	fmt.Fprintf(w, "Status:\t%s\n", string(s.Status))
@@ -135,7 +141,7 @@ func PrintScheduleListHuman(items []Schedule) {
 
 	dimStyle := tui.DimStyle.Padding(0, 1)
 
-	headers := []string{"SCHEDULE ID", "VERSION", "CRON", "TIMEZONE", "STATUS", "UPDATED"}
+	headers := []string{"SCHEDULE ID", "VERSION", "IMAGE ID", "IMG VER", "CRON", "TIMEZONE", "STATUS", "UPDATED"}
 
 	updatedCol := slices.Index(headers, "UPDATED")
 
@@ -159,6 +165,8 @@ func PrintScheduleListHuman(items []Schedule) {
 		t.Row(
 			s.ScheduleID,
 			fmt.Sprintf("v%d", s.Version),
+			s.ImageID,
+			fmt.Sprintf("v%d", s.ImageVersion),
 			s.CronExpression,
 			s.Timezone,
 			string(s.Status),

--- a/internal/pipeline/schedule_test.go
+++ b/internal/pipeline/schedule_test.go
@@ -24,74 +24,83 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateSchedule_LockedOnlyURLAndBody(t *testing.T) {
+func TestCreateSchedule_URLAndBody(t *testing.T) {
 	installSkipAuth(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/api/v2/pipelines/p-1/versions/2/schedules", r.URL.Path)
+		assert.Equal(t, "/api/v2/pipelines/p-1/schedules", r.URL.Path)
 
 		var body ScheduleCreateRequest
 
 		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		assert.Equal(t, "0 * * * *", body.CronExpression)
+		assert.Equal(t, 2, body.PipelineVersionID)
 		assert.Equal(t, "in-1", body.PipelineInputID)
+		assert.Equal(t, "img-1", body.ImageID)
+		assert.Equal(t, 3, body.ImageVersion)
 		assert.Equal(t, "America/Los_Angeles", body.Timezone)
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"s-1","pipelineId":"p-1","version":2,"cronExpression":"0 * * * *","timezone":"America/Los_Angeles","status":"ACTIVE"}`))
+		_, _ = w.Write([]byte(`{"id":"s-1","pipelineId":"p-1","version":2,"imageId":"img-1","imageVersion":3,"cronExpression":"0 * * * *","timezone":"America/Los_Angeles","status":"ACTIVE","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"}`))
 	}))
 
 	defer srv.Close()
 
 	installEndpoint(t, srv.URL)
 
-	got, err := CreateSchedule("p-1", 2, ScheduleCreateRequest{
-		CronExpression:  "0 * * * *",
-		PipelineInputID: "in-1",
-		Timezone:        "America/Los_Angeles",
+	got, err := CreateSchedule("p-1", ScheduleCreateRequest{
+		CronExpression:    "0 * * * *",
+		PipelineVersionID: 2,
+		PipelineInputID:   "in-1",
+		ImageID:           "img-1",
+		ImageVersion:      3,
+		Timezone:          "America/Los_Angeles",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "s-1", got.ScheduleID)
 	assert.Equal(t, ScheduleStatusActive, got.Status)
+	assert.Equal(t, "img-1", got.ImageID)
+	assert.Equal(t, 3, got.ImageVersion)
 }
 
 func TestListSchedules_QueryAndDecode(t *testing.T) {
 	installSkipAuth(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v2/pipelines/p-1/versions/2/schedules", r.URL.Path)
+		assert.Equal(t, "/api/v2/pipelines/p-1/schedules", r.URL.Path)
 		assert.Equal(t, "5", r.URL.Query().Get("limit"))
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[{"id":"s-1","pipelineId":"p-1","version":2,"cronExpression":"0 0 * * *","timezone":"UTC","status":"ACTIVE"}],"totalCount":1,"count":1}`))
+		_, _ = w.Write([]byte(`{"data":[{"id":"s-1","pipelineId":"p-1","version":2,"imageId":"img-1","imageVersion":1,"cronExpression":"0 0 * * *","timezone":"UTC","status":"ACTIVE","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"}],"totalCount":1,"count":1}`))
 	}))
 
 	defer srv.Close()
 
 	installEndpoint(t, srv.URL)
 
-	items, err := ListSchedules("p-1", 2, 0, 5)
+	items, err := ListSchedules("p-1", 0, 5)
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 	assert.Equal(t, "s-1", items[0].ScheduleID)
+	assert.Equal(t, "img-1", items[0].ImageID)
 }
 
 func TestGetSchedule_TargetsCorrectURL(t *testing.T) {
 	installSkipAuth(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v2/pipelines/p-1/versions/2/schedules/s-1", r.URL.Path)
+		assert.Equal(t, "/api/v2/pipelines/p-1/schedules/s-1", r.URL.Path)
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"s-1","pipelineId":"p-1","version":2,"cronExpression":"0 * * * *","timezone":"UTC","status":"PAUSED"}`))
+		_, _ = w.Write([]byte(`{"id":"s-1","pipelineId":"p-1","version":2,"imageId":"img-1","imageVersion":1,"cronExpression":"0 * * * *","timezone":"UTC","status":"PAUSED","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"}`))
 	}))
 
 	defer srv.Close()
 
 	installEndpoint(t, srv.URL)
 
-	got, err := GetSchedule("p-1", 2, "s-1")
+	got, err := GetSchedule("p-1", "s-1")
 	require.NoError(t, err)
 	assert.Equal(t, ScheduleStatusPaused, got.Status)
 }
@@ -101,7 +110,7 @@ func TestUpdateSchedule_OmitsUnsuppliedFields(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)
-		assert.Equal(t, "/api/v2/pipelines/p-1/versions/2/schedules/s-1", r.URL.Path)
+		assert.Equal(t, "/api/v2/pipelines/p-1/schedules/s-1", r.URL.Path)
 
 		var raw map[string]any
 
@@ -112,7 +121,7 @@ func TestUpdateSchedule_OmitsUnsuppliedFields(t *testing.T) {
 		assert.False(t, hasTZ, "expected timezone to be omitted")
 
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"id":"s-1","pipelineId":"p-1","version":2,"cronExpression":"*/15 * * * *","timezone":"UTC","status":"ACTIVE"}`))
+		_, _ = w.Write([]byte(`{"id":"s-1","pipelineId":"p-1","version":2,"imageId":"img-1","imageVersion":1,"cronExpression":"*/15 * * * *","timezone":"UTC","status":"ACTIVE","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z"}`))
 	}))
 
 	defer srv.Close()
@@ -120,17 +129,17 @@ func TestUpdateSchedule_OmitsUnsuppliedFields(t *testing.T) {
 	installEndpoint(t, srv.URL)
 
 	cron := "*/15 * * * *"
-	got, err := UpdateSchedule("p-1", 2, "s-1", ScheduleUpdateRequest{CronExpression: &cron})
+	got, err := UpdateSchedule("p-1", "s-1", ScheduleUpdateRequest{CronExpression: &cron})
 	require.NoError(t, err)
 	assert.Equal(t, "*/15 * * * *", got.CronExpression)
 }
 
-func TestDeleteSchedule_DeletesLockedURL(t *testing.T) {
+func TestDeleteSchedule_DeletesCorrectURL(t *testing.T) {
 	installSkipAuth(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
-		assert.Equal(t, "/api/v2/pipelines/p-1/versions/2/schedules/s-1", r.URL.Path)
+		assert.Equal(t, "/api/v2/pipelines/p-1/schedules/s-1", r.URL.Path)
 		w.WriteHeader(http.StatusNoContent)
 	}))
 
@@ -138,5 +147,5 @@ func TestDeleteSchedule_DeletesLockedURL(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	require.NoError(t, DeleteSchedule("p-1", 2, "s-1"))
+	require.NoError(t, DeleteSchedule("p-1", "s-1"))
 }

--- a/internal/pipeline/source.go
+++ b/internal/pipeline/source.go
@@ -1,0 +1,45 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// source.go wraps the pipeline source endpoints:
+//
+//	GET /api/v2/pipelines/{id}/source
+//	GET /api/v2/pipelines/{id}/versions/{v}/source
+package pipeline
+
+import "net/http"
+
+// PipelineSourceResponse mirrors PipelineSourceResponse from the pipelines-api.
+type PipelineSourceResponse struct {
+	Source string `json:"source"`
+}
+
+// GetPipelineSource fetches the full source.py content of a pipeline.
+// For draft scope it calls GET /pipelines/{id}/source; for locked scope
+// it calls GET /pipelines/{id}/versions/{v}/source.
+func GetPipelineSource(pipelineID string, scope Scope, version *int) (*PipelineSourceResponse, error) {
+	endpoint, err := EndpointFor(pipelineID, scope, version, "source")
+	if err != nil {
+		return nil, err
+	}
+
+	var result PipelineSourceResponse
+
+	err = doJSON(http.MethodGet, endpoint, nil, "pipeline source", &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}


### PR DESCRIPTION
# RATIONALE

Propagates the public API changes from `pipelines-api` and `pipelines-api` PR #154. This PR covers two waves of changes on top of the image schema work:

**Wave 1 — API gap sync (spec items missed in earlier PRs):**
- Schedule endpoints use a non-versioned URL path (`/api/v2/pipelines/{id}/schedules`, not `.../versions/{v}/schedules`); `--version` removed from all 5 schedule subcommands
- `PipelineScheduleCreateRequest` now requires `cronExpression`, `pipelineVersionId`, `imageId`, and `imageVersion` → `--image` and `--image-version` added as required flags to `schedule create`
- `imageId` is required (not optional) on run dispatch → `--image` marked required on `run create`
- `dr pipeline run task {list,get,logs,result}` — new subcommand group backed by `TaskExecution` client functions for `/api/v2/pipelines/{pid}/dispatches/{did}/tasks/…`
- `dr pipeline list --search` for name-substring filtering
- `RunStatusPreparing = "PREPARING"` constant

**Wave 2 — pipelines-api PR #154 (optional file on PATCH, name/description updates):**
- `PATCH /pipelines/{id}` no longer requires a file; `name` and `description` can be updated independently
- `--name` and `--description` flags added to `dr pipeline update`
- `CreateResponse` carries optional `Description` field

## CHANGES

### `internal/pipeline/schedule.go`
- Fix URL: `scheduleBase(pipelineID)` → `/api/v2/pipelines/{id}/schedules` (non-versioned)
- Remove `version int` from all 5 function signatures
- `ScheduleCreateRequest`: add `CronExpression`, `PipelineVersionID`, `ImageID`, `ImageVersion`; `Schedule` struct: add `ImageID`, `ImageVersion`

### `cmd/pipeline/schedule/create`
- Add required `--image` and `--image-version` flags; remove `--version` from list/get/update/delete

### `internal/pipeline/run.go`
- Add `RunStatusPreparing = "PREPARING"`

### `cmd/pipeline/run/create`
- `--image` changed from optional to required

### `internal/pipeline/run_task.go` (new)
- `TaskExecution`, `TaskExecutionLogs`, `TaskExecutionDurableLog`, `TaskExecutionResult` structs
- `ListTaskExecutions`, `GetTaskExecution`, `GetTaskLogs`, `GetTaskDurableLog`, `GetTaskResult`

### `cmd/pipeline/run/task/` (new — 4 subcommands)
- `list`: table of task executions for a run
- `get`: detail view of a single task by sequential ID
- `logs`: live pod logs via `GetTaskLogs`; durable S3 logs via `GetTaskDurableLog` when `--stream stdout|stderr` is set
- `result`: show result URL, content type, expiry, and value preview

### `internal/pipeline/pipeline.go`
- `ListPipelines` signature: add `search string` parameter
- `CreateResponse`: add `Description *string`
- `UpdatePipeline` signature: add `name`, `description`; `filePath` is now optional
- `buildMultipartBody`: only write the `file` part when `filePath != ""`

### `cmd/pipeline/list`
- Add `--search` flag

### `cmd/pipeline/update`
- File is now optional; add `--name` and `--description`; validate at least one of file/name/description/image

### `internal/pipeline/pipeline_output.go`
- `printCreateResponseHuman`: show Description line when present

---

> [!NOTE]
> **Medium Risk**
> Schedule URL fix is a correctness change (prior code targeted a non-existent versioned endpoint). Run task commands are additive. PR #154 changes make file optional without breaking existing callers.