### PR TITLE
Add opencode plugin v0.1.4

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -210,6 +210,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.4",
+          "url": "opencode/opencode-0.1.4.tar.xz",
+          "sha256": "e2cfc5b7701d3c16641465a0d65c2ff84283f55849d90130a763eeb9f94c28da",
+          "releaseDate": "2026-07-16"
+        },
+        {
           "version": "0.1.3",
           "url": "opencode/opencode-0.1.3.tar.xz",
           "sha256": "4906a66f2f5a93567dd68b3c7c82fce25dbda92815fb5791d54696ecec2b5d66",


### PR DESCRIPTION
## Summary

Adds the opencode plugin v0.1.4 to the CLI plugin index.

- Plugin: opencode
- Version: 0.1.4
- Release: https://github.com/datarobot/opencode-cli-plugin/releases/tag/v0.1.4
- SHA256: e2cfc5b7701d3c16641465a0d65c2ff84283f55849d90130a763eeb9f94c28da

## Test Plan

- [ ] dr plugin install opencode installs successfully
- [ ] dr opencode --help shows usage
<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784196849.911539 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only registry update with no application code changes; install behavior depends on the published artifact matching the listed SHA256.
> 
> **Overview**
> Registers **opencode** **0.1.4** in `docs/plugins/index.json` so the CLI can install it as the latest release (tarball URL, SHA256, release date **2026-07-16**), ahead of existing **0.1.3** and older entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e46a64e817ce6cb7a2e0973ada6b66eb8a768b9f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->