### PR TITLE
CFX-6670: add brew trust for Homebrew 6.0+ tap trust feature

### DIFF
--- a/smoke_test_scripts/run_self_update_smoke_test.sh
+++ b/smoke_test_scripts/run_self_update_smoke_test.sh
@@ -189,8 +189,10 @@ test_brew_self_update() {
     cleanup_curl_install
 
     echo "Installing dr-cli via brew..."
-    brew tap datarobot-oss/taps 2>/dev/null || true
-    brew install --cask dr-cli 2>/dev/null || brew upgrade --cask dr-cli 2>/dev/null || true
+    brew tap datarobot-oss/taps || true
+    # Homebrew 6.0+ requires explicit trust for third-party taps
+    brew trust datarobot-oss/taps 2>/dev/null || true
+    brew install --cask dr-cli || brew upgrade --cask dr-cli || true
 
     # Find the brew-installed binary (cask installs to a predictable location)
     brew_dr=$(brew --prefix 2>/dev/null)/bin/dr


### PR DESCRIPTION
# RATIONALE

Daily smoke test runs have been failing since approximately June 12, 2026.

It looks like Homebrew 6.0.0 (shipped June 11, 2026) introduced a [tap trust](https://www.techtimes.com/articles/318270/20260612/homebrew-600-adds-tap-trust) security feature that blocks casks/formulae from third-party taps until explicitly trusted. The GitHub Actions macOS runner image was then updated to include Homebrew 6.0+, which caused the self-update smoke test (`brew install --cask dr-cli`) to silently fail with:

```
Refusing to load cask datarobot-oss/taps/dr-cli from untrusted tap datarobot-oss/taps.
Run `brew trust --cask datarobot-oss/taps/dr-cli` or `brew trust datarobot-oss/taps` to trust it.
```

The failure was hidden because the brew commands suppressed stderr with `2>/dev/null`.

## CHANGES

- Add `brew trust datarobot-oss/taps` before `brew install --cask dr-cli` in `smoke_test_scripts/run_self_update_smoke_test.sh` (with `2>/dev/null` only on the trust command, since `brew trust` does not exist on pre-6.0 Homebrew)
- Remove `2>/dev/null` stderr suppression from `brew tap`, `brew install --cask`, and `brew upgrade --cask` commands so future brew failures are visible in CI logs

## TESTING

Verified the failure reproduces across all recent smoke test runs (both before and after commit aee2b6c5). The root cause was confirmed by triggering a [debug run with `debug_brew: true`](https://github.com/datarobot-oss/cli/actions/runs/28257450338) which revealed the trust error message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI smoke-test script only; no runtime CLI or install-path behavior changes for end users.
> 
> **Overview**
> Fixes **TEST 3** (brew install → `dr self update`) on macOS runners with **Homebrew 6.0+**, which refuses casks from untrusted third-party taps unless explicitly trusted.
> 
> The script now runs **`brew trust datarobot-oss/taps`** before **`brew install --cask dr-cli`** (trust is ignored on older Homebrew via `2>/dev/null || true`). **`brew tap`**, **install**, and **upgrade** no longer redirect stderr to `/dev/null`, so tap/trust/install failures appear in smoke-test logs instead of failing silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11c3beee8eec48155609114fb8865c44cf3360a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->