### PR TITLE
[CFX-6846] Fix flaky smoke-test apt-get update failure (MS repo)

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -10,6 +10,11 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
+        # Runner image pre-seeds these MS apt sources; we don't use them and they're
+        # a source of flaky/noisy apt-get update failures (packages.microsoft.com
+        # sporadically serves a corrupted InRelease file). Removed for that reason only —
+        # if we ever actually need an MS package repo, re-add it explicitly for that job.
+        sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt-get update
         sudo apt-get install -y expect bash-completion
 

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -281,6 +281,11 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Runner image pre-seeds these MS apt sources; we don't use them and they're
+          # a source of flaky/noisy apt-get update failures (packages.microsoft.com
+          # sporadically serves a corrupted InRelease file). Removed for that reason only —
+          # if we ever actually need an MS package repo, re-add it explicitly for that job.
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
           sudo apt-get install -y expect bash-completion
 


### PR DESCRIPTION
## Summary

The nightly smoke test occasionally fails at the "Install smoke-test dependencies" step because `packages.microsoft.com` (azure-cli / microsoft-prod apt sources, pre-seeded by GitHub's `ubuntu-latest` runner image) served a corrupted/unsigned `InRelease` file, which fails `apt-get update` outright.

See [run 28896705873](https://github.com/datarobot-oss/cli/actions/runs/28896705873/job/85722945755).
See [run 28900829395](https://github.com/datarobot-oss/cli/actions/runs/28900829395/job/85736940035).

We don't install anything from those Microsoft repos (for eaxample, azure-cli), so this removes the two pre-seeded source list files before `apt-get update` in both places that install `expect`/`bash-completion`: [.github/actions/install-deps/action.yaml](.github/actions/install-deps/action.yaml) and the duplicated inline step in [.github/workflows/pr-checks.yaml](.github/workflows/pr-checks.yaml).

Confirmed this is a transient issue: I checked the last 15 `nightly-smoke` runs — this was the only failure, bracketed by successful runs 1h13m before and 47m after with no code changes in between.

If a future job genuinely needs a Microsoft apt repo, it should add that repo + signing key explicitly for that job — independent of these two unused pre-baked files. Alternately, we can remove these changes.

## Test plan
- [x] `task lint` passes
- [ ] CI: confirm `pr-checks.yaml`'s "Install dependencies" step succeeds
- [ ] Manually trigger `nightly-smoke` / `smoke-on-demand` after merge and confirm the "Install smoke-test dependencies" step no longer depends on Microsoft's mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only apt setup change; no application code, auth, or data paths affected.
> 
> **Overview**
> Addresses sporadic CI failures where **`apt-get update`** dies on GitHub **`ubuntu-latest`** runners because pre-seeded **`packages.microsoft.com`** sources (`azure-cli.list`, `microsoft-prod.list`) sometimes return a bad **`InRelease`**.
> 
> Before **`apt-get update`**, both Linux dependency install paths now **`sudo rm -f`** those two list files (with comments that the repo does not use those repos and any future MS package should be added explicitly per job): the **`install-deps`** composite action and the inline **Install dependencies** step in **`pr-checks.yaml`** completion tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af36104e23a578133bcf2a20b402bb5eb67b4fa7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->