### PR TITLE
ci: improve Trivy reporting for fork smoke tests

### DIFF
--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -101,20 +101,96 @@ jobs:
           fetch-depth: 0
 
       - name: Run Trivy vulnerability scanner
+        id: trivy_scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 #v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
+          format: 'json'
+          output: 'trivy-results.json'
           severity: 'CRITICAL,HIGH'
           exit-code: '1'  # Fail if vulnerabilities found
 
+      - name: Convert results to SARIF
+        id: trivy_convert
+        if: always()
+        run: trivy convert --format sarif --output trivy-results.sarif trivy-results.json
+
       - name: Upload Trivy results
+        id: trivy_upload
         uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+
+      - name: Display vulnerability table
+        if: always()
+        run: trivy convert --format table trivy-results.json
+
+      - name: Publish Trivy run summary
+        if: always()
+        env:
+          TRIVY_SCAN_OUTCOME: ${{ steps.trivy_scan.outcome }}
+          TRIVY_CONVERT_OUTCOME: ${{ steps.trivy_convert.outcome }}
+          TRIVY_UPLOAD_OUTCOME: ${{ steps.trivy_upload.outcome }}
+        run: |
+          {
+            echo "## Trivy scan summary"
+            echo ""
+            echo "| Stage | Outcome |"
+            echo "| --- | --- |"
+            echo "| Scan | \`${TRIVY_SCAN_OUTCOME}\` |"
+            echo "| Convert to SARIF | \`${TRIVY_CONVERT_OUTCOME}\` |"
+            echo "| Upload SARIF | \`${TRIVY_UPLOAD_OUTCOME}\` |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -f trivy-results.json ]; then
+            total="$(jq '[.Results[]?.Vulnerabilities[]?] | length' trivy-results.json)"
+            critical="$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length' trivy-results.json)"
+            high="$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH")] | length' trivy-results.json)"
+
+            {
+              echo "### Vulnerability counts"
+              echo ""
+              echo "| Severity | Count |"
+              echo "| --- | --- |"
+              echo "| CRITICAL | ${critical} |"
+              echo "| HIGH | ${high} |"
+              echo "| Total | ${total} |"
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::trivy-results.json was not created. The scan likely failed before producing output."
+            echo "- trivy-results.json: missing" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Annotate Trivy failure reason
+        if: failure()
+        env:
+          TRIVY_SCAN_OUTCOME: ${{ steps.trivy_scan.outcome }}
+          TRIVY_CONVERT_OUTCOME: ${{ steps.trivy_convert.outcome }}
+          TRIVY_UPLOAD_OUTCOME: ${{ steps.trivy_upload.outcome }}
+        run: |
+          if [ "${TRIVY_SCAN_OUTCOME}" = "failure" ]; then
+            echo "::error title=Trivy scan failed::The 'Run Trivy vulnerability scanner' step failed. Check that step logs for scanner errors or vulnerability threshold failures."
+          fi
+
+          if [ "${TRIVY_CONVERT_OUTCOME}" = "failure" ]; then
+            echo "::error title=SARIF conversion failed::The JSON-to-SARIF conversion failed. This often happens when trivy-results.json is missing or malformed."
+          fi
+
+          if [ "${TRIVY_UPLOAD_OUTCOME}" = "failure" ]; then
+            echo "::error title=SARIF upload failed::Uploading trivy-results.sarif to GitHub Security failed. Check upload step logs for API or SARIF validation details."
+          fi
+
+          if [ ! -f trivy-results.json ]; then
+            echo "::error title=Missing Trivy JSON output::Expected trivy-results.json was not found in the workspace."
+          fi
+
+          if [ ! -f trivy-results.sarif ]; then
+            echo "::error title=Missing Trivy SARIF output::Expected trivy-results.sarif was not found in the workspace."
+          fi
       # S6: gosec removed — it ran with || true (can never fail) and was pure noise.
       # govulncheck in security-scan.yaml covers Go CVEs more reliably.
 

--- a/.github/workflows/pr-security.yaml
+++ b/.github/workflows/pr-security.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run Trivy vulnerability scanner
+        id: trivy_scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 #v0.36.0
         with:
           scan-type: 'fs'
@@ -42,6 +43,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM'
 
       - name: Convert results to SARIF
+        id: trivy_convert
         # trivy is in PATH after the action step above.
         # if: always() mirrors the upload step — ensures SARIF conversion is attempted even if the
         # scan step fails, so the upload step can still run (and report what it can).
@@ -49,13 +51,82 @@ jobs:
         run: trivy convert --format sarif --output trivy-results.sarif trivy-results.json
 
       - name: Upload Trivy results to GitHub Security tab
+        id: trivy_upload
         uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
 
       - name: Display vulnerability table
+        if: always()
         run: trivy convert --format table trivy-results.json
+
+      - name: Publish Trivy run summary
+        if: always()
+        env:
+          TRIVY_SCAN_OUTCOME: ${{ steps.trivy_scan.outcome }}
+          TRIVY_CONVERT_OUTCOME: ${{ steps.trivy_convert.outcome }}
+          TRIVY_UPLOAD_OUTCOME: ${{ steps.trivy_upload.outcome }}
+        run: |
+          {
+            echo "## Trivy scan summary"
+            echo ""
+            echo "| Stage | Outcome |"
+            echo "| --- | --- |"
+            echo "| Scan | \`${TRIVY_SCAN_OUTCOME}\` |"
+            echo "| Convert to SARIF | \`${TRIVY_CONVERT_OUTCOME}\` |"
+            echo "| Upload SARIF | \`${TRIVY_UPLOAD_OUTCOME}\` |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -f trivy-results.json ]; then
+            total="$(jq '[.Results[]?.Vulnerabilities[]?] | length' trivy-results.json)"
+            critical="$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "CRITICAL")] | length' trivy-results.json)"
+            high="$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "HIGH")] | length' trivy-results.json)"
+            medium="$(jq '[.Results[]?.Vulnerabilities[]? | select(.Severity == "MEDIUM")] | length' trivy-results.json)"
+
+            {
+              echo "### Vulnerability counts"
+              echo ""
+              echo "| Severity | Count |"
+              echo "| --- | --- |"
+              echo "| CRITICAL | ${critical} |"
+              echo "| HIGH | ${high} |"
+              echo "| MEDIUM | ${medium} |"
+              echo "| Total | ${total} |"
+              echo ""
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::trivy-results.json was not created. The scan likely failed before producing output."
+            echo "- trivy-results.json: missing" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Annotate Trivy failure reason
+        if: failure()
+        env:
+          TRIVY_SCAN_OUTCOME: ${{ steps.trivy_scan.outcome }}
+          TRIVY_CONVERT_OUTCOME: ${{ steps.trivy_convert.outcome }}
+          TRIVY_UPLOAD_OUTCOME: ${{ steps.trivy_upload.outcome }}
+        run: |
+          if [ "${TRIVY_SCAN_OUTCOME}" = "failure" ]; then
+            echo "::error title=Trivy scan failed::The 'Run Trivy vulnerability scanner' step failed. Check that step logs for the underlying scanner error."
+          fi
+
+          if [ "${TRIVY_CONVERT_OUTCOME}" = "failure" ]; then
+            echo "::error title=SARIF conversion failed::The JSON-to-SARIF conversion failed. This often happens when trivy-results.json is missing or malformed."
+          fi
+
+          if [ "${TRIVY_UPLOAD_OUTCOME}" = "failure" ]; then
+            echo "::error title=SARIF upload failed::Uploading trivy-results.sarif to GitHub Security failed. Check upload step logs for API or SARIF validation details."
+          fi
+
+          if [ ! -f trivy-results.json ]; then
+            echo "::error title=Missing Trivy JSON output::Expected trivy-results.json was not found in the workspace."
+          fi
+
+          if [ ! -f trivy-results.sarif ]; then
+            echo "::error title=Missing Trivy SARIF output::Expected trivy-results.sarif was not found in the workspace."
+          fi
 
 # Skip this scan for now due to false positives and performance issues
   # gosec-scan:


### PR DESCRIPTION
## Summary
- update `fork-smoke-tests.yaml` security-scan Trivy flow to mirror the richer diagnostics used in `pr-security.yaml`
- scan to JSON first, then convert to SARIF, upload SARIF, and always render the table output
- add run summary output (`GITHUB_STEP_SUMMARY`) with per-stage outcomes and vulnerability counts
- add explicit failure annotations for scan/convert/upload stages and missing output artifacts

## Why
Fork smoke-test workflow runs were hard to debug when Trivy failed. This makes failures actionable directly from the run summary and annotations.

## Validation
- `task lint`
- `task build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflow steps and reporting; they do not alter application code or security enforcement semantics beyond clearer failure visibility.
> 
> **Overview**
> **Trivy CI flows** in `fork-smoke-tests.yaml` and `pr-security.yaml` now emit richer diagnostics when scans fail or partially succeed.
> 
> In **fork smoke tests**, the security job no longer writes SARIF directly from the action. It scans to **JSON**, converts to SARIF, uploads to GitHub Security, and always prints a **table** in the logs—matching the pattern already used on main PR security runs. Step IDs were added so outcomes can be referenced downstream.
> 
> Both workflows add a **`GITHUB_STEP_SUMMARY`** block with per-stage outcomes (scan, convert, upload) and **severity counts** parsed from `trivy-results.json` (fork smoke: CRITICAL/HIGH; `pr-security`: also MEDIUM). On job failure, **workflow annotations** call out which stage failed and whether JSON/SARIF artifacts are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2939afcd535f3bc3a1a17ee120d924e6199bdc78. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->