### PR TITLE
Add opencode plugin v0.1.3

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -204,6 +204,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.3",
+          "url": "opencode/opencode-0.1.3.tar.xz",
+          "sha256": "4906a66f2f5a93567dd68b3c7c82fce25dbda92815fb5791d54696ecec2b5d66",
+          "releaseDate": "2026-07-13"
+        },
+        {
           "version": "0.1.2",
           "url": "opencode/opencode-0.1.2.tar.xz",
           "sha256": "18aea99ed54ca4d37879152c0f4ea6d078264749e124885782e226445ac42b0f",


### PR DESCRIPTION
## Summary

Adds the opencode plugin v0.1.3 to the CLI plugin index.

- Plugin: opencode
- Version: 0.1.3
- Release: https://github.com/datarobot/opencode-cli-plugin/releases/tag/v0.1.3
- SHA256: 4906a66f2f5a93567dd68b3c7c82fce25dbda92815fb5791d54696ecec2b5d66

## Test Plan

- [ ] dr plugin install opencode installs successfully
- [ ] dr opencode --help shows usage
<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1783947027.737169 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only registry update; install behavior unchanged aside from offering a new version with existing SHA256 verification.
> 
> **Overview**
> Registers **opencode** **0.1.3** in `docs/plugins/index.json` so `dr plugin install opencode` can resolve the latest release. The new entry is inserted ahead of **0.1.2** with tarball path `opencode/opencode-0.1.3.tar.xz`, SHA256, and release date **2026-07-13**.
> 
> No CLI or plugin runtime code changes—only the published registry metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 519e65ba73b7a460cf42d9653f0f70c110e40ab9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->