### PR TITLE
[CFX-6308] refactor(artifact): wrap artifact list JSON in envelope object

### DIFF
--- a/internal/workload/output.go
+++ b/internal/workload/output.go
@@ -71,14 +71,7 @@ func printArtifactsJSON(artifacts []Artifact) error {
 		outputs = append(outputs, NewArtifactOutput(a))
 	}
 
-	data, err := json.MarshalIndent(outputs, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(string(data))
-
-	return nil
+	return outputformat.PrintJSONEnvelope(os.Stdout, "artifacts", outputs)
 }
 
 func printArtifactDetails(artifact Artifact) {

--- a/internal/workload/output_test.go
+++ b/internal/workload/output_test.go
@@ -124,14 +124,21 @@ func TestPrintArtifactsJSON(t *testing.T) {
 		require.NoError(t, printArtifactsJSON(artifacts))
 	})
 
-	var parsed []map[string]any
+	var parsed map[string]any
 
 	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
-	assert.Len(t, parsed, 2)
-	assert.Equal(t, "art-001", parsed[0]["id"])
-	assert.Equal(t, "ver-001", parsed[0]["versionId"])
-	assert.Equal(t, "art-002", parsed[1]["id"])
-	assert.Empty(t, parsed[1]["versionId"])
+
+	items, ok := parsed["artifacts"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, items, 2)
+
+	item0 := items[0].(map[string]interface{})
+	assert.Equal(t, "art-001", item0["id"])
+	assert.Equal(t, "ver-001", item0["versionId"])
+
+	item1 := items[1].(map[string]interface{})
+	assert.Equal(t, "art-002", item1["id"])
+	assert.Empty(t, item1["versionId"])
 }
 
 func TestPrintArtifactsJSON_Empty(t *testing.T) {
@@ -139,10 +146,13 @@ func TestPrintArtifactsJSON_Empty(t *testing.T) {
 		require.NoError(t, printArtifactsJSON([]Artifact{}))
 	})
 
-	var parsed []any
+	var parsed map[string]any
 
 	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
-	assert.Empty(t, parsed)
+
+	items, ok := parsed["artifacts"].([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, items)
 }
 
 func TestPrintArtifactDetails_WithCodeRef(t *testing.T) {


### PR DESCRIPTION
### Rationale

`dr artifact list --output-format json` currently emits a bare JSON array:

**Before:**
```json
[
  {
    "id": "art-001",
    "name": "my-agent",
    "status": "draft",
    "catalogId": "cat-001",
    "versionId": "ver-001",
    "createdAt": "2026-04-01T08:00:00Z",
    "updatedAt": "2026-04-01T08:00:00Z"
  }
]
```

This PR wraps it in a consistent JSON envelope object using the existing `PrintJSONEnvelope` helper (introduced in #582):

**After:**
```json
{
  "artifacts": [
    {
      "id": "art-001",
      "name": "my-agent",
      "status": "draft",
      "catalogId": "cat-001",
      "versionId": "ver-001",
      "createdAt": "2026-04-01T08:00:00Z",
      "updatedAt": "2026-04-01T08:00:00Z"
    }
  ]
}
```

### Changes

- `internal/workload/output.go`: Replaced `json.MarshalIndent` in `printArtifactsJSON()` with `outputformat.PrintJSONEnvelope(os.Stdout, "artifacts", outputs)`
- `internal/workload/output_test.go`: Updated `TestPrintArtifactsJSON` and `TestPrintArtifactsJSON_Empty` to parse the envelope format

### Notes

This is a **breaking change** for JSON consumers. Please confirm the new shape is acceptable for your integrations. Part of CFX-6308.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking JSON output shape for `artifact list` consumers; scope is limited to that command and tests were updated.
> 
> **Overview**
> **`dr artifact list --output-format json`** now emits `{"artifacts": [...]}` instead of a top-level JSON array, via `outputformat.PrintJSONEnvelope` in `printArtifactsJSON`.
> 
> This aligns artifact list output with the shared envelope helper (same pattern as other CLI JSON list commands). **Breaking change** for integrations that parsed a bare array (e.g. `jq '.[0]'` must become `jq '.artifacts[0]'`). Single-artifact JSON (`printArtifactJSON`) is unchanged. Tests assert the `artifacts` key for populated and empty lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06283e7eb19a9cdee6e4cd059cb0cc114eb2d766. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->