### PR TITLE
[CFX-3973] Fix task date

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -4,7 +4,7 @@ vars:
   VERSION_PACKAGE: "github.com/datarobot/cli/internal/version"
   VERSION: { sh: 'git describe --dirty --tags --long --always --abbrev=15' }
   COMMIT: { sh: "git describe --dirty --long --always --abbrev=15" }
-  BUILD_DATE: { sh: 'date -u +"%Y-%m-%dT%H:%M:%SZ"' }
+  BUILD_DATE: '{{now.UTC.Format "2006-01-02T15:04:05Z"}}'
   LDFLAGS_COMMON: |
     -X {{.VERSION_PACKAGE}}.GitCommit={{.COMMIT}} \
     -X {{.VERSION_PACKAGE}}.Version={{.VERSION}} \


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

To note: This command works in GitHub Actions runners for Windows so this is really only an issue if a user is trying to contribute and working on a Windows machine.

The problematic line is:
`BUILD_DATE: { sh: 'date -u +"%Y-%m-%dT%H:%M:%SZ"' }`

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784297902.366819 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single build-metadata variable change in Task; no runtime app logic or security impact.
> 
> **Overview**
> **`BUILD_DATE`** in `Taskfile.yaml` no longer runs a shell `date -u` command. It is set with Task’s **`{{now.UTC.Format "2006-01-02T15:04:05Z"}}`** template so the same RFC3339 UTC timestamp is produced when **`LDFLAGS_COMMON`** injects **`BuildDate`** into **`run`** / **`build`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5e2972b8c74393f5691e8cb3eef558875f5f6b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->