### PR TITLE
[-] refactor: consolidate internal/plugin test fixtures

### DIFF
--- a/internal/plugin/discover_test.go
+++ b/internal/plugin/discover_test.go
@@ -41,19 +41,7 @@ var (
 func createMockPlugin(t *testing.T, dir, name, manifestJSON string) string {
 	t.Helper()
 
-	script := fmt.Sprintf(`#!/bin/sh
-if [ "$1" = "--dr-plugin-manifest" ]; then
-  echo '%s'
-else
-  exit 0
-fi
-`, manifestJSON)
-
-	path := filepath.Join(dir, name)
-	err := os.WriteFile(path, []byte(script), 0o755)
-	require.NoError(t, err)
-
-	return path
+	return writePluginManifestScript(t, dir, name, manifestJSON)
 }
 
 // DiscoverTestSuite tests discovery functions with filesystem fixtures
@@ -122,7 +110,7 @@ func (s *DiscoverTestSuite) TestDiscoverInDirSkipsNonDrFiles() {
 	createMockPlugin(s.T(), s.tempDir, "dr-valid", validManifest)
 
 	// Create non-dr files
-	s.Require().NoError(os.WriteFile(filepath.Join(s.tempDir, "other-binary"), []byte("#!/bin/sh\nexit 0"), 0o755))
+	createScript(s.T(), filepath.Join(s.tempDir, "other-binary"), "#!/bin/sh\nexit 0")
 	s.Require().NoError(os.WriteFile(filepath.Join(s.tempDir, "random.txt"), []byte("text"), 0o644))
 
 	seen := make(map[string]bool)
@@ -337,7 +325,7 @@ func (s *PathDirsTestSuite) TestPartialResultsWhenContextExpiresAfterFastPlugin(
 	// sleep process directly, stdout closes immediately, and cmd.Output() returns without
 	// waiting for an orphaned child to finish.
 	slowScript := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"%s\" ]; then\n  exec sleep 30\nfi\n", PluginManifestFlag)
-	s.Require().NoError(os.WriteFile(filepath.Join(s.dir2, "dr-slow"), []byte(slowScript), 0o755))
+	createScript(s.T(), filepath.Join(s.dir2, "dr-slow"), slowScript)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -419,11 +407,7 @@ func (s *ManifestTestSuite) TestGetManifestWithConfiguredTimeout() {
 
 func (s *ManifestTestSuite) TestGetManifestCommandFailure() {
 	// Create a script that exits with error
-	script := `#!/bin/sh
-exit 1
-`
-	path := filepath.Join(s.tempDir, "dr-failing")
-	s.Require().NoError(os.WriteFile(path, []byte(script), 0o755))
+	path := writeExitScript(s.T(), s.tempDir, "dr-failing", 1)
 
 	manifest, err := getManifest(context.Background(), path)
 	s.Require().Error(err)
@@ -525,7 +509,7 @@ func (s *DiscoverWithContextSuite) TestPartialResultsOnTimeout() {
 	defer os.RemoveAll(slowDir)
 
 	slowScript := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"%s\" ]; then\n  exec sleep 30\nfi\n", PluginManifestFlag)
-	s.Require().NoError(os.WriteFile(filepath.Join(slowDir, "dr-ctx-slow"), []byte(slowScript), 0o755))
+	createScript(s.T(), filepath.Join(slowDir, "dr-ctx-slow"), slowScript)
 
 	s.T().Setenv("PATH", s.pluginDir+string(os.PathListSeparator)+slowDir)
 
@@ -587,7 +571,7 @@ func createManagedTestPlugin(t *testing.T, pluginsDir, dirName, pluginName strin
 	)
 
 	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "manifest.json"), []byte(manifestJSON), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "scripts", "run.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	createScript(t, filepath.Join(pluginDir, "scripts", "run.sh"), "#!/bin/sh\nexit 0\n")
 	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "scripts", "run.ps1"), []byte("exit 0"), 0o644))
 }
 

--- a/internal/plugin/exec_test.go
+++ b/internal/plugin/exec_test.go
@@ -57,35 +57,22 @@ func (s *ExecTestSuite) TearDownTest() {
 	}
 }
 
