### PR TITLE
[CMPT-6689]: surface task result text preview in `dr pipeline run task result` [CMPT-6689]

### DIFF
--- a/cmd/pipeline/run/task/result/cmd.go
+++ b/cmd/pipeline/run/task/result/cmd.go
@@ -17,7 +17,7 @@ package result
 import (
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 	"strconv"
 	"text/tabwriter"
 
@@ -38,10 +38,16 @@ func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "result <task-id>",
 		Short: "Get the presigned URL for a completed task's result",
-		Long: `Return the presigned S3 URL for a completed @task electron's result blob.
+		Long: `Return the presigned S3 URL for a completed @task's result blob,
+plus a preview of the returned value.
 
 The result is a cloudpickle payload. Download the URL directly from S3
 and decode with cloudpickle.loads(). pipelines-api never proxies the bytes.
+
+A text preview of the value is also shown: for JSON-serializable results
+the structured value is displayed; for others (e.g. a DataFrame or numpy
+array) a str() text preview is shown so you can eyeball the data without
+downloading and unpickling the full object.
 
 Returns 409 when the task has not yet reached COMPLETED state.
 
@@ -64,7 +70,7 @@ Example:
 				return err
 			}
 
-			return renderResult(outputFormat, res)
+			return renderResult(cmd.OutOrStdout(), outputFormat, res)
 		},
 	}
 
@@ -87,25 +93,25 @@ Example:
 	return cmd
 }
 
