### PR TITLE
[CFX-6856] Added `dr plugin version`

### DIFF
--- a/cmd/plugin/cmd.go
+++ b/cmd/plugin/cmd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/datarobot/cli/cmd/plugin/list"
 	"github.com/datarobot/cli/cmd/plugin/uninstall"
 	"github.com/datarobot/cli/cmd/plugin/update"
+	"github.com/datarobot/cli/cmd/plugin/version"
 	"github.com/spf13/cobra"
 )
 
@@ -36,6 +37,7 @@ func Cmd() *cobra.Command {
 		install.Cmd(),
 		uninstall.Cmd(),
 		update.Cmd(),
+		version.Cmd(),
 	)
 
 	return cmd

--- a/cmd/plugin/discovery.go
+++ b/cmd/plugin/discovery.go
@@ -52,7 +52,16 @@ func RegisterPluginCommands(rootCmd *cobra.Command) {
 		builtinNames[cmd.Name()] = true
 	}
 
-	plugins := internalPlugin.DiscoverPluginsWithContext(ctx)
+	plugins, conflicts := internalPlugin.DiscoverPluginsWithContext(ctx)
+
+	// Registering commands considers every discovered plugin, so every
+	// conflict is relevant here (it affects which binary wins a command name).
+	internalPlugin.LogConflicts(conflicts)
+
+	// Seed the shared discovery cache so a later plugin.GetPlugins() call
+	// (e.g. from `dr plugin list` or `dr plugin version`) reuses this result
+	// instead of re-scanning PATH from scratch.
+	internalPlugin.PrimeCache(plugins, conflicts)
 
 	if len(plugins) == 0 {
 		// No plugins found, don't add empty group header

--- a/cmd/plugin/list/cmd.go
+++ b/cmd/plugin/list/cmd.go
@@ -122,7 +122,10 @@ func printPluginsTable(plugins []plugin.DiscoveredPlugin) error {
 }
 
 func runList(cmd *cobra.Command, _ []string) error {
-	plugins := plugin.GetPlugins()
+	plugins, conflicts := plugin.GetPlugins()
+
+	// `list` shows every discovered plugin, so every conflict is relevant.
+	plugin.LogConflicts(conflicts)
 
 	format := outputformat.GetFormat(cmd)
 	if format == outputformat.OutputFormatJSON {

--- a/cmd/plugin/version/cmd.go
+++ b/cmd/plugin/version/cmd.go
@@ -1,0 +1,97 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/plugin"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+// PluginVersionOutput is the JSON representation of a plugin's version for --output-format json.
+type PluginVersionOutput struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:     "version <plugin-name>",
+		Short:   "🏷️ Show a plugin's version",
+		Long:    "Display the version of a discovered plugin, as reported in its manifest.",
+		Example: "  dr plugin version assist\n  dr plugin version assist --output-format json",
+		Args:    cobra.ExactArgs(1),
+		RunE:    runVersion,
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"plugin_name": telemetry.FirstArg(args),
+		}
+	})
+
+	return cmd
+}
+
+// findPlugin returns the discovered plugin named pluginName, or nil if not found.
+func findPlugin(plugins []plugin.DiscoveredPlugin, pluginName string) *plugin.DiscoveredPlugin {
+	for _, p := range plugins {
+		if p.Manifest.Name == pluginName {
+			return &p
+		}
+	}
+
+	return nil
+}
+
+func runVersion(cmd *cobra.Command, args []string) error {
+	pluginName := args[0]
+
+	plugins, conflicts := plugin.GetPlugins()
+
+	// Only warn about conflicts for the specific plugin being asked about —
+	// unrelated name clashes elsewhere on PATH aren't relevant to this query.
+	plugin.LogConflicts(plugin.ConflictsForName(conflicts, pluginName))
+
+	p := findPlugin(plugins, pluginName)
+	if p == nil {
+		return fmt.Errorf("plugin %q not found", pluginName)
+	}
+
+	format := outputformat.GetFormat(cmd)
+	if format == outputformat.OutputFormatJSON {
+		output := PluginVersionOutput{Name: p.Manifest.Name, Version: p.Manifest.Version}
+
+		return outputformat.PrintJSONEnvelope(os.Stdout, "plugin", output)
+	}
+
+	if p.Manifest.Version == "" {
+		fmt.Printf("Plugin %q does not report a version.\n", pluginName)
+
+		return nil
+	}
+
+	fmt.Println(p.Manifest.Version)
+
+	return nil
+}

--- a/cmd/plugin/version/cmd_test.go
+++ b/cmd/plugin/version/cmd_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindPlugin(t *testing.T) {
+	plugins := []plugin.DiscoveredPlugin{
+		{
+			Manifest: plugin.PluginManifest{
+				BasicPluginManifest: plugin.BasicPluginManifest{
+					Name:    "my-plugin",
+					Version: "1.2.3",
+				},
+			},
+			Executable: "/path/to/plugin",
+		},
+		{
+			Manifest: plugin.PluginManifest{
+				BasicPluginManifest: plugin.BasicPluginManifest{
+					Name:    "empty-plugin",
+					Version: "",
+				},
+			},
+			Executable: "/path/to/empty",
+		},
+	}
+
+	found := findPlugin(plugins, "my-plugin")
+	require.NotNil(t, found)
+	assert.Equal(t, "1.2.3", found.Manifest.Version)
+
+	found = findPlugin(plugins, "empty-plugin")
+	require.NotNil(t, found)
+	assert.Empty(t, found.Manifest.Version)
+
+	assert.Nil(t, findPlugin(plugins, "missing-plugin"))
+}
+
+func TestFindPluginEmpty(t *testing.T) {
+	assert.Nil(t, findPlugin(nil, "anything"))
+}

--- a/internal/plugin/discover.go
+++ b/internal/plugin/discover.go
@@ -41,22 +41,67 @@ const PluginRegistryURL = "https://cli.datarobot.com/plugins/index.json"
 // TODO: Consider adding ResetRegistry() for testing, as package-level state makes unit tests harder
 var registry = &DiscoveredPluginsRegistry{}
 
-// GetPlugins returns discovered plugins, discovering lazily on first call
+// GetPlugins returns discovered plugins and any name conflicts found along
+// the way, discovering lazily on first call. If PrimeCache already populated
+// the registry (e.g. RegisterPluginCommands ran during startup), that result
+// is reused instead of discovering again.
 // TODO: Consider file-based caching with TTL to avoid manifest fetching on every CLI invocation
-func GetPlugins() []DiscoveredPlugin {
+func GetPlugins() ([]DiscoveredPlugin, []PluginConflict) {
 	registry.once.Do(func() {
-		registry.plugins = DiscoverPluginsWithContext(context.Background())
+		registry.plugins, registry.conflicts = DiscoverPluginsWithContext(context.Background())
 	})
 
-	return registry.plugins
+	return registry.plugins, registry.conflicts
 }
 
-// DiscoverPluginsWithContext discovers all plugins under the given context deadline.
+// PrimeCache seeds the discovery cache with an already-computed plugin list
+// and its conflicts, so a later GetPlugins() call reuses them instead of
+// discovering again. This is a no-op if GetPlugins() already ran. It exists
+// because command registration (RegisterPluginCommands) discovers plugins
+// under a user-configurable timeout before any command runs; without priming
+// the cache, GetPlugins() would redo that same PATH scan from scratch.
+func PrimeCache(plugins []DiscoveredPlugin, conflicts []PluginConflict) {
+	registry.once.Do(func() {
+		registry.plugins = plugins
+		registry.conflicts = conflicts
+	})
+}
+
+// LogConflicts logs a WARN for each conflict, in the same format previously
+// emitted directly by discovery internals. Callers choose which conflicts to
+// pass in — e.g. all of them for a full listing, or only those returned by
+// ConflictsForName when only one specific plugin was requested.
+func LogConflicts(conflicts []PluginConflict) {
+	for _, c := range conflicts {
+		log.Warn("Plugin name already registered, skipping", "name", c.Name, "path", c.Path)
+	}
+}
+
+// ConflictsForName filters conflicts down to those matching a single plugin
+// name, so callers that only care about one plugin (e.g. `dr plugin version
+// <name>`) don't surface warnings about unrelated plugins.
+func ConflictsForName(conflicts []PluginConflict, name string) []PluginConflict {
+	var matched []PluginConflict
+
+	for _, c := range conflicts {
+		if c.Name == name {
+			matched = append(matched, c)
+		}
+	}
+
+	return matched
+}
+
+// DiscoverPluginsWithContext discovers all plugins under the given context deadline,
+// along with any name conflicts encountered (a plugin skipped because another
+// plugin already claimed its manifest name from a higher-priority location).
 // Managed and local plugins (file I/O only) always complete before PATH scanning starts,
 // so they are always returned even when ctx is cancelled mid-discovery. PATH plugins
 // return whatever finished before ctx is done.
-func DiscoverPluginsWithContext(ctx context.Context) []DiscoveredPlugin {
+func DiscoverPluginsWithContext(ctx context.Context) ([]DiscoveredPlugin, []PluginConflict) {
 	plugins := make([]DiscoveredPlugin, 0)
+
+	var conflicts []PluginConflict
 
 	seen := make(map[string]bool)
 
@@ -65,8 +110,9 @@ func DiscoverPluginsWithContext(ctx context.Context) []DiscoveredPlugin {
 	managedDirs, err := ManagedPluginsDirs()
 	if err == nil {
 		for _, managedDir := range managedDirs {
-			managedPlugins, errs := discoverManagedPlugins(managedDir, seen)
+			managedPlugins, managedConflicts, errs := discoverManagedPlugins(managedDir, seen)
 			plugins = append(plugins, managedPlugins...)
+			conflicts = append(conflicts, managedConflicts...)
 
 			for _, err := range errs {
 				log.Debug("Plugin discovery error in managed dir", "dir", managedDir, "error", err)
@@ -76,8 +122,9 @@ func DiscoverPluginsWithContext(ctx context.Context) []DiscoveredPlugin {
 
 	// 2. Check project-local directory (higher priority than PATH)
 	// TODO: LocalPluginDir shares path with QuickstartScriptPath - consider dedicated plugin directory
-	localPlugins, errs := discoverInDir(ctx, repo.LocalPluginDir, seen)
+	localPlugins, localConflicts, errs := discoverInDir(ctx, repo.LocalPluginDir, seen)
 	plugins = append(plugins, localPlugins...)
+	conflicts = append(conflicts, localConflicts...)
 
 	for _, err := range errs {
 		log.Debug("Plugin discovery error in local dir", "dir", repo.LocalPluginDir, "error", err)
@@ -88,7 +135,9 @@ func DiscoverPluginsWithContext(ctx context.Context) []DiscoveredPlugin {
 	// without sharing mutable state. Cross-dir dedup is handled inside the helper.
 	baseSeen := maps.Clone(seen)
 
-	plugins = append(plugins, discoverPathDirsParallel(ctx, filepath.SplitList(os.Getenv("PATH")), baseSeen)...)
+	pathPlugins, pathConflicts := discoverPathDirsParallel(ctx, uniqueDirs(filepath.SplitList(os.Getenv("PATH"))), baseSeen)
+	plugins = append(plugins, pathPlugins...)
+	conflicts = append(conflicts, pathConflicts...)
 
 	if ctx.Err() != nil {
 		log.Warn("Plugin discovery timed out; some PATH plugins may be missing — use --plugin-discovery-timeout to adjust", "discovered", len(plugins))
@@ -96,17 +145,40 @@ func DiscoverPluginsWithContext(ctx context.Context) []DiscoveredPlugin {
 
 	log.Debug("Plugin discovery complete", "count", len(plugins))
 
-	return plugins
+	return plugins, conflicts
+}
+
+// uniqueDirs removes duplicate directory entries from PATH, preserving order.
+// PATH commonly lists the same directory more than once (e.g. sourced twice
+// by shell rc files); scanning it twice would make discoverPathDirsParallel
+// re-report every plugin in that directory as an "already registered"
+// conflict with itself.
+func uniqueDirs(dirs []string) []string {
+	seen := make(map[string]bool, len(dirs))
+	unique := make([]string, 0, len(dirs))
+
+	for _, dir := range dirs {
+		if seen[dir] {
+			continue
+		}
+
+		seen[dir] = true
+
+		unique = append(unique, dir)
+	}
+
+	return unique
 }
 
 // discoverPathDirsParallel runs discoverInDir for each PATH directory concurrently.
 // Each goroutine receives its own copy of baseSeen so managed/local plugins are filtered
 // without cross-goroutine map races. Goroutines not yet started are skipped when ctx is done.
-// Results are merged in directory order and cross-dir duplicates are skipped.
-func discoverPathDirsParallel(ctx context.Context, pathDirs []string, baseSeen map[string]bool) []DiscoveredPlugin {
+// Results are merged in directory order and cross-dir duplicates are recorded as conflicts.
+func discoverPathDirsParallel(ctx context.Context, pathDirs []string, baseSeen map[string]bool) ([]DiscoveredPlugin, []PluginConflict) {
 	type dirResult struct {
-		plugins []DiscoveredPlugin
-		errs    []error
+		plugins   []DiscoveredPlugin
+		conflicts []PluginConflict
+		errs      []error
 	}
 
 	dirResults := make([]dirResult, len(pathDirs))
@@ -123,8 +195,11 @@ func discoverPathDirsParallel(ctx context.Context, pathDirs []string, baseSeen m
 			default:
 			}
 
-			p, e := discoverInDir(ctx, dir, localSeen)
-			dirResults[i] = dirResult{plugins: p, errs: e}
+			// A conflict here means the name was already seen in baseSeen
+			// (i.e. claimed by a managed/local plugin); genuine cross-dir
+			// PATH conflicts are detected below during the merge step.
+			p, c, e := discoverInDir(ctx, dir, localSeen)
+			dirResults[i] = dirResult{plugins: p, conflicts: c, errs: e}
 		})
 	}
 
@@ -135,16 +210,18 @@ func discoverPathDirsParallel(ctx context.Context, pathDirs []string, baseSeen m
 
 	var plugins []DiscoveredPlugin
 
+	var conflicts []PluginConflict
+
 	for i, dr := range dirResults {
 		for _, e := range dr.errs {
 			log.Debug("Plugin discovery error", "dir", pathDirs[i], "error", e)
 		}
 
+		conflicts = append(conflicts, dr.conflicts...)
+
 		for _, p := range dr.plugins {
 			if crossDirSeen[p.Manifest.Name] {
-				log.Warn("Plugin name already registered, skipping",
-					"name", p.Manifest.Name,
-					"path", p.Executable)
+				conflicts = append(conflicts, PluginConflict{Name: p.Manifest.Name, Path: p.Executable})
 
 				continue
 			}
@@ -155,24 +232,26 @@ func discoverPathDirsParallel(ctx context.Context, pathDirs []string, baseSeen m
 		}
 	}
 
-	return plugins
+	return plugins, conflicts
 }
 
 // discoverManagedPlugins discovers plugins installed via `dr plugin install`
 // These are in subdirectories with a manifest.json and platform-specific scripts
-func discoverManagedPlugins(dir string, seen map[string]bool) ([]DiscoveredPlugin, []error) {
+func discoverManagedPlugins(dir string, seen map[string]bool) ([]DiscoveredPlugin, []PluginConflict, []error) {
 	plugins := make([]DiscoveredPlugin, 0)
+
+	var conflicts []PluginConflict
 
 	var errs []error
 
 	info, err := os.Stat(dir)
 	if err != nil || !info.IsDir() {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, []error{err}
+		return nil, nil, []error{err}
 	}
 
 	for _, entry := range entries {
@@ -180,7 +259,7 @@ func discoverManagedPlugins(dir string, seen map[string]bool) ([]DiscoveredPlugi
 			continue
 		}
 
-		plugin, err := loadManagedPlugin(dir, entry.Name(), seen)
+		plugin, conflict, err := loadManagedPlugin(dir, entry.Name(), seen)
 		if err != nil {
 			errs = append(errs, err)
 
@@ -190,45 +269,45 @@ func discoverManagedPlugins(dir string, seen map[string]bool) ([]DiscoveredPlugi
 		if plugin != nil {
 			plugins = append(plugins, *plugin)
 		}
+
+		if conflict != nil {
+			conflicts = append(conflicts, *conflict)
+		}
 	}
 
-	return plugins, errs
+	return plugins, conflicts, errs
 }
 
-func loadManagedPlugin(dir, name string, seen map[string]bool) (*DiscoveredPlugin, error) {
+func loadManagedPlugin(dir, name string, seen map[string]bool) (*DiscoveredPlugin, *PluginConflict, error) {
 	pluginDir := filepath.Join(dir, name)
 	manifestPath := filepath.Join(pluginDir, "manifest.json")
 
 	if _, err := os.Stat(manifestPath); err != nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	manifestData, err := os.ReadFile(manifestPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var manifest PluginManifest
 
 	if err := json.Unmarshal(manifestData, &manifest); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if manifest.Name == "" {
-		return nil, errMissingManifestField("name")
+		return nil, nil, errMissingManifestField("name")
 	}
 
 	if seen[manifest.Name] {
-		log.Warn("Plugin name already registered, skipping",
-			"name", manifest.Name,
-			"path", pluginDir)
-
-		return nil, nil
+		return nil, &PluginConflict{Name: manifest.Name, Path: pluginDir}, nil
 	}
 
 	executable, err := resolvePlatformExecutable(pluginDir, &manifest)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	seen[manifest.Name] = true
@@ -236,7 +315,7 @@ func loadManagedPlugin(dir, name string, seen map[string]bool) (*DiscoveredPlugi
 	return &DiscoveredPlugin{
 		Manifest:   manifest,
 		Executable: executable,
-	}, nil
+	}, nil, nil
 }
 
 // resolvePlatformExecutable returns the appropriate script path for the current platform
@@ -271,17 +350,17 @@ func errMissingManifestField(field string) error {
 	return errors.New("plugin manifest missing required field: " + field)
 }
 
-func discoverInDir(ctx context.Context, dir string, seen map[string]bool) ([]DiscoveredPlugin, []error) {
+func discoverInDir(ctx context.Context, dir string, seen map[string]bool) ([]DiscoveredPlugin, []PluginConflict, []error) {
 	// Check if directory exists
 	info, err := os.Stat(dir)
 	if err != nil || !info.IsDir() {
-		return nil, nil // Directory doesn't exist, not an error
+		return nil, nil, nil // Directory doesn't exist, not an error
 	}
 
 	// Read directory entries
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, []error{err}
+		return nil, nil, []error{err}
 	}
 
 	// Phase 1: collect valid executables (fast, no goroutines)
@@ -315,7 +394,7 @@ func discoverInDir(ctx context.Context, dir string, seen map[string]bool) ([]Dis
 // deduplicates results against seen in lexicographic (input) order. Preserves the
 // "first binary wins" guarantee that os.ReadDir's alphabetical ordering provides.
 // Goroutines that have not yet called getManifest are skipped when ctx is done.
-func getManifestsParallel(ctx context.Context, executables []string, seen map[string]bool) ([]DiscoveredPlugin, []error) {
+func getManifestsParallel(ctx context.Context, executables []string, seen map[string]bool) ([]DiscoveredPlugin, []PluginConflict, []error) {
 	type result struct {
 		path     string
 		manifest *PluginManifest
@@ -344,6 +423,8 @@ func getManifestsParallel(ctx context.Context, executables []string, seen map[st
 	// Deduplicate on manifest.Name (the actual command name), preserving lexicographic order
 	var plugins []DiscoveredPlugin
 
+	var conflicts []PluginConflict
+
 	var errs []error
 
 	for _, r := range results {
@@ -358,9 +439,7 @@ func getManifestsParallel(ctx context.Context, executables []string, seen map[st
 		}
 
 		if seen[r.manifest.Name] {
-			log.Warn("Plugin name already registered, skipping",
-				"name", r.manifest.Name,
-				"path", r.path)
+			conflicts = append(conflicts, PluginConflict{Name: r.manifest.Name, Path: r.path})
 
 			continue
 		}
@@ -373,7 +452,7 @@ func getManifestsParallel(ctx context.Context, executables []string, seen map[st
 		})
 	}
 
-	return plugins, errs
+	return plugins, conflicts, errs
 }
 
 func getManifest(ctx context.Context, executable string) (*PluginManifest, error) {

--- a/internal/plugin/discover_test.go
+++ b/internal/plugin/discover_test.go
@@ -89,17 +89,19 @@ func (s *DiscoverTestSuite) TearDownTest() {
 
 func (s *DiscoverTestSuite) TestDiscoverInDirEmptyDirectory() {
 	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(context.Background(), s.tempDir, seen)
+	plugins, conflicts, errs := discoverInDir(context.Background(), s.tempDir, seen)
 
 	s.Empty(plugins)
+	s.Empty(conflicts)
 	s.Empty(errs)
 }
 
 func (s *DiscoverTestSuite) TestDiscoverInDirNonExistent() {
 	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(context.Background(), filepath.Join(s.tempDir, "nonexistent"), seen)
+	plugins, conflicts, errs := discoverInDir(context.Background(), filepath.Join(s.tempDir, "nonexistent"), seen)
 
 	s.Nil(plugins)
+	s.Nil(conflicts)
 	s.Nil(errs)
 }
 
@@ -107,9 +109,10 @@ func (s *DiscoverTestSuite) TestDiscoverInDirValidPlugin() {
 	createMockPlugin(s.T(), s.tempDir, "dr-testplugin", validManifest)
 
 	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(context.Background(), s.tempDir, seen)
+	plugins, conflicts, errs := discoverInDir(context.Background(), s.tempDir, seen)
 
 	s.Require().Len(plugins, 1, "Expected exactly one plugin")
+	s.Empty(conflicts)
 	s.Empty(errs)
 	s.Equal("test-plugin", plugins[0].Manifest.Name)
 	s.Equal("1.0.0", plugins[0].Manifest.Version)
@@ -126,7 +129,7 @@ func (s *DiscoverTestSuite) TestDiscoverInDirSkipsNonDrFiles() {
 	s.Require().NoError(os.WriteFile(filepath.Join(s.tempDir, "random.txt"), []byte("text"), 0o644))
 
 	seen := make(map[string]bool)
-	plugins, _ := discoverInDir(context.Background(), s.tempDir, seen)
+	plugins, _, _ := discoverInDir(context.Background(), s.tempDir, seen)
 
 	s.Require().Len(plugins, 1, "Expected exactly one plugin (non-dr files should be skipped)")
 	s.Equal("test-plugin", plugins[0].Manifest.Name)
@@ -138,9 +141,10 @@ func (s *DiscoverTestSuite) TestDiscoverInDirSkipsNonExecutable() {
 	s.Require().NoError(os.WriteFile(path, []byte("not executable"), 0o644))
 
 	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(context.Background(), s.tempDir, seen)
+	plugins, conflicts, errs := discoverInDir(context.Background(), s.tempDir, seen)
 
 	s.Empty(plugins)
+	s.Empty(conflicts)
 	s.Empty(errs)
 }
 
@@ -152,10 +156,12 @@ func (s *DiscoverTestSuite) TestDiscoverInDirHandlesDuplicates() {
 		"test-plugin": true, // validManifest has name: "test-plugin"
 	}
 
-	plugins, _ := discoverInDir(context.Background(), s.tempDir, seen)
+	plugins, conflicts, _ := discoverInDir(context.Background(), s.tempDir, seen)
 
 	// Should be skipped due to duplicate manifest name
 	s.Empty(plugins)
+	s.Require().Len(conflicts, 1, "pre-existing manifest name must be recorded as a conflict")
+	s.Equal("test-plugin", conflicts[0].Name)
 }
 
 func (s *DiscoverTestSuite) TestDiscoverInDirDeduplicatesByManifestName() {
@@ -165,7 +171,7 @@ func (s *DiscoverTestSuite) TestDiscoverInDirDeduplicatesByManifestName() {
 	createMockPlugin(s.T(), s.tempDir, "dr-second", manifest)
 
 	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(context.Background(), s.tempDir, seen)
+	plugins, conflicts, errs := discoverInDir(context.Background(), s.tempDir, seen)
 
 	// Log manifest-fetch errors so future test failures show *why* discovery
 	// returned zero plugins instead of only asserting *that* it did.
@@ -177,15 +183,18 @@ func (s *DiscoverTestSuite) TestDiscoverInDirDeduplicatesByManifestName() {
 	s.Require().Len(plugins, 1, "Expected exactly one plugin when two share the same manifest name")
 	s.Empty(errs)
 	s.Equal("shared-name", plugins[0].Manifest.Name)
+	s.Require().Len(conflicts, 1, "the second binary sharing the manifest name must be recorded as a conflict")
+	s.Equal("shared-name", conflicts[0].Name)
 }
 
 func (s *DiscoverTestSuite) TestDiscoverInDirInvalidManifest() {
 	createMockPlugin(s.T(), s.tempDir, "dr-invalid", invalidManifest)
 
 	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(context.Background(), s.tempDir, seen)
+	plugins, conflicts, errs := discoverInDir(context.Background(), s.tempDir, seen)
 
 	s.Empty(plugins)
+	s.Empty(conflicts)
 	s.Len(errs, 1) // JSON parse error logged
 }
 
@@ -197,9 +206,10 @@ func (s *DiscoverTestSuite) TestDiscoverInDirMultipleValidPlugins() {
 	createMockPlugin(s.T(), s.tempDir, "dr-two", manifest2)
 
 	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(context.Background(), s.tempDir, seen)
+	plugins, conflicts, errs := discoverInDir(context.Background(), s.tempDir, seen)
 
 	s.Len(plugins, 2)
+	s.Empty(conflicts)
 	s.Empty(errs)
 
 	// Verify both plugins discovered
@@ -219,9 +229,10 @@ func (s *DiscoverTestSuite) TestDiscoverInDirCancelledContext() {
 	cancel()
 
 	seen := make(map[string]bool)
-	plugins, errs := discoverInDir(ctx, s.tempDir, seen)
+	plugins, conflicts, errs := discoverInDir(ctx, s.tempDir, seen)
 
 	s.Empty(plugins)
+	s.Empty(conflicts)
 	s.Empty(errs)
 }
 
@@ -257,9 +268,10 @@ func (s *PathDirsTestSuite) TearDownTest() {
 }
 
 func (s *PathDirsTestSuite) TestEmptyPathDirs() {
-	plugins := discoverPathDirsParallel(context.Background(), []string{}, map[string]bool{})
+	plugins, conflicts := discoverPathDirsParallel(context.Background(), []string{}, map[string]bool{})
 
 	s.Empty(plugins)
+	s.Empty(conflicts)
 }
 
 func (s *PathDirsTestSuite) TestMultipleDirsCollectsAll() {
@@ -269,9 +281,10 @@ func (s *PathDirsTestSuite) TestMultipleDirsCollectsAll() {
 	createMockPlugin(s.T(), s.dir1, "dr-alpha", m1)
 	createMockPlugin(s.T(), s.dir2, "dr-beta", m2)
 
-	plugins := discoverPathDirsParallel(context.Background(), []string{s.dir1, s.dir2}, map[string]bool{})
+	plugins, conflicts := discoverPathDirsParallel(context.Background(), []string{s.dir1, s.dir2}, map[string]bool{})
 
 	s.Len(plugins, 2)
+	s.Empty(conflicts)
 
 	names := make(map[string]bool)
 	for _, p := range plugins {
@@ -289,11 +302,15 @@ func (s *PathDirsTestSuite) TestCrossDirDeduplicationFirstDirWins() {
 	createMockPlugin(s.T(), s.dir1, "dr-shared", manifest)
 	createMockPlugin(s.T(), s.dir2, "dr-shared", manifest)
 
-	plugins := discoverPathDirsParallel(context.Background(), []string{s.dir1, s.dir2}, map[string]bool{})
+	plugins, conflicts := discoverPathDirsParallel(context.Background(), []string{s.dir1, s.dir2}, map[string]bool{})
 
 	s.Require().Len(plugins, 1)
 	s.Equal("shared-plugin", plugins[0].Manifest.Name)
 	s.Equal(filepath.Join(s.dir1, "dr-shared"), plugins[0].Executable)
+
+	s.Require().Len(conflicts, 1, "the second dir's binary sharing the manifest name must be recorded as a conflict")
+	s.Equal("shared-plugin", conflicts[0].Name)
+	s.Equal(filepath.Join(s.dir2, "dr-shared"), conflicts[0].Path)
 }
 
 func (s *PathDirsTestSuite) TestBaseSeenFiltersPlugins() {
@@ -301,9 +318,11 @@ func (s *PathDirsTestSuite) TestBaseSeenFiltersPlugins() {
 	createMockPlugin(s.T(), s.dir1, "dr-testplugin", validManifest)
 
 	baseSeen := map[string]bool{"test-plugin": true}
-	plugins := discoverPathDirsParallel(context.Background(), []string{s.dir1}, baseSeen)
+	plugins, conflicts := discoverPathDirsParallel(context.Background(), []string{s.dir1}, baseSeen)
 
 	s.Empty(plugins)
+	s.Require().Len(conflicts, 1)
+	s.Equal("test-plugin", conflicts[0].Name)
 }
 
 func (s *PathDirsTestSuite) TestBaseSeenNotMutated() {
@@ -312,7 +331,7 @@ func (s *PathDirsTestSuite) TestBaseSeenNotMutated() {
 	createMockPlugin(s.T(), s.dir1, "dr-alpha", m1)
 
 	baseSeen := map[string]bool{}
-	_ = discoverPathDirsParallel(context.Background(), []string{s.dir1}, baseSeen)
+	_, _ = discoverPathDirsParallel(context.Background(), []string{s.dir1}, baseSeen)
 
 	s.Empty(baseSeen)
 }
@@ -323,7 +342,7 @@ func (s *PathDirsTestSuite) TestCancelledContextReturnsEmpty() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	plugins := discoverPathDirsParallel(ctx, []string{s.dir1}, map[string]bool{})
+	plugins, _ := discoverPathDirsParallel(ctx, []string{s.dir1}, map[string]bool{})
 
 	s.Empty(plugins)
 }
@@ -342,7 +361,7 @@ func (s *PathDirsTestSuite) TestPartialResultsWhenContextExpiresAfterFastPlugin(
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	plugins := discoverPathDirsParallel(ctx, []string{s.dir1, s.dir2}, map[string]bool{})
+	plugins, _ := discoverPathDirsParallel(ctx, []string{s.dir1, s.dir2}, map[string]bool{})
 
 	names := make(map[string]bool)
 	for _, p := range plugins {
@@ -506,7 +525,7 @@ func (s *DiscoverWithContextSuite) TestDiscoversPATHPlugin() {
 		`{"name":"ctx-alpha","version":"1.0.0","description":"Alpha"}`)
 	s.T().Setenv("PATH", s.pluginDir)
 
-	plugins := DiscoverPluginsWithContext(context.Background())
+	plugins, _ := DiscoverPluginsWithContext(context.Background())
 
 	s.NotNil(pluginByName(plugins, "ctx-alpha"), "plugin from controlled PATH dir must be discovered")
 }
@@ -535,7 +554,7 @@ func (s *DiscoverWithContextSuite) TestPartialResultsOnTimeout() {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	plugins := DiscoverPluginsWithContext(ctx)
+	plugins, _ := DiscoverPluginsWithContext(ctx)
 
 	s.NotNil(pluginByName(plugins, "ctx-fast"), "fast plugin must be returned before deadline")
 	s.Nil(pluginByName(plugins, "ctx-slow"), "slow plugin must be absent after deadline")
@@ -568,9 +587,31 @@ func (s *DiscoverWithContextSuite) TestCancelledContextSkipsPATHPlugins() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	plugins := DiscoverPluginsWithContext(ctx)
+	plugins, _ := DiscoverPluginsWithContext(ctx)
 
 	s.Nil(pluginByName(plugins, "ctx-skip"), "cancelled context must skip PATH plugins")
+}
+
+func (s *DiscoverWithContextSuite) TestDuplicatePATHEntryDoesNotWarn() {
+	createMockPlugin(s.T(), s.pluginDir, "dr-ctx-dup",
+		`{"name":"ctx-dup","version":"1.0.0","description":"Dup"}`)
+	// The same directory listed twice in PATH used to make discovery scan it
+	// twice, reporting a false conflict against itself.
+	s.T().Setenv("PATH", s.pluginDir+string(os.PathListSeparator)+s.pluginDir)
+
+	plugins, conflicts := DiscoverPluginsWithContext(context.Background())
+
+	s.Empty(conflicts, "duplicate PATH entries for the same dir must not produce a conflict")
+
+	matches := 0
+
+	for _, p := range plugins {
+		if p.Manifest.Name == "ctx-dup" {
+			matches++
+		}
+	}
+
+	s.Equal(1, matches, "plugin must only appear once even though its dir is listed twice in PATH")
 }
 
 // createManagedTestPlugin creates a minimal managed plugin directory structure under pluginsDir.
@@ -613,7 +654,7 @@ func TestDiscoverPlugins_FindsPluginsInXDGConfigDirs(t *testing.T) {
 	createManagedTestPlugin(t, xdgPluginsDir, "xdg-plugin", "xdg-plugin")
 	createManagedTestPlugin(t, configDirPluginsDir, "config-dir-plugin", "config-dir-plugin")
 
-	plugins := DiscoverPluginsWithContext(context.Background())
+	plugins, _ := DiscoverPluginsWithContext(context.Background())
 
 	names := make(map[string]bool)
 
@@ -623,4 +664,47 @@ func TestDiscoverPlugins_FindsPluginsInXDGConfigDirs(t *testing.T) {
 
 	assert.True(t, names["xdg-plugin"], "plugin in XDG_CONFIG_HOME directory should be discovered")
 	assert.True(t, names["config-dir-plugin"], "plugin in XDG_CONFIG_DIRS directory should be discovered")
+}
+
+func TestUniqueDirs(t *testing.T) {
+	assert.Equal(t, []string{"/a", "/b", "/c"}, uniqueDirs([]string{"/a", "/b", "/a", "/c", "/b"}))
+	assert.Empty(t, uniqueDirs(nil))
+}
+
+func TestLogConflicts(t *testing.T) {
+	output := captureLogOutput(t, func() {
+		LogConflicts([]PluginConflict{
+			{Name: "potato", Path: "/usr/local/bin/dr-potato"},
+			{Name: "carrot", Path: "/opt/bin/dr-carrot"},
+		})
+	})
+
+	assert.Contains(t, output, "potato")
+	assert.Contains(t, output, "/usr/local/bin/dr-potato")
+	assert.Contains(t, output, "carrot")
+	assert.Contains(t, output, "/opt/bin/dr-carrot")
+}
+
+func TestLogConflictsEmpty(t *testing.T) {
+	output := captureLogOutput(t, func() {
+		LogConflicts(nil)
+	})
+
+	assert.Empty(t, output)
+}
+
+func TestConflictsForName(t *testing.T) {
+	conflicts := []PluginConflict{
+		{Name: "potato", Path: "/usr/local/bin/dr-potato"},
+		{Name: "carrot", Path: "/opt/bin/dr-carrot"},
+		{Name: "potato", Path: "/opt/bin/dr-potato"},
+	}
+
+	assert.Equal(t, []PluginConflict{
+		{Name: "potato", Path: "/usr/local/bin/dr-potato"},
+		{Name: "potato", Path: "/opt/bin/dr-potato"},
+	}, ConflictsForName(conflicts, "potato"))
+
+	assert.Empty(t, ConflictsForName(conflicts, "turnip"))
+	assert.Empty(t, ConflictsForName(nil, "potato"))
 }

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -80,8 +80,23 @@ type DiscoveredPlugin struct {
 	Executable string // Full path to executable
 }
 
+// PluginConflict records a plugin executable that was skipped during
+// discovery because a plugin with the same manifest name was already
+// registered from a higher-priority location (managed dirs > local plugin
+// dir > PATH; first match within a tier wins).
+//
+// Discovery returns conflicts as data instead of logging them directly, so
+// each caller can decide which ones are relevant: `dr plugin list` and
+// command registration warn about all of them, while `dr plugin version
+// <name>` only surfaces conflicts for the plugin actually being asked about.
+type PluginConflict struct {
+	Name string // manifest name that was already registered
+	Path string // executable (or managed plugin dir) that was skipped
+}
+
 // DiscoveredPluginsRegistry holds discovered plugins with lazy initialization
 type DiscoveredPluginsRegistry struct {
-	plugins []DiscoveredPlugin
-	once    sync.Once
+	plugins   []DiscoveredPlugin
+	conflicts []PluginConflict
+	once      sync.Once
 }


### PR DESCRIPTION
# RATIONALE

Plugins always have a version in their manifest, but we don't have a way to output them. This adds that

## CHANGES

* Creates `dr plugin version <plugin>` command that returns the current version.
* Improved plugin pathing to deduplicate paths so duplicate plugin warnings are real
* Refactored GetPlugins to use a cache and return a warnings struct along with the plugin struct for the caller to decide if warnings should be displayed and for which plugins


<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1783882051.368249 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CLI and isolated plugin lookup; no changes to install/auth or data handling.
> 
> **Overview**
> Adds **`dr plugin version <plugin-name>`** so users can read a plugin’s manifest version without listing every plugin.
> 
> Resolution uses a new **`FindPlugin`** helper that follows the same priority as full discovery (managed dirs → project-local → PATH) but only touches the requested name, avoiding unrelated PATH scans and duplicate-name warnings from **`DiscoverPluginsWithContext`**.
> 
> Output is the version string by default, a message when the manifest has no version, or JSON via **`--output-format json`**. Telemetry records the plugin name. Unit tests cover **`FindPlugin`** and the not-found CLI path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96ad6e3bf17fb03f8a0bd7458f9f77bf92551079. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->