### PR TITLE
[CFX-6854] Update to go 1.26.5

### DIFF
--- a/.github/documentation-style-spec.md
+++ b/.github/documentation-style-spec.md
@@ -262,7 +262,7 @@ Add periods to descriptions
 
 **Format**
 ```markdown
-✅ **Note:** The CLI requires Go 1.26.4 or later.
+✅ **Note:** The CLI requires Go 1.26.5 or later.
 
 ✅ **Important:** Never commit `.env` files to version control.
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: 1.26.4
+  go: 1.26.5
 linters:
   enable:
     - asasalint

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ If you would like to build and install from source, you can do so by following t
 
 #### Prerequisites
 
-- Go 1.26.4 or later (for building from source)
+- Go 1.26.5 or later (for building from source)
 - Git
 - [Task](https://taskfile.dev/) (for development and task running)
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -65,7 +65,7 @@ See [Building](building.md) for detailed workflow documentation.
 
 Before you begin development:
 
-- **Go 1.26.4 or later**&mdash;required for building the CLI.
+- **Go 1.26.5 or later**&mdash;required for building the CLI.
 - **Git**&mdash;version control.
 - **Task**&mdash;task runner for development commands.
 - **golangci-lint**&mdash;installed automatically via `task dev-init`.

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -18,7 +18,7 @@ This guide outlines how to build, test, and develop with the DataRobot CLI.
 
 ### Prerequisites
 
-- [Go 1.26.4+](https://golang.org/dl/)
+- [Go 1.26.5+](https://golang.org/dl/)
 - Git version control
 - [Task](https://taskfile.dev/installation/) (The task runner)
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -6,7 +6,7 @@ This page outlines how to set up your development environment to build and devel
 
 ## Prerequisites
 
-- [Go 1.26.4](https://golang.org/dl/)
+- [Go 1.26.5](https://golang.org/dl/)
 - Git for version control
 - [Task](https://taskfile.dev/installation/) (A task runner)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datarobot/cli
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
# RATIONALE

Security scans of the CLI repo are failing now due to CVEs present in Go 1.26.4. These appear to be resolved in 1.26.5, so let's upgrade the codebase.

Example:
https://github.com/datarobot-oss/cli/actions/runs/28966239143/job/85950016548?pr=649

```log
=== Symbol Results ===

Vulnerability #1: GO-2026-5856
    Invoking Encrypted Client Hello privacy leak in crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2026-5856
  Standard library
    Found in: crypto/tls@go1.26.4
    Fixed in: crypto/tls@go1.26.5
    Example traces found:
Error:       #1: internal/auth/auth.go:242:22: auth.WaitForAPIKeyCallback calls http.Server.Serve, which eventually calls tls.Conn.HandshakeContext
Error:       #2: internal/drapi/filesapi/allfiles.go:94:19: filesapi.httpClient.DownloadFile calls io.Copy, which eventually calls tls.Conn.Read
Error:       #3: cmd/start/model.go:472:16: start.Model.View calls fmt.Fprintf, which calls tls.Conn.Write
Error:       #4: internal/config/api.go:119:45: config.RedactedReqInfo calls httputil.DumpRequestOut, which eventually calls tls.Dialer.DialContext

Your code is affected by 1 vulnerability from the Go standard library.
This scan also found 1 vulnerability in packages you import and 1 vulnerability
in modules you require, but your code doesn't appear to call these
vulnerabilities.
Use '-show verbose' for more details.
Error: Process completed with exit code 3.
```

## CHANGES

go 1.26.4 -> go 1.26.5

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 47b3af0ef29ace78cf5c62325002f08e34ff3297. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->