### PR TITLE
[CFX-6922] cancelReader on Windows

### DIFF
--- a/cmd/plugin/install/cmd_test.go
+++ b/cmd/plugin/install/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/plugin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,11 +93,11 @@ func TestConfirmPluginDepsInstall_UserAnswersY(t *testing.T) {
 	_, _ = w.WriteString("y\n")
 	w.Close()
 
-	origStdin := os.Stdin
-	os.Stdin = r
+	origStdin := reader.Stdin
+	reader.Stdin = r
 
 	defer func() {
-		os.Stdin = origStdin
+		reader.Stdin = origStdin
 
 		r.Close()
 	}()
@@ -111,11 +112,11 @@ func TestConfirmPluginDepsInstall_UserAnswersN(t *testing.T) {
 	_, _ = w.WriteString("n\n")
 	w.Close()
 
-	origStdin := os.Stdin
-	os.Stdin = r
+	origStdin := reader.Stdin
+	reader.Stdin = r
 
 	defer func() {
-		os.Stdin = origStdin
+		reader.Stdin = origStdin
 
 		r.Close()
 	}()
@@ -158,11 +159,11 @@ func TestCheckAndInstallPluginDeps_SkipsInstallWhenUserDeclines(t *testing.T) {
 	_, _ = w.WriteString("n\n")
 	w.Close()
 
-	origStdin := os.Stdin
-	os.Stdin = r
+	origStdin := reader.Stdin
+	reader.Stdin = r
 
 	defer func() {
-		os.Stdin = origStdin
+		reader.Stdin = origStdin
 
 		r.Close()
 	}()

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -318,7 +318,6 @@ func askForNewHost() bool {
 
 	selectedOption, err := reader.ReadString()
 	if err != nil {
-		fmt.Println("reader.ReadString => err :", err)
 		return false
 	}
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -318,6 +318,7 @@ func askForNewHost() bool {
 
 	selectedOption, err := reader.ReadString()
 	if err != nil {
+		fmt.Println("reader.ReadString => err :", err)
 		return false
 	}
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -330,7 +330,7 @@ func SetURLAction() bool {
 			printSetURLPrompt()
 
 			url, err := reader.ReadString()
-			if err != nil || url == "\n" {
+			if err != nil || url == "" {
 				break
 			}
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -325,6 +325,13 @@ func askForNewHost() bool {
 }
 
 func SetURLAction() bool {
+	if !reader.IsStdinTerminal() {
+		log.Error("No DataRobot URL configured and no terminal available to prompt for one. " +
+			"Run 'dr auth set-url <url>' or set DATAROBOT_ENDPOINT to configure it non-interactively.")
+
+		return false
+	}
+
 	if askForNewHost() {
 		for {
 			printSetURLPrompt()

--- a/internal/misc/reader/reader.go
+++ b/internal/misc/reader/reader.go
@@ -55,7 +55,6 @@ func ReadString() (string, error) {
 
 	str, err := readLine(reader)
 	if err != nil {
-		fmt.Println("readLine err => : ", err)
 		fmt.Println()
 	}
 

--- a/internal/misc/reader/reader.go
+++ b/internal/misc/reader/reader.go
@@ -66,10 +66,14 @@ const (
 	ctrlC     = 0x03 // ASCII ETX, sent by Ctrl+C
 	backspace = '\b'
 	del       = 0x7f // ASCII DEL, sent by Backspace on some terminals; also the exclusive upper bound of printable ASCII
+	esc       = 0x1b // ASCII ESC, begins VT100/ANSI escape sequences (arrows, Home/End, etc.)
 
 	printableASCIIMin = 0x20 // ' ', the lowest printable ASCII byte
 
 	eraseSequence = "\b \b" // backspace, overwrite with space, backspace again
+
+	csiFinalByteMin = 0x40 // '@', low end of the CSI final-byte range (ECMA-48)
+	csiFinalByteMax = 0x7e // '~', high end of the CSI final-byte range (ECMA-48)
 )
 
 // readLine reads bytes until '\n' or '\r', whichever comes first, without
@@ -96,18 +100,17 @@ func readLine(r *bufio.Reader) (string, error) {
 			return sb.String(), err
 		}
 
-		// Ctrl+C (ASCII ETX, 0x03). On POSIX this byte never reaches us —
-		// the tty driver intercepts it at the ISIG layer and raises a real
-		// SIGINT before it's ever placed in the input stream. On Windows,
-		// cancelreader disables ENABLE_PROCESSED_INPUT (required so it can
-		// implement its own Cancel()), which per Microsoft's docs means
-		// "CTRL+C is reported as keyboard input rather than as a signal" —
-		// so this is the only place Ctrl+C is ever observable on Windows.
-		if b == ctrlC {
-			return sb.String(), cancelreader.ErrCanceled
+		// Ctrl+C and escape sequences (arrow keys, Home/End, etc.) never
+		// belong in the answer — see handleControlByte.
+		if consumed, err := handleControlByte(r, b); consumed {
+			if err != nil {
+				return sb.String(), err
+			}
+
+			continue
 		}
 
-		if b == '\n' || b == '\r' {
+		if isLineEnd(b) {
 			if echo {
 				fmt.Println()
 			}
@@ -131,9 +134,76 @@ func readLine(r *bufio.Reader) (string, error) {
 	}
 }
 
+// isLineEnd reports whether b is '\n' or '\r'.
+func isLineEnd(b byte) bool {
+	return b == '\n' || b == '\r'
+}
+
+// handleControlByte handles the two byte values that never belong in the
+// answer text itself. consumed is true if b was one of them, in which case
+// the caller should `continue` its read loop when err is nil, or stop and
+// return err otherwise.
+//
+//   - Ctrl+C (ASCII ETX, 0x03): on POSIX this byte never reaches us — the tty
+//     driver intercepts it at the ISIG layer and raises a real SIGINT before
+//     it's ever placed in the input stream. On Windows, cancelreader disables
+//     ENABLE_PROCESSED_INPUT (required so it can implement its own Cancel()),
+//     which per Microsoft's docs means "CTRL+C is reported as keyboard input
+//     rather than as a signal" — so this is the only place Ctrl+C is ever
+//     observable on Windows.
+//   - Escape sequences (ESC, 0x1b): arrow keys, Home/End, Delete, etc. are
+//     sent as VT100/ANSI escape sequences (e.g. Right arrow is ESC '[' 'C')
+//     on every platform — this is how terminals encode special keys,
+//     independent of cooked vs. raw console/tty mode. Without discarding
+//     these, the bytes get echoed and appended into the answer as literal
+//     control characters (e.g. a typed URL ending up as
+//     "abcdefghi\x1b[C\x1b[C" and failing url.Parse downstream). We don't yet
+//     act on them (e.g. actually moving the cursor) — just discard them so
+//     they can't corrupt the answer.
+func handleControlByte(r *bufio.Reader, b byte) (consumed bool, err error) {
+	switch b {
+	case ctrlC:
+		return true, cancelreader.ErrCanceled
+	case esc:
+		return true, discardEscapeSequence(r)
+	}
+
+	return false, nil
+}
+
 // isBackspace reports whether b is a backspace or DEL byte.
 func isBackspace(b byte) bool {
 	return b == backspace || b == del
+}
+
+// discardEscapeSequence consumes and discards a VT100/ANSI escape sequence
+// following an ESC byte already read from r, so it isn't echoed or appended
+// to the answer as literal control bytes (e.g. arrow keys send ESC '[' 'C'/'D').
+// A CSI sequence is ESC '[' followed by any number of parameter/intermediate
+// bytes and a single final byte in the 0x40-0x7e range (ECMA-48).
+// If the byte after ESC isn't '[', this wasn't a CSI sequence (e.g. a bare
+// Escape keypress) — that byte is pushed back via UnreadByte so the caller
+// processes it normally instead of silently swallowing an unrelated keystroke.
+func discardEscapeSequence(r *bufio.Reader) error {
+	next, err := r.ReadByte()
+	if err != nil {
+		return err
+	}
+
+	if next != '[' {
+		return r.UnreadByte()
+	}
+
+	for {
+		b, err := r.ReadByte()
+		if err != nil {
+			return err
+		}
+
+		if b >= csiFinalByteMin && b <= csiFinalByteMax {
+			return nil
+		}
+	}
 }
 
 // eraseLastByte removes the last byte from sb, if any, and erases its

--- a/internal/misc/reader/reader.go
+++ b/internal/misc/reader/reader.go
@@ -62,6 +62,16 @@ func ReadString() (string, error) {
 	return str, err
 }
 
+const (
+	ctrlC     = 0x03 // ASCII ETX, sent by Ctrl+C
+	backspace = '\b'
+	del       = 0x7f // ASCII DEL, sent by Backspace on some terminals; also the exclusive upper bound of printable ASCII
+
+	printableASCIIMin = 0x20 // ' ', the lowest printable ASCII byte
+
+	eraseSequence = "\b \b" // backspace, overwrite with space, backspace again
+)
+
 // readLine reads bytes until '\n' or '\r', whichever comes first, without
 // looking ahead for a paired '\r\n'. That lookahead would block: with
 // ENABLE_LINE_INPUT off, Windows' raw console mode delivers a bare '\r' for
@@ -93,8 +103,7 @@ func readLine(r *bufio.Reader) (string, error) {
 		// implement its own Cancel()), which per Microsoft's docs means
 		// "CTRL+C is reported as keyboard input rather than as a signal" —
 		// so this is the only place Ctrl+C is ever observable on Windows.
-		if b == 0x03 {
-			fmt.Println("ReadByte 0x03", err)
+		if b == ctrlC {
 			return sb.String(), cancelreader.ErrCanceled
 		}
 
@@ -106,11 +115,9 @@ func readLine(r *bufio.Reader) (string, error) {
 			return sb.String(), nil
 		}
 
-		if echo && (b == '\b' || b == 0x7f) {
-			if s := sb.String(); s != "" {
-				sb.Reset()
-				sb.WriteString(s[:len(s)-1])
-				fmt.Print("\b \b")
+		if isBackspace(b) {
+			if echo {
+				eraseLastByte(&sb)
 			}
 
 			continue
@@ -118,9 +125,34 @@ func readLine(r *bufio.Reader) (string, error) {
 
 		sb.WriteByte(b)
 
-		if echo && b >= 0x20 && b < 0x7f {
-			fmt.Printf("%c", b)
+		if echo {
+			echoByte(b)
 		}
+	}
+}
+
+// isBackspace reports whether b is a backspace or DEL byte.
+func isBackspace(b byte) bool {
+	return b == backspace || b == del
+}
+
+// eraseLastByte removes the last byte from sb, if any, and erases its
+// on-screen representation via the standard backspace-space-backspace trick.
+func eraseLastByte(sb *strings.Builder) {
+	s := sb.String()
+	if s == "" {
+		return
+	}
+
+	sb.Reset()
+	sb.WriteString(s[:len(s)-1])
+	fmt.Print(eraseSequence)
+}
+
+// echoByte prints b if it falls in the printable ASCII range.
+func echoByte(b byte) {
+	if b >= printableASCIIMin && b < del {
+		fmt.Printf("%c", b)
 	}
 }
 

--- a/internal/misc/reader/reader.go
+++ b/internal/misc/reader/reader.go
@@ -47,8 +47,17 @@ func ReadString() (string, error) {
 	defer signal.Stop(cancelChan)
 
 	go func() {
-		<-cancelChan
-		cr.Cancel()
+		// ok is false only when cancelChan was closed (normal completion)
+		// with nothing pending — not from a genuine signal. Without this
+		// check, every successful read would still call cr.Cancel() here
+		// (close() unblocks a pending receive same as a real send would),
+		// racing the deferred cr.Close() above: cancelreader has no
+		// synchronization between Cancel() and Close(), and on Windows
+		// Close() skips console-mode restoration entirely if the race makes
+		// CloseHandle(cancelEvent) fail — the exact bug this file fixes.
+		if _, ok := <-cancelChan; ok {
+			cr.Cancel()
+		}
 	}()
 
 	reader := bufio.NewReader(cr)

--- a/internal/misc/reader/reader.go
+++ b/internal/misc/reader/reader.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"runtime"
 	"strings"
 	"syscall"
 
@@ -29,14 +28,16 @@ import (
 )
 
 func ReadString() (string, error) {
-	if runtime.GOOS == "windows" {
-		return bufio.NewReader(os.Stdin).ReadString('\n')
-	}
-
 	cr, err := cancelreader.NewReader(os.Stdin)
 	if err != nil {
 		return "", err
 	}
+
+	// cancelreader must be closed. That never happened here: leaks epoll/pipe
+	// fds on Linux/macOS, and leaves Windows in raw console mode (no echo) —
+	// the garbled input CFX-4799 papered over by bypassing cancelreader on
+	// Windows instead of closing it.
+	defer cr.Close()
 
 	cancelChan := make(chan os.Signal, 1)
 	defer close(cancelChan)

--- a/internal/misc/reader/reader.go
+++ b/internal/misc/reader/reader.go
@@ -54,6 +54,7 @@ func ReadString() (string, error) {
 
 	str, err := readLine(reader)
 	if err != nil {
+		fmt.Println("readLine err => : ", err)
 		fmt.Println()
 	}
 
@@ -74,6 +75,7 @@ func readLine(r *bufio.Reader) (string, error) {
 	for {
 		b, err := r.ReadByte()
 		if err != nil {
+			fmt.Println("ReadByte err", err)
 			return sb.String(), err
 		}
 
@@ -93,6 +95,7 @@ func readLine(r *bufio.Reader) (string, error) {
 func AskYesNo() bool {
 	line, err := ReadString()
 	if err != nil {
+		fmt.Println("err", err)
 		return false
 	}
 

--- a/internal/misc/reader/reader.go
+++ b/internal/misc/reader/reader.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -72,6 +73,13 @@ func ReadString() (string, error) {
 func readLine(r *bufio.Reader) (string, error) {
 	var sb strings.Builder
 
+	// cancelreader's Windows raw console mode also disables ENABLE_ECHO_INPUT,
+	// so the console stops echoing typed characters (and doesn't erase them
+	// on backspace) on its own — we have to do both ourselves there. POSIX
+	// never touches termios, so the tty keeps echoing normally on its own;
+	// echoing here too would double every character.
+	echo := runtime.GOOS == "windows"
+
 	for {
 		b, err := r.ReadByte()
 		if err != nil {
@@ -91,10 +99,28 @@ func readLine(r *bufio.Reader) (string, error) {
 		}
 
 		if b == '\n' || b == '\r' {
+			if echo {
+				fmt.Println()
+			}
+
 			return sb.String(), nil
 		}
 
+		if echo && (b == '\b' || b == 0x7f) {
+			if s := sb.String(); s != "" {
+				sb.Reset()
+				sb.WriteString(s[:len(s)-1])
+				fmt.Print("\b \b")
+			}
+
+			continue
+		}
+
 		sb.WriteByte(b)
+
+		if echo && b >= 0x20 && b < 0x7f {
+			fmt.Printf("%c", b)
+		}
 	}
 }
 

--- a/internal/misc/reader/reader.go
+++ b/internal/misc/reader/reader.go
@@ -75,8 +75,19 @@ func readLine(r *bufio.Reader) (string, error) {
 	for {
 		b, err := r.ReadByte()
 		if err != nil {
-			fmt.Println("ReadByte err", err)
 			return sb.String(), err
+		}
+
+		// Ctrl+C (ASCII ETX, 0x03). On POSIX this byte never reaches us —
+		// the tty driver intercepts it at the ISIG layer and raises a real
+		// SIGINT before it's ever placed in the input stream. On Windows,
+		// cancelreader disables ENABLE_PROCESSED_INPUT (required so it can
+		// implement its own Cancel()), which per Microsoft's docs means
+		// "CTRL+C is reported as keyboard input rather than as a signal" —
+		// so this is the only place Ctrl+C is ever observable on Windows.
+		if b == 0x03 {
+			fmt.Println("ReadByte 0x03", err)
+			return sb.String(), cancelreader.ErrCanceled
 		}
 
 		if b == '\n' || b == '\r' {

--- a/internal/misc/reader/reader.go
+++ b/internal/misc/reader/reader.go
@@ -242,7 +242,6 @@ func echoByte(b byte) {
 func AskYesNo() bool {
 	line, err := ReadString()
 	if err != nil {
-		fmt.Println("err", err)
 		return false
 	}
 

--- a/internal/misc/reader/reader.go
+++ b/internal/misc/reader/reader.go
@@ -52,12 +52,37 @@ func ReadString() (string, error) {
 
 	reader := bufio.NewReader(cr)
 
-	str, err := reader.ReadString('\n')
+	str, err := readLine(reader)
 	if err != nil {
 		fmt.Println()
 	}
 
 	return str, err
+}
+
+// readLine reads bytes until '\n' or '\r', whichever comes first, without
+// looking ahead for a paired '\r\n'. That lookahead would block: with
+// ENABLE_LINE_INPUT off, Windows' raw console mode delivers a bare '\r' for
+// Enter and nothing more until the next keystroke, so waiting to see whether
+// '\n' follows would hang until the user types again. POSIX terminals
+// already translate Enter to a bare '\n' at the tty layer, so they never hit
+// the '\r' branch here. This also means redirected/piped input is handled
+// regardless of its line-ending convention ('\n', '\r', or '\r\n').
+func readLine(r *bufio.Reader) (string, error) {
+	var sb strings.Builder
+
+	for {
+		b, err := r.ReadByte()
+		if err != nil {
+			return sb.String(), err
+		}
+
+		if b == '\n' || b == '\r' {
+			return sb.String(), nil
+		}
+
+		sb.WriteByte(b)
+	}
 }
 
 // AskYesNo prints nothing itself — the caller is expected to have already

--- a/internal/misc/reader/reader.go
+++ b/internal/misc/reader/reader.go
@@ -17,6 +17,7 @@ package reader
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"runtime"
@@ -28,8 +29,20 @@ import (
 	"golang.org/x/term"
 )
 
+// Stdin is the source ReadString reads from. It defaults to os.Stdin; tests
+// override it to inject canned input instead of reassigning the os.Stdin
+// global. Reassigning os.Stdin itself doesn't work on Windows: cancelreader's
+// Windows implementation special-cases "is this reader's fd the same as
+// os.Stdin's fd?" and, when true, discards the reader it was given in favor
+// of opening the real console handle (CONIN$) directly — so a test-supplied
+// pipe assigned to os.Stdin gets ignored and the read blocks forever waiting
+// for real keystrokes. Overriding this var instead leaves the real os.Stdin
+// untouched, so the fds never match and cancelreader takes its generic
+// fallback path, which actually reads from the injected pipe.
+var Stdin io.Reader = os.Stdin
+
 func ReadString() (string, error) {
-	cr, err := cancelreader.NewReader(os.Stdin)
+	cr, err := cancelreader.NewReader(Stdin)
 	if err != nil {
 		return "", err
 	}

--- a/internal/misc/reader/reader_test.go
+++ b/internal/misc/reader/reader_test.go
@@ -73,6 +73,36 @@ func TestReadLine_EmptyInput(t *testing.T) {
 	assert.Empty(t, line)
 }
 
+func TestReadLine_ArrowKeysDiscarded(t *testing.T) {
+	// Reproduces a real bug: pressing Right arrow twice while typing a URL
+	// embedded raw escape bytes ("abcdefghi\x1b[C\x1b[C") into the answer,
+	// which then failed url.Parse downstream. Arrow keys send VT100 escape
+	// sequences (ESC '[' 'C'/'D') on every platform, regardless of
+	// cooked/raw console mode, so they must be discarded rather than
+	// appended.
+	line, err := readLine(bufio.NewReader(strings.NewReader("abcdefghi\x1b[C\x1b[C\n")))
+
+	require.NoError(t, err)
+	assert.Equal(t, "abcdefghi", line)
+}
+
+func TestReadLine_EscapeSequenceMidLine(t *testing.T) {
+	line, err := readLine(bufio.NewReader(strings.NewReader("abc\x1b[Ddef\n")))
+
+	require.NoError(t, err)
+	assert.Equal(t, "abcdef", line)
+}
+
+func TestReadLine_BareEscapeKeypress(t *testing.T) {
+	// A bare Escape keypress (not part of a CSI sequence) has no '[' after
+	// it; that next byte must be pushed back and processed normally rather
+	// than silently swallowed.
+	line, err := readLine(bufio.NewReader(strings.NewReader("ab\x1bcd\n")))
+
+	require.NoError(t, err)
+	assert.Equal(t, "abcd", line)
+}
+
 func TestIsNonInteractive(t *testing.T) {
 	cases := map[string]bool{
 		"":      false,

--- a/internal/misc/reader/reader_test.go
+++ b/internal/misc/reader/reader_test.go
@@ -16,7 +16,6 @@ package reader
 
 import (
 	"bufio"
-	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -63,17 +62,15 @@ func TestReadLine_OnlyFirstLineConsumed(t *testing.T) {
 func TestReadLine_EOFWithoutNewline(t *testing.T) {
 	line, err := readLine(bufio.NewReader(strings.NewReader("no newline")))
 
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, io.EOF))
+	require.ErrorIs(t, err, io.EOF)
 	assert.Equal(t, "no newline", line)
 }
 
 func TestReadLine_EmptyInput(t *testing.T) {
 	line, err := readLine(bufio.NewReader(strings.NewReader("")))
 
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, io.EOF))
-	assert.Equal(t, "", line)
+	require.ErrorIs(t, err, io.EOF)
+	assert.Empty(t, line)
 }
 
 func TestIsNonInteractive(t *testing.T) {

--- a/internal/misc/reader/reader_test.go
+++ b/internal/misc/reader/reader_test.go
@@ -15,10 +15,66 @@
 package reader
 
 import (
+	"bufio"
+	"errors"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestReadLine_UnixNewline(t *testing.T) {
+	line, err := readLine(bufio.NewReader(strings.NewReader("yes\nrest")))
+
+	require.NoError(t, err)
+	assert.Equal(t, "yes", line)
+}
+
+func TestReadLine_BareCarriageReturn(t *testing.T) {
+	// Simulates Windows raw console-mode Enter, which delivers a bare '\r'
+	// with no paired '\n' (ENABLE_LINE_INPUT is off).
+	line, err := readLine(bufio.NewReader(strings.NewReader("yes\r")))
+
+	require.NoError(t, err)
+	assert.Equal(t, "yes", line)
+}
+
+func TestReadLine_WindowsCRLF(t *testing.T) {
+	line, err := readLine(bufio.NewReader(strings.NewReader("yes\r\nrest")))
+
+	require.NoError(t, err)
+	assert.Equal(t, "yes", line)
+}
+
+func TestReadLine_OnlyFirstLineConsumed(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("first\nsecond\n"))
+
+	line, err := readLine(r)
+	require.NoError(t, err)
+	assert.Equal(t, "first", line)
+
+	line, err = readLine(r)
+	require.NoError(t, err)
+	assert.Equal(t, "second", line)
+}
+
+func TestReadLine_EOFWithoutNewline(t *testing.T) {
+	line, err := readLine(bufio.NewReader(strings.NewReader("no newline")))
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, io.EOF))
+	assert.Equal(t, "no newline", line)
+}
+
+func TestReadLine_EmptyInput(t *testing.T) {
+	line, err := readLine(bufio.NewReader(strings.NewReader("")))
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, io.EOF))
+	assert.Equal(t, "", line)
+}
 
 func TestIsNonInteractive(t *testing.T) {
 	cases := map[string]bool{


### PR DESCRIPTION
# RATIONALE

<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->


`internal/misc/reader.ReadString()` (used by every `y/N` prompt and free-text prompt in the CLI, e.g. `dr auth set-url`) had a Windows-specific escape hatch: `if runtime.GOOS == "windows" { return bufio.NewReader(os.Stdin).ReadString('\n') }`.
That bypassed `cancelreader` entirely on Windows, which meant:

- Ctrl+C never canceled a pending prompt on Windows.
- Console echo/backspace handling was inconsistent, since Windows raw  console mode disables `ENABLE_ECHO_INPUT` and nothing was replacing it.
- Arrow keys / Home / End sent raw VT100 escape bytes (e.g. `ESC [ C`) that got appended straight into the answer, corrupting typed input (a URL like `abcdefghi\x1b[C\x1b[C` failing `url.Parse`).

Removing that bypass and routing Windows through `cancelreader` properly surfaced a second, unrelated problem: `cancelreader`'s Windows implementation special-cases stdin — if the reader you hand it has the same fd as the real `os.Stdin`, it silently discards your reader and opens the real console handle (`CONIN$`) instead. Our tests simulate input by reassigning the `os.Stdin` global to a pipe, which on Windows made `cancelreader` ignore that pipe and block on `WaitForMultipleObjects` forever, waiting for real keystrokes that never come on a headless CI runner — surfacing as a 10-minute test timeout panic in `cmd/plugin/install` and, separately, in `internal/auth` (`TestEnsureAuthenticated_NoURL`, which drives the interactive "choose your DataRobot URL" prompt with no stdin stubbed at all).

This PR is the accumulated fix for both the original garbled-input bug and the Windows CI hangs it exposed along the way.


## CHANGES
- **Rewrote line reading in `internal/misc/reader/reader.go`** to work correctly through `cancelreader` on every platform instead of bypassing it on Windows:
  - Reads byte-by-byte via a new `readLine()`, discarding Ctrl+C and VT100  escape sequences (arrow keys, Home/End, etc.) instead of appending them  to the answer.
  - Handles Windows raw console mode manually: echoes typed characters and  erases them on backspace, since `cancelreader` disables `ENABLE_ECHO_INPUT` on Windows and the console no longer does this for us.
  - Accepts a bare `\r` as a line ending (not just `\n`), since Windows raw console mode delivers Enter as a lone `\r` with `ENABLE_LINE_INPUT` off.
- **Fixed a `cancelreader` lifecycle bug**: `cr.Close()` was never called, leaking epoll/pipe fds on Linux/macOS and leaving the Windows console stuck in raw mode (no echo) after every prompt. Added the missing `defer cr.Close()`, and guarded the cancel goroutine so a normal (non-canceled) read doesn't also call `cr.Cancel()` on completion — `cancelreader` has no synchronization between `Cancel()` and `Close()`, and racing them made Windows skip console-mode restoration.
- **Added an injectable `reader.Stdin` seam** so tests can supply canned input without reassigning the global `os.Stdin`. Reassigning `os.Stdin` itself doesn't work on Windows: `cancelreader` compares the given reader's fd against `os.Stdin`'s fd and, when a test points `os.Stdin` at a pipe, the fds trivially match and `cancelreader` throws the pipe away in favor of reading from the real console — hanging forever on a headless runner. Overriding `reader.Stdin` instead leaves the real `os.Stdin` untouched, so `cancelreader` correctly falls back to reading from the injected pipe. 
- **Guarded `auth.SetURLAction()` behind `reader.IsStdinTerminal()`**, matching the non-interactive convention already used elsewhere in the CLI (`cmd/artifact/del`, `cmd/workload/del`, `cmd/plugin/discovery.go`). Without a terminal attached, the interactive "choose your DataRobot URL" prompt now fails fast with an actionable message instead of blocking indefinitely — fixing both the Windows CI hang and the underlying real-world case of `dr` running headless (CI, Docker, scripts) with no endpoint configured. Users running non-interactively already have `dr auth set-url <url>` or `DATAROBOT_ENDPOINT` for this.
- Also fixed a matching bug in the same function: the "no URL entered" break condition checked `url == "\n"`, which `readLine()` never returns (it strips the line ending); corrected to `url == ""`.
- Added `internal/misc/reader/reader_test.go` coverage for `readLine()`:  Unix `\n`, bare `\r`, `\r\n`, multiple sequential reads, EOF with and without a trailing newline, and escape-sequence handling (arrow keys mid-line and a bare Escape keypress that isn't part of a CSI sequence).

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all interactive CLI prompts via `ReadString`; fixes are localized but incorrect terminal handling would affect every stdin prompt on Windows and cancellation paths on all platforms.
> 
> **Overview**
> **Fixes interactive stdin on Windows** by using `cancelreader` everywhere again (reverting the CFX-4799 bypass) and addressing the real lifecycle bugs: **`defer cr.Close()`** so console mode is restored and fds are not leaked, and **only calling `cr.Cancel()` when a real SIGINT/SIGTERM was received** so a successful read does not race `Close()` and leave the terminal in raw mode.
> 
> **Replaces `bufio.Reader.ReadString('\n')` with a custom `readLine` path** tailored to `cancelreader`’s raw Windows console: treat `\r` or `\n` as end-of-line without CRLF lookahead (avoids hangs), **manual echo and backspace** on Windows only, map **Ctrl+C** to `cancelreader.ErrCanceled`, and **strip VT100/ANSI escape sequences** so arrow keys do not corrupt prompts (e.g. URLs). POSIX behavior stays largely unchanged because the tty still echoes.
> 
> Adds **unit tests** for `readLine` covering newlines/CRLF, EOF, escape discarding, and bare Escape handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b2c409e962ed9a04585b2081266d984901a2bc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->