### PR TITLE
Add Review Router workflow and reconcile CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-* @datarobot/applications
-**/*.md @datarobot/api-docs
+* @datarobot-oss/cli-maintainers
+cmd/workload/ @datarobot-oss/workload-cli
+internal/workload/ @datarobot-oss/workload-cli

--- a/.github/workflows/review-router.yml
+++ b/.github/workflows/review-router.yml
@@ -1,0 +1,16 @@
+name: Review Router
+
+on:
+  pull_request_target:
+    types: [labeled, opened, closed]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+jobs:
+  route:
+    uses: datarobot-oss/.github/.github/workflows/review-router.yml@main
+    secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,18 @@ Feature gates allow commands to be hidden until ready for release. For comprehen
 - Filtering happens via `cli.CommandAdder.AddCommand` at registration time — `CommandAdder` is the only filtering mechanism
 - To gate a **nested** subcommand, wrap the parent with `&cli.CommandAdder{Command: parent}` and call `adder.AddCommand(...)` instead of `parent.AddCommand(...)`
 
+## Pull Request Workflow
+
+**Always open PRs as draft first.** This repo uses [Review Router](https://github.com/datarobot-oss/review-router) to automatically route PRs to the right reviewing teams based on changed files. Review Router only fires when a PR transitions to "Ready for Review" (either by flipping the draft flag or applying the "Ready for Review" label). PRs that are opened as non-draft and never get the label will **not** be routed, leaving reviewers unaware.
+
+Workflow:
+1. Open your PR as a **draft** while you are still working on it
+2. Push updates, iterate, and run `task lint` + `task test`
+3. When the PR is genuinely ready for review, mark it **"Ready for Review"** (or add the "Ready for Review" label)
+4. Review Router will read `.github/CODEOWNERS`, request reviews from the appropriate teams, and post a summary comment
+
+Do not open non-draft PRs directly unless the change is trivially ready. Early draft PRs help reviewers see work in progress and ensure routing works correctly when the PR is ready.
+
 ## PR Output Format
 
 Output change summaries in Markdown format using the template in `.github/PULL_REQUEST_TEMPLATE.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,16 @@ When opening an issue:
 
 ## Submitting Pull Requests
 
+### Open as Draft First
+
+**Always open your PR as a draft.** This repository uses [Review Router](https://github.com/datarobot-oss/review-router) to automatically route PRs to the appropriate reviewing teams based on the files changed. Review Router only triggers when a PR is marked "Ready for Review" (by flipping the draft flag or adding the "Ready for Review" label). If you open a non-draft PR directly, it will not be routed to reviewers.
+
+**Recommended workflow:**
+1. Open your PR as a **draft** while you are still working on it
+2. Push updates, iterate, and ensure `task lint` and `task test` pass
+3. When your PR is genuinely ready for review, mark it **"Ready for Review"**
+4. Review Router will automatically request reviews from the right teams based on [CODEOWNERS](https://github.com/datarobot-oss/cli/blob/main/.github/CODEOWNERS)
+
 ### Pull Request Process
 
 After pushing your changes to your fork, create a pull request from your fork to the upstream repository:

--- a/DRCODEOWNERS
+++ b/DRCODEOWNERS
@@ -1,3 +1,0 @@
-* @datarobot-oss/cli-maintainers
-cmd/workload/ @datarobot-oss/workload-cli
-internal/workload/ @datarobot-oss/workload-cli

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -57,7 +57,8 @@ task run -- templates list
 4. Run `task lint` to format and lint code
 5. Run `task test` to verify tests pass
 6. Commit and push your changes
-7. Open a pull request
+7. Open a **draft** pull request (see [Contributing](https://github.com/datarobot-oss/cli/blob/main/CONTRIBUTING.md#submitting-pull-requests) for details)
+8. When ready for review, mark the PR "Ready for Review" so [Review Router](https://github.com/datarobot-oss/review-router) can route it to the right teams
 
 See [Building](building.md) for detailed workflow documentation.
 


### PR DESCRIPTION
## RATIONALE

This PR sets up the Review Router workflow.

Review Router reads `.github/CODEOWNERS`, which exists in this repo, but this file references teams from `datarobot` org, not `datarobot-oss`.

The newer `DRCODEOWNERS` file at the repo root had the correct `datarobot-oss` team mappings, so let's settle on using .github/CODEOWNERS as the source of truth.

but was not read by Review Router, which only looks at `.github/CODEOWNERS`. This PR reconciles the two files and adds the Review Router caller workflow so PRs get automatically routed to the right reviewing teams. It also updates contributor docs to strongly encourage the draft-PR-first workflow that Review Router depends on.

## CHANGES

**Reconciled .github/CODEOWNERS**
**Deleted DRCODEOWNERS**
**Added review-router.yml as a GH Workflow**
**Update AGENTS.md, CONTRIBUTING.md, dev docs**

## NOTES

- The reusable workflow in `datarobot-oss/.github` [already exists](https://github.com/datarobot-oss/.github) and pulls config from `datarobot/.review-router-config`

- A separate PR to `datarobot/.review-router-config` is needed to add a `datarobot-oss` org section with team-to-label-to-Slack-channel mappings (requires Slack channel IDs)

- The `datarobot-pr-review-router` GitHub App must be installed on the `datarobot-oss` org (or this repo specifically) before routing will work. _I believe it already is._

- The "Ready for Review" label should already exist.

## RELATED

- Review Router action: https://github.com/datarobot-oss/review-router
- Reusable workflow: https://github.com/datarobot-oss/.github/blob/main/.github/workflows/review-router.yml
- Slack thread: https://datarobot.slack.com/archives/C02SCP35Y/p1783510880897969

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and GitHub automation only; no application code or runtime behavior changes.
> 
> **Overview**
> Wires up **Review Router** by adding `.github/workflows/review-router.yml`, which delegates to the shared `datarobot-oss/.github` reusable workflow on PR lifecycle events (labels, reviews, comments).
> 
> **CODEOWNERS** is consolidated into `.github/CODEOWNERS` as the single source of truth: legacy `datarobot` org teams are replaced with `datarobot-oss/cli-maintainers` and `datarobot-oss/workload-cli` paths for `cmd/workload/` and `internal/workload/`. The root **`DRCODEOWNERS`** file is removed because Review Router only reads `.github/CODEOWNERS`.
> 
> Contributor docs (**`AGENTS.md`**, **`CONTRIBUTING.md`**, **`docs/development/README.md`**) now require opening PRs as **drafts** first and marking **Ready for Review** when done, so routing and team review requests actually run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6904416e808013e0359d3f5fd782eebcc99dae4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->