### PR TITLE
Add assist plugin v0.1.30

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.30",
+          "url": "assist/assist-0.1.30.tar.xz",
+          "sha256": "55a3f2ff1e2b09270372cd128d6c44628d20c4586081c9b42c627149d24331cc",
+          "releaseDate": "2026-07-07"
+        },
+        {
           "version": "0.1.29",
           "url": "assist/assist-0.1.29.tar.xz",
           "sha256": "f581396252189eaf057150e818f13f92b9f07e0fb1e6b372512bfc825dc6c28b",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.30 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.30
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.30
- **SHA256:** `55a3f2ff1e2b09270372cd128d6c44628d20c4586081c9b42c627149d24331cc`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 55843eb082462746245434655b26a346f1def1a2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->