### PR TITLE
[CFX-6025] Prerequisite validation

### DIFF
--- a/internal/tools/prerequisites.go
+++ b/internal/tools/prerequisites.go
@@ -30,19 +30,19 @@ import (
 
 // InstallCommands holds platform-specific install commands for a dependency.
 type InstallCommands struct {
-	MacOS   string `yaml:"macos"`
-	Linux   string `yaml:"linux"`
+	MacOS   string `yaml:"macos"   validate:"required"`
+	Linux   string `yaml:"linux"   validate:"required"`
 	Windows string `yaml:"windows"`
 }
 
 // Prerequisite represents a required tool
 type Prerequisite struct {
 	Key            string
-	Name           string          `yaml:"name"`
-	MinimumVersion string          `yaml:"minimum-version"`
-	Command        string          `yaml:"command"`
-	URL            string          `yaml:"url"`
-	Install        InstallCommands `yaml:"install"`
+	Name           string          `yaml:"name"            validate:"required"`
+	MinimumVersion string          `yaml:"minimum-version" validate:"required,semver"`
+	Command        string          `yaml:"command"         validate:"required"`
+	URL            string          `yaml:"url"             validate:"required"`
+	Install        InstallCommands `yaml:"install"         validate:"required"`
 }
 
 // PlatformInstallCommand returns the install command for the current OS.

--- a/internal/tools/validation.go
+++ b/internal/tools/validation.go
@@ -15,142 +15,76 @@
 package tools
 
 import (
+	"errors"
 	"fmt"
-	"runtime"
+	"reflect"
+	"sync"
 
 	semver "github.com/Masterminds/semver/v3"
+	"github.com/go-playground/validator/v10"
 
 	"github.com/datarobot/cli/internal/log"
 )
 
-const formatSemver = "semver"
+// createPrereqValidatorOnce initializes the shared validator exactly once.
+// validator.New() is expensive (allocates reflection caches) and RegisterValidation /
+// RegisterTagNameFunc are not safe to call concurrently, so we use sync.OnceValue
+// to guarantee a single, goroutine-safe initialization.
+var createPrereqValidatorOnce = sync.OnceValue(func() *validator.Validate {
+	v := validator.New()
 
-// FieldRule defines validation constraints for a single string field.
-type FieldRule struct {
-	Required bool
-	Format   string // "semver" validates semantic version format when non-empty
-}
-
-// InstallCommandsSchema defines validation constraints for InstallCommands fields.
-type InstallCommandsSchema struct {
-	MacOS   FieldRule
-	Linux   FieldRule
-	Windows FieldRule
-}
-
-// YAMLSchema defines the expected structure and constraints for versions.yaml entries.
-type YAMLSchema struct {
-	Name           FieldRule
-	MinimumVersion FieldRule
-	Command        FieldRule
-	URL            FieldRule
-	Install        InstallCommandsSchema
-}
-
-// installCommandsSchema is the authoritative schema for InstallCommands in versions.yaml.
-// As for Milestone 1, we decided to make Windows install command optional .
-// We can always add a warning in validation if Windows command is not provided, but it won't be a hard requirement.
-var installCommandsSchema = InstallCommandsSchema{
-	MacOS: FieldRule{Required: true},
-	Linux: FieldRule{Required: true},
-	// InstallCommands for Windows is optional for now.
-	Windows: FieldRule{Required: false},
-}
-
-// versionsYamlSchema is the authoritative schema for versions.yaml.
-var versionsYamlSchema = YAMLSchema{
-	Name:           FieldRule{Required: true},
-	MinimumVersion: FieldRule{Required: true, Format: formatSemver},
-	Command:        FieldRule{Required: true},
-	URL:            FieldRule{Required: true},
-	Install:        installCommandsSchema,
-}
-
-// validate logs a warning if value violates the field rule and returns the violation message.
-func (r FieldRule) validate(key, fieldName, value string) string {
-	if r.Required && value == "" {
-		msg := fmt.Sprintf("versions.yaml [%s]: '%s' is required", key, fieldName)
-		log.Warn(msg)
-
-		return msg
-	}
-
-	if r.Format == formatSemver && value != "" {
-		if _, err := semver.NewVersion(value); err != nil {
-			msg := fmt.Sprintf("versions.yaml [%s]: '%s' %q is not a valid semantic version", key, fieldName, value)
-			log.Warn(msg)
-
-			return msg
-		}
-	}
-
-	return ""
-}
-
-// Validate checks every entry in the parsed versions.yaml, logs warnings for violations,
-// and returns the list of violation messages.
-func (s YAMLSchema) Validate(data versionsYaml) []string {
-	var violations []string
-
-	for key, p := range data {
-		for _, v := range []string{
-			s.Name.validate(key, "name", p.Name),
-			s.MinimumVersion.validate(key, "minimum-version", p.MinimumVersion),
-			s.Command.validate(key, "command", p.Command),
-			s.URL.validate(key, "url", p.URL),
-		} {
-			if v != "" {
-				violations = append(violations, v)
-			}
+	// Use the yaml struct tag as the field name in validation errors so that
+	// messages reference YAML keys ("minimum-version") rather than Go field
+	// names ("MinimumVersion"), matching what users see in versions.yaml.
+	v.RegisterTagNameFunc(func(f reflect.StructField) string {
+		if name := f.Tag.Get("yaml"); name != "" && name != "-" {
+			return name
 		}
 
-		violations = append(violations, s.Install.validate(key, p.Install)...)
+		return f.Name
+	})
+
+	_ = v.RegisterValidation("semver", func(fl validator.FieldLevel) bool {
+		_, err := semver.NewVersion(fl.Field().String())
+
+		return err == nil
+	})
+
+	return v
+})
+
+// validatePrerequisite validates a single Prerequisite entry from versions.yaml.
+// Violations are returned as human-readable strings and logged as warnings.
+func validatePrerequisite(key string, p Prerequisite) []string {
+	var errs validator.ValidationErrors
+
+	prereqValidator := createPrereqValidatorOnce()
+
+	if err := prereqValidator.Struct(p); !errors.As(err, &errs) {
+		return nil
+	}
+
+	violations := make([]string, 0, len(errs))
+
+	for _, fe := range errs {
+		violations = append(violations, fieldViolationMsg(key, fe))
 	}
 
 	return violations
 }
 
-// validate checks that install commands are provided
-// according to the InstallCommandsSchema rules, with special attention to the current platform.
-func (s InstallCommandsSchema) validate(key string, ic InstallCommands) []string {
-	if ic.MacOS == "" && ic.Linux == "" && ic.Windows == "" {
-		msg := fmt.Sprintf("versions.yaml [%s]: 'install' is not defined", key)
-		log.Warn(msg)
+func fieldViolationMsg(key string, fe validator.FieldError) string {
+	var msg string
 
-		return []string{msg}
+	switch fe.Tag() {
+	case "required":
+		msg = fmt.Sprintf("versions.yaml [%s]: '%s' is required", key, fe.Field())
+	case "semver":
+		msg = fmt.Sprintf("versions.yaml [%s]: '%s' %q is not a valid semantic version", key, fe.Field(), fe.Value())
+	default:
+		msg = fmt.Sprintf("versions.yaml [%s]: '%s' failed validation (%s)", key, fe.Field(), fe.Tag())
 	}
 
-	var violations []string
-
-	for _, v := range []string{
-		s.validatePlatform(key, "install.macos", ic.MacOS, s.MacOS, "darwin"),
-		s.validatePlatform(key, "install.linux", ic.Linux, s.Linux, "linux"),
-		s.validatePlatform(key, "install.windows", ic.Windows, s.Windows, "windows"),
-	} {
-		if v != "" {
-			violations = append(violations, v)
-		}
-	}
-
-	return violations
-}
-
-// validatePlatform logs Error if the install command for the current platform is missing and it's required, otherwise logs a warning.
-// Returns the violation message, or "" if no violation.
-func (s InstallCommandsSchema) validatePlatform(key, fieldName, value string, rule FieldRule, goos string) string {
-	if !rule.Required || value != "" {
-		return ""
-	}
-
-	// For now it's only warning if the install command for the current platform is missing
-	if runtime.GOOS == goos {
-		msg := fmt.Sprintf("versions.yaml [%s]: '%s' is required for the current platform", key, fieldName)
-		log.Error(msg)
-
-		return msg
-	}
-
-	msg := fmt.Sprintf("versions.yaml [%s]: '%s' is required", key, fieldName)
 	log.Warn(msg)
 
 	return msg

--- a/internal/tools/validation_test.go
+++ b/internal/tools/validation_test.go
@@ -17,7 +17,6 @@ package tools
 import (
 	"bytes"
 	"os"
-	"runtime"
 	"testing"
 
 	"github.com/datarobot/cli/internal/log"
@@ -56,229 +55,157 @@ func captureLog(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
-// TestVersionsYamlSchemaDefinition verifies the authoritative schema has the expected field rules.
-func TestVersionsYamlSchemaDefinition(t *testing.T) {
-	assert.True(t, versionsYamlSchema.Name.Required, "name must be required")
-	assert.True(t, versionsYamlSchema.MinimumVersion.Required, "minimum-version must be required")
-	assert.Equal(t, formatSemver, versionsYamlSchema.MinimumVersion.Format, "minimum-version must use semver format")
-	assert.True(t, versionsYamlSchema.Command.Required, "command must be required")
-	assert.True(t, versionsYamlSchema.URL.Required, "url must be required")
+func validPrerequisite() Prerequisite {
+	return Prerequisite{
+		Name:           "Python",
+		MinimumVersion: "3.9.0",
+		Command:        "python3 --version",
+		URL:            "https://python.org",
+		Install:        InstallCommands{MacOS: "brew install python", Linux: "apt install python3"},
+	}
 }
 
-// TestInstallCommandsSchemaDefinition verifies platform rules: macOS and Linux required, Windows optional.
-func TestInstallCommandsSchemaDefinition(t *testing.T) {
-	assert.True(t, installCommandsSchema.MacOS.Required, "macOS install command must be required")
-	assert.True(t, installCommandsSchema.Linux.Required, "Linux install command must be required")
-	assert.False(t, installCommandsSchema.Windows.Required, "Windows install command must be optional")
+func TestValidatePrerequisite_ValidEntry(t *testing.T) {
+	violations := validatePrerequisite("python", validPrerequisite())
+
+	assert.Empty(t, violations)
 }
 
-func TestFieldRuleValidate(t *testing.T) {
-	t.Run("required field missing — WARN logged", func(t *testing.T) {
-		rule := FieldRule{Required: true}
-
-		output := captureLog(t, func() {
-			rule.validate("tool", "name", "")
-		})
-
-		assert.Contains(t, output, "WARN")
-		assert.Contains(t, output, "[tool]")
-		assert.Contains(t, output, "'name' is required")
-	})
-
-	t.Run("required field present — nothing logged", func(t *testing.T) {
-		rule := FieldRule{Required: true}
-
-		output := captureLog(t, func() {
-			rule.validate("tool", "name", "Python")
-		})
-
-		assert.Empty(t, output)
-	})
-
-	t.Run("semver field with invalid version — WARN logged", func(t *testing.T) {
-		rule := FieldRule{Format: formatSemver}
-
-		output := captureLog(t, func() {
-			rule.validate("tool", "minimum-version", "not-a-version")
-		})
-
-		assert.Contains(t, output, "WARN")
-		assert.Contains(t, output, "[tool]")
-		assert.Contains(t, output, "'minimum-version'")
-		assert.Contains(t, output, "not a valid semantic version")
-	})
-
-	t.Run("semver field with valid version — nothing logged", func(t *testing.T) {
-		rule := FieldRule{Format: formatSemver}
-
-		output := captureLog(t, func() {
-			rule.validate("tool", "minimum-version", "3.9.0")
-		})
-
-		assert.Empty(t, output)
-	})
-
-	t.Run("semver field empty and not required — nothing logged", func(t *testing.T) {
-		rule := FieldRule{Format: formatSemver}
-
-		output := captureLog(t, func() {
-			rule.validate("tool", "minimum-version", "")
-		})
-
-		assert.Empty(t, output)
-	})
-
-	t.Run("optional field empty — nothing logged", func(t *testing.T) {
-		rule := FieldRule{}
-
-		output := captureLog(t, func() {
-			rule.validate("tool", "command", "")
-		})
-
-		assert.Empty(t, output)
-	})
-}
-
-func TestInstallCommandsSchemaValidate(t *testing.T) {
-	schema := InstallCommandsSchema{
-		MacOS:   FieldRule{Required: true},
-		Linux:   FieldRule{Required: true},
-		Windows: FieldRule{Required: false},
+func TestValidatePrerequisite_RequiredFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Prerequisite)
+		wantMsg string
+	}{
+		{
+			name:    "missing name",
+			mutate:  func(p *Prerequisite) { p.Name = "" },
+			wantMsg: "'name' is required",
+		},
+		{
+			name:    "missing minimum-version",
+			mutate:  func(p *Prerequisite) { p.MinimumVersion = "" },
+			wantMsg: "'minimum-version' is required",
+		},
+		{
+			name:    "missing command",
+			mutate:  func(p *Prerequisite) { p.Command = "" },
+			wantMsg: "'command' is required",
+		},
+		{
+			name:    "missing url",
+			mutate:  func(p *Prerequisite) { p.URL = "" },
+			wantMsg: "'url' is required",
+		},
 	}
 
-	t.Run("all platforms absent — WARN 'install is not defined'", func(t *testing.T) {
-		output := captureLog(t, func() {
-			schema.validate("tool", InstallCommands{})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := validPrerequisite()
+			tt.mutate(&p)
+
+			var violations []string
+
+			output := captureLog(t, func() {
+				violations = validatePrerequisite("tool", p)
+			})
+
+			assert.Contains(t, output, "WARN")
+			assert.Contains(t, output, "[tool]")
+
+			found := false
+
+			for _, v := range violations {
+				if assert.Contains(t, v, tt.wantMsg) {
+					found = true
+
+					break
+				}
+			}
+
+			assert.True(t, found, "expected violation containing %q", tt.wantMsg)
 		})
-
-		assert.Contains(t, output, "WARN")
-		assert.Contains(t, output, "[tool]")
-		assert.Contains(t, output, "'install' is not defined")
-	})
-
-	t.Run("all required platforms present — nothing logged", func(t *testing.T) {
-		ic := InstallCommands{MacOS: "brew install x", Linux: "apt install x"}
-
-		output := captureLog(t, func() {
-			schema.validate("tool", ic)
-		})
-
-		assert.Empty(t, output)
-	})
-
-	t.Run("Windows optional and absent — nothing logged for Windows", func(t *testing.T) {
-		ic := InstallCommands{MacOS: "brew install x", Linux: "apt install x"}
-
-		output := captureLog(t, func() {
-			schema.validate("tool", ic)
-		})
-
-		assert.NotContains(t, output, "install.windows")
-	})
-
-	t.Run("current platform missing — ERROR logged", func(t *testing.T) {
-		var ic InstallCommands
-
-		switch runtime.GOOS {
-		case "darwin":
-			ic = InstallCommands{Linux: "apt install x"}
-		case "linux":
-			ic = InstallCommands{MacOS: "brew install x"}
-		default:
-			t.Skip("current platform not covered by required fields in this schema")
-		}
-
-		output := captureLog(t, func() {
-			schema.validate("tool", ic)
-		})
-
-		assert.Contains(t, output, "ERRO")
-		assert.Contains(t, output, "[tool]")
-		assert.Contains(t, output, "required for the current platform")
-	})
-
-	t.Run("non-current platform missing — WARN logged", func(t *testing.T) {
-		var ic InstallCommands
-
-		switch runtime.GOOS {
-		case "darwin":
-			ic = InstallCommands{MacOS: "brew install x"}
-		case "linux":
-			ic = InstallCommands{Linux: "apt install x"}
-		default:
-			t.Skip("current platform not covered by required fields in this schema")
-		}
-
-		output := captureLog(t, func() {
-			schema.validate("tool", ic)
-		})
-
-		assert.Contains(t, output, "WARN")
-		assert.Contains(t, output, "[tool]")
-		assert.Contains(t, output, "is required")
-	})
+	}
 }
 
-func TestYAMLSchemaValidate(t *testing.T) {
-	t.Run("fully valid entry — nothing logged, nil returned", func(t *testing.T) {
-		input := versionsYaml{
-			"python": {
-				Name: "Python", MinimumVersion: "3.9.0", Command: "python3", URL: "https://python.org",
-				Install: InstallCommands{MacOS: "brew install python", Linux: "apt install python3"},
-			},
-		}
+func TestValidatePrerequisite_InvalidSemver(t *testing.T) {
+	p := validPrerequisite()
+	p.MinimumVersion = "not-a-version"
 
-		output := captureLog(t, func() {
-			versionsYamlSchema.Validate(input)
-		})
+	var violations []string
 
-		assert.Empty(t, output)
+	output := captureLog(t, func() {
+		violations = validatePrerequisite("python", p)
 	})
 
-	t.Run("missing required fields — WARN logged, nil returned", func(t *testing.T) {
-		input := versionsYaml{
-			"python": {},
-		}
+	assert.Contains(t, output, "WARN")
+	assert.Contains(t, output, "[python]")
+	assert.Contains(t, output, "not a valid semantic version")
 
-		output := captureLog(t, func() {
-			versionsYamlSchema.Validate(input)
-		})
+	assert.NotEmpty(t, violations)
+	assert.Contains(t, violations[0], "not a valid semantic version")
+}
 
-		assert.Contains(t, output, "WARN")
-		assert.Contains(t, output, "[python]")
+func TestValidatePrerequisite_InstallMacOSRequired(t *testing.T) {
+	p := validPrerequisite()
+	p.Install.MacOS = ""
+
+	var violations []string
+
+	output := captureLog(t, func() {
+		violations = validatePrerequisite("tool", p)
 	})
 
-	t.Run("invalid semver — WARN logged, nil returned", func(t *testing.T) {
-		input := versionsYaml{
-			"python": {Name: "Python", Command: "python3", URL: "https://python.org", MinimumVersion: "bad"},
-		}
+	assert.Contains(t, output, "WARN")
+	assert.NotEmpty(t, violations)
+	assert.Contains(t, violations[0], "macos")
+}
 
-		output := captureLog(t, func() {
-			versionsYamlSchema.Validate(input)
-		})
+func TestValidatePrerequisite_InstallLinuxRequired(t *testing.T) {
+	p := validPrerequisite()
+	p.Install.Linux = ""
 
-		assert.Contains(t, output, "WARN")
-		assert.Contains(t, output, "not a valid semantic version")
+	var violations []string
+
+	output := captureLog(t, func() {
+		violations = validatePrerequisite("tool", p)
 	})
 
-	t.Run("no install commands — WARN 'install is not defined', nil returned", func(t *testing.T) {
-		input := versionsYaml{
-			"python": {Name: "Python", MinimumVersion: "3.9.0", Command: "python3", URL: "https://python.org"},
-		}
+	assert.Contains(t, output, "WARN")
+	assert.NotEmpty(t, violations)
+	assert.Contains(t, violations[0], "linux")
+}
 
-		output := captureLog(t, func() {
-			versionsYamlSchema.Validate(input)
-		})
+func TestValidatePrerequisite_WindowsOptional(t *testing.T) {
+	p := validPrerequisite()
+	p.Install.Windows = ""
 
-		assert.Contains(t, output, "WARN")
-		assert.Contains(t, output, "'install' is not defined")
+	output := captureLog(t, func() {
+		violations := validatePrerequisite("tool", p)
+		assert.Empty(t, violations)
 	})
 
-	t.Run("empty map — nothing logged, nil returned", func(t *testing.T) {
-		output := captureLog(t, func() {
-			versionsYamlSchema.Validate(versionsYaml{})
-		})
+	assert.Empty(t, output)
+}
 
-		assert.Empty(t, output)
+func TestValidatePrerequisite_ViolationsLoggedAsWarn(t *testing.T) {
+	p := validPrerequisite()
+	p.Name = ""
+
+	output := captureLog(t, func() {
+		validatePrerequisite("tool", p)
 	})
+
+	assert.Contains(t, output, "WARN")
+	assert.NotContains(t, output, "ERRO")
+}
+
+func TestValidatePrerequisite_MessageContainsKey(t *testing.T) {
+	p := validPrerequisite()
+	p.Name = ""
+
+	violations := validatePrerequisite("my-tool", p)
+
+	assert.NotEmpty(t, violations)
+	assert.Contains(t, violations[0], "[my-tool]")
 }

--- a/internal/tools/versions.go
+++ b/internal/tools/versions.go
@@ -51,13 +51,13 @@ func GetRequirementsFromDir(dir string) ([]Prerequisite, []string, error) {
 		return nil, nil, fmt.Errorf("Failed to unmarshal versions yaml file %s: %w", yamlFile, err)
 	}
 
-	violations := versionsYamlSchema.Validate(fileParsed)
+	var violations []string
 
 	versions := make([]Prerequisite, 0, len(fileParsed))
 
 	for key, version := range fileParsed {
 		version.Key = key
-
+		violations = append(violations, validatePrerequisite(key, version)...)
 		versions = append(versions, version)
 	}
 


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->
## Summary

- Replace the hand-rolled declarative schema (`FieldRule`, `YAMLSchema`, `InstallCommandsSchema`) in `internal/tools/validation.go` with `go-playground/validator/v10` struct tags. The library was already a dependency; this removes ~140 lines of bespoke validation boilerplate.
- Validation rules are unchanged: `name`, `minimum-version`, `command`, `url` are required; `minimum-version` must be valid semver; `install.macos` and `install.linux` are required; `install.windows` is optional.

## CHANGES

**`internal/tools/prerequisites.go`**
- Add `validate:"required"` tags to `Name`, `Command`, `URL`, `Install`
- Add `validate:"required,semver"` to `MinimumVersion`
- Add `validate:"required"` to `InstallCommands.MacOS` and `InstallCommands.Linux`

**`internal/tools/validation.go`**
- Delete `FieldRule`, `YAMLSchema`, `InstallCommandsSchema`, `versionsYamlSchema`, `validateInstall`, `validatePlatform`
- Add `createPrereqValidatorOnce` (`sync.OnceValue`) — initialises the shared `*validator.Validate` once: registers a custom `semver` tag (backed by `Masterminds/semver`) and `RegisterTagNameFunc` so error messages use YAML key names (`"minimum-version"`) instead of Go field names (`"MinimumVersion"`)
- Add `validatePrerequisite(key, p)` — calls `validator.Struct`, translates `ValidationErrors` to the existing `"versions.yaml [key]: 'field' …"` message format, logs at Warn
- Add `fieldViolationMsg` — formats per-tag messages for `required` and `semver`

**`internal/tools/versions.go`**
- Replace `versionsYamlSchema.Validate(fileParsed)` with an inline call to `validatePrerequisite` inside the existing loop, removing the separate validation pass

**`internal/tools/validation_test.go`**
- Rewrite: remove tests for deleted schema types, add `TestValidatePrerequisite_*` suite covering valid entry, each required field missing, invalid semver, `install.macos` / `install.linux` required, `install.windows` optional, Warn-only logging, and key present in message


## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of config validation only; rules are preserved and covered by updated unit tests, with a minor logging severity change for missing platform install commands.
> 
> **Overview**
> Replaces the custom `FieldRule` / `YAMLSchema` validation layer for `versions.yaml` with **go-playground/validator** rules declared on `Prerequisite` and `InstallCommands` struct tags (`required`, custom `semver`, required macOS/Linux install commands).
> 
> Validation now runs per entry inside `GetRequirementsFromDir` via `validatePrerequisite`, still returning the same `versions.yaml [key]: 'field' …` violation strings and **Warn** logging. Error messages use YAML key names through `RegisterTagNameFunc`, and the shared validator is initialized once with `sync.OnceValue`.
> 
> Tests are rewritten around `validatePrerequisite_*` instead of the deleted schema types. **Behavior change:** missing install commands for the current platform no longer emit **Error**-level logs—only warnings like other field violations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae91afd25fd91bc74a03a0f8a75fb2c24621d51e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->