### PR TITLE
Add opencode plugin v0.1.2-rc.3

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -174,6 +174,18 @@
           "releaseDate": "2026-05-27"
         }
       ]
+    },
+    "opencode": {
+      "name": "opencode",
+      "description": "Adds opencode commands to dr",
+      "versions": [
+        {
+          "version": "0.1.2-rc.3",
+          "url": "opencode/opencode-0.1.2-rc.3.tar.xz",
+          "sha256": "493815b3bc2892946e1304866a61d49e03d764e06f2dcd2d494ab0c3a78e24f1",
+          "releaseDate": "2026-06-30"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds the opencode plugin v0.1.2-rc.3 to the CLI plugin index.

- Plugin: opencode
- Version: 0.1.2-rc.3
- Release: https://github.com/datarobot/opencode-cli-plugin/releases/tag/v0.1.2-rc.3
- SHA256: 493815b3bc2892946e1304866a61d49e03d764e06f2dcd2d494ab0c3a78e24f1

## Test Plan

- [ ] dr plugin install opencode installs successfully
- [ ] dr opencode --help shows usage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog-only metadata change with no runtime or security logic; incorrect SHA256/URL would only affect install verification for this new plugin.
> 
> **Overview**
> Registers the **opencode** plugin in `docs/plugins/index.json` so the DataRobot CLI can discover and install it via `dr plugin install opencode`.
> 
> The new entry describes the plugin as adding opencode commands to `dr`, and pins **0.1.2-rc.3** with tarball URL, SHA256, and release date—matching the existing pattern used for `assist` and `xp`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37e05802676b860030ffca08755f23def696a1f1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->