### PR TITLE
[CFX-6668] feature gating private CA

### DIFF
--- a/cmd/plugin/discovery.go
+++ b/cmd/plugin/discovery.go
@@ -29,6 +29,7 @@ import (
 	internaltls "github.com/datarobot/cli/internal/tls"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // RegisterPluginCommands discovers installed plugins and registers them as sub-commands

--- a/cmd/plugin/discovery.go
+++ b/cmd/plugin/discovery.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/plugin/shared"
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/features"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/misc/reader"
 	internalPlugin "github.com/datarobot/cli/internal/plugin"
@@ -117,25 +118,30 @@ func createPluginCommand(p internalPlugin.DiscoveredPlugin) *cobra.Command {
 		DisableFlagParsing: true, // Pass all args to plugin
 		DisableSuggestions: true,
 		Run: func(pluginCmd *cobra.Command, args []string) {
-			// DisableFlagParsing means Cobra never processes persistent flags,
-			// so -k/--skip-certificate-check/--ca-cert land in raw args unparsed.
-			// Apply TLS here so the auth check in ExecutePlugin and the subprocess
-			// both see the correct configuration.
-			skipVerify, caCert := scanTLSArgs(args)
-			tlsOpts := internaltls.Options{SkipVerify: skipVerify, CACertPath: caCert}
+			// Gated behind "private-ca" (DATAROBOT_CLI_FEATURE_PRIVATE_CA) so
+			// plugin invocations are byte-for-byte unchanged when the feature
+			// is disabled (the default).
+			if features.Enabled("private-ca") {
+				// DisableFlagParsing means Cobra never processes persistent flags,
+				// so -k/--skip-certificate-check/--ca-cert land in raw args unparsed.
+				// Apply TLS here so the auth check in ExecutePlugin and the subprocess
+				// both see the correct configuration.
+				skipVerify, caCert := scanTLSArgs(args)
+				tlsOpts := internaltls.Options{SkipVerify: skipVerify, CACertPath: caCert}
 
-			if err := internaltls.Apply(tlsOpts); err != nil {
-				fmt.Fprintf(pluginCmd.ErrOrStderr(), "error: %v\n", err)
-				telemetry.ExitWithContext(pluginCmd.Context(), 1)
+				if err := internaltls.Apply(tlsOpts); err != nil {
+					fmt.Fprintf(pluginCmd.ErrOrStderr(), "error: %v\n", err)
+					telemetry.ExitWithContext(pluginCmd.Context(), 1)
 
-				return
-			}
+					return
+				}
 
-			if err := internaltls.PropagateEnv(tlsOpts); err != nil {
-				fmt.Fprintf(pluginCmd.ErrOrStderr(), "error: %v\n", err)
-				telemetry.ExitWithContext(pluginCmd.Context(), 1)
+				if err := internaltls.PropagateEnv(tlsOpts); err != nil {
+					fmt.Fprintf(pluginCmd.ErrOrStderr(), "error: %v\n", err)
+					telemetry.ExitWithContext(pluginCmd.Context(), 1)
 
-				return
+					return
+				}
 			}
 
 			checkAndPromptPluginUpdate(pluginName, manifest.Version, pluginPath)
@@ -251,8 +257,12 @@ func performPluginUpdate(result *internalPlugin.UpdateCheckResult) {
 // Uses pflag to correctly handle --flag=value syntax, -- terminators, and
 // dash-leading paths. Unknown flags are whitelisted so plugin-specific args
 // pass through without error.
+//
+// TODO(CFX-6668): This raw-arg scan is a stopgap gated behind the
+// "private-ca" feature. Once #625's TraverseChildren + universalFlags
+// forwarding table lands, register ca-cert/skip-certificate-check there
+// instead and delete this function.
 func scanTLSArgs(args []string) (skipVerify bool, caCert string) {
-    // NOTE This code and behavior is likely to change
 	fs := pflag.NewFlagSet("tls-args", pflag.ContinueOnError)
 	fs.ParseErrorsWhitelist = pflag.ParseErrorsWhitelist{UnknownFlags: true}
 

--- a/cmd/plugin/discovery.go
+++ b/cmd/plugin/discovery.go
@@ -264,7 +264,7 @@ func performPluginUpdate(result *internalPlugin.UpdateCheckResult) {
 // instead and delete this function.
 func scanTLSArgs(args []string) (skipVerify bool, caCert string) {
 	fs := pflag.NewFlagSet("tls-args", pflag.ContinueOnError)
-	fs.ParseErrorsWhitelist = pflag.ParseErrorsWhitelist{UnknownFlags: true}
+	fs.ParseErrorsAllowlist = pflag.ParseErrorsAllowlist{UnknownFlags: true}
 
 	fs.BoolP("skip-certificate-check", "k", false, "")
 	fs.String("ca-cert", "", "")

--- a/cmd/plugin/discovery_test.go
+++ b/cmd/plugin/discovery_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScanTLSArgs(t *testing.T) {
+	tests := []struct {
+		name               string
+		args               []string
+		expectedSkipVerify bool
+		expectedCACert     string
+	}{
+		{
+			name:               "no flags",
+			args:               []string{"foo", "bar"},
+			expectedSkipVerify: false,
+			expectedCACert:     "",
+		},
+		{
+			name:               "short skip-verify flag",
+			args:               []string{"-k", "foo"},
+			expectedSkipVerify: true,
+			expectedCACert:     "",
+		},
+		{
+			name:               "long skip-verify flag",
+			args:               []string{"--skip-certificate-check", "foo"},
+			expectedSkipVerify: true,
+			expectedCACert:     "",
+		},
+		{
+			name:               "ca-cert space-separated form",
+			args:               []string{"--ca-cert", "/path/to/ca.pem"},
+			expectedSkipVerify: false,
+			expectedCACert:     "/path/to/ca.pem",
+		},
+		{
+			name:               "ca-cert equals form",
+			args:               []string{"--ca-cert=/path/to/ca.pem"},
+			expectedSkipVerify: false,
+			expectedCACert:     "/path/to/ca.pem",
+		},
+		{
+			name:               "ca-cert with dash-leading value",
+			args:               []string{"--ca-cert", "-my-cert.pem"},
+			expectedSkipVerify: false,
+			expectedCACert:     "-my-cert.pem",
+		},
+		{
+			name:               "unknown flags pass through without error",
+			args:               []string{"--some-plugin-flag", "value", "-k"},
+			expectedSkipVerify: true,
+			expectedCACert:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skipVerify, caCert := scanTLSArgs(tt.args)
+
+			assert.Equal(t, tt.expectedSkipVerify, skipVerify)
+			assert.Equal(t, tt.expectedCACert, caCert)
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,7 @@ import (
 	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/features"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/outputformat"
 	internalPlugin "github.com/datarobot/cli/internal/plugin"
@@ -192,9 +193,20 @@ func init() {
 	RootCmd.PersistentFlags().Duration("plugin-update-check-interval", internalPlugin.DefaultUpdateCheckInterval, "cooldown between plugin update checks (0s disables)")
 	RootCmd.PersistentFlags().Bool("skip-plugin-update-check", false, "skip plugin update checks before running plugins")
 	RootCmd.PersistentFlags().Bool("disable-telemetry", false, "disable anonymous usage telemetry")
-	RootCmd.PersistentFlags().BoolP("skip-certificate-check", "k", false, "skip TLS certificate verification (insecure)")
-	RootCmd.PersistentFlags().String("ca-cert", "", "path to a PEM-encoded CA certificate bundle")
-	registerExportWindowsCertsFlag(RootCmd.Command)
+
+	// Private CA / TLS flags are gated behind "private-ca"
+	// (DATAROBOT_CLI_FEATURE_PRIVATE_CA) while the design is still subject to
+	// change (see cmd/tls.go and cmd/plugin/discovery.go). When disabled
+	// (the default), these flags do not exist and CLI behavior for all
+	// other customers is unchanged.
+	if features.Enabled("private-ca") {
+		RootCmd.PersistentFlags().BoolP("skip-certificate-check", "k", false, "skip TLS certificate verification (insecure)")
+		RootCmd.PersistentFlags().String("ca-cert", "", "path to a PEM-encoded CA certificate bundle")
+		registerExportWindowsCertsFlag(RootCmd.Command)
+
+		_ = viperx.BindPFlag("ca-cert", RootCmd.PersistentFlags().Lookup("ca-cert"))
+	}
+
 	outputformat.AddPersistentFlag(RootCmd.Command, &rootOutputFormat)
 
 	// Make some of these flags available via Viper
@@ -208,7 +220,6 @@ func init() {
 	_ = viperx.BindPFlag("skip-plugin-update-check", RootCmd.PersistentFlags().Lookup("skip-plugin-update-check"))
 	_ = viperx.BindPFlag("disable-telemetry", RootCmd.PersistentFlags().Lookup("disable-telemetry"))
 	_ = viperx.BindPFlag("output-format", RootCmd.PersistentFlags().Lookup("output-format"))
-	_ = viperx.BindPFlag("ca-cert", RootCmd.PersistentFlags().Lookup("ca-cert"))
 
 	// Add command groups (plugin group added conditionally by registerPluginCommands)
 	RootCmd.AddGroup(

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -353,3 +353,15 @@ func TestArtifactCommandNotPresentByDefault(t *testing.T) {
 
 	assert.False(t, found, "artifact command should not be present when feature gate is not enabled")
 }
+
+// TestPrivateCATLSFlagsNotPresentByDefault verifies that the private-ca
+// TLS flags are gated behind the "private-ca" feature and are not
+// registered on RootCmd by default, matching the gating pattern used for
+// the "workload"/"artifact" commands above. Flag gating happens during
+// init(), so this tests the actual registered state.
+func TestPrivateCATLSFlagsNotPresentByDefault(t *testing.T) {
+	for _, name := range []string{"skip-certificate-check", "ca-cert", "export-windows-certs"} {
+		assert.Nil(t, RootCmd.PersistentFlags().Lookup(name),
+			"flag --%s should not be registered when the private-ca feature gate is not enabled", name)
+	}
+}

--- a/cmd/tls.go
+++ b/cmd/tls.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/features"
 	internaltls "github.com/datarobot/cli/internal/tls"
 	"github.com/spf13/cobra"
 )
@@ -23,7 +24,15 @@ import (
 // setupTLS configures http.DefaultTransport based on TLS-related flags and
 // the persisted ca-cert config value. Must run after initializeConfig so that
 // the ca-cert value from drconfig.yaml is available via viper.
+//
+// Gated behind "private-ca" (DATAROBOT_CLI_FEATURE_PRIVATE_CA) while this
+// design is still subject to change; a no-op when the gate is disabled
+// (the default), regardless of what the persisted config contains.
 func setupTLS(cmd *cobra.Command) error {
+	if !features.Enabled("private-ca") {
+		return nil
+	}
+
 	skipVerify, _ := cmd.Flags().GetBool("skip-certificate-check")
 	caCert := viperx.GetString("ca-cert")
 

--- a/cmd/tls_windows.go
+++ b/cmd/tls_windows.go
@@ -17,11 +17,10 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 
+	"github.com/datarobot/cli/internal/config"
 	internaltls "github.com/datarobot/cli/internal/tls"
 	"github.com/spf13/cobra"
 )
@@ -31,13 +30,16 @@ func registerExportWindowsCertsFlag(cmd *cobra.Command) {
 		"export Windows certificate store to the DataRobot CA bundle")
 }
 
+// windowsCACertPath returns the path where the exported CA bundle is
+// written, reusing the same config directory as drconfig.yaml
+// (config.GetConfigDir()) instead of a separate %APPDATA%-derived path.
 func windowsCACertPath() (string, error) {
-	appData := os.Getenv("APPDATA")
-	if appData == "" {
-		return "", errors.New("APPDATA environment variable is not set")
+	dir, err := config.GetConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("determining CA bundle path: %w", err)
 	}
 
-	return filepath.Join(appData, "DataRobot", "ca-bundle.pem"), nil
+	return filepath.Join(dir, "ca-bundle.pem"), nil
 }
 
 func applyWindowsCerts(cmd *cobra.Command, caCert *string) error {

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -26,6 +26,24 @@ These flags are available for all commands:
 > [!NOTE]
 > The `--force-interactive` flag forces commands to behave as if setup has never been completed, while still updating the state file. This is useful for testing or forcing re-execution of setup steps.
 
+### Private CA / TLS flags (experimental, feature-gated)
+
+```bash
+  -k, --skip-certificate-check    Skip TLS certificate verification (insecure)
+      --ca-cert string           Path to a PEM-encoded CA certificate bundle
+      --export-windows-certs     Export the Windows certificate store to the DataRobot CA bundle (Windows only)
+```
+
+> [!NOTE]
+> These flags only exist when the `private-ca` feature gate is enabled via
+> `DATAROBOT_CLI_FEATURE_PRIVATE_CA=true`. They are not available by default,
+> and the underlying mechanism is subject to change (see
+> [Feature gates](../development/feature-gates.md)) as the design evolves.
+
+> [!WARNING]
+> `--skip-certificate-check` disables TLS certificate verification entirely
+> and should only be used against known, trusted endpoints for testing.
+
 ## Commands
 
 ### Main commands

--- a/docs/development/plugins.md
+++ b/docs/development/plugins.md
@@ -127,6 +127,32 @@ When `authentication` is enabled:
 - Authentication can be bypassed with the global `--skip-auth` flag (for advanced users).
 - Your plugin will receive a clean environment with authentication already validated
 
+### Private CA / TLS support (experimental, feature-gated)
+
+> **Subject to change:** this mechanism is gated behind
+> `DATAROBOT_CLI_FEATURE_PRIVATE_CA=true` and is expected to be reworked
+> once the CLI's generic root-flag-forwarding mechanism (a `DATAROBOT_CLI_*`
+> env var table for flags placed before the plugin name) lands. Do not treat
+> the exact env vars below as a stable contract yet.
+
+When the `private-ca` feature gate is enabled and a user passes
+`-k`/`--skip-certificate-check` or `--ca-cert <path>` before your plugin's
+name (e.g. `dr --ca-cert /path/to/ca.pem myplugin [args...]`), the CLI
+forwards the equivalent runtime configuration to your plugin subprocess via
+these environment variables:
+
+| Variable | Set when | Value |
+|---|---|---|
+| `NODE_TLS_REJECT_UNAUTHORIZED` | `--skip-certificate-check`/`-k` is used | `0` |
+| `NODE_EXTRA_CA_CERTS` | `--ca-cert <path>` is used | `<path>` |
+| `SSL_CERT_FILE` | `--ca-cert <path>` is used | `<path>` |
+
+Plugins written in Node.js/Bun automatically honour `NODE_TLS_REJECT_UNAUTHORIZED`
+and `NODE_EXTRA_CA_CERTS` without any extra code. Other runtimes that respect
+`SSL_CERT_FILE` (e.g. many Go/OpenSSL-based tools) will pick up the custom CA
+bundle the same way. If your plugin uses a different HTTP client, read these
+variables at startup and configure your client's TLS trust store accordingly.
+
 ## Developing a plugin
 
 Minimum requirements:


### PR DESCRIPTION
# RATIONALE

Would like to get #609 merged into main. That one was designed to only work if specific flags or env vars are set; let's add a proper feature gate for now.

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TLS trust and skip-verify paths (security-sensitive), but default behavior is unchanged unless the feature env is set; when enabled, `--skip-certificate-check` weakens verification.
> 
> **Overview**
> Private CA and custom TLS behavior is now **experimental and off by default**. Enabling `DATAROBOT_CLI_FEATURE_PRIVATE_CA` is required for `--skip-certificate-check`/`-k`, `--ca-cert`, and (on Windows) `--export-windows-certs` to exist at all; `setupTLS` becomes a no-op when the gate is off, even if `ca-cert` is persisted in config.
> 
> Plugin runs only scan raw args and apply/propagate TLS when the gate is on, so default plugin invocations stay unchanged. `scanTLSArgs` is documented as a stopgap (CFX-6668 / future flag-forwarding), uses `ParseErrorsAllowlist`, and is covered by new unit tests. A root test asserts those TLS flags are not registered without the gate.
> 
> On Windows, the exported CA bundle path now follows **`config.GetConfigDir()`** (same tree as `drconfig.yaml`) instead of a separate `%APPDATA%` path. Command and plugin docs describe the gated flags and plugin env forwarding (`NODE_TLS_*`, `SSL_CERT_FILE`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76c0b2643e296252a5a988ec2ac75457af5d6858. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->