### PR TITLE
Add assist plugin v0.1.31

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.31",
+          "url": "assist/assist-0.1.31.tar.xz",
+          "sha256": "7650745f3606713d2032c941f9b5a52dabd6d7e6648d181c602ef35dd3260232",
+          "releaseDate": "2026-07-10"
+        },
+        {
           "version": "0.1.30",
           "url": "assist/assist-0.1.30.tar.xz",
           "sha256": "55a3f2ff1e2b09270372cd128d6c44628d20c4586081c9b42c627149d24331cc",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.31 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.31
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.31
- **SHA256:** `7650745f3606713d2032c941f9b5a52dabd6d7e6648d181c602ef35dd3260232`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1783672376.192789 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine registry metadata only; no application or install logic changes in this PR.
> 
> **Overview**
> Registers **assist** **0.1.31** as the newest entry in `docs/plugins/index.json`, with tarball path, SHA256, and release date **2026-07-10**, so `dr plugin install assist` and `latest` resolution can pick up this release.
> 
> No other plugins or index structure are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d49afab6220f76a59a2033aed32db2fe07b1e394. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->