### PR TITLE
[CFX-6990] Remove jscpd from precommit task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -175,7 +175,7 @@ tasks:
 
   precommit:
     silent: true
-    desc: "Run pre-commit checks (format, tidy, vet, lint, dupcheck)"
+    desc: "Run pre-commit checks (format, tidy, vet, lint)"
     deps: [install-tools]
     cmds:
       - echo "🧹 Formatting…"
@@ -192,8 +192,6 @@ tasks:
       - "{{.BIN_DIR}}/golangci-lint config verify"
       - echo "🧹 Checking go.mod/go.sum are tidy…"
       - git diff --exit-code go.mod go.sum
-      - echo "🧹 Checking for duplicate code…"
-      - "{{.BIN_DIR}}/jscpd --no-tips --config .jscpd.json ."
 
   dupcheck:
     silent: true


### PR DESCRIPTION
## RATIONALE

I added in #674 `task precommit`, which runs on every commit that touches `.go` files (via lefthook).

It includes a **jscpd** duplicate-code detection step that reports 149 clones, the vast majority of which are false positives: Apache license headers (14 identical lines per file), import blocks, and standard cobra command boilerplate.

Meh.

Currently, the codebase sits at 4.25% duplicated lines vs the 5% jscpd threshold. Adding one more command file with a license header could push it over 5%, at which point jscpd exits non-zero and **blocks every Go commit** until someone reduces duplication - a poor developer experience for something that is mostly noise.

I think this tool is useful to have, but I don't know if we're in a good place to make it a requirement for development.

## CHANGES

The standalone `task dupcheck` remains available for manual runs and CI integration. This change only removes jscpd from the precommit task.

## TESTING

Verified `task precommit` runs cleanly without jscpd output:

```
🧹 Formatting…
🧹 Checking Go files are formatted…
🧹 Tidying go.mod…
🧹 Vetting…
🧹 Linting new changes…
0 issues.
🧹 Verifying golangci-lint config…
🧹 Checking go.mod/go.sum are tidy…
```

## RELATED

- #674 (added lefthook git hooks and jscpd duplicate code detection)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-workflow only; no runtime or application code changes.
> 
> **Overview**
> **Removes duplicate-code detection from the default pre-commit path** so Go commits are no longer gated on jscpd’s 5% threshold, which was easy to trip on license headers and boilerplate.
> 
> The `precommit` task description no longer mentions dupcheck, and the jscpd invocation is dropped from its command list. **`task dupcheck`** is unchanged for manual runs or CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72853e324fed1e6d362179aa78a3cb8d7889eb8e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->