### PR TITLE
[CFX-6647] test(completion,windows): windows smoke tests for exercising `dr self completion install`

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -226,8 +226,10 @@ tasks:
     cmds:
       # Clear PSModulePath so powershell.exe (5.1) reconstructs its own module
       # path instead of inheriting pwsh 7's incompatible module paths.
+      # Taskfile uses mvdan/sh (POSIX sh), so we use env-prefix assignment
+      # syntax (not cmd.exe `set` or pwsh `$env:` syntax).
       # See: https://github.com/PowerShell/PowerShell/issues/18530#issuecomment-1325691850
-      - set "PSModulePath=" && powershell.exe -ExecutionPolicy Bypass -File ./smoke_test_scripts/windows/run_smoke_test.ps1 {{if .DR_API_TOKEN}}{{.DR_API_TOKEN}}{{else}}$env:DR_API_TOKEN{{end}}
+      - PSModulePath= powershell.exe -ExecutionPolicy Bypass -File ./smoke_test_scripts/windows/run_smoke_test.ps1 {{if .DR_API_TOKEN}}{{.DR_API_TOKEN}}{{else}}$env:DR_API_TOKEN{{end}}
 
   docs-serve:
     silent: true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -227,7 +227,7 @@ tasks:
       # Clear PSModulePath so powershell.exe (5.1) reconstructs its own module
       # path instead of inheriting pwsh 7's incompatible module paths.
       # See: https://github.com/PowerShell/PowerShell/issues/18530#issuecomment-1325691850
-      - $env:PSModulePath = ''; powershell.exe -ExecutionPolicy Bypass -File ./smoke_test_scripts/windows/run_smoke_test.ps1 {{if .DR_API_TOKEN}}{{.DR_API_TOKEN}}{{else}}$env:DR_API_TOKEN{{end}}
+      - set "PSModulePath=" && powershell.exe -ExecutionPolicy Bypass -File ./smoke_test_scripts/windows/run_smoke_test.ps1 {{if .DR_API_TOKEN}}{{.DR_API_TOKEN}}{{else}}$env:DR_API_TOKEN{{end}}
 
   docs-serve:
     silent: true

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -224,7 +224,10 @@ tasks:
   smoke-test-windows:
     desc: "Run smoke tests (Windows)"
     cmds:
-      - powershell.exe -ExecutionPolicy Bypass -File ./smoke_test_scripts/windows/run_smoke_test.ps1 {{if .DR_API_TOKEN}}{{.DR_API_TOKEN}}{{else}}$env:DR_API_TOKEN{{end}}
+      # Clear PSModulePath so powershell.exe (5.1) reconstructs its own module
+      # path instead of inheriting pwsh 7's incompatible module paths.
+      # See: https://github.com/PowerShell/PowerShell/issues/18530#issuecomment-1325691850
+      - $env:PSModulePath = ''; powershell.exe -ExecutionPolicy Bypass -File ./smoke_test_scripts/windows/run_smoke_test.ps1 {{if .DR_API_TOKEN}}{{.DR_API_TOKEN}}{{else}}$env:DR_API_TOKEN{{end}}
 
   docs-serve:
     silent: true

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -150,6 +150,54 @@ if (Test-Path $completion_file) {
 }
 Write-End
 
+# Test completion install under a fresh-machine execution policy.
+# This intentionally exposes the bug: dr self completion install writes a
+# profile that PowerShell refuses to load when the default Restricted policy
+# is in effect. The CLI does not yet fix the policy, so the assertion below
+# expects the policy to remain Restricted after install.
+Write-Delimiter "Testing dr self completion install (Restricted execution policy)"
+
+$originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
+
+# Simulate a fresh Windows machine where the default execution policy is Restricted.
+Set-ExecutionPolicy Restricted -Scope CurrentUser -Force
+
+# Run the completion installer. This is the exact user path that is broken.
+dr self completion install powershell --yes
+if ($LASTEXITCODE -ne 0) {
+    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "dr self completion install powershell --yes failed"
+}
+
+# Verify the completion profile was written.
+$profilePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
+if (-not (Test-Path $profilePath)) {
+    $profilePath = "$env:USERPROFILE\Documents\PowerShell\Microsoft.PowerShell_profile.ps1"
+}
+if (-not (Test-Path $profilePath)) {
+    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: PowerShell profile was not created"
+}
+$profileContent = Get-Content $profilePath -Raw
+if ($profileContent -notmatch "dr completion powershell") {
+    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: profile does not contain completion block"
+}
+Write-SuccessMsg "Assertion passed: profile written and contains completion block"
+
+# Verify the bug: the installer does NOT change the execution policy, so a
+# fresh machine remains Restricted and the profile will not load next session.
+$policy = Get-ExecutionPolicy -Scope CurrentUser
+if ($policy -ne "Restricted") {
+    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: expected execution policy to remain Restricted (proving the bug), but it is '$policy'"
+}
+Write-SuccessMsg "Assertion passed: execution policy remains '$policy' after install, confirming the bug"
+
+# Restore the original policy so the rest of the smoke test is not affected.
+Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+Write-End
+
 # Test dr run command
 Write-Delimiter "Testing dr run command"
 dr run

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -25,6 +25,7 @@ function Write-InfoMsg {
     Write-Host $Message
 }
 
+# Prints a section header banner centered around the given message.
 function Write-Delimiter {
     param([string]$Message)
     Write-Host ""
@@ -35,6 +36,7 @@ function Write-Delimiter {
     Write-Host ("=" * 20)
 }
 
+# Prints a closing END banner to delimit test sections.
 function Write-End {
     Write-Host ("=" * 20) -NoNewline
     Write-Host " END " -NoNewline
@@ -51,6 +53,7 @@ function Test-URLAccessible {
     }
 }
 
+# Installs PowerShell completions under a given execution policy and asserts warning behavior, profile contents, and policy preservation.
 function Test-DRCompletionInstallWithExecutionPolicy {
     param(
         [string]$TestName,
@@ -59,9 +62,11 @@ function Test-DRCompletionInstallWithExecutionPolicy {
         [bool]$ExpectWarning
     )
 
+    # Save the current policy so it can be restored after the test, then apply the policy under test.
     $originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
     Set-ExecutionPolicy $Policy -Scope CurrentUser -Force
 
+    # Run the installer and fail fast if it exits non-zero.
     $installOutput = (dr self completion install powershell --yes 2>&1 | Out-String)
     $installExitCode = $LASTEXITCODE
     if ($installExitCode -ne 0) {
@@ -69,6 +74,7 @@ function Test-DRCompletionInstallWithExecutionPolicy {
         Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCode"
     }
 
+    # Assert the installer warned (or did not warn) about the execution policy fix command.
     $fixCommand = "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser"
     $hasWarning = $installOutput -match $fixCommand
 
@@ -84,8 +90,7 @@ function Test-DRCompletionInstallWithExecutionPolicy {
 
     Write-SuccessMsg "Assertion passed [$TestName]: warning behavior correct"
 
-    # Match the order used by the Go installer: prefer PowerShell Core if the
-    # directory exists, otherwise fall back to Windows PowerShell.
+    # Resolve the PowerShell profile path, preferring PowerShell Core over Windows PowerShell (matches the Go installer).
     $documentsPath = "$env:USERPROFILE\Documents"
     $psCoreDir = Join-Path $documentsPath "PowerShell"
     $windowsPsDir = Join-Path $documentsPath "WindowsPowerShell"
@@ -96,6 +101,7 @@ function Test-DRCompletionInstallWithExecutionPolicy {
         $profilePath = Join-Path $windowsPsDir "Microsoft.PowerShell_profile.ps1"
     }
 
+    # Assert the profile exists and contains the dr completion block.
     if (-not (Test-Path $profilePath)) {
         Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
         Write-ErrorMsg "Assertion failed: PowerShell profile was not found at $profilePath"
@@ -109,6 +115,7 @@ function Test-DRCompletionInstallWithExecutionPolicy {
 
     Write-SuccessMsg "Assertion passed: profile contains completion block"
 
+    # Assert the execution policy was not modified by the installer.
     $actualPolicy = Get-ExecutionPolicy -Scope CurrentUser
     if ($actualPolicy -ne $ExpectedPolicy) {
         Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
@@ -117,6 +124,7 @@ function Test-DRCompletionInstallWithExecutionPolicy {
 
     Write-SuccessMsg "Assertion passed [$TestName]: execution policy remains '$actualPolicy'"
 
+    # Restore the original execution policy.
     Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
 }
 

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -71,43 +71,21 @@ function Test-DRCompletionInstallWithExecutionPolicy {
         [bool]$ExpectWarning
     )
 
+    # Guard: Get-ExecutionPolicy may not be available on every PowerShell
+    # build (e.g. some Windows Server 2025 runner images fail to auto-load
+    # the Microsoft.PowerShell.Security module).  Skip gracefully instead of
+    # crashing the entire smoke-test suite.
+    try {
+        $null = Get-ExecutionPolicy -Scope CurrentUser -ErrorAction Stop
+    } catch {
+        Write-InfoMsg "Skipping [$TestName]: Get-ExecutionPolicy cmdlet not available on this system."
+
+        return
+    }
+
     # Save the current policy so it can be restored after the test, then apply the policy under test.
     $originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
     Set-ExecutionPolicy $Policy -Scope CurrentUser -Force
-
-    # Run the installer and fail fast if it exits non-zero.
-    $installOutput = (dr self completion install powershell --yes 2>&1 | Out-String)
-    $installExitCode = $LASTEXITCODE
-    if ($installExitCode -ne 0) {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCode"
-    }
-
-    # Assert the installer warned (or did not warn) about the execution policy fix command.
-    $fixCommand = "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser"
-    $hasWarning = $installOutput -match $fixCommand
-
-    if ($ExpectWarning -and -not $hasWarning) {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-
-        # XFAIL: when testing Restricted policy without the Phase 2 Go fix,
-        # the warning is expected to be absent. Track as an expected failure
-        # instead of a hard error. Remove this branch when Phase 2 lands.
-        $isXFail = $ExpectWarning -and ($Policy -eq "Restricted")
-
-        if ($isXFail) {
-            Write-XFailMsg "Assertion xfail [$TestName]: installer did not warn user with the execution policy fix command (expected: Phase 2 not yet merged)"
-        } else {
-            Write-ErrorMsg "Assertion failed [$TestName]: installer did not warn user with the execution policy fix command"
-        }
-    }
-
-    if (-not $ExpectWarning -and $hasWarning) {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "Assertion failed [$TestName]: installer warned about execution policy when policy was already permissive"
-    }
-
-    Write-SuccessMsg "Assertion passed [$TestName]: warning behavior correct"
 
     # Resolve the PowerShell profile path, preferring PowerShell Core over Windows PowerShell (matches the Go installer).
     $documentsPath = "$env:USERPROFILE\Documents"
@@ -119,6 +97,50 @@ function Test-DRCompletionInstallWithExecutionPolicy {
     } else {
         $profilePath = Join-Path $windowsPsDir "Microsoft.PowerShell_profile.ps1"
     }
+
+    # Clean up any existing profile from a previous test so each run starts fresh.
+    if (Test-Path $profilePath) {
+        Remove-Item $profilePath -Force -ErrorAction SilentlyContinue
+    }
+
+    # Run the installer with --force so each invocation performs a real install.
+    $installOutput = (dr self completion install powershell --yes --force 2>&1 | Out-String)
+    $installExitCode = $LASTEXITCODE
+    if ($installExitCode -ne 0) {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "dr self completion install powershell --yes --force failed with exit code $installExitCode"
+    }
+
+    # Assert the installer warned (or did not warn) about the execution policy fix command.
+    $fixCommand = "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser"
+    $hasWarning = $installOutput -match $fixCommand
+
+    if ($ExpectWarning -and -not $hasWarning) {
+        # XFAIL: when testing Restricted policy without the Phase 2 Go fix,
+        # the warning is expected to be absent. Track as an expected failure
+        # and return early — the remaining assertions (profile, policy) are
+        # not meaningful when the warning behavior isn't yet implemented.
+        # Remove this branch when Phase 2 lands.
+        $isXFail = $ExpectWarning -and ($Policy -eq "Restricted")
+
+        if ($isXFail) {
+            Write-XFailMsg "Assertion xfail [$TestName]: installer did not warn user with the execution policy fix command (expected: Phase 2 not yet merged)"
+            Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+            if (Test-Path $profilePath) { Remove-Item $profilePath -Force -ErrorAction SilentlyContinue }
+
+            return
+        }
+
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed [$TestName]: installer did not warn user with the execution policy fix command"
+    }
+
+    if (-not $ExpectWarning -and $hasWarning) {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed [$TestName]: installer warned about execution policy when policy was already permissive"
+    }
+
+    Write-SuccessMsg "Assertion passed [$TestName]: warning behavior correct"
 
     # Assert the profile exists and contains the dr completion block.
     if (-not (Test-Path $profilePath)) {
@@ -143,8 +165,9 @@ function Test-DRCompletionInstallWithExecutionPolicy {
 
     Write-SuccessMsg "Assertion passed [$TestName]: execution policy remains '$actualPolicy'"
 
-    # Restore the original execution policy.
+    # Restore the original execution policy and clean up the profile.
     Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    if (Test-Path $profilePath) { Remove-Item $profilePath -Force -ErrorAction SilentlyContinue }
 }
 
 # Main execution

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -51,39 +51,6 @@ function Test-URLAccessible {
     }
 }
 
-function Get-DRCompletionProfilePath {
-    # Match the order used by the Go installer: prefer PowerShell Core if the
-    # directory exists, otherwise fall back to Windows PowerShell.
-    $documentsPath = "$env:USERPROFILE\Documents"
-    $psCoreDir = Join-Path $documentsPath "PowerShell"
-    $windowsPsDir = Join-Path $documentsPath "WindowsPowerShell"
-
-    if (Test-Path $psCoreDir) {
-        return Join-Path $psCoreDir "Microsoft.PowerShell_profile.ps1"
-    }
-    return Join-Path $windowsPsDir "Microsoft.PowerShell_profile.ps1"
-}
-
-function Test-DRCompletionProfile {
-    param(
-        [string]$ProfilePath,
-        [string]$OriginalPolicy
-    )
-
-    if (-not (Test-Path $ProfilePath)) {
-        Set-ExecutionPolicy $OriginalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "Assertion failed: PowerShell profile was not found at $ProfilePath"
-    }
-
-    $profileContent = Get-Content $ProfilePath -Raw
-    if ($profileContent -notmatch "dr completion powershell") {
-        Set-ExecutionPolicy $OriginalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "Assertion failed: profile does not contain completion block"
-    }
-
-    Write-SuccessMsg "Assertion passed: profile contains completion block"
-}
-
 function Test-DRCompletionInstallWithExecutionPolicy {
     param(
         [string]$TestName,
@@ -117,8 +84,30 @@ function Test-DRCompletionInstallWithExecutionPolicy {
 
     Write-SuccessMsg "Assertion passed [$TestName]: warning behavior correct"
 
-    $profilePath = Get-DRCompletionProfilePath
-    Test-DRCompletionProfile -ProfilePath $profilePath -OriginalPolicy $originalPolicy
+    # Match the order used by the Go installer: prefer PowerShell Core if the
+    # directory exists, otherwise fall back to Windows PowerShell.
+    $documentsPath = "$env:USERPROFILE\Documents"
+    $psCoreDir = Join-Path $documentsPath "PowerShell"
+    $windowsPsDir = Join-Path $documentsPath "WindowsPowerShell"
+
+    if (Test-Path $psCoreDir) {
+        $profilePath = Join-Path $psCoreDir "Microsoft.PowerShell_profile.ps1"
+    } else {
+        $profilePath = Join-Path $windowsPsDir "Microsoft.PowerShell_profile.ps1"
+    }
+
+    if (-not (Test-Path $profilePath)) {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed: PowerShell profile was not found at $profilePath"
+    }
+
+    $profileContent = Get-Content $profilePath -Raw
+    if ($profileContent -notmatch "dr completion powershell") {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed: profile does not contain completion block"
+    }
+
+    Write-SuccessMsg "Assertion passed: profile contains completion block"
 
     $actualPolicy = Get-ExecutionPolicy -Scope CurrentUser
     if ($actualPolicy -ne $ExpectedPolicy) {

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -76,18 +76,22 @@ function Test-DRCompletionInstallWithExecutionPolicy {
     # the Microsoft.PowerShell.Security module).  Skip gracefully instead of
     # crashing the entire smoke-test suite.
     try {
-        $null = Get-ExecutionPolicy -Scope CurrentUser -ErrorAction Stop
+        $null = Get-ExecutionPolicy -ErrorAction Stop
     } catch {
         Write-InfoMsg "Skipping [$TestName]: Get-ExecutionPolicy cmdlet not available on this system."
 
         return
     }
 
-    # Save the current policy so it can be restored after the test, then apply the policy under test.
-    $originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
+    # Save the current effective policy so it can be restored after the test.
+    # Use -Scope Process for Set-ExecutionPolicy so we don't touch the registry
+    # (some CI runners lock down CurrentUser/Machine policy via Group Policy).
+    # Get-ExecutionPolicy (no -Scope) returns the effective policy, which
+    # correctly reflects the Process-scope override.
+    $originalPolicy = Get-ExecutionPolicy
 
     try {
-        Set-ExecutionPolicy $Policy -Scope CurrentUser -Force -ErrorAction Stop
+        Set-ExecutionPolicy $Policy -Scope Process -Force -ErrorAction Stop
     } catch {
         Write-InfoMsg "Skipping [$TestName]: unable to set execution policy to $Policy."
 
@@ -119,7 +123,7 @@ function Test-DRCompletionInstallWithExecutionPolicy {
     $installExitCode = $LASTEXITCODE
     $ErrorActionPreference = $prevEAP
     if ($installExitCode -ne 0) {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
         Write-ErrorMsg "dr self completion install powershell --yes --force failed with exit code $installExitCode"
     }
 
@@ -137,18 +141,18 @@ function Test-DRCompletionInstallWithExecutionPolicy {
 
         if ($isXFail) {
             Write-XFailMsg "Assertion xfail [$TestName]: installer did not warn user with the execution policy fix command (expected: Phase 2 not yet merged)"
-            Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+            Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
             if (Test-Path $profilePath) { Remove-Item $profilePath -Force -ErrorAction SilentlyContinue }
 
             return
         }
 
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
         Write-ErrorMsg "Assertion failed [$TestName]: installer did not warn user with the execution policy fix command"
     }
 
     if (-not $ExpectWarning -and $hasWarning) {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
         Write-ErrorMsg "Assertion failed [$TestName]: installer warned about execution policy when policy was already permissive"
     }
 
@@ -156,29 +160,29 @@ function Test-DRCompletionInstallWithExecutionPolicy {
 
     # Assert the profile exists and contains the dr completion block.
     if (-not (Test-Path $profilePath)) {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
         Write-ErrorMsg "Assertion failed: PowerShell profile was not found at $profilePath"
     }
 
     $profileContent = Get-Content $profilePath -Raw
     if ($profileContent -notmatch "dr completion powershell") {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
         Write-ErrorMsg "Assertion failed: profile does not contain completion block"
     }
 
     Write-SuccessMsg "Assertion passed: profile contains completion block"
 
     # Assert the execution policy was not modified by the installer.
-    $actualPolicy = Get-ExecutionPolicy -Scope CurrentUser
+    $actualPolicy = Get-ExecutionPolicy
     if ($actualPolicy -ne $ExpectedPolicy) {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
         Write-ErrorMsg "Assertion failed [$TestName]: expected execution policy to be $ExpectedPolicy, but it is '$actualPolicy'"
     }
 
     Write-SuccessMsg "Assertion passed [$TestName]: execution policy remains '$actualPolicy'"
 
     # Restore the original execution policy and clean up the profile.
-    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
     if (Test-Path $profilePath) { Remove-Item $profilePath -Force -ErrorAction SilentlyContinue }
 }
 

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -5,12 +5,21 @@ $DR_API_TOKEN = $args[0]
 
 $ErrorActionPreference = "Stop"
 
+$global:XFailCount = 0
+
 function Write-ErrorMsg {
     param([string]$Message)
     Write-Host "[ERROR] " -NoNewline -ForegroundColor Red
     Write-Host $Message
     Write-Host ""
     exit 1
+}
+
+function Write-XFailMsg {
+    param([string]$Message)
+    Write-Host "[XFAIL] " -NoNewline -ForegroundColor Yellow
+    Write-Host $Message
+    $global:XFailCount++
 }
 
 function Write-SuccessMsg {
@@ -80,7 +89,17 @@ function Test-DRCompletionInstallWithExecutionPolicy {
 
     if ($ExpectWarning -and -not $hasWarning) {
         Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "Assertion failed [$TestName]: installer did not warn user with the execution policy fix command"
+
+        # XFAIL: when testing Restricted policy without the Phase 2 Go fix,
+        # the warning is expected to be absent. Track as an expected failure
+        # instead of a hard error. Remove this branch when Phase 2 lands.
+        $isXFail = $ExpectWarning -and ($Policy -eq "Restricted")
+
+        if ($isXFail) {
+            Write-XFailMsg "Assertion xfail [$TestName]: installer did not warn user with the execution policy fix command (expected: Phase 2 not yet merged)"
+        } else {
+            Write-ErrorMsg "Assertion failed [$TestName]: installer did not warn user with the execution policy fix command"
+        }
     }
 
     if (-not $ExpectWarning -and $hasWarning) {
@@ -325,6 +344,14 @@ if (-not $url_accessible) {
     Write-InfoMsg "Testing template setup would require interactive input..."
     Write-InfoMsg "Skipping template clone test on Windows (requires interactive expect-like tool)"
     Write-End
+}
+
+if ($global:XFailCount -gt 0) {
+    Write-Host ""
+    Write-Host ("=" * 20) -NoNewline
+    Write-Host " XFAIL SUMMARY " -NoNewline -ForegroundColor Yellow
+    Write-Host ("=" * 20)
+    Write-Host "$global:XFailCount expected failure(s) (xfail) -- these will pass after Phase 2 (CFX-6647 Go fix) is merged."
 }
 
 Write-SuccessMsg "Smoke tests for Windows completed successfully."

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -51,6 +51,86 @@ function Test-URLAccessible {
     }
 }
 
+function Get-DRCompletionProfilePath {
+    # Match the order used by the Go installer: prefer PowerShell Core if the
+    # directory exists, otherwise fall back to Windows PowerShell.
+    $documentsPath = "$env:USERPROFILE\Documents"
+    $psCoreDir = Join-Path $documentsPath "PowerShell"
+    $windowsPsDir = Join-Path $documentsPath "WindowsPowerShell"
+
+    if (Test-Path $psCoreDir) {
+        return Join-Path $psCoreDir "Microsoft.PowerShell_profile.ps1"
+    }
+    return Join-Path $windowsPsDir "Microsoft.PowerShell_profile.ps1"
+}
+
+function Test-DRCompletionProfile {
+    param(
+        [string]$ProfilePath,
+        [string]$OriginalPolicy
+    )
+
+    if (-not (Test-Path $ProfilePath)) {
+        Set-ExecutionPolicy $OriginalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed: PowerShell profile was not found at $ProfilePath"
+    }
+
+    $profileContent = Get-Content $ProfilePath -Raw
+    if ($profileContent -notmatch "dr completion powershell") {
+        Set-ExecutionPolicy $OriginalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed: profile does not contain completion block"
+    }
+
+    Write-SuccessMsg "Assertion passed: profile contains completion block"
+}
+
+function Test-DRCompletionInstallWithExecutionPolicy {
+    param(
+        [string]$TestName,
+        [string]$Policy,
+        [string]$ExpectedPolicy,
+        [bool]$ExpectWarning
+    )
+
+    $originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
+    Set-ExecutionPolicy $Policy -Scope CurrentUser -Force
+
+    $installOutput = (dr self completion install powershell --yes 2>&1 | Out-String)
+    $installExitCode = $LASTEXITCODE
+    if ($installExitCode -ne 0) {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCode"
+    }
+
+    $fixCommand = "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser"
+    $hasWarning = $installOutput -match $fixCommand
+
+    if ($ExpectWarning -and -not $hasWarning) {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed [$TestName]: installer did not warn user with the execution policy fix command"
+    }
+
+    if (-not $ExpectWarning -and $hasWarning) {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed [$TestName]: installer warned about execution policy when policy was already permissive"
+    }
+
+    Write-SuccessMsg "Assertion passed [$TestName]: warning behavior correct"
+
+    $profilePath = Get-DRCompletionProfilePath
+    Test-DRCompletionProfile -ProfilePath $profilePath -OriginalPolicy $originalPolicy
+
+    $actualPolicy = Get-ExecutionPolicy -Scope CurrentUser
+    if ($actualPolicy -ne $ExpectedPolicy) {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed [$TestName]: expected execution policy to be $ExpectedPolicy, but it is '$actualPolicy'"
+    }
+
+    Write-SuccessMsg "Assertion passed [$TestName]: execution policy remains '$actualPolicy'"
+
+    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+}
+
 # Main execution
 Write-Host 'Running smoke tests for Windows...'
 
@@ -155,105 +235,13 @@ Write-End
 # default Restricted policy and print the exact command to fix it, but it should
 # not modify the policy itself.
 Write-Delimiter "Testing dr self completion install (Restricted execution policy)"
-
-$originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
-
-# Simulate a fresh Windows machine where the default execution policy is Restricted.
-Set-ExecutionPolicy Restricted -Scope CurrentUser -Force
-
-# Run the completion installer and capture its output so we can verify the warning.
-$installOutput = (dr self completion install powershell --yes 2>&1 | Out-String)
-$installExitCode = $LASTEXITCODE
-if ($installExitCode -ne 0) {
-    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCode"
-}
-
-# Verify the installer warned the user with the exact fix command.
-if ($installOutput -notmatch "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser") {
-    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: installer did not warn user with the execution policy fix command"
-}
-Write-SuccessMsg "Assertion passed: installer warned about Restricted execution policy"
-
-# Verify the completion profile was written.
-$profilePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
-if (-not (Test-Path $profilePath)) {
-    $profilePath = "$env:USERPROFILE\Documents\PowerShell\Microsoft.PowerShell_profile.ps1"
-}
-if (-not (Test-Path $profilePath)) {
-    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: PowerShell profile was not created"
-}
-$profileContent = Get-Content $profilePath -Raw
-if ($profileContent -notmatch "dr completion powershell") {
-    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: profile does not contain completion block"
-}
-Write-SuccessMsg "Assertion passed: profile written and contains completion block"
-
-# Verify the policy remains unchanged (warn-only behavior; the fix is left to the user).
-$policy = Get-ExecutionPolicy -Scope CurrentUser
-if ($policy -ne "Restricted") {
-    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: expected execution policy to remain Restricted (warn-only), but it is '$policy'"
-}
-Write-SuccessMsg "Assertion passed: execution policy remains '$policy' (installer only warned)"
-
-# Restore the original policy so the rest of the smoke test is not affected.
-Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+Test-DRCompletionInstallWithExecutionPolicy -TestName "Restricted" -Policy "Restricted" -ExpectedPolicy "Restricted" -ExpectWarning $true
 Write-End
 
 # Test completion install under a permissive execution policy.
 # The installer should complete silently without warning the user.
 Write-Delimiter "Testing dr self completion install (permissive execution policy)"
-
-$originalPolicyPermissive = Get-ExecutionPolicy -Scope CurrentUser
-
-# Simulate a machine where the user has already relaxed the execution policy.
-Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-
-# Run the completion installer and capture its output.
-$installOutputPermissive = (dr self completion install powershell --yes 2>&1 | Out-String)
-$installExitCodePermissive = $LASTEXITCODE
-if ($installExitCodePermissive -ne 0) {
-    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCodePermissive"
-}
-
-# Verify the installer did NOT warn about execution policy.
-if ($installOutputPermissive -match "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser") {
-    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: installer warned about execution policy when policy was already permissive"
-}
-Write-SuccessMsg "Assertion passed: installer did not warn when execution policy is permissive"
-
-# Verify the completion profile exists and contains the completion block.
-$profilePathPermissive = "$env:USERPROFILE\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
-if (-not (Test-Path $profilePathPermissive)) {
-    $profilePathPermissive = "$env:USERPROFILE\Documents\PowerShell\Microsoft.PowerShell_profile.ps1"
-}
-if (-not (Test-Path $profilePathPermissive)) {
-    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: PowerShell profile was not found"
-}
-$profileContentPermissive = Get-Content $profilePathPermissive -Raw
-if ($profileContentPermissive -notmatch "dr completion powershell") {
-    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: profile does not contain completion block"
-}
-Write-SuccessMsg "Assertion passed: profile contains completion block"
-
-# Verify the policy remains unchanged.
-$policyPermissive = Get-ExecutionPolicy -Scope CurrentUser
-if ($policyPermissive -ne "RemoteSigned") {
-    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: expected execution policy to remain RemoteSigned, but it is '$policyPermissive'"
-}
-Write-SuccessMsg "Assertion passed: execution policy remains '$policyPermissive'"
-
-# Restore the original policy.
-Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+Test-DRCompletionInstallWithExecutionPolicy -TestName "RemoteSigned" -Policy "RemoteSigned" -ExpectedPolicy "RemoteSigned" -ExpectWarning $false
 Write-End
 
 # Test dr run command

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -204,6 +204,58 @@ Write-SuccessMsg "Assertion passed: execution policy remains '$policy' (installe
 Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
 Write-End
 
+# Test completion install under a permissive execution policy.
+# The installer should complete silently without warning the user.
+Write-Delimiter "Testing dr self completion install (permissive execution policy)"
+
+$originalPolicyPermissive = Get-ExecutionPolicy -Scope CurrentUser
+
+# Simulate a machine where the user has already relaxed the execution policy.
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+
+# Run the completion installer and capture its output.
+$installOutputPermissive = (dr self completion install powershell --yes 2>&1 | Out-String)
+$installExitCodePermissive = $LASTEXITCODE
+if ($installExitCodePermissive -ne 0) {
+    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCodePermissive"
+}
+
+# Verify the installer did NOT warn about execution policy.
+if ($installOutputPermissive -match "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser") {
+    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: installer warned about execution policy when policy was already permissive"
+}
+Write-SuccessMsg "Assertion passed: installer did not warn when execution policy is permissive"
+
+# Verify the completion profile exists and contains the completion block.
+$profilePathPermissive = "$env:USERPROFILE\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
+if (-not (Test-Path $profilePathPermissive)) {
+    $profilePathPermissive = "$env:USERPROFILE\Documents\PowerShell\Microsoft.PowerShell_profile.ps1"
+}
+if (-not (Test-Path $profilePathPermissive)) {
+    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: PowerShell profile was not found"
+}
+$profileContentPermissive = Get-Content $profilePathPermissive -Raw
+if ($profileContentPermissive -notmatch "dr completion powershell") {
+    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: profile does not contain completion block"
+}
+Write-SuccessMsg "Assertion passed: profile contains completion block"
+
+# Verify the policy remains unchanged.
+$policyPermissive = Get-ExecutionPolicy -Scope CurrentUser
+if ($policyPermissive -ne "RemoteSigned") {
+    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: expected execution policy to remain RemoteSigned, but it is '$policyPermissive'"
+}
+Write-SuccessMsg "Assertion passed: execution policy remains '$policyPermissive'"
+
+# Restore the original policy.
+Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+Write-End
+
 # Test dr run command
 Write-Delimiter "Testing dr run command"
 dr run

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -85,7 +85,14 @@ function Test-DRCompletionInstallWithExecutionPolicy {
 
     # Save the current policy so it can be restored after the test, then apply the policy under test.
     $originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
-    Set-ExecutionPolicy $Policy -Scope CurrentUser -Force
+
+    try {
+        Set-ExecutionPolicy $Policy -Scope CurrentUser -Force -ErrorAction Stop
+    } catch {
+        Write-InfoMsg "Skipping [$TestName]: unable to set execution policy to $Policy."
+
+        return
+    }
 
     # Resolve the PowerShell profile path, preferring PowerShell Core over Windows PowerShell (matches the Go installer).
     $documentsPath = "$env:USERPROFILE\Documents"
@@ -104,8 +111,13 @@ function Test-DRCompletionInstallWithExecutionPolicy {
     }
 
     # Run the installer with --force so each invocation performs a real install.
+    # Relax EAP to "Continue" so stderr lines from the native command are
+    # captured, not thrown (same pattern as the --debug test above).
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
     $installOutput = (dr self completion install powershell --yes --force 2>&1 | Out-String)
     $installExitCode = $LASTEXITCODE
+    $ErrorActionPreference = $prevEAP
     if ($installExitCode -ne 0) {
         Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
         Write-ErrorMsg "dr self completion install powershell --yes --force failed with exit code $installExitCode"

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -151,10 +151,9 @@ if (Test-Path $completion_file) {
 Write-End
 
 # Test completion install under a fresh-machine execution policy.
-# This intentionally exposes the bug: dr self completion install writes a
-# profile that PowerShell refuses to load when the default Restricted policy
-# is in effect. The CLI does not yet fix the policy, so the assertion below
-# expects the policy to remain Restricted after install.
+# The installer should warn the user that the profile will not load under the
+# default Restricted policy and print the exact command to fix it, but it should
+# not modify the policy itself.
 Write-Delimiter "Testing dr self completion install (Restricted execution policy)"
 
 $originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
@@ -162,12 +161,20 @@ $originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
 # Simulate a fresh Windows machine where the default execution policy is Restricted.
 Set-ExecutionPolicy Restricted -Scope CurrentUser -Force
 
-# Run the completion installer. This is the exact user path that is broken.
-dr self completion install powershell --yes
-if ($LASTEXITCODE -ne 0) {
+# Run the completion installer and capture its output so we can verify the warning.
+$installOutput = (dr self completion install powershell --yes 2>&1 | Out-String)
+$installExitCode = $LASTEXITCODE
+if ($installExitCode -ne 0) {
     Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "dr self completion install powershell --yes failed"
+    Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCode"
 }
+
+# Verify the installer warned the user with the exact fix command.
+if ($installOutput -notmatch "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser") {
+    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: installer did not warn user with the execution policy fix command"
+}
+Write-SuccessMsg "Assertion passed: installer warned about Restricted execution policy"
 
 # Verify the completion profile was written.
 $profilePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
@@ -185,14 +192,13 @@ if ($profileContent -notmatch "dr completion powershell") {
 }
 Write-SuccessMsg "Assertion passed: profile written and contains completion block"
 
-# Verify the bug: the installer does NOT change the execution policy, so a
-# fresh machine remains Restricted and the profile will not load next session.
+# Verify the policy remains unchanged (warn-only behavior; the fix is left to the user).
 $policy = Get-ExecutionPolicy -Scope CurrentUser
 if ($policy -ne "Restricted") {
     Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: expected execution policy to remain Restricted (proving the bug), but it is '$policy'"
+    Write-ErrorMsg "Assertion failed: expected execution policy to remain Restricted (warn-only), but it is '$policy'"
 }
-Write-SuccessMsg "Assertion passed: execution policy remains '$policy' after install, confirming the bug"
+Write-SuccessMsg "Assertion passed: execution policy remains '$policy' (installer only warned)"
 
 # Restore the original policy so the rest of the smoke test is not affected.
 Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
# RATIONALE

On a fresh Windows machine, `dr self completion install` writes a PowerShell profile that won't load under the default `Restricted` execution policy. This smoke test proves the bug by exercising `dr self completion install powershell --yes` under both `Restricted` and `RemoteSigned` policies.

The Restricted-policy warning assertion is marked as **xfail** (expected failure) — it will pass once Phase 2 (CFX-6647-phase2, the Go fix in #702) is merged. CI stays green.

Related: CFX-6647

## CHANGES

Adds Windows smoke test coverage for `dr self completion install` with execution policy handling:

- `Test-DRCompletionInstallWithExecutionPolicy` function with parametrized policy, warning expectation, and xfail support
- Tests under `Restricted` policy: expects `Write-XFailMsg` (warning not yet emitted; will pass after Phase 2)
- Tests under `RemoteSigned` policy: expects silent completion (no warning)
- Asserts profile is created with completion blocks
- Asserts the installer never mutates the execution policy
- `Write-XFailMsg` helper logs expected failures in yellow without exiting
- `$global:XFailCount` tracks expected failures for a summary at the end
- `exit 0` even when xfail assertions fire

### Taskfile fix: PSModulePath clearing

GitHub Actions `windows-latest` runners use `pwsh` (PowerShell 7) as the default shell. When `task` launches `powershell.exe` (5.1) via the Taskfile, it inherits pwsh 7's `PSModulePath`, which contains incompatible PowerShell 7 module paths. This causes `Microsoft.PowerShell.Security` to fail to load and `Get-ExecutionPolicy` to be unavailable.

Fix: `PSModulePath= powershell.exe ...` (POSIX env-prefix assignment, since Taskfile uses mvdan/sh) clears the env var so 5.1 reconstructs its own default module path.

Ref: https://github.com/PowerShell/PowerShell/issues/18530#issuecomment-1325691850
Ref: https://github.com/actions/runner-images/issues/13221

### Execution policy scope: Process instead of CurrentUser

`Set-ExecutionPolicy -Scope CurrentUser` fails on GHA Windows runners (Group Policy locks down registry-based policy changes). Switched to `-Scope Process`, which only affects the current PowerShell session and doesn't touch the registry. `Get-ExecutionPolicy` (effective, no `-Scope`) correctly reflects the Process-scope override.

The `$fixCommand` string literal still says `-Scope CurrentUser` — that's the user-facing advice the Go installer should print (users should set it at CurrentUser scope, not Process scope).

### Safeguards

- `Get-ExecutionPolicy` guard: try/catch to skip gracefully if the security module can't load
- `Set-ExecutionPolicy` guard: try/catch to skip gracefully if the runner restricts policy changes
- `--force` flag on installer: ensures real install each time instead of short-circuiting on existing profile
- Profile cleanup before/after each test for isolation
- EAP relaxation around installer call (consistent with the `--debug` test pattern)

## TESTING

- Windows smoke test CI: `task smoke-test-windows` exercises the full flow
- CI run verified: Restricted test xfails correctly, RemoteSigned test passes all assertions (warning behavior, profile creation, policy preservation)

```
==================== Testing dr self completion install (Restricted execution policy) ====================
[XFAIL] Assertion xfail [Restricted]: installer did not warn user with the execution policy fix command (expected: Phase 2 not yet merged)

==================== Testing dr self completion install (permissive execution policy) ====================
[OK] Assertion passed [RemoteSigned]: warning behavior correct
[OK] Assertion passed: profile contains completion block
[OK] Assertion passed [RemoteSigned]: execution policy remains 'RemoteSigned'

==================== XFAIL SUMMARY ====================
1 expected failure(s) (xfail) -- these will pass after Phase 2 (CFX-6647 Go fix) is merged.
[OK] Smoke tests for Windows completed successfully.
```

## NOTES

- **Follow-up needed**: Add pwsh 7 (PowerShell Core) smoke test coverage. Currently only `powershell.exe` (5.1) is tested. Real users may have either version, and profile paths, module availability, and execution policy handling differ between them.
- **Phase 2 dependency**: The XFAIL for the Restricted warning assertion will become a hard failure once #702 is merged. At that point, remove the `$isXFail` branch and the XFAIL summary logic.
- **PSModulePath fix is in the Taskfile** (not the script) because that's where `powershell.exe` is launched from the pwsh parent. The fix applies to anyone running `task smoke-test-windows` from a pwsh 7 terminal, not just CI.

## RELATED

- #702 — Phase 2 Go fix: warn Windows users when execution policy blocks PowerShell profile
- #689 — Add windows-latest to the unit-test CI matrix (no conflict; different Taskfile tasks)

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.
<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784844142.385159 -->
<!-- rr:slack:end -->