### PR TITLE
[CFX-6984] Include DataRobot-deployed LLMs in dr llm-gateway list and select

### DIFF
--- a/cmd/llm-gateway/list/cmd.go
+++ b/cmd/llm-gateway/list/cmd.go
@@ -54,7 +54,7 @@ func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "list",
 		Aliases:      []string{"ls"},
-		Short:        "List available LLM Gateway models",
+		Short:        "List available LLMs",
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		PreRunE:      auth.EnsureAuthenticatedE,

--- a/cmd/llm-gateway/list/cmd.go
+++ b/cmd/llm-gateway/list/cmd.go
@@ -33,14 +33,19 @@ import (
 )
 
 // LLMOutput is the JSON representation of an LLM for --output-format json.
+// Source discriminates gateway catalog models from DataRobot-deployed LLMs;
+// DeploymentID is set only for deployed entries and is what downstream tooling
+// uses to write the deployed-model .env keys.
 type LLMOutput struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Provider    string `json:"provider"`
-	Model       string `json:"model"`
-	Description string `json:"description"`
-	ContextSize int    `json:"context_size"`
-	Selected    bool   `json:"selected"`
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Source       string `json:"source"`
+	Provider     string `json:"provider"`
+	Model        string `json:"model"`
+	Description  string `json:"description"`
+	ContextSize  int    `json:"context_size"`
+	DeploymentID string `json:"deployment_id"`
+	Selected     bool   `json:"selected"`
 }
 
 func Cmd() *cobra.Command {
@@ -54,7 +59,7 @@ func Cmd() *cobra.Command {
 		SilenceUsage: true,
 		PreRunE:      auth.EnsureAuthenticatedE,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			llmList, err := drapi.GetLLMs()
+			llmList, err := drapi.GetLLMsAndDeployed()
 			if err != nil {
 				return err
 			}
@@ -90,13 +95,15 @@ func toLLMOutputs(llms []drapi.LLM, selectedID string) []LLMOutput {
 
 	for i, l := range llms {
 		outputs[i] = LLMOutput{
-			ID:          l.LlmID,
-			Name:        l.Name,
-			Provider:    l.Provider,
-			Model:       l.Model,
-			Description: l.Description,
-			ContextSize: l.ContextSize,
-			Selected:    l.LlmID == selectedID,
+			ID:           l.LlmID,
+			Name:         l.Name,
+			Source:       l.Kind,
+			Provider:     l.Provider,
+			Model:        l.Model,
+			Description:  l.Description,
+			ContextSize:  l.ContextSize,
+			DeploymentID: l.DeploymentID,
+			Selected:     l.LlmID == selectedID,
 		}
 	}
 
@@ -123,7 +130,7 @@ func formatContextSize(n int) string {
 }
 
 func printLLMTable(llms []drapi.LLM, selectedID string) {
-	fmt.Println(tui.SubTitleStyle.Render("LLM Gateway Models"))
+	fmt.Println(tui.SubTitleStyle.Render("Available LLMs"))
 
 	idStyle := tui.BaseTextStyle.
 		Foreground(tui.GetAdaptiveColor(tui.DrPurple, tui.DrPurpleDark)).
@@ -148,7 +155,7 @@ func printLLMTable(llms []drapi.LLM, selectedID string) {
 				return dimStyle
 			}
 		}).
-		Headers("ID", "NAME", "PROVIDER", "MODEL", "CONTEXT")
+		Headers("ID", "NAME", "SOURCE", "PROVIDER", "MODEL", "CONTEXT")
 
 	for _, l := range llms {
 		id := "  " + l.LlmID
@@ -156,7 +163,15 @@ func printLLMTable(llms []drapi.LLM, selectedID string) {
 			id = "* " + l.LlmID
 		}
 
-		t.Row(id, l.Name, l.Provider, l.Model, formatContextSize(l.ContextSize))
+		// Deployed rows carry no provider and only the litellm sentinel model;
+		// both are noise in the table (the SOURCE column already says
+		// "deployed"), so show "-" and keep the sentinel in JSON output only.
+		provider, model := l.Provider, l.Model
+		if l.Kind == drapi.LLMKindDeployed {
+			provider, model = "-", "-"
+		}
+
+		t.Row(id, l.Name, l.Kind, provider, model, formatContextSize(l.ContextSize))
 	}
 
 	rendered := t.Render()

--- a/cmd/llm-gateway/list/cmd_test.go
+++ b/cmd/llm-gateway/list/cmd_test.go
@@ -37,6 +37,14 @@ var testLLMs = []drapi.LLM{
 	{LlmID: "llm-002", Name: "Claude 3.5", Provider: "anthropic", Model: "claude-3-5-sonnet", IsActive: true, Description: "balanced reasoning model", ContextSize: 200000},
 }
 
+// testMixedLLMs pairs a gateway model with a deployed LLM. The deployed row
+// carries no provider/context and the litellm sentinel model; its LlmID is the
+// deployment id.
+var testMixedLLMs = []drapi.LLM{
+	{LlmID: "llm-001", Name: "GPT-4o", Provider: "azure", Model: "gpt-4o", IsActive: true, ContextSize: 128000, Kind: drapi.LLMKindGateway},
+	{LlmID: "6650f0aa11bb22cc33dd44ee", Name: "Support RAG LLM", Model: "datarobot/datarobot-deployed-llm", IsActive: true, Kind: drapi.LLMKindDeployed, DeploymentID: "6650f0aa11bb22cc33dd44ee"},
+}
+
 // setupLLMServer starts an httptest.Server serving a fixed LLM catalog and wires viperx config.
 func setupLLMServer(t *testing.T, llms []drapi.LLM) {
 	t.Helper()
@@ -261,4 +269,46 @@ func TestListCmd_APIError(t *testing.T) {
 
 	err := root.Execute()
 	assert.Error(t, err)
+}
+
+// --- deployed-LLM union ---
+
+func TestToLLMOutputs_DeployedFields(t *testing.T) {
+	outputs := toLLMOutputs(testMixedLLMs, "")
+
+	require.Len(t, outputs, 2)
+
+	assert.Equal(t, "gateway", outputs[0].Source)
+	assert.Empty(t, outputs[0].DeploymentID)
+
+	assert.Equal(t, "deployed", outputs[1].Source)
+	assert.Equal(t, "6650f0aa11bb22cc33dd44ee", outputs[1].ID)
+	assert.Equal(t, "6650f0aa11bb22cc33dd44ee", outputs[1].DeploymentID)
+	assert.Equal(t, "datarobot/datarobot-deployed-llm", outputs[1].Model)
+}
+
+// TestToLLMOutputs_DeployedJSONKeys locks the wire contract CFX-6980 consumes:
+// snake_case source + deployment_id present on every entry.
+func TestToLLMOutputs_DeployedJSONKeys(t *testing.T) {
+	data, err := json.Marshal(toLLMOutputs(testMixedLLMs, ""))
+	require.NoError(t, err)
+
+	out := string(data)
+	assert.Contains(t, out, `"source":"gateway"`)
+	assert.Contains(t, out, `"source":"deployed"`)
+	assert.Contains(t, out, `"deployment_id":"6650f0aa11bb22cc33dd44ee"`)
+}
+
+func TestPrintLLMTable_DeployedRow(t *testing.T) {
+	out := captureStdout(t, func() {
+		printLLMTable(testMixedLLMs, "")
+	})
+
+	// SOURCE column carries the kind, and the deployed row shows its label + id.
+	assert.Contains(t, out, "deployed")
+	assert.Contains(t, out, "Support RAG LLM")
+	assert.Contains(t, out, "6650f0aa11bb22cc33dd44ee")
+
+	// The sentinel model is blanked to "-" in the table (JSON-only contract).
+	assert.NotContains(t, out, "datarobot/datarobot-deployed-llm")
 }

--- a/cmd/llm-gateway/select/cmd.go
+++ b/cmd/llm-gateway/select/cmd.go
@@ -17,6 +17,7 @@ package selectcmd
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/internal/auth"
@@ -50,6 +51,13 @@ func Cmd() *cobra.Command {
 			}
 
 			if err != nil {
+				// One source may have failed while the other returned a partial
+				// list. Surface that so a "not found" isn't blamed on the user
+				// when the model is really just missing from an unreachable source.
+				if len(llmList.Warnings) > 0 {
+					return fmt.Errorf("%w (%s)", err, strings.Join(llmList.Warnings, "; "))
+				}
+
 				return err
 			}
 

--- a/cmd/llm-gateway/select/cmd.go
+++ b/cmd/llm-gateway/select/cmd.go
@@ -31,12 +31,12 @@ import (
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "select [llm-id]",
-		Short:        "Set the default LLM Gateway model",
+		Short:        "Set the default LLM",
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		PreRunE:      auth.EnsureAuthenticatedE,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			llmList, err := drapi.GetLLMs()
+			llmList, err := drapi.GetLLMsAndDeployed()
 			if err != nil {
 				return err
 			}
@@ -81,12 +81,12 @@ func findByID(llms []drapi.LLM, id string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("LLM %q not found in the active catalog", id)
+	return "", fmt.Errorf("LLM %q not found", id)
 }
 
 func runPicker(llms []drapi.LLM) (string, error) {
 	if len(llms) == 0 {
-		return "", errors.New("no active LLMs available in the LLM Gateway catalog")
+		return "", errors.New("no active LLMs available")
 	}
 
 	m := NewPickerModel(llms)

--- a/cmd/llm-gateway/select/cmd_test.go
+++ b/cmd/llm-gateway/select/cmd_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/datarobot/cli/internal/config"
@@ -120,15 +121,47 @@ func TestSelectCmd_DirectArg_Valid(t *testing.T) {
 }
 
 func TestSelectCmd_DirectArg_Invalid(t *testing.T) {
-	// setupLLMServer serves catalog-shaped JSON on every path, so the deployed
-	// source fails to decode. That partial-failure state is what triggers the
-	// error enrichment, so the message names both the id and the dead source.
 	setupLLMServer(t, testLLMs)
 
 	cmd, _ := newTestCmd(t)
 	cmd.SetArgs([]string{"not-a-real-llm"})
 
 	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not-a-real-llm")
+}
+
+// TestSelectCmd_InvalidID_PartialFailure routes the two sources independently:
+// the catalog answers, the deployments endpoint 500s. The deployed-source
+// failure is explicit (not an incidental decode error), so an unknown id errors
+// with both the id and the unavailable-source note.
+func TestSelectCmd_InvalidID_PartialFailure(t *testing.T) {
+	body, err := json.Marshal(drapi.LLMList{LLMs: testLLMs, Count: len(testLLMs), TotalCount: len(testLLMs)})
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/deployments") {
+			http.Error(w, "boom", http.StatusInternalServerError)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+
+	t.Cleanup(func() {
+		srv.Close()
+		viperx.Reset()
+	})
+
+	viperx.Set(config.DataRobotURL, srv.URL+"/api/v2")
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+
+	cmd, _ := newTestCmd(t)
+	cmd.SetArgs([]string{"not-a-real-llm"})
+
+	err = cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not-a-real-llm")
 	assert.Contains(t, err.Error(), "DataRobot-deployed LLMs unavailable")

--- a/cmd/llm-gateway/select/cmd_test.go
+++ b/cmd/llm-gateway/select/cmd_test.go
@@ -120,6 +120,9 @@ func TestSelectCmd_DirectArg_Valid(t *testing.T) {
 }
 
 func TestSelectCmd_DirectArg_Invalid(t *testing.T) {
+	// setupLLMServer serves catalog-shaped JSON on every path, so the deployed
+	// source fails to decode. That partial-failure state is what triggers the
+	// error enrichment, so the message names both the id and the dead source.
 	setupLLMServer(t, testLLMs)
 
 	cmd, _ := newTestCmd(t)
@@ -128,6 +131,7 @@ func TestSelectCmd_DirectArg_Invalid(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not-a-real-llm")
+	assert.Contains(t, err.Error(), "DataRobot-deployed LLMs unavailable")
 }
 
 func TestSelectCmd_DirectArg_APIError(t *testing.T) {

--- a/cmd/llm-gateway/select/cmd_test.go
+++ b/cmd/llm-gateway/select/cmd_test.go
@@ -92,6 +92,18 @@ func TestFindByID_Empty(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestFindByID_DeployedID(t *testing.T) {
+	llms := []drapi.LLM{
+		{LlmID: "llm-001", Name: "GPT-4o", Provider: "azure", Model: "gpt-4o", IsActive: true, Kind: drapi.LLMKindGateway},
+		{LlmID: "6650f0aa11bb22cc33dd44ee", Name: "Support RAG LLM", Model: "datarobot/datarobot-deployed-llm", IsActive: true, Kind: drapi.LLMKindDeployed, DeploymentID: "6650f0aa11bb22cc33dd44ee"},
+	}
+
+	id, err := findByID(llms, "6650f0aa11bb22cc33dd44ee")
+
+	require.NoError(t, err)
+	assert.Equal(t, "6650f0aa11bb22cc33dd44ee", id)
+}
+
 // --- select with direct arg ---
 
 func TestSelectCmd_DirectArg_Valid(t *testing.T) {

--- a/cmd/llm-gateway/select/model.go
+++ b/cmd/llm-gateway/select/model.go
@@ -29,10 +29,23 @@ type llmItem struct {
 	name     string
 	provider string
 	model    string
+	kind     string
 }
 
-func (i llmItem) Title() string       { return i.name }
-func (i llmItem) Description() string { return i.provider + " · " + i.model }
+func (i llmItem) Title() string { return i.name }
+
+// Description is the dim second line under each row. Deployed LLMs carry no
+// provider and only the litellm sentinel model, so surface the source and the
+// deployment id (what the user selects by) instead of an empty "· sentinel".
+func (i llmItem) descriptionText() string {
+	if i.kind == drapi.LLMKindDeployed {
+		return "deployed · " + i.llmID
+	}
+
+	return i.provider + " · " + i.model
+}
+
+func (i llmItem) Description() string { return i.descriptionText() }
 func (i llmItem) FilterValue() string { return i.name }
 
 type llmItemDelegate struct{}
@@ -60,7 +73,7 @@ func (d llmItemDelegate) Render(w io.Writer, m list.Model, index int, listItem l
 
 		fmt.Fprint(w, titleStyle.Render("▶ "+i.name))
 		fmt.Fprint(w, "\n")
-		fmt.Fprint(w, descStyle.Render("  "+i.provider+" · "+i.model))
+		fmt.Fprint(w, descStyle.Render("  "+i.descriptionText()))
 	} else {
 		titleStyle := lipgloss.NewStyle().
 			Foreground(lipgloss.AdaptiveColor{Light: "#000000", Dark: "#FFFFFF"})
@@ -71,7 +84,7 @@ func (d llmItemDelegate) Render(w io.Writer, m list.Model, index int, listItem l
 
 		fmt.Fprint(w, titleStyle.Render("  "+i.name))
 		fmt.Fprint(w, "\n")
-		fmt.Fprint(w, descStyle.Render("  "+i.provider+" · "+i.model))
+		fmt.Fprint(w, descStyle.Render("  "+i.descriptionText()))
 	}
 }
 
@@ -91,6 +104,7 @@ func NewPickerModel(llms []drapi.LLM) PickerModel {
 			name:     l.Name,
 			provider: l.Provider,
 			model:    l.Model,
+			kind:     l.Kind,
 		}
 	}
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -56,7 +56,7 @@ These flags are available for all commands:
 | [`dotenv`](dotenv.md)             | Manage environment variables.                               |
 | [`self`](self.md)                 | CLI utility commands (update, version, completion, plugin). |
 | [`plugin`](plugins.md)            | Inspect and manage CLI plugins.                             |
-| [`llm-gateway`](llm-gateway.md)   | List and select the default LLM Gateway model.              |
+| [`llm-gateway`](llm-gateway.md)   | List and select the default LLM (gateway + deployed models). |
 | [`pipeline`](pipeline.md)         | Manage pipelines via the pipelines API (feature-gated).     |
 | [`artifact`](artifact.md)         | Build and manage workload artifacts (feature-gated).        |
 | [`workload`](workload.md)         | Deploy and manage workloads from artifacts (feature-gated). |
@@ -93,9 +93,9 @@ dr
 │   ├── install        Install a plugin
 │   ├── uninstall      Uninstall a plugin
 │   └── update         Update plugins
-├── llm-gateway        LLM Gateway model management (alias: llm, llm-gateways)
-│   ├── list           List active LLM Gateway models (alias: ls)
-│   └── select         Set the default LLM Gateway model
+├── llm-gateway        LLM model management (alias: llm, llm-gateways)
+│   ├── list           List available LLMs: gateway + deployed (alias: ls)
+│   └── select         Set the default LLM
 ├── pipeline           Pipelines API management (feature-gated)
 │   ├── create         Upload a Python file to create a pipeline
 │   ├── list           List pipelines
@@ -239,7 +239,7 @@ dr dotenv validate
 ### LLM Gateway
 
 ```bash
-# List active LLM Gateway models
+# List available LLMs (gateway + deployed)
 dr llm-gateway list
 
 # List as JSON
@@ -345,9 +345,9 @@ For detailed documentation on each command, see:
 
 - **[plugin](plugins.md)**&mdash;inspect and manage installed CLI plugins (alias: `plugins`).
 
-- **[llm-gateway](llm-gateway.md)**&mdash;list and configure the default LLM Gateway model (aliases: `llm`, `llm-gateways`).
-  - `list` (`ls`)&mdash;fetch all active LLMs from the catalog and display them in a table (`ID · NAME · PROVIDER · MODEL`). The currently-selected model is marked with `*`. Supports `--output-format json` (includes a `selected` boolean field per entry).
-  - `select [llm-id]`&mdash;set the default LLM. Without an argument, launches an interactive TUI picker. With an argument, validates the ID against the active catalog and persists it immediately. The selection is saved to `drconfig.yaml` under the key `default-llm-id`.
+- **[llm-gateway](llm-gateway.md)**&mdash;list and configure the default LLM, across LLM Gateway catalog models and DataRobot-deployed LLMs (aliases: `llm`, `llm-gateways`).
+  - `list` (`ls`)&mdash;fetch available LLMs from both sources and display them in a table (`ID · NAME · SOURCE · PROVIDER · MODEL · CONTEXT`). The currently-selected model is marked with `*`. Supports `--output-format json` (each entry includes `source`, `deployment_id`, and a `selected` boolean).
+  - `select [llm-id]`&mdash;set the default LLM. Without an argument, launches an interactive TUI picker. With an argument (a gateway model id or a deployment id), validates it against the available LLMs and persists it immediately. The selection is saved to `drconfig.yaml` under the key `default-llm-id`.
 
 - **[pipeline](pipeline.md)**&mdash;manage AI/ML pipelines orchestrated by Covalent (feature-gated behind `DATAROBOT_CLI_FEATURE_PIPELINE=true`).
   - `create`&mdash;upload a Python file to register a new pipeline.
@@ -402,7 +402,7 @@ DATAROBOT_ENDPOINT                  # DataRobot URL
 DATAROBOT_API_TOKEN                 # API token (not recommended)
 DATAROBOT_CLI_CONFIG                # Path to config file
 DATAROBOT_CLI_PLUGIN_DISCOVERY_TIMEOUT  # Timeout for plugin discovery (e.g. 2s; 0s disables)
-DATAROBOT_CLI_DEFAULT_LLM_ID        # Default LLM Gateway model ID (overrides drconfig.yaml)
+DATAROBOT_CLI_DEFAULT_LLM_ID        # Default LLM ID: gateway model or deployment id (overrides drconfig.yaml)
 VISUAL                              # External editor for file editing
 EDITOR                              # External editor for file editing (fallback)
 ```

--- a/docs/commands/llm-gateway.md
+++ b/docs/commands/llm-gateway.md
@@ -1,6 +1,6 @@
-# `dr llm-gateway` — LLM Gateway model management
+# `dr llm-gateway` — LLM model management
 
-List active LLM Gateway models and configure which one the CLI uses by default.
+List available LLMs — both LLM Gateway catalog models and DataRobot-deployed LLMs — and configure which one the CLI uses by default.
 
 ## Synopsis
 
@@ -13,8 +13,10 @@ dr llm [flags]           # alias
 
 The `dr llm-gateway` group exposes two subcommands:
 
-- **`list`** — fetch all active LLMs from `/api/v2/genai/llmgw/catalog/` and display them as a table or JSON.
+- **`list`** — fetch available LLMs from two sources and display them as a table or JSON: active LLM Gateway catalog models (`/api/v2/genai/llmgw/catalog/`) and DataRobot-deployed LLMs (`/api/v2/deployments/`, deployments whose champion model is a `TextGeneration` model). A `SOURCE` column / `source` field distinguishes the two.
 - **`select`** — choose a default LLM, either by ID or through an interactive TUI picker. The selection is persisted to `drconfig.yaml` and read by other CLI commands.
+
+Each source is best-effort: if one source cannot be reached (e.g. an empty LLM Gateway on-prem, or no deployment access), the command logs a warning and lists the other. It errors only when both sources fail.
 
 **Aliases:** `llm`, `llm-gateways`
 
@@ -22,7 +24,7 @@ The `dr llm-gateway` group exposes two subcommands:
 
 ### `list`
 
-Fetch all active LLMs from the LLM Gateway catalog and display them.
+Fetch available LLMs — LLM Gateway catalog models and DataRobot-deployed LLMs — and display them.
 
 ```bash
 dr llm-gateway list [flags]
@@ -37,11 +39,12 @@ dr llm ls               # shortest alias
 
 | Column     | Description                                      |
 |------------|--------------------------------------------------|
-| `ID`       | LLM identifier. Prefixed with `*` if selected, `  ` otherwise. |
-| `NAME`     | Human-readable model name.                       |
-| `PROVIDER` | Provider (e.g. `azure`, `anthropic`, `google`).  |
-| `MODEL`    | Underlying model identifier.                     |
-| `CONTEXT`  | Context-window size in tokens. `-` when the catalog does not report it. |
+| `ID`       | LLM identifier — a gateway model id or a deployment id. Prefixed with `*` if selected, `  ` otherwise. |
+| `NAME`     | Human-readable model name (a deployment's label for deployed LLMs). |
+| `SOURCE`   | `gateway` for LLM Gateway catalog models, `deployed` for DataRobot-deployed LLMs. |
+| `PROVIDER` | Provider (e.g. `azure`, `anthropic`, `google`). `-` for deployed LLMs. |
+| `MODEL`    | Underlying model identifier. `-` for deployed LLMs (the deployment id in `ID` is the routing key). |
+| `CONTEXT`  | Context-window size in tokens. `-` when not reported (always `-` for deployed LLMs). |
 
 The table width is content-driven and capped at the terminal width to prevent overflow. `description` is omitted from the table (it is long enough to wrap unreadably across a full catalog) and appears in JSON output only.
 
@@ -49,15 +52,19 @@ The table width is content-driven and capped at the terminal width to prevent ov
 
 ```json
 {
-  "id":           "llm-abc123",
-  "name":         "GPT-4o",
-  "provider":     "azure",
-  "model":        "gpt-4o",
-  "description":  "OpenAI's flagship multimodal model.",
-  "context_size": 128000,
-  "selected":     true
+  "id":            "llm-abc123",
+  "name":          "GPT-4o",
+  "source":        "gateway",
+  "provider":      "azure",
+  "model":         "gpt-4o",
+  "description":   "OpenAI's flagship multimodal model.",
+  "context_size":  128000,
+  "deployment_id": "",
+  "selected":      true
 }
 ```
+
+For a deployed LLM, `source` is `deployed`, `deployment_id` carries the deployment id, and `model` is the litellm sentinel `datarobot/datarobot-deployed-llm`.
 
 **Examples:**
 
@@ -77,7 +84,7 @@ dr llm ls
 
 ### `select`
 
-Set the default LLM Gateway model. The chosen ID is written to `drconfig.yaml` under the key `default-llm-id` and is also readable via `DATAROBOT_CLI_DEFAULT_LLM_ID`.
+Set the default LLM. The chosen ID — a gateway model id or a deployment id — is written to `drconfig.yaml` under the key `default-llm-id` and is also readable via `DATAROBOT_CLI_DEFAULT_LLM_ID`.
 
 ```bash
 dr llm-gateway select [llm-id]
@@ -86,7 +93,7 @@ dr llm select [llm-id]   # alias
 
 **Arguments:**
 
-- `[llm-id]` — optional. When provided, the ID is validated against the active catalog and persisted immediately. When omitted, an interactive TUI picker is launched.
+- `[llm-id]` — optional. When provided, the ID is validated against the available LLMs (gateway models and deployed LLMs) and persisted immediately. When omitted, an interactive TUI picker is launched.
 
 **Interactive picker:**
 
@@ -103,16 +110,16 @@ dr llm-gateway select
 # Set directly by ID
 dr llm-gateway select llm-abc123
 
-# Error — ID not found in active catalog
+# Error — ID not found among available LLMs
 dr llm-gateway select unknown-id
-# Error: LLM "unknown-id" not found in the active catalog
+# Error: LLM "unknown-id" not found
 ```
 
 ---
 
 ## Configuration
 
-The selected LLM ID is stored in `drconfig.yaml`:
+The selected LLM ID is stored in `drconfig.yaml`. This is a gateway model id or a DataRobot deployment id, depending on which was selected:
 
 ```yaml
 default-llm-id: llm-abc123

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -20,7 +20,8 @@ const (
 
 	APIConsumerTrackingEnabled = "api-consumer-tracking-enabled"
 
-	// DefaultLLMID is the config key for the user's default LLM Gateway model ID.
+	// DefaultLLMID is the config key for the user's default LLM ID. The value is
+	// either an LLM Gateway model id or a DataRobot deployment id.
 	DefaultLLMID = "default-llm-id"
 
 	// EnvPrefix is the canonical prefix for all DATAROBOT_CLI_* environment

--- a/internal/drapi/llms.go
+++ b/internal/drapi/llms.go
@@ -163,7 +163,7 @@ type deploymentList struct {
 // query params and return every deployment, so rows are re-filtered
 // client-side on target type and active status.
 func GetDeployedLLMs() ([]LLM, error) {
-	url, err := config.GetEndpointURL("/api/v2/deployments/?championModelTargetType=TextGeneration&limit=100")
+	url, err := config.GetEndpointURL("/api/v2/deployments/?championModelTargetType=" + targetTypeTextGeneration + "&limit=100")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/drapi/llms.go
+++ b/internal/drapi/llms.go
@@ -89,6 +89,11 @@ type LLMList struct {
 	TotalCount int    `json:"totalCount"`
 	Next       string `json:"next"`
 	Previous   string `json:"previous"`
+
+	// Warnings is set programmatically (not decoded) by GetLLMsAndDeployed when
+	// one source failed but the other succeeded, so callers can surface why the
+	// list is partial instead of silently treating a missing source as empty.
+	Warnings []string `json:"-"`
 }
 
 func GetLLMs() (*LLMList, error) {
@@ -177,9 +182,16 @@ func GetDeployedLLMs() ([]LLM, error) {
 				continue
 			}
 
+			// A deployment's label is nullable; fall back to its id so the name
+			// column is never blank.
+			name := d.Label
+			if name == "" {
+				name = d.ID
+			}
+
 			deployed = append(deployed, LLM{
 				LlmID:        d.ID,
-				Name:         d.Label,
+				Name:         name,
 				Model:        deployedModelSentinel,
 				Description:  d.Description,
 				IsActive:     true,
@@ -209,12 +221,19 @@ func GetDeployedLLMs() ([]LLM, error) {
 // list. An error is returned only when both sources fail.
 func GetLLMsAndDeployed() (*LLMList, error) {
 	gateway, gwErr := GetLLMs()
+	deployed, depErr := GetDeployedLLMs()
+
+	var warnings []string
+
 	if gwErr != nil {
+		warnings = append(warnings, "LLM Gateway catalog unavailable: "+gwErr.Error())
+
 		log.Warnf("Could not list LLM Gateway models: %s", gwErr.Error())
 	}
 
-	deployed, depErr := GetDeployedLLMs()
 	if depErr != nil {
+		warnings = append(warnings, "DataRobot-deployed LLMs unavailable: "+depErr.Error())
+
 		log.Warnf("Could not list DataRobot-deployed LLMs: %s", depErr.Error())
 	}
 
@@ -230,5 +249,5 @@ func GetLLMsAndDeployed() (*LLMList, error) {
 
 	llms = append(llms, deployed...)
 
-	return &LLMList{LLMs: llms, Count: len(llms), TotalCount: len(llms)}, nil
+	return &LLMList{LLMs: llms, Count: len(llms), TotalCount: len(llms), Warnings: warnings}, nil
 }

--- a/internal/drapi/llms.go
+++ b/internal/drapi/llms.go
@@ -15,7 +15,28 @@
 package drapi
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/log"
+)
+
+// LLM source kinds. Gateway models come from the LLM Gateway catalog; deployed
+// models are DataRobot Deployments whose champion model is a TextGeneration
+// (chat) model, used on-prem or wherever the gateway catalog is empty.
+const (
+	LLMKindGateway  = "gateway"
+	LLMKindDeployed = "deployed"
+
+	// deployedModelSentinel is the litellm model string a deployed LLM is
+	// addressed by; the deployment id carries the actual routing. Matches the
+	// deployed-model .env contract consumed by downstream tooling.
+	deployedModelSentinel = "datarobot/datarobot-deployed-llm"
+
+	// targetTypeTextGeneration is the champion-model target type that marks a
+	// deployment as a chat LLM.
+	targetTypeTextGeneration = "TextGeneration"
 )
 
 type LLM struct {
@@ -27,6 +48,12 @@ type LLM struct {
 
 	Description string `json:"description"`
 	ContextSize int    `json:"contextSize"`
+
+	// Kind and DeploymentID are set programmatically, not decoded from any API:
+	// gateway rows are LLMKindGateway; deployed rows are LLMKindDeployed and
+	// carry the deployment id.
+	Kind         string `json:"-"`
+	DeploymentID string `json:"-"`
 
 	//Version              string   `json:"version"`
 	//Creator              string   `json:"creator"`
@@ -84,6 +111,7 @@ func GetLLMs() (*LLMList, error) {
 
 		for _, llm := range llmList.LLMs {
 			if llm.IsActive {
+				llm.Kind = LLMKindGateway
 				active = append(active, llm)
 			}
 		}
@@ -102,4 +130,105 @@ func GetLLMs() (*LLMList, error) {
 	llmList.LLMs = active
 
 	return &llmList, nil
+}
+
+// deployment is the subset of the /api/v2/deployments/ response the CLI needs
+// to present a deployed model as a selectable LLM.
+type deployment struct {
+	ID          string `json:"id"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+	Status      string `json:"status"`
+	Model       struct {
+		TargetType string `json:"targetType"`
+	} `json:"model"`
+}
+
+type deploymentList struct {
+	Data       []deployment `json:"data"`
+	Count      int          `json:"count"`
+	TotalCount int          `json:"totalCount"`
+	Next       string       `json:"next"`
+	Previous   string       `json:"previous"`
+}
+
+// GetDeployedLLMs lists DataRobot Deployments serving as chat LLMs (champion
+// model target type TextGeneration). The server-side championModelTargetType
+// filter is honored on recent platforms; older on-prem builds ignore unknown
+// query params and return every deployment, so rows are re-filtered
+// client-side on target type and active status.
+func GetDeployedLLMs() ([]LLM, error) {
+	url, err := config.GetEndpointURL("/api/v2/deployments/?championModelTargetType=TextGeneration&limit=100")
+	if err != nil {
+		return nil, err
+	}
+
+	var deployed []LLM
+
+	for url != "" {
+		var dl deploymentList
+
+		if err = GetJSON(url, "deployed LLMs", &dl); err != nil {
+			return nil, err
+		}
+
+		for _, d := range dl.Data {
+			if d.Model.TargetType != targetTypeTextGeneration || !strings.EqualFold(d.Status, "active") {
+				continue
+			}
+
+			deployed = append(deployed, LLM{
+				LlmID:        d.ID,
+				Name:         d.Label,
+				Model:        deployedModelSentinel,
+				Description:  d.Description,
+				IsActive:     true,
+				Kind:         LLMKindDeployed,
+				DeploymentID: d.ID,
+			})
+		}
+
+		if dl.Next == "" {
+			break
+		}
+
+		if err = AssertNextOnSameHost(dl.Next); err != nil {
+			return nil, err
+		}
+
+		url = dl.Next
+	}
+
+	return deployed, nil
+}
+
+// GetLLMsAndDeployed returns the union of LLM Gateway catalog models and
+// DataRobot-deployed LLMs. Each source is best-effort: a single-source failure
+// is logged and the other source is still returned, so an empty or disabled
+// gateway (common on-prem) or missing deployment access does not blank the
+// list. An error is returned only when both sources fail.
+func GetLLMsAndDeployed() (*LLMList, error) {
+	gateway, gwErr := GetLLMs()
+	if gwErr != nil {
+		log.Warnf("Could not list LLM Gateway models: %s", gwErr.Error())
+	}
+
+	deployed, depErr := GetDeployedLLMs()
+	if depErr != nil {
+		log.Warnf("Could not list DataRobot-deployed LLMs: %s", depErr.Error())
+	}
+
+	if gwErr != nil && depErr != nil {
+		return nil, errors.Join(gwErr, depErr)
+	}
+
+	var llms []LLM
+
+	if gateway != nil {
+		llms = append(llms, gateway.LLMs...)
+	}
+
+	llms = append(llms, deployed...)
+
+	return &LLMList{LLMs: llms, Count: len(llms), TotalCount: len(llms)}, nil
 }

--- a/internal/drapi/llms_test.go
+++ b/internal/drapi/llms_test.go
@@ -157,6 +157,9 @@ func TestGetLLMsAndDeployed_GatewayFailsSoftDegrade(t *testing.T) {
 
 	require.Len(t, list.LLMs, 1)
 	assert.Equal(t, LLMKindDeployed, list.LLMs[0].Kind)
+
+	require.Len(t, list.Warnings, 1)
+	assert.Contains(t, list.Warnings[0], "LLM Gateway catalog unavailable")
 }
 
 func TestGetLLMsAndDeployed_DeployedFailsSoftDegrade(t *testing.T) {
@@ -167,6 +170,29 @@ func TestGetLLMsAndDeployed_DeployedFailsSoftDegrade(t *testing.T) {
 
 	require.Len(t, list.LLMs, 1)
 	assert.Equal(t, LLMKindGateway, list.LLMs[0].Kind)
+
+	require.Len(t, list.Warnings, 1)
+	assert.Contains(t, list.Warnings[0], "DataRobot-deployed LLMs unavailable")
+}
+
+func TestGetLLMsAndDeployed_BothSucceedNoWarnings(t *testing.T) {
+	setupRoutedServer(t, routeResponse{body: gatewayBody}, routeResponse{body: deployedBody})
+
+	list, err := GetLLMsAndDeployed()
+	require.NoError(t, err)
+
+	assert.Empty(t, list.Warnings)
+}
+
+func TestGetDeployedLLMs_EmptyLabelFallsBackToID(t *testing.T) {
+	body := `{"data":[{"id":"dep-no-label","label":"","status":"active","model":{"targetType":"TextGeneration"}}]}`
+	setupRoutedServer(t, routeResponse{}, routeResponse{body: body})
+
+	deployed, err := GetDeployedLLMs()
+	require.NoError(t, err)
+
+	require.Len(t, deployed, 1)
+	assert.Equal(t, "dep-no-label", deployed[0].Name)
 }
 
 func TestGetLLMsAndDeployed_BothFail(t *testing.T) {

--- a/internal/drapi/llms_test.go
+++ b/internal/drapi/llms_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drapi
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type routeResponse struct {
+	status int
+	body   string
+}
+
+// setupRoutedServer serves distinct bodies for the LLM Gateway catalog and the
+// deployments routes, so the two sources GetLLMsAndDeployed queries can be
+// exercised (and failed) independently. A zero status defaults to 200.
+func setupRoutedServer(t *testing.T, catalog, deployments routeResponse) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var resp routeResponse
+
+		switch {
+		case strings.Contains(r.URL.Path, "/deployments"):
+			resp = deployments
+		case strings.Contains(r.URL.Path, "/catalog"):
+			resp = catalog
+		default:
+			http.NotFound(w, r)
+			return
+		}
+
+		if resp.status == 0 {
+			resp.status = http.StatusOK
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(resp.status)
+		_, _ = io.WriteString(w, resp.body)
+	}))
+
+	viperx.Reset()
+	viperx.Set(config.DataRobotURL, srv.URL)
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+	// skip_auth trusts the viper token directly; without it resolveToken makes a
+	// server-side verification request the routed handler would 404.
+	viperx.Set("skip_auth", true)
+
+	t.Cleanup(func() {
+		srv.Close()
+		viperx.Reset()
+	})
+}
+
+const gatewayBody = `{"data":[{"llmId":"llm-001","name":"GPT-4o","provider":"azure","model":"gpt-4o","isActive":true}],"count":1,"totalCount":1}`
+
+// deployedBody mixes a valid chat deployment with two that must be filtered
+// out client-side: an inactive TextGeneration deployment and an active
+// non-TextGeneration deployment.
+const deployedBody = `{"data":[
+	{"id":"dep-active-tg","label":"RAG LLM","status":"active","model":{"targetType":"TextGeneration"}},
+	{"id":"dep-inactive","label":"Old LLM","status":"inactive","model":{"targetType":"TextGeneration"}},
+	{"id":"dep-binary","label":"Churn model","status":"active","model":{"targetType":"Binary"}}
+],"count":3,"totalCount":3}`
+
+func TestGetDeployedLLMs_MapsAndFilters(t *testing.T) {
+	setupRoutedServer(t, routeResponse{}, routeResponse{body: deployedBody})
+
+	deployed, err := GetDeployedLLMs()
+	require.NoError(t, err)
+
+	require.Len(t, deployed, 1)
+	got := deployed[0]
+	assert.Equal(t, "dep-active-tg", got.LlmID)
+	assert.Equal(t, "dep-active-tg", got.DeploymentID)
+	assert.Equal(t, "RAG LLM", got.Name)
+	assert.Equal(t, deployedModelSentinel, got.Model)
+	assert.Equal(t, LLMKindDeployed, got.Kind)
+	assert.True(t, got.IsActive)
+}
+
+func TestGetDeployedLLMs_Pagination(t *testing.T) {
+	var srv *httptest.Server
+
+	page := 0
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		page++
+		if page == 1 {
+			// Point Next at the same host (AssertNextOnSameHost requirement).
+			_, _ = io.WriteString(w, `{"data":[{"id":"dep-1","label":"LLM One","status":"active","model":{"targetType":"TextGeneration"}}],"next":"`+srv.URL+`/api/v2/deployments/?offset=100"}`)
+			return
+		}
+
+		_, _ = io.WriteString(w, `{"data":[{"id":"dep-2","label":"LLM Two","status":"active","model":{"targetType":"TextGeneration"}}],"next":""}`)
+	}))
+
+	viperx.Reset()
+	viperx.Set(config.DataRobotURL, srv.URL)
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+	viperx.Set("skip_auth", true)
+
+	t.Cleanup(func() {
+		srv.Close()
+		viperx.Reset()
+	})
+
+	deployed, err := GetDeployedLLMs()
+	require.NoError(t, err)
+
+	require.Len(t, deployed, 2)
+	assert.Equal(t, "dep-1", deployed[0].LlmID)
+	assert.Equal(t, "dep-2", deployed[1].LlmID)
+}
+
+func TestGetLLMsAndDeployed_Union(t *testing.T) {
+	setupRoutedServer(t, routeResponse{body: gatewayBody}, routeResponse{body: deployedBody})
+
+	list, err := GetLLMsAndDeployed()
+	require.NoError(t, err)
+
+	require.Len(t, list.LLMs, 2)
+	assert.Equal(t, LLMKindGateway, list.LLMs[0].Kind)
+	assert.Equal(t, "llm-001", list.LLMs[0].LlmID)
+	assert.Equal(t, LLMKindDeployed, list.LLMs[1].Kind)
+	assert.Equal(t, "dep-active-tg", list.LLMs[1].LlmID)
+	assert.Equal(t, 2, list.Count)
+}
+
+func TestGetLLMsAndDeployed_GatewayFailsSoftDegrade(t *testing.T) {
+	setupRoutedServer(t, routeResponse{status: http.StatusInternalServerError, body: "boom"}, routeResponse{body: deployedBody})
+
+	list, err := GetLLMsAndDeployed()
+	require.NoError(t, err)
+
+	require.Len(t, list.LLMs, 1)
+	assert.Equal(t, LLMKindDeployed, list.LLMs[0].Kind)
+}
+
+func TestGetLLMsAndDeployed_DeployedFailsSoftDegrade(t *testing.T) {
+	setupRoutedServer(t, routeResponse{body: gatewayBody}, routeResponse{status: http.StatusInternalServerError, body: "boom"})
+
+	list, err := GetLLMsAndDeployed()
+	require.NoError(t, err)
+
+	require.Len(t, list.LLMs, 1)
+	assert.Equal(t, LLMKindGateway, list.LLMs[0].Kind)
+}
+
+func TestGetLLMsAndDeployed_BothFail(t *testing.T) {
+	setupRoutedServer(t,
+		routeResponse{status: http.StatusInternalServerError, body: "boom"},
+		routeResponse{status: http.StatusInternalServerError, body: "boom"},
+	)
+
+	_, err := GetLLMsAndDeployed()
+	assert.Error(t, err)
+}

--- a/internal/drapi/llms_test.go
+++ b/internal/drapi/llms_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -193,6 +194,40 @@ func TestGetDeployedLLMs_EmptyLabelFallsBackToID(t *testing.T) {
 
 	require.Len(t, deployed, 1)
 	assert.Equal(t, "dep-no-label", deployed[0].Name)
+}
+
+// TestGetDeployedLLMs_SendsFilterAndLimit asserts the outgoing request carries
+// the server-side target-type filter and page limit. Without this, dropping the
+// filter from the URL would still pass the mapping tests (the client re-filter
+// masks it) while silently losing the server-side narrowing.
+func TestGetDeployedLLMs_SendsFilterAndLimit(t *testing.T) {
+	// Buffered so the handler goroutine's send happens-before the test's read.
+	queryCh := make(chan string, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queryCh <- r.URL.RawQuery
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":[]}`)
+	}))
+
+	viperx.Reset()
+	viperx.Set(config.DataRobotURL, srv.URL)
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+	viperx.Set("skip_auth", true)
+
+	t.Cleanup(func() {
+		srv.Close()
+		viperx.Reset()
+	})
+
+	_, err := GetDeployedLLMs()
+	require.NoError(t, err)
+
+	values, err := url.ParseQuery(<-queryCh)
+	require.NoError(t, err)
+	assert.Equal(t, targetTypeTextGeneration, values.Get("championModelTargetType"))
+	assert.Equal(t, "100", values.Get("limit"))
 }
 
 func TestGetLLMsAndDeployed_BothFail(t *testing.T) {


### PR DESCRIPTION
## Summary

`dr llm-gateway list` and `dr llm-gateway select` only knew about LLM Gateway catalog models. On-prem and air-gapped installs where the gateway catalog is empty had nothing to list or select. This adds DataRobot-deployed LLMs (deployments whose champion model is a text-generation/chat model) alongside the gateway models, so those installs get a usable list and you can pick a deployed model by its id.

## How it works

`list` and `select` now pull from two sources: the LLM Gateway catalog and `/api/v2/deployments/` filtered to active text-generation deployments. The two are merged into one list. A `SOURCE` column (and a `source` field in JSON output) marks each entry `gateway` or `deployed`, and deployed entries carry a `deployment_id` so downstream tooling knows to route through the deployment instead of the gateway.

Fetching is best-effort. If one source is unavailable (an empty gateway on-prem, or no deployment access on SaaS), the command warns and lists the other, and only errors when both fail. When a source is down and you `select` an id that isn't in the surviving list, the error names the unavailable source instead of a bare "not found". `dr dotenv`'s model picker is unchanged (gateway-only).

## Technical Changes

- internal/drapi/llms.go: `GetDeployedLLMs` lists active `TextGeneration` deployments (server-side `championModelTargetType` filter plus a client re-filter for older builds that ignore it, and a label-to-id fallback). `GetLLMsAndDeployed` unions gateway + deployed, records per-source failures on `LLMList.Warnings`, and errors only if both sources fail.
- cmd/llm-gateway/list/cmd.go: JSON gains `source` + `deployment_id`; the table gains a `SOURCE` column, deployed rows show `-` for provider/model/context.
- cmd/llm-gateway/select/cmd.go + model.go: `select` accepts a deployment id; a not-found error names the unavailable source when one failed; the TUI picker labels deployed rows with the deployment id.
- docs/commands/llm-gateway.md, docs/commands/README.md: document the two sources, the `SOURCE` column, and the new JSON fields.
- internal/drapi/llms_test.go: 8 new drapi tests (mapping, target-type/active filter, pagination, soft-degrade + warnings, empty-label fallback), plus list/select coverage for the union rendering, the JSON contract, and the enriched select error.

Verified end-to-end against a live environment with deployed LLMs: `list` shows both sources, `select` persists a deployment id, and `list` then marks it selected.

### Screenshots

`dr llm list`

<img width="2028" height="1076" alt="image" src="https://github.com/user-attachments/assets/d1af4810-9f3a-4e9c-8c8f-d16fbc57c702" /><img width="2034" height="1164" alt="image" src="https://github.com/user-attachments/assets/83a1bf58-b0f2-45fc-a30d-ca534cfe72a6" />

`dr llm select`

<img width="879" height="1059" alt="image" src="https://github.com/user-attachments/assets/4b28d699-0bd9-44f3-8e2a-5713a34d4370" />


<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784736200.407139 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches default LLM selection and a new deployments API path with partial-failure semantics; behavior change for on-prem users but well-tested and backward-compatible for gateway-only IDs.
> 
> **Overview**
> **`dr llm-gateway list`** and **`select`** now load LLMs from the gateway catalog and from active **TextGeneration** deployments, merged via **`GetLLMsAndDeployed`**. One failing source is warned and skipped; the command fails only when both fail. **`select`** appends those warnings when lookup fails on a partial list.
> 
> **List output** adds a **`SOURCE`** column and JSON **`source`** / **`deployment_id`** (deployed rows use `-` for provider/model in the table; the litellm sentinel stays in JSON). **`default-llm-id`** may be a gateway id or a deployment id. The TUI picker shows **`deployed · <id>`** for deployment rows. Docs and tests cover the union, soft-degrade behavior, and the JSON wire contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 194893e337e1d5b30393811f07a95f1a58b9da1d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->