### PR TITLE
[CFX-6985] Add description and context size to dr llm-gateway list

### DIFF
--- a/cmd/llm-gateway/list/cmd.go
+++ b/cmd/llm-gateway/list/cmd.go
@@ -112,6 +112,16 @@ func terminalWidth() int {
 	return w
 }
 
+// formatContextSize renders a context-window size for the table. A zero or
+// missing value shows as "-" so it reads as unknown, not a real zero-token limit.
+func formatContextSize(n int) string {
+	if n <= 0 {
+		return "-"
+	}
+
+	return strconv.Itoa(n)
+}
+
 func printLLMTable(llms []drapi.LLM, selectedID string) {
 	fmt.Println(tui.SubTitleStyle.Render("LLM Gateway Models"))
 
@@ -146,7 +156,7 @@ func printLLMTable(llms []drapi.LLM, selectedID string) {
 			id = "* " + l.LlmID
 		}
 
-		t.Row(id, l.Name, l.Provider, l.Model, strconv.Itoa(l.ContextSize))
+		t.Row(id, l.Name, l.Provider, l.Model, formatContextSize(l.ContextSize))
 	}
 
 	rendered := t.Render()

--- a/cmd/llm-gateway/list/cmd.go
+++ b/cmd/llm-gateway/list/cmd.go
@@ -17,6 +17,7 @@ package list
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
@@ -33,11 +34,13 @@ import (
 
 // LLMOutput is the JSON representation of an LLM for --output-format json.
 type LLMOutput struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Provider string `json:"provider"`
-	Model    string `json:"model"`
-	Selected bool   `json:"selected"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Provider    string `json:"provider"`
+	Model       string `json:"model"`
+	Description string `json:"description"`
+	ContextSize int    `json:"context_size"`
+	Selected    bool   `json:"selected"`
 }
 
 func Cmd() *cobra.Command {
@@ -87,11 +90,13 @@ func toLLMOutputs(llms []drapi.LLM, selectedID string) []LLMOutput {
 
 	for i, l := range llms {
 		outputs[i] = LLMOutput{
-			ID:       l.LlmID,
-			Name:     l.Name,
-			Provider: l.Provider,
-			Model:    l.Model,
-			Selected: l.LlmID == selectedID,
+			ID:          l.LlmID,
+			Name:        l.Name,
+			Provider:    l.Provider,
+			Model:       l.Model,
+			Description: l.Description,
+			ContextSize: l.ContextSize,
+			Selected:    l.LlmID == selectedID,
 		}
 	}
 
@@ -133,7 +138,7 @@ func printLLMTable(llms []drapi.LLM, selectedID string) {
 				return dimStyle
 			}
 		}).
-		Headers("ID", "NAME", "PROVIDER", "MODEL")
+		Headers("ID", "NAME", "PROVIDER", "MODEL", "CONTEXT")
 
 	for _, l := range llms {
 		id := "  " + l.LlmID
@@ -141,7 +146,7 @@ func printLLMTable(llms []drapi.LLM, selectedID string) {
 			id = "* " + l.LlmID
 		}
 
-		t.Row(id, l.Name, l.Provider, l.Model)
+		t.Row(id, l.Name, l.Provider, l.Model, strconv.Itoa(l.ContextSize))
 	}
 
 	rendered := t.Render()

--- a/cmd/llm-gateway/list/cmd_test.go
+++ b/cmd/llm-gateway/list/cmd_test.go
@@ -33,8 +33,8 @@ import (
 )
 
 var testLLMs = []drapi.LLM{
-	{LlmID: "llm-001", Name: "GPT-4o", Provider: "azure", Model: "gpt-4o", IsActive: true},
-	{LlmID: "llm-002", Name: "Claude 3.5", Provider: "anthropic", Model: "claude-3-5-sonnet", IsActive: true},
+	{LlmID: "llm-001", Name: "GPT-4o", Provider: "azure", Model: "gpt-4o", IsActive: true, Description: "flagship multimodal model", ContextSize: 128000},
+	{LlmID: "llm-002", Name: "Claude 3.5", Provider: "anthropic", Model: "claude-3-5-sonnet", IsActive: true, Description: "balanced reasoning model", ContextSize: 200000},
 }
 
 // setupLLMServer starts an httptest.Server serving a fixed LLM catalog and wires viperx config.
@@ -106,6 +106,8 @@ func TestToLLMOutputs_Basic(t *testing.T) {
 	assert.Equal(t, "GPT-4o", outputs[0].Name)
 	assert.Equal(t, "azure", outputs[0].Provider)
 	assert.Equal(t, "gpt-4o", outputs[0].Model)
+	assert.Equal(t, "flagship multimodal model", outputs[0].Description)
+	assert.Equal(t, 128000, outputs[0].ContextSize)
 	assert.False(t, outputs[0].Selected)
 	assert.False(t, outputs[1].Selected)
 }
@@ -141,6 +143,20 @@ func TestPrintLLMTable_NoneSelected(t *testing.T) {
 	assert.NotContains(t, out, "* ")
 	assert.Contains(t, out, "  llm-001")
 	assert.Contains(t, out, "  llm-002")
+}
+
+// The table shows a CONTEXT column but deliberately omits description
+// (it wraps into unreadable multi-line rows across a large catalog).
+func TestPrintLLMTable_ContextColumnNoDescription(t *testing.T) {
+	out := captureStdout(t, func() {
+		printLLMTable(testLLMs, "")
+	})
+
+	assert.Contains(t, out, "CONTEXT")
+	assert.Contains(t, out, "128000")
+	assert.Contains(t, out, "200000")
+	assert.NotContains(t, out, "flagship multimodal model")
+	assert.NotContains(t, out, "balanced reasoning model")
 }
 
 // --- full command ---
@@ -192,8 +208,13 @@ func TestListCmd_JSONOutput(t *testing.T) {
 	require.Len(t, envelope.LLMs, 2)
 	assert.Equal(t, "llm-001", envelope.LLMs[0].ID)
 	assert.Equal(t, "llm-002", envelope.LLMs[1].ID)
+	assert.Equal(t, "flagship multimodal model", envelope.LLMs[0].Description)
+	assert.Equal(t, 128000, envelope.LLMs[0].ContextSize)
 	assert.False(t, envelope.LLMs[0].Selected)
 	assert.False(t, envelope.LLMs[1].Selected)
+
+	// Lock the wire key as snake_case: the contract CFX-6981 consumes.
+	assert.Contains(t, out, `"context_size"`)
 }
 
 func TestListCmd_JSONOutput_SelectedField(t *testing.T) {

--- a/cmd/llm-gateway/list/cmd_test.go
+++ b/cmd/llm-gateway/list/cmd_test.go
@@ -159,6 +159,12 @@ func TestPrintLLMTable_ContextColumnNoDescription(t *testing.T) {
 	assert.NotContains(t, out, "balanced reasoning model")
 }
 
+func TestFormatContextSize(t *testing.T) {
+	assert.Equal(t, "128000", formatContextSize(128000))
+	assert.Equal(t, "-", formatContextSize(0))
+	assert.Equal(t, "-", formatContextSize(-1))
+}
+
 // --- full command ---
 
 func TestListCmd_TableOutput(t *testing.T) {

--- a/docs/commands/llm-gateway.md
+++ b/docs/commands/llm-gateway.md
@@ -41,18 +41,21 @@ dr llm ls               # shortest alias
 | `NAME`     | Human-readable model name.                       |
 | `PROVIDER` | Provider (e.g. `azure`, `anthropic`, `google`).  |
 | `MODEL`    | Underlying model identifier.                     |
+| `CONTEXT`  | Context-window size in tokens. `-` when the catalog does not report it. |
 
-The table width is content-driven and capped at the terminal width to prevent overflow.
+The table width is content-driven and capped at the terminal width to prevent overflow. `description` is omitted from the table (it is long enough to wrap unreadably across a full catalog) and appears in JSON output only.
 
 **JSON output** (`--output-format json`) returns an envelope with a `llms` array. Each entry includes:
 
 ```json
 {
-  "id":       "llm-abc123",
-  "name":     "GPT-4o",
-  "provider": "azure",
-  "model":    "gpt-4o",
-  "selected": true
+  "id":           "llm-abc123",
+  "name":         "GPT-4o",
+  "provider":     "azure",
+  "model":        "gpt-4o",
+  "description":  "OpenAI's flagship multimodal model.",
+  "context_size": 128000,
+  "selected":     true
 }
 ```
 

--- a/internal/drapi/llms.go
+++ b/internal/drapi/llms.go
@@ -25,10 +25,11 @@ type LLM struct {
 	IsActive bool   `json:"isActive"`
 	Model    string `json:"model"`
 
+	Description string `json:"description"`
+	ContextSize int    `json:"contextSize"`
+
 	//Version              string   `json:"version"`
-	//Description          string   `json:"description"`
 	//Creator              string   `json:"creator"`
-	//ContextSize          int      `json:"contextSize"`
 	//MaxCompletionTokens  int      `json:"maxCompletionTokens"`
 	//Capabilities         []string `json:"capabilities"`
 	//SupportedLanguages   []string `json:"supportedLanguages"`


### PR DESCRIPTION
# RATIONALE

The LLM Gateway catalog API already returns each model's `description` and context-window size, but `dr llm-gateway list` dropped both. AI coding agents (and the agent-assist skill, via CFX-6981) need those two fields to pick an appropriate model for an agent spec. This surfaces them.

## CHANGES

- `dr llm-gateway list --output-format json` now includes `description` and `context_size` for every model.
- The text table gains a `CONTEXT` column (context-window size in tokens). A model the catalog does not report a size for shows `-` rather than a misleading `0`.
- `description` stays JSON-only. It is long enough to wrap unreadably across a full catalog, and the machine consumer reads JSON anyway.
- Both fields were already on the wire from `/api/v2/genai/llmgw/catalog/` and silently discarded. This activates them, no transport change.

Technical breakdown:

- `internal/drapi/llms.go`: activate `Description` and `ContextSize` on the `LLM` struct (they were commented out; the API returns them as `description` / `contextSize`).
- `cmd/llm-gateway/list/cmd.go`: add both to the JSON output struct (`context_size`, snake_case per the CLI's output convention). Add the `CONTEXT` table column via a `formatContextSize` helper that renders `-` for zero or missing.
- `docs/commands/llm-gateway.md`: document the `CONTEXT` column and the two new JSON fields.
- `cmd/llm-gateway/list/cmd_test.go`: assert the JSON carries both fields and the `context_size` key, assert the table shows `CONTEXT` and omits `description`, plus a unit test for `formatContextSize`.

Verified by running the built binary against the live catalog (65 models): table renders the `CONTEXT` column, JSON carries both fields. Full `task test` and golangci-lint pass.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI output and API struct fields only; no auth, transport, or behavior changes beyond displaying existing catalog data.
> 
> **Overview**
> **`dr llm-gateway list`** now surfaces catalog **description** and **context-window size** that the API already returned but the CLI ignored.
> 
> JSON output (`--output-format json`) adds **`description`** and **`context_size`** (snake_case) on each model entry for downstream consumers (e.g. agent-assist). The text table adds a **`CONTEXT`** column with token counts; missing or zero sizes render as **`-`** via `formatContextSize`, not `0`. **Description stays JSON-only** so wide catalogs do not get unreadable wrapped rows.
> 
> `internal/drapi/llms.go` unmarshals **`Description`** and **`ContextSize`** from the catalog payload. Docs and tests cover the new column, JSON fields, and the `context_size` wire key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c05fbe27dec416233f91040c31e6c9e83bdbace. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->