### PR TITLE
[CFX-6308] refactor(pipeline): wrap pipeline list JSON in envelope object

### DIFF
--- a/cmd/pipeline/list/cmd_test.go
+++ b/cmd/pipeline/list/cmd_test.go
@@ -57,13 +57,16 @@ func TestPrintListJSON(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	var parsed []interface{}
+	var parsed map[string]interface{}
 
 	err := json.Unmarshal([]byte(output), &parsed)
 	require.NoError(t, err)
-	require.Len(t, parsed, 1)
 
-	item := parsed[0].(map[string]interface{})
+	items, ok := parsed["pipelines"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, items, 1)
+
+	item := items[0].(map[string]interface{})
 	assert.Equal(t, "confluence_to_vdb", item["name"])
 	assert.Equal(t, "draft", item["mode"])
 }

--- a/internal/pipeline/pipeline_output.go
+++ b/internal/pipeline/pipeline_output.go
@@ -81,14 +81,9 @@ func printPipelineJSON(p Pipeline) error {
 }
 
 func printPipelinesJSON(page DataPage[ListItem]) error {
-	data, err := json.MarshalIndent(page.Data, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(string(data))
-
-	return nil
+	// TODO: Consider including pagination metadata (totalCount, count, next, previous)
+	// from DataPage in the JSON envelope for richer output.
+	return outputformat.PrintJSONEnvelope(os.Stdout, "pipelines", page.Data)
 }
 
 func printCreateResponseJSON(result CreateResponse) error {

--- a/internal/pipeline/pipeline_output_test.go
+++ b/internal/pipeline/pipeline_output_test.go
@@ -226,10 +226,13 @@ func TestRenderPipelines_JSON(t *testing.T) {
 		require.NoError(t, RenderPipelines(outputformat.OutputFormatJSON, page))
 	})
 
-	var parsed []any
+	var parsed map[string]any
 
 	require.NoError(t, json.Unmarshal([]byte(out), &parsed))
-	assert.Len(t, parsed, 1)
+
+	items, ok := parsed["pipelines"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, items, 1)
 }
 
 func TestRenderPipelines_Human(t *testing.T) {


### PR DESCRIPTION
### Rationale

`dr pipeline list --output-format json` currently emits a bare JSON array:

**Before:**
```json
[
  {
    "id": "pid1",
    "name": "confluence_to_vdb",
    "mode": "draft",
    "isActive": true,
    "latestVersion": 3,
    "createdAt": "2026-04-28T11:42:28Z",
    "updatedAt": "2026-04-28T12:25:11Z"
  }
]
```

This PR wraps it in a consistent JSON envelope object using the existing `PrintJSONEnvelope` helper (introduced in #582):

**After:**
```json
{
  "pipelines": [
    {
      "id": "pid1",
      "name": "confluence_to_vdb",
      "mode": "draft",
      "isActive": true,
      "latestVersion": 3,
      "createdAt": "2026-04-28T11:42:28Z",
      "updatedAt": "2026-04-28T12:25:11Z"
    }
  ]
}
```

### Changes

- `internal/pipeline/pipeline_output.go`: Replaced `json.MarshalIndent` in `printPipelinesJSON()` with `outputformat.PrintJSONEnvelope(os.Stdout, "pipelines", page.Data)`, plus a TODO about future pagination metadata
- `internal/pipeline/pipeline_output_test.go`: Updated `TestRenderPipelines_JSON` to parse the envelope format
- `cmd/pipeline/list/cmd_test.go`: Updated `TestPrintListJSON` to parse the envelope format

### Notes

This is a **breaking change** for JSON consumers. Please confirm the new shape is acceptable for your integrations. Part of CFX-6308.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for JSON consumers of `dr pipeline list`; scope is CLI output only, not server APIs or auth.
> 
> **Overview**
> **`dr pipeline list --output-format json`** no longer prints a bare array; it now emits a **`{"pipelines": [...]}`** object via **`outputformat.PrintJSONEnvelope`**, matching the envelope pattern used elsewhere (e.g. #582).
> 
> `printPipelinesJSON` delegates to that helper instead of marshaling `page.Data` directly. A **TODO** notes possibly adding **`DataPage`** pagination fields (`totalCount`, `count`, `next`, `previous`) to the envelope later. Tests in **`pipeline_output_test`** and **`cmd/pipeline/list`** were updated to assert the **`pipelines`** key.
> 
> This is a **breaking change** for anything that parsed the old top-level array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a528d2146bf66e44b909686bb2adf3a2d9782b6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->