### PR TITLE
[CFX-6841] fix(plugin): eliminate SIGTERM race in exec_test.go via sentinel file

### DIFF
--- a/internal/plugin/exec_test.go
+++ b/internal/plugin/exec_test.go
@@ -161,6 +161,28 @@ exit %d
 	}
 }
 
+// waitForTrapInstalledSentinel polls until the given sentinel file exists or the
+// timeout elapses. The SIGTERM tests below use this instead of a fixed
+// time.Sleep to wait for their subprocess to install its trap handler: a fixed
+// sleep is a race under system load, since the subprocess may not have started
+// and installed the trap by the time the sleep elapses, causing the test's
+// later cancel() to kill the subprocess before it can react to SIGTERM.
+func waitForTrapInstalledSentinel(t *testing.T, sentinelPath string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(sentinelPath); err == nil {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for trap-installed sentinel file %s", sentinelPath)
+}
+
 // TestExecutePluginContextCancellation verifies that cancelling the context sends
 // SIGTERM to the plugin subprocess (not SIGKILL), allowing graceful shutdown.
 func TestExecutePluginContextCancellation(t *testing.T) {
@@ -168,14 +190,20 @@ func TestExecutePluginContextCancellation(t *testing.T) {
 		t.Skip("SIGTERM handling is Unix-specific")
 	}
 
-	// Create a script that traps SIGTERM, writes a marker, and exits cleanly
-	markerFile := filepath.Join(t.TempDir(), "sigterm-received")
+	tmpDir := t.TempDir()
+
+	// trapInstalledSentinel is touched by the script right after it installs its
+	// SIGTERM trap, letting the test wait deterministically for that point
+	// instead of guessing with a fixed sleep (see waitForTrapInstalledSentinel).
+	trapInstalledSentinel := filepath.Join(tmpDir, "trap-installed.sentinel")
+	markerFile := filepath.Join(tmpDir, "sigterm-received")
 	script := fmt.Sprintf(`#!/bin/sh
 trap 'touch %s; exit 55' TERM
+touch %s
 while true; do sleep 0.1; done
-`, markerFile)
+`, markerFile, trapInstalledSentinel)
 
-	scriptPath := filepath.Join(t.TempDir(), "trap-term.sh")
+	scriptPath := filepath.Join(tmpDir, "trap-term.sh")
 	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -186,8 +214,7 @@ while true; do sleep 0.1; done
 		done <- ExecutePlugin(ctx, PluginManifest{}, scriptPath, []string{})
 	}()
 
-	// Give the subprocess time to start and install its signal handler
-	time.Sleep(500 * time.Millisecond)
+	waitForTrapInstalledSentinel(t, trapInstalledSentinel, 5*time.Second)
 
 	cancel()
 
@@ -210,13 +237,19 @@ func TestExecutePluginContextCancellationKillsUnresponsive(t *testing.T) {
 		t.Skip("SIGTERM handling is Unix-specific")
 	}
 
-	// Create a script that ignores SIGTERM entirely
-	script := `#!/bin/sh
-trap '' TERM
-while true; do sleep 0.1; done
-`
+	tmpDir := t.TempDir()
 
-	scriptPath := filepath.Join(t.TempDir(), "ignore-term.sh")
+	// trapInstalledSentinel is touched by the script right after it installs its
+	// no-op SIGTERM trap, letting the test wait deterministically for that point
+	// instead of guessing with a fixed sleep (see waitForTrapInstalledSentinel).
+	trapInstalledSentinel := filepath.Join(tmpDir, "trap-installed.sentinel")
+	script := fmt.Sprintf(`#!/bin/sh
+trap '' TERM
+touch %s
+while true; do sleep 0.1; done
+`, trapInstalledSentinel)
+
+	scriptPath := filepath.Join(tmpDir, "ignore-term.sh")
 	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -227,8 +260,7 @@ while true; do sleep 0.1; done
 		done <- ExecutePlugin(ctx, PluginManifest{}, scriptPath, []string{})
 	}()
 
-	// Give the subprocess time to start
-	time.Sleep(500 * time.Millisecond)
+	waitForTrapInstalledSentinel(t, trapInstalledSentinel, 5*time.Second)
 
 	cancel()
 


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

Currently, `TestExecutePluginContextCancellation` and `TestExecutePluginContextCancellationKillsUnresponsive` in `internal/plugin/exec_test.go` occasionally fail when I run them as part of the entire test suite via `task test`. 

They rely on a fixed `time.Sleep(500ms)` to guess when their test subprocess has started and installed its SIGTERM trap handler before the test cancels the context. This works most of the time, but under appropriate load the subprocess sometimes hasn't been scheduled yet by the time the sleep elapses. When that happens, `cancel()` sends SIGTERM before the trap is installed, so the OS's default SIGTERM disposition kills the process outright — exit code `-1`, no marker file, and a failed assertion (`expected: 55, actual: -1`).

That makes the test flaky in exactly the way that's most damaging: intermittent, load-dependent, and hard to reproduce locally. Reproducing it before this change, 3 of 10 full-suite runs failed, one of them a direct hit on this exact assertion.

So let's replace the sleep with a real readiness signal instead of a wider guess: the subprocess now touches a `trap-installed.sentinel` file immediately after installing its trap, and the test polls for that file (bounded by a timeout) before calling `cancel()`. This removes the race entirely rather than just narrowing the window for it.

## CHANGES

- **Replace fixed sleep with a sentinel-file readiness check** (`internal/plugin/exec_test.go`): both tests now have their shell script touch a `trap-installed.sentinel` file right after installing the SIGTERM trap, and poll for it via a new `waitForTrapInstalledSentinel` helper instead of `time.Sleep(500 * time.Millisecond)`.
- **Consolidate to a single shared `t.TempDir()` per test** (`internal/plugin/exec_test.go`): both tests now derive the sentinel, marker, and script paths from one temp dir instead of calling `t.TempDir()` twice.

## TESTING

| Test name | What it verifies |
|---|---|
| `TestExecutePluginContextCancellation` | Cancelling the context sends SIGTERM (not SIGKILL) to a plugin subprocess that traps it, allowing graceful shutdown (exit 55) |
| `TestExecutePluginContextCancellationKillsUnresponsive` | A plugin that ignores SIGTERM is force-killed via `cmd.WaitDelay` after the grace period |

Verified with `task test` (`go test -race -shuffle=on ./...`), run 10x before and after this change:

| | Before | After |
|---|---|---|
| Target test failures | 1/10 (`TestExecutePluginContextCancellation`: exit -1, no marker file) | 0/10 |

(A separate, unrelated flake in `TestManifestTestSuite/TestGetManifestValid` — `signal: killed` — occurred at a similar rate before and after; it is not addressed by this change.)

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.
