### PR TITLE
[CFX-6839] Use adrg/xdg for XDG directories resolution

### DIFF
--- a/cmd/dotenv/template.go
+++ b/cmd/dotenv/template.go
@@ -45,7 +45,7 @@ const (
 func getStateDir() (string, error) {
 	stateDir, err := config.GetStateDir()
 	if err != nil {
-		return "", fmt.Errorf("Failed to get user home directory: %w", err)
+		return "", fmt.Errorf("Failed to get state directory: %w", err)
 	}
 
 	drStateDir := filepath.Join(stateDir, "dr", "backups")

--- a/cmd/dotenv/template.go
+++ b/cmd/dotenv/template.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/envbuilder"
 	"github.com/datarobot/cli/internal/log"
 )
@@ -42,15 +43,9 @@ const (
 
 // getStateDir returns the XDG_STATE_HOME directory for the dr app
 func getStateDir() (string, error) {
-	// TODO Rewrite this to retrieve state dir from Viper config
-	stateDir := os.Getenv("XDG_STATE_HOME")
-	if stateDir == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("Failed to get user home directory: %w", err)
-		}
-
-		stateDir = filepath.Join(homeDir, ".local", "state")
+	stateDir, err := config.GetStateDir()
+	if err != nil {
+		return "", fmt.Errorf("Failed to get user home directory: %w", err)
 	}
 
 	drStateDir := filepath.Join(stateDir, "dr", "backups")

--- a/cmd/dotenv/template_test.go
+++ b/cmd/dotenv/template_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/datarobot/cli/internal/envbuilder"
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -150,7 +151,7 @@ func (suite *TemplateTestSuite) TestMultipleSavesDoNotDuplicateHeader() {
 func (suite *TemplateTestSuite) TestGetStateDir() {
 	// Test with XDG_STATE_HOME set
 	xdgStateHome := filepath.Join(suite.tempDir, "xdg_state")
-	suite.T().Setenv("XDG_STATE_HOME", xdgStateHome)
+	testutil.SetXDGEnv(suite.T(), "XDG_STATE_HOME", xdgStateHome)
 
 	stateDir, err := getStateDir()
 	suite.Require().NoError(err)
@@ -158,7 +159,7 @@ func (suite *TemplateTestSuite) TestGetStateDir() {
 	suite.DirExists(stateDir)
 
 	// Test without XDG_STATE_HOME (should use default)
-	suite.T().Setenv("XDG_STATE_HOME", "")
+	testutil.SetXDGEnv(suite.T(), "XDG_STATE_HOME", "")
 
 	stateDir, err = getStateDir()
 	suite.Require().NoError(err)
@@ -199,7 +200,7 @@ func (suite *TemplateTestSuite) TestBackupCreatesFile() {
 
 	// Set up a temporary XDG_STATE_HOME
 	xdgStateHome := filepath.Join(suite.tempDir, "xdg_state")
-	suite.T().Setenv("XDG_STATE_HOME", xdgStateHome)
+	testutil.SetXDGEnv(suite.T(), "XDG_STATE_HOME", xdgStateHome)
 
 	// Perform backup
 	err = backup(suite.dotfile)
@@ -231,7 +232,7 @@ func (suite *TemplateTestSuite) TestBackupCreatesFile() {
 func (suite *TemplateTestSuite) TestBackupNonExistentFile() {
 	// Set up a temporary XDG_STATE_HOME
 	xdgStateHome := filepath.Join(suite.tempDir, "xdg_state")
-	suite.T().Setenv("XDG_STATE_HOME", xdgStateHome)
+	testutil.SetXDGEnv(suite.T(), "XDG_STATE_HOME", xdgStateHome)
 
 	// Try to backup a file that doesn't exist
 	nonExistentFile := filepath.Join(suite.tempDir, "nonexistent.env")
@@ -252,7 +253,8 @@ func (suite *TemplateTestSuite) TestBackupNonExistentFile() {
 func (suite *TemplateTestSuite) TestCleanOldBackups() {
 	// Set up a temporary XDG_STATE_HOME
 	xdgStateHome := filepath.Join(suite.tempDir, "xdg_state")
-	suite.T().Setenv("XDG_STATE_HOME", xdgStateHome)
+	testutil.SetXDGEnv(suite.T(), "XDG_STATE_HOME", xdgStateHome)
+
 	stateDir := filepath.Join(xdgStateHome, "dr", "backups")
 	err := os.MkdirAll(stateDir, 0o755)
 	suite.Require().NoError(err)
@@ -289,7 +291,8 @@ func (suite *TemplateTestSuite) TestCleanOldBackups() {
 func (suite *TemplateTestSuite) TestCleanOldBackupsKeepsThreeOrLess() {
 	// Set up a temporary XDG_STATE_HOME
 	xdgStateHome := filepath.Join(suite.tempDir, "xdg_state")
-	suite.T().Setenv("XDG_STATE_HOME", xdgStateHome)
+	testutil.SetXDGEnv(suite.T(), "XDG_STATE_HOME", xdgStateHome)
+
 	stateDir := filepath.Join(xdgStateHome, "dr", "backups")
 	err := os.MkdirAll(stateDir, 0o755)
 	suite.Require().NoError(err)
@@ -318,7 +321,8 @@ func (suite *TemplateTestSuite) TestCleanOldBackupsKeepsThreeOrLess() {
 func (suite *TemplateTestSuite) TestMultipleBackupsIntegration() {
 	// Set up a temporary XDG_STATE_HOME
 	xdgStateHome := filepath.Join(suite.tempDir, "xdg_state")
-	suite.T().Setenv("XDG_STATE_HOME", xdgStateHome)
+	testutil.SetXDGEnv(suite.T(), "XDG_STATE_HOME", xdgStateHome)
+
 	stateDir := filepath.Join(xdgStateHome, "dr", "backups")
 
 	// Create initial file
@@ -349,7 +353,7 @@ func (suite *TemplateTestSuite) TestMultipleBackupsIntegration() {
 func (suite *TemplateTestSuite) TestBackupDifferentFiles() {
 	// Set up a temporary XDG_STATE_HOME
 	xdgStateHome := filepath.Join(suite.tempDir, "xdg_state")
-	suite.T().Setenv("XDG_STATE_HOME", xdgStateHome)
+	testutil.SetXDGEnv(suite.T(), "XDG_STATE_HOME", xdgStateHome)
 
 	// Create two different .env files in different directories
 	dir1 := filepath.Join(suite.tempDir, "project1")

--- a/cmd/llm-gateway/select/cmd_test.go
+++ b/cmd/llm-gateway/select/cmd_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -95,7 +96,7 @@ func TestFindByID_Empty(t *testing.T) {
 
 func TestSelectCmd_DirectArg_Valid(t *testing.T) {
 	setupLLMServer(t, testLLMs)
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", t.TempDir())
 
 	cmd, buf := newTestCmd(t)
 	cmd.SetArgs([]string{"llm-001"})

--- a/cmd/plugin/discovery_test.go
+++ b/cmd/plugin/discovery_test.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,7 +26,7 @@ func TestIsManagedPlugin(t *testing.T) {
 	t.Run("returns true for plugin in primary XDG dir", func(t *testing.T) {
 		tmpXDG := t.TempDir()
 
-		t.Setenv("XDG_CONFIG_HOME", tmpXDG)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpXDG)
 
 		pluginPath := filepath.Join(tmpXDG, "datarobot", "plugins", "my-plugin", "scripts", "run.sh")
 
@@ -38,8 +39,8 @@ func TestIsManagedPlugin(t *testing.T) {
 		tmpConfigDir := t.TempDir()
 
 		t.Setenv("HOME", tmpHome)
-		t.Setenv("XDG_CONFIG_HOME", tmpXDG)
-		t.Setenv("XDG_CONFIG_DIRS", tmpConfigDir)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpXDG)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_DIRS", tmpConfigDir)
 
 		configDirPath := filepath.Join(tmpConfigDir, "datarobot", "plugins", "my-plugin", "scripts", "run.sh")
 
@@ -51,7 +52,7 @@ func TestIsManagedPlugin(t *testing.T) {
 		tmpXDG := t.TempDir()
 
 		t.Setenv("HOME", tmpHome)
-		t.Setenv("XDG_CONFIG_HOME", tmpXDG)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpXDG)
 
 		pathPlugin := filepath.Join("/usr", "local", "bin", "dr-myplugin")
 

--- a/cmd/templates/setup/loginModel_test.go
+++ b/cmd/templates/setup/loginModel_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/yaml.v3"
 )
@@ -43,7 +44,8 @@ func (suite *LoginModelTestSuite) SetupTest() {
 	dir, _ := os.MkdirTemp("", "datarobot-config-test")
 	suite.tempDir = dir
 	suite.T().Setenv("HOME", suite.tempDir)
-	suite.T().Setenv("XDG_CONFIG_HOME", "")
+	testutil.SetXDGEnv(suite.T(), "XDG_CONFIG_HOME", "")
+
 	suite.configFile = filepath.Join(suite.tempDir, ".config/datarobot/drconfig.yaml")
 
 	err := config.ReadConfigFile("")
@@ -94,7 +96,8 @@ func (suite *LoginModelTestSuite) AfterTest(suiteName, testName string) {
 	dir, _ := os.MkdirTemp("", "datarobot-config-test")
 	suite.tempDir = dir
 	suite.T().Setenv("HOME", suite.tempDir)
-	suite.T().Setenv("XDG_CONFIG_HOME", "")
+	testutil.SetXDGEnv(suite.T(), "XDG_CONFIG_HOME", "")
+
 	suite.configFile = filepath.Join(suite.tempDir, ".config/datarobot/drconfig.yaml")
 
 	viperx.Reset()

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
+	github.com/adrg/xdg v0.5.3
 	github.com/amplitude/analytics-go v1.3.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
+github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.27.0 h1:FodwmyOBgJULFYmDqibcp9pvfDLWdtPRh9v/r5BXYZs=

--- a/internal/config/api_test.go
+++ b/internal/config/api_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
@@ -37,7 +38,7 @@ func (suite *APITestSuite) SetupTest() {
 	dir, _ := os.MkdirTemp("", "datarobot-api-test")
 	suite.tempDir = dir
 	suite.T().Setenv("HOME", suite.tempDir)
-	suite.T().Setenv("XDG_CONFIG_HOME", "")
+	testutil.SetXDGEnv(suite.T(), "XDG_CONFIG_HOME", "")
 	viper.Reset()
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/adrg/xdg"
 	"github.com/spf13/viper"
 )
 
@@ -30,17 +31,56 @@ var configFileName = "drconfig.yaml"
 // GetConfigDir returns the config directory, respecting XDG_CONFIG_HOME if set.
 // Falls back to ~/.config/datarobot if XDG_CONFIG_HOME is not set.
 func GetConfigDir() (string, error) {
-	configHome := os.Getenv("XDG_CONFIG_HOME")
-	if configHome == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("failed to get home directory: %w", err)
-		}
-
-		configHome = filepath.Join(homeDir, ".config")
+	configHome, err := resolveConfigHome()
+	if err != nil {
+		return "", err
 	}
 
 	return filepath.Join(configHome, "datarobot"), nil
+}
+
+// resolveConfigHome returns the XDG config home directory. It uses the value
+// parsed by github.com/adrg/xdg when XDG_CONFIG_HOME is explicitly set;
+// otherwise it falls back to ~/.config regardless of OS.
+func resolveConfigHome() (string, error) {
+	if os.Getenv("XDG_CONFIG_HOME") != "" {
+		return xdg.ConfigHome, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	return filepath.Join(homeDir, ".config"), nil
+}
+
+// GetConfigDirs returns additional XDG config search directories from
+// XDG_CONFIG_DIRS, in priority order, parsed via github.com/adrg/xdg. It
+// returns nil when the environment variable is not explicitly set: searching
+// extra system directories is opt-in only, no OS-specific defaults are used.
+func GetConfigDirs() []string {
+	if os.Getenv("XDG_CONFIG_DIRS") == "" {
+		return nil
+	}
+
+	return xdg.ConfigDirs
+}
+
+// GetStateDir returns the XDG state directory, respecting XDG_STATE_HOME if
+// set. Falls back to ~/.local/state if not set, regardless of OS (mirroring
+// GetConfigDir's fallback behavior).
+func GetStateDir() (string, error) {
+	if os.Getenv("XDG_STATE_HOME") != "" {
+		return xdg.StateHome, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	return filepath.Join(homeDir, ".local", "state"), nil
 }
 
 func CreateConfigFileDirIfNotExists() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,7 +40,7 @@ func (suite *ConfigTestSuite) SetupTest() {
 	dir, _ := os.MkdirTemp("", "datarobot-config-test")
 	suite.tempDir = dir
 	suite.T().Setenv("HOME", suite.tempDir)
-	suite.T().Setenv("XDG_CONFIG_HOME", "")
+	testutil.SetXDGEnv(suite.T(), "XDG_CONFIG_HOME", "")
 }
 
 func (suite *ConfigTestSuite) TestCreateConfigFileDirIfNotExists() {
@@ -87,7 +88,7 @@ func (suite *ConfigTestSuite) TestReadConfigFileWithPreviousFile() {
 
 func (suite *ConfigTestSuite) TestCreateConfigFileDirWithXDGConfigHome() {
 	xdgConfigDir := filepath.Join(suite.tempDir, "custom-config")
-	suite.T().Setenv("XDG_CONFIG_HOME", xdgConfigDir)
+	testutil.SetXDGEnv(suite.T(), "XDG_CONFIG_HOME", xdgConfigDir)
 
 	err := CreateConfigFileDirIfNotExists()
 	suite.Require().NoError(err)

--- a/internal/plugin/dependencies_test.go
+++ b/internal/plugin/dependencies_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -159,7 +160,7 @@ func TestCheckAndInstallDeps_FallbackDirChecked(t *testing.T) {
 	tmpXDG := t.TempDir()
 
 	t.Setenv("HOME", tmpHome)
-	t.Setenv("XDG_CONFIG_HOME", tmpXDG)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpXDG)
 
 	const pluginName = "test-dr-cli-deps-fallback"
 

--- a/internal/plugin/discover_test.go
+++ b/internal/plugin/discover_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -601,8 +602,8 @@ func TestDiscoverPlugins_FindsPluginsInXDGConfigDirs(t *testing.T) {
 	tmpConfigDir := t.TempDir()
 
 	t.Setenv("HOME", tmpHome)
-	t.Setenv("XDG_CONFIG_HOME", tmpXDG)
-	t.Setenv("XDG_CONFIG_DIRS", tmpConfigDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpXDG)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_DIRS", tmpConfigDir)
 
 	viperx.Reset()
 	viperx.Set("plugin.manifest_timeout_ms", 5000)

--- a/internal/plugin/paths.go
+++ b/internal/plugin/paths.go
@@ -15,7 +15,6 @@
 package plugin
 
 import (
-	"os"
 	"path/filepath"
 
 	"github.com/datarobot/cli/internal/config"
@@ -47,16 +46,13 @@ func ManagedPluginsDirs() ([]string, error) {
 	seen := map[string]bool{primaryDir: true}
 
 	// Add directories from XDG_CONFIG_DIRS (only if explicitly set)
-	configDirs := os.Getenv("XDG_CONFIG_DIRS")
-	if configDirs != "" {
-		for _, dir := range filepath.SplitList(configDirs) {
-			pluginDir := filepath.Join(dir, "datarobot", "plugins")
+	for _, dir := range config.GetConfigDirs() {
+		pluginDir := filepath.Join(dir, "datarobot", "plugins")
 
-			// Deduplicate
-			if !seen[pluginDir] {
-				dirs = append(dirs, pluginDir)
-				seen[pluginDir] = true
-			}
+		// Deduplicate
+		if !seen[pluginDir] {
+			dirs = append(dirs, pluginDir)
+			seen[pluginDir] = true
 		}
 	}
 

--- a/internal/plugin/paths_test.go
+++ b/internal/plugin/paths_test.go
@@ -19,24 +19,15 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestManagedPluginsDir(t *testing.T) {
 	t.Run("respects XDG_CONFIG_HOME", func(t *testing.T) {
-		originalXDG := os.Getenv("XDG_CONFIG_HOME")
-
-		defer func() {
-			if originalXDG != "" {
-				os.Setenv("XDG_CONFIG_HOME", originalXDG)
-			} else {
-				os.Unsetenv("XDG_CONFIG_HOME")
-			}
-		}()
-
 		testConfigHome := "/custom/config"
-		os.Setenv("XDG_CONFIG_HOME", testConfigHome)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", testConfigHome)
 
 		dir, err := ManagedPluginsDir()
 
@@ -45,17 +36,7 @@ func TestManagedPluginsDir(t *testing.T) {
 	})
 
 	t.Run("falls back to ~/.config when XDG_CONFIG_HOME not set", func(t *testing.T) {
-		originalXDG := os.Getenv("XDG_CONFIG_HOME")
-
-		defer func() {
-			if originalXDG != "" {
-				os.Setenv("XDG_CONFIG_HOME", originalXDG)
-			} else {
-				os.Unsetenv("XDG_CONFIG_HOME")
-			}
-		}()
-
-		os.Unsetenv("XDG_CONFIG_HOME")
+		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", "")
 
 		dir, err := ManagedPluginsDir()
 
@@ -72,8 +53,8 @@ func TestManagedPluginsDirs(t *testing.T) {
 		tmpHome := t.TempDir()
 
 		t.Setenv("HOME", tmpHome)
-		t.Setenv("XDG_CONFIG_HOME", "")
-		t.Setenv("XDG_CONFIG_DIRS", "")
+		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", "")
+		testutil.SetXDGEnv(t, "XDG_CONFIG_DIRS", "")
 
 		dirs, err := ManagedPluginsDirs()
 
@@ -89,8 +70,8 @@ func TestManagedPluginsDirs(t *testing.T) {
 		tmpConfigDir2 := t.TempDir()
 
 		t.Setenv("HOME", tmpHome)
-		t.Setenv("XDG_CONFIG_HOME", tmpXDG)
-		t.Setenv("XDG_CONFIG_DIRS", tmpConfigDir1+string(filepath.ListSeparator)+tmpConfigDir2)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpXDG)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_DIRS", tmpConfigDir1+string(filepath.ListSeparator)+tmpConfigDir2)
 
 		dirs, err := ManagedPluginsDirs()
 
@@ -106,9 +87,9 @@ func TestManagedPluginsDirs(t *testing.T) {
 		tmpXDG := t.TempDir()
 
 		t.Setenv("HOME", tmpHome)
-		t.Setenv("XDG_CONFIG_HOME", tmpXDG)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpXDG)
 		// Set XDG_CONFIG_DIRS to include the same path as XDG_CONFIG_HOME
-		t.Setenv("XDG_CONFIG_DIRS", tmpXDG)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_DIRS", tmpXDG)
 
 		dirs, err := ManagedPluginsDirs()
 
@@ -122,8 +103,8 @@ func TestManagedPluginsDirs(t *testing.T) {
 		tmpConfigDir := t.TempDir()
 
 		t.Setenv("HOME", tmpHome)
-		t.Setenv("XDG_CONFIG_HOME", "")
-		t.Setenv("XDG_CONFIG_DIRS", tmpConfigDir)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", "")
+		testutil.SetXDGEnv(t, "XDG_CONFIG_DIRS", tmpConfigDir)
 
 		dirs, err := ManagedPluginsDirs()
 

--- a/internal/telemetry/properties_test.go
+++ b/internal/telemetry/properties_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/state"
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -113,7 +114,7 @@ func TestGetOrCreateDeviceID_CreatesAndPersists(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	id1 := getOrCreateDeviceID()
 
@@ -139,7 +140,7 @@ func TestGetOrCreateDeviceID_ReadsExistingID(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	configDir := filepath.Join(tmpDir, "datarobot")
 
@@ -165,7 +166,7 @@ func TestGetOrCreateDeviceID_IgnoresBlankFile(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	configDir := filepath.Join(tmpDir, "datarobot")
 
@@ -191,7 +192,7 @@ func TestGetOrCreateDeviceID_FallbackIDHasPrefix(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	id := getOrCreateDeviceID()
 
@@ -202,7 +203,7 @@ func TestGetOrCreateDeviceID_FallbackIDHasPrefix(t *testing.T) {
 func TestCollectCommonProperties_SetsDeviceID(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	props := CollectCommonProperties()
 
@@ -212,7 +213,7 @@ func TestCollectCommonProperties_SetsDeviceID(t *testing.T) {
 func TestCollectCommonProperties_UserIDNilWhenUnauthenticated(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	defer viperx.Reset()
 
@@ -226,7 +227,7 @@ func TestCollectCommonProperties_UserIDNilWhenUnauthenticated(t *testing.T) {
 func TestCollectCommonProperties_UserIDFromCacheWhenAuthenticated(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	defer viperx.Reset()
 
@@ -376,7 +377,7 @@ func TestCollectCommonProperties_TemplateNameFromState(t *testing.T) {
 	err = os.Chdir(tmpDir)
 	require.NoError(t, err)
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	props := CollectCommonProperties()
 
@@ -405,7 +406,7 @@ func TestCollectCommonProperties_TemplateNameNilOutsideProject(t *testing.T) {
 	err = os.Chdir(tmpDir)
 	require.NoError(t, err)
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	props := CollectCommonProperties()
 

--- a/internal/telemetry/userid_test.go
+++ b/internal/telemetry/userid_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +42,7 @@ func sha256Fingerprint(token string) string {
 func TestRetrieveAccountInfo_FreshAPI(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/api/v2/account/info/", r.URL.Path)
@@ -84,7 +85,7 @@ func TestRetrieveAccountInfo_FreshAPI(t *testing.T) {
 func TestRetrieveAccountInfo_FilePermissions(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -110,7 +111,7 @@ func TestRetrieveAccountInfo_FilePermissions(t *testing.T) {
 func TestRetrieveAccountInfo_CacheHit(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	defer viperx.Reset()
 	defer resetTokenForTest(t, "test-token")()
@@ -150,7 +151,7 @@ func TestRetrieveAccountInfo_CacheHit(t *testing.T) {
 func TestRetrieveAccountInfo_CacheMiss_EndpointChanged(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -195,7 +196,7 @@ func TestRetrieveAccountInfo_CacheMiss_EndpointChanged(t *testing.T) {
 func TestRetrieveAccountInfo_CacheMiss_TokenChanged(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -240,7 +241,7 @@ func TestRetrieveAccountInfo_CacheMiss_TokenChanged(t *testing.T) {
 func TestRetrieveAccountInfo_CacheMiss_NoFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -264,7 +265,7 @@ func TestRetrieveAccountInfo_CacheMiss_NoFile(t *testing.T) {
 func TestRetrieveAccountInfo_CacheMiss_CorruptJSON(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -298,7 +299,7 @@ func TestRetrieveAccountInfo_CacheMiss_CorruptJSON(t *testing.T) {
 func TestRetrieveAccountInfo_TokenChange_UpdatesCache(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -359,7 +360,7 @@ func TestRetrieveAccountInfo_TokenChange_UpdatesCache(t *testing.T) {
 func TestRetrieveAccountInfo_APIFailureReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
@@ -419,7 +420,7 @@ func TestGetAccountInfo_Unauthorized(t *testing.T) {
 func TestRetrieveAccountInfo_PartialCache_RefetchesAndUpgrades(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/api/v2/account/info/", r.URL.Path)
@@ -484,7 +485,7 @@ func TestRetrieveAccountInfo_PartialCache_RefetchesAndUpgrades(t *testing.T) {
 func TestRetrieveAccountInfo_PartialCache_NetworkErrorReturnsUID(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	// Create and immediately close server to force a network error.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -537,7 +538,7 @@ func TestRetrieveAccountInfo_PartialCache_NetworkErrorReturnsUID(t *testing.T) {
 func TestRetrieveAccountInfo_CompleteCache_NetworkErrorReturnsAllCachedFields(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	// Create and immediately close server to force a network error.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -587,7 +588,7 @@ func TestRetrieveAccountInfo_CompleteCache_NetworkErrorReturnsAllCachedFields(t 
 func TestRetrieveAccountInfo_StaleCache_NetworkErrorReturnsError(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", tmpDir)
 
 	// Create and immediately close server to force a network error.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/testutil/home.go
+++ b/internal/testutil/home.go
@@ -14,7 +14,11 @@
 
 package testutil
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/adrg/xdg"
+)
 
 // SetTestHomeDir sets the home directory for tests to work cross-platform.
 // Both HOME (Unix) and USERPROFILE (Windows) are set so os.UserHomeDir() works everywhere.
@@ -23,5 +27,16 @@ func SetTestHomeDir(t *testing.T, dir string) {
 	t.Helper()
 	t.Setenv("HOME", dir)
 	t.Setenv("USERPROFILE", dir)
-	t.Setenv("XDG_CONFIG_HOME", "")
+	SetXDGEnv(t, "XDG_CONFIG_HOME", "")
+}
+
+// SetXDGEnv sets an XDG_* environment variable for the duration of the test
+// and reloads github.com/adrg/xdg's cached base directories so the change
+// takes effect immediately. Without this, xdg.ConfigHome/xdg.StateHome/
+// xdg.ConfigDirs would keep reflecting whatever the environment looked like
+// at process start (or the last Reload), ignoring the env var set here.
+func SetXDGEnv(t *testing.T, key, value string) {
+	t.Helper()
+	t.Setenv(key, value)
+	xdg.Reload()
 }


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

Using [adrg/xdg](https://github.com/adrg/xdg) package instead of manual resolution for XDG directories.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784040710.562779 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where config, plugins, dotenv backups, and telemetry caches are stored on disk; behavior is intentionally preserved for unset XDG vars but differs if callers relied on implicit OS XDG defaults when env vars were empty.
> 
> **Overview**
> **Centralizes XDG base-directory resolution** on [`github.com/adrg/xdg`](https://github.com/adrg/xdg) instead of ad-hoc `os.Getenv` / home-dir joins scattered across the CLI.
> 
> `internal/config` now exposes **`GetStateDir`**, **`GetConfigDirs`**, and refactored **`GetConfigDir`** via `resolveConfigHome`: explicit `XDG_*` vars use `xdg`’s parsed values; when unset, config/state still fall back to **`~/.config`** and **`~/.local/state`** (not OS-specific XDG defaults). **`XDG_CONFIG_DIRS`** is **opt-in only**—`GetConfigDirs` returns nil unless the env var is set, and plugin search paths use that helper instead of manual list splitting.
> 
> **`dr dotenv`** backup state under `getStateDir` now calls **`config.GetStateDir`** (replacing inline `XDG_STATE_HOME` logic).
> 
> Tests across dotenv, plugins, telemetry, and config switch to **`testutil.SetXDGEnv`**, which sets the env var and calls **`xdg.Reload()`** so `adrg/xdg`’s cache matches per-test overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89f6a2f143c9f4e9b26b1ab1041e1c438212f482. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->