### PR TITLE
[CFX-6590] Update Phase 5 actions and implement security checks

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         # M1: single Go-version source of truth.
         go-version-file: go.mod
@@ -27,7 +27,7 @@ runs:
 
     - name: Install Taskfile
       if: inputs.install-task == 'true'
-      uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+      uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
       with:
         version: 3.x
         repo-token: ${{ github.token }}

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: datarobot-oss/cli/.github/actions/setup@main
 
       - name: Cross-compile binaries with GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.github/workflows/_pre-release-smoke.yaml
+++ b/.github/workflows/_pre-release-smoke.yaml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.version }}
 
@@ -54,7 +54,7 @@ jobs:
       # NOTE: keep this version in sync with the Agentic Starter template's
       # required Node version (currently 24).
       - name: Set up Node.js (template prerequisite)
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
 

--- a/.github/workflows/_smoke-windows.yaml
+++ b/.github/workflows/_smoke-windows.yaml
@@ -32,7 +32,7 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Download Windows Binary
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: C:\temp\dr-bin
@@ -46,7 +46,7 @@ jobs:
           echo "$INSTALL_DIR" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install Taskfile
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -101,7 +101,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 #v0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 #v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/.github/workflows/nightly-smoke.yaml
+++ b/.github/workflows/nightly-smoke.yaml
@@ -95,8 +95,10 @@ jobs:
           echo "failed_jobs=${failed}" >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack
-        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "❌ DR CLI Daily Smoke Tests Failed",
@@ -150,6 +152,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install uv
-        uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "latest"
       - name: Set up Python
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           # Upload entire docs directory (includes dev-preview/ and symlinks)
           path: 'docs/'

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Detect file changes
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
           filters: |
@@ -83,7 +83,7 @@ jobs:
           echo "version=$(grep 'GOLANGCI_LINT_VERSION' Taskfile.yaml | grep -oP 'v[\d.]+')" >> "$GITHUB_OUTPUT"
 
       - name: Cache golangci-lint binary and analysis
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             tmp/bin/golangci-lint
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Check License Header
-        uses: apache/skywalking-eyes/header@8e837beb243c264ffcd5ea3abd3d5d8975cd0077 # main 2025-01-13
+        uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
         with:
           config: .licenserc.yaml
 
@@ -177,7 +177,7 @@ jobs:
           install-task: 'false'
 
       - name: Build all platforms with GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: '~> v2'
@@ -269,7 +269,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download Binary
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dr-ubuntu
           path: /tmp/dr-bin
@@ -285,7 +285,7 @@ jobs:
           sudo apt-get install -y expect bash-completion
 
       - name: Install Taskfile
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-security.yaml
+++ b/.github/workflows/pr-security.yaml
@@ -69,7 +69,7 @@ jobs:
   #       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
   #     - name: Set up Go
-  #       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+  #       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
   #       with:
   #         go-version-file: go.mod
 
@@ -111,14 +111,10 @@ jobs:
           fail-on-severity: moderate
           comment-summary-in-pr: on-failure
 
-  # Phase 0 safety net — non-blocking baseline scan.
-  # Promoted to required (remove continue-on-error) in Phase 5.
   govulncheck:
     runs-on: ubuntu-latest
     name: Go Vulnerability Check
     timeout-minutes: 15
-    # Non-blocking during Phase 0 — results visible in job logs without failing the PR.
-    continue-on-error: true
     permissions:
       contents: read
     steps:
@@ -139,15 +135,10 @@ jobs:
 
   # CodeQL (Go) SAST. Folded in from the former codeql.yaml in Phase 4 — the
   # triggers (pull_request + push → main) already match this workflow.
-  # Phase 0 safety net — non-blocking baseline scan.
-  # Promoted to required (remove continue-on-error) in Phase 5.
   analyze:
     name: Analyze (Go)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Non-blocking during Phase 0 — results flow to the Security tab without
-    # failing the PR. Remove continue-on-error in Phase 5.
-    continue-on-error: true
     permissions:
       contents: read
       security-events: write
@@ -156,7 +147,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
 
@@ -164,7 +155,6 @@ jobs:
         uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           languages: go
-          # Default query suite; upgrade to security-extended in Phase 5
           queries: security-and-quality
 
       - name: Autobuild

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
           install-task: 'false'
 
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           distribution: goreleaser
           version: latest
@@ -51,8 +51,10 @@ jobs:
 
       - name: Notify Slack on Failure
         if: failure()
-        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "❌ DR CLI Release Failed",
@@ -86,9 +88,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   verify-installation:
     needs: release
