### PR TITLE
[RAPTOR 18591] Schema change: doc & examples

### DIFF
--- a/cmd/workload/create/cmd.go
+++ b/cmd/workload/create/cmd.go
@@ -46,10 +46,10 @@ stay strings (for example "0644" or "1.10"), and unquoted dates are sent
 as RFC3339 timestamps. The server validates field-level shape and returns
 a 422 with a JSON-path detail on a mismatch.
 
-Two flows:
+Three flows:
 
-  1. Deploy an existing artifact (e.g. one built with 'dr artifact code sync'
-     and a build):
+  1. Deploy an existing artifact with a fixed replica count (e.g. one built with
+     'dr artifact code sync' and a build):
 
   {
     "name": "my-app",
@@ -66,7 +66,34 @@ Two flows:
     }
   }
 
-  2. Define a draft artifact inline and deploy it in one call:
+  2. Deploy with autoscaling (replica bounds on autoscaling, not per policy).
+     Use replicaCount OR autoscaling.enabled=true per container group, not both.
+     See docs/examples/workload-autoscaling.yaml.
+
+  {
+    "name": "my-app",
+    "artifactId": "68b0c1d2e3f4a5b6c7d8e9f0",
+    "runtime": {
+      "containerGroups": [{
+        "name": "default",
+        "autoscaling": {
+          "enabled": true,
+          "minReplicaCount": 1,
+          "maxReplicaCount": 10,
+          "policies": [{
+            "scalingMetric": "cpuAverageUtilization",
+            "target": 80
+          }]
+        },
+        "containers": [{
+          "name": "primary",
+          "resourceAllocation": {"cpu": 1, "memory": "512MB"}
+        }]
+      }]
+    }
+  }
+
+  3. Define a draft artifact inline and deploy it in one call:
 
   {
     "name": "hello-whoami",

--- a/docs/commands/workload.md
+++ b/docs/commands/workload.md
@@ -67,7 +67,7 @@ dr workload create --spec-file <path> [--output-format text|json]
 - `--spec-file <path>`: path to the JSON or YAML spec (required).
 - `--output-format <text|json>`: output format. Defaults to `text`.
 
-**Example:**
+**Example (fixed replica count):**
 
 ```yaml
 # workload.yaml - deploy an existing artifact
@@ -83,6 +83,35 @@ runtime:
             cpu: 1
             memory: 512MB
 ```
+
+**Example (autoscaling):**
+
+Replica bounds live on `autoscaling` (`minReplicaCount` / `maxReplicaCount`). Each policy only needs `scalingMetric` and `target`. A full copy-paste spec is in [workload-autoscaling.yaml](../examples/workload-autoscaling.yaml).
+
+```yaml
+name: my-app
+artifactId: 68b0c1d2e3f4a5b6c7d8e9f0
+runtime:
+  containerGroups:
+    - name: default
+      autoscaling:
+        enabled: true
+        minReplicaCount: 1
+        maxReplicaCount: 10
+        policies:
+          - scalingMetric: cpuAverageUtilization
+            target: 80
+      containers:
+        - name: primary
+          resourceAllocation:
+            cpu: 1
+            memory: 512MB
+```
+
+Use **either** `replicaCount` (fixed scale) **or** `autoscaling.enabled: true` (dynamic scale) per container group — not both. Omit `replicaCount` when autoscaling is enabled.
+
+> [!NOTE]
+> The Workload API still accepts the legacy per-policy `minCount` / `maxCount` fields on input and hoists them automatically, but responses always use `minReplicaCount` / `maxReplicaCount` on `autoscaling`. Prefer the new shape in new specs.
 
 ```bash
 dr workload create --spec-file workload.yaml
@@ -207,7 +236,7 @@ dr workload delete <workload-id>
 | `403`  | Starting the workload would exceed your concurrent workload limits.                                         |
 | `404`  | The workload does not exist.                                                                                |
 | `409`  | The workload must finish its current transition first (for example a `start` while it is still `stopping`). |
-| `422`  | The spec failed server validation; the response names the offending JSON path.                              |
+| `422`  | The spec failed server validation; the response names the offending JSON path (for example `replicaCount` set alongside `autoscaling.enabled: true`, or `maxReplicaCount` below 1). |
 
 ## See also
 

--- a/docs/examples/workload-autoscaling.yaml
+++ b/docs/examples/workload-autoscaling.yaml
@@ -1,0 +1,19 @@
+# Deploy an existing artifact with CPU autoscaling.
+# Replace artifactId with your artifact id.
+name: my-app
+artifactId: 68b0c1d2e3f4a5b6c7d8e9f0
+runtime:
+  containerGroups:
+    - name: default
+      autoscaling:
+        enabled: true
+        minReplicaCount: 1
+        maxReplicaCount: 10
+        policies:
+          - scalingMetric: cpuAverageUtilization
+            target: 80
+      containers:
+        - name: primary
+          resourceAllocation:
+            cpu: 1
+            memory: 512MB


### PR DESCRIPTION
# RATIONALE

Documents the Workload API autoscaling schema change from [workload-api#984](https://github.com/datarobot/workload-api/pull/984) so `dr workload create` users see the new spec shape before hitting a server `422`.

Replica bounds (`minReplicaCount` / `maxReplicaCount`) now live on `autoscaling`, not on each `policies[]` entry. `replicaCount` and `autoscaling.enabled: true` are mutually exclusive per container group. The CLI still forwards specs verbatim to WAPI — this PR is **docs and examples only**.

**Ticket:** [RAPTOR-18591](https://datarobot.atlassian.net/browse/RAPTOR-18591)

## CHANGES

| File | Change |
|------|--------|
| `docs/commands/workload.md` | Split create examples into fixed replica vs autoscaling; document mutual exclusivity, legacy compat shim note, expanded `422` row |
| `docs/examples/workload-autoscaling.yaml` | New copy-paste workload spec with CPU autoscaling |
| `cmd/workload/create/cmd.go` | Extend `--help` from 2 to 3 flows; add JSON autoscaling example |

**Schema shape documented:**

```yaml
runtime:
  containerGroups:
    - name: default
      autoscaling:
        enabled: true
        minReplicaCount: 1
        maxReplicaCount: 10
        policies:
          - scalingMetric: cpuAverageUtilization
            target: 80
```

**Out of scope (follow-up PRs):** client-side preflight validation (`replicaCount` ↔ `autoscaling.enabled`).

## TESTING

Docs-only — no unit test changes required.

**Manual verification:**

```bash
GOPROXY=https://proxy.golang.org,direct go build -o dr .
export DATAROBOT_CLI_FEATURE_WORKLOAD=true
./dr workload create --help   # flow 2 shows autoscaling JSON
```

Optional end-to-end (requires auth + WAPI with #984 deployed):

```bash
./dr workload create --spec-file docs/examples/workload-autoscaling.yaml
```

## RELATED

- WAPI: [workload-api#984](https://github.com/datarobot/workload-api/pull/984) — global autoscaling bounds, mutual exclusivity
- WAPI schema: `src/workload_api/schemas/protons/runtime.py` (`AutoscalingProperties`, `AutoscalingPolicy`)

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

**Branch:** `RAPTOR-18591-schema-change-doc-examples` → `main` (non-forked)

**Diff size:** 3 files, ~81 insertions / 6 deletions

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784295621.746929 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and help text only; workload create still POSTs specs verbatim with no new client validation.
> 
> **Overview**
> Documents the Workload API autoscaling shape so **`dr workload create`** users can write specs that match server validation after workload-api#984.
> 
> **`docs/commands/workload.md`** splits create examples into fixed **`replicaCount`** vs **`autoscaling`** (bounds on **`minReplicaCount`/`maxReplicaCount`**, policies with **`scalingMetric`** and **`target` only**), states mutual exclusivity per container group, notes legacy per-policy **`minCount`/`maxCount`** input shim, and expands the **`422`** row with example causes.
> 
> **`cmd/workload/create/cmd.go`** **`--help`** grows from two to three flows with a matching JSON autoscaling example and a pointer to **`docs/examples/workload-autoscaling.yaml`**.
> 
> Adds **`docs/examples/workload-autoscaling.yaml`** as a copy-paste CPU autoscaling spec. No CLI validation or API forwarding behavior changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a917acab73ab6c140a8cb7c30e0f151dba3885f2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->