### PR TITLE
[CFX-6634] fix(update): prevent circular dr symlink

### DIFF
--- a/cmd/self/update/cmd.go
+++ b/cmd/self/update/cmd.go
@@ -125,7 +125,9 @@ with your default shell.
 			execCmd.Stdout = os.Stdout
 			execCmd.Stderr = os.Stderr
 
-			// On Linux/macOS the install script defaults INSTALL_DIR to
+			// On Linux/macOS the install script (install.sh, see
+			// https://raw.githubusercontent.com/datarobot-oss/cli/main/install.sh)
+			// defaults INSTALL_DIR to
 			// ~/.local/bin, ignoring where dr is actually installed. Point it at
 			// the running binary's directory so the update lands in place instead
 			// of scattering files (e.g. DataRobot Codespaces install dr under a

--- a/cmd/self/update/cmd.go
+++ b/cmd/self/update/cmd.go
@@ -125,18 +125,14 @@ with your default shell.
 			execCmd.Stdout = os.Stdout
 			execCmd.Stderr = os.Stderr
 
-			// On Linux/macOS the install script (install.sh, see
-			// https://raw.githubusercontent.com/datarobot-oss/cli/main/install.sh)
-			// defaults INSTALL_DIR to
-			// ~/.local/bin, ignoring where dr is actually installed. Point it at
-			// the running binary's directory so the update lands in place instead
-			// of scattering files (e.g. DataRobot Codespaces install dr under a
+			// The install scripts (install.sh, install.ps1) default INSTALL_DIR to
+			// ~/.local/bin or %LOCALAPPDATA%\Programs\dr, ignoring where dr is
+			// actually installed. Point it at the running binary's directory so the
+			// update lands in place (e.g. DataRobot Codespaces install dr under a
 			// dr/ directory on PATH). Respect a user-provided INSTALL_DIR.
