### PR TITLE
[CFX-6846] Fix smoke-test MS apt-source cleanup to match by content, not filename

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -13,11 +13,10 @@ runs:
         # Runner image pre-seeds MS apt sources (azure-cli/microsoft-prod); we don't use
         # them and they're a source of flaky/noisy apt-get update failures
         # (packages.microsoft.com sporadically serves a corrupted InRelease file).
-        # Matched by content, not a fixed filename, since Ubuntu 24.04 runners may use
-        # either legacy .list or deb822 .sources files for these entries. Removed for
-        # that reason only — if we ever actually need an MS package repo, re-add it
-        # explicitly for that job.
-        sudo grep -rl 'packages.microsoft.com' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r sudo rm -f
+        # Matching by content allows us to manage both legacy.list and deb822 .sources files.
+        # NOTE: if we ever actually need an MS package repo, re-add it explicitly for that job.
+        # NOTE: or true is used to avoid failing the step if no files are found to delete.
+        sudo grep -rl 'packages.microsoft.com' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r sudo rm -f || true
         sudo apt-get update
         sudo apt-get install -y expect bash-completion
 

--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -10,11 +10,14 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        # Runner image pre-seeds these MS apt sources; we don't use them and they're
-        # a source of flaky/noisy apt-get update failures (packages.microsoft.com
-        # sporadically serves a corrupted InRelease file). Removed for that reason only —
-        # if we ever actually need an MS package repo, re-add it explicitly for that job.
-        sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+        # Runner image pre-seeds MS apt sources (azure-cli/microsoft-prod); we don't use
+        # them and they're a source of flaky/noisy apt-get update failures
+        # (packages.microsoft.com sporadically serves a corrupted InRelease file).
+        # Matched by content, not a fixed filename, since Ubuntu 24.04 runners may use
+        # either legacy .list or deb822 .sources files for these entries. Removed for
+        # that reason only — if we ever actually need an MS package repo, re-add it
+        # explicitly for that job.
+        sudo grep -rl 'packages.microsoft.com' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r sudo rm -f
         sudo apt-get update
         sudo apt-get install -y expect bash-completion
 

--- a/.github/workflows/_smoke.yaml
+++ b/.github/workflows/_smoke.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install smoke-test dependencies
         if: ${{ inputs.install-deps }}
-        uses: ./.github/actions/install-deps
+        uses: datarobot-oss/cli/.github/actions/install-deps@main
 
       - name: Debug brew environment (macOS only)
         if: ${{ runner.os == 'macOS' && inputs.debug-brew }}
@@ -122,11 +122,11 @@ jobs:
 
       - name: Set up Go and Task
         if: ${{ inputs.setup }}
-        uses: ./.github/actions/setup
+        uses: datarobot-oss/cli/.github/actions/setup@main
 
       - name: Build and Install the DR CLI Binary
         if: ${{ inputs.install-bin }}
-        uses: ./.github/actions/install-dr-bin
+        uses: datarobot-oss/cli/.github/actions/install-dr-bin@main
 
       - name: Build binary
         if: ${{ inputs.build }}

--- a/.github/workflows/_smoke.yaml
+++ b/.github/workflows/_smoke.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install smoke-test dependencies
         if: ${{ inputs.install-deps }}
-        uses: datarobot-oss/cli/.github/actions/install-deps@main
+        uses: ./.github/actions/install-deps
 
       - name: Debug brew environment (macOS only)
         if: ${{ runner.os == 'macOS' && inputs.debug-brew }}
@@ -122,11 +122,11 @@ jobs:
 
       - name: Set up Go and Task
         if: ${{ inputs.setup }}
-        uses: datarobot-oss/cli/.github/actions/setup@main
+        uses: ./.github/actions/setup
 
       - name: Build and Install the DR CLI Binary
         if: ${{ inputs.install-bin }}
-        uses: datarobot-oss/cli/.github/actions/install-dr-bin@main
+        uses: ./.github/actions/install-dr-bin
 
       - name: Build binary
         if: ${{ inputs.build }}

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -281,11 +281,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # Runner image pre-seeds these MS apt sources; we don't use them and they're
-          # a source of flaky/noisy apt-get update failures (packages.microsoft.com
-          # sporadically serves a corrupted InRelease file). Removed for that reason only —
-          # if we ever actually need an MS package repo, re-add it explicitly for that job.
-          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+          # Runner image pre-seeds MS apt sources (azure-cli/microsoft-prod); we don't use
+          # them and they're a source of flaky/noisy apt-get update failures
+          # (packages.microsoft.com sporadically serves a corrupted InRelease file).
+          # Matched by content, not a fixed filename, since Ubuntu 24.04 runners may use
+          # either legacy .list or deb822 .sources files for these entries. Removed for
+          # that reason only — if we ever actually need an MS package repo, re-add it
+          # explicitly for that job.
+          sudo grep -rl 'packages.microsoft.com' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r sudo rm -f
           sudo apt-get update
           sudo apt-get install -y expect bash-completion
 

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -284,11 +284,10 @@ jobs:
           # Runner image pre-seeds MS apt sources (azure-cli/microsoft-prod); we don't use
           # them and they're a source of flaky/noisy apt-get update failures
           # (packages.microsoft.com sporadically serves a corrupted InRelease file).
-          # Matched by content, not a fixed filename, since Ubuntu 24.04 runners may use
-          # either legacy .list or deb822 .sources files for these entries. Removed for
-          # that reason only — if we ever actually need an MS package repo, re-add it
-          # explicitly for that job.
-          sudo grep -rl 'packages.microsoft.com' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r sudo rm -f
+          # Matching by content allows us to manage both legacy.list and deb822 .sources files.
+          # NOTE: if we ever actually need an MS package repo, re-add it explicitly for that job.
+          # NOTE: or true is used to avoid failing the step if no files are found to delete.
+          sudo grep -rl 'packages.microsoft.com' /etc/apt/sources.list.d/ 2>/dev/null | xargs -r sudo rm -f || true
           sudo apt-get update
           sudo apt-get install -y expect bash-completion
 


### PR DESCRIPTION
## Summary
- #635 removed `azure-cli.list`/`microsoft-prod.list` before `apt-get update`, but [post-merge CI](https://github.com/datarobot-oss/cli/actions/runs/28903178959/job/85744465110) showed apt still fetching `packages.microsoft.com` — the `rm -f` missed the actual file. Root cause: Ubuntu 24.04 can register apt sources in the newer [deb822 `.sources` format](https://wiki.debian.org/DebianRepository/Format#Deb822_Format) instead of legacy `.list`, so the hardcoded filenames didn't match.
- Fix: grep `/etc/apt/sources.list.d/` for any file containing `packages.microsoft.com` and remove by content instead of guessing the filename/extension, in [install-deps/action.yaml](.github/actions/install-deps/action.yaml) and [pr-checks.yaml](.github/workflows/pr-checks.yaml).
- Validated on this PR by temporarily pointing `_smoke.yaml`'s composite-action refs at this branch instead of `@main` (composite actions here are intentionally pinned to `@main`, so that change has been reverted — [CI run confirming the fix](https://github.com/datarobot-oss/cli/actions/runs/28903619743/job/85745872514) shows `apt-get update` no longer contacts `packages.microsoft.com` at all).

```
Run # Runner image pre-seeds MS apt sources (azure-cli/microsoft-prod); we don't use
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
Get:6 https://dl.google.com/linux/chrome-stable/deb stable InRelease [1825 B]
Get:7 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1079 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu noble-updates/main Translation-en [267 kB]
Get:9 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Components [181 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 c-n-f Metadata [17.7 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1659 kB]
Get:12 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe Translation-en [327 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Components [388 kB]
Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 c-n-f Metadata [34.9 kB]
Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [1196 kB]
Get:16 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted Translation-en [271 kB]
[...]
```

This log shows that from [run #13, in main](https://github.com/datarobot-oss/cli/actions/runs/28900829395/job/85740818689) we are pulling from packages.microsoft.com:

```
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Get:6 https://packages.microsoft.com/repos/azure-cli noble InRelease [3564 B]
Get:7 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease [3600 B]
Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
Get:8 https://dl.google.com/linux/chrome-stable/deb stable InRelease [1825 B]
Get:9 https://packages.microsoft.com/repos/azure-cli noble/main amd64 Packages [2314 B]
Get:10 https://packages.microsoft.com/ubuntu/24.04/prod noble/main arm64 Packages [172 kB]
Get:11 https://packages.microsoft.com/ubuntu/24.04/prod noble/main amd64 Packages [205 kB]
Get:12 https://packages.microsoft.com/ubuntu/24.04/prod noble/main armhf Packages [11.7 kB]
Get:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1079 kB]
[...]
```

And this log from 

## Test plan
- [x] `task lint` passes
- [x] Validated via a temporary same-ref override (since reverted) that the grep matches/removes the actual source file and `apt-get update` succeeds without touching `packages.microsoft.com`
- [ ] After merge, confirm a nightly-smoke run never contacts `packages.microsoft.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI install steps; no runtime product code or auth/data paths are affected.
> 
> **Overview**
> **Ubuntu apt prep** no longer deletes fixed `azure-cli.list` / `microsoft-prod.list` paths. It now removes any file under `/etc/apt/sources.list.d/` that references `packages.microsoft.com`, so cleanup works when runners use deb822 `.sources` as well as legacy `.list` files. The same logic is applied in the **install-deps** composite action and the **completion-tests** inline install step in `pr-checks.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c1697e8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->