### PR TITLE
[CFX-6907] Fix frozen wizard spinners and unify on a shared tui.Loading component

### DIFF
--- a/cmd/component/shared/addModel.go
+++ b/cmd/component/shared/addModel.go
@@ -47,7 +47,7 @@ const (
 type AddModel struct {
 	screen   addScreens
 	list     list.Model
-	spinner  spinner.Model
+	spinner  tui.Loading
 	width    int
 	height   int
 	errorMsg string
@@ -55,13 +55,9 @@ type AddModel struct {
 }
 
 func NewAddModel() AddModel {
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	s.Style = tui.InfoStyle
-
 	return AddModel{
 		screen:  addLoadingScreen,
-		spinner: s,
+		spinner: tui.NewLoading(),
 	}
 }
 
@@ -156,7 +152,7 @@ func (am AddModel) loadComponents() tea.Cmd {
 }
 
 func (am AddModel) Init() tea.Cmd {
-	return tea.Batch(am.loadComponents(), am.spinner.Tick, tea.WindowSize())
+	return tea.Batch(am.loadComponents(), am.spinner.Init(), tea.WindowSize())
 }
 
 func (am AddModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop

--- a/cmd/component/shared/updateModel.go
+++ b/cmd/component/shared/updateModel.go
@@ -109,7 +109,7 @@ type UpdateModel struct {
 	viewport    viewport.Model
 	help        help.Model
 	keys        detailKeyMap
-	spinner     spinner.Model
+	spinner     tui.Loading
 	updating    bool
 	ready       bool
 	ExitMessage string
@@ -199,21 +199,17 @@ func NewUpdateComponentModel(updateFlags copier.UpdateFlags) UpdateModel {
 	h.Styles.ShortKey = lipgloss.NewStyle().Foreground(tui.DrPurple)
 	h.Styles.ShortDesc = lipgloss.NewStyle().Foreground(tui.DimStyle.GetForeground())
 
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	s.Style = tui.InfoStyle
-
 	return UpdateModel{
 		screen:      listScreen,
 		help:        h,
 		keys:        newDetailKeys(),
 		updateFlags: updateFlags,
-		spinner:     s,
+		spinner:     tui.NewLoading(),
 	}
 }
 
 func (m UpdateModel) Init() tea.Cmd {
-	return tea.Batch(m.loadComponents(), m.spinner.Tick, tea.WindowSize())
+	return tea.Batch(m.loadComponents(), m.spinner.Init(), tea.WindowSize())
 }
 
 func (m UpdateModel) loadComponents() tea.Cmd {
@@ -365,7 +361,7 @@ func (m UpdateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:cyclop
 
 					cmd := tea.Sequence(cmdsToRun...)
 
-					return m, tea.Batch(m.spinner.Tick, cmd)
+					return m, tea.Batch(m.spinner.Init(), cmd)
 				}
 			default:
 				// If we have an error allow any keypress to exit screen/quit
@@ -476,7 +472,7 @@ func (m UpdateModel) viewListScreen() string {
 	if m.updating {
 		sb.WriteString(tui.WelcomeStyle.Render("Available Components for Recipe Agent Template:"))
 		sb.WriteString("\n\n")
-		sb.WriteString(tui.RenderStatusBar(m.width, m.spinner, "Updating selected components...", true))
+		sb.WriteString(tui.RenderStatusBar(m.width, m.spinner.Spinner, "Updating selected components...", true))
 
 		return sb.String()
 	}

--- a/cmd/dotenv/promptModel.go
+++ b/cmd/dotenv/promptModel.go
@@ -41,7 +41,7 @@ type promptModel struct {
 	Values     []string
 	successCmd tea.Cmd
 	loading    bool
-	spinner    spinner.Model
+	spinner    tui.Loading
 }
 
 var (
@@ -125,18 +125,14 @@ func newPromptModel(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptMod
 }
 
 func newLLMListPromptAsync(prompt envbuilder.UserPrompt, successCmd tea.Cmd) (promptModel, tea.Cmd) {
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	s.Style = tui.InfoStyle
-
 	pm := promptModel{
 		prompt:     prompt,
 		successCmd: successCmd,
 		loading:    true,
-		spinner:    s,
+		spinner:    tui.NewLoading(),
 	}
 
-	return pm, tea.Batch(pm.spinner.Tick, loadLLMCatalogCmd())
+	return pm, tea.Batch(pm.spinner.Init(), loadLLMCatalogCmd())
 }
 
 func loadLLMCatalogCmd() tea.Cmd {

--- a/cmd/dotenv/promptModel_test.go
+++ b/cmd/dotenv/promptModel_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/envbuilder"
+	"github.com/datarobot/cli/tui"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -221,7 +222,7 @@ func TestPromptModelView_LoadingState(t *testing.T) {
 	pm := promptModel{
 		prompt:  envbuilder.UserPrompt{Type: "llmgw_catalog", Env: "LLM_VAR", Help: "help text"},
 		loading: true,
-		spinner: spinner.New(),
+		spinner: tui.NewLoading(),
 	}
 
 	view := pm.View()

--- a/cmd/templates/clone/model.go
+++ b/cmd/templates/clone/model.go
@@ -50,7 +50,7 @@ func (k keyMap) FullHelp() [][]key.Binding {
 type Model struct {
 	template       drapi.Template
 	directoryInput textinput.Model
-	spinner        spinner.Model
+	spinner        tui.Loading
 	help           help.Model
 	keys           keyMap
 	debounceID     int
@@ -137,7 +137,7 @@ func (m Model) validateDir() tea.Cmd {
 }
 
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(m.spinner.Tick, focusInput, m.validateDir())
+	return tea.Batch(m.spinner.Init(), focusInput, m.validateDir())
 }
 
 const debounceDuration = 350 * time.Millisecond
@@ -234,7 +234,10 @@ func (m Model) View() string {
 	sb.WriteString("\n\n")
 
 	if m.cloning {
-		// Show cloning progress
+		// Show cloning progress. The animated spinner for this state is
+		// rendered by the parent wizard's status bar (setup.Model.View),
+		// which is shown whenever isLoading is true - rendering one here
+		// too would duplicate it.
 		message := lipgloss.NewStyle().
 			Foreground(lipgloss.AdaptiveColor{Light: "#6124DF", Dark: "#9D7EDF"}).
 			Render(fmt.Sprintf("Cloning into %s...", m.Dir))
@@ -308,7 +311,7 @@ func (m Model) View() string {
 
 	// Status bar
 	sb.WriteString("\n")
-	sb.WriteString(tui.RenderStatusBar(m.width, m.spinner, "Enter directory name and press Enter to clone", false))
+	sb.WriteString(tui.RenderStatusBar(m.width, m.spinner.Spinner, "Enter directory name and press Enter to clone", false))
 
 	return sb.String()
 }
@@ -332,9 +335,7 @@ func (m *Model) SetTemplate(template drapi.Template) {
 
 	m.template = template
 
-	m.spinner = spinner.New()
-	m.spinner.Spinner = spinner.Dot
-	m.spinner.Style = tui.InfoStyle
+	m.spinner = tui.NewLoading()
 
 	m.help = help.New()
 	m.help.ShowAll = false

--- a/cmd/templates/setup/model.go
+++ b/cmd/templates/setup/model.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
-	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/datarobot/cli/cmd/dotenv"
@@ -56,7 +55,7 @@ type Model struct {
 	screen   screens
 	template drapi.Template
 
-	spinner         spinner.Model
+	spinner         tui.Loading
 	help            help.Model
 	keys            keyMap
 	isLoading       bool
@@ -272,10 +271,6 @@ func NewModel(fromStartCommand bool) Model {
 		skipDotenv = state.HasCompletedDotenvSetup(repoRoot)
 	}
 
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	s.Style = tui.InfoStyle
-
 	h := help.New()
 	h.ShowAll = false
 
@@ -294,7 +289,7 @@ func NewModel(fromStartCommand bool) Model {
 		screen:   welcomeScreen,
 		template: drapi.Template{},
 
-		spinner:         s,
+		spinner:         tui.NewLoading(),
 		help:            h,
 		keys:            keys,
 		isLoading:       true,
@@ -325,7 +320,7 @@ func NewModel(fromStartCommand bool) Model {
 }
 
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(m.spinner.Tick, getTemplates(1))
+	return tea.Batch(m.spinner.Init(), getTemplates(1))
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
@@ -340,12 +335,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 				return m, tea.Quit
 			}
 		}
-	case spinner.TickMsg:
-		var cmd tea.Cmd
-
-		m.spinner, cmd = m.spinner.Update(msg)
-
-		return m, cmd
 	case getHostMsg:
 		m.screen = hostScreen
 		m.isLoading = false
@@ -477,6 +466,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		return m, tea.Sequence(tea.ExitAltScreen, tea.Quit)
 	}
 
+	// Advance the wizard's own spinner. spinner.Model.Update no-ops on ticks
+	// that don't carry its ID, so this is safe to call unconditionally
+	// alongside forwarding the same message to whichever child screen is
+	// active below - otherwise a child's own spinner.TickMsg would be
+	// swallowed here before it ever reaches the child, leaving the child's
+	// spinner frozen after one frame.
+	var spinnerCmd tea.Cmd
+
+	m.spinner, spinnerCmd = m.spinner.Update(msg)
+
 	var cmd tea.Cmd
 
 	switch m.screen {
@@ -484,28 +483,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		// No interaction needed - loading starts automatically
 	case hostScreen:
 		m.hostModel, cmd = m.hostModel.Update(msg)
-
-		return m, cmd
 	case loginScreen:
-		switch msg := msg.(type) {
-		case tea.KeyMsg:
-			switch keypress := msg.String(); keypress {
-			case "esc":
-				m.login.server.Close()
-				// Reset authentication flag when user goes back to change URL
-				m.isAuthenticated = false
-
-				return m, getHost
-			}
+		if keyMsg, ok := msg.(tea.KeyMsg); ok && keyMsg.String() == "esc" {
+			m.login.server.Close()
+			// Reset authentication flag when user goes back to change URL
+			m.isAuthenticated = false
+			cmd = getHost
+		} else {
+			m.login, cmd = m.login.Update(msg)
 		}
-
-		m.login, cmd = m.login.Update(msg)
-
-		return m, cmd
 	case listScreen:
 		m.list, cmd = m.list.Update(msg)
-
-		return m, cmd
 	case cloneScreen:
 		m.clone, cmd = m.clone.Update(msg)
 
@@ -514,18 +502,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 			m.isLoading = true
 			m.loadingMessage = "Cloning template to your computer..."
 		}
-
-		return m, cmd
 	case dotenvScreen:
-		dotenvModel, cmd := m.dotenv.Update(msg)
+		var dotenvModel tea.Model
+
+		dotenvModel, cmd = m.dotenv.Update(msg)
 		// Type assertion to appease compiler
 		m.dotenv = dotenvModel.(dotenv.Model)
-
-		return m, cmd
 	case exitScreen:
 	}
 
-	return m, nil
+	return m, tea.Batch(spinnerCmd, cmd)
 }
 
 func (m Model) View() string { //nolint: cyclop
@@ -677,16 +663,16 @@ func (m Model) View() string { //nolint: cyclop
 	sb.WriteString("\n")
 
 	if m.isLoading {
-		sb.WriteString(tui.RenderStatusBar(m.width, m.spinner, m.loadingMessage, m.isLoading))
+		sb.WriteString(tui.RenderStatusBar(m.width, m.spinner.Spinner, m.loadingMessage, m.isLoading))
 	} else if m.screen == welcomeScreen {
 		// Show idle status bar only on welcome screen
-		sb.WriteString(tui.RenderStatusBar(m.width, m.spinner, "Ready to start your AI journey", false))
+		sb.WriteString(tui.RenderStatusBar(m.width, m.spinner.Spinner, "Ready to start your AI journey", false))
 	} else if m.screen == hostScreen {
 		// Show status bar on host selection screen (waiting for input, no spinner)
-		sb.WriteString(tui.RenderStatusBar(m.width, m.spinner, "Waiting for environment host selection", false))
+		sb.WriteString(tui.RenderStatusBar(m.width, m.spinner.Spinner, "Waiting for environment host selection", false))
 	} else if m.screen == listScreen {
 		// Show status bar on template selection screen
-		sb.WriteString(tui.RenderStatusBar(m.width, m.spinner, "Choose your template to get started", false))
+		sb.WriteString(tui.RenderStatusBar(m.width, m.spinner.Spinner, "Choose your template to get started", false))
 	}
 
 	return sb.String()

--- a/cmd/templates/setup/model_test.go
+++ b/cmd/templates/setup/model_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression test for a bug where Model.Update's top-level switch intercepted
+// every spinner.TickMsg (matching by type alone) and returned before the
+// per-screen dispatch that forwards messages to the active child screen
+// (m.clone, m.dotenv). That silently swallowed tick messages meant for a
+// child's own spinner, freezing it after a single frame - e.g. the clone
+// screen and the dotenv wizard's "Fetching available LLMs..." spinner.
+func TestUpdate_SpinnerTickReachesCloneScreenDispatch(t *testing.T) {
+	// NewModel reads the on-disk CLI config via a process-global viper
+	// instance (internal/config). Isolate HOME/XDG so this test doesn't
+	// read the real machine's config, and reset viper afterward so no state
+	// leaks into other tests in this package - mirroring the isolation
+	// pattern in loginModel_test.go's SetupTest/AfterTest.
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Cleanup(viperx.Reset)
+
+	m := NewModel(false)
+	m.screen = cloneScreen
+	m.clone.SetTemplate(drapi.Template{
+		Repository: drapi.Repository{URL: "https://example.com/repo.git"},
+	})
+
+	// Drive the clone child into its "cloning" state via a real Update call,
+	// exactly as the wizard would when the user presses enter.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m, ok := updated.(Model)
+	require.True(t, ok)
+	require.True(t, m.clone.IsCloning())
+
+	// A zero-value spinner.TickMsg is accepted by any spinner.Model (bubbles
+	// only rejects ticks with a non-zero, mismatched ID), so both the
+	// parent's own spinner AND the clone screen's own spinner (still ticking
+	// internally, even though the wizard's status bar is the only place it's
+	// rendered - see clone.Model.View) will produce a reschedule cmd for it,
+	// if - and only if - the message actually reaches m.clone.Update.
+	//
+	// tea.Batch collapses to a single cmd when only one of its inputs is
+	// non-nil, and only produces a tea.BatchMsg when 2+ are non-nil. So if
+	// the child's tick was swallowed by the parent's top-level switch (the
+	// regression), only the parent's own spinner cmd would exist and this
+	// would NOT be a BatchMsg.
+	_, cmd := m.Update(spinner.TickMsg{})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	_, isBatch := msg.(tea.BatchMsg)
+	assert.True(t, isBatch,
+		"expected both the parent's and the clone screen's own spinner cmds to be batched - "+
+			"if not, the child's tick was swallowed before reaching the cloneScreen dispatch")
+}

--- a/tui/loading.go
+++ b/tui/loading.go
@@ -1,0 +1,67 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tui
+
+import (
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Loading is an embeddable spinner sub-model for use inside larger Bubble Tea
+// models (unlike RunWithSpinner, which owns its own tea.Program and isn't
+// meant to be nested inside another model's Update loop).
+//
+// bubbles/spinner stamps every spinner.TickMsg with the emitting spinner's
+// own ID, and spinner.Model.Update no-ops (no rescheduled tick) when the ID
+// doesn't match. So Update is always safe to call with any message a parent
+// forwards down, including ticks belonging to a sibling or child's own
+// Loading. What Loading does NOT do is guarantee delivery: a parent model
+// must still forward every message to its active child before/alongside
+// handling its own spinner, rather than consuming a message by type alone
+// and returning early - otherwise a child's ticks never arrive and its
+// spinner freezes after one frame.
+type Loading struct {
+	Spinner spinner.Model
+}
+
+// NewLoading creates a Loading using the CLI's standard spinner glyph/style.
+func NewLoading() Loading {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = InfoStyle
+
+	return Loading{Spinner: s}
+}
+
+// Init starts the spinner ticking. Callers must include the returned command,
+// typically batched with any other work started concurrently.
+func (l Loading) Init() tea.Cmd {
+	return l.Spinner.Tick
+}
+
+// Update advances the spinner on its own tick messages and no-ops for
+// anything else.
+func (l Loading) Update(msg tea.Msg) (Loading, tea.Cmd) {
+	var cmd tea.Cmd
+
+	l.Spinner, cmd = l.Spinner.Update(msg)
+
+	return l, cmd
+}
+
+// View renders the spinner glyph.
+func (l Loading) View() string {
+	return l.Spinner.View()
+}

--- a/tui/loading_test.go
+++ b/tui/loading_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tui
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLoading_UsesStandardGlyphAndStyle(t *testing.T) {
+	l := NewLoading()
+
+	assert.NotEmpty(t, l.View())
+}
+
+func TestLoading_InitReturnsTickCmd(t *testing.T) {
+	l := NewLoading()
+
+	cmd := l.Init()
+
+	assert.NotNil(t, cmd)
+}
+
+func TestLoading_UpdateAdvancesOnOwnTick(t *testing.T) {
+	l := NewLoading()
+
+	updated, cmd := l.Update(spinner.TickMsg{ID: l.Spinner.ID()})
+
+	assert.NotNil(t, cmd)
+	assert.Equal(t, l.Spinner.ID(), updated.Spinner.ID())
+}
+
+func TestLoading_UpdateNoOpsOnMismatchedID(t *testing.T) {
+	l := NewLoading()
+
+	// A tick carrying an ID that isn't this spinner's own must not schedule
+	// a follow-up tick - this is the exact scenario that starves a nested
+	// child's spinner if a parent forwards its own stale/foreign ticks.
+	foreignTick := spinner.TickMsg{ID: l.Spinner.ID() + 1}
+
+	updated, cmd := l.Update(foreignTick)
+
+	assert.Nil(t, cmd)
+	assert.Equal(t, l, updated)
+}
+
+func TestLoading_UpdateNoOpsOnUnrelatedMsg(t *testing.T) {
+	l := NewLoading()
+
+	type unknownMsg struct{}
+
+	updated, cmd := l.Update(unknownMsg{})
+
+	assert.Nil(t, cmd)
+	assert.Equal(t, l, updated)
+}

--- a/tui/spinner.go
+++ b/tui/spinner.go
@@ -18,13 +18,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/internal/misc/reader"
 )
 
 type spinnerModel struct {
-	spinner spinner.Model
+	spinner Loading
 	label   string
 	fn      func() error
 	done    bool
@@ -34,7 +33,7 @@ type spinnerDoneMsg struct{ err error }
 
 func (m spinnerModel) Init() tea.Cmd {
 	return tea.Batch(
-		m.spinner.Tick,
+		m.spinner.Init(),
 		func() tea.Msg {
 			return spinnerDoneMsg{err: m.fn()}
 		},
@@ -47,15 +46,13 @@ func (m spinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.done = true
 
 		return m, tea.Quit
-	case spinner.TickMsg:
+	default:
 		var cmd tea.Cmd
 
 		m.spinner, cmd = m.spinner.Update(msg)
 
 		return m, cmd
 	}
-
-	return m, nil
 }
 
 func (m spinnerModel) View() string {
@@ -79,14 +76,10 @@ func RunWithSpinner(label string, fn func() error) error {
 		return fn()
 	}
 
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	s.Style = InfoStyle
-
 	var fnErr error
 
 	m := spinnerModel{
-		spinner: s,
+		spinner: NewLoading(),
 		label:   label,
 		fn: func() error {
 			fnErr = fn()

--- a/tui/spinner_test.go
+++ b/tui/spinner_test.go
@@ -30,7 +30,7 @@ func TestSpinnerModel_ViewShowsLabelWhileRunning(t *testing.T) {
 	s.Style = InfoStyle
 
 	m := spinnerModel{
-		spinner: s,
+		spinner: Loading{Spinner: s},
 		label:   "Loading…",
 	}
 
@@ -44,7 +44,7 @@ func TestSpinnerModel_ViewEmptyWhenDone(t *testing.T) {
 	s.Spinner = spinner.Dot
 
 	m := spinnerModel{
-		spinner: s,
+		spinner: Loading{Spinner: s},
 		label:   "Loading…",
 		done:    true,
 	}
@@ -57,7 +57,7 @@ func TestSpinnerModel_UpdateOnDoneMsg(t *testing.T) {
 	s.Spinner = spinner.Dot
 
 	m := spinnerModel{
-		spinner: s,
+		spinner: Loading{Spinner: s},
 		label:   "Loading…",
 	}
 
@@ -72,7 +72,7 @@ func TestSpinnerModel_UpdateOnDoneMsgWithError(t *testing.T) {
 	s.Spinner = spinner.Dot
 
 	m := spinnerModel{
-		spinner: s,
+		spinner: Loading{Spinner: s},
 		label:   "Loading…",
 	}
 
@@ -127,7 +127,7 @@ func TestRunWithSpinner_LabelRendered(t *testing.T) {
 	s.Style = InfoStyle
 
 	m := spinnerModel{
-		spinner: s,
+		spinner: Loading{Spinner: s},
 		label:   "my special label",
 	}
 
@@ -141,7 +141,7 @@ func TestSpinnerModel_InitReturnsBatch(t *testing.T) {
 	s.Spinner = spinner.Dot
 
 	m := spinnerModel{
-		spinner: s,
+		spinner: Loading{Spinner: s},
 		label:   "Loading…",
 		fn:      func() error { return nil },
 	}
@@ -160,7 +160,7 @@ func TestSpinnerModel_UpdateTickMsg(t *testing.T) {
 	s.Spinner = spinner.Dot
 
 	m := spinnerModel{
-		spinner: s,
+		spinner: Loading{Spinner: s},
 		label:   "Loading…",
 	}
 
@@ -179,7 +179,7 @@ func TestSpinnerModel_UpdateUnknownMsg(t *testing.T) {
 	type unknownMsg struct{}
 
 	m := spinnerModel{
-		spinner: s,
+		spinner: Loading{Spinner: s},
 		label:   "Loading…",
 	}
 
@@ -194,7 +194,7 @@ func TestSpinnerModel_UpdateReturnsSelf(t *testing.T) {
 	s.Spinner = spinner.Dot
 
 	m := spinnerModel{
-		spinner: s,
+		spinner: Loading{Spinner: s},
 		label:   "Loading…",
 	}
 


### PR DESCRIPTION
# RATIONALE

Every TUI flow (`RunWithSpinner`, `setup.Model`, `clone.Model`, `promptModel`, `AddModel`, `UpdateModel`) hand-rolled its own `spinner.Model` field with duplicated Init/Update/View boilerplate and inconsistent glyphs (`Dot` vs `Points`).

That duplication was hiding a real bug: the "Fetching available LLMs from DataRobot..." spinner looked frozen after its first frame whenever the dotenv wizard ran nested inside `dr templates setup` / `dr start` (it worked fine standalone via `dr dotenv setup`).

**Root cause:** `setup.Model.Update()`'s top-level switch intercepted every `spinner.TickMsg` by type alone and returned before the per-screen dispatch that forwards messages to the active child screen (`m.clone`, `m.dotenv` → nested `promptModel`). Since `bubbles/spinner` stamps ticks with the emitting spinner's own ID and no-ops on mismatch, the child's own tick was rejected by the parent's spinner and the function returned immediately — the child's spinner never got rescheduled and froze after one frame.

Once ticks started flowing correctly to the clone screen too, a second issue surfaced: the clone screen showed **two** spinners at once (its own inline one plus the parent wizard's status bar, both now animating). Fixed by dropping the redundant one — the parent's status bar is the single source of truth for that loading state.

## CHANGES

- Fixes `setup.Model.Update()` so `spinner.TickMsg` (and every other message) always reaches the per-screen dispatch instead of being swallowed by the parent's own spinner handling.
- Removes the duplicate spinner render on the clone screen.
- Extracts `tui.Loading`, a single embeddable spinner sub-model, and migrates all hand-rolled spinners onto it (standardizing on the `Dot` glyph, including `RunWithSpinner` which previously used `Points`).
- Adds a regression test proving a `spinner.TickMsg` sent while the wizard is on the clone screen reaches the child's `Update` (verified it fails against the pre-fix code and passes against the fix).
- Adds `tui/loading_test.go` for the new shared component.

https://github.com/user-attachments/assets/3e90145a-32ff-4c1c-97bf-b971202413e3


## TESTING

- `task lint` — clean.
- `task test` — full suite, race detector, clean; also re-ran with `-shuffle=on` repeatedly to confirm no flakiness.
- Manually reasoned through every screen with both a parent status bar and a child spinner (`hostScreen`, `loginScreen`, `listScreen`, `dotenvScreen`, `cloneScreen`) to confirm the clone screen was the only case of double-rendering.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CLI TUI loading UX and message routing; no auth, API, or data-path changes, with regression tests for the main bug.
> 
> **Overview**
> Fixes **frozen loading spinners** when the dotenv wizard (e.g. “Fetching available LLMs…”) or clone flow runs inside `dr templates setup` / `dr start`. The setup wizard no longer handles `spinner.TickMsg` in a top-level switch that returned before child screens; it updates its own spinner and **forwards every message** to the active screen, batching spinner and child commands.
> 
> Introduces **`tui.Loading`** as the standard embeddable spinner (`Dot` + `InfoStyle`) and migrates component add/update, dotenv prompts, template clone/setup, and `RunWithSpinner` off duplicated `spinner.Model` setup. Status bars that need the raw bubble use `m.spinner.Spinner`. During clone, the **inline duplicate spinner** is removed so only the wizard status bar animates.
> 
> Adds **`tui/loading_test.go`** and a **setup regression test** that spinner ticks reach `m.clone.Update` while cloning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cecfa770027077c73f77e927fabbafad69711e53. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->