@@ -146,8 +145,10 @@ jobs:
             /tmp/release-assets/*
 
       - name: Notify Slack on Success
-        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "✅ New DR CLI Release Published!",
@@ -181,9 +182,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   notify-verification-failure:
     needs: [verify-installation, pre-release-smoke-test]
@@ -196,8 +194,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Notify Slack of Installation Failure
-        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "⚠️ DR CLI Release Requires Review",
@@ -238,6 +238,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

### ⚠️ Breaking change — `slackapi/slack-github-action` v1 → v3

Bumping to v3 requires migrating from env-var webhook config to explicit `with:` inputs. The old `SLACK_WEBHOOK_URL` / `SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK` env vars are silently ignored in v2+, causing all Slack notifications to fail with a missing-input error.

**Affected locations (4):** `release.yaml` (×3), `nightly-smoke.yaml` (×1)

```yaml
# Before (v1)
uses: slackapi/slack-github-action@... # v1.27.0
with:
  payload: |
    { ... }
env:
  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
  SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

# After (v3)
uses: slackapi/slack-github-action@... # v3.0.3
with:
  webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
  webhook-type: incoming-webhook
  payload: |
    { ... }
```

---

### Action version bump table

| Action | From | To | Breaking changes |
|---|---|---|---|
| `slackapi/slack-github-action` | v1.27.0 | **v3.0.3** | Yes — see above |
| `astral-sh/setup-uv` | v4 | **v8.2.0** | Custom version manifests format changed (not used here) |
| `actions/setup-go` | v5 | **v6.5.0** | Toolchain handling updated; `go-version-file` usage unaffected |
| `actions/download-artifact` | v4 | **v8.0.1** | Hash mismatches now error by default (stricter); auto-decompress removed (binary artifacts unaffected) |
| `actions/cache` | v4 | **v6.1.0** | None — ESM migration only |
| `actions/upload-pages-artifact` | v3 | **v5.0.0** | None |
| `goreleaser/goreleaser-action` | v6 | **v7.2.3** | None — Node 24 runtime, no input changes |
| `arduino/setup-task` | v2.0.0 | **v3.0.0** | None — Node 24 runtime only |
| `dorny/paths-filter` | v3 | **v4.0.1** | None — Node 24 runtime only |
| `apache/skywalking-eyes/header` | main (2025-01-13 SHA) | **v0.8.0** | None — pinned to released tag |
| `aquasecurity/trivy-action` | v0.35.0 *(fork-smoke only)* | **v0.36.0** | None — sync with `pr-security.yaml` |
| `actions/setup-node` | `@v6` (unpinned) | **v6.4.0** (SHA-pinned) | None — pinned for supply-chain safety |
| `actions/checkout` in `_pre-release-smoke` | `@v7` (unpinned) | **v7.0.0** (SHA-pinned) | None — pinned for supply-chain safety |

### Already current (no change)

`actions/checkout` (v7.0.0), `actions/upload-artifact` (v7.0.1), `actions/github-script` (v9.0.0), `actions/dependency-review-action` (v5.0.0), `actions/configure-pages` (v6.0.0), `actions/deploy-pages` (v5.0.0), `github/codeql-action` (v3.36.2), `dcarbone/install-yq-action` (v1.3.1)

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES
This pull request updates the versions of several GitHub Actions used across the repository's workflow files to improve security, compatibility, and feature support. The changes primarily focus on upgrading third-party action dependencies to their latest stable releases and updating configuration for Slack notifications.

**Security and Analysis Tools:**
- Updated `aquasecurity/trivy-action` to `v0.36.0` for vulnerability scanning.
- Upgraded `apache/skywalking-eyes/header` to `v0.8.0` for license header checks.
- Updated `actions/cache` to `v6.1.0` for caching dependencies.
- Updated `astral-sh/setup-uv` to `v8.2.0` for Python environment setup.

**Slack Notification Configuration:**
- Upgraded `slackapi/slack-github-action` to `v3.0.3`, switching from environment variables to explicit `webhook` and `webhook-type` inputs for Slack integration, and removed now-unnecessary environment variable configuration. [[1]](diffhunk://#diff-ec614b0cd34abe3fa9e330ea8728ad09781f993ab15f1b17ea7341c0d075c492L98-R101) [[2]](diffhunk://#diff-ec614b0cd34abe3fa9e330ea8728ad09781f993ab15f1b17ea7341c0d075c492L153-L155) [[3]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL54-R57) [[4]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL89-L91) [[5]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL149-R151) [[6]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL184-L186) [[7]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL199-R200) [[8]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL241-L243)

**Workflow Behavior Adjustments:**
- Removed `continue-on-error: true` from security-related jobs (`govulncheck`, `analyze`) in `pr-security.yaml`, making these checks required instead of non-blocking. [[1]](diffhunk://#diff-9bf37d36c18067404360d2d2cc7c59b9c9468d64441058327653f463e18e1998L114-L121) [[2]](diffhunk://#diff-9bf37d36c18067404360d2d2cc7c59b9c9468d64441058327653f463e18e1998L142-L150)

These updates ensure that CI/CD workflows remain secure, up-to-date, and maintain compatibility with the latest features and best practices.


## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
