### PR TITLE
[CFX-6915] Fix plugin update/discovery bug in XDG_CONFIG_DIRS

### DIFF
--- a/internal/plugin/remote.go
+++ b/internal/plugin/remote.go
@@ -360,17 +360,35 @@ func installPluginFromArchive(archivePath, pluginDir string, entry RegistryPlugi
 	return nil
 }
 
-// UninstallPlugin removes an installed plugin
-func UninstallPlugin(name string) error {
-	managedDir, err := ManagedPluginsDir()
-	if err != nil {
-		return fmt.Errorf("Failed to get plugins directory: %w", err)
+// findPluginDir searches all managed plugin directories in priority order and
+// returns the full path to the first directory that contains the named plugin.
+// Returns an error if the plugin is not found in any managed directory.
+func findPluginDir(name string) (string, error) {
+	if err := validatePluginName(name); err != nil {
+		return "", err
 	}
 
-	pluginDir := filepath.Join(managedDir, name)
+	managedDirs, err := ManagedPluginsDirs()
+	if err != nil {
+		return "", fmt.Errorf("Failed to get plugins directories: %w", err)
+	}
 
-	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
-		return fmt.Errorf("Plugin %s is not installed", name)
+	for _, dir := range managedDirs {
+		pluginDir := filepath.Join(dir, name)
+
+		if _, err := os.Stat(pluginDir); err == nil {
+			return pluginDir, nil
+		}
+	}
+
+	return "", fmt.Errorf("Plugin %s is not installed", name)
+}
+
+// UninstallPlugin removes an installed plugin
+func UninstallPlugin(name string) error {
+	pluginDir, err := findPluginDir(name)
+	if err != nil {
+		return err
 	}
 
 	if err := os.RemoveAll(pluginDir); err != nil {
@@ -613,15 +631,9 @@ func saveInstalledMetadata(pluginDir string, entry RegistryPlugin, version Regis
 // BackupPlugin creates a backup of an installed plugin in a temporary directory
 // Returns the path to the backup directory
 func BackupPlugin(name string) (string, error) {
-	managedDir, err := ManagedPluginsDir()
+	pluginDir, err := findPluginDir(name)
 	if err != nil {
-		return "", fmt.Errorf("Failed to get plugins directory: %w", err)
-	}
-
-	pluginDir := filepath.Join(managedDir, name)
-
-	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
-		return "", fmt.Errorf("Plugin %s is not installed", name)
+		return "", err
 	}
 
 	backupDir, err := os.MkdirTemp("", fmt.Sprintf("dr-plugin-backup-%s-*", name))
@@ -667,12 +679,10 @@ func CleanupBackup(backupPath string) {
 
 // ValidatePlugin validates that a plugin installation is working correctly
 func ValidatePlugin(name string) error {
-	managedDir, err := ManagedPluginsDir()
+	pluginDir, err := findPluginDir(name)
 	if err != nil {
-		return fmt.Errorf("failed to get plugins directory: %w", err)
+		return err
 	}
-
-	pluginDir := filepath.Join(managedDir, name)
 
 	metadataPath := filepath.Join(pluginDir, ".installed.json")
 	if _, err := os.Stat(metadataPath); os.IsNotExist(err) {
@@ -690,6 +700,7 @@ func ValidatePlugin(name string) error {
 	}
 
 	var manifest PluginManifest
+
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return fmt.Errorf("Failed to parse manifest: %w", err)
 	}

--- a/internal/plugin/remote.go
+++ b/internal/plugin/remote.go
@@ -380,13 +380,39 @@ func UninstallPlugin(name string) error {
 	return nil
 }
 
-// GetInstalledPlugins returns metadata about installed managed plugins
+// GetInstalledPlugins returns metadata about installed managed plugins.
+// It searches all managed plugin directories in priority order (XDG_CONFIG_HOME first,
+// then XDG_CONFIG_DIRS), returning the first occurrence of each plugin name.
 func GetInstalledPlugins() ([]InstalledPlugin, error) {
-	managedDir, err := ManagedPluginsDir()
+	managedDirs, err := ManagedPluginsDirs()
 	if err != nil {
 		return nil, err
 	}
 
+	seen := map[string]bool{}
+
+	var installed []InstalledPlugin
+
+	for _, managedDir := range managedDirs {
+		plugins, err := getInstalledPluginsInDir(managedDir)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, p := range plugins {
+			if seen[p.Name] {
+				continue
+			}
+
+			seen[p.Name] = true
+			installed = append(installed, p)
+		}
+	}
+
+	return installed, nil
+}
+
+func getInstalledPluginsInDir(managedDir string) ([]InstalledPlugin, error) {
 	entries, err := os.ReadDir(managedDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/plugin/remote_test.go
+++ b/internal/plugin/remote_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -335,6 +336,120 @@ func TestResolveVersion(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetInstalledPlugins tests multi-directory discovery behaviour
+func TestGetInstalledPlugins(t *testing.T) {
+	// writeMetadata is a small helper that creates a plugin directory with a
+	// .installed.json so loadPluginMetadata can find it.
+	writeMetadata := func(t *testing.T, dir, name, version string) {
+		t.Helper()
+
+		pluginDir := filepath.Join(dir, name)
+		require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+
+		meta := InstalledPlugin{Name: name, Version: version}
+
+		data, err := json.Marshal(meta)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(pluginDir, ".installed.json"), data, 0o644))
+	}
+
+	t.Run("discovers plugin only in XDG_CONFIG_DIRS", func(t *testing.T) {
+		primaryDir := t.TempDir()
+		xdgDir := t.TempDir()
+
+		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", primaryDir)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_DIRS", xdgDir)
+
+		writeMetadata(t, filepath.Join(xdgDir, "datarobot", "plugins"), "remote-only", "2.0.0")
+
+		plugins, err := GetInstalledPlugins()
+		require.NoError(t, err)
+
+		var found bool
+
+		for _, p := range plugins {
+			if p.Name == "remote-only" {
+				found = true
+
+				assert.Equal(t, "2.0.0", p.Version)
+			}
+		}
+
+		assert.True(t, found, "plugin from XDG_CONFIG_DIRS should be discovered")
+	})
+
+	t.Run("primary dir shadows same-named plugin in XDG_CONFIG_DIRS", func(t *testing.T) {
+		primaryDir := t.TempDir()
+		xdgDir := t.TempDir()
+
+		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", primaryDir)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_DIRS", xdgDir)
+
+		writeMetadata(t, filepath.Join(primaryDir, "datarobot", "plugins"), "shared-plugin", "1.0.0")
+		writeMetadata(t, filepath.Join(xdgDir, "datarobot", "plugins"), "shared-plugin", "9.9.9")
+
+		plugins, err := GetInstalledPlugins()
+		require.NoError(t, err)
+
+		var count int
+
+		for _, p := range plugins {
+			if p.Name == "shared-plugin" {
+				count++
+
+				assert.Equal(t, "1.0.0", p.Version, "primary dir version should win")
+			}
+		}
+
+		assert.Equal(t, 1, count, "same-named plugin should appear only once")
+	})
+
+	t.Run("plugins from both dirs are returned when names differ", func(t *testing.T) {
+		primaryDir := t.TempDir()
+		xdgDir := t.TempDir()
+
+		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", primaryDir)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_DIRS", xdgDir)
+
+		writeMetadata(t, filepath.Join(primaryDir, "datarobot", "plugins"), "plugin-a", "1.0.0")
+		writeMetadata(t, filepath.Join(xdgDir, "datarobot", "plugins"), "plugin-b", "2.0.0")
+
+		plugins, err := GetInstalledPlugins()
+		require.NoError(t, err)
+
+		names := make(map[string]bool)
+
+		for _, p := range plugins {
+			names[p.Name] = true
+		}
+
+		assert.True(t, names["plugin-a"], "plugin-a from primary dir should be present")
+		assert.True(t, names["plugin-b"], "plugin-b from XDG_CONFIG_DIRS should be present")
+	})
+
+	t.Run("non-existent XDG_CONFIG_DIRS dir is silently skipped", func(t *testing.T) {
+		primaryDir := t.TempDir()
+
+		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", primaryDir)
+		testutil.SetXDGEnv(t, "XDG_CONFIG_DIRS", "/does/not/exist")
+
+		writeMetadata(t, filepath.Join(primaryDir, "datarobot", "plugins"), "only-plugin", "1.0.0")
+
+		plugins, err := GetInstalledPlugins()
+		require.NoError(t, err)
+
+		var found bool
+
+		for _, p := range plugins {
+			if p.Name == "only-plugin" {
+				found = true
+			}
+		}
+
+		assert.True(t, found, "plugin from primary dir should still be returned")
+	})
 }
 
 // TestResolveVersionEmpty tests error handling for empty version list


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

In plugin update/validate/backup flows, plugin discovery did not take into account plugins installed in `XDG_CONFIG_DIRS` (only those installed in `XDG_CONFIG_HOME` or `~/.config` were discovered). This PR fixes it.

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784294994.177569 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to installed-plugin metadata listing with behavior covered by new tests; install/uninstall paths still use the primary dir only.
> 
> **Overview**
> **`GetInstalledPlugins`** no longer reads only the primary managed plugins path (`XDG_CONFIG_HOME` / `~/.config`). It now walks every directory returned by **`ManagedPluginsDirs`**, in priority order, and deduplicates by plugin name so **`XDG_CONFIG_HOME` wins** when the same name exists in multiple locations.
> 
> The per-directory scan is moved into **`getInstalledPluginsInDir`**; missing secondary dirs are still treated as empty (no error). New tests cover discovery-only-in-`XDG_CONFIG_DIRS`, shadowing, merging distinct names, and skipping a non-existent `XDG_CONFIG_DIRS` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e0a2cf6611a0bae0bb317682be028eed70d2742. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->