### PR TITLE
Add opencode plugin v0.1.2

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -174,6 +174,18 @@
           "releaseDate": "2026-05-27"
         }
       ]
+    },
+    "opencode": {
+      "name": "opencode",
+      "description": "AI agent design, coding, and deployment assistant",
+      "versions": [
+        {
+          "version": "0.1.2",
+          "url": "opencode/opencode-0.1.2.tar.xz",
+          "sha256": "18aea99ed54ca4d37879152c0f4ea6d078264749e124885782e226445ac42b0f",
+          "releaseDate": "2026-07-01"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds the opencode plugin v0.1.2 to the CLI plugin index.

- Plugin: opencode
- Version: 0.1.2
- Release: https://github.com/datarobot/opencode-cli-plugin/releases/tag/v0.1.2
- SHA256: 18aea99ed54ca4d37879152c0f4ea6d078264749e124885782e226445ac42b0f

## Test Plan

- [ ] dr plugin install opencode installs successfully
- [ ] dr opencode --help shows usage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Index-only catalog update with no runtime or security logic changes; install behavior depends on the published tarball matching the listed checksum.
> 
> **Overview**
> Registers the **opencode** plugin in `docs/plugins/index.json` so the CLI can discover and install it via the standard plugin registry.
> 
> The new entry includes **v0.1.2**, tarball path `opencode/opencode-0.1.2.tar.xz`, SHA256 checksum, and release date **2026-07-01**, with the same metadata shape as existing plugins (`assist`, `xp`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b92d68b1f284425d595cd40ea179a19d3c0f887. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->