-// createScript creates a shell script that exits with the given code
-func (s *ExecTestSuite) createScript(name string, exitCode int) string {
-	script := fmt.Sprintf(`#!/bin/sh
-exit %d
-`, exitCode)
-
-	path := filepath.Join(s.tempDir, name)
-	err := os.WriteFile(path, []byte(script), 0o755)
-	s.Require().NoError(err)
-
-	return path
-}
-
 func (s *ExecTestSuite) TestExecutePluginSuccessfulExecution() {
-	path := s.createScript("success", 0)
+	path := writeExitScript(s.T(), s.tempDir, "success", 0)
 
 	exitCode := ExecutePlugin(context.Background(), PluginManifest{}, path, []string{}, nil)
 	s.Equal(0, exitCode)
 }
 
 func (s *ExecTestSuite) TestExecutePluginExitCodeOne() {
-	path := s.createScript("fail-one", 1)
+	path := writeExitScript(s.T(), s.tempDir, "fail-one", 1)
 
 	exitCode := ExecutePlugin(context.Background(), PluginManifest{}, path, []string{}, nil)
 	s.Equal(1, exitCode)
 }
 
 func (s *ExecTestSuite) TestExecutePluginExitCodeFortyTwo() {
-	path := s.createScript("fail-42", 42)
+	path := writeExitScript(s.T(), s.tempDir, "fail-42", 42)
 
 	exitCode := ExecutePlugin(context.Background(), PluginManifest{}, path, []string{}, nil)
 	s.Equal(42, exitCode)
@@ -106,7 +93,7 @@ else
 fi
 `
 	path := filepath.Join(s.tempDir, "with-args")
-	s.Require().NoError(os.WriteFile(path, []byte(script), 0o755))
+	createScript(s.T(), path, script)
 
 	exitCode := ExecutePlugin(context.Background(), PluginManifest{}, path, []string{"expected", "args"}, nil)
 	s.Equal(0, exitCode)
@@ -122,7 +109,7 @@ else
 fi
 `
 	path := filepath.Join(s.tempDir, "with-args-fail")
-	s.Require().NoError(os.WriteFile(path, []byte(script), 0o755))
+	createScript(s.T(), path, script)
 
 	exitCode := ExecutePlugin(context.Background(), PluginManifest{}, path, []string{"wrong", "arguments"}, nil)
 	s.Equal(1, exitCode)
@@ -150,12 +137,7 @@ func TestExecutePluginExitCodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			script := fmt.Sprintf(`#!/bin/sh
-exit %d
-`, tt.exitCode)
-
-			path := filepath.Join(tempDir, fmt.Sprintf("exit-%d", tt.exitCode))
-			require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+			path := writeExitScript(t, tempDir, fmt.Sprintf("exit-%d", tt.exitCode), tt.exitCode)
 
 			result := ExecutePlugin(context.Background(), PluginManifest{}, path, []string{}, nil)
 			require.Equal(t, tt.expectedCode, result)
@@ -178,7 +160,7 @@ while true; do sleep 0.1; done
 `, markerFile)
 
 	scriptPath := filepath.Join(t.TempDir(), "trap-term.sh")
-	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+	createScript(t, scriptPath, script)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -219,7 +201,7 @@ while true; do sleep 0.1; done
 `
 
 	scriptPath := filepath.Join(t.TempDir(), "ignore-term.sh")
-	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+	createScript(t, scriptPath, script)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -262,7 +244,7 @@ func TestExecutePluginCustomUserAgent(t *testing.T) {
 	os.Unsetenv("DATAROBOT_API_TOKEN")
 
 	scriptPath := filepath.Join(t.TempDir(), "test.sh")
-	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	createScript(t, scriptPath, "#!/bin/sh\nexit 0\n")
 
 	manifest := PluginManifest{
 		BasicPluginManifest: BasicPluginManifest{Name: "test-plugin", Version: "1.2.3", Authentication: true},
@@ -570,7 +552,7 @@ func TestExecutePluginSkipAuthBypassesAuthCheck(t *testing.T) {
 	os.Unsetenv("DATAROBOT_API_TOKEN")
 
 	scriptPath := filepath.Join(t.TempDir(), "skip-auth-test.sh")
-	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	createScript(t, scriptPath, "#!/bin/sh\nexit 0\n")
 
 	manifest := PluginManifest{
 		BasicPluginManifest: BasicPluginManifest{Name: "test-plugin", Version: "1.0.0", Authentication: true},
@@ -599,7 +581,7 @@ func TestExecutePluginAuthCalledWithoutSkipAuth(t *testing.T) {
 	os.Unsetenv("DATAROBOT_API_TOKEN")
 
 	scriptPath := filepath.Join(t.TempDir(), "no-skip-auth-test.sh")
-	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	createScript(t, scriptPath, "#!/bin/sh\nexit 0\n")
 
 	manifest := PluginManifest{
 		BasicPluginManifest: BasicPluginManifest{Name: "test-plugin", Version: "1.0.0", Authentication: true},

--- a/internal/plugin/testhelpers_test.go
+++ b/internal/plugin/testhelpers_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writePluginManifestScript creates a cross-platform executable that responds to
+// --dr-plugin-manifest by echoing manifestJSON. Returns the script path.
+func writePluginManifestScript(t *testing.T, dir, name, manifestJSON string) string {
+	t.Helper()
+
+	var scriptPath, scriptContent string
+
+	if runtime.GOOS == "windows" {
+		scriptPath = filepath.Join(dir, name+".ps1")
+		scriptContent = "#!/usr/bin/env pwsh\n" +
+			"if ($args[0] -eq '--dr-plugin-manifest') {\n" +
+			"  Write-Output '" + manifestJSON + "'\n" +
+			"}\n"
+	} else {
+		scriptPath = filepath.Join(dir, name)
+		scriptContent = "#!/bin/sh\n" +
+			"if [ \"$1\" = \"--dr-plugin-manifest\" ]; then\n" +
+			"  echo '" + manifestJSON + "'\n" +
+			"else\n" +
+			"  exit 0\n" +
+			"fi\n"
+	}
+
+	createScript(t, scriptPath, scriptContent)
+
+	return scriptPath
+}
+
+// writeExitScript creates a Unix shell script that exits with the given code.
+// Returns the script path.
+func writeExitScript(t *testing.T, dir, name string, exitCode int) string {
+	t.Helper()
+
+	script := fmt.Sprintf("#!/bin/sh\nexit %d\n", exitCode)
+	path := filepath.Join(dir, name)
+
+	createScript(t, path, script)
+
+	return path
+}
+
+// createScript writes content to path with executable permissions.
+func createScript(t *testing.T, path, content string) {
+	t.Helper()
+
+	err := os.WriteFile(path, []byte(content), 0o755)
+	require.NoError(t, err)
+}

--- a/internal/plugin/validation_test.go
+++ b/internal/plugin/validation_test.go
@@ -16,7 +16,6 @@ package plugin
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -321,56 +320,6 @@ func TestExecPluginManifest_ExtraField(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid manifest JSON")
 	assert.Contains(t, err.Error(), "authenticated")
-}
-
-// Helper functions
-
-// writePluginManifestScript creates a cross-platform executable that responds to
-// --dr-plugin-manifest by echoing manifestJSON. Returns the script path.
-func writePluginManifestScript(t *testing.T, dir, name, manifestJSON string) string {
-	t.Helper()
-
-	var scriptPath, scriptContent string
-
-	if runtime.GOOS == "windows" {
-		scriptPath = filepath.Join(dir, name+".ps1")
-		scriptContent = "#!/usr/bin/env pwsh\n" +
-			"if ($args[0] -eq '--dr-plugin-manifest') {\n" +
-			"  Write-Output '" + manifestJSON + "'\n" +
-			"}\n"
-	} else {
-		scriptPath = filepath.Join(dir, name)
-		scriptContent = "#!/bin/sh\n" +
-			"if [ \"$1\" = \"--dr-plugin-manifest\" ]; then\n" +
-			"  echo '" + manifestJSON + "'\n" +
-			"else\n" +
-			"  exit 0\n" +
-			"fi\n"
-	}
-
-	createScript(t, scriptPath, scriptContent)
-
-	return scriptPath
-}
-
-// writeExitScript creates a Unix shell script that exits with the given code.
-// Returns the script path.
-func writeExitScript(t *testing.T, dir, name string, exitCode int) string {
-	t.Helper()
-
-	script := fmt.Sprintf("#!/bin/sh\nexit %d\n", exitCode)
-	path := filepath.Join(dir, name)
-
-	createScript(t, path, script)
-
-	return path
-}
-
-func createScript(t *testing.T, path, content string) {
-	t.Helper()
-
-	err := os.WriteFile(path, []byte(content), 0o755)
-	require.NoError(t, err)
 }
 
 func TestValidateLicense_Success(t *testing.T) {

--- a/internal/plugin/validation_test.go
+++ b/internal/plugin/validation_test.go
@@ -16,6 +16,7 @@ package plugin
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -285,7 +286,10 @@ func TestExecPluginManifest(t *testing.T) {
 		MinCLIVersion: "1.0.0",
 	}
 
-	scriptPath := createTestScript(t, tempDir, expected)
+	data, err := json.Marshal(expected)
+	require.NoError(t, err)
+
+	scriptPath := writePluginManifestScript(t, tempDir, "dr-test", string(data))
 
 	result, err := ExecPluginManifest(scriptPath)
 
@@ -296,24 +300,7 @@ func TestExecPluginManifest(t *testing.T) {
 func TestExecPluginManifest_InvalidJSON(t *testing.T) {
 	tempDir := t.TempDir()
 
-	scriptPath := filepath.Join(tempDir, "dr-test")
-
-	var scriptContent string
-
-	if runtime.GOOS == "windows" {
-		scriptPath = filepath.Join(tempDir, "dr-test.ps1")
-		scriptContent = "#!/usr/bin/env pwsh\n" +
-			"if ($args[0] -eq '--dr-plugin-manifest') {\n" +
-			"  Write-Output 'invalid json'\n" +
-			"}\n"
-	} else {
-		scriptContent = "#!/bin/sh\n" +
-			"if [ \"$1\" = \"--dr-plugin-manifest\" ]; then\n" +
-			"  echo 'invalid json'\n" +
-			"fi\n"
-	}
-
-	createScript(t, scriptPath, scriptContent)
+	scriptPath := writePluginManifestScript(t, tempDir, "dr-test", "invalid json")
 
 	_, err := ExecPluginManifest(scriptPath)
 
@@ -324,27 +311,10 @@ func TestExecPluginManifest_InvalidJSON(t *testing.T) {
 func TestExecPluginManifest_ExtraField(t *testing.T) {
 	tempDir := t.TempDir()
 
-	scriptPath := filepath.Join(tempDir, "dr-test")
-
-	var scriptContent string
-
 	// Script outputs extra field "authenticated" (typo)
 	invalidJSON := `{"name":"test","version":"1.0.0","description":"Test plugin","authentication":false,"authenticated":true}`
 
-	if runtime.GOOS == "windows" {
-		scriptPath = filepath.Join(tempDir, "dr-test.ps1")
-		scriptContent = "#!/usr/bin/env pwsh\n" +
-			"if ($args[0] -eq '--dr-plugin-manifest') {\n" +
-			"  Write-Output '" + invalidJSON + "'\n" +
-			"}\n"
-	} else {
-		scriptContent = "#!/bin/sh\n" +
-			"if [ \"$1\" = \"--dr-plugin-manifest\" ]; then\n" +
-			"  echo '" + invalidJSON + "'\n" +
-			"fi\n"
-	}
-
-	createScript(t, scriptPath, scriptContent)
+	scriptPath := writePluginManifestScript(t, tempDir, "dr-test", invalidJSON)
 
 	_, err := ExecPluginManifest(scriptPath)
 
@@ -355,33 +325,45 @@ func TestExecPluginManifest_ExtraField(t *testing.T) {
 
 // Helper functions
 
-func createTestScript(t *testing.T, dir string, manifest PluginManifest) string {
+// writePluginManifestScript creates a cross-platform executable that responds to
+// --dr-plugin-manifest by echoing manifestJSON. Returns the script path.
+func writePluginManifestScript(t *testing.T, dir, name, manifestJSON string) string {
 	t.Helper()
 
-	data, err := json.Marshal(manifest)
-	require.NoError(t, err)
-
-	var scriptPath string
-
-	var scriptContent string
+	var scriptPath, scriptContent string
 
 	if runtime.GOOS == "windows" {
-		scriptPath = filepath.Join(dir, "dr-test.ps1")
+		scriptPath = filepath.Join(dir, name+".ps1")
 		scriptContent = "#!/usr/bin/env pwsh\n" +
 			"if ($args[0] -eq '--dr-plugin-manifest') {\n" +
-			"  Write-Output '" + string(data) + "'\n" +
+			"  Write-Output '" + manifestJSON + "'\n" +
 			"}\n"
 	} else {
-		scriptPath = filepath.Join(dir, "dr-test")
+		scriptPath = filepath.Join(dir, name)
 		scriptContent = "#!/bin/sh\n" +
 			"if [ \"$1\" = \"--dr-plugin-manifest\" ]; then\n" +
-			"  echo '" + string(data) + "'\n" +
+			"  echo '" + manifestJSON + "'\n" +
+			"else\n" +
+			"  exit 0\n" +
 			"fi\n"
 	}
 
 	createScript(t, scriptPath, scriptContent)
 
 	return scriptPath
+}
+
+// writeExitScript creates a Unix shell script that exits with the given code.
+// Returns the script path.
+func writeExitScript(t *testing.T, dir, name string, exitCode int) string {
+	t.Helper()
+
+	script := fmt.Sprintf("#!/bin/sh\nexit %d\n", exitCode)
+	path := filepath.Join(dir, name)
+
+	createScript(t, path, script)
+
+	return path
 }
 
 func createScript(t *testing.T, path, content string) {
@@ -424,9 +406,12 @@ func TestValidatePluginScript_MissingLicense(t *testing.T) {
 		},
 	}
 
-	createTestScript(t, tempDir, manifest)
+	data, err := json.Marshal(manifest)
+	require.NoError(t, err)
 
-	err := ValidatePluginScript(tempDir, manifest)
+	writePluginManifestScript(t, tempDir, "dr-test", string(data))
+
+	err = ValidatePluginScript(tempDir, manifest)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "plugin must contain LICENSE.txt file")
@@ -444,10 +429,13 @@ func TestValidatePluginScript_WithLicense(t *testing.T) {
 		},
 	}
 
-	createTestScript(t, tempDir, manifest)
+	data, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	writePluginManifestScript(t, tempDir, "dr-test", string(data))
 
 	licensePath := filepath.Join(tempDir, "LICENSE.txt")
-	err := os.WriteFile(licensePath, []byte("Apache License 2.0"), 0o644)
+	err = os.WriteFile(licensePath, []byte("Apache License 2.0"), 0o644)
 	require.NoError(t, err)
 
 	err = ValidatePluginScript(tempDir, manifest)


### PR DESCRIPTION
# RATIONALE

Reviewing #669 I noticed we have a ton of "test scripts" as fixtures now, which makes sense for testing CLI features. I wanted to see if there was any room for cleanup.

There's a ton of duplicate code in internal/plugin around `os.WriteFile` scripts.

## CHANGES

Add shared helper functions

- `writePluginManifestScript(t, dir, name, manifestJSON string) string` -- cross-platform plugin manifest script writer (Unix #!/bin/sh + Windows #!/usr/bin/env pwsh), responds to --dr-plugin-manifest by echoing the JSON. Supersedes createTestScript.
- `writeExitScript(t, dir, name string, exitCode int) string` -- package-level helper that creates a script exiting with the given code. Replaces the suite-scoped ExecTestSuite.createScript.

Migrate to use shared helpers

Remove older functions

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784058001.778059 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes; behavior should be equivalent aside from shared helper consolidation.
> 
> **Overview**
> Consolidates duplicated **test-only** shell/PowerShell fixture setup in `internal/plugin` behind shared helpers in `validation_test.go`.
> 
> **`writePluginScript`** creates cross-platform mock plugins that echo JSON on `--dr-plugin-manifest`, replacing **`createTestScript`** and inlined logic in **`createMockPlugin`**. **`writeExitScript`** replaces **`ExecTestSuite.createScript`** and repeated `#!/bin/sh` + `exit N` writes. Call sites in **`discover_test.go`**, **`exec_test.go`**, and **`validation_test.go`** now use **`createScript`**, **`writePluginScript`**, or **`writeExitScript`** instead of direct **`os.WriteFile`** with `0o755`.
> 
> Unix mock plugins gain a default **`exit 0`** path when the manifest flag is not passed, matching prior **`createMockPlugin`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1267a34716d9dfde82043ffad399006d6ae1bae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->