### PR TITLE
Feat: Allow dr auth login to accept hostname and default to https protocol

### DIFF
--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -30,8 +30,20 @@ const DRAPIURLSuffix = "/api/v2"
 var ErrInvalidURL = errors.New("Invalid URL.")
 
 // SchemeHostOnly takes a URL like: https://app.datarobot.com/api/v2 and just
-// returns https://app.datarobot.com (no trailing slash)
+// returns https://app.datarobot.com (no trailing slash).
+//
+// A bare hostname without a scheme (e.g. "app.datarobot.com") is also accepted
+// and defaults to the https scheme, so "app.datarobot.com" is treated the same
+// as "https://app.datarobot.com".
 func SchemeHostOnly(longURL string) (string, error) {
+	longURL = strings.TrimSpace(longURL)
+
+	// Default to https when no scheme is provided so that a bare hostname is
+	// accepted in addition to a full URL.
+	if longURL != "" && !strings.Contains(longURL, "://") {
+		longURL = "https://" + longURL
+	}
+
 	parsedURL, err := url.Parse(longURL)
 	if err != nil {
 		return "", err

--- a/internal/config/api_test.go
+++ b/internal/config/api_test.go
@@ -60,6 +60,16 @@ func (suite *APITestSuite) TestSetURLToConfig() {
 			expectedURL: "https://app.datarobot.com/api/v2",
 		},
 		{
+			name:        "bare hostname defaults to https",
+			input:       "app.datarobot.com",
+			expectedURL: "https://app.datarobot.com/api/v2",
+		},
+		{
+			name:        "bare hostname with path gets trimmed and defaults to https",
+			input:       "app.datarobot.com/api/v2",
+			expectedURL: "https://app.datarobot.com/api/v2",
+		},
+		{
 			name:        "shortcut 1 resolves to app.datarobot.com",
 			input:       "1",
 			expectedURL: "https://app.datarobot.com/api/v2",
@@ -80,8 +90,8 @@ func (suite *APITestSuite) TestSetURLToConfig() {
 			expectedURL: "https://custom.example.com/api/v2",
 		},
 		{
-			name:        "invalid URL without host returns error",
-			input:       "not-a-url",
+			name:        "invalid URL with space in host returns error",
+			input:       "not a url",
 			expectError: true,
 		},
 	}


### PR DESCRIPTION
## RATIONALE

I keep tripping over `dr auth login some-host.datarobot.com` complaining its not a full URL.  It's a minor annoyance that is easily preventable.

This allows specifying a hostname only and using `https://` as the default implied protocol.
<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784724901.149969 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to URL parsing for CLI config; defaulting to https is the expected behavior for DataRobot endpoints.
> 
> **Overview**
> **`SchemeHostOnly`** now trims whitespace and, when the input has no `://`, prepends **`https://`** before parsing. That lets **`dr auth login`** (and **`SetURLToConfig` / `SaveURLToConfig`**) accept values like `app.datarobot.com` or `app.datarobot.com/api/v2` the same as full `https://…` URLs.
> 
> Tests add cases for bare hostname and hostname-with-path; the invalid-input example is updated to **`not a url`** (spaces in the host) so it still fails after the implicit-scheme behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a7c774837fd8028f50ee3437fffe12a84af5cd6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->