### PR TITLE
refactor(auth): handle user cancellation gracefully during auth flow

### DIFF
--- a/cmd/auth/login/cmd.go
+++ b/cmd/auth/login/cmd.go
@@ -89,6 +89,12 @@ func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop
 		return waitErr
 	})
 	if err != nil {
+		if errors.Is(err, auth.ErrInterrupt) {
+			log.Info("Authentication cancelled.")
+
+			return cli.ErrSilent
+		}
+
 		log.Error(err)
 
 		cmd.SilenceUsage = true

--- a/cmd/templates/setup/loginModel.go
+++ b/cmd/templates/setup/loginModel.go
@@ -145,7 +145,7 @@ func (lm LoginModel) waitForAPIKey() tea.Cmd {
 
 		// empty apiKey means we need to interrupt current auth flow
 		if apiKey == "" {
-			return errMsg{errors.New("Interrupt request received.")}
+			return errMsg{auth.ErrInterrupt}
 		}
 
 		viperx.Set(config.DataRobotAPIKey, apiKey)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -54,6 +54,9 @@ func PrintAuthInstructions(authURL string) {
 // ErrEnvCredentialsNotSet is returned when environment credentials are not fully configured.
 var ErrEnvCredentialsNotSet = errors.New("environment credentials not set")
 
+// ErrInterrupt is returned when the user cancels the authentication flow.
+var ErrInterrupt = errors.New("Authentication cancelled.")
+
 // PrintUnsetTokenInstructions prints platform-specific instructions for unsetting DATAROBOT_API_TOKEN.
 func PrintUnsetTokenInstructions() {
 	fmt.Print(tui.InfoStyle.Render("  unset DATAROBOT_API_TOKEN"))
@@ -99,21 +102,26 @@ func VerifyEnvCredentials(ctx context.Context) (*EnvCredentials, error) {
 // triggers the login flow automatically. Returns an error if authentication
 // fails, suitable for use in Cobra PreRunE hooks.
 func EnsureAuthenticatedE(cmd *cobra.Command, _ []string) error {
-	if !EnsureAuthenticated(cmd.Context()) {
-		return errors.New("Authentication failed.")
+	ok, err := EnsureAuthenticated(cmd.Context())
+	if ok {
+		return nil
 	}
 
-	return nil
+	if errors.Is(err, ErrInterrupt) {
+		return err
+	}
+
+	return errors.New("Authentication failed.")
 }
 
 // EnsureAuthenticated checks if valid authentication exists, and if not,
 // triggers the login flow automatically. Returns true if authentication
-// is valid or was successfully obtained.
-func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
+// is valid or was successfully obtained, and an error describing why it failed.
+func EnsureAuthenticated(ctx context.Context) (bool, error) { //nolint: cyclop
 	if viperx.GetBool("skip_auth") {
 		log.Warn("Authentication checks are disabled via the '--skip-auth' flag. This may cause API calls to fail.")
 
-		return true
+		return true, nil
 	}
 
 	// bindValidAuthEnv binds DATAROBOT ENDPOINT/API_TOKEN to viper config only if these credentials are valid
@@ -126,19 +134,19 @@ func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
 		_ = viperx.BindEnv("endpoint", "DATAROBOT_ENDPOINT", "DATAROBOT_API_ENDPOINT")
 		_ = viperx.BindEnv("token", "DATAROBOT_API_TOKEN")
 
-		return true
+		return true, nil
 	}
 
 	datarobotHost := GetBaseURLOrAsk()
 	if datarobotHost == "" {
 		// Appropriate error message was already displayed in GetBaseURLOrAsk() and SetURLAction()
-		return false
+		return false, nil
 	}
 
 	_, viperErr := config.GetAPIKey(ctx)
 	if viperErr == nil {
 		// Valid token exists in viper config file
-		return true
+		return true, nil
 	}
 
 	skipAuthFlow := false
@@ -170,7 +178,7 @@ func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
 	}
 
 	if skipAuthFlow {
-		return false
+		return false, nil
 	}
 
 	// No valid token, attempt to get one
@@ -183,8 +191,15 @@ func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
 
 	key, err := APIKeyCallbackFunc(ctx, datarobotHost)
 	if err != nil {
+		if errors.Is(err, ErrInterrupt) {
+			log.Info("Authentication cancelled.")
+
+			return false, ErrInterrupt
+		}
+
 		log.Error("Failed to retrieve API key.", "error", err)
-		return false
+
+		return false, err
 	}
 
 	viperx.Set(config.DataRobotAPIKey, strings.ReplaceAll(key, "\n", ""))
@@ -192,12 +207,13 @@ func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
 	err = WriteConfigFileSilent()
 	if err != nil {
 		log.Error("Failed to write config file.", "error", err)
-		return false
+
+		return false, err
 	}
 
 	log.Info("Authentication successful")
 
-	return true
+	return true, nil
 }
 
 func WaitForAPIKeyCallback(ctx context.Context, datarobotHost string) (string, error) {
@@ -255,7 +271,7 @@ func WaitForAPIKeyCallback(ctx context.Context, datarobotHost string) (string, e
 
 		// empty apiKey means we need to interrupt current auth flow
 		if apiKey == "" {
-			return "", errors.New("Interrupt request received.")
+			return "", ErrInterrupt
 		}
 
 		log.Debug("Successfully consumed API key from API request")
@@ -263,7 +279,8 @@ func WaitForAPIKeyCallback(ctx context.Context, datarobotHost string) (string, e
 		return apiKey, nil
 	case <-ctx.Done():
 		log.Debug("Ctrl-C received, exiting auth wait")
-		return "", errors.New("Interrupt request received.")
+
+		return "", ErrInterrupt
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -103,10 +103,30 @@ func TestEnsureAuthenticated_MissingCredentials(t *testing.T) {
 	}
 
 	// EnsureAuthenticated should detect missing credentials.
-	result := EnsureAuthenticated(context.Background())
+	result, _ := EnsureAuthenticated(context.Background())
 	assert.False(t, result, "Expected EnsureAuthenticated to return false with missing credentials")
 
 	// Verify the URL is properly configured.
+	baseURL := config.GetBaseURL()
+	assert.Equal(t, server.URL, baseURL, "Expected base URL to be set from test server")
+}
+
+func TestEnsureAuthenticated_Interrupted(t *testing.T) {
+	server, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	viperx.Set(config.DataRobotAPIKey, "")
+	os.Unsetenv("DATAROBOT_API_TOKEN")
+
+	// Mock the callback to simulate the user cancelling the auth flow.
+	APIKeyCallbackFunc = func(_ context.Context, _ string) (string, error) {
+		return "", ErrInterrupt
+	}
+
+	result, err := EnsureAuthenticated(context.Background())
+	assert.False(t, result, "Expected EnsureAuthenticated to return false when interrupted")
+	require.ErrorIs(t, err, ErrInterrupt, "Expected ErrInterrupt to be returned")
+
 	baseURL := config.GetBaseURL()
 	assert.Equal(t, server.URL, baseURL, "Expected base URL to be set from test server")
 }
@@ -126,7 +146,7 @@ func TestEnsureAuthenticated_ExpiredCredentials(t *testing.T) {
 		return "", errors.New("simulated authentication failure")
 	}
 
-	result := EnsureAuthenticated(context.Background())
+	result, _ := EnsureAuthenticated(context.Background())
 	assert.False(t, result, "Expected EnsureAuthenticated to return false with expired credentials")
 }
 
@@ -140,7 +160,7 @@ func TestEnsureAuthenticated_ValidCredentials(t *testing.T) {
 	apiKey, _ := config.GetAPIKey(context.Background())
 	assert.Equal(t, "valid-token", apiKey, "Expected GetAPIKey to return valid token")
 
-	result := EnsureAuthenticated(context.Background())
+	result, _ := EnsureAuthenticated(context.Background())
 	assert.True(t, result, "Expected EnsureAuthenticated to return true with valid credentials")
 }
 
@@ -154,7 +174,7 @@ func TestEnsureAuthenticated_ValidEnvironmentToken(t *testing.T) {
 	apiKey, _ := config.GetAPIKey(context.Background())
 	assert.Empty(t, apiKey, "Expected GetAPIKey before EnsureAuthenticated to return empty string")
 
-	result := EnsureAuthenticated(context.Background())
+	result, _ := EnsureAuthenticated(context.Background())
 	assert.True(t, result, "Expected EnsureAuthenticated to return true with valid environment credentials")
 
 	apiKey, _ = config.GetAPIKey(context.Background())
@@ -177,14 +197,14 @@ func TestEnsureAuthenticated_SkipAuth(t *testing.T) {
 
 	defer os.Setenv("DATAROBOT_API_TOKEN", existingToken)
 
-	result := EnsureAuthenticated(context.Background())
+	result, _ := EnsureAuthenticated(context.Background())
 	assert.True(t, result, "Expected EnsureAuthenticated to return true when skip_auth is enabled via config")
 
 	os.Setenv("DATAROBOT_CLI_SKIP_AUTH", "true")
 
 	defer os.Unsetenv("DATAROBOT_CLI_SKIP_AUTH")
 
-	result = EnsureAuthenticated(context.Background())
+	result, _ = EnsureAuthenticated(context.Background())
 	assert.True(t, result, "Expected EnsureAuthenticated to return true when skip_auth is enabled via environment variable")
 }
 
@@ -208,7 +228,7 @@ func TestEnsureAuthenticated_DefaultUserAgent(t *testing.T) {
 	os.Unsetenv("DATAROBOT_ENDPOINT")
 	os.Unsetenv("DATAROBOT_API_TOKEN")
 
-	result := EnsureAuthenticated(context.Background())
+	result, _ := EnsureAuthenticated(context.Background())
 	assert.True(t, result)
 
 	expectedUserAgent := "DataRobot CLI version: dev"
@@ -234,7 +254,7 @@ func TestEnsureAuthenticated_NoURL(t *testing.T) {
 	baseURL := config.GetBaseURL()
 	assert.Empty(t, baseURL, "Expected GetBaseURL to return empty string")
 
-	result := EnsureAuthenticated(context.Background())
+	result, _ := EnsureAuthenticated(context.Background())
 	assert.False(t, result, "Expected EnsureAuthenticated to return false without configured URL")
 }
 

--- a/internal/plugin/exec.go
+++ b/internal/plugin/exec.go
@@ -79,7 +79,12 @@ func ExecutePlugin(ctx context.Context, manifest PluginManifest, executable stri
 		userAgent := fmt.Sprintf("DataRobot CLI plugin: %s (version %s)", manifest.Name, manifest.Version)
 		authCtx := config.WithUserAgent(ctx, userAgent)
 
-		if !auth.EnsureAuthenticated(authCtx) {
+		ok, err := auth.EnsureAuthenticated(authCtx)
+		if !ok {
+			if errors.Is(err, auth.ErrInterrupt) {
+				return 130
+			}
+
 			return 1
 		}
 	}

--- a/internal/plugin/exec_test.go
+++ b/internal/plugin/exec_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/stretchr/testify/assert"
@@ -332,4 +333,33 @@ func TestCheckAndInstallPluginPrereqs_TrueWhenAllDepsSatisfied(t *testing.T) {
 	result := checkAndInstallPluginDeps(manifest, []string{})
 
 	assert.True(t, result)
+}
+
+// TestExecutePluginAuthCancelled verifies that cancelling the auth flow returns
+// the conventional SIGINT exit code (130) instead of treating it as a failure.
+func TestExecutePluginAuthCancelled(t *testing.T) {
+	originalCallback := auth.APIKeyCallbackFunc
+	auth.APIKeyCallbackFunc = func(_ context.Context, _ string) (string, error) {
+		return "", auth.ErrInterrupt
+	}
+
+	defer func() { auth.APIKeyCallbackFunc = originalCallback }()
+
+	viperx.Reset()
+	viperx.Set(config.DataRobotURL, "https://app.datarobot.com")
+	viperx.Set(config.DataRobotAPIKey, "")
+
+	os.Unsetenv("DATAROBOT_ENDPOINT")
+	os.Unsetenv("DATAROBOT_API_TOKEN")
+
+	scriptPath := filepath.Join(t.TempDir(), "test.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	manifest := PluginManifest{
+		BasicPluginManifest: BasicPluginManifest{Name: "cancelled-plugin", Version: "1.0.0", Authentication: true},
+	}
+
+	exitCode := ExecutePlugin(context.Background(), manifest, scriptPath, []string{})
+
+	assert.Equal(t, 130, exitCode, "Expected exit code 130 when auth is cancelled")
 }


### PR DESCRIPTION
# RATIONALE

Followup from #615 -- it'd be nice to get an obvious message for user cancellation of the auth flow.

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
