### PR TITLE
[CMPT-6793] [CMPT-6787] feat(pipeline): fan-out --node-id for run task + review fixes

### DIFF
--- a/cmd/pipeline/cmd.go
+++ b/cmd/pipeline/cmd.go
@@ -41,6 +41,9 @@ func Cmd() *cobra.Command {
 		Short:   "Pipelines API management commands",
 		Long: `Manage AI/ML pipelines orchestrated by Covalent.
 
+NOTE: Pipelines are in Private Preview. Behavior and command surface may
+change, and access is limited to enabled organizations.
+
 Create, list, inspect, and update pipelines registered with the
 DataRobot pipelines service. Sub-commands are also available for managing
 input payloads, runs, and recurring schedules.`,

--- a/cmd/pipeline/image/create/cmd.go
+++ b/cmd/pipeline/image/create/cmd.go
@@ -57,10 +57,8 @@ Example:
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			if name == "" {
-				return errors.New("--name is required")
-			}
-
+			// --name is enforced by MarkFlagRequired below; Cobra rejects a
+			// missing required flag before RunE runs, so no manual check here.
 			pip := pipeline.NormalizePackageList(rawPackages)
 			conda := pipeline.BuildCondaValue(rawConda, rawCondaChans)
 

--- a/cmd/pipeline/run/task/get/cmd.go
+++ b/cmd/pipeline/run/task/get/cmd.go
@@ -36,6 +36,7 @@ func Cmd() *cobra.Command {
 	var (
 		pipelineID   string
 		runID        string
+		nodeID       int
 		outputFormat outputformat.OutputFormat
 	)
 
@@ -47,8 +48,14 @@ func Cmd() *cobra.Command {
 <task-id> is the sequential task number (1, 2, 3, …) as returned by
 "dr pipeline run task list".
 
+When the same @task runs at more than one graph node (fan-out), all its
+invocations share one <task-id>. Pass --node-id (the NODE ID column from
+"dr pipeline run task list") to select a specific invocation; without it an
+ambiguous task returns an error listing the candidate node ids.
+
 Example:
   dr pipeline run task get --pipeline <id> --run <run-id> 1
+  dr pipeline run task get --pipeline <id> --run <run-id> 3 --node-id 7
   dr pipeline run task get --pipeline <id> --run <run-id> 2 --output-format json`,
 		Args:         cobra.ExactArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
@@ -61,7 +68,12 @@ Example:
 				return err
 			}
 
-			task, err := pipeline.GetTaskExecution(pipelineID, runID, taskID)
+			var node *int
+			if cmd.Flags().Changed("node-id") {
+				node = &nodeID
+			}
+
+			task, err := pipeline.GetTaskExecution(pipelineID, runID, taskID, node)
 			if err != nil {
 				return handleNotFound(err, args[0])
 			}
@@ -76,6 +88,7 @@ Example:
 	_ = cmd.MarkFlagRequired("pipeline")
 	cmd.Flags().StringVar(&runID, "run", "", "Run (dispatch) ID")
 	_ = cmd.MarkFlagRequired("run")
+	cmd.Flags().IntVar(&nodeID, "node-id", 0, "Select a specific fan-out invocation by its nodeId (from `task list`)")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
@@ -121,6 +134,11 @@ func printTaskHuman(task *pipeline.TaskExecution) {
 		taskIDStr = strconv.Itoa(*task.TaskID)
 	}
 
+	nodeIDStr := "-"
+	if task.NodeID != nil {
+		nodeIDStr = strconv.Itoa(*task.NodeID)
+	}
+
 	startedStr := "-"
 	if task.StartedAt != nil {
 		startedStr = task.StartedAt.UTC().Format("2006-01-02 15:04:05")
@@ -139,6 +157,7 @@ func printTaskHuman(task *pipeline.TaskExecution) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
 	fmt.Fprintf(w, "Task ID:\t%s\n", taskIDStr)
+	fmt.Fprintf(w, "Node ID:\t%s\n", nodeIDStr)
 	fmt.Fprintf(w, "Name:\t%s\n", task.Name)
 	fmt.Fprintf(w, "Status:\t%s\n", task.Status)
 	fmt.Fprintf(w, "Started:\t%s\n", startedStr)

--- a/cmd/pipeline/run/task/list/cmd.go
+++ b/cmd/pipeline/run/task/list/cmd.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"slices"
 	"strconv"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
@@ -104,7 +105,7 @@ func renderTaskList(format outputformat.OutputFormat, tasks []pipeline.TaskExecu
 
 	dimStyle := tui.DimStyle.Padding(0, 1)
 
-	headers := []string{"TASK ID", "NAME", "STATUS", "STARTED", "COMPLETED"}
+	headers := []string{"TASK ID", "NODE ID", "NAME", "STATUS", "STARTED", "COMPLETED"}
 
 	completedCol := slices.Index(headers, "COMPLETED")
 
@@ -125,25 +126,39 @@ func renderTaskList(format outputformat.OutputFormat, tasks []pipeline.TaskExecu
 		Headers(headers...)
 
 	for _, task := range tasks {
-		taskIDStr := "-"
-		if task.TaskID != nil {
-			taskIDStr = strconv.Itoa(*task.TaskID)
-		}
-
-		startedStr := "-"
-		if task.StartedAt != nil {
-			startedStr = task.StartedAt.UTC().Format("2006-01-02 15:04:05")
-		}
-
-		completedStr := "-"
-		if task.CompletedAt != nil {
-			completedStr = task.CompletedAt.UTC().Format("2006-01-02 15:04:05")
-		}
-
-		t.Row(taskIDStr, task.Name, task.Status, startedStr, completedStr)
+		t.Row(taskRowCells(task)...)
 	}
 
 	fmt.Fprintln(os.Stdout, t.Render())
 
 	return nil
+}
+
+// taskRowCells renders one task-execution row's cells in header order,
+// substituting "-" for absent optional fields.
+func taskRowCells(task pipeline.TaskExecution) []string {
+	return []string{
+		optIntCell(task.TaskID),
+		optIntCell(task.NodeID),
+		task.Name,
+		task.Status,
+		optTimeCell(task.StartedAt),
+		optTimeCell(task.CompletedAt),
+	}
+}
+
+func optIntCell(v *int) string {
+	if v == nil {
+		return "-"
+	}
+
+	return strconv.Itoa(*v)
+}
+
+func optTimeCell(t *time.Time) string {
+	if t == nil {
+		return "-"
+	}
+
+	return t.UTC().Format("2006-01-02 15:04:05")
 }

--- a/cmd/pipeline/run/task/logs/cmd.go
+++ b/cmd/pipeline/run/task/logs/cmd.go
@@ -32,6 +32,7 @@ func Cmd() *cobra.Command {
 		runID        string
 		stream       string
 		tailLines    int
+		nodeID       int
 		verbosity    string
 		outputFormat outputformat.OutputFormat
 	)
@@ -48,9 +49,14 @@ With --stream stdout or --stream stderr: reads the durable S3-uploaded
 log captured by the electron runner at process exit. Use this for
 post-mortem debugging after the pod has been GC'd.
 
+When the same @task runs at multiple graph nodes (fan-out), all invocations
+share one <task-id>. Pass --node-id (the NODE ID column from
+"dr pipeline run task list") to read a specific invocation's logs; without it
+an ambiguous task returns an error listing the candidate node ids.
+
 Example:
   dr pipeline run task logs --pipeline <id> --run <run-id> 1
-  dr pipeline run task logs --pipeline <id> --run <run-id> 1 --stream stdout
+  dr pipeline run task logs --pipeline <id> --run <run-id> 3 --node-id 7 --stream stderr
   dr pipeline run task logs --pipeline <id> --run <run-id> 1 --tail 100 --verbosity all`,
 		Args:         cobra.ExactArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
@@ -67,8 +73,13 @@ Example:
 				return fmt.Errorf("--stream must be stdout or stderr (got %q)", stream)
 			}
 
+			var node *int
+			if cmd.Flags().Changed("node-id") {
+				node = &nodeID
+			}
+
 			if stream != "" {
-				return fetchDurableLog(pipelineID, runID, taskID, stream, verbosity, outputFormat)
+				return fetchDurableLog(pipelineID, runID, taskID, node, stream, verbosity, outputFormat)
 			}
 
 			var tail *int
@@ -77,7 +88,7 @@ Example:
 				tail = &tailLines
 			}
 
-			return fetchLiveLogs(pipelineID, runID, taskID, tail, verbosity, outputFormat)
+			return fetchLiveLogs(pipelineID, runID, taskID, node, tail, verbosity, outputFormat)
 		},
 	}
 
@@ -89,6 +100,7 @@ Example:
 	_ = cmd.MarkFlagRequired("run")
 	cmd.Flags().StringVar(&stream, "stream", "", "Read durable S3 log: stdout or stderr")
 	cmd.Flags().IntVar(&tailLines, "tail", 0, "Limit to last N lines (live logs only)")
+	cmd.Flags().IntVar(&nodeID, "node-id", 0, "Select a specific fan-out invocation by its nodeId (from `task list`)")
 	cmd.Flags().StringVar(&verbosity, "verbosity", "", "Log verbosity: user (default) or all")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
@@ -104,8 +116,8 @@ Example:
 	return cmd
 }
 
-func fetchLiveLogs(pipelineID, runID string, taskID int, tailLines *int, verbosity string, format outputformat.OutputFormat) error {
-	logs, err := pipeline.GetTaskLogs(pipelineID, runID, taskID, tailLines, verbosity)
+func fetchLiveLogs(pipelineID, runID string, taskID int, nodeID, tailLines *int, verbosity string, format outputformat.OutputFormat) error {
+	logs, err := pipeline.GetTaskLogs(pipelineID, runID, taskID, nodeID, tailLines, verbosity)
 	if err != nil {
 		return err
 	}
@@ -126,8 +138,8 @@ func fetchLiveLogs(pipelineID, runID string, taskID int, tailLines *int, verbosi
 	return nil
 }
 
-func fetchDurableLog(pipelineID, runID string, taskID int, stream, verbosity string, format outputformat.OutputFormat) error {
-	log, err := pipeline.GetTaskDurableLog(pipelineID, runID, taskID, stream, verbosity)
+func fetchDurableLog(pipelineID, runID string, taskID int, nodeID *int, stream, verbosity string, format outputformat.OutputFormat) error {
+	log, err := pipeline.GetTaskDurableLog(pipelineID, runID, taskID, nodeID, stream, verbosity)
 	if err != nil {
 		return err
 	}

--- a/cmd/pipeline/run/task/result/cmd.go
+++ b/cmd/pipeline/run/task/result/cmd.go
@@ -32,6 +32,7 @@ func Cmd() *cobra.Command {
 	var (
 		pipelineID   string
 		runID        string
+		nodeID       int
 		outputFormat outputformat.OutputFormat
 	)
 
@@ -49,10 +50,13 @@ the structured value is displayed; for others (e.g. a DataFrame or numpy
 array) a str() text preview is shown so you can eyeball the data without
 downloading and unpickling the full object.
 
-Returns 409 when the task has not yet reached COMPLETED state.
+Returns 409 when the task has not yet reached COMPLETED state, or when the
+task ran at multiple graph nodes (fan-out) and no --node-id was given — the
+error lists the candidate node ids from "dr pipeline run task list".
 
 Example:
   dr pipeline run task result --pipeline <id> --run <run-id> 1
+  dr pipeline run task result --pipeline <id> --run <run-id> 3 --node-id 7
   dr pipeline run task result --pipeline <id> --run <run-id> 1 --output-format json`,
 		Args:         cobra.ExactArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
@@ -65,7 +69,12 @@ Example:
 				return fmt.Errorf("invalid task-id %q: must be a positive integer", args[0])
 			}
 
-			res, err := pipeline.GetTaskResult(pipelineID, runID, taskID)
+			var node *int
+			if cmd.Flags().Changed("node-id") {
+				node = &nodeID
+			}
+
+			res, err := pipeline.GetTaskResult(pipelineID, runID, taskID, node)
 			if err != nil {
 				return err
 			}
@@ -80,6 +89,7 @@ Example:
 	_ = cmd.MarkFlagRequired("pipeline")
 	cmd.Flags().StringVar(&runID, "run", "", "Run (dispatch) ID")
 	_ = cmd.MarkFlagRequired("run")
+	cmd.Flags().IntVar(&nodeID, "node-id", 0, "Select a specific fan-out invocation by its nodeId (from `task list`)")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{

--- a/docs/commands/pipeline.md
+++ b/docs/commands/pipeline.md
@@ -432,6 +432,51 @@ the run ID, status, and Covalent dispatch ID.
 
 `run cancel` returns `409 Conflict` if the run is already terminal.
 
+#### `run task`
+
+Inspect the per-`@task` executions of a single run (dispatch): their lifecycle
+status, logs, and results. Distinct from `dr pipeline task …`, which inspects the
+*static* task definitions in a pipeline; `run task` reports what actually happened
+in one execution.
+
+```bash
+dr pipeline run task list   --pipeline <id> --run <run-id>
+dr pipeline run task get    --pipeline <id> --run <run-id> <task-id> [--node-id N]
+dr pipeline run task logs   --pipeline <id> --run <run-id> <task-id> [--node-id N] [--stream stdout|stderr] [--tail N] [--verbosity user|all]
+dr pipeline run task result --pipeline <id> --run <run-id> <task-id> [--node-id N]
+```
+
+`<task-id>` is the sequential task number (1, 2, 3, …) shown in the **TASK ID**
+column of `run task list`.
+
+**Fan-out and `--node-id`.** When the same `@task` runs at more than one graph
+node (fan-out — e.g. the same function called on several inputs), every one of
+its invocations shares one `<task-id>` but has a distinct **NODE ID** (the
+`run task list` NODE ID column). Pass `--node-id <N>` to address a specific
+invocation. Without it, a task that ran more than once returns `409 Conflict`
+whose message lists the candidate node ids — so `get`/`logs`/`result` never
+silently return the wrong invocation's data. Tasks that ran exactly once need no
+`--node-id`.
+
+- `run task list` — one row per invocation, with both TASK ID and NODE ID.
+  Returns an empty list while the run is still `PENDING`/`PREPARING`.
+- `run task get` — lifecycle record (status, timestamps, error) for one invocation.
+- `run task logs` — without `--stream`, live Kubernetes pod logs (available only
+  while the pod exists, ~60s after the task finishes); with `--stream stdout` or
+  `--stream stderr`, the durable S3-archived log for post-mortem debugging.
+  `--tail N` limits live logs to the last N lines; `--verbosity all` includes the
+  task runner's own bookkeeping lines (default `user` hides them).
+- `run task result` — presigned S3 URL for a completed task's cloudpickle result,
+  plus an inline value preview. Returns `409 Conflict` until the task reaches
+  `COMPLETED`.
+
+```bash
+# Discover invocations, then address a specific fan-out node:
+dr pipeline run task list --pipeline <id> --run <run-id>
+dr pipeline run task result --pipeline <id> --run <run-id> 3 --node-id 7
+dr pipeline run task logs   --pipeline <id> --run <run-id> 3 --node-id 7 --stream stderr
+```
+
 ### `image`
 
 Manage pipeline execution images — named, immutable-versioned environments (pip

--- a/docs/commands/pipelines-reference.md
+++ b/docs/commands/pipelines-reference.md
@@ -127,6 +127,17 @@ term `dispatches` / `dispatch_id`, but the CLI's `--output-format json` remaps t
 | `dr pipeline run status` | `GET /pipelines/{id}/dispatches/{dispatch_id}/status` (draft) <br> `GET /pipelines/{id}/versions/{ver}/dispatches/{dispatch_id}/status` (locked) | `dr pipeline run status --pipeline <id> <run-id>` | **Positional:** `<run-id>` (required). **Flags:** `--pipeline <id>` (required), `--scope`, `--version`, `--output-format json`. |
 | `dr pipeline run cancel` | `DELETE /pipelines/{id}/dispatches/{dispatch_id}` (draft) <br> `DELETE /pipelines/{id}/versions/{ver}/dispatches/{dispatch_id}` (locked) | `dr pipeline run cancel --pipeline <id> <run-id>` | **Positional:** `<run-id>` (required). **Flags:** `--pipeline <id>` (required), `--scope`, `--version`. |
 
+### Run tasks (`dr pipeline run task …`)
+
+Per-invocation execution records for a single run. `<task-id>` is the sequential TASK ID from `run task list`; when the same `@task` runs at multiple graph nodes (fan-out), pass `--node-id <N>` (the NODE ID column) to select one invocation — otherwise `get`/`logs`/`result` return `409 Conflict` listing the candidate node ids.
+
+| Command | API endpoint | Usage | Inputs |
+|---|---|---|---|
+| `dr pipeline run task list` | `GET /pipelines/{id}/dispatches/{dispatch_id}/tasks` | `dr pipeline run task list --pipeline <id> --run <run-id>` | **Flags:** `--pipeline <id>` (required), `--run <run-id>` (required), `--output-format json`. |
+| `dr pipeline run task get` | `GET /pipelines/{id}/dispatches/{dispatch_id}/tasks/{task_id}` | `dr pipeline run task get --pipeline <id> --run <run-id> <task-id>` <br> `dr pipeline run task get --pipeline <id> --run <run-id> 3 --node-id 7` | **Positional:** `<task-id>` (required). **Flags:** `--pipeline <id>` (required), `--run <run-id>` (required), `--node-id <n>` (fan-out selector), `--output-format json`. |
+| `dr pipeline run task logs` | `GET /pipelines/{id}/dispatches/{dispatch_id}/tasks/{task_id}/logs` <br> `GET …/tasks/{task_id}/logs/{stream}` (durable) | `dr pipeline run task logs --pipeline <id> --run <run-id> <task-id>` <br> `dr pipeline run task logs --pipeline <id> --run <run-id> 3 --node-id 7 --stream stderr` | **Positional:** `<task-id>` (required). **Flags:** `--pipeline <id>` (required), `--run <run-id>` (required), `--node-id <n>`, `--stream stdout\|stderr` (durable S3 log), `--tail <n>` (live only), `--verbosity user\|all`, `--output-format json`. |
+| `dr pipeline run task result` | `GET /pipelines/{id}/dispatches/{dispatch_id}/tasks/{task_id}/result` | `dr pipeline run task result --pipeline <id> --run <run-id> <task-id>` <br> `dr pipeline run task result --pipeline <id> --run <run-id> 3 --node-id 7` | **Positional:** `<task-id>` (required). **Flags:** `--pipeline <id>` (required), `--run <run-id>` (required), `--node-id <n>`, `--output-format json`. Returns `409` until the task is `COMPLETED`, or when a fan-out task is addressed without `--node-id`. |
+
 ---
 
 ## Schedules (`dr pipeline schedule …`)
@@ -186,6 +197,10 @@ TASK ID column of `dr pipeline graph` and can be used to inspect individual task
 | `GET /pipelines/{id}/dispatches` | `dr pipeline run list` (draft) |
 | `GET /pipelines/{id}/dispatches/{dispatch_id}` | `dr pipeline run get` (draft) |
 | `DELETE /pipelines/{id}/dispatches/{dispatch_id}` | `dr pipeline run cancel` (draft) |
+| `GET /pipelines/{id}/dispatches/{dispatch_id}/tasks` | `dr pipeline run task list` |
+| `GET /pipelines/{id}/dispatches/{dispatch_id}/tasks/{task_id}` | `dr pipeline run task get` |
+| `GET /pipelines/{id}/dispatches/{dispatch_id}/tasks/{task_id}/logs` | `dr pipeline run task logs` |
+| `GET /pipelines/{id}/dispatches/{dispatch_id}/tasks/{task_id}/result` | `dr pipeline run task result` |
 | `POST /pipelines/{id}/inputs` | `dr pipeline input create` (draft) |
 | `POST /pipelines/{id}/versions/{ver}/inputs` | `dr pipeline input create` (locked) |
 | `GET /pipelines/{id}/inputs` | `dr pipeline input list` (draft) |

--- a/internal/pipeline/image_output.go
+++ b/internal/pipeline/image_output.go
@@ -118,10 +118,10 @@ func toImageSummaryJSON(img ImageSummary) imageSummaryJSON {
 // RenderImage routes a single image to JSON or human output.
 func RenderImage(format outputformat.OutputFormat, img Image) error {
 	if format == outputformat.OutputFormatJSON {
-		return PrintImageJSON(img)
+		return printImageJSON(img)
 	}
 
-	PrintImageHuman(img)
+	printImageHuman(img)
 
 	return nil
 }
@@ -129,16 +129,16 @@ func RenderImage(format outputformat.OutputFormat, img Image) error {
 // RenderImages routes a list of images to JSON or human output.
 func RenderImages(format outputformat.OutputFormat, items []ImageSummary) error {
 	if format == outputformat.OutputFormatJSON {
-		return PrintImageListJSON(items)
+		return printImageListJSON(items)
 	}
 
-	PrintImageListHuman(items)
+	printImageListHuman(items)
 
 	return nil
 }
 
-// PrintImageJSON marshals an image record as indented JSON through the DTO.
-func PrintImageJSON(img Image) error {
+// printImageJSON marshals an image record as indented JSON through the DTO.
+func printImageJSON(img Image) error {
 	data, err := json.MarshalIndent(toImageJSON(img), "", "  ")
 	if err != nil {
 		return err
@@ -149,9 +149,9 @@ func PrintImageJSON(img Image) error {
 	return nil
 }
 
-// PrintImageHuman renders the key facts about a single image record,
+// printImageHuman renders the key facts about a single image record,
 // including its full version history.
-func PrintImageHuman(img Image) {
+func printImageHuman(img Image) {
 	desc := emptyValuePlaceholder
 	if img.Description != nil && *img.Description != "" {
 		desc = *img.Description
@@ -227,8 +227,8 @@ func printImageVersionsHuman(versions []ImageVersion) {
 	fmt.Fprintln(os.Stdout, t.Render())
 }
 
-// PrintImageListJSON marshals a list of images as indented JSON through the DTO.
-func PrintImageListJSON(items []ImageSummary) error {
+// printImageListJSON marshals a list of images as indented JSON through the DTO.
+func printImageListJSON(items []ImageSummary) error {
 	view := make([]imageSummaryJSON, len(items))
 
 	for i, img := range items {
@@ -245,8 +245,8 @@ func PrintImageListJSON(items []ImageSummary) error {
 	return nil
 }
 
-// PrintImageListHuman renders a lipgloss table summary of images.
-func PrintImageListHuman(items []ImageSummary) {
+// printImageListHuman renders a lipgloss table summary of images.
+func printImageListHuman(items []ImageSummary) {
 	if len(items) == 0 {
 		fmt.Println(tui.DimStyle.Render("No images found"))
 

--- a/internal/pipeline/image_output_test.go
+++ b/internal/pipeline/image_output_test.go
@@ -117,7 +117,7 @@ func TestPrintImageHuman_ShowsCondaChannels(t *testing.T) {
 		},
 	}
 
-	out := captureStdout(t, func() { PrintImageHuman(img) })
+	out := captureStdout(t, func() { printImageHuman(img) })
 
 	assert.Contains(t, out, "[conda-forge]", "channels must appear in human output")
 	assert.Contains(t, out, "scipy", "dependencies must appear in human output")
@@ -144,7 +144,7 @@ func TestPrintImageHuman_HidesCondaWhenEmpty(t *testing.T) {
 		},
 	}
 
-	out := captureStdout(t, func() { PrintImageHuman(img) })
+	out := captureStdout(t, func() { printImageHuman(img) })
 
 	assert.Contains(t, out, emptyValuePlaceholder, "conda cell should show placeholder when no conda packages")
 }

--- a/internal/pipeline/input_output.go
+++ b/internal/pipeline/input_output.go
@@ -65,10 +65,10 @@ func toInputJSON(input Input) inputJSON {
 // RenderInput routes a single input to JSON or human output.
 func RenderInput(format outputformat.OutputFormat, input Input) error {
 	if format == outputformat.OutputFormatJSON {
-		return PrintInputJSON(input)
+		return printInputJSON(input)
 	}
 
-	PrintInputHuman(input)
+	printInputHuman(input)
 
 	return nil
 }
@@ -76,16 +76,16 @@ func RenderInput(format outputformat.OutputFormat, input Input) error {
 // RenderInputs routes a list of inputs to JSON or human output.
 func RenderInputs(format outputformat.OutputFormat, inputs []Input) error {
 	if format == outputformat.OutputFormatJSON {
-		return PrintInputListJSON(inputs)
+		return printInputListJSON(inputs)
 	}
 
-	PrintInputListHuman(inputs)
+	printInputListHuman(inputs)
 
 	return nil
 }
 
-// PrintInputJSON marshals an input record as indented JSON through the DTO.
-func PrintInputJSON(input Input) error {
+// printInputJSON marshals an input record as indented JSON through the DTO.
+func printInputJSON(input Input) error {
 	data, err := json.MarshalIndent(toInputJSON(input), "", "  ")
 	if err != nil {
 		return err
@@ -96,8 +96,8 @@ func PrintInputJSON(input Input) error {
 	return nil
 }
 
-// PrintInputHuman renders the key facts about a single input record.
-func PrintInputHuman(input Input) {
+// printInputHuman renders the key facts about a single input record.
+func printInputHuman(input Input) {
 	scope := "draft"
 	versionDisplay := emptyValuePlaceholder
 
@@ -128,8 +128,8 @@ func PrintInputHuman(input Input) {
 	fmt.Println(string(payload))
 }
 
-// PrintInputListJSON marshals a list of inputs as indented JSON through the DTO.
-func PrintInputListJSON(inputs []Input) error {
+// printInputListJSON marshals a list of inputs as indented JSON through the DTO.
+func printInputListJSON(inputs []Input) error {
 	view := make([]inputJSON, len(inputs))
 
 	for i, in := range inputs {
@@ -146,8 +146,8 @@ func PrintInputListJSON(inputs []Input) error {
 	return nil
 }
 
-// PrintInputListHuman renders a lipgloss table summary of inputs.
-func PrintInputListHuman(inputs []Input) {
+// printInputListHuman renders a lipgloss table summary of inputs.
+func printInputListHuman(inputs []Input) {
 	if len(inputs) == 0 {
 		fmt.Println(tui.DimStyle.Render("No inputs found"))
 

--- a/internal/pipeline/input_output_test.go
+++ b/internal/pipeline/input_output_test.go
@@ -103,18 +103,18 @@ func TestRenderInput_JSON(t *testing.T) {
 }
 
 func TestRenderInput_Human(t *testing.T) {
-	out := captureStdout(t, func() { PrintInputHuman(sampleInput()) })
+	out := captureStdout(t, func() { printInputHuman(sampleInput()) })
 
 	assert.Contains(t, out, "in-1")
 	assert.Contains(t, out, "locked")
 	assert.Contains(t, out, string(InputStateValid))
 }
 
-// ── PrintInputListJSON ───────────────────────────────────────────────────────
+// ── printInputListJSON ───────────────────────────────────────────────────────
 
 func TestPrintInputListJSON_RemapsFields(t *testing.T) {
 	out := captureStdout(t, func() {
-		require.NoError(t, PrintInputListJSON([]Input{sampleInput()}))
+		require.NoError(t, printInputListJSON([]Input{sampleInput()}))
 	})
 
 	var parsed []map[string]any
@@ -125,15 +125,15 @@ func TestPrintInputListJSON_RemapsFields(t *testing.T) {
 	assert.Equal(t, "locked", parsed[0]["scope"])
 }
 
-// ── PrintInputListHuman ──────────────────────────────────────────────────────
+// ── printInputListHuman ──────────────────────────────────────────────────────
 
 func TestPrintInputListHuman_Empty(t *testing.T) {
-	out := captureStdout(t, func() { PrintInputListHuman(nil) })
+	out := captureStdout(t, func() { printInputListHuman(nil) })
 	assert.Contains(t, out, "No inputs found")
 }
 
 func TestPrintInputListHuman_RendersTable(t *testing.T) {
-	out := captureStdout(t, func() { PrintInputListHuman([]Input{sampleInput()}) })
+	out := captureStdout(t, func() { printInputListHuman([]Input{sampleInput()}) })
 
 	assert.Contains(t, out, "INPUT ID")
 	assert.Contains(t, out, "in-1")

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -330,7 +330,13 @@ func buildMultipartRequest(method, endpoint, filePath string, fields map[string]
 // decodeHTTPError reads a non-2xx response body and turns it into a meaningful error.
 // Always returns *drapi.HTTPError so callers can use errors.As for status-code checks.
 func decodeHTTPError(resp *http.Response, endpoint string) error {
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		// Best-effort: we still return the status-coded error even if the body
+		// couldn't be read, but log it — a truncated/unreadable error body is
+		// exactly what makes a failed request hard to diagnose.
+		log.Warnf("reading error response body from %s: %v", endpoint, err)
+	}
 
 	detail := extractErrorDetail(respBody)
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -282,7 +282,7 @@ func doMultipart(method, endpoint, filePath string, fields map[string]string, in
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("request %s: %w", endpoint, err)
 	}
 
 	defer resp.Body.Close()
@@ -295,7 +295,11 @@ func doMultipart(method, endpoint, filePath string, fields map[string]string, in
 		return nil
 	}
 
-	return json.NewDecoder(resp.Body).Decode(out)
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("decode response from %s: %w", endpoint, err)
+	}
+
+	return nil
 }
 
 // buildMultipartRequest assembles the multipart body and HTTP request with

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -114,6 +114,31 @@ func TestDecodeHTTPError_WithoutDetail_ReturnsHTTPError(t *testing.T) {
 	assert.Equal(t, "http://example/api/v2/pipelines/abc", httpErr.URL)
 }
 
+// errReadCloser fails on Read, simulating a broken/truncated response body.
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) { return 0, errors.New("connection reset") }
+func (errReadCloser) Close() error             { return nil }
+
+func TestDecodeHTTPError_BodyReadError_StillReturnsHTTPError(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Body:       errReadCloser{},
+	}
+
+	// A failed body read must be handled gracefully: no panic, and the
+	// status-coded *drapi.HTTPError is still returned so callers can
+	// errors.As on it (the read failure is logged, not swallowed silently).
+	err := decodeHTTPError(resp, "http://example/api/v2/pipelines")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusBadGateway, httpErr.StatusCode)
+	assert.Equal(t, "http://example/api/v2/pipelines", httpErr.URL)
+}
+
 func TestBuildMultipartBody_IncludesFileAndFields(t *testing.T) {
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "pipeline.py")

--- a/internal/pipeline/run_output.go
+++ b/internal/pipeline/run_output.go
@@ -90,10 +90,10 @@ func toRunStatusJSON(s RunStatus) runStatusJSON {
 // RenderRun routes a single run to JSON or human output.
 func RenderRun(format outputformat.OutputFormat, r Run) error {
 	if format == outputformat.OutputFormatJSON {
-		return PrintRunJSON(r)
+		return printRunJSON(r)
 	}
 
-	PrintRunHuman(r)
+	printRunHuman(r)
 
 	return nil
 }
@@ -101,10 +101,10 @@ func RenderRun(format outputformat.OutputFormat, r Run) error {
 // RenderRuns routes a list of runs to JSON or human output.
 func RenderRuns(format outputformat.OutputFormat, items []Run) error {
 	if format == outputformat.OutputFormatJSON {
-		return PrintRunListJSON(items)
+		return printRunListJSON(items)
 	}
 
-	PrintRunListHuman(items)
+	printRunListHuman(items)
 
 	return nil
 }
@@ -112,16 +112,16 @@ func RenderRuns(format outputformat.OutputFormat, items []Run) error {
 // RenderRunStatus routes a run status to JSON or human output.
 func RenderRunStatus(format outputformat.OutputFormat, s RunStatus) error {
 	if format == outputformat.OutputFormatJSON {
-		return PrintStatusJSON(s)
+		return printStatusJSON(s)
 	}
 
-	PrintStatusHuman(s)
+	printStatusHuman(s)
 
 	return nil
 }
 
-// PrintRunJSON marshals a run as indented JSON using CLI-vocabulary keys.
-func PrintRunJSON(r Run) error {
+// printRunJSON marshals a run as indented JSON using CLI-vocabulary keys.
+func printRunJSON(r Run) error {
 	data, err := json.MarshalIndent(toRunJSON(r), "", "  ")
 	if err != nil {
 		return err
@@ -132,8 +132,8 @@ func PrintRunJSON(r Run) error {
 	return nil
 }
 
-// PrintRunHuman renders a single run in a human-friendly form.
-func PrintRunHuman(r Run) {
+// printRunHuman renders a single run in a human-friendly form.
+func printRunHuman(r Run) {
 	scope := "draft"
 	versionDisplay := emptyValuePlaceholder
 
@@ -178,9 +178,9 @@ func PrintRunHuman(r Run) {
 	w.Flush()
 }
 
-// PrintRunListJSON marshals a list of runs as indented JSON using
+// printRunListJSON marshals a list of runs as indented JSON using
 // CLI-vocabulary keys.
-func PrintRunListJSON(items []Run) error {
+func printRunListJSON(items []Run) error {
 	view := make([]runJSON, len(items))
 
 	for i, r := range items {
@@ -197,8 +197,8 @@ func PrintRunListJSON(items []Run) error {
 	return nil
 }
 
-// PrintRunListHuman renders a lipgloss table summary of runs.
-func PrintRunListHuman(items []Run) {
+// printRunListHuman renders a lipgloss table summary of runs.
+func printRunListHuman(items []Run) {
 	if len(items) == 0 {
 		fmt.Println(tui.DimStyle.Render("No runs found"))
 
@@ -244,9 +244,9 @@ func PrintRunListHuman(items []Run) {
 	fmt.Fprintln(os.Stdout, t.Render())
 }
 
-// PrintStatusJSON marshals a lightweight status response as indented JSON
+// printStatusJSON marshals a lightweight status response as indented JSON
 // using CLI-vocabulary keys.
-func PrintStatusJSON(s RunStatus) error {
+func printStatusJSON(s RunStatus) error {
 	data, err := json.MarshalIndent(toRunStatusJSON(s), "", "  ")
 	if err != nil {
 		return err
@@ -257,8 +257,8 @@ func PrintStatusJSON(s RunStatus) error {
 	return nil
 }
 
-// PrintStatusHuman renders a lightweight status response.
-func PrintStatusHuman(s RunStatus) {
+// printStatusHuman renders a lightweight status response.
+func printStatusHuman(s RunStatus) {
 	covalent := s.CovalentDispatchID
 	if covalent == "" {
 		covalent = emptyValuePlaceholder

--- a/internal/pipeline/run_output_test.go
+++ b/internal/pipeline/run_output_test.go
@@ -89,7 +89,7 @@ func TestRenderRun_JSON(t *testing.T) {
 }
 
 func TestRenderRun_Human(t *testing.T) {
-	out := captureStdout(t, func() { PrintRunHuman(sampleRun()) })
+	out := captureStdout(t, func() { printRunHuman(sampleRun()) })
 
 	assert.Contains(t, out, "d-1")
 	assert.Contains(t, out, "locked")
@@ -115,11 +115,11 @@ func TestRenderRunStatus_JSON(t *testing.T) {
 	assert.NotContains(t, parsed, "covalentDispatchId")
 }
 
-// ── PrintRunListJSON ─────────────────────────────────────────────────────────
+// ── printRunListJSON ─────────────────────────────────────────────────────────
 
 func TestPrintRunListJSON_RemapsFields(t *testing.T) {
 	out := captureStdout(t, func() {
-		require.NoError(t, PrintRunListJSON([]Run{sampleRun()}))
+		require.NoError(t, printRunListJSON([]Run{sampleRun()}))
 	})
 
 	var parsed []map[string]any
@@ -131,12 +131,12 @@ func TestPrintRunListJSON_RemapsFields(t *testing.T) {
 }
 
 func TestPrintRunListHuman_Empty(t *testing.T) {
-	out := captureStdout(t, func() { PrintRunListHuman(nil) })
+	out := captureStdout(t, func() { printRunListHuman(nil) })
 	assert.Contains(t, out, "No runs found")
 }
 
 func TestPrintRunListHuman_RendersTable(t *testing.T) {
-	out := captureStdout(t, func() { PrintRunListHuman([]Run{sampleRun()}) })
+	out := captureStdout(t, func() { printRunListHuman([]Run{sampleRun()}) })
 
 	assert.Contains(t, out, "RUN ID")
 	assert.Contains(t, out, "d-1")

--- a/internal/pipeline/run_task.go
+++ b/internal/pipeline/run_task.go
@@ -29,8 +29,16 @@ import (
 )
 
 // TaskExecution mirrors TaskExecutionResponse.
+//
+// NodeID is unique per invocation within a run: when the same @task runs at
+// multiple graph nodes (fan-out), every execution shares one TaskID but has
+// its own NodeID. Pass it as --node-id to address a specific invocation on
+// the per-task endpoints. GraphNodeID links the invocation back to a static
+// pipeline-graph node (nil when no 1:1 mapping exists, e.g. loops).
 type TaskExecution struct {
 	TaskID      *int       `json:"taskId,omitempty"`
+	NodeID      *int       `json:"nodeId,omitempty"`
+	GraphNodeID *int       `json:"graphNodeId,omitempty"`
 	Name        string     `json:"name"`
 	Status      string     `json:"status"`
 	StartedAt   *time.Time `json:"startedAt,omitempty"`
@@ -78,6 +86,25 @@ func taskBase(pipelineID, runID string) (string, error) {
 	)
 }
 
+// setNodeID adds the optional nodeId selector to a query. It disambiguates a
+// specific fan-out invocation when the same @task ran at multiple graph nodes
+// (all sharing one taskId); when nodeID is nil the API returns 409 for an
+// ambiguous taskId, listing the candidate node ids.
+func setNodeID(query url.Values, nodeID *int) {
+	if nodeID != nil {
+		query.Set("nodeId", strconv.Itoa(*nodeID))
+	}
+}
+
+// withQuery appends an encoded query string to an endpoint, if non-empty.
+func withQuery(endpoint string, query url.Values) string {
+	if encoded := query.Encode(); encoded != "" {
+		return endpoint + "?" + encoded
+	}
+
+	return endpoint
+}
+
 // ListTaskExecutions returns all task execution records for a run.
 func ListTaskExecutions(pipelineID, runID string) ([]TaskExecution, error) {
 	endpoint, err := taskBase(pipelineID, runID)
@@ -96,13 +123,16 @@ func ListTaskExecutions(pipelineID, runID string) ([]TaskExecution, error) {
 }
 
 // GetTaskExecution fetches a single task execution by its sequential task ID.
-func GetTaskExecution(pipelineID, runID string, taskID int) (*TaskExecution, error) {
+// nodeID (optional) selects a specific fan-out invocation; see setNodeID.
+func GetTaskExecution(pipelineID, runID string, taskID int, nodeID *int) (*TaskExecution, error) {
 	base, err := taskBase(pipelineID, runID)
 	if err != nil {
 		return nil, err
 	}
 
-	endpoint := base + "/" + strconv.Itoa(taskID)
+	query := url.Values{}
+	setNodeID(query, nodeID)
+	endpoint := withQuery(base+"/"+strconv.Itoa(taskID), query)
 
 	var task TaskExecution
 
@@ -116,7 +146,7 @@ func GetTaskExecution(pipelineID, runID string, taskID int) (*TaskExecution, err
 
 // GetTaskLogs reads live K8s pod logs for a task. tailLines limits the number
 // of trailing lines returned (nil = no limit). verbosity is "user" or "all".
-func GetTaskLogs(pipelineID, runID string, taskID int, tailLines *int, verbosity string) (*TaskExecutionLogs, error) {
+func GetTaskLogs(pipelineID, runID string, taskID int, nodeID, tailLines *int, verbosity string) (*TaskExecutionLogs, error) {
 	base, err := taskBase(pipelineID, runID)
 	if err != nil {
 		return nil, err
@@ -131,11 +161,9 @@ func GetTaskLogs(pipelineID, runID string, taskID int, tailLines *int, verbosity
 		query.Set("verbosity", verbosity)
 	}
 
-	endpoint := base + "/" + strconv.Itoa(taskID) + "/logs"
+	setNodeID(query, nodeID)
 
-	if encoded := query.Encode(); encoded != "" {
-		endpoint = endpoint + "?" + encoded
-	}
+	endpoint := withQuery(base+"/"+strconv.Itoa(taskID)+"/logs", query)
 
 	var logs TaskExecutionLogs
 
@@ -149,7 +177,7 @@ func GetTaskLogs(pipelineID, runID string, taskID int, tailLines *int, verbosity
 
 // GetTaskDurableLog reads the S3-uploaded log for a task. stream must be
 // "stdout" or "stderr". verbosity is "user" or "all".
-func GetTaskDurableLog(pipelineID, runID string, taskID int, stream, verbosity string) (*TaskExecutionDurableLog, error) {
+func GetTaskDurableLog(pipelineID, runID string, taskID int, nodeID *int, stream, verbosity string) (*TaskExecutionDurableLog, error) {
 	base, err := taskBase(pipelineID, runID)
 	if err != nil {
 		return nil, err
@@ -160,11 +188,9 @@ func GetTaskDurableLog(pipelineID, runID string, taskID int, stream, verbosity s
 		query.Set("verbosity", verbosity)
 	}
 
-	endpoint := base + "/" + strconv.Itoa(taskID) + "/logs/" + stream
+	setNodeID(query, nodeID)
 
-	if encoded := query.Encode(); encoded != "" {
-		endpoint = endpoint + "?" + encoded
-	}
+	endpoint := withQuery(base+"/"+strconv.Itoa(taskID)+"/logs/"+stream, query)
 
 	var log TaskExecutionDurableLog
 
@@ -177,13 +203,16 @@ func GetTaskDurableLog(pipelineID, runID string, taskID int, stream, verbosity s
 }
 
 // GetTaskResult returns the presigned S3 URL for a completed task's result.
-func GetTaskResult(pipelineID, runID string, taskID int) (*TaskExecutionResult, error) {
+// nodeID (optional) selects a specific fan-out invocation; see setNodeID.
+func GetTaskResult(pipelineID, runID string, taskID int, nodeID *int) (*TaskExecutionResult, error) {
 	base, err := taskBase(pipelineID, runID)
 	if err != nil {
 		return nil, err
 	}
 
-	endpoint := base + "/" + strconv.Itoa(taskID) + "/result"
+	query := url.Values{}
+	setNodeID(query, nodeID)
+	endpoint := withQuery(base+"/"+strconv.Itoa(taskID)+"/result", query)
 
 	var result TaskExecutionResult
 

--- a/internal/pipeline/run_task_test.go
+++ b/internal/pipeline/run_task_test.go
@@ -66,12 +66,84 @@ func TestGetTaskExecution_URLAndDecode(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	task, err := GetTaskExecution("p-1", "d-1", 2)
+	task, err := GetTaskExecution("p-1", "d-1", 2, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "train_model", task.Name)
 	assert.Equal(t, "FAILED", task.Status)
 	require.NotNil(t, task.ErrorDetail)
 	assert.Equal(t, "OOM", *task.ErrorDetail)
+}
+
+func TestListTaskExecutions_DecodesNodeAndGraphNodeID(t *testing.T) {
+	installSkipAuth(t)
+
+	// Fan-out: two invocations of the same @task share taskId 3 but carry
+	// distinct nodeIds and graphNodeIds.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"taskId":3,"nodeId":4,"graphNodeId":0,"name":"to_dataframe","status":"COMPLETED"},
+			{"taskId":3,"nodeId":7,"graphNodeId":1,"name":"to_dataframe","status":"RUNNING"}
+		]`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	tasks, err := ListTaskExecutions("p-1", "d-1")
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+	require.NotNil(t, tasks[0].NodeID)
+	require.NotNil(t, tasks[1].NodeID)
+	assert.Equal(t, 4, *tasks[0].NodeID)
+	assert.Equal(t, 7, *tasks[1].NodeID)
+	require.NotNil(t, tasks[0].GraphNodeID)
+	assert.Equal(t, 0, *tasks[0].GraphNodeID)
+	// Fan-out siblings share the taskId; the nodeId is what disambiguates them.
+	assert.Equal(t, *tasks[0].TaskID, *tasks[1].TaskID)
+}
+
+func TestPerTaskEndpoints_SendNodeIDQueryWhenSet(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Every per-task fetch must forward the nodeId selector verbatim.
+		assert.Equal(t, "7", r.URL.Query().Get("nodeId"))
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v2/pipelines/p-1/dispatches/d-1/tasks/3":
+			_, _ = w.Write([]byte(`{"taskId":3,"nodeId":7,"name":"to_dataframe","status":"RUNNING"}`))
+		case "/api/v2/pipelines/p-1/dispatches/d-1/tasks/3/result":
+			_, _ = w.Write([]byte(`{"url":"https://s3/x","expiresIn":900,"valueAvailable":false}`))
+		case "/api/v2/pipelines/p-1/dispatches/d-1/tasks/3/logs":
+			_, _ = w.Write([]byte(`{"logs":"","filteredLineCount":0}`))
+		case "/api/v2/pipelines/p-1/dispatches/d-1/tasks/3/logs/stdout":
+			_, _ = w.Write([]byte(`{"content":"","totalBytes":0}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	node := 7
+
+	_, err := GetTaskExecution("p-1", "d-1", 3, &node)
+	require.NoError(t, err)
+
+	_, err = GetTaskResult("p-1", "d-1", 3, &node)
+	require.NoError(t, err)
+
+	_, err = GetTaskLogs("p-1", "d-1", 3, &node, nil, "")
+	require.NoError(t, err)
+
+	_, err = GetTaskDurableLog("p-1", "d-1", 3, &node, "stdout", "")
+	require.NoError(t, err)
 }
 
 func TestGetTaskLogs_URLQueryAndDecode(t *testing.T) {
@@ -91,7 +163,7 @@ func TestGetTaskLogs_URLQueryAndDecode(t *testing.T) {
 	installEndpoint(t, srv.URL)
 
 	tail := 50
-	logs, err := GetTaskLogs("p-1", "d-1", 1, &tail, "all")
+	logs, err := GetTaskLogs("p-1", "d-1", 1, nil, &tail, "all")
 	require.NoError(t, err)
 	assert.Equal(t, "hello from task\n", logs.Logs)
 	assert.Equal(t, 0, logs.FilteredLineCount)
@@ -113,7 +185,7 @@ func TestGetTaskLogs_NoQueryParamsWhenAbsent(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	_, err := GetTaskLogs("p-1", "d-1", 1, nil, "")
+	_, err := GetTaskLogs("p-1", "d-1", 1, nil, nil, "")
 	require.NoError(t, err)
 }
 
@@ -132,7 +204,7 @@ func TestGetTaskDurableLog_URLAndDecode(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	log, err := GetTaskDurableLog("p-1", "d-1", 3, "stdout", "user")
+	log, err := GetTaskDurableLog("p-1", "d-1", 3, nil, "stdout", "user")
 	require.NoError(t, err)
 	assert.Equal(t, "task output\n", log.Content)
 	assert.Equal(t, 12, log.TotalBytes)
@@ -160,7 +232,7 @@ func TestGetTaskResult_URLAndDecode(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	res, err := GetTaskResult("p-1", "d-1", 1)
+	res, err := GetTaskResult("p-1", "d-1", 1, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "https://s3.example.com/result.tobj?sig=abc", res.URL)
 	assert.Equal(t, 900, res.ExpiresIn)
@@ -191,7 +263,7 @@ func TestGetTaskResult_ValueUnavailable(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	res, err := GetTaskResult("p-1", "d-1", 1)
+	res, err := GetTaskResult("p-1", "d-1", 1, nil)
 	require.NoError(t, err)
 	assert.False(t, res.ValueAvailable)
 	require.NotNil(t, res.ValueUnavailableReason)
@@ -221,7 +293,7 @@ func TestGetTaskResult_TextPreviewForNonSerializable(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	res, err := GetTaskResult("p-1", "d-1", 1)
+	res, err := GetTaskResult("p-1", "d-1", 1, nil)
 	require.NoError(t, err)
 	assert.False(t, res.ValueAvailable)
 	assert.Equal(t, "   x  y\n0  1  3\n1  2  4", res.ValueText)

--- a/internal/pipeline/schedule_output.go
+++ b/internal/pipeline/schedule_output.go
@@ -62,10 +62,10 @@ func toScheduleJSON(s Schedule) scheduleJSON {
 // RenderSchedule routes a single schedule to JSON or human output.
 func RenderSchedule(format outputformat.OutputFormat, s Schedule) error {
 	if format == outputformat.OutputFormatJSON {
-		return PrintScheduleJSON(s)
+		return printScheduleJSON(s)
 	}
 
-	PrintScheduleHuman(s)
+	printScheduleHuman(s)
 
 	return nil
 }
@@ -73,16 +73,16 @@ func RenderSchedule(format outputformat.OutputFormat, s Schedule) error {
 // RenderSchedules routes a list of schedules to JSON or human output.
 func RenderSchedules(format outputformat.OutputFormat, items []Schedule) error {
 	if format == outputformat.OutputFormatJSON {
-		return PrintScheduleListJSON(items)
+		return printScheduleListJSON(items)
 	}
 
-	PrintScheduleListHuman(items)
+	printScheduleListHuman(items)
 
 	return nil
 }
 
-// PrintScheduleJSON marshals a schedule as indented JSON through the DTO.
-func PrintScheduleJSON(s Schedule) error {
+// printScheduleJSON marshals a schedule as indented JSON through the DTO.
+func printScheduleJSON(s Schedule) error {
 	data, err := json.MarshalIndent(toScheduleJSON(s), "", "  ")
 	if err != nil {
 		return err
@@ -93,8 +93,8 @@ func PrintScheduleJSON(s Schedule) error {
 	return nil
 }
 
-// PrintScheduleHuman renders a single schedule in human-friendly form.
-func PrintScheduleHuman(s Schedule) {
+// printScheduleHuman renders a single schedule in human-friendly form.
+func printScheduleHuman(s Schedule) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
 	fmt.Fprintf(w, "Schedule ID:\t%s\n", s.ScheduleID)
@@ -111,8 +111,8 @@ func PrintScheduleHuman(s Schedule) {
 	w.Flush()
 }
 
-// PrintScheduleListJSON marshals a list of schedules as indented JSON through the DTO.
-func PrintScheduleListJSON(items []Schedule) error {
+// printScheduleListJSON marshals a list of schedules as indented JSON through the DTO.
+func printScheduleListJSON(items []Schedule) error {
 	view := make([]scheduleJSON, len(items))
 
 	for i, s := range items {
@@ -129,8 +129,8 @@ func PrintScheduleListJSON(items []Schedule) error {
 	return nil
 }
 
-// PrintScheduleListHuman renders a lipgloss table summary of schedules.
-func PrintScheduleListHuman(items []Schedule) {
+// printScheduleListHuman renders a lipgloss table summary of schedules.
+func printScheduleListHuman(items []Schedule) {
 	if len(items) == 0 {
 		fmt.Println(tui.DimStyle.Render("No schedules found"))
 

--- a/internal/pipeline/task_output.go
+++ b/internal/pipeline/task_output.go
@@ -70,16 +70,16 @@ func toTaskJSON(t PipelineTask) taskJSON {
 // RenderTask routes a single task to JSON or human output.
 func RenderTask(format outputformat.OutputFormat, t PipelineTask) error {
 	if format == outputformat.OutputFormatJSON {
-		return PrintTaskJSON(t)
+		return printTaskJSON(t)
 	}
 
-	PrintTaskHuman(t)
+	printTaskHuman(t)
 
 	return nil
 }
 
-// PrintTaskJSON marshals a task as indented JSON using CLI-vocabulary keys.
-func PrintTaskJSON(t PipelineTask) error {
+// printTaskJSON marshals a task as indented JSON using CLI-vocabulary keys.
+func printTaskJSON(t PipelineTask) error {
 	data, err := json.MarshalIndent(toTaskJSON(t), "", "  ")
 	if err != nil {
 		return err
@@ -90,8 +90,8 @@ func PrintTaskJSON(t PipelineTask) error {
 	return nil
 }
 
-// PrintTaskHuman renders a single task in a human-friendly tabwriter form.
-func PrintTaskHuman(t PipelineTask) {
+// printTaskHuman renders a single task in a human-friendly tabwriter form.
+func printTaskHuman(t PipelineTask) {
 	scope := "draft"
 	versionDisplay := emptyValuePlaceholder
 

--- a/internal/pipeline/task_output_test.go
+++ b/internal/pipeline/task_output_test.go
@@ -129,7 +129,7 @@ func TestRenderTask_JSON(t *testing.T) {
 }
 
 func TestRenderTask_Human(t *testing.T) {
-	out := captureStdout(t, func() { PrintTaskHuman(sampleTask()) })
+	out := captureStdout(t, func() { printTaskHuman(sampleTask()) })
 
 	assert.Contains(t, out, "Task ID:")
 	assert.Contains(t, out, "locked")
@@ -143,7 +143,7 @@ func TestPrintTaskHuman_DraftNoInputs(t *testing.T) {
 	tk.VersionID = nil
 	tk.Inputs = nil
 
-	out := captureStdout(t, func() { PrintTaskHuman(tk) })
+	out := captureStdout(t, func() { printTaskHuman(tk) })
 
 	assert.Contains(t, out, "draft")
 	assert.NotContains(t, out, "Inputs:")

--- a/internal/pipeline/transport.go
+++ b/internal/pipeline/transport.go
@@ -27,6 +27,7 @@ package pipeline
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/datarobot/cli/internal/config"
@@ -60,7 +61,7 @@ func doJSON(method, endpoint string, body any, info string, out any) error {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("request %s: %w", endpoint, err)
 	}
 
 	defer resp.Body.Close()
@@ -73,7 +74,11 @@ func doJSON(method, endpoint string, body any, info string, out any) error {
 		return nil
 	}
 
-	return json.NewDecoder(resp.Body).Decode(out)
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("decode response from %s: %w", endpoint, err)
+	}
+
+	return nil
 }
 
 // buildJSONRequest assembles an authenticated *http.Request with a
@@ -143,7 +148,7 @@ func doDelete(endpoint, info string) error {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("request %s: %w", endpoint, err)
 	}
 
 	defer resp.Body.Close()

--- a/internal/pipeline/version_output.go
+++ b/internal/pipeline/version_output.go
@@ -58,10 +58,10 @@ func toVersionJSON(v PipelineVersion) versionJSON {
 // RenderVersion routes a single version to JSON or human output.
 func RenderVersion(format outputformat.OutputFormat, v PipelineVersion) error {
 	if format == outputformat.OutputFormatJSON {
-		return PrintVersionJSON(v)
+		return printVersionJSON(v)
 	}
 
-	PrintVersionHuman(v)
+	printVersionHuman(v)
 
 	return nil
 }
@@ -69,16 +69,16 @@ func RenderVersion(format outputformat.OutputFormat, v PipelineVersion) error {
 // RenderVersions routes a list of versions to JSON or human output.
 func RenderVersions(format outputformat.OutputFormat, items []PipelineVersion) error {
 	if format == outputformat.OutputFormatJSON {
-		return PrintVersionListJSON(items)
+		return printVersionListJSON(items)
 	}
 
-	PrintVersionListHuman(items)
+	printVersionListHuman(items)
 
 	return nil
 }
 
-// PrintVersionJSON marshals a single version as indented JSON through the DTO.
-func PrintVersionJSON(v PipelineVersion) error {
+// printVersionJSON marshals a single version as indented JSON through the DTO.
+func printVersionJSON(v PipelineVersion) error {
 	data, err := json.MarshalIndent(toVersionJSON(v), "", "  ")
 	if err != nil {
 		return err
@@ -89,8 +89,8 @@ func PrintVersionJSON(v PipelineVersion) error {
 	return nil
 }
 
-// PrintVersionHuman renders the key facts about a single version.
-func PrintVersionHuman(v PipelineVersion) {
+// printVersionHuman renders the key facts about a single version.
+func printVersionHuman(v PipelineVersion) {
 	tasks := emptyValuePlaceholder
 	if len(v.TaskNames) > 0 {
 		tasks = strings.Join(v.TaskNames, ", ")
@@ -117,8 +117,8 @@ func PrintVersionHuman(v PipelineVersion) {
 	w.Flush()
 }
 
-// PrintVersionListJSON marshals a list of versions as indented JSON through the DTO.
-func PrintVersionListJSON(items []PipelineVersion) error {
+// printVersionListJSON marshals a list of versions as indented JSON through the DTO.
+func printVersionListJSON(items []PipelineVersion) error {
 	view := make([]versionJSON, len(items))
 
 	for i, v := range items {
@@ -135,8 +135,8 @@ func PrintVersionListJSON(items []PipelineVersion) error {
 	return nil
 }
 
-// PrintVersionListHuman renders a lipgloss table summary of versions.
-func PrintVersionListHuman(items []PipelineVersion) {
+// printVersionListHuman renders a lipgloss table summary of versions.
+func printVersionListHuman(items []PipelineVersion) {
 	if len(items) == 0 {
 		fmt.Println(tui.DimStyle.Render("No versions found"))
 


### PR DESCRIPTION
## RATIONALE

When the same `@task` runs at more than one graph node (fan-out), every one of its invocations shares a single sequential `taskId`. The per-task endpoints (`get`/`logs`/`result`) then can't tell the invocations apart. pipelines-api now disambiguates with a `nodeId` (unique per invocation) and returns `409` for an ambiguous `taskId`; this brings the CLI in line so `dr pipeline run task …` can address a specific fan-out invocation. 

It also folds in feedback on the merged pipelines CLI PR (error-handling, an unused validation, unexporting internal helpers) and adds the `dr pipeline run task` docs that were missing as per CMPT-6793

## CHANGES

- `TaskExecution` gains `nodeId` + `graphNodeId`; `--node-id` flag on `run task get|logs|result`, forwarded as `?nodeId=`.
- `run task list` shows a NODE ID column; `run task get` shows a Node ID row. The API's fan-out `409` (candidate node ids) surfaces via existing error-detail extraction.
- Wrap bare `client.Do` and `json.Decode` errors with context (`transport.go`, `pipeline.go`).
- Remove redundant manual `--name` check in `image create` (Cobra `MarkFlagRequired` already enforces it).
- Unexport internal-only `print*` output helpers (`Render*` stay the public entrypoints).
- Note "Private Preview" in the `dr pipeline` long description.
- Document `dr pipeline run task …` in `pipeline.md` and `pipelines-reference.md`, including `--node-id` and the fan-out `409`.

## TESTING

- `go build ./...`, `gofmt` clean, `golangci-lint` 0 issues on changed packages.
- `go test ./internal/pipeline/... ./cmd/pipeline/...` all pass; new tests assert `?nodeId=` is forwarded on all four per-task calls and that `nodeId`/`graphNodeId` decode.

## NOTES

- Requires pipelines-api PR datarobot/pipelines-api#203 (the `graphNodeId` field + `?nodeId=`/`409` contract) to be deployed to exercise fan-out end to end; degrades gracefully against older API versions (`nodeId`/`graphNodeId` simply absent).
- AJ's "some bits around the `--image` flag" note wasn't actioned — `--image` is already documented on `create`, `update`, and `run create`; happy to adjust with specifics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change for ambiguous fan-out task IDs (409 instead of a silent wrong invocation) depends on pipelines-api; API signature changes to GetTask* are localized to pipeline commands with new tests.
> 
> **Overview**
> Adds **`--node-id`** support for fan-out runs so `dr pipeline run task get`, `logs`, and `result` can target one invocation when the same `@task` shares a **TASK ID** across multiple graph nodes. The client forwards `?nodeId=` on those API calls; omitting the flag leaves ambiguous tasks to the API’s **409** (candidate node ids) instead of returning the wrong invocation.
> 
> **`run task list`** and **`run task get`** now surface **NODE ID** in the table and human output. **`TaskExecution`** gains `nodeId` and `graphNodeId`; list rendering is refactored with shared row helpers.
> 
> Also includes review follow-ups: **Private Preview** note on `dr pipeline`, removal of redundant **`image create --name`** validation, wrapped HTTP/decode errors in **`transport.go`** / **`pipeline.go`**, unexported internal **`print*`** render helpers ( **`Render*`** unchanged), and new **`run task`** docs in **`pipeline.md`** and **`pipelines-reference.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee465e30ec107669cb1f19507ff813a1d06454f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->