### PR TITLE
⬆️ CI(Actions): Bump github/codeql-action from 3.36.2 to 4.36.3

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,3 +13,7 @@ updates:
       interval: weekly
     commit-message:
       prefix: "⬆️ CI(Actions): "
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/fork-smoke-tests.yaml
+++ b/.github/workflows/fork-smoke-tests.yaml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload Trivy results
         id: trivy_upload
-        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/pr-security.yaml
+++ b/.github/workflows/pr-security.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload Trivy results to GitHub Security tab
         id: trivy_upload
-        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
@@ -152,7 +152,7 @@ jobs:
   #         gosec -fmt=sarif -out=gosec-results.sarif -exclude-dir=smoke_test_scripts ./... || true
 
   #     - name: Upload gosec results to GitHub Security tab
-  #       uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+  #       uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
   #       if: always()
   #       continue-on-error: true
   #       with:
@@ -223,15 +223,15 @@ jobs:
           go-version-file: go.mod
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
         with:
           languages: go
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
         with:
           category: /language:go


### PR DESCRIPTION
# RATIONALE

In GH Actions logs you see:

```
Warning: CodeQL Action v3 will be deprecated in December 2026. Please update all occurrences of the CodeQL Action in your workflow files to v4. For more information, see https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/
```

Turns out Dependabot indirectly tried to fix it, but opened three separate PRs that each bump one `github/codeql-action` sub-action from v3.36.2 to v4.36.3 in `pr-security.yaml` / `fork-smoke-tests.yaml`:

- Closes #640 (`upload-sarif`)
- Closes #639 (`autobuild`)
- Closes #638 (`analyze`)

Since all three bump the same dependency to the same version and overlap in `pr-security.yaml`, this PR consolidates them into a single update rather than merging three separate one-line PRs.

While consolidating, I noticed a fourth usage — `github/codeql-action/init` — was left on the old v3 SHA by all three original PRs (no Dependabot PR covers it). `init`, `autobuild`, and `analyze` run in the same CodeQL job and are expected to be version-matched, so leaving `init` behind risked a version-compatibility failure. This PR bumps `init` to the same v4.36.3 SHA for consistency.

## CHANGES

- Bump `github/codeql-action/upload-sarif` from `dd903d2e...` (v3.36.2) to `54f647b7...` (v4.36.3) in `.github/workflows/pr-security.yaml` (active trivy-scan step + commented-out gosec step) and `.github/workflows/fork-smoke-tests.yaml`
- Bump `github/codeql-action/autobuild` to the same SHA in `.github/workflows/pr-security.yaml`
- Bump `github/codeql-action/analyze` to the same SHA in `.github/workflows/pr-security.yaml`
- Bump `github/codeql-action/init` to the same SHA in `.github/workflows/pr-security.yaml` (extra, not from any of the three original PRs — keeps the CodeQL job on a consistent action version)

- Add a `groups: codeql-action` rule (pattern `github/codeql-action*`) to `.github/dependabot.yaml` so future `codeql-action` releases land as one PR instead of splitting across sub-actions. Reference: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--

> When groups is used to define rules:
> All updates for dependencies that match a rule are combined in a single pull request.


No other changes.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.