-			if runtime.GOOS != "windows" {
-				if _, ok := os.LookupEnv("INSTALL_DIR"); !ok {
-					if dir, ok := resolveInstallDir(); ok {
-						execCmd.Env = append(os.Environ(), "INSTALL_DIR="+dir)
-					}
+			if _, ok := os.LookupEnv("INSTALL_DIR"); !ok {
+				if dir, ok := resolveInstallDir(); ok {
+					execCmd.Env = append(os.Environ(), "INSTALL_DIR="+dir)
 				}
 			}
 

--- a/cmd/self/update/cmd.go
+++ b/cmd/self/update/cmd.go
@@ -125,6 +125,19 @@ with your default shell.
 			execCmd.Stdout = os.Stdout
 			execCmd.Stderr = os.Stderr
 
+			// On Linux/macOS the install script defaults INSTALL_DIR to
+			// ~/.local/bin, ignoring where dr is actually installed. Point it at
+			// the running binary's directory so the update lands in place instead
+			// of scattering files (e.g. DataRobot Codespaces install dr under a
+			// dr/ directory on PATH). Respect a user-provided INSTALL_DIR.
+			if runtime.GOOS != "windows" {
+				if _, ok := os.LookupEnv("INSTALL_DIR"); !ok {
+					if dir, ok := resolveInstallDir(); ok {
+						execCmd.Env = append(os.Environ(), "INSTALL_DIR="+dir)
+					}
+				}
+			}
+
 			if err := execCmd.Run(); err != nil {
 				if runtime.GOOS == "windows" {
 					// rename back if update failed
@@ -144,6 +157,24 @@ with your default shell.
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force update to latest version")
 
 	return cmd
+}
+
+// resolveInstallDir returns the directory of the currently running executable,
+// resolving any symlinks first so the path points at the real binary. It is used
+// to tell the install script where dr actually lives. The boolean is false when
+// the executable path cannot be determined, in which case callers should fall
+// back to the install script's default location.
+func resolveInstallDir() (string, bool) {
+	executable, err := os.Executable()
+	if err != nil {
+		return "", false
+	}
+
+	if resolved, err := filepath.EvalSymlinks(executable); err == nil {
+		executable = resolved
+	}
+
+	return filepath.Dir(executable), true
 }
 
 // backupExecutable creates a backup of the current CLI executable before updating.

--- a/cmd/self/update/cmd_test.go
+++ b/cmd/self/update/cmd_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveInstallDir(t *testing.T) {
+	dir, ok := resolveInstallDir()
+
+	require.True(t, ok, "expected resolveInstallDir to succeed for the test binary")
+	assert.True(t, filepath.IsAbs(dir), "expected an absolute directory, got %q", dir)
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	resolved, err := filepath.EvalSymlinks(exe)
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Dir(resolved), dir,
+		"install dir should be the directory of the resolved executable")
+}
+
+// TestResolveInstallDirFollowsSymlink verifies that when dr is invoked through a
+// symlink (as on PATH), the resolved install dir points at the real binary's
+// directory, not the symlink's directory.
+func TestResolveInstallDirFollowsSymlink(t *testing.T) {
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	realExe, err := filepath.EvalSymlinks(exe)
+	require.NoError(t, err)
+
+	// Create a symlink to the test binary in a separate temp directory.
+	linkDir := t.TempDir()
+	link := filepath.Join(linkDir, "dr")
+
+	if err := os.Symlink(realExe, link); err != nil {
+		t.Skipf("symlinks not supported in this environment: %v", err)
+	}
+
+	resolved, err := filepath.EvalSymlinks(link)
+	require.NoError(t, err)
+
+	// Resolving the symlink should yield the real binary's directory, which is
+	// not the directory containing the symlink itself.
+	assert.Equal(t, filepath.Dir(realExe), filepath.Dir(resolved))
+	assert.NotEqual(t, linkDir, filepath.Dir(resolved))
+}

--- a/install.sh
+++ b/install.sh
@@ -316,14 +316,9 @@ download_and_install() {
 }
 
 # Create or refresh the 'datarobot' alias symlink (datarobot -> dr).
-#
-# Uses `ln -sfn` (no-dereference; supported by both GNU and BSD/macOS ln) and
-# removes any existing entry first. This is critical: if `dr` is installed as a
-# directory on PATH (as in DataRobot Codespaces, where the binary lives at
-# dr/dr) then a prior run leaves `datarobot` as a symlink to that directory.
-# A plain `ln -sf dr datarobot` would follow that symlink and create the new
-# link *inside* the directory, clobbering the real binary at dr/dr with a
-# self-referential `dr -> dr` symlink ("too many levels of symbolic links").
+# Removes the existing entry first to avoid ln following a symlink into a
+# directory (e.g. Codespaces installs dr as dr/dr) and creating a
+# self-referential link inside it.
 ensure_datarobot_alias() {
     rm -f "$INSTALL_DIR/datarobot"
     ln -sfn "$BINARY_NAME" "$INSTALL_DIR/datarobot"

--- a/install.sh
+++ b/install.sh
@@ -199,7 +199,7 @@ check_existing_installation() {
             # Ensure datarobot alias symlink exists
             if [ ! -L "$INSTALL_DIR/datarobot" ]; then
                 step "Creating missing 'datarobot' alias..."
-                ln -sf "$BINARY_NAME" "$INSTALL_DIR/datarobot"
+                ensure_datarobot_alias
             fi
 
             if ! echo ":$PATH:" | grep -q ":$INSTALL_DIR:"; then
@@ -312,7 +312,21 @@ download_and_install() {
 
     # Create datarobot alias
     step "Creating 'datarobot' alias..."
-    ln -sf "$BINARY_NAME" "$INSTALL_DIR/datarobot"
+    ensure_datarobot_alias
+}
+
+# Create or refresh the 'datarobot' alias symlink (datarobot -> dr).
+#
+# Uses `ln -sfn` (no-dereference; supported by both GNU and BSD/macOS ln) and
+# removes any existing entry first. This is critical: if `dr` is installed as a
+# directory on PATH (as in DataRobot Codespaces, where the binary lives at
+# dr/dr) then a prior run leaves `datarobot` as a symlink to that directory.
+# A plain `ln -sf dr datarobot` would follow that symlink and create the new
+# link *inside* the directory, clobbering the real binary at dr/dr with a
+# self-referential `dr -> dr` symlink ("too many levels of symbolic links").
+ensure_datarobot_alias() {
+    rm -f "$INSTALL_DIR/datarobot"
+    ln -sfn "$BINARY_NAME" "$INSTALL_DIR/datarobot"
 }
 
 # Show PATH configuration instructions
@@ -548,4 +562,7 @@ EOF
     echo ""
 }
 
-main "$@"
+# Allow sourcing individual functions in tests without running the installer.
+if [ -z "${DR_INSTALL_SH_NO_MAIN:-}" ]; then
+    main "$@"
+fi

--- a/smoke_test_scripts/run_install_alias_test.sh
+++ b/smoke_test_scripts/run_install_alias_test.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Regression test for the 'datarobot' alias logic in install.sh (CFX-6634).
+#
+# In DataRobot Codespaces `dr` is installed as a *directory* on PATH, with the
+# binary at dr/dr. A prior bug used `ln -sf dr datarobot`; on the second
+# `dr self update` the existing `datarobot -> dr` symlink (to the directory) was
+# followed and the new link written *inside* it, turning dr/dr into a
+# self-referential `dr -> dr` symlink ("too many levels of symbolic links").
+#
+# These tests source install.sh (without running the installer) and exercise
+# ensure_datarobot_alias directly, asserting it never creates a self-loop.
+#
+# Usage:
+#   bash smoke_test_scripts/run_install_alias_test.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SCRIPT="$REPO_ROOT/install.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert() {
+    local label="$1"
+
+    if [ "$2" -eq 0 ]; then
+        echo "  ✅ $label"
+        PASS_COUNT=$((PASS_COUNT + 1))
+    else
+        echo "  ❌ $label"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+    fi
+}
+
+# Source install.sh function definitions without executing main.
+# shellcheck disable=SC1090
+DR_INSTALL_SH_NO_MAIN=1 . "$INSTALL_SCRIPT"
+
+BINARY_NAME="dr"
+
+# ──────────────────────────────────────────────────────────────
+# Test 1: Codespace directory layout — twice — never self-links dr/dr
+# ──────────────────────────────────────────────────────────────
+test_codespace_layout_no_self_link() {
+    echo ""
+    echo "TEST 1: Codespace dir layout (dr/dr) survives repeated alias creation"
+
+    INSTALL_DIR=$(mktemp -d /tmp/dr-alias-test.XXXXXX)
+    mkdir "$INSTALL_DIR/dr"
+    printf '#!/bin/sh\necho dr\n' > "$INSTALL_DIR/dr/dr"
+    chmod +x "$INSTALL_DIR/dr/dr"
+
+    # Run-1 then run-2 effect.
+    ensure_datarobot_alias
+    ensure_datarobot_alias
+
+    [ -f "$INSTALL_DIR/dr/dr" ] && [ ! -L "$INSTALL_DIR/dr/dr" ]
+    assert "dr/dr is still a real (non-symlink) file" $?
+
+    [ -L "$INSTALL_DIR/datarobot" ]
+    assert "datarobot is a symlink" $?
+
+    "$INSTALL_DIR/dr/dr" >/dev/null 2>&1
+    assert "dr/dr still executes (no 'too many levels of symbolic links')" $?
+
+    rm -rf "$INSTALL_DIR"
+}
+
+# ──────────────────────────────────────────────────────────────
+# Test 2: Flat layout — alias points at the dr binary, idempotent
+# ──────────────────────────────────────────────────────────────
+test_flat_layout() {
+    echo ""
+    echo "TEST 2: flat layout (dr file) — datarobot -> dr, idempotent"
+
+    INSTALL_DIR=$(mktemp -d /tmp/dr-alias-test.XXXXXX)
+    printf '#!/bin/sh\necho dr\n' > "$INSTALL_DIR/dr"
+    chmod +x "$INSTALL_DIR/dr"
+
+    ensure_datarobot_alias
+    ensure_datarobot_alias
+
+    [ -L "$INSTALL_DIR/datarobot" ] && [ "$(readlink "$INSTALL_DIR/datarobot")" = "dr" ]
+    assert "datarobot is a symlink -> dr" $?
+
+    "$INSTALL_DIR/datarobot" >/dev/null 2>&1
+    assert "datarobot alias executes the binary" $?
+
+    rm -rf "$INSTALL_DIR"
+}
+
+main() {
+    echo "╔══════════════════════════════════════════════════════════╗"
+    echo "║   install.sh — datarobot alias regression tests          ║"
+    echo "╚══════════════════════════════════════════════════════════╝"
+
+    test_codespace_layout_no_self_link
+    test_flat_layout
+
+    echo ""
+    echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+
+    if [ "$FAIL_COUNT" -gt 0 ]; then
+        echo "❌ Some tests failed."
+        exit 1
+    fi
+
+    echo "✅ All alias regression tests passed."
+}
+
+main "$@"


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

In DataRobot Codespaces, running `dr self update` twice left `dr` a self-referential symlink (`dr → dr`), breaking the CLI with "too many levels of symbolic links". Codespaces install `dr` as a directory on `PATH` (`dr/dr`) rather than a flat file; `install.sh`'s `ln -sf dr datarobot` then followed the `datarobot → dr` directory symlink on the second run and wrote the new link *inside* the directory, clobbering the real binary. This is critical (CFX-6634) since the CLI becomes unusable, and reproduces only in Codespaces.

## CHANGES

- `install.sh`: add `ensure_datarobot_alias()` using `rm -f` + `ln -sfn` so `ln` never dereferences a symlinked directory.
- `cmd/self/update`: pass `INSTALL_DIR` resolved from the running binary so updates land where `dr` actually lives.
- Add `resolveInstallDir` unit tests and an `install.sh` alias regression smoke test.

## NOTES

- Fix reaches users as soon as it merges to `main` (`dr self update` fetches `install.sh` from `main`); the Go change ships in the next build.
- Already-broken Codespaces recover by re-running the installer directly.

## TESTING

- `task lint` (0 issues), `go test -race ./cmd/self/...`, install alias + install integration smoke tests all pass.

## PR Automation

> [!IMPORTANT]
> **Forked PR:** the `run-smoke-tests` label won't work — a maintainer needs to `/approve-smoke-tests` or `/skip-smoke-tests` to clear the required Smoke Tests check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches self-update and install scripting paths that can brick the CLI if wrong, but changes are narrow and covered by unit and smoke tests.
> 
> **Overview**
> Fixes a **Codespaces-only** failure where a second `dr self update` could replace the real binary with a self-referential `dr → dr` symlink (“too many levels of symbolic links”).
> 
> **`install.sh`** centralizes alias creation in `ensure_datarobot_alias()`: remove any existing `datarobot` entry, then `ln -sfn` so `ln` does not follow a `datarobot → dr` directory symlink and write a link inside `dr/dr`. The script can be sourced for tests via `DR_INSTALL_SH_NO_MAIN`.
> 
> **`dr self update`** sets `INSTALL_DIR` from the running binary’s directory (symlinks resolved) when the user has not set `INSTALL_DIR`, so the fetched installer updates in place instead of defaulting to `~/.local/bin`.
> 
> Adds Go tests for `resolveInstallDir` and a shell smoke test for the alias behavior in Codespace vs flat layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ebb9088200798237542f9ef546a831a486ff35. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->