### PR TITLE
[CFX-6846] Document composite-action @main-pinning testing gap

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -30,3 +30,9 @@ Ensure consistency and maintainability.
 
 - **bugbot-testing.md** — Race detector, error paths, test seams, mocking
 - **bugbot-cmd.md** — Table rendering, file organization, output consistency
+
+## CI & Workflow Rules
+
+Informational callouts about GitHub Actions workflows and composite actions.
+
+- **bugbot-ci.md** — Composite action changes can't be validated by their own PR's CI

--- a/.cursor/bugbot-ci.md
+++ b/.cursor/bugbot-ci.md
@@ -1,0 +1,18 @@
+# CI Workflows & Composite Actions
+
+## Composite Action Changes Require Special Testing
+
+Reusable composite actions under `.github/actions/` (e.g. `install-deps`, `setup`,
+`install-dr-bin`) are referenced by workflows like `_smoke.yaml` and
+`_pre-release-smoke.yaml` via a pinned `@main` ref
+(`datarobot-oss/cli/.github/actions/<name>@main`), not the calling ref. This is
+intentional — but it means **a PR that modifies a composite action's `action.yaml`
+cannot exercise that change through its own CI run**: the workflow always pulls the
+action's code from `main`, so the fix only takes effect after merge.
+
+When reviewing a PR that touches `.github/actions/*/action.yaml`, flag it as an
+**informational callout**: CI on this PR does not validate the new behavior. Confirm
+the author has a plan to verify it — e.g., temporarily pointing the ref at the PR
+branch to get a real CI run (then reverting before merge), or verifying immediately
+after merge via a manual `workflow_dispatch` run of a workflow that exercises that
+action (see `.github/workflows/README.md` for which workflows call which suites).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,9 @@ All PRs are reviewed against **bugbot rules** in [.cursor/BUGBOT.md](.cursor/BUG
 - **Testing** — Test coverage, mocking, pagination tests
 - **Commands** — Table rendering, file organization, output formatting
 
+**CI & Workflows** (informational callouts, not correctness bugs):
+- **Composite Actions** — Changes to `.github/actions/*/action.yaml` can't be validated by their own PR's CI
+
 **When working on code**, apply these quick principles:
 - **Concurrency**: Recover from panics, capture loop variables, pair WaitGroups, close channels safely
 - **Errors**: Wrap with context, specialize messages (404 vs 500), log before returning
@@ -153,6 +156,15 @@ All PRs are reviewed against **bugbot rules** in [.cursor/BUGBOT.md](.cursor/BUG
 - **Platforms**: Add build tags, match signatures, test on target platforms
 
 Refer to [.cursor/BUGBOT.md](.cursor/BUGBOT.md) for detailed rules and examples during PR review.
+
+> [!NOTE]
+> **Composite action changes need special testing.** Workflows like `_smoke.yaml` and
+> `_pre-release-smoke.yaml` reference `.github/actions/*` via a pinned `@main` ref, not
+> the calling ref — so a PR that edits a composite action's `action.yaml` does not
+> exercise that change in its own CI run; the fix only takes effect after merge. Either
+> temporarily point the ref at the PR branch to get a real CI run (reverting before
+> merge), or verify immediately after merge via a manual `workflow_dispatch` run. See
+> [.cursor/bugbot-ci.md](.cursor/bugbot-ci.md).
 
 ## Feature Gates
 


### PR DESCRIPTION
## RATIONALE

While fixing the flaky smoke-test apt-get issue (#635, #636), we found that composite actions under `.github/actions/` are referenced by `_smoke.yaml`/`_pre-release-smoke.yaml` via a pinned `@main` ref rather than the caller's ref. This means a PR that edits a composite action's `action.yaml` doesn't exercise that change in its own CI — it silently tests against `main`'s existing version, so a broken fix can merge without ever being validated.

## CHANGES

Adds a new informational bugbot rule, [.cursor/bugbot-ci.md](.cursor/bugbot-ci.md), and wires it into [.cursor/BUGBOT.md](.cursor/BUGBOT.md) under a new "CI & Workflow Rules" section, so reviewers flag this as a callout (not a correctness bug) on PRs touching `.github/actions/*/action.yaml`.

Adds the same guidance to [AGENTS.md](AGENTS.md) so contributors know upfront that they'll need to verify out-of-band (temporary ref override, or a manual `workflow_dispatch` post-merge).
<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1783956422.746789 -->
<!-- rr:slack:end -->