### PR TITLE
[CFX-6919][CFX-7059] Add windows-latest to the unit-test CI matrix

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -100,8 +100,20 @@ jobs:
   test:
     needs: detect-changes
     if: needs.detect-changes.outputs.go_code == 'true'
-    runs-on: ubuntu-latest
-    name: Run Tests
+    # CFX-6919: run unit tests on Linux and Windows so runtime.GOOS=="windows"
+    # branches (and //go:build windows files) are exercised in CI. Windows uses
+    # a lighter run (no -race/coverage) to avoid the CGO/gcc dependency and keep
+    # runner cost down; fail-fast:false so one OS failing does not cancel the other.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            task: test
+          - os: windows-latest
+            task: test-windows
+    runs-on: ${{ matrix.os }}
+    name: Run Tests (${{ matrix.os }})
     timeout-minutes: 20
     permissions:
       contents: read
@@ -115,8 +127,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Run Golang Test Command
-        run: |
-          task test
+        run: task ${{ matrix.task }}
 
   copyright:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -29,6 +29,7 @@ jobs:
       go_code: ${{ steps.changes.outputs.go_code }}
       deps: ${{ steps.changes.outputs.deps }}
       install_sh: ${{ steps.changes.outputs.install_sh }}
+      test_config: ${{ steps.changes.outputs.test_config }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -59,6 +60,13 @@ jobs:
             install_sh:
               - 'install.sh'
               - 'smoke_test_scripts/run_install_integration_test.sh'
+            # Re-run the test job when the test tooling itself changes, so
+            # changes to CI config / Taskfile can be validated even on PRs that
+            # touch no Go files (CFX-6919).
+            test_config:
+              - 'Taskfile.yaml'
+              - '.github/workflows/pr-checks.yaml'
+              - '.github/actions/setup/**'
 
   lint:
     needs: detect-changes
@@ -99,7 +107,7 @@ jobs:
 
   test:
     needs: detect-changes
-    if: needs.detect-changes.outputs.go_code == 'true'
+    if: needs.detect-changes.outputs.go_code == 'true' || needs.detect-changes.outputs.test_config == 'true'
     # CFX-6919: run unit tests on Linux and Windows so runtime.GOOS=="windows"
     # branches (and //go:build windows files) are exercised in CI. Windows uses
     # a lighter run (no -race/coverage) to avoid the CGO/gcc dependency and keep

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -122,6 +122,11 @@ jobs:
             task: test-windows
     runs-on: ${{ matrix.os }}
     name: Run Tests (${{ matrix.os }})
+    # CFX-6919: the windows-latest leg is informational for now — it surfaces
+    # pre-existing Windows unit-test failures (tracked in CFX-7059) without
+    # blocking merges. Flip this off (make Windows required) once those are
+    # fixed. The ubuntu-latest leg stays blocking.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     timeout-minutes: 20
     permissions:
       contents: read

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -157,6 +157,12 @@ tasks:
     cmds:
       - go test -count=1 -race -shuffle=on ./...
 
+  test-windows:
+    silent: true
+    desc: "Run tests without race detector or coverage (Windows CI leg, CFX-6919)"
+    cmds:
+      - go test -count=1 -shuffle=on ./...
+
   test-coverage:
     silent: true
     desc: "Run tests with coverage rendered in HTML"

--- a/cmd/plugin/install/cmd_test.go
+++ b/cmd/plugin/install/cmd_test.go
@@ -46,6 +46,7 @@ const versionsYAMLWrongVersion = `echo-tool:
   install:
     macos: "echo install"
     linux: "echo install"
+    windows: "echo install"
 `
 
 // writePluginVersionsYAML creates a plugin dir under the managed plugins directory

--- a/cmd/self/completion/uninstall/cmd_test.go
+++ b/cmd/self/completion/uninstall/cmd_test.go
@@ -17,6 +17,7 @@ package uninstall
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -134,6 +135,13 @@ func TestGetUninstallPaths(t *testing.T) {
 	testHome := "/test/home"
 	testutil.SetTestHomeDir(t, testHome)
 
+	// On Windows, PowerShell has two profile locations (PowerShell Core and
+	// Windows PowerShell); other platforms have one.
+	powershellCount := 1
+	if runtime.GOOS == "windows" {
+		powershellCount = 2
+	}
+
 	tests := []struct {
 		name          string
 		shell         internalShell.Shell
@@ -156,12 +164,12 @@ func TestGetUninstallPaths(t *testing.T) {
 			name:          "fish paths",
 			shell:         internalShell.Fish,
 			expectedCount: 2,
-			checkPath:     ".config/fish",
+			checkPath:     filepath.Join(".config", "fish"),
 		},
 		{
 			name:          "powershell paths",
 			shell:         internalShell.PowerShell,
-			expectedCount: 1,
+			expectedCount: powershellCount,
 			checkPath:     "PowerShell",
 		},
 	}

--- a/cmd/templates/setup/loginModel_test.go
+++ b/cmd/templates/setup/loginModel_test.go
@@ -43,8 +43,7 @@ type LoginModelTestSuite struct {
 func (suite *LoginModelTestSuite) SetupTest() {
 	dir, _ := os.MkdirTemp("", "datarobot-config-test")
 	suite.tempDir = dir
-	suite.T().Setenv("HOME", suite.tempDir)
-	testutil.SetXDGEnv(suite.T(), "XDG_CONFIG_HOME", "")
+	testutil.SetTestHomeDir(suite.T(), suite.tempDir)
 
 	suite.configFile = filepath.Join(suite.tempDir, ".config/datarobot/drconfig.yaml")
 
@@ -77,7 +76,10 @@ func (suite *LoginModelTestSuite) WaitFor(tm *teatest.TestModel, contains string
 			return bytes.Contains(bts, []byte(contains))
 		},
 		teatest.WithCheckInterval(time.Millisecond*100),
-		teatest.WithDuration(time.Second*3),
+		// teatest's PTY rendering is markedly slower on Windows CI runners, so
+		// use a generous deadline. Healthy runs still return as soon as the
+		// awaited output appears, so non-Windows pays no penalty on success.
+		teatest.WithDuration(time.Second*10),
 	)
 }
 
@@ -95,8 +97,7 @@ func (suite *LoginModelTestSuite) AfterTest(suiteName, testName string) {
 
 	dir, _ := os.MkdirTemp("", "datarobot-config-test")
 	suite.tempDir = dir
-	suite.T().Setenv("HOME", suite.tempDir)
-	testutil.SetXDGEnv(suite.T(), "XDG_CONFIG_HOME", "")
+	testutil.SetTestHomeDir(suite.T(), suite.tempDir)
 
 	suite.configFile = filepath.Join(suite.tempDir, ".config/datarobot/drconfig.yaml")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,9 +108,15 @@ func CreateConfigFileDirIfNotExists() error {
 		return fmt.Errorf("Failed to create config file directory: %w", err)
 	}
 
-	_, err = os.Create(defaultConfigFilePath)
+	f, err := os.Create(defaultConfigFilePath)
 	if err != nil {
 		return fmt.Errorf("Failed to create config file: %w", err)
+	}
+
+	// Close the handle immediately. On Windows an open handle blocks the file
+	// from being removed (e.g. t.TempDir cleanup); POSIX silently tolerates it.
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("Failed to close config file: %w", err)
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,8 +39,9 @@ type ConfigTestSuite struct {
 func (suite *ConfigTestSuite) SetupTest() {
 	dir, _ := os.MkdirTemp("", "datarobot-config-test")
 	suite.tempDir = dir
-	suite.T().Setenv("HOME", suite.tempDir)
-	testutil.SetXDGEnv(suite.T(), "XDG_CONFIG_HOME", "")
+	// Sets HOME + USERPROFILE (Windows) and clears XDG_CONFIG_HOME so the
+	// config dir resolves under the temp dir on every platform.
+	testutil.SetTestHomeDir(suite.T(), suite.tempDir)
 }
 
 func (suite *ConfigTestSuite) TestCreateConfigFileDirIfNotExists() {

--- a/internal/dependencies/installer_test.go
+++ b/internal/dependencies/installer_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -342,6 +343,10 @@ func TestLastSuccessDepsCheck_UpdatedByInstallPrerequisites(t *testing.T) {
 // --- isPermissionDenied tests ---
 
 func TestIsPermissionDenied_ExitCode126(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exit code 126 is a POSIX-shell permission convention; not applicable on Windows")
+	}
+
 	assert.True(t, isPermissionDenied(126, ""))
 }
 

--- a/internal/dependencies/registry/registry_test.go
+++ b/internal/dependencies/registry/registry_test.go
@@ -17,6 +17,7 @@ package registry
 import (
 	"fmt"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -189,6 +190,10 @@ func TestDetectEnvironment_NVM_ViaEnvVar(t *testing.T) {
 }
 
 func TestDetectEnvironment_NVM_ViaHomeFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("relies on os.UserHomeDir honoring $HOME, which is POSIX-only")
+	}
+
 	t.Setenv("HOME", "/home/user")
 
 	dirExists := func(p string) bool { return p == "/home/user/.nvm" }

--- a/internal/envbuilder/discover_test.go
+++ b/internal/envbuilder/discover_test.go
@@ -135,8 +135,8 @@ func (suite *DiscoverTestSuite) TestDiscoverFindsFiles() {
 	suite.Require().NoError(err)
 
 	suite.Len(foundPaths, 2, "Expected to find 2 YAML files")
-	suite.Contains(foundPaths, suite.tempDir+"/.datarobot/parakeet.yaml")
-	suite.Contains(foundPaths, suite.tempDir+"/.datarobot/another_parakeet.yaml")
+	suite.Contains(foundPaths, filepath.Join(suite.tempDir, ".datarobot", "parakeet.yaml"))
+	suite.Contains(foundPaths, filepath.Join(suite.tempDir, ".datarobot", "another_parakeet.yaml"))
 }
 
 func (suite *DiscoverTestSuite) TestDiscoverFindsNestedFiles() {
@@ -165,9 +165,9 @@ func (suite *DiscoverTestSuite) TestDiscoverFindsNestedFiles() {
 	suite.Require().NoError(err)
 
 	suite.Len(foundPaths, 3, "Expected to find 3 YAML files")
-	suite.Contains(foundPaths, suite.tempDir+"/.datarobot/parakeet.yaml")
-	suite.Contains(foundPaths, suite.tempDir+"/.datarobot/another_parakeet.yaml")
-	suite.Contains(foundPaths, suite.tempDir+"/.datarobot/parakeet/yet_another_parakeet.yml")
+	suite.Contains(foundPaths, filepath.Join(suite.tempDir, ".datarobot", "parakeet.yaml"))
+	suite.Contains(foundPaths, filepath.Join(suite.tempDir, ".datarobot", "another_parakeet.yaml"))
+	suite.Contains(foundPaths, filepath.Join(suite.tempDir, ".datarobot", "parakeet", "yet_another_parakeet.yml"))
 }
 
 // Non-prompt YAML files (copier answers, versions.yaml, etc.) are now filtered

--- a/internal/plugin/dependencies_test.go
+++ b/internal/plugin/dependencies_test.go
@@ -47,6 +47,7 @@ const (
   install:
     macos: "echo install"
     linux: "echo install"
+    windows: "echo install"
 `
 )
 

--- a/internal/plugin/discover_test.go
+++ b/internal/plugin/discover_test.go
@@ -45,6 +45,20 @@ func createMockPlugin(t *testing.T, dir, name, manifestJSON string) string {
 	return writePluginManifestScript(t, dir, name, manifestJSON)
 }
 
+// setDiscoveryPath sets PATH to value for the test. On Windows the existing
+// PATH is appended so powershell.exe — used to run .ps1 plugins during
+// discovery — stays resolvable; on POSIX the value is used as-is to keep
+// discovery scoped to the controlled dirs (scripts run via their shebang).
+func setDiscoveryPath(t *testing.T, value string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		value += string(os.PathListSeparator) + os.Getenv("PATH")
+	}
+
+	t.Setenv("PATH", value)
+}
+
 // DiscoverTestSuite tests discovery functions with filesystem fixtures
 type DiscoverTestSuite struct {
 	suite.Suite
@@ -288,18 +302,20 @@ func (s *PathDirsTestSuite) TestCrossDirDeduplicationFirstDirWins() {
 	// Same manifest name in both dirs — dir1 must win because results are
 	// merged in directory order after all goroutines complete.
 	manifest := `{"name":"shared-plugin","version":"1.0.0","description":"Shared"}`
-	createMockPlugin(s.T(), s.dir1, "dr-shared", manifest)
-	createMockPlugin(s.T(), s.dir2, "dr-shared", manifest)
+	// createMockPlugin returns the actual script path, which carries a .ps1
+	// extension on Windows — assert against it rather than reconstructing.
+	exe1 := createMockPlugin(s.T(), s.dir1, "dr-shared", manifest)
+	exe2 := createMockPlugin(s.T(), s.dir2, "dr-shared", manifest)
 
 	plugins, conflicts := discoverPathDirsParallel(context.Background(), []string{s.dir1, s.dir2}, map[string]bool{})
 
 	s.Require().Len(plugins, 1)
 	s.Equal("shared-plugin", plugins[0].Manifest.Name)
-	s.Equal(filepath.Join(s.dir1, "dr-shared"), plugins[0].Executable)
+	s.Equal(exe1, plugins[0].Executable)
 
 	s.Require().Len(conflicts, 1, "the second dir's binary sharing the manifest name must be recorded as a conflict")
 	s.Equal("shared-plugin", conflicts[0].Name)
-	s.Equal(filepath.Join(s.dir2, "dr-shared"), conflicts[0].Path)
+	s.Equal(exe2, conflicts[0].Path)
 }
 
 func (s *PathDirsTestSuite) TestBaseSeenFiltersPlugins() {
@@ -508,7 +524,7 @@ func (s *DiscoverWithContextSuite) TearDownTest() {
 func (s *DiscoverWithContextSuite) TestDiscoversPATHPlugin() {
 	createMockPlugin(s.T(), s.pluginDir, "dr-ctx-alpha",
 		`{"name":"ctx-alpha","version":"1.0.0","description":"Alpha"}`)
-	s.T().Setenv("PATH", s.pluginDir)
+	setDiscoveryPath(s.T(), s.pluginDir)
 
 	plugins, _ := DiscoverPluginsWithContext(context.Background())
 
@@ -531,7 +547,7 @@ func (s *DiscoverWithContextSuite) TestPartialResultsOnTimeout() {
 	slowScript := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"%s\" ]; then\n  exec sleep 30\nfi\n", PluginManifestFlag)
 	createScript(s.T(), filepath.Join(slowDir, "dr-ctx-slow"), slowScript)
 
-	s.T().Setenv("PATH", s.pluginDir+string(os.PathListSeparator)+slowDir)
+	setDiscoveryPath(s.T(), s.pluginDir+string(os.PathListSeparator)+slowDir)
 
 	// 2 s gives the fast plugin plenty of time to respond; the slow plugin is
 	// killed by the per-manifest timeout (5 s set in SetupTest capped by the
@@ -551,7 +567,7 @@ func (s *DiscoverWithContextSuite) TestTimeoutLogsWarn() {
 	// which is the condition that triggers the WARN — no real-time dependency.
 	createMockPlugin(s.T(), s.pluginDir, "dr-ctx-warn",
 		`{"name":"ctx-warn","version":"1.0.0","description":"Warn"}`)
-	s.T().Setenv("PATH", s.pluginDir)
+	setDiscoveryPath(s.T(), s.pluginDir)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -567,7 +583,7 @@ func (s *DiscoverWithContextSuite) TestTimeoutLogsWarn() {
 func (s *DiscoverWithContextSuite) TestCancelledContextSkipsPATHPlugins() {
 	createMockPlugin(s.T(), s.pluginDir, "dr-ctx-skip",
 		`{"name":"ctx-skip","version":"1.0.0","description":"Skip"}`)
-	s.T().Setenv("PATH", s.pluginDir)
+	setDiscoveryPath(s.T(), s.pluginDir)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -582,7 +598,7 @@ func (s *DiscoverWithContextSuite) TestDuplicatePATHEntryDoesNotWarn() {
 		`{"name":"ctx-dup","version":"1.0.0","description":"Dup"}`)
 	// The same directory listed twice in PATH used to make discovery scan it
 	// twice, reporting a false conflict against itself.
-	s.T().Setenv("PATH", s.pluginDir+string(os.PathListSeparator)+s.pluginDir)
+	setDiscoveryPath(s.T(), s.pluginDir+string(os.PathListSeparator)+s.pluginDir)
 
 	plugins, conflicts := DiscoverPluginsWithContext(context.Background())
 

--- a/internal/plugin/exec_test.go
+++ b/internal/plugin/exec_test.go
@@ -84,32 +84,14 @@ func (s *ExecTestSuite) TestExecutePluginCommandNotFound() {
 }
 
 func (s *ExecTestSuite) TestExecutePluginWithArguments() {
-	// Create a script that uses arguments
-	script := `#!/bin/sh
-if [ "$1" = "expected" ] && [ "$2" = "args" ]; then
-  exit 0
-else
-  exit 1
-fi
-`
-	path := filepath.Join(s.tempDir, "with-args")
-	createScript(s.T(), path, script)
+	path := writeArgCheckScript(s.T(), s.tempDir, "with-args")
 
 	exitCode := ExecutePlugin(context.Background(), PluginManifest{}, path, []string{"expected", "args"}, nil)
 	s.Equal(0, exitCode)
 }
 
 func (s *ExecTestSuite) TestExecutePluginWithWrongArguments() {
-	// Create a script that uses arguments
-	script := `#!/bin/sh
-if [ "$1" = "expected" ] && [ "$2" = "args" ]; then
-  exit 0
-else
-  exit 1
-fi
-`
-	path := filepath.Join(s.tempDir, "with-args-fail")
-	createScript(s.T(), path, script)
+	path := writeArgCheckScript(s.T(), s.tempDir, "with-args-fail")
 
 	exitCode := ExecutePlugin(context.Background(), PluginManifest{}, path, []string{"wrong", "arguments"}, nil)
 	s.Equal(1, exitCode)
@@ -307,8 +289,7 @@ func TestExecutePluginCustomUserAgent(t *testing.T) {
 	os.Unsetenv("DATAROBOT_ENDPOINT")
 	os.Unsetenv("DATAROBOT_API_TOKEN")
 
-	scriptPath := filepath.Join(t.TempDir(), "test.sh")
-	createScript(t, scriptPath, "#!/bin/sh\nexit 0\n")
+	scriptPath := writeExitScript(t, t.TempDir(), "test", 0)
 
 	manifest := PluginManifest{
 		BasicPluginManifest: BasicPluginManifest{Name: "test-plugin", Version: "1.2.3", Authentication: true},
@@ -615,8 +596,7 @@ func TestExecutePluginSkipAuthBypassesAuthCheck(t *testing.T) {
 	os.Unsetenv("DATAROBOT_ENDPOINT")
 	os.Unsetenv("DATAROBOT_API_TOKEN")
 
-	scriptPath := filepath.Join(t.TempDir(), "skip-auth-test.sh")
-	createScript(t, scriptPath, "#!/bin/sh\nexit 0\n")
+	scriptPath := writeExitScript(t, t.TempDir(), "skip-auth-test", 0)
 
 	manifest := PluginManifest{
 		BasicPluginManifest: BasicPluginManifest{Name: "test-plugin", Version: "1.0.0", Authentication: true},
@@ -644,8 +624,7 @@ func TestExecutePluginAuthCalledWithoutSkipAuth(t *testing.T) {
 	os.Unsetenv("DATAROBOT_ENDPOINT")
 	os.Unsetenv("DATAROBOT_API_TOKEN")
 
-	scriptPath := filepath.Join(t.TempDir(), "no-skip-auth-test.sh")
-	createScript(t, scriptPath, "#!/bin/sh\nexit 0\n")
+	scriptPath := writeExitScript(t, t.TempDir(), "no-skip-auth-test", 0)
 
 	manifest := PluginManifest{
 		BasicPluginManifest: BasicPluginManifest{Name: "test-plugin", Version: "1.0.0", Authentication: true},

--- a/internal/plugin/paths_test.go
+++ b/internal/plugin/paths_test.go
@@ -26,7 +26,9 @@ import (
 
 func TestManagedPluginsDir(t *testing.T) {
 	t.Run("respects XDG_CONFIG_HOME", func(t *testing.T) {
-		testConfigHome := "/custom/config"
+		// Use an absolute temp dir: adrg/xdg discards a non-absolute
+		// XDG_CONFIG_HOME, and "/custom/config" is not absolute on Windows.
+		testConfigHome := t.TempDir()
 		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", testConfigHome)
 
 		dir, err := ManagedPluginsDir()
@@ -52,8 +54,7 @@ func TestManagedPluginsDirs(t *testing.T) {
 	t.Run("returns only primary dir when XDG_CONFIG_DIRS is not set", func(t *testing.T) {
 		tmpHome := t.TempDir()
 
-		t.Setenv("HOME", tmpHome)
-		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", "")
+		testutil.SetTestHomeDir(t, tmpHome)
 		testutil.SetXDGEnv(t, "XDG_CONFIG_DIRS", "")
 
 		dirs, err := ManagedPluginsDirs()
@@ -102,8 +103,7 @@ func TestManagedPluginsDirs(t *testing.T) {
 		tmpHome := t.TempDir()
 		tmpConfigDir := t.TempDir()
 
-		t.Setenv("HOME", tmpHome)
-		testutil.SetXDGEnv(t, "XDG_CONFIG_HOME", "")
+		testutil.SetTestHomeDir(t, tmpHome)
 		testutil.SetXDGEnv(t, "XDG_CONFIG_DIRS", tmpConfigDir)
 
 		dirs, err := ManagedPluginsDirs()

--- a/internal/plugin/testhelpers_test.go
+++ b/internal/plugin/testhelpers_test.go
@@ -52,13 +52,41 @@ func writePluginManifestScript(t *testing.T, dir, name, manifestJSON string) str
 	return scriptPath
 }
 
-// writeExitScript creates a Unix shell script that exits with the given code.
-// Returns the script path.
+// writeExitScript creates a cross-platform script that exits with the given
+// code. On Windows it emits a .ps1 (which buildPluginCommand wraps in
+// PowerShell); elsewhere a POSIX shell script. Returns the script path.
 func writeExitScript(t *testing.T, dir, name string, exitCode int) string {
 	t.Helper()
 
-	script := fmt.Sprintf("#!/bin/sh\nexit %d\n", exitCode)
-	path := filepath.Join(dir, name)
+	var path, script string
+
+	if runtime.GOOS == "windows" {
+		path = filepath.Join(dir, name+".ps1")
+		script = fmt.Sprintf("exit %d\n", exitCode)
+	} else {
+		path = filepath.Join(dir, name)
+		script = fmt.Sprintf("#!/bin/sh\nexit %d\n", exitCode)
+	}
+
+	createScript(t, path, script)
+
+	return path
+}
+
+// writeArgCheckScript creates a cross-platform script that exits 0 iff its
+// first two args are exactly "expected" "args", else 1. Returns the script path.
+func writeArgCheckScript(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	var path, script string
+
+	if runtime.GOOS == "windows" {
+		path = filepath.Join(dir, name+".ps1")
+		script = "if ($args[0] -eq 'expected' -and $args[1] -eq 'args') { exit 0 } else { exit 1 }\n"
+	} else {
+		path = filepath.Join(dir, name)
+		script = "#!/bin/sh\nif [ \"$1\" = \"expected\" ] && [ \"$2\" = \"args\" ]; then\n  exit 0\nelse\n  exit 1\nfi\n"
+	}
 
 	createScript(t, path, script)
 

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -90,6 +90,13 @@ func DetectShell() (string, error) {
 		return normalizeShellName(filepath.Base(shellPath)), nil
 	}
 
+	// On Windows, $SHELL is a Unix convention and is normally unset, and the
+	// parent process is often a non-shell (e.g. the installer). Default to
+	// PowerShell, which the CLI fully supports, rather than failing detection.
+	if runtime.GOOS == "windows" {
+		return string(PowerShell), nil
+	}
+
 	return "", errors.New("Could not detect shell. Please set SHELL environment variable")
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -209,6 +209,11 @@ func HasCompletedDotenvSetup(repoRoot string) bool {
 		return false
 	}
 
+	// Treat a timestamp that is not in the future as "completed". Using a strict
+	// Before(now) is fragile: the stored time comes from time.Now().UTC() (which
+	// strips the monotonic reading), so a write-then-read within a single coarse
+	// wall-clock tick — observed on Windows CI — would otherwise read as
+	// not-completed. !After(now) still rejects future timestamps (clock skew).
 	return existingState.LastDotenvSetup != nil &&
-		existingState.LastDotenvSetup.Before(time.Now())
+		!existingState.LastDotenvSetup.After(time.Now())
 }

--- a/internal/telemetry/userid_test.go
+++ b/internal/telemetry/userid_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/datarobot/cli/internal/config"
@@ -105,6 +106,11 @@ func TestRetrieveAccountInfo_FilePermissions(t *testing.T) {
 	info, err := os.Stat(cachePath)
 
 	require.NoError(t, err)
+
+	if runtime.GOOS == "windows" {
+		return // Unix permission bits are not enforced on Windows.
+	}
+
 	assert.Equal(t, os.FileMode(0o600), info.Mode()&os.ModePerm)
 }
 

--- a/internal/workload/wapi/atomic_test.go
+++ b/internal/workload/wapi/atomic_test.go
@@ -17,6 +17,7 @@ package wapi
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,7 +37,11 @@ func TestAtomicWriteFile_CreatesNew(t *testing.T) {
 
 	info, err := os.Stat(target)
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+
+	if runtime.GOOS != "windows" {
+		// Windows does not enforce Unix permission bits.
+		assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+	}
 }
 
 func TestAtomicWriteFile_OverwritesExisting(t *testing.T) {


### PR DESCRIPTION
# RATIONALE

CI ran `task test` only on `ubuntu-latest`, so `runtime.GOOS == "windows"` unit-test branches and `//go:build windows` files never executed on real Windows — the blind spot that let the CFX-6918 PowerShell plugin bug ship undetected. This adds a `windows-latest` unit-test leg and fixes every failure it surfaced.

Tracks https://datarobot.atlassian.net/browse/CFX-6919 (CI matrix) and https://datarobot.atlassian.net/browse/CFX-7059 (the Windows test fixes), both under epic CFX-6916.

## CHANGES

**CI matrix (CFX-6919)**
- `.github/workflows/pr-checks.yaml`: `test` job is now an OS matrix (`ubuntu-latest` + `windows-latest`, `fail-fast: false`), command selected per-OS via `matrix.task`.
- New `test_config` path filter so the job runs when the test tooling itself changes (Taskfile / workflow / setup action) — lets CI-only PRs validate the matrix.
- `Taskfile.yaml`: new `task test-windows` (`go test -count=1 -shuffle=on ./...`, no `-race`/coverage) to avoid the CGO/gcc dependency and cut runner cost.
- The `windows-latest` leg is currently `continue-on-error` (informational). Now that it is **green**, it can be flipped to required in a follow-up.

**Windows test/robustness fixes (CFX-7059)** — 3 real cross-platform production fixes + test-only cleanups:
- `internal/config/config.go`: close the leaked `os.Create` handle (Windows temp-cleanup lock; a resource leak on every platform).
- `internal/shell/shell.go`: `DetectShell` defaults to PowerShell on Windows instead of erroring (real `dr completion install` gap).
- `internal/state/state.go`: `HasCompletedDotenvSetup` tolerates coarse Windows wall clocks (`!After(now)` instead of strict `Before`).
- Test-only: `.ps1` test helpers, `testutil.SetTestHomeDir` (HOME+USERPROFILE), `filepath.Join` expectations, PATH preservation for `powershell.exe`, Unix perm-bit guards, POSIX-only skips, teatest timeout bump, Windows install-key fixtures.

## STATUS

- ✅ `Run Tests (ubuntu-latest)` and `Run Tests (windows-latest)` both green.
- This branch temporarily includes the CFX-6918 plugin fix (cherry-pick) because the plugin discovery/manifest tests depend on it. CFX-6918 is being reviewed independently in #698; once #698 merges, this branch will be rebased onto `main` and the duplicate commit drops out automatically.

## TESTING

- Both matrix legs pass in CI (14 previously-failing Windows packages now green).
- Locally: `task test` / `task test-windows` / `task lint` all clean.

> [!IMPORTANT]
> **Branch-protection update.** The required check name changed from `Run Tests` to `Run Tests (ubuntu-latest)` / `Run Tests (windows-latest)`. A repo admin should require `Run Tests (ubuntu-latest)` on `main` (leave the Windows leg non-required while it is `continue-on-error`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shell detection, dotenv setup state, and config file creation used on every platform; CI-only risk is low but admins must update required check names to `Run Tests (ubuntu-latest)`.
> 
> **Overview**
> Adds **real Windows coverage in PR CI** and fixes production/test gaps that only showed up there.
> 
> **CI:** The `test` job is now a **ubuntu-latest + windows-latest** matrix (`fail-fast: false`). Linux runs `task test`; Windows runs new **`task test-windows`** (no `-race`/coverage). A **`test_config`** path filter runs tests when Taskfile/workflow/setup change, even without `.go` edits. **`windows-latest` is `continue-on-error`** until branch protection is updated; Linux stays blocking.
> 
> **Runtime fixes:** **`CreateConfigFileDirIfNotExists`** closes the config file after create (Windows temp cleanup). **`DetectShell`** defaults to **PowerShell** on Windows when `$SHELL` is unset. **`HasCompletedDotenvSetup`** uses **`!After(now)`** instead of strict `Before` to handle coarse Windows wall clocks after UTC round-trip.
> 
> **Tests:** Cross-platform helpers (`.ps1` scripts, **`setDiscoveryPath`**, **`SetTestHomeDir`**), `filepath.Join` expectations, Windows install keys in fixtures, POSIX-only skips, and permission-bit guards so the suite passes on both OSes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8816e46245ba661174f738cd58b6434e4e751b2d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->