### PR TITLE
Add compute-services as CODEOWNERS for pipeline code, tests, and docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 * @datarobot-oss/cli-maintainers
 cmd/workload/ @datarobot-oss/workload-cli
 internal/workload/ @datarobot-oss/workload-cli
+cmd/pipeline/ @datarobot-oss/compute-services
+internal/pipeline/ @datarobot-oss/compute-services
+docs/commands/pipeline*.md @datarobot-oss/compute-services


### PR DESCRIPTION
# RATIONALE

Currently, pipeline code (`cmd/pipeline/`, `internal/pipeline/`) and pipeline docs (`docs/commands/pipeline*.md`) have no explicit CODEOWNERS entry. This means Review Router routes PRs touching pipeline files to `cli-maintainers` by default, rather than the Compute Services team that actually owns and maintains that code. Adding explicit ownership ensures the right reviewers are notified automatically when pipeline files change.

## CHANGES

- **Assign `@datarobot-oss/compute-services` as owners of relevant code

## NOTES

- The [Review Router external config (`datarobot/.review-router-config`)](https://github.com/datarobot/.review-router-config/blob/main/config.yml#L89-L91) already includes a `compute-services` team entry with the label "Needs Review: Compute Services" and Slack channel `C04TWA6MFEX`, so no config update is needed on that side.
- Pipeline test files (`*_test.go`) are automatically covered by the directory-level ownership rules — no separate test-specific entries required.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1783967680.610729 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process-only change to review routing; no runtime or application code is modified.
> 
> **Overview**
> Adds **CODEOWNERS** rules so `@datarobot-oss/compute-services` is requested on PRs that touch pipeline implementation and docs, instead of falling through to the repo-wide `@datarobot-oss/cli-maintainers` default.
> 
> Coverage is `cmd/pipeline/`, `internal/pipeline/`, and `docs/commands/pipeline*.md` (including tests under those directories via path rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae7637f67f862413e4d13de84ca105acddcdb077. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->