### PR TITLE
Add opencode plugin v0.1.5

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -210,6 +210,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.5",
+          "url": "opencode/opencode-0.1.5.tar.xz",
+          "sha256": "75b0eb84e4462d37c3ef5d0ee61bd7c11066da4c266fdd70b1be1af9b8ce9198",
+          "releaseDate": "2026-07-17"
+        },
+        {
           "version": "0.1.4",
           "url": "opencode/opencode-0.1.4.tar.xz",
           "sha256": "e2cfc5b7701d3c16641465a0d65c2ff84283f55849d90130a763eeb9f94c28da",


### PR DESCRIPTION
## Summary

Adds the opencode plugin v0.1.5 to the CLI plugin index.

- Plugin: opencode
- Version: 0.1.5
- Release: https://github.com/datarobot/opencode-cli-plugin/releases/tag/v0.1.5
- SHA256: 75b0eb84e4462d37c3ef5d0ee61bd7c11066da4c266fdd70b1be1af9b8ce9198

## Test Plan

- [ ] dr plugin install opencode installs successfully
- [ ] dr opencode --help shows usage
<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784280156.368759 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Index-only metadata update; risk is limited to incorrect URL or checksum blocking installs until fixed.
> 
> **Overview**
> Registers **opencode 0.1.5** as the newest entry in `docs/plugins/index.json`, so `dr plugin install opencode` can resolve and verify that release (tarball URL, SHA256, release date **2026-07-17**).
> 
> No other plugins or application code are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7ebc70e463656af0334ec24d74b888e75daddc8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->