### PR TITLE
Made it so `optional: true` no longer ask even if they have empty values

### DIFF
--- a/cmd/dotenv/model_test.go
+++ b/cmd/dotenv/model_test.go
@@ -426,9 +426,10 @@ func (suite *DotenvModelTestSuite) Test__externalEditorCmd() {
 }
 
 func (suite *DotenvModelTestSuite) TestDotenvModel_SkipsPromptsWithDefaults() {
-	// This test validates that prompts with default values are skipped
-	// The first prompt (PULUMI_CONFIG_PASSPHRASE) has default: 123, so it should be skipped
-	// The wizard should start directly at DATAROBOT_DEFAULT_USE_CASE
+	// This test validates that prompts are skipped when:
+	//   - they have a default value (PULUMI_CONFIG_PASSPHRASE: default: 123)
+	//   - they are optional with an empty default (DATAROBOT_DEFAULT_USE_CASE: optional: true, default: "")
+	// The wizard should skip both and start directly at data_source.
 	tm := suite.NewTestModel(Model{
 		screen:         wizardScreen,
 		initialScreen:  wizardScreen,
@@ -436,11 +437,8 @@ func (suite *DotenvModelTestSuite) TestDotenvModel_SkipsPromptsWithDefaults() {
 		ShowAllPrompts: false, // Default behavior - skip prompts with defaults
 	})
 
-	// Should skip PULUMI_CONFIG_PASSPHRASE and start at DATAROBOT_DEFAULT_USE_CASE
-	suite.WaitFor(tm, "The default use case for this application")
-	suite.Send(tm, "my_use_case", "enter")
-
-	// Leave data source blank
+	// Should skip PULUMI_CONFIG_PASSPHRASE (has default) and DATAROBOT_DEFAULT_USE_CASE
+	// (optional + empty default), starting directly at data_source.
 	suite.WaitFor(tm, "The data source to use for this application")
 	suite.Send(tm, "enter")
 
@@ -464,7 +462,8 @@ func (suite *DotenvModelTestSuite) TestDotenvModel_SkipsPromptsWithDefaults() {
 
 	// PULUMI_CONFIG_PASSPHRASE should still have the default value written
 	suite.Contains(actualContentsStr, "PULUMI_CONFIG_PASSPHRASE=\"123\"\n", "Expected env file to contain the default passphrase")
-	suite.Contains(actualContentsStr, "DATAROBOT_DEFAULT_USE_CASE=\"my_use_case\"\n", "Expected env file to contain the entered use case")
+	// DATAROBOT_DEFAULT_USE_CASE was skipped (optional + empty default) so its value is empty
+	suite.Contains(actualContentsStr, "DATAROBOT_DEFAULT_USE_CASE=\"\"\n", "Expected env file to contain empty use case since it was skipped")
 
 	os.Remove(fm.DotenvFile)
 }

--- a/internal/envbuilder/builder.go
+++ b/internal/envbuilder/builder.go
@@ -201,12 +201,26 @@ func (up UserPrompt) ShouldAsk(showAll bool) bool {
 		return false
 	}
 
-	// Skip prompts that have a default and value equals default (not user-modified)
-	if up.Default != "" && up.Value == up.Default {
+	// Skip when the current value matches the effective default.
+	// For optional prompts with no explicit default, empty string is the implicit default.
+	if up.valueIsAtEffectiveDefault() {
 		return false
 	}
 
 	return true
+}
+
+// valueIsAtEffectiveDefault reports whether the prompt's value should be treated
+// as "already answered by the default", meaning there is nothing to ask the user.
+//
+//   - Non-empty default: skip when value equals the explicit default.
+//   - Optional + empty default: skip when value is also empty (blank is the implicit answer).
+func (up UserPrompt) valueIsAtEffectiveDefault() bool {
+	if up.Default != "" {
+		return up.Value == up.Default
+	}
+
+	return up.Optional && up.Value == ""
 }
 
 // GenerateRandomSecret creates a cryptographically random base64-encoded secret of the specified length.

--- a/internal/envbuilder/builder_test.go
+++ b/internal/envbuilder/builder_test.go
@@ -553,6 +553,36 @@ func (suite *BuilderTestSuite) TestShouldAsk_ShowsPromptWithoutDefault() {
 	suite.True(prompt.ShouldAsk(false), "Should show prompt when no default is set")
 }
 
+func (suite *BuilderTestSuite) TestShouldAsk_SkipsOptionalWithNonEmptyDefaultAndMatchingValue() {
+	// ENABLE_DRAGENT_SERVER case: optional: true, default: "true", value: "true" — already works, must not regress
+	prompt := UserPrompt{Active: true, Hidden: false, Optional: true, Default: "true", Value: "true"}
+	suite.False(prompt.ShouldAsk(false), "Should skip optional prompt when value equals non-empty default")
+}
+
+func (suite *BuilderTestSuite) TestShouldAsk_SkipsOptionalWithEmptyDefaultAndEmptyValue() {
+	// OTEL_SDK_DISABLED case: optional: true, default: ""
+	prompt := UserPrompt{Active: true, Hidden: false, Optional: true, Default: "", Value: ""}
+	suite.False(prompt.ShouldAsk(false), "Should skip optional prompt with empty default and empty value")
+}
+
+func (suite *BuilderTestSuite) TestShouldAsk_SkipsOptionalWithNullDefault() {
+	// DATAROBOT_DEFAULT_USE_CASE case: optional: true, default: (omitted in YAML)
+	prompt := UserPrompt{Active: true, Hidden: false, Optional: true, Value: ""}
+	suite.False(prompt.ShouldAsk(false), "Should skip optional prompt with null/omitted default and empty value")
+}
+
+func (suite *BuilderTestSuite) TestShouldAsk_ShowsOptionalWithValueSetAndEmptyDefault() {
+	// Optional + empty default, but user already has a value — show it for confirmation
+	prompt := UserPrompt{Active: true, Hidden: false, Optional: true, Default: "", Value: "some_value"}
+	suite.True(prompt.ShouldAsk(false), "Should show optional prompt when a value is set even if default is empty")
+}
+
+func (suite *BuilderTestSuite) TestShouldAsk_ShowAllOverridesOptionalEmptyDefault() {
+	// showAll forces all active non-hidden prompts to show, even optional+empty-default
+	prompt := UserPrompt{Active: true, Hidden: false, Optional: true, Default: "", Value: ""}
+	suite.True(prompt.ShouldAsk(true), "showAll should override optional+empty-default skip")
+}
+
 func (suite *BuilderTestSuite) TestShouldAsk_AlwaysPromptOverridesDefault() {
 	prompt := UserPrompt{Active: true, Hidden: false, Default: "default_value", Value: "default_value", AlwaysPrompt: true}
 	suite.True(prompt.ShouldAsk(false), "Should show prompt when always_prompt is true even if value equals default")


### PR DESCRIPTION
# RATIONALE
`optional: true` prompts were still getting asked if the default value was empty even when that was in fact the default value.

Corrected the `shouldAsk` logic for it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to wizard prompt visibility only; required prompts without defaults still ask, with broad unit and integration test coverage.
> 
> **Overview**
> The dotenv wizard no longer stops on **`optional: true`** prompts when the effective answer is blank—same as leaving them unset.
> 
> **`UserPrompt.ShouldAsk`** now delegates to **`valueIsAtEffectiveDefault`**: non-empty YAML defaults still skip when `value` matches; for optional prompts with an empty or omitted default, an empty `value` is treated as already answered and the prompt is skipped (unless **`showAll`**, **`always_prompt`**, or **`requires`** options force it). Pre-filled values on optional fields are still shown for confirmation.
> 
> Unit tests cover optional + empty/null default, regression for optional + non-empty default, and **`showAll`** override. The dotenv model test expects the wizard to jump past **`DATAROBOT_DEFAULT_USE_CASE`** to **`data_source`** and write an empty use-case in `.env`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c7b808e800929b8769abad347ae45e8f5cc9589. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->