### PR TITLE
[-] Konami Code 

### DIFF
--- a/tui/easter_egg.go
+++ b/tui/easter_egg.go
@@ -48,7 +48,15 @@ func (m *easterEggModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *easterEggModel) updateRocket(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// Always forward messages to the inner model so background operations
+	// Key presses are consumed by the easter egg and not forwarded to the inner
+	// model. Enter (or any key) dismisses the animation immediately.
+	if _, ok := msg.(tea.KeyMsg); ok {
+		m.rocket = nil
+
+		return m, nil
+	}
+
+	// Forward non-key messages to the inner model so background operations
 	// (e.g. network fetches, spinner ticks) continue during the animation.
 	innerUpdated, innerCmd := m.inner.Update(msg)
 	m.inner = innerUpdated

--- a/tui/easter_egg.go
+++ b/tui/easter_egg.go
@@ -1,0 +1,91 @@
+package tui
+
+// Easter egg: entering the Konami code triggers a rocket animation.
+// To remove: delete easter_egg.go, konami.go, rocket.go, konami_test.go,
+// and the wrapWithEasterEgg call in program.go.
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/internal/log"
+)
+
+type easterEggModel struct {
+	inner      tea.Model
+	konami     konamiDetector
+	rocket     *RocketModel
+	termWidth  int
+	termHeight int
+}
+
+func wrapWithEasterEgg(m tea.Model) tea.Model {
+	return &easterEggModel{inner: m}
+}
+
+func (m *easterEggModel) Init() tea.Cmd {
+	return m.inner.Init()
+}
+
+func (m *easterEggModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if sizeMsg, ok := msg.(tea.WindowSizeMsg); ok {
+		m.termWidth = sizeMsg.Width
+		m.termHeight = sizeMsg.Height
+	}
+
+	if m.rocket != nil {
+		return m.updateRocket(msg)
+	}
+
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		if cmd := m.handleKonami(keyMsg); cmd != nil {
+			return m, cmd
+		}
+	}
+
+	updated, cmd := m.inner.Update(msg)
+	m.inner = updated
+
+	return m, cmd
+}
+
+func (m *easterEggModel) updateRocket(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Always forward messages to the inner model so background operations
+	// (e.g. network fetches, spinner ticks) continue during the animation.
+	innerUpdated, innerCmd := m.inner.Update(msg)
+	m.inner = innerUpdated
+
+	if _, ok := msg.(RocketDoneMsg); ok {
+		m.rocket = nil
+
+		return m, innerCmd
+	}
+
+	rocketUpdated, rocketCmd := m.rocket.Update(msg)
+	rocket := rocketUpdated.(RocketModel)
+	m.rocket = &rocket
+
+	return m, tea.Batch(rocketCmd, innerCmd)
+}
+
+func (m *easterEggModel) handleKonami(keyMsg tea.KeyMsg) tea.Cmd {
+	if !m.konami.Feed(keyMsg) {
+		return nil
+	}
+
+	log.Info("Konami code activated!")
+
+	w := max(m.termWidth, 80)
+	h := max(m.termHeight, 24)
+
+	rocket := newRocketModel(w, h)
+	m.rocket = &rocket
+
+	return rocket.Init()
+}
+
+func (m *easterEggModel) View() string {
+	if m.rocket != nil {
+		return m.rocket.View()
+	}
+
+	return m.inner.View()
+}

--- a/tui/interrupt.go
+++ b/tui/interrupt.go
@@ -24,7 +24,11 @@ import (
 // checking for Ctrl-C and immediately quitting if detected. This guarantees
 // users can never get stuck in the program, regardless of what the model does.
 type InterruptibleModel struct {
-	Model tea.Model
+	Model      tea.Model
+	konami     konamiDetector
+	rocket     *RocketModel
+	termWidth  int
+	termHeight int
 }
 
 // NewInterruptibleModel wraps a model to ensure Ctrl-C always works everywhere.
@@ -43,6 +47,12 @@ func (m InterruptibleModel) Init() tea.Cmd {
 }
 
 func (m InterruptibleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Track terminal size for rocket animation
+	if sizeMsg, ok := msg.(tea.WindowSizeMsg); ok {
+		m.termWidth = sizeMsg.Width
+		m.termHeight = sizeMsg.Height
+	}
+
 	// Universal Ctrl-C handling - ALWAYS checked FIRST before any model logic
 	// This ensures users can always interrupt, regardless of nested components,
 	// screen state, or what the underlying model does
@@ -50,7 +60,30 @@ func (m InterruptibleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if keyMsg.String() == "ctrl+c" {
 			// Log the interrupt for debugging purposes
 			log.Info("Ctrl-C detected, quitting...")
+
 			return m, tea.Quit
+		}
+	}
+
+	// When the rocket animation is running, route messages to it
+	if m.rocket != nil {
+		if _, ok := msg.(RocketDoneMsg); ok {
+			m.rocket = nil
+
+			return m, nil
+		}
+
+		updated, cmd := m.rocket.Update(msg)
+		rocket := updated.(RocketModel)
+		m.rocket = &rocket
+
+		return m, cmd
+	}
+
+	// Check for Konami code on key presses
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		if cmd := m.handleKonami(keyMsg); cmd != nil {
+			return m, cmd
 		}
 	}
 
@@ -63,6 +96,26 @@ func (m InterruptibleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m *InterruptibleModel) handleKonami(keyMsg tea.KeyMsg) tea.Cmd {
+	if !m.konami.Feed(keyMsg) {
+		return nil
+	}
+
+	log.Info("Konami code activated!")
+
+	w := max(m.termWidth, 80)
+	h := max(m.termHeight, 24)
+
+	rocket := newRocketModel(w, h)
+	m.rocket = &rocket
+
+	return rocket.Init()
+}
+
 func (m InterruptibleModel) View() string {
+	if m.rocket != nil {
+		return m.rocket.View()
+	}
+
 	return m.Model.View()
 }

--- a/tui/interrupt.go
+++ b/tui/interrupt.go
@@ -24,11 +24,7 @@ import (
 // checking for Ctrl-C and immediately quitting if detected. This guarantees
 // users can never get stuck in the program, regardless of what the model does.
 type InterruptibleModel struct {
-	Model      tea.Model
-	konami     konamiDetector
-	rocket     *RocketModel
-	termWidth  int
-	termHeight int
+	Model tea.Model
 }
 
 // NewInterruptibleModel wraps a model to ensure Ctrl-C always works everywhere.
@@ -47,12 +43,6 @@ func (m InterruptibleModel) Init() tea.Cmd {
 }
 
 func (m InterruptibleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// Track terminal size for rocket animation
-	if sizeMsg, ok := msg.(tea.WindowSizeMsg); ok {
-		m.termWidth = sizeMsg.Width
-		m.termHeight = sizeMsg.Height
-	}
-
 	// Universal Ctrl-C handling - ALWAYS checked FIRST before any model logic
 	// This ensures users can always interrupt, regardless of nested components,
 	// screen state, or what the underlying model does
@@ -65,28 +55,6 @@ func (m InterruptibleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	// When the rocket animation is running, route messages to it
-	if m.rocket != nil {
-		if _, ok := msg.(RocketDoneMsg); ok {
-			m.rocket = nil
-
-			return m, nil
-		}
-
-		updated, cmd := m.rocket.Update(msg)
-		rocket := updated.(RocketModel)
-		m.rocket = &rocket
-
-		return m, cmd
-	}
-
-	// Check for Konami code on key presses
-	if keyMsg, ok := msg.(tea.KeyMsg); ok {
-		if cmd := m.handleKonami(keyMsg); cmd != nil {
-			return m, cmd
-		}
-	}
-
 	// Pass the message to the wrapped model
 	updatedModel, cmd := m.Model.Update(msg)
 
@@ -96,26 +64,6 @@ func (m InterruptibleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-func (m *InterruptibleModel) handleKonami(keyMsg tea.KeyMsg) tea.Cmd {
-	if !m.konami.Feed(keyMsg) {
-		return nil
-	}
-
-	log.Info("Konami code activated!")
-
-	w := max(m.termWidth, 80)
-	h := max(m.termHeight, 24)
-
-	rocket := newRocketModel(w, h)
-	m.rocket = &rocket
-
-	return rocket.Init()
-}
-
 func (m InterruptibleModel) View() string {
-	if m.rocket != nil {
-		return m.rocket.View()
-	}
-
 	return m.Model.View()
 }

--- a/tui/konami.go
+++ b/tui/konami.go
@@ -1,0 +1,38 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// konamiSequence is the Konami code: Up Down Left Right Left Right B
+var konamiSequence = []string{
+	"up", "up", "down", "down", "left", "right", "left", "right", "b", "a",
+}
+
+// konamiDetector tracks progress through the Konami code sequence.
+type konamiDetector struct {
+	pos int
+}
+
+// Feed advances the detector with a key. Returns true when the full sequence is complete.
+// Resets to zero on any wrong key.
+func (k *konamiDetector) Feed(msg tea.KeyMsg) bool {
+	key := msg.String()
+
+	if key == konamiSequence[k.pos] {
+		k.pos++
+
+		if k.pos == len(konamiSequence) {
+			k.pos = 0
+
+			return true
+		}
+	} else {
+		k.pos = 0
+
+		// Re-check from position 0 in case the wrong key starts a new sequence
+		if key == konamiSequence[0] {
+			k.pos = 1
+		}
+	}
+
+	return false
+}

--- a/tui/konami.go
+++ b/tui/konami.go
@@ -2,7 +2,7 @@ package tui
 
 import tea "github.com/charmbracelet/bubbletea"
 
-// konamiSequence is the Konami code: Up Up Down Down Left Right Left Right B A
+// konamiSequence is the Konami code: ↑ ↑ ↓ ↓ ← → ← → B A
 var konamiSequence = []string{
 	"up", "up", "down", "down", "left", "right", "left", "right", "b", "a",
 }

--- a/tui/konami.go
+++ b/tui/konami.go
@@ -2,7 +2,7 @@ package tui
 
 import tea "github.com/charmbracelet/bubbletea"
 
-// konamiSequence is the Konami code: Up Down Left Right Left Right B
+// konamiSequence is the Konami code: Up Up Down Down Left Right Left Right B A
 var konamiSequence = []string{
 	"up", "up", "down", "down", "left", "right", "left", "right", "b", "a",
 }

--- a/tui/konami_overlay.go
+++ b/tui/konami_overlay.go
@@ -1,15 +1,15 @@
 package tui
 
 // Easter egg: entering the Konami code triggers a rocket animation.
-// To remove: delete easter_egg.go, konami.go, rocket.go, konami_test.go,
-// and the wrapWithEasterEgg call in program.go.
+// To remove: delete konami_overlay.go, konami.go, rocket.go, konami_test.go,
+// and the wrapWithKonamiOverlay call in program.go.
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/internal/log"
 )
 
-type easterEggModel struct {
+type konamiOverlay struct {
 	inner      tea.Model
 	konami     konamiDetector
 	rocket     *RocketModel
@@ -17,15 +17,15 @@ type easterEggModel struct {
 	termHeight int
 }
 
-func wrapWithEasterEgg(m tea.Model) tea.Model {
-	return &easterEggModel{inner: m}
+func wrapWithKonamiOverlay(m tea.Model) tea.Model {
+	return &konamiOverlay{inner: m}
 }
 
-func (m *easterEggModel) Init() tea.Cmd {
+func (m *konamiOverlay) Init() tea.Cmd {
 	return m.inner.Init()
 }
 
-func (m *easterEggModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m *konamiOverlay) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if sizeMsg, ok := msg.(tea.WindowSizeMsg); ok {
 		m.termWidth = sizeMsg.Width
 		m.termHeight = sizeMsg.Height
@@ -47,9 +47,9 @@ func (m *easterEggModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-func (m *easterEggModel) updateRocket(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// Key presses are consumed by the easter egg and not forwarded to the inner
-	// model. Enter (or any key) dismisses the animation immediately.
+func (m *konamiOverlay) updateRocket(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Key presses are consumed by the overlay and not forwarded to the inner
+	// model. Any key dismisses the animation immediately.
 	if _, ok := msg.(tea.KeyMsg); ok {
 		m.rocket = nil
 
@@ -74,7 +74,7 @@ func (m *easterEggModel) updateRocket(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(rocketCmd, innerCmd)
 }
 
-func (m *easterEggModel) handleKonami(keyMsg tea.KeyMsg) tea.Cmd {
+func (m *konamiOverlay) handleKonami(keyMsg tea.KeyMsg) tea.Cmd {
 	if !m.konami.Feed(keyMsg) {
 		return nil
 	}
@@ -90,7 +90,7 @@ func (m *easterEggModel) handleKonami(keyMsg tea.KeyMsg) tea.Cmd {
 	return rocket.Init()
 }
 
-func (m *easterEggModel) View() string {
+func (m *konamiOverlay) View() string {
 	if m.rocket != nil {
 		return m.rocket.View()
 	}

--- a/tui/konami_overlay.go
+++ b/tui/konami_overlay.go
@@ -1,99 +1,21 @@
 package tui
 
-// Easter egg: entering the Konami code triggers a rocket animation.
+// Easter egg: the Konami code (↑ ↑ ↓ ↓ ← → ← → B A) triggers the rocket animation.
 // To remove: delete konami_overlay.go, konami.go, rocket.go, konami_test.go,
 // and the wrapWithKonamiOverlay call in program.go.
+// sequence_overlay.go can stay — it is general-purpose infrastructure.
 
-import (
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/datarobot/cli/internal/log"
-)
+import tea "github.com/charmbracelet/bubbletea"
 
-type konamiOverlay struct {
-	inner      tea.Model
-	konami     konamiDetector
-	rocket     *RocketModel
-	termWidth  int
-	termHeight int
-}
-
+// wrapWithKonamiOverlay wraps m in a sequenceOverlay that fires the rocket
+// animation when the Konami code is entered. To swap the animation for
+// something else, replace newRocketModel with a different overlayFactory.
+// To add more sequences, pass additional overlayTrigger values.
 func wrapWithKonamiOverlay(m tea.Model) tea.Model {
-	return &konamiOverlay{inner: m}
-}
-
-func (m *konamiOverlay) Init() tea.Cmd {
-	return m.inner.Init()
-}
-
-func (m *konamiOverlay) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if sizeMsg, ok := msg.(tea.WindowSizeMsg); ok {
-		m.termWidth = sizeMsg.Width
-		m.termHeight = sizeMsg.Height
-	}
-
-	if m.rocket != nil {
-		return m.updateRocket(msg)
-	}
-
-	if keyMsg, ok := msg.(tea.KeyMsg); ok {
-		if cmd := m.handleKonami(keyMsg); cmd != nil {
-			return m, cmd
-		}
-	}
-
-	updated, cmd := m.inner.Update(msg)
-	m.inner = updated
-
-	return m, cmd
-}
-
-func (m *konamiOverlay) updateRocket(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// Key presses are consumed by the overlay and not forwarded to the inner
-	// model. Any key dismisses the animation immediately.
-	if _, ok := msg.(tea.KeyMsg); ok {
-		m.rocket = nil
-
-		return m, nil
-	}
-
-	// Forward non-key messages to the inner model so background operations
-	// (e.g. network fetches, spinner ticks) continue during the animation.
-	innerUpdated, innerCmd := m.inner.Update(msg)
-	m.inner = innerUpdated
-
-	if _, ok := msg.(RocketDoneMsg); ok {
-		m.rocket = nil
-
-		return m, innerCmd
-	}
-
-	rocketUpdated, rocketCmd := m.rocket.Update(msg)
-	rocket := rocketUpdated.(RocketModel)
-	m.rocket = &rocket
-
-	return m, tea.Batch(rocketCmd, innerCmd)
-}
-
-func (m *konamiOverlay) handleKonami(keyMsg tea.KeyMsg) tea.Cmd {
-	if !m.konami.Feed(keyMsg) {
-		return nil
-	}
-
-	log.Info("Konami code activated!")
-
-	w := max(m.termWidth, 80)
-	h := max(m.termHeight, 24)
-
-	rocket := newRocketModel(w, h)
-	m.rocket = &rocket
-
-	return rocket.Init()
-}
-
-func (m *konamiOverlay) View() string {
-	if m.rocket != nil {
-		return m.rocket.View()
-	}
-
-	return m.inner.View()
+	return newSequenceOverlay(m, overlayTrigger{
+		detector: &konamiDetector{},
+		create: func(w, h int) tea.Model {
+			return newRocketModel(w, h)
+		},
+	})
 }

--- a/tui/konami_test.go
+++ b/tui/konami_test.go
@@ -1,0 +1,122 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+)
+
+func key(k string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(k)}
+}
+
+func arrowKey(t tea.KeyType) tea.KeyMsg {
+	return tea.KeyMsg{Type: t}
+}
+
+func feedSequence(d *konamiDetector, keys []tea.KeyMsg) bool {
+	var result bool
+
+	for _, k := range keys {
+		result = d.Feed(k)
+	}
+
+	return result
+}
+
+func TestKonamiDetector_FullSequence(t *testing.T) {
+	d := &konamiDetector{}
+
+	sequence := []tea.KeyMsg{
+		arrowKey(tea.KeyUp),
+		arrowKey(tea.KeyUp),
+		arrowKey(tea.KeyDown),
+		arrowKey(tea.KeyDown),
+		arrowKey(tea.KeyLeft),
+		arrowKey(tea.KeyRight),
+		arrowKey(tea.KeyLeft),
+		arrowKey(tea.KeyRight),
+		key("b"),
+		key("a"),
+	}
+
+	triggered := feedSequence(d, sequence)
+
+	assert.True(t, triggered, "full Konami sequence should trigger")
+}
+
+func TestKonamiDetector_WrongKeyResets(t *testing.T) {
+	d := &konamiDetector{}
+
+	// Feed up, then a wrong key
+	d.Feed(arrowKey(tea.KeyUp))
+	d.Feed(arrowKey(tea.KeyUp))
+
+	result := d.Feed(key("x"))
+
+	assert.False(t, result, "wrong key should not trigger")
+
+	// Now the full sequence from scratch should still work
+	sequence := []tea.KeyMsg{
+		arrowKey(tea.KeyUp),
+		arrowKey(tea.KeyUp),
+		arrowKey(tea.KeyDown),
+		arrowKey(tea.KeyDown),
+		arrowKey(tea.KeyLeft),
+		arrowKey(tea.KeyRight),
+		arrowKey(tea.KeyLeft),
+		arrowKey(tea.KeyRight),
+		key("b"),
+		key("a"),
+	}
+
+	triggered := feedSequence(d, sequence)
+
+	assert.True(t, triggered, "fresh full sequence should trigger after reset")
+}
+
+func TestKonamiDetector_PartialSequenceNoTrigger(t *testing.T) {
+	d := &konamiDetector{}
+
+	// Feed only first 9 keys of the 10-key sequence
+	sequence := []tea.KeyMsg{
+		arrowKey(tea.KeyUp),
+		arrowKey(tea.KeyUp),
+		arrowKey(tea.KeyDown),
+		arrowKey(tea.KeyDown),
+		arrowKey(tea.KeyLeft),
+		arrowKey(tea.KeyRight),
+		arrowKey(tea.KeyLeft),
+		arrowKey(tea.KeyRight),
+		key("b"),
+	}
+
+	triggered := feedSequence(d, sequence)
+
+	assert.False(t, triggered, "partial sequence should not trigger")
+}
+
+func TestKonamiDetector_ResetsAfterTrigger(t *testing.T) {
+	d := &konamiDetector{}
+
+	sequence := []tea.KeyMsg{
+		arrowKey(tea.KeyUp),
+		arrowKey(tea.KeyUp),
+		arrowKey(tea.KeyDown),
+		arrowKey(tea.KeyDown),
+		arrowKey(tea.KeyLeft),
+		arrowKey(tea.KeyRight),
+		arrowKey(tea.KeyLeft),
+		arrowKey(tea.KeyRight),
+		key("b"),
+		key("a"),
+	}
+
+	feedSequence(d, sequence)
+
+	// After triggering, feeding a single 'a' should not trigger again
+	result := d.Feed(key("a"))
+
+	assert.False(t, result, "single key after trigger should not retrigger")
+}

--- a/tui/program.go
+++ b/tui/program.go
@@ -28,7 +28,7 @@ func Run(model tea.Model, opts ...tea.ProgramOption) (tea.Model, error) {
 
 	defer log.StartStderr()
 
-	p := tea.NewProgram(NewInterruptibleModel(model), opts...)
+	p := tea.NewProgram(NewInterruptibleModel(wrapWithEasterEgg(model)), opts...)
 	finalModel, err := p.Run()
 
 	return finalModel, err

--- a/tui/program.go
+++ b/tui/program.go
@@ -28,7 +28,7 @@ func Run(model tea.Model, opts ...tea.ProgramOption) (tea.Model, error) {
 
 	defer log.StartStderr()
 
-	p := tea.NewProgram(NewInterruptibleModel(wrapWithEasterEgg(model)), opts...)
+	p := tea.NewProgram(NewInterruptibleModel(wrapWithKonamiOverlay(model)), opts...)
 	finalModel, err := p.Run()
 
 	return finalModel, err

--- a/tui/rocket.go
+++ b/tui/rocket.go
@@ -106,8 +106,8 @@ func (m RocketModel) flyingView() string {
 	}
 
 	placeAt(m.row, "🚀")
-	placeAt(m.row+1, " ✨")
-	placeAt(m.row+2, "  ·")
+	placeAt(m.row+1, "✨")
+	placeAt(m.row+2, " ·")
 
 	return strings.Join(lines, "\n")
 }

--- a/tui/rocket.go
+++ b/tui/rocket.go
@@ -33,7 +33,6 @@ type RocketModel struct {
 	height int
 	row    int
 	phase  rocketPhase
-	done   bool
 }
 
 // RocketDoneMsg is sent when the rocket animation finishes, so the parent can resume.
@@ -72,8 +71,6 @@ func (m RocketModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case rocketDoneMsg:
-		m.done = true
-
 		return m, func() tea.Msg { return RocketDoneMsg{} }
 	}
 

--- a/tui/rocket.go
+++ b/tui/rocket.go
@@ -136,9 +136,7 @@ func tickRocket() tea.Cmd {
 }
 
 func showMessageThenDone() tea.Cmd {
-	return func() tea.Msg {
-		<-time.After(rocketMessageDelay)
-
+	return tea.Tick(rocketMessageDelay, func(_ time.Time) tea.Msg {
 		return rocketDoneMsg{}
-	}
+	})
 }

--- a/tui/rocket.go
+++ b/tui/rocket.go
@@ -88,7 +88,7 @@ func (m RocketModel) View() string {
 func (m RocketModel) flyingView() string {
 	lines := make([]string, m.height)
 
-	rocketCol := m.width/2 - 1
+	rocketCol := (m.width - 2) / 2
 
 	for i := range lines {
 		lines[i] = ""

--- a/tui/rocket.go
+++ b/tui/rocket.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	rocketTickInterval = 60 * time.Millisecond
-	rocketMessageDelay = 1500 * time.Millisecond
+	rocketMessageDelay = 4000 * time.Millisecond
 )
 
 type (
@@ -120,13 +120,15 @@ func (m RocketModel) messageView() string {
 		Foreground(GetAdaptiveColor(DrGreen, DrGreenDark)).
 		Bold(true)
 
-	rendered := style.Render(msg1)
-	rendered += "\n\n" + style.Render(msg2)
+	center := func(s string) string {
+		pad := strings.Repeat(" ", max(0, (m.width-len(s))/2))
 
-	pad := strings.Repeat(" ", max(0, (m.width-len(msg1))/2))
+		return pad + style.Render(s)
+	}
+
 	verticalPad := strings.Repeat("\n", max(0, m.height/2-1))
 
-	return verticalPad + pad + rendered
+	return verticalPad + center(msg1) + "\n\n" + center(msg2)
 }
 
 func tickRocket() tea.Cmd {

--- a/tui/rocket.go
+++ b/tui/rocket.go
@@ -113,15 +113,17 @@ func (m RocketModel) flyingView() string {
 }
 
 func (m RocketModel) messageView() string {
-	msg := "Godspeed, Artemis II!"
+	msg1 := "The crew of Artemis II now bound for the moon."
+	msg2 := "Humanity's next great voyage begins."
 
 	style := lipgloss.NewStyle().
 		Foreground(GetAdaptiveColor(DrGreen, DrGreenDark)).
 		Bold(true)
 
-	rendered := style.Render(msg)
+	rendered := style.Render(msg1)
+	rendered += "\n\n" + style.Render(msg2)
 
-	pad := strings.Repeat(" ", max(0, (m.width-len(msg))/2))
+	pad := strings.Repeat(" ", max(0, (m.width-len(msg1))/2))
 	verticalPad := strings.Repeat("\n", max(0, m.height/2-1))
 
 	return verticalPad + pad + rendered

--- a/tui/rocket.go
+++ b/tui/rocket.go
@@ -35,9 +35,6 @@ type RocketModel struct {
 	phase  rocketPhase
 }
 
-// RocketDoneMsg is sent when the rocket animation finishes, so the parent can resume.
-type RocketDoneMsg struct{}
-
 func newRocketModel(width, height int) RocketModel {
 	return RocketModel{
 		width:  width,
@@ -71,7 +68,7 @@ func (m RocketModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case rocketDoneMsg:
-		return m, func() tea.Msg { return RocketDoneMsg{} }
+		return m, func() tea.Msg { return OverlayDoneMsg{} }
 	}
 
 	return m, nil

--- a/tui/rocket.go
+++ b/tui/rocket.go
@@ -118,9 +118,10 @@ func (m RocketModel) messageView() string {
 		Bold(true)
 
 	center := func(s string) string {
-		pad := strings.Repeat(" ", max(0, (m.width-len(s))/2))
+		rendered := style.Render(s)
+		pad := strings.Repeat(" ", max(0, (m.width-lipgloss.Width(rendered))/2))
 
-		return pad + style.Render(s)
+		return pad + rendered
 	}
 
 	verticalPad := strings.Repeat("\n", max(0, m.height/2-1))

--- a/tui/rocket.go
+++ b/tui/rocket.go
@@ -1,0 +1,142 @@
+package tui
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	rocketTickInterval = 60 * time.Millisecond
+	rocketMessageDelay = 1500 * time.Millisecond
+)
+
+type (
+	rocketTickMsg struct{}
+	rocketDoneMsg struct{}
+)
+
+// rocketPhase represents the current phase of the animation.
+type rocketPhase int
+
+const (
+	rocketPhaseFlying rocketPhase = iota
+	rocketPhaseMessage
+)
+
+// RocketModel is a Bubble Tea model that animates a rocket flying up the screen,
+// then shows "Godspeed, Artemis II!" before signalling completion.
+type RocketModel struct {
+	width  int
+	height int
+	row    int
+	phase  rocketPhase
+	done   bool
+}
+
+// RocketDoneMsg is sent when the rocket animation finishes, so the parent can resume.
+type RocketDoneMsg struct{}
+
+func newRocketModel(width, height int) RocketModel {
+	return RocketModel{
+		width:  width,
+		height: height,
+		row:    height - 1,
+		phase:  rocketPhaseFlying,
+	}
+}
+
+func (m RocketModel) Init() tea.Cmd {
+	return tickRocket()
+}
+
+func (m RocketModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+
+	case rocketTickMsg:
+		if m.phase == rocketPhaseFlying {
+			m.row--
+
+			if m.row < -2 {
+				m.phase = rocketPhaseMessage
+
+				return m, showMessageThenDone()
+			}
+
+			return m, tickRocket()
+		}
+
+	case rocketDoneMsg:
+		m.done = true
+
+		return m, func() tea.Msg { return RocketDoneMsg{} }
+	}
+
+	return m, nil
+}
+
+func (m RocketModel) View() string {
+	if m.phase == rocketPhaseMessage {
+		return m.messageView()
+	}
+
+	return m.flyingView()
+}
+
+func (m RocketModel) flyingView() string {
+	lines := make([]string, m.height)
+
+	rocketCol := m.width/2 - 1
+
+	for i := range lines {
+		lines[i] = ""
+	}
+
+	placeAt := func(row int, content string) {
+		if row >= 0 && row < m.height {
+			pad := strings.Repeat(" ", rocketCol)
+
+			lines[row] = pad + content
+		}
+	}
+
+	placeAt(m.row, "🚀")
+	placeAt(m.row+1, " ✨")
+	placeAt(m.row+2, "  ·")
+
+	return strings.Join(lines, "\n")
+}
+
+func (m RocketModel) messageView() string {
+	msg := "Godspeed, Artemis II!"
+
+	style := lipgloss.NewStyle().
+		Foreground(GetAdaptiveColor(DrGreen, DrGreenDark)).
+		Bold(true)
+
+	rendered := style.Render(msg)
+
+	pad := strings.Repeat(" ", max(0, (m.width-len(msg))/2))
+	verticalPad := strings.Repeat("\n", max(0, m.height/2-1))
+
+	return verticalPad + pad + rendered
+}
+
+func tickRocket() tea.Cmd {
+	return tea.Tick(rocketTickInterval, func(_ time.Time) tea.Msg {
+		return rocketTickMsg{}
+	})
+}
+
+func showMessageThenDone() tea.Cmd {
+	return func() tea.Msg {
+		<-time.After(rocketMessageDelay)
+
+		return rocketDoneMsg{}
+	}
+}

--- a/tui/sequence_overlay.go
+++ b/tui/sequence_overlay.go
@@ -1,0 +1,121 @@
+package tui
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// OverlayDoneMsg is the contract an overlay model must send when it finishes.
+// sequenceOverlay listens for this to dismiss the overlay and resume the inner model.
+type OverlayDoneMsg struct{}
+
+// sequenceDetector detects a key sequence one keystroke at a time.
+// Feed returns true exactly once when the complete sequence is entered.
+type sequenceDetector interface {
+	Feed(tea.KeyMsg) bool
+}
+
+// overlayFactory creates a new overlay model sized to the current terminal.
+type overlayFactory func(width, height int) tea.Model
+
+// overlayTrigger pairs a sequence detector with the overlay it should show.
+type overlayTrigger struct {
+	detector sequenceDetector
+	create   overlayFactory
+}
+
+// sequenceOverlay wraps a tea.Model and watches for registered key sequences.
+// When a sequence fires, the corresponding overlay is rendered on top of the
+// inner model until it sends OverlayDoneMsg or any key is pressed.
+//
+// Background messages (non-key) are always forwarded to the inner model so
+// async operations continue uninterrupted while an overlay is active.
+//
+// To add a new overlay, call newSequenceOverlay with additional overlayTrigger
+// values — each with its own sequenceDetector and overlayFactory.
+type sequenceOverlay struct {
+	inner      tea.Model
+	triggers   []overlayTrigger
+	active     tea.Model
+	termWidth  int
+	termHeight int
+}
+
+func newSequenceOverlay(inner tea.Model, triggers ...overlayTrigger) *sequenceOverlay {
+	return &sequenceOverlay{inner: inner, triggers: triggers}
+}
+
+func (m *sequenceOverlay) Init() tea.Cmd {
+	return m.inner.Init()
+}
+
+func (m *sequenceOverlay) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if sizeMsg, ok := msg.(tea.WindowSizeMsg); ok {
+		m.termWidth = sizeMsg.Width
+		m.termHeight = sizeMsg.Height
+	}
+
+	if m.active != nil {
+		return m.updateActive(msg)
+	}
+
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		if cmd := m.checkTriggers(keyMsg); cmd != nil {
+			return m, cmd
+		}
+	}
+
+	updated, cmd := m.inner.Update(msg)
+	m.inner = updated
+
+	return m, cmd
+}
+
+// updateActive routes messages while an overlay is showing.
+// Key presses are consumed here — they dismiss the overlay without reaching
+// the inner model. All other messages flow through to both so background
+// work (network calls, ticks) keeps running.
+func (m *sequenceOverlay) updateActive(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if _, ok := msg.(tea.KeyMsg); ok {
+		m.active = nil
+
+		return m, nil
+	}
+
+	innerUpdated, innerCmd := m.inner.Update(msg)
+	m.inner = innerUpdated
+
+	if _, ok := msg.(OverlayDoneMsg); ok {
+		m.active = nil
+
+		return m, innerCmd
+	}
+
+	activeUpdated, activeCmd := m.active.Update(msg)
+	m.active = activeUpdated
+
+	return m, tea.Batch(activeCmd, innerCmd)
+}
+
+// checkTriggers feeds the key to every registered detector and activates the
+// first one that completes its sequence.
+func (m *sequenceOverlay) checkTriggers(keyMsg tea.KeyMsg) tea.Cmd {
+	for i := range m.triggers {
+		if m.triggers[i].detector.Feed(keyMsg) {
+			w := max(m.termWidth, 80)
+			h := max(m.termHeight, 24)
+
+			overlay := m.triggers[i].create(w, h)
+			m.active = overlay
+
+			return overlay.Init()
+		}
+	}
+
+	return nil
+}
+
+func (m *sequenceOverlay) View() string {
+	if m.active != nil {
+		return m.active.View()
+	}
+
+	return m.inner.View()
+}


### PR DESCRIPTION
# RATIONALE

Let's add a Konami code easter egg (↑ ↑ ↓ ↓ ← → ← → B A) that triggers a rocket flying up the terminal followed by an Artemis II message. The implementation is built on a generic sequence-overlay framework, so it is trivial to
- extend with new sequences
- swap the animation
- remove entirely

## CHANGES

**Add generic sequence-overlay infrastructure** (`tui/sequence_overlay.go`)
- New `sequenceOverlay` model wraps any `tea.Model` and watches for registered key sequences via pluggable `sequenceDetector` implementations. When a sequence completes, the corresponding overlay model is activated and rendered on top. The overlay is dismissed when it sends `OverlayDoneMsg` or when any key is pressed. Non-key messages (ticks, network responses) are always forwarded to the inner model so background work continues uninterrupted while an overlay is showing.

**Add Konami code detector** (`tui/konami.go`)
- `konamiDetector` tracks progress through the 10-key Konami sequence. Resets on any wrong key, with a re-check from position 0 in case the wrong key itself starts a new sequence.

**Add rocket animation model** (`tui/rocket.go`)
- `RocketModel` animates a rocket emoji flying up the terminal window and does other things. Signals completion via `OverlayDoneMsg`.

**Wire up the Konami overlay** (`tui/konami_overlay.go`, `tui/program.go`)
- `wrapWithKonamiOverlay` is a thin constructor that pairs the konami detector with the rocket factory and passes them to `newSequenceOverlay`. `Run()` now wraps the user model with `wrapWithKonamiOverlay` before passing it to `NewInterruptibleModel`. Includes a removal comment block documenting exactly which files to delete.

**Minor whitespace** (`tui/interrupt.go`)
- Blank line after the Ctrl-C log statement for readability.

### Before

```mermaid
flowchart LR
    A["tea.Program"] --> B["InterruptibleModel"]
    B --> C["User Model"]
```

### After

```mermaid
flowchart LR
    A["tea.Program"] --> B["InterruptibleModel"]
    B --> C["SequenceOverlay"]
    C -->|normal keys| D["User Model"]
    C -->|Konami code| E["Rocket Overlay"]
    E -->|OverlayDoneMsg| C
```

## NOTES

- **Removal is documented.** The comment at the top of `konami_overlay.go` lists every file to delete and the one call site to revert. `sequence_overlay.go` is general-purpose infrastructure and can stay independently.

- **No impact on normal operation.** The sequence overlay is transparent during normal use. It forwards **every** keypress to the inner model unless a registered sequence is being matched, and it **always** forwards non-key messages regardless of overlay state.

- **Extensibility.** Adding a new easter egg is a matter of implementing a `sequenceDetector`, an overlay model that sends `OverlayDoneMsg` when done, and passing a new `overlayTrigger` to `newSequenceOverlay`.

## TESTING

| Test name | What it verifies |
|---|---|
| `TestKonamiDetector_FullSequence` | Entering all 10 keys in order triggers the detector |
| `TestKonamiDetector_WrongKeyResets` | A wrong key mid-sequence resets progress, and a fresh full sequence still triggers afterward |
| `TestKonamiDetector_PartialSequenceNoTrigger` | Feeding only the first 9 keys does not trigger |
| `TestKonamiDetector_ResetsAfterTrigger` | After a successful trigger, the detector resets and a single key cannot retrigger |

Run with `task test` (race detector enabled).

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.
