### PR TITLE
[CFX-4898] Add llm-gateway command

### DIFF
--- a/cmd/llm-gateway/cmd.go
+++ b/cmd/llm-gateway/cmd.go
@@ -1,0 +1,34 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llmgateway
+
+import (
+	"github.com/datarobot/cli/cmd/llm-gateway/list"
+	selectcmd "github.com/datarobot/cli/cmd/llm-gateway/select"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "llm-gateway",
+		Aliases: []string{"llm-gateways", "llm"},
+		GroupID: "core",
+		Short:   "Manage LLM Gateway models",
+	}
+
+	cmd.AddCommand(list.Cmd(), selectcmd.Cmd())
+
+	return cmd
+}

--- a/cmd/llm-gateway/cmd_test.go
+++ b/cmd/llm-gateway/cmd_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package llmgateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCmd_Use(t *testing.T) {
+	cmd := Cmd()
+
+	assert.Equal(t, "llm-gateway", cmd.Use)
+}
+
+func TestCmd_Aliases(t *testing.T) {
+	cmd := Cmd()
+
+	assert.Contains(t, cmd.Aliases, "llm")
+	assert.Contains(t, cmd.Aliases, "llm-gateways")
+}
+
+func TestCmd_Subcommands(t *testing.T) {
+	cmd := Cmd()
+
+	names := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		names[sub.Name()] = true
+	}
+
+	assert.True(t, names["list"], "expected 'list' subcommand")
+	assert.True(t, names["select"], "expected 'select' subcommand")
+}
+
+func TestCmd_GroupID(t *testing.T) {
+	cmd := Cmd()
+
+	assert.Equal(t, "core", cmd.GroupID)
+}

--- a/cmd/llm-gateway/list/cmd.go
+++ b/cmd/llm-gateway/list/cmd.go
@@ -1,0 +1,153 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// LLMOutput is the JSON representation of an LLM for --output-format json.
+type LLMOutput struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+	Selected bool   `json:"selected"`
+}
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:          "list",
+		Aliases:      []string{"ls"},
+		Short:        "List available LLM Gateway models",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			llmList, err := drapi.GetLLMs()
+			if err != nil {
+				return err
+			}
+
+			selectedID := viperx.GetString(config.DefaultLLMID)
+
+			format := outputformat.GetFormat(cmd)
+			if format == outputformat.OutputFormatJSON {
+				outputs := toLLMOutputs(llmList.LLMs, selectedID)
+
+				return outputformat.PrintJSONEnvelope(os.Stdout, "llms", outputs)
+			}
+
+			printLLMTable(llmList.LLMs, selectedID)
+
+			return nil
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		return map[string]any{
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}
+
+func toLLMOutputs(llms []drapi.LLM, selectedID string) []LLMOutput {
+	outputs := make([]LLMOutput, len(llms))
+
+	for i, l := range llms {
+		outputs[i] = LLMOutput{
+			ID:       l.LlmID,
+			Name:     l.Name,
+			Provider: l.Provider,
+			Model:    l.Model,
+			Selected: l.LlmID == selectedID,
+		}
+	}
+
+	return outputs
+}
+
+func terminalWidth() int {
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w <= 0 {
+		return 120
+	}
+
+	return w
+}
+
+func printLLMTable(llms []drapi.LLM, selectedID string) {
+	fmt.Println(tui.SubTitleStyle.Render("LLM Gateway Models"))
+
+	idStyle := tui.BaseTextStyle.
+		Foreground(tui.GetAdaptiveColor(tui.DrPurple, tui.DrPurpleDark)).
+		Padding(0, 1)
+
+	nameStyle := tui.BaseTextStyle.
+		Padding(0, 1)
+
+	dimStyle := tui.DimStyle.
+		Padding(0, 1)
+
+	t := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(tui.TableBorderStyle).
+		StyleFunc(func(_, col int) lipgloss.Style {
+			switch col {
+			case 0:
+				return idStyle
+			case 1:
+				return nameStyle
+			default:
+				return dimStyle
+			}
+		}).
+		Headers("ID", "NAME", "PROVIDER", "MODEL")
+
+	for _, l := range llms {
+		id := "  " + l.LlmID
+		if l.LlmID == selectedID {
+			id = "* " + l.LlmID
+		}
+
+		t.Row(id, l.Name, l.Provider, l.Model)
+	}
+
+	rendered := t.Render()
+	if lipgloss.Width(rendered) > terminalWidth() {
+		rendered = t.Width(terminalWidth()).Render()
+	}
+
+	_, _ = fmt.Fprintln(os.Stdout, rendered)
+}

--- a/cmd/llm-gateway/list/cmd_test.go
+++ b/cmd/llm-gateway/list/cmd_test.go
@@ -1,0 +1,235 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testLLMs = []drapi.LLM{
+	{LlmID: "llm-001", Name: "GPT-4o", Provider: "azure", Model: "gpt-4o", IsActive: true},
+	{LlmID: "llm-002", Name: "Claude 3.5", Provider: "anthropic", Model: "claude-3-5-sonnet", IsActive: true},
+}
+
+// setupLLMServer starts an httptest.Server serving a fixed LLM catalog and wires viperx config.
+func setupLLMServer(t *testing.T, llms []drapi.LLM) {
+	t.Helper()
+
+	body := drapi.LLMList{LLMs: llms, Count: len(llms), TotalCount: len(llms)}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+
+	viperx.Set(config.DataRobotURL, srv.URL+"/api/v2")
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+
+	t.Cleanup(func() {
+		srv.Close()
+		viperx.Reset()
+	})
+}
+
+// captureStdout redirects os.Stdout for the duration of fn and returns what was written.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	return buf.String()
+}
+
+// newTestCmd builds a minimal root → list command tree with PreRunE stripped.
+func newTestCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+
+	root := &cobra.Command{Use: "dr"}
+
+	var rootOutputFormat outputformat.OutputFormat
+
+	outputformat.AddPersistentFlag(root, &rootOutputFormat)
+
+	listCmd := Cmd()
+	listCmd.PreRunE = nil
+	root.AddCommand(listCmd)
+
+	return root
+}
+
+// --- toLLMOutputs ---
+
+func TestToLLMOutputs_Basic(t *testing.T) {
+	outputs := toLLMOutputs(testLLMs, "")
+
+	require.Len(t, outputs, 2)
+	assert.Equal(t, "llm-001", outputs[0].ID)
+	assert.Equal(t, "GPT-4o", outputs[0].Name)
+	assert.Equal(t, "azure", outputs[0].Provider)
+	assert.Equal(t, "gpt-4o", outputs[0].Model)
+	assert.False(t, outputs[0].Selected)
+	assert.False(t, outputs[1].Selected)
+}
+
+func TestToLLMOutputs_SelectedMarked(t *testing.T) {
+	outputs := toLLMOutputs(testLLMs, "llm-002")
+
+	assert.False(t, outputs[0].Selected)
+	assert.True(t, outputs[1].Selected)
+}
+
+func TestToLLMOutputs_Empty(t *testing.T) {
+	assert.Empty(t, toLLMOutputs(nil, ""))
+	assert.Empty(t, toLLMOutputs([]drapi.LLM{}, "any"))
+}
+
+// --- printLLMTable ---
+
+func TestPrintLLMTable_SelectedPrefix(t *testing.T) {
+	out := captureStdout(t, func() {
+		printLLMTable(testLLMs, "llm-001")
+	})
+
+	assert.Contains(t, out, "* llm-001")
+	assert.Contains(t, out, "  llm-002")
+}
+
+func TestPrintLLMTable_NoneSelected(t *testing.T) {
+	out := captureStdout(t, func() {
+		printLLMTable(testLLMs, "")
+	})
+
+	assert.NotContains(t, out, "* ")
+	assert.Contains(t, out, "  llm-001")
+	assert.Contains(t, out, "  llm-002")
+}
+
+// --- full command ---
+
+func TestListCmd_TableOutput(t *testing.T) {
+	setupLLMServer(t, testLLMs)
+
+	root := newTestCmd(t)
+	root.SetArgs([]string{"list"})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, root.Execute())
+	})
+
+	assert.Contains(t, out, "llm-001")
+	assert.Contains(t, out, "llm-002")
+}
+
+func TestListCmd_TableOutput_SelectedMarker(t *testing.T) {
+	setupLLMServer(t, testLLMs)
+	viperx.Set(config.DefaultLLMID, "llm-001")
+
+	root := newTestCmd(t)
+	root.SetArgs([]string{"list"})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, root.Execute())
+	})
+
+	assert.Contains(t, out, "* llm-001")
+	assert.Contains(t, out, "  llm-002")
+}
+
+func TestListCmd_JSONOutput(t *testing.T) {
+	setupLLMServer(t, testLLMs)
+
+	root := newTestCmd(t)
+	root.SetArgs([]string{"list", "--output-format", "json"})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, root.Execute())
+	})
+
+	var envelope struct {
+		LLMs []LLMOutput `json:"llms"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(out), &envelope))
+	require.Len(t, envelope.LLMs, 2)
+	assert.Equal(t, "llm-001", envelope.LLMs[0].ID)
+	assert.Equal(t, "llm-002", envelope.LLMs[1].ID)
+	assert.False(t, envelope.LLMs[0].Selected)
+	assert.False(t, envelope.LLMs[1].Selected)
+}
+
+func TestListCmd_JSONOutput_SelectedField(t *testing.T) {
+	setupLLMServer(t, testLLMs)
+	viperx.Set(config.DefaultLLMID, "llm-002")
+
+	root := newTestCmd(t)
+	root.SetArgs([]string{"list", "--output-format", "json"})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, root.Execute())
+	})
+
+	var envelope struct {
+		LLMs []LLMOutput `json:"llms"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(out), &envelope))
+	assert.False(t, envelope.LLMs[0].Selected)
+	assert.True(t, envelope.LLMs[1].Selected)
+}
+
+func TestListCmd_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+
+	t.Cleanup(func() {
+		srv.Close()
+		viperx.Reset()
+	})
+
+	viperx.Set(config.DataRobotURL, srv.URL+"/api/v2")
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+
+	root := newTestCmd(t)
+	root.SetArgs([]string{"list"})
+
+	err := root.Execute()
+	assert.Error(t, err)
+}

--- a/cmd/llm-gateway/list/cmd_test.go
+++ b/cmd/llm-gateway/list/cmd_test.go
@@ -64,6 +64,7 @@ func captureStdout(t *testing.T, fn func()) string {
 	old := os.Stdout
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
+
 	os.Stdout = w
 
 	fn()
@@ -72,6 +73,7 @@ func captureStdout(t *testing.T, fn func()) string {
 	os.Stdout = old
 
 	var buf bytes.Buffer
+
 	_, _ = io.Copy(&buf, r)
 
 	return buf.String()

--- a/cmd/llm-gateway/select/cmd.go
+++ b/cmd/llm-gateway/select/cmd.go
@@ -1,0 +1,114 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selectcmd
+
+import (
+	"errors"
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "select [llm-id]",
+		Short:        "Set the default LLM Gateway model",
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			llmList, err := drapi.GetLLMs()
+			if err != nil {
+				return err
+			}
+
+			var chosenID string
+
+			if len(args) == 1 {
+				chosenID, err = findByID(llmList.LLMs, args[0])
+			} else {
+				chosenID, err = runPicker(llmList.LLMs)
+			}
+
+			if err != nil {
+				return err
+			}
+
+			viperx.Set(config.DefaultLLMID, chosenID)
+
+			if err = config.UpdateConfigFile(config.DefaultLLMID); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "Default LLM set to: %s\n", chosenID)
+
+			return nil
+		},
+	}
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"direct": len(args) == 1,
+		}
+	})
+
+	return cmd
+}
+
+func findByID(llms []drapi.LLM, id string) (string, error) {
+	for _, l := range llms {
+		if l.LlmID == id {
+			return l.LlmID, nil
+		}
+	}
+
+	return "", fmt.Errorf("LLM %q not found in the active catalog", id)
+}
+
+func runPicker(llms []drapi.LLM) (string, error) {
+	if len(llms) == 0 {
+		return "", errors.New("no active LLMs available in the LLM Gateway catalog")
+	}
+
+	m := NewPickerModel(llms)
+
+	finalModel, err := tui.Run(m, tea.WithAltScreen())
+	if err != nil {
+		return "", err
+	}
+
+	interruptible, ok := finalModel.(tui.InterruptibleModel)
+	if !ok {
+		return "", errors.New("unexpected model type returned from TUI")
+	}
+
+	picker, ok := interruptible.Model.(PickerModel)
+	if !ok {
+		return "", errors.New("unexpected inner model type returned from TUI")
+	}
+
+	if picker.selectedID == "" {
+		return "", errors.New("no LLM selected")
+	}
+
+	return picker.selectedID, nil
+}

--- a/cmd/llm-gateway/select/cmd_test.go
+++ b/cmd/llm-gateway/select/cmd_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selectcmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testLLMs = []drapi.LLM{
+	{LlmID: "llm-001", Name: "GPT-4o", Provider: "azure", Model: "gpt-4o", IsActive: true},
+	{LlmID: "llm-002", Name: "Claude 3.5", Provider: "anthropic", Model: "claude-3-5-sonnet", IsActive: true},
+}
+
+// setupLLMServer starts an httptest.Server serving a fixed LLM catalog and wires viperx config.
+func setupLLMServer(t *testing.T, llms []drapi.LLM) {
+	t.Helper()
+
+	body := drapi.LLMList{LLMs: llms, Count: len(llms), TotalCount: len(llms)}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+
+	viperx.Set(config.DataRobotURL, srv.URL+"/api/v2")
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+
+	t.Cleanup(func() {
+		srv.Close()
+		viperx.Reset()
+	})
+}
+
+// newTestCmd returns Cmd() with PreRunE stripped, wired to a writable output buffer.
+func newTestCmd(t *testing.T) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+
+	cmd := Cmd()
+	cmd.PreRunE = nil
+
+	var buf bytes.Buffer
+
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	return cmd, &buf
+}
+
+// --- findByID ---
+
+func TestFindByID_Found(t *testing.T) {
+	id, err := findByID(testLLMs, "llm-002")
+
+	require.NoError(t, err)
+	assert.Equal(t, "llm-002", id)
+}
+
+func TestFindByID_NotFound(t *testing.T) {
+	_, err := findByID(testLLMs, "does-not-exist")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does-not-exist")
+}
+
+func TestFindByID_Empty(t *testing.T) {
+	_, err := findByID(nil, "llm-001")
+
+	require.Error(t, err)
+}
+
+// --- select with direct arg ---
+
+func TestSelectCmd_DirectArg_Valid(t *testing.T) {
+	setupLLMServer(t, testLLMs)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cmd, buf := newTestCmd(t)
+	cmd.SetArgs([]string{"llm-001"})
+
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, "llm-001", viperx.GetString(config.DefaultLLMID))
+	assert.Contains(t, buf.String(), "llm-001")
+}
+
+func TestSelectCmd_DirectArg_Invalid(t *testing.T) {
+	setupLLMServer(t, testLLMs)
+
+	cmd, _ := newTestCmd(t)
+	cmd.SetArgs([]string{"not-a-real-llm"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not-a-real-llm")
+}
+
+func TestSelectCmd_DirectArg_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+
+	t.Cleanup(func() {
+		srv.Close()
+		viperx.Reset()
+	})
+
+	viperx.Set(config.DataRobotURL, srv.URL+"/api/v2")
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+
+	cmd, _ := newTestCmd(t)
+	cmd.SetArgs([]string{"llm-001"})
+
+	err := cmd.Execute()
+	assert.Error(t, err)
+}
+
+// --- runPicker edge case (no TUI) ---
+
+func TestRunPicker_EmptyCatalog(t *testing.T) {
+	_, err := runPicker(nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no active LLMs")
+}

--- a/cmd/llm-gateway/select/model.go
+++ b/cmd/llm-gateway/select/model.go
@@ -1,0 +1,156 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selectcmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+type llmItem struct {
+	llmID    string
+	name     string
+	provider string
+	model    string
+}
+
+func (i llmItem) Title() string       { return i.name }
+func (i llmItem) Description() string { return i.provider + " · " + i.model }
+func (i llmItem) FilterValue() string { return i.name }
+
+type llmItemDelegate struct{}
+
+func (d llmItemDelegate) Height() int                             { return 2 }
+func (d llmItemDelegate) Spacing() int                            { return 1 }
+func (d llmItemDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (d llmItemDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	i, ok := listItem.(llmItem)
+	if !ok {
+		return
+	}
+
+	isSelected := index == m.Index()
+
+	if isSelected {
+		titleStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.AdaptiveColor{Light: "#6124DF", Dark: "#9D7EDF"}).
+			Bold(true)
+
+		descStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.AdaptiveColor{Light: "#6124DF", Dark: "#9D7EDF"}).
+			Faint(true)
+
+		fmt.Fprint(w, titleStyle.Render("▶ "+i.name))
+		fmt.Fprint(w, "\n")
+		fmt.Fprint(w, descStyle.Render("  "+i.provider+" · "+i.model))
+	} else {
+		titleStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.AdaptiveColor{Light: "#000000", Dark: "#FFFFFF"})
+
+		descStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.AdaptiveColor{Light: "#666666", Dark: "#888888"}).
+			Faint(true)
+
+		fmt.Fprint(w, titleStyle.Render("  "+i.name))
+		fmt.Fprint(w, "\n")
+		fmt.Fprint(w, descStyle.Render("  "+i.provider+" · "+i.model))
+	}
+}
+
+// PickerModel is the TUI model for the LLM picker.
+type PickerModel struct {
+	list       list.Model
+	selectedID string
+}
+
+// NewPickerModel constructs the TUI picker from a slice of LLMs.
+func NewPickerModel(llms []drapi.LLM) PickerModel {
+	items := make([]list.Item, len(llms))
+
+	for i, l := range llms {
+		items[i] = llmItem{
+			llmID:    l.LlmID,
+			name:     l.Name,
+			provider: l.Provider,
+			model:    l.Model,
+		}
+	}
+
+	delegate := llmItemDelegate{}
+	l := list.New(items, delegate, 0, 0)
+
+	l.Title = "Select Default LLM"
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(true)
+	l.SetShowHelp(true)
+	l.Styles.Title = lipgloss.NewStyle().
+		Foreground(lipgloss.AdaptiveColor{Light: "#6124DF", Dark: "#9D7EDF"}).
+		Bold(true).
+		MarginLeft(2).
+		MarginBottom(1)
+
+	l.SetSize(80, 20)
+
+	return PickerModel{list: l}
+}
+
+func (m PickerModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		listWidth := msg.Width - 4
+		listHeight := msg.Height - 8
+
+		if listWidth < 60 {
+			listWidth = 60
+		}
+
+		if listHeight < 10 {
+			listHeight = 10
+		}
+
+		m.list.SetSize(listWidth, listHeight)
+
+		return m, nil
+
+	case tea.KeyMsg:
+		if msg.String() == "enter" {
+			if item, ok := m.list.SelectedItem().(llmItem); ok {
+				m.selectedID = item.llmID
+
+				return m, tea.Quit
+			}
+		}
+	}
+
+	var cmd tea.Cmd
+
+	m.list, cmd = m.list.Update(msg)
+
+	return m, cmd
+}
+
+func (m PickerModel) View() string {
+	return m.list.View()
+}

--- a/cmd/llm-gateway/select/model.go
+++ b/cmd/llm-gateway/select/model.go
@@ -135,6 +135,14 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		if m.list.FilterState() == list.Filtering {
+			var cmd tea.Cmd
+
+			m.list, cmd = m.list.Update(msg)
+
+			return m, cmd
+		}
+
 		if msg.String() == "enter" {
 			if item, ok := m.list.SelectedItem().(llmItem); ok {
 				m.selectedID = item.llmID

--- a/cmd/llm-gateway/select/model_test.go
+++ b/cmd/llm-gateway/select/model_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selectcmd
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sendKey calls Update with a KeyMsg and returns the resulting model and cmd.
+func sendKey(m PickerModel, key tea.KeyType) (PickerModel, tea.Cmd) {
+	next, cmd := m.Update(tea.KeyMsg{Type: key})
+	return next.(PickerModel), cmd
+}
+
+// sendRune calls Update with a rune KeyMsg (e.g. '/' to start filtering).
+func sendRune(m PickerModel, r rune) (PickerModel, tea.Cmd) {
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	return next.(PickerModel), cmd
+}
+
+// isQuit invokes cmd and reports whether it produced a tea.QuitMsg.
+func isQuit(cmd tea.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+
+	_, ok := cmd().(tea.QuitMsg)
+
+	return ok
+}
+
+// --- PickerModel.Update ---
+
+func TestPickerModel_EnterSelectsItem(t *testing.T) {
+	m := NewPickerModel(testLLMs)
+
+	next, cmd := sendKey(m, tea.KeyEnter)
+
+	assert.Equal(t, testLLMs[0].LlmID, next.selectedID)
+	assert.True(t, isQuit(cmd), "expected tea.Quit after Enter")
+}
+
+func TestPickerModel_EnterWhileFiltering_DoesNotSelect(t *testing.T) {
+	m := NewPickerModel(testLLMs)
+
+	// '/' activates filtering in bubbles/list
+	m, _ = sendRune(m, '/')
+	require.Equal(t, list.Filtering, m.list.FilterState(), "list should be in filtering state")
+
+	// Enter while filtering should confirm the filter, not select an item
+	next, cmd := sendKey(m, tea.KeyEnter)
+
+	assert.Empty(t, next.selectedID, "selectedID must remain empty when Enter confirms a filter")
+	assert.False(t, isQuit(cmd), "Enter during filtering must not quit")
+}
+
+func TestPickerModel_WindowSizeMsg(t *testing.T) {
+	m := NewPickerModel(testLLMs)
+
+	next, cmd := m.Update(tea.WindowSizeMsg{Width: 200, Height: 50})
+	picker := next.(PickerModel)
+
+	assert.Nil(t, cmd)
+	// List width = 200-4 = 196, height = 50-8 = 42
+	w, h := picker.list.Width(), picker.list.Height()
+	assert.Equal(t, 196, w)
+	assert.Equal(t, 42, h)
+}
+
+func TestPickerModel_WindowSizeMsg_MinimumClamp(t *testing.T) {
+	m := NewPickerModel(testLLMs)
+
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 10, Height: 5})
+	picker := next.(PickerModel)
+
+	w, h := picker.list.Width(), picker.list.Height()
+	assert.Equal(t, 60, w, "width should clamp to 60")
+	assert.Equal(t, 10, h, "height should clamp to 10")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/datarobot/cli/cmd/component"
 	"github.com/datarobot/cli/cmd/dependencies"
 	"github.com/datarobot/cli/cmd/dotenv"
+	llmgateway "github.com/datarobot/cli/cmd/llm-gateway"
 	"github.com/datarobot/cli/cmd/pipeline"
 	"github.com/datarobot/cli/cmd/plugin"
 	"github.com/datarobot/cli/cmd/self"
@@ -263,6 +264,7 @@ func init() {
 		component.Cmd(),
 		dependencies.Cmd(),
 		dotenv.Cmd(),
+		llmgateway.Cmd(),
 		run.Cmd(),
 		self.Cmd(),
 		start.Cmd(),

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -59,6 +59,7 @@ These flags are available for all commands:
 | [`dotenv`](dotenv.md)             | Manage environment variables.                               |
 | [`self`](self.md)                 | CLI utility commands (update, version, completion, plugin). |
 | [`plugin`](plugins.md)            | Inspect and manage CLI plugins.                             |
+| [`llm-gateway`](llm-gateway.md)   | List and select the default LLM Gateway model.              |
 | [`pipeline`](pipeline.md)         | Manage pipelines via the pipelines API (feature-gated).     |
 | [`artifact`](artifact.md)         | Build and manage workload artifacts (feature-gated).        |
 | [`workload`](workload.md)         | Deploy and manage workloads from artifacts (feature-gated). |
@@ -95,6 +96,9 @@ dr
 │   ├── install        Install a plugin
 │   ├── uninstall      Uninstall a plugin
 │   └── update         Update plugins
+├── llm-gateway        LLM Gateway model management (alias: llm, llm-gateways)
+│   ├── list           List active LLM Gateway models (alias: ls)
+│   └── select         Set the default LLM Gateway model
 ├── pipeline           Pipelines API management (feature-gated)
 │   ├── create         Upload a Python file to create a pipeline
 │   ├── list           List pipelines
@@ -235,6 +239,30 @@ dr dotenv edit
 dr dotenv validate
 ```
 
+### LLM Gateway
+
+```bash
+# List active LLM Gateway models
+dr llm-gateway list
+
+# List as JSON
+dr llm-gateway list --output-format json
+
+# Select a default LLM interactively (TUI picker)
+dr llm-gateway select
+
+# Set a default LLM directly by ID
+dr llm-gateway select <llm-id>
+```
+
+Aliases:
+
+```bash
+dr llm list       # llm-gateway → llm
+dr llm ls         # list → ls
+dr llm select
+```
+
 ### Running tasks
 
 ```bash
@@ -320,6 +348,10 @@ For detailed documentation on each command, see:
 
 - **[plugin](plugins.md)**&mdash;inspect and manage installed CLI plugins (alias: `plugins`).
 
+- **[llm-gateway](llm-gateway.md)**&mdash;list and configure the default LLM Gateway model (aliases: `llm`, `llm-gateways`).
+  - `list` (`ls`)&mdash;fetch all active LLMs from the catalog and display them in a table (`ID · NAME · PROVIDER · MODEL`). The currently-selected model is marked with `*`. Supports `--output-format json` (includes a `selected` boolean field per entry).
+  - `select [llm-id]`&mdash;set the default LLM. Without an argument, launches an interactive TUI picker. With an argument, validates the ID against the active catalog and persists it immediately. The selection is saved to `drconfig.yaml` under the key `default-llm-id`.
+
 - **[pipeline](pipeline.md)**&mdash;manage AI/ML pipelines orchestrated by Covalent (feature-gated behind `DATAROBOT_CLI_FEATURE_PIPELINE=true`).
   - `create`&mdash;upload a Python file to register a new pipeline.
   - `list`&mdash;list pipelines with mode filtering and pagination.
@@ -373,6 +405,7 @@ DATAROBOT_ENDPOINT                  # DataRobot URL
 DATAROBOT_API_TOKEN                 # API token (not recommended)
 DATAROBOT_CLI_CONFIG                # Path to config file
 DATAROBOT_CLI_PLUGIN_DISCOVERY_TIMEOUT  # Timeout for plugin discovery (e.g. 2s; 0s disables)
+DATAROBOT_CLI_DEFAULT_LLM_ID        # Default LLM Gateway model ID (overrides drconfig.yaml)
 VISUAL                              # External editor for file editing
 EDITOR                              # External editor for file editing (fallback)
 ```

--- a/docs/commands/llm-gateway.md
+++ b/docs/commands/llm-gateway.md
@@ -1,0 +1,133 @@
+# `dr llm-gateway` — LLM Gateway model management
+
+List active LLM Gateway models and configure which one the CLI uses by default.
+
+## Synopsis
+
+```bash
+dr llm-gateway <command> [flags]
+dr llm [flags]           # alias
+```
+
+## Description
+
+The `dr llm-gateway` group exposes two subcommands:
+
+- **`list`** — fetch all active LLMs from `/api/v2/genai/llmgw/catalog/` and display them as a table or JSON.
+- **`select`** — choose a default LLM, either by ID or through an interactive TUI picker. The selection is persisted to `drconfig.yaml` and read by other CLI commands.
+
+**Aliases:** `llm`, `llm-gateways`
+
+## Subcommands
+
+### `list`
+
+Fetch all active LLMs from the LLM Gateway catalog and display them.
+
+```bash
+dr llm-gateway list [flags]
+dr llm ls               # shortest alias
+```
+
+**Flags:**
+
+- `--output-format <json>` — emit machine-parseable JSON instead of a table.
+
+**Output columns (table):**
+
+| Column     | Description                                      |
+|------------|--------------------------------------------------|
+| `ID`       | LLM identifier. Prefixed with `*` if selected, `  ` otherwise. |
+| `NAME`     | Human-readable model name.                       |
+| `PROVIDER` | Provider (e.g. `azure`, `anthropic`, `google`).  |
+| `MODEL`    | Underlying model identifier.                     |
+
+The table width is content-driven and capped at the terminal width to prevent overflow.
+
+**JSON output** (`--output-format json`) returns an envelope with a `llms` array. Each entry includes:
+
+```json
+{
+  "id":       "llm-abc123",
+  "name":     "GPT-4o",
+  "provider": "azure",
+  "model":    "gpt-4o",
+  "selected": true
+}
+```
+
+**Examples:**
+
+```bash
+# Table view
+dr llm-gateway list
+
+# JSON output
+dr llm-gateway list --output-format json
+
+# Aliases
+dr llm list
+dr llm ls
+```
+
+---
+
+### `select`
+
+Set the default LLM Gateway model. The chosen ID is written to `drconfig.yaml` under the key `default-llm-id` and is also readable via `DATAROBOT_CLI_DEFAULT_LLM_ID`.
+
+```bash
+dr llm-gateway select [llm-id]
+dr llm select [llm-id]   # alias
+```
+
+**Arguments:**
+
+- `[llm-id]` — optional. When provided, the ID is validated against the active catalog and persisted immediately. When omitted, an interactive TUI picker is launched.
+
+**Interactive picker:**
+
+- Arrow keys to navigate, `/` to filter by name.
+- `Enter` to confirm selection.
+- `Ctrl-C` or `Esc` to cancel without saving.
+
+**Examples:**
+
+```bash
+# Interactive TUI picker
+dr llm-gateway select
+
+# Set directly by ID
+dr llm-gateway select llm-abc123
+
+# Error — ID not found in active catalog
+dr llm-gateway select unknown-id
+# Error: LLM "unknown-id" not found in the active catalog
+```
+
+---
+
+## Configuration
+
+The selected LLM ID is stored in `drconfig.yaml`:
+
+```yaml
+default-llm-id: llm-abc123
+```
+
+It can also be set or overridden via the environment variable:
+
+```bash
+export DATAROBOT_CLI_DEFAULT_LLM_ID=llm-abc123
+```
+
+The `dr llm-gateway list` output uses this value to mark the currently selected model with `*`.
+
+## Authentication
+
+Both subcommands require valid DataRobot credentials. Run `dr auth login` first if you haven't already.
+
+## See also
+
+- [auth](auth.md) — authenticate with DataRobot.
+- [Command reference](README.md) — overview of all commands.

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -20,6 +20,9 @@ const (
 
 	APIConsumerTrackingEnabled = "api-consumer-tracking-enabled"
 
+	// DefaultLLMID is the config key for the user's default LLM Gateway model ID.
+	DefaultLLMID = "default-llm-id"
+
 	// EnvPrefix is the canonical prefix for all DATAROBOT_CLI_* environment
 	// variables. Use this constant instead of hard-coding the string literal.
 	EnvPrefix = "DATAROBOT_CLI_"

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -40,6 +40,7 @@ var PersistableKeys = map[string]struct{}{
 	"ssl_verify":               {},
 	"pulumi_config_passphrase": {},
 	"ca-cert":                  {},
+	DefaultLLMID:               {},
 }
 
 // UpdateConfigFile writes only the allowlisted keys from viper back to the


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

Users need a way to inspect and configure which LLM Gateway model the CLI uses by default. This adds `dr llm-gateway` (`llm`, `llm-gateways`) as a new core command group with two subcommands.

## CHANGES

- **`dr llm-gateway list`** (`ls`) — fetches active LLMs from `/api/v2/genai/llmgw/catalog/` and renders a table (`ID · NAME · PROVIDER · MODEL`). The currently-selected model is prefixed with `*`; others are indented with two spaces for alignment. Table is content-driven (auto-sizes to widest cell) but capped at terminal width to prevent overflow. Supports `--output-format json` with a `selected` boolean field per entry.

- **`dr llm-gateway select [llm-id]`** — sets the default LLM. With an argument, validates the ID exists in the active catalog and persists immediately. Without an argument, launches an interactive `bubbles/list` TUI picker. Selection is written to `drconfig.yaml` via `config.UpdateConfigFile` (allowlisted under `DefaultLLMID = "default-llm-id"`).

- **`internal/config`** — added `DefaultLLMID` constant and added it to `PersistableKeys` so the key is safe to persist.

- **Tests** — 20 tests across three packages: `toLLMOutputs`, `printLLMTable` (selected/unselected prefixes), full command execution against an `httptest` server (table, JSON, API error), `findByID`, `select` with valid/invalid/API-error args, `runPicker` empty-catalog guard, and command structure (aliases, subcommands, `GroupID`).


## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New CLI surface and config key only; follows existing auth, API, and config persistence patterns with solid test coverage.
> 
> **Overview**
> Adds a new **core** command group `dr llm-gateway` (aliases `llm`, `llm-gateways`) so users can see and set the CLI’s default LLM Gateway model.
> 
> **`list`** (`ls`) loads the active catalog via `drapi.GetLLMs()`, marks the configured default with `*` in a terminal table (or `selected` in JSON), and respects `--output-format json`. **`select [llm-id]`** either validates an ID against the catalog or opens an interactive `bubbles/list` picker, then persists `default-llm-id` through `config.UpdateConfigFile`.
> 
> Config wiring adds `DefaultLLMID` and includes it in `PersistableKeys`; the group is registered on the root command. Broad unit/integration-style tests cover table/JSON output, selection persistence, API errors, and command structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9090c0b33a3e0683683d8f065dcb129a22edc47. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->