### PR TITLE
[CFX-6931] Handle DR prerquisites

### DIFF
--- a/internal/tools/prerequisites.go
+++ b/internal/tools/prerequisites.go
@@ -100,18 +100,6 @@ var RequiredTools = []Prerequisite{
 	{Name: "pulumi", Command: "pulumi version", URL: "https://www.pulumi.com/docs/get-started/download-install/", MinimumVersion: "3.245.0", Install: pulumiInstallCmd},
 }
 
-func CheckPrerequisite(name string) error {
-	for _, tool := range RequiredTools {
-		if tool.Name == name {
-			if !isInstalled(tool.Command) {
-				return fmt.Errorf("%s is not installed.", name)
-			}
-		}
-	}
-
-	return nil
-}
-
 // CheckResult holds the outcome of a CheckPrerequisites call.
 type CheckResult struct {
 	MissingTools         []Prerequisite
@@ -153,7 +141,11 @@ func CheckPrerequisiteList(prereqs []Prerequisite) CheckResult {
 	var result CheckResult
 
 	for _, tool := range prereqs {
-		if !isInstalled(tool.Command) {
+		command, args := commandArgs(tool.Command)
+
+		if command == "dr" {
+			checkDrPrerequisite(&result, tool, command, args)
+		} else if !isInstalled(tool.Command) {
 			log.Debug("deps: tool missing", "name", tool.Name)
 
 			result.MissingTools = append(result.MissingTools, tool)
@@ -169,6 +161,49 @@ func CheckPrerequisiteList(prereqs []Prerequisite) CheckResult {
 	}
 
 	return result
+}
+
+// checkDrPrerequisite handles a Prerequisite whose command invokes the dr CLI itself:
+// either "dr plugin version <name>" (a dependency on another installed dr plugin) or
+// the CLI's own self-version entry (e.g. "dr self version").
+func checkDrPrerequisite(result *CheckResult, tool Prerequisite, command string, args []string) {
+	if len(args) > 2 && args[0] == "plugin" && args[1] == "version" {
+		versionOutput, err := exec.Command(command, args...).Output()
+		if err != nil {
+			log.Debug("deps: plugin dependency missing", "name", tool.Name)
+
+			result.MissingTools = append(result.MissingTools, tool)
+			result.MissingMsgs = append(result.MissingMsgs, fmt.Sprintf("%s %s (%s)", tool.Name, tool.MinimumVersion, tool.URL))
+
+			return
+		}
+
+		if versionInstalled, ok := sufficientVersion(string(versionOutput), tool.MinimumVersion); !ok {
+			log.Debug("deps: plugin dependency wrong version", "name", tool.Name, "msg", versionInstalled)
+
+			result.WrongVersionTools = append(result.WrongVersionTools, tool)
+			result.WrongVersionMsgs = append(result.WrongVersionMsgs, fmt.Sprintf("%s (minimal: v%s, installed: %s)\n%s\n",
+				tool.Name, tool.MinimumVersion, versionInstalled, tool.URL))
+
+			return
+		}
+
+		log.Debug("deps: plugin dependency ok", "name", tool.Name)
+
+		return
+	}
+
+	if !SufficientSelfVersion(tool.MinimumVersion) {
+		log.Debug("deps: tool wrong version", "name", tool.Name)
+
+		result.WrongVersionTools = append(result.WrongVersionTools, tool)
+		result.WrongVersionMsgs = append(result.WrongVersionMsgs, fmt.Sprintf("%s (minimal: v%s, installed: %s)\n%s\n",
+			tool.Name, tool.MinimumVersion, version.Version, tool.URL))
+
+		return
+	}
+
+	log.Debug("deps: tool ok", "name", tool.Name)
 }
 
 // PrerequisitesMsg formats the message to display to the user about missing/wrong-version prerequisites.
@@ -208,10 +243,6 @@ func commandArgs(fullCommand string) (string, []string) {
 func isInstalled(fullCommand string) bool {
 	command, _ := commandArgs(fullCommand)
 
-	if command == "dr" {
-		return true
-	}
-
 	_, err := exec.LookPath(command)
 
 	return err == nil
@@ -221,15 +252,6 @@ func isInstalled(fullCommand string) bool {
 func isVersionInstalled(tool Prerequisite) (string, bool) {
 	// Return success result if no version or no version command specified
 	if tool.MinimumVersion == "" || tool.Command == "" {
-		return "", true
-	}
-
-	if tool.Key == "dr" {
-		if !SufficientSelfVersion(tool.MinimumVersion) {
-			return fmt.Sprintf("%s (minimal: v%s, installed: %s)\n%s\n",
-				tool.Name, tool.MinimumVersion, version.Version, tool.URL), false
-		}
-
 		return "", true
 	}
 
@@ -279,32 +301,4 @@ func sufficientVersion(versionOutput, minimalStr string) (string, bool) {
 	}
 
 	return installedStr, true
-}
-
-// CheckTool verifies if a specific tool is installed
-func CheckTool(name string) error {
-	for _, tool := range RequiredTools {
-		if tool.Name == name {
-			if !isInstalled(tool.Command) {
-				return fmt.Errorf("%s is not installed.", name)
-			}
-
-			return nil
-		}
-	}
-
-	return fmt.Errorf("Unknown tool: %s.", name)
-}
-
-// GetMissingTools returns a list of missing prerequisite tools
-func GetMissingTools() []string {
-	var missing []string
-
-	for _, tool := range RequiredTools {
-		if !isInstalled(tool.Command) {
-			missing = append(missing, tool.Name)
-		}
-	}
-
-	return missing
 }

--- a/internal/tools/prerequisites.go
+++ b/internal/tools/prerequisites.go
@@ -19,6 +19,7 @@ import (
 	"os/exec"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/datarobot/cli/internal/log"
@@ -143,7 +144,7 @@ func CheckPrerequisiteList(prereqs []Prerequisite) CheckResult {
 	for _, tool := range prereqs {
 		command, args := commandArgs(tool.Command)
 
-		if command == "dr" {
+		if command == version.CliName || slices.Contains(version.CliAliases, command) {
 			checkDrPrerequisite(&result, tool, command, args)
 		} else if !isInstalled(tool.Command) {
 			log.Debug("deps: tool missing", "name", tool.Name)
@@ -170,7 +171,7 @@ func checkDrPrerequisite(result *CheckResult, tool Prerequisite, command string,
 	if len(args) > 2 && args[0] == "plugin" && args[1] == "version" {
 		versionOutput, err := exec.Command(command, args...).Output()
 		if err != nil {
-			log.Debug("deps: plugin dependency missing", "name", tool.Name)
+			log.Debug("deps: plugin dependency missing", "name", tool.Name, "err", err)
 
 			result.MissingTools = append(result.MissingTools, tool)
 			result.MissingMsgs = append(result.MissingMsgs, fmt.Sprintf("%s %s (%s)", tool.Name, tool.MinimumVersion, tool.URL))

--- a/internal/tools/prerequisites_test.go
+++ b/internal/tools/prerequisites_test.go
@@ -588,7 +588,6 @@ func TestCheckPrerequisiteList_PluginDependency_WrongVersion(t *testing.T) {
 // The dr-self-version branch (checkDrPrerequisite falling through to
 // SufficientSelfVersion) never shells out — it only compares the version.Version
 // package var — so these tests don't need a fake "dr" binary on PATH at all.
-
 func TestCheckPrerequisiteList_DrSelfVersion_Sufficient(t *testing.T) {
 	originalVersion := version.Version
 

--- a/internal/tools/prerequisites_test.go
+++ b/internal/tools/prerequisites_test.go
@@ -70,6 +70,13 @@ func TestSufficientVersionTrue(t *testing.T) {
 		{installed: "v0.2.55-beta.0-0-gabcd1234", minimal: "0.2.55"},
 		// Fallback format for fresh clones
 		{installed: "v0.0.0-dev.42.gabcd1234", minimal: "0.0.0"},
+		// SNAPSHOT format emitted by Java / Maven-style plugins
+		{installed: "1.3.1-SNAPSHOT-b3cdbb6", minimal: "1.3.0"},
+		{installed: "1.3.1-SNAPSHOT-b3cdbb6", minimal: "1.3.1"},
+		// Plugin-style output: CLI wrapper prints a header line before the version.
+		// sufficientVersion must skip the non-numeric header and parse the second line.
+		{installed: "🔌 Running plugin: xp\n1.3.1-SNAPSHOT-b3cdbb6", minimal: "1.3.0"},
+		{installed: "🔌 Running plugin: xp\n1.3.1-SNAPSHOT-b3cdbb6", minimal: "1.3.1"},
 	}
 
 	for _, testCase := range sufficientCases {
@@ -88,6 +95,10 @@ func TestSufficientVersionFalse(t *testing.T) {
 		{installed: "v0.2.55-beta.0-0-gabcd1234", minimal: "0.2.56"},
 		// Fallback format is insufficient for higher minimal
 		{installed: "v0.0.0-dev.42.gabcd1234", minimal: "0.1.0"},
+		// SNAPSHOT format — version number extracted correctly, then compared
+		{installed: "1.3.1-SNAPSHOT-b3cdbb6", minimal: "2.0.0"},
+		// Plugin-style output with header — version still insufficient
+		{installed: "🔌 Running plugin: xp\n1.3.1-SNAPSHOT-b3cdbb6", minimal: "2.0.0"},
 	}
 
 	for _, testCase := range sufficientCases {
@@ -486,4 +497,134 @@ func TestCheckPrerequisiteList_NeverSetsValidationViolations(t *testing.T) {
 	result := CheckPrerequisiteList(prereqs)
 
 	assert.Empty(t, result.ValidationViolations)
+}
+
+// writeFakeDrScript writes a temp shell script named "dr" emulating
+// `dr plugin version <pluginName>`: prints installedVersion and exits 0 when
+// invoked with exactly that plugin name, exits 1 for any other invocation.
+// Prepends its directory to PATH so exec.Command("dr", ...) resolves to it;
+// t.Setenv restores the original PATH and t.TempDir removes the script when
+// the test completes.
+func writeFakeDrScript(t *testing.T, pluginName, installedVersion string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "dr")
+	content := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"plugin\" ] && [ \"$2\" = \"version\" ] && [ \"$3\" = \"" + pluginName + "\" ]; then\n" +
+		"  echo '" + installedVersion + "'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+
+	err := os.WriteFile(script, []byte(content), 0o755)
+	require.NoError(t, err)
+
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestCheckPrerequisiteList_PluginDependency_Installed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script approach not applicable on Windows")
+	}
+
+	writeFakeDrScript(t, "myplugin", "1.2.3")
+
+	prereqs := []Prerequisite{
+		{Name: "myplugin", Command: "dr plugin version myplugin", MinimumVersion: "1.0.0", URL: "https://example.com"},
+	}
+
+	result := CheckPrerequisiteList(prereqs)
+
+	assert.Empty(t, result.MissingTools)
+	assert.Empty(t, result.WrongVersionTools)
+	assert.Empty(t, result.MissingMsgs)
+	assert.Empty(t, result.WrongVersionMsgs)
+}
+
+func TestCheckPrerequisiteList_PluginDependency_Missing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script approach not applicable on Windows")
+	}
+
+	// Fake "dr" only recognizes "otherplugin" — "myplugin" is not installed.
+	writeFakeDrScript(t, "otherplugin", "1.2.3")
+
+	prereqs := []Prerequisite{
+		{Name: "myplugin", Command: "dr plugin version myplugin", MinimumVersion: "1.0.0", URL: "https://example.com"},
+	}
+
+	result := CheckPrerequisiteList(prereqs)
+
+	require.Len(t, result.MissingTools, 1)
+	assert.Equal(t, "myplugin", result.MissingTools[0].Name)
+	assert.Empty(t, result.WrongVersionTools)
+	require.Len(t, result.MissingMsgs, 1)
+	assert.Contains(t, result.MissingMsgs[0], "myplugin")
+	assert.Empty(t, result.WrongVersionMsgs)
+}
+
+func TestCheckPrerequisiteList_PluginDependency_WrongVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script approach not applicable on Windows")
+	}
+
+	writeFakeDrScript(t, "myplugin", "1.2.3")
+
+	prereqs := []Prerequisite{
+		{Name: "myplugin", Command: "dr plugin version myplugin", MinimumVersion: "2.0.0", URL: "https://example.com"},
+	}
+
+	result := CheckPrerequisiteList(prereqs)
+
+	assert.Empty(t, result.MissingTools)
+	assert.Empty(t, result.MissingMsgs)
+	require.Len(t, result.WrongVersionTools, 1)
+	assert.Equal(t, "myplugin", result.WrongVersionTools[0].Name)
+	require.Len(t, result.WrongVersionMsgs, 1)
+	assert.Contains(t, result.WrongVersionMsgs[0], "myplugin")
+}
+
+// The dr-self-version branch (checkDrPrerequisite falling through to
+// SufficientSelfVersion) never shells out — it only compares the version.Version
+// package var — so these tests don't need a fake "dr" binary on PATH at all.
+
+func TestCheckPrerequisiteList_DrSelfVersion_Sufficient(t *testing.T) {
+	originalVersion := version.Version
+
+	defer func() { version.Version = originalVersion }()
+
+	version.Version = "2.0.0"
+
+	prereqs := []Prerequisite{
+		{Name: "dr", Command: "dr self version", MinimumVersion: "1.0.0", URL: "https://example.com"},
+	}
+
+	result := CheckPrerequisiteList(prereqs)
+
+	assert.Empty(t, result.MissingTools)
+	assert.Empty(t, result.WrongVersionTools)
+	assert.Empty(t, result.MissingMsgs)
+	assert.Empty(t, result.WrongVersionMsgs)
+}
+
+func TestCheckPrerequisiteList_DrSelfVersion_Insufficient(t *testing.T) {
+	originalVersion := version.Version
+
+	defer func() { version.Version = originalVersion }()
+
+	version.Version = "1.0.0"
+
+	prereqs := []Prerequisite{
+		{Name: "dr", Command: "dr self version", MinimumVersion: "2.0.0", URL: "https://example.com"},
+	}
+
+	result := CheckPrerequisiteList(prereqs)
+
+	assert.Empty(t, result.MissingTools)
+	assert.Empty(t, result.MissingMsgs)
+	require.Len(t, result.WrongVersionTools, 1)
+	assert.Equal(t, "dr", result.WrongVersionTools[0].Name)
+	require.Len(t, result.WrongVersionMsgs, 1)
+	assert.Contains(t, result.WrongVersionMsgs[0], "dr")
 }


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

`Prerequisite.Command` entries that invoke `dr` itself (e.g. a plugin declaring a dependency on another installed `dr` plugin via `dr plugin version <name>`, or the CLI's own self-version check) need different handling than a regular system-binary prerequisite: `dr` is always on `PATH` (it's the running binary), so `exec.LookPath("dr")` can't tell you whether a *named plugin* is actually installed, and the previous code had dead/broken branches trying to special-case this inside `isInstalled`/`isVersionInstalled` (gated on the wrong field, `tool.Key` instead of the command shape).

This change centralizes all `dr`-command handling into one place, checked *before* the generic `isInstalled` path, and removes several long-unused, already-commented-out helpers (`CheckPrerequisite`, `CheckTool`, `GetMissingTools`) that had no remaining callers.

## CHANGES

- `CheckPrerequisiteList` now parses `tool.Command` up front and branches on `command == "dr"` before falling into the generic `isInstalled`/`isVersionInstalled` path.
- Added `checkDrPrerequisite`, which handles both `dr`-command shapes:
  - `dr plugin version <name>` — dependency on another installed `dr` plugin. Runs the command once (`exec.Command(...).Output()`) and checks both "is it installed" and "does it satisfy `MinimumVersion`" from the same invocation.
  - Any other `dr ...` command (e.g. the CLI's own self-version entry) — falls back to `SufficientSelfVersion`.
- `isInstalled` and `isVersionInstalled` reverted to plain, generic implementations with no `dr`-specific branching.
- Removed dead code: `CheckPrerequisite`, `CheckTool`, `GetMissingTools`.


## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784042729.516819 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how dependency checks run for plugin-declared prerequisites (subprocess `dr` invocations) on the quickstart/deps path; behavior is improved over broken prior logic and is heavily tested, but mistakes could block or mis-report installs.
> 
> **Overview**
> **Prerequisite checks now treat `dr`-invoking commands separately** before the normal PATH/version path, so plugin dependencies and CLI self-version are validated correctly instead of assuming `dr` on PATH means every plugin is installed.
> 
> `CheckPrerequisiteList` parses each command and calls new **`checkDrPrerequisite`** when the binary is `dr`: for **`dr plugin version <name>`** it runs that command once and classifies missing vs wrong version from the output; for other `dr` commands (e.g. **`dr self version`**) it uses **`SufficientSelfVersion`**. **`isInstalled`** / **`isVersionInstalled`** no longer special-case `dr` (including the broken `tool.Key == "dr"` branch). Unused helpers **`CheckPrerequisite`**, **`CheckTool`**, and **`GetMissingTools`** are removed.
> 
> Tests add fake-`dr` coverage for plugin installed/missing/wrong version and self-version, plus **`sufficientVersion`** cases for SNAPSHOT strings and multi-line plugin output with a header line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78cb1317991feef62174ad004adb6608b288985e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->