### PR TITLE
[CFX-6026] Plugin manifest validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/gitsight/go-vcsurl v1.0.1
 	github.com/go-playground/validator/v10 v10.30.3
-	github.com/google/go-cmp v0.7.0
 	github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade
 	github.com/joho/godotenv v1.5.1
 	github.com/muesli/cancelreader v0.2.2

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -30,7 +30,7 @@ type PluginScripts struct {
 
 // BasicPluginManifest contains the core fields that all plugin manifests must have.
 type BasicPluginManifest struct {
-	Name           string `json:"name"`
+	Name           string `json:"name"                  validate:"required,dr_id"`
 	Version        string `json:"version,omitempty"`
 	Description    string `json:"description,omitempty"`
 	Authentication bool   `json:"authentication,omitempty"`

--- a/internal/plugin/validation.go
+++ b/internal/plugin/validation.go
@@ -109,6 +109,9 @@ var createManifestValidatorOnce = sync.OnceValue(func() *validator.Validate {
 // core BasicPluginManifest fields match expected. Scripts and MinCLIVersion
 // are intentionally ignored — they are optional managed-plugin fields that
 // PATH plugins do not output.
+//
+// The field-by-field comparison below could be replaced with go-cmp, but was
+// written out explicitly to avoid adding that dependency.
 func validateManifests(expected, actual PluginManifest) error {
 	manifestValidator := createManifestValidatorOnce()
 

--- a/internal/plugin/validation.go
+++ b/internal/plugin/validation.go
@@ -22,11 +22,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/datarobot/cli/internal/log"
-	"github.com/google/go-cmp/cmp"
+	"github.com/datarobot/cli/internal/validate"
+	"github.com/go-playground/validator/v10"
 )
 
 // validatePluginName checks that name is a safe single-segment identifier with no path separators.
@@ -82,17 +85,63 @@ func ValidateLicense(pluginDir string) error {
 	return nil
 }
 
-// validateManifests compares two manifests and returns an error if they differ.
+// createManifestValidatorOnce initializes the shared validator exactly once.
+// validator.New() allocates reflection caches and RegisterValidation /
+// RegisterTagNameFunc are not goroutine-safe to call concurrently, so
+// sync.OnceValue guarantees a single initialization.
+var createManifestValidatorOnce = sync.OnceValue(func() *validator.Validate {
+	v := validator.New()
+
+	v.RegisterTagNameFunc(func(f reflect.StructField) string {
+		if name, _, _ := strings.Cut(f.Tag.Get("json"), ","); name != "" && name != "-" {
+			return name
+		}
+
+		return f.Name
+	})
+
+	_ = validate.RegisterDRTags(v)
+
+	return v
+})
+
+// validateManifests validates the script output manifest and checks that the
+// core BasicPluginManifest fields match expected. Scripts and MinCLIVersion
+// are intentionally ignored — they are optional managed-plugin fields that
+// PATH plugins do not output.
 func validateManifests(expected, actual PluginManifest) error {
-	opts := cmp.Options{
-		// Ignore Scripts and MinCLIVersion - they're optional managed plugin fields
-		cmp.FilterPath(func(p cmp.Path) bool {
-			return p.String() == "Scripts" || p.String() == "MinCLIVersion"
-		}, cmp.Ignore()),
+	manifestValidator := createManifestValidatorOnce()
+
+	if err := manifestValidator.Struct(actual); err != nil {
+		var ve validator.ValidationErrors
+		if errors.As(err, &ve) {
+			return fmt.Errorf("plugin script output is invalid: field %q failed %q validation", ve[0].Field(), ve[0].Tag())
+		}
+
+		return fmt.Errorf("plugin script output is invalid: %w", err)
 	}
 
-	if diff := cmp.Diff(expected, actual, opts); diff != "" {
-		return fmt.Errorf("plugin script output does not match manifest.json:\n%s", diff)
+	var mismatches []string
+
+	// Fields `Scripts` and `MinCLIVersion` are ignored as they're optional managed plugin fields
+	if actual.Name != expected.Name {
+		mismatches = append(mismatches, fmt.Sprintf("Name: expected %q, got %q", expected.Name, actual.Name))
+	}
+
+	if actual.Version != expected.Version {
+		mismatches = append(mismatches, fmt.Sprintf("Version: expected %q, got %q", expected.Version, actual.Version))
+	}
+
+	if actual.Description != expected.Description {
+		mismatches = append(mismatches, fmt.Sprintf("Description: expected %q, got %q", expected.Description, actual.Description))
+	}
+
+	if actual.Authentication != expected.Authentication {
+		mismatches = append(mismatches, fmt.Sprintf("Authentication: expected %v, got %v", expected.Authentication, actual.Authentication))
+	}
+
+	if len(mismatches) > 0 {
+		return fmt.Errorf("plugin script output does not match manifest.json:\n  %s", strings.Join(mismatches, "\n  "))
 	}
 
 	log.Debug("Plugin script manifest validation passed")


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->


- Replace `go-cmp` manifest comparison in `validateManifests` with explicit struct tag validation + field-by-field mismatch reporting
- Add `validate:"required,dr_id"` to `BasicPluginManifest.Name`, enforcing non-empty and path-safe names via the existing `dr_id` tag
- Add `createManifestValidatorOnce` (`sync.OnceValue`) in `validation.go` — shared validator initialised once with json tag names and DataRobot custom tags (`dr_id`)
- `validateManifests` now first validates the script-output manifest struct (catching empty/unsafe names before the comparison), then reports all field mismatches (`Name`, `Version`, `Description`, `Authentication`) in a single, human-readable error; `Scripts` and `MinCLIVersion` remain intentionally excluded — same fields compared and same fields ignored as before, only the implementation changes from `go-cmp` to explicit checks
- Drop `github.com/google/go-cmp` from `go.mod` — it was only used in the one non-test file being replaced

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized plugin validation refactor with stricter name checks; no auth or data-path changes beyond existing manifest comparison behavior.
> 
> **Overview**
> Plugin script manifest validation now uses **go-playground/validator** (with shared `sync.OnceValue` init and DataRobot `dr_id` tags) instead of **go-cmp**, and **`BasicPluginManifest.Name`** is tagged **`required,dr_id`** so empty or path-unsafe names fail before comparison.
> 
> **`validateManifests`** first validates the script’s JSON output struct, then compares **`Name`**, **`Version`**, **`Description`**, and **`Authentication`** to the expected manifest in one error listing all mismatches; **`Scripts`** and **`MinCLIVersion`** are still ignored. **`github.com/google/go-cmp`** is removed from **`go.mod`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db04d7befb973319bd8cf3ee67d741b5674a26ff. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->