-func renderResult(format outputformat.OutputFormat, res *pipeline.TaskExecutionResult) error {
+func renderResult(w io.Writer, format outputformat.OutputFormat, res *pipeline.TaskExecutionResult) error {
 	if format == outputformat.OutputFormatJSON {
 		data, err := json.MarshalIndent(res, "", "  ")
 		if err != nil {
 			return err
 		}
 
-		fmt.Println(string(data))
+		fmt.Fprintln(w, string(data))
 
 		return nil
 	}
 
-	printResultHuman(res)
+	printResultHuman(w, res)
 
 	return nil
 }
 
-func printResultHuman(res *pipeline.TaskExecutionResult) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+func printResultHuman(out io.Writer, res *pipeline.TaskExecutionResult) {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 
 	fmt.Fprintf(w, "URL:\t%s\n", res.URL)
 	fmt.Fprintf(w, "Expires In:\t%ds\n", res.ExpiresIn)
@@ -124,4 +130,17 @@ func printResultHuman(res *pipeline.TaskExecutionResult) {
 	}
 
 	w.Flush()
+
+	// When the JSON value can't represent the result (e.g. a DataFrame or
+	// numpy array), fall back to the str() text preview the task pod
+	// recorded. Printed outside the tabwriter so multi-line reprs keep
+	// their own layout.
+	if !res.ValueAvailable && res.ValueText != "" {
+		header := "Text Preview:"
+		if res.ValueTextTruncated {
+			header = "Text Preview (truncated):"
+		}
+
+		fmt.Fprintf(out, "\n%s\n%s\n", header, res.ValueText)
+	}
 }

--- a/cmd/pipeline/run/task/result/cmd_test.go
+++ b/cmd/pipeline/run/task/result/cmd_test.go
@@ -15,9 +15,12 @@
 package result
 
 import (
+	"bytes"
 	"io"
 	"testing"
 
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,4 +72,118 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 	for _, name := range []string{"pipeline", "run", "output-format"} {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
+}
+
+func TestPrintResultHuman_TextPreview(t *testing.T) {
+	notSerializable := "not_json_serializable"
+	noResult := "no_result_recorded"
+
+	tests := []struct {
+		name        string
+		res         pipeline.TaskExecutionResult
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name: "unavailable value with truncated text preview",
+			res: pipeline.TaskExecutionResult{
+				URL:                    "https://s3.example.com/result.tobj",
+				ExpiresIn:              900,
+				ContentType:            "application/octet-stream",
+				ValueAvailable:         false,
+				ValueUnavailableReason: &notSerializable,
+				ValueText:              "   x  y\n0  1  3\n1  2  4",
+				ValueTextTruncated:     true,
+			},
+			wantContain: []string{
+				"(not available: not_json_serializable)",
+				"Text Preview (truncated):",
+				"0  1  3",
+			},
+			wantAbsent: []string{},
+		},
+		{
+			name: "unavailable value with non-truncated text preview",
+			res: pipeline.TaskExecutionResult{
+				URL:                    "https://s3.example.com/result.tobj",
+				ExpiresIn:              900,
+				ContentType:            "application/octet-stream",
+				ValueAvailable:         false,
+				ValueUnavailableReason: &notSerializable,
+				ValueText:              "some repr",
+				ValueTextTruncated:     false,
+			},
+			wantContain: []string{"Text Preview:", "some repr"},
+			wantAbsent:  []string{"(truncated)"},
+		},
+		{
+			name: "unavailable value with no text preview",
+			res: pipeline.TaskExecutionResult{
+				URL:                    "https://s3.example.com/result.tobj",
+				ExpiresIn:              900,
+				ContentType:            "application/octet-stream",
+				ValueAvailable:         false,
+				ValueUnavailableReason: &noResult,
+				ValueText:              "",
+			},
+			wantContain: []string{"(not available: no_result_recorded)"},
+			wantAbsent:  []string{"Text Preview"},
+		},
+		{
+			name: "available value suppresses text preview",
+			res: pipeline.TaskExecutionResult{
+				URL:            "https://s3.example.com/result.tobj",
+				ExpiresIn:      900,
+				ContentType:    "application/octet-stream",
+				Value:          "42",
+				ValueAvailable: true,
+				// A text preview may still be present, but the JSON value
+				// wins and the text preview block must be suppressed.
+				ValueText: "should not be shown",
+			},
+			wantContain: []string{"Value Preview:", "42"},
+			wantAbsent:  []string{"Text Preview", "should not be shown"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := tt.res
+
+			var buf bytes.Buffer
+
+			printResultHuman(&buf, &res)
+
+			out := buf.String()
+
+			for _, want := range tt.wantContain {
+				assert.Contains(t, out, want)
+			}
+
+			for _, absent := range tt.wantAbsent {
+				assert.NotContains(t, out, absent)
+			}
+		})
+	}
+}
+
+// TestRenderResult_JSONIncludesTruncatedFlag guards the valueTextTruncated
+// JSON tag: it must NOT use omitempty, so a false value stays in the output
+// and "not truncated" is distinguishable from "field absent".
+func TestRenderResult_JSONIncludesTruncatedFlag(t *testing.T) {
+	res := &pipeline.TaskExecutionResult{
+		URL:                "https://s3.example.com/result.tobj",
+		ValueAvailable:     false,
+		ValueText:          "some repr",
+		ValueTextTruncated: false,
+	}
+
+	var buf bytes.Buffer
+
+	require.NoError(t, renderResult(&buf, outputformat.OutputFormatJSON, res))
+
+	out := buf.String()
+
+	assert.Contains(t, out, `"valueText": "some repr"`)
+	assert.Contains(t, out, `"valueTextTruncated": false`)
 }

--- a/internal/pipeline/run_task.go
+++ b/internal/pipeline/run_task.go
@@ -56,6 +56,11 @@ type TaskExecutionDurableLog struct {
 
 // TaskExecutionResult mirrors TaskExecutionResultResponse (presigned S3 URL
 // for the task's cloudpickle result blob).
+//
+// ValueText is a human-readable str() preview the task pod records for every
+// result — present even when Value (the JSON-safe preview) is unavailable,
+// so a DataFrame/array/custom object shows *something* inline. It may be
+// truncated (see ValueTextTruncated); the full object is via URL.
 type TaskExecutionResult struct {
 	URL                    string  `json:"url"`
 	ExpiresIn              int     `json:"expiresIn"`
@@ -63,6 +68,8 @@ type TaskExecutionResult struct {
 	Value                  any     `json:"value,omitempty"`
 	ValueAvailable         bool    `json:"valueAvailable"`
 	ValueUnavailableReason *string `json:"valueUnavailableReason,omitempty"`
+	ValueText              string  `json:"valueText,omitempty"`
+	ValueTextTruncated     bool    `json:"valueTextTruncated"`
 }
 
 func taskBase(pipelineID, runID string) (string, error) {

--- a/internal/pipeline/run_task_test.go
+++ b/internal/pipeline/run_task_test.go
@@ -197,3 +197,33 @@ func TestGetTaskResult_ValueUnavailable(t *testing.T) {
 	require.NotNil(t, res.ValueUnavailableReason)
 	assert.Equal(t, "not_json_serializable", *res.ValueUnavailableReason)
 }
+
+func TestGetTaskResult_TextPreviewForNonSerializable(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// A DataFrame result: no JSON value, but a str() text preview
+		// the task pod recorded is surfaced instead.
+		_, _ = w.Write([]byte(`{
+			"url":"https://s3.example.com/result.tobj",
+			"expiresIn":900,
+			"contentType":"application/octet-stream",
+			"value":null,
+			"valueAvailable":false,
+			"valueUnavailableReason":"not_json_serializable",
+			"valueText":"   x  y\n0  1  3\n1  2  4",
+			"valueTextTruncated":true
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	res, err := GetTaskResult("p-1", "d-1", 1)
+	require.NoError(t, err)
+	assert.False(t, res.ValueAvailable)
+	assert.Equal(t, "   x  y\n0  1  3\n1  2  4", res.ValueText)
+	assert.True(t, res.ValueTextTruncated)
+}


### PR DESCRIPTION
## CMPT-6689

Downstream companion to the pipelines-api change that adds a `str()` **text preview** to the task result endpoint (`GET /api/v2/pipelines/{id}/dispatches/{run}/tasks/{task}/result`).

## Context

The `/result` response already carried a JSON-safe `value` preview, but that only works for JSON-serializable results — a pandas DataFrame, numpy array, or custom object came back as `valueAvailable: false` with **no data to show**. pipelines-api now also returns **`valueText`** (a `str(result)` preview the task pod records for every result) and **`valueTextTruncated`**. The value is produced in-pod where the object already lives; nothing is unpickled client-side.

## Changes

- **`TaskExecutionResult`** (`internal/pipeline/run_task.go`): add `ValueText` / `ValueTextTruncated` fields (decoding is automatic via `drapi.GetJSON`).
- **`dr pipeline run task result`** (`cmd/pipeline/run/task/result/cmd.go`): when the JSON value is unavailable, print the `str()` **Text Preview** (with a `(truncated)` marker) instead of a dead-end `(not available: not_json_serializable)`. `--output-format json` gains the fields automatically. Help text updated (and drops the stale "electron" term in favor of "task").
- **Test**: decode + surface `valueText`/`valueTextTruncated` for a DataFrame-style response.

## Example

`dr pipeline run task result --pipeline <id> --run <run> 3` for a task returning a DataFrame:

```
URL:            https://s3.../result.tobj?sig=...
Expires In:     900s
Content Type:   application/octet-stream
Value Preview:  (not available: not_json_serializable)

Text Preview:
    name  score
0    ada   91.5
1   alan   88.0
2  grace   99.2
```

The full object is still downloadable via `URL`.

## Verification

`task lint` → 0 issues. `task build` passes. All `internal/pipeline` and `cmd/pipeline/**` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1783961858.183439 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CLI display and JSON field mapping for an existing result endpoint; no auth, persistence, or execution-path changes.
> 
> **Overview**
> **`dr pipeline run task result`** now shows a **`str()` text preview** when the API cannot return a JSON-safe `value` (e.g. DataFrames, numpy arrays), instead of stopping at `(not available: not_json_serializable)`.
> 
> `TaskExecutionResult` gains **`valueText`** / **`valueTextTruncated`** from pipelines-api; human output prints **Text Preview** (with a truncated marker) outside the tabwriter so multi-line reprs stay readable. **`--output-format json`** includes the new fields via the struct. Command help is updated to describe previews and replaces the stale “electron” wording with “task”.
> 
> A test asserts decoding and surfacing of text preview fields for a non-serializable result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7071d61a5c3911ad93402c47fbd7c8079637a0e5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->