### PR TITLE
[CFX-6672] fix(ci): use full repo path for composite actions in reusable workflows

### DIFF
--- a/.github/workflows/.build-matrix.yaml
+++ b/.github/workflows/.build-matrix.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go and Task
-        uses: ./.github/actions/setup
+        uses: datarobot-oss/cli/.github/actions/setup@main
 
       - name: Build the DR CLI Binary
         run: task build

--- a/.github/workflows/.build-windows.yaml
+++ b/.github/workflows/.build-windows.yaml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Set up Go and Task
-        uses: ./.github/actions/setup
+        uses: datarobot-oss/cli/.github/actions/setup@main
 
       - name: Build Windows Binary with GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6

--- a/.github/workflows/.deps-install-smoke-tests-matrix.yaml
+++ b/.github/workflows/.deps-install-smoke-tests-matrix.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go and Task
-        uses: ./.github/actions/setup
+        uses: datarobot-oss/cli/.github/actions/setup@main
 
       - name: Build binary
         run: task build

--- a/.github/workflows/.install-integration-tests-matrix.yaml
+++ b/.github/workflows/.install-integration-tests-matrix.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go and Task
-        uses: ./.github/actions/setup
+        uses: datarobot-oss/cli/.github/actions/setup@main
 
       - name: Build binary
         run: task build

--- a/.github/workflows/.pre-release-smoke-tests-matrix.yaml
+++ b/.github/workflows/.pre-release-smoke-tests-matrix.yaml
@@ -36,7 +36,7 @@ jobs:
           ref: ${{ inputs.version }}
 
       - name: Install smoke-test dependencies
-        uses: ./.github/actions/install-deps
+        uses: datarobot-oss/cli/.github/actions/install-deps@main
 
       - name: MacOS - Install coreutils (gtimeout)
         if: matrix.sys.os == 'macos-latest'
@@ -55,10 +55,10 @@ jobs:
           node-version: '24'
 
       - name: Set up Go and Task
-        uses: ./.github/actions/setup
+        uses: datarobot-oss/cli/.github/actions/setup@main
 
       - name: Build and Install the DR CLI Binary
-        uses: ./.github/actions/install-dr-bin
+        uses: datarobot-oss/cli/.github/actions/install-dr-bin@main
 
       - name: Run Pre-Release Smoke Tests
         env:

--- a/.github/workflows/.smoke-tests-matrix.yaml
+++ b/.github/workflows/.smoke-tests-matrix.yaml
@@ -41,13 +41,13 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Install smoke-test dependencies
-        uses: ./.github/actions/install-deps
+        uses: datarobot-oss/cli/.github/actions/install-deps@main
 
       - name: Set up Go and Task
-        uses: ./.github/actions/setup
+        uses: datarobot-oss/cli/.github/actions/setup@main
 
       - name: Build and Install the DR CLI Binary
-        uses: ./.github/actions/install-dr-bin
+        uses: datarobot-oss/cli/.github/actions/install-dr-bin@main
 
       - name: Run Smoke Tests for Binary
         env:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,6 +9,26 @@ reusable workflows (which share whole jobs), composite actions share *steps*, so
 they replace the copy-pasted checkout→Go→Task setup across jobs. They run in the
 caller's job, so the repo must be checked out **before** they are used.
 
+> **Important: reusable workflows must use the full repo path.**
+>
+> In top-level workflows (e.g. `checks.yaml`), reference composite actions with
+> the local path: `./.github/actions/setup`. In **reusable workflows** (those
+> with `on: workflow_call`), use the full repo path instead:
+> `datarobot-oss/cli/.github/actions/setup@main`.
+>
+> GitHub resolves `uses:` paths **before** `actions/checkout` runs, so local
+> paths (`./`) don't work in reusable workflows — the `.github/actions/`
+> directory isn't populated yet. This is a known GitHub Actions limitation
+> ([community discussion #18601](https://github.com/orgs/community/discussions/18601)).
+>
+> We use `@main` rather than pinning to a SHA because these are internal
+> same-repo utility actions. SHA pinning creates a chicken-and-egg problem:
+> you can't know the new SHA until the change merges to `main`, so PR CI would
+> test against the old version. The GitHub Actions Team is developing a native
+> `$/` syntax ([discussion #26245](https://github.com/orgs/community/discussions/26245))
+> to resolve same-repo actions at the same SHA automatically, but it hasn't
+> shipped yet.
+
 ### `setup`
 Sets up Go (version pinned by `go.mod` via `go-version-file`) and, optionally,
 Taskfile, with `setup-go`'s built-in module/build caching.


### PR DESCRIPTION
# RATIONALE

Fork PR smoke tests fail with `Can't find action.yml ... under .github/actions/install-deps` because reusable workflows (`workflow_call`-triggered) cannot resolve local composite actions (`./.github/actions/...`). GitHub resolves `uses:` paths **before** `actions/checkout` populates the workspace, so the `.github/actions/` directory doesn't exist at resolution time.

This was introduced in [CFX-6588](https://github.com/datarobot-oss/cli/pull/592) (`aee2b6c5`), which extracted inline workflow steps into composite actions. Top-level workflows (e.g. `checks.yaml`) are unaffected because they check out the repo before referencing local actions.

JIRA: [CFX-6672](https://datarobot.atlassian.net/browse/CFX-6672)

## CHANGES

Replaced `./.github/actions/X` with `datarobot-oss/cli/.github/actions/X@main` in all reusable workflows:

- `.github/workflows/.smoke-tests-matrix.yaml` (3 references)
- `.github/workflows/.build-windows.yaml` (1 reference)
- `.github/workflows/.build-matrix.yaml` (1 reference)
- `.github/workflows/.deps-install-smoke-tests-matrix.yaml` (1 reference)
- `.github/workflows/.install-integration-tests-matrix.yaml` (1 reference)
- `.github/workflows/.pre-release-smoke-tests-matrix.yaml` (3 references)

Top-level workflows (`checks.yaml`, `release.yaml`, `security-scan.yaml`) keep using `./.github/actions/...` unchanged.

## NOTES

### Why `@main` instead of pinning to a SHA

The repo pins all third-party actions to SHAs, but pinning internal same-repo composite actions to a SHA creates two problems:

1. **Chicken-and-egg**: If you modify a composite action (e.g. bump Go version in `setup/action.yaml`), you can't know the new SHA until that commit lands on `main`. Your PR's CI would test against the old SHA, not your changes.
2. **Maintenance burden**: Every composite action change would require updating SHAs across 6 workflow files (10 references).

Additionally, GitHub resolves `@main` at **workflow parse time** (before any steps run), so it always uses the latest version on `main` regardless of which branch or commit triggered the caller workflow. This is acceptable because:
- The composite actions are generic utilities (install deps, setup Go, build binary) with no PR-specific logic
- The actual code being tested comes from the `actions/checkout` step, which uses the PR's ref
- Changes to composite actions are tested via top-level workflows (like `checks.yaml`) which still use `./.github/actions/...` and pick up PR-branch changes

The GitHub Actions Team is developing a native `$/` syntax ([Discussion #26245](https://github.com/orgs/community/discussions/26245)) that would resolve same-repo composite actions at the same SHA as the workflow automatically. Until that ships, `@main` is the standard community workaround for internal actions.

### Known GitHub Actions limitation

- [Community Discussion #18601](https://github.com/orgs/community/discussions/18601) - primary thread on this exact issue
- [Community Discussion #26245](https://github.com/orgs/community/discussions/26245) - GitHub Actions Team proposed `$/` syntax (Jan 2026), not yet shipped
- [actions/toolkit #1264](https://github.com/actions/toolkit/issues/1264) - open feature request
- [GitHub Docs](https://docs.github.com/en/actions/reference/reusable-workflows-reference) - notes that `github` context is always the caller's

## RELATED

- Observed in [PR #608](https://github.com/datarobot-oss/cli/pull/608) ([run #28259067943](https://github.com/datarobot-oss/cli/actions/runs/28259067943))
- Introduced by [CFX-6588](https://github.com/datarobot-oss/cli/pull/592) (`aee2b6c5`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only path changes with no application or security logic; `@main` for internal composites is a known tradeoff versus SHA pinning.
> 
> **Overview**
> Fixes **fork PR and `workflow_call` smoke/build jobs** that failed because GitHub resolves `uses: ./.github/actions/...` before checkout, so local composite actions were missing.
> 
> All **reusable** matrix workflows now reference **`datarobot-oss/cli/.github/actions/{setup,install-deps,install-dr-bin}@main`** instead of `./.github/actions/...` (10 references across build, Windows build, smoke, deps-install, install-integration, and pre-release smoke matrices). **Top-level** workflows are unchanged and still use local `./.github/actions/...` paths.
> 
> The tested CLI source still comes from **`actions/checkout`** on the PR/ref; only the shared setup/install composite steps are pulled from `@main` at workflow parse time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ec30d5e9421b8639c20e07ee77513b229f7d9de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->