### PR TITLE
[CFX-6918] Run .ps1 plugin scripts through PowerShell on Windows

### DIFF
--- a/internal/plugin/discover.go
+++ b/internal/plugin/discover.go
@@ -465,7 +465,9 @@ func getManifest(ctx context.Context, executable string) (*PluginManifest, error
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, executable, PluginManifestFlag)
+	name, cmdArgs := pluginCommandArgs(executable, PluginManifestFlag)
+
+	cmd := exec.CommandContext(ctx, name, cmdArgs...)
 
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/plugin/exec.go
+++ b/internal/plugin/exec.go
@@ -111,26 +111,34 @@ func executePluginCommand(ctx context.Context, executable string, args []string,
 	return 0
 }
 
+// pluginCommandArgs returns the executable and argument list to invoke a plugin
+// script. On Windows, .ps1 files are run through PowerShell, since Windows
+// cannot execute a .ps1 text file directly.
+func pluginCommandArgs(executable string, args ...string) (string, []string) {
+	return pluginCommandArgsFor(runtime.GOOS, executable, args...)
+}
+
+// pluginCommandArgsFor is the goos-parameterized core of pluginCommandArgs,
+// exposed as a test seam so the Windows-wrapping branch can be exercised on
+// any platform.
+func pluginCommandArgsFor(goos, executable string, args ...string) (string, []string) {
+	if goos == "windows" && filepath.Ext(executable) == ".ps1" {
+		psArgs := append([]string{"-ExecutionPolicy", "Bypass", "-File", executable}, args...)
+
+		return "powershell.exe", psArgs
+	}
+
+	return executable, args
+}
+
 // buildPluginCommand creates the appropriate exec.Cmd for the given executable.
 // On Windows, .ps1 files are executed via PowerShell.
 // ctx cancellation sends SIGTERM to the process, with a 5-second grace
 // period before SIGKILL.
 func buildPluginCommand(ctx context.Context, executable string, args []string, requireAuth bool, rootFlags *pflag.FlagSet) *exec.Cmd {
-	ext := filepath.Ext(executable)
+	name, cmdArgs := pluginCommandArgs(executable, args...)
 
-	// On Windows, execute .ps1 files through PowerShell
-	if runtime.GOOS == "windows" && ext == ".ps1" {
-		psArgs := append([]string{"-ExecutionPolicy", "Bypass", "-File", executable}, args...)
-
-		cmd := exec.CommandContext(ctx, "powershell.exe", psArgs...)
-		cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }
-		cmd.WaitDelay = 5 * time.Second
-		cmd.Env = buildPluginEnv(executable, requireAuth, rootFlags)
-
-		return cmd
-	}
-
-	cmd := exec.CommandContext(ctx, executable, args...)
+	cmd := exec.CommandContext(ctx, name, cmdArgs...)
 	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) }
 	cmd.WaitDelay = 5 * time.Second
 	cmd.Env = buildPluginEnv(executable, requireAuth, rootFlags)

--- a/internal/plugin/exec_test.go
+++ b/internal/plugin/exec_test.go
@@ -115,6 +115,70 @@ fi
 	s.Equal(1, exitCode)
 }
 
+// TestPluginCommandArgsFor verifies the goos-parameterized wrapping decision so
+// the Windows PowerShell branch is exercised on any platform (the real Windows
+// runners are not yet part of CI).
+func TestPluginCommandArgsFor(t *testing.T) {
+	tests := []struct {
+		name         string
+		goos         string
+		executable   string
+		args         []string
+		expectedName string
+		expectedArgs []string
+	}{
+		{
+			name:         "windows ps1 is wrapped in powershell",
+			goos:         "windows",
+			executable:   `C:\plugins\dr-foo.ps1`,
+			args:         []string{PluginManifestFlag},
+			expectedName: "powershell.exe",
+			expectedArgs: []string{"-ExecutionPolicy", "Bypass", "-File", `C:\plugins\dr-foo.ps1`, PluginManifestFlag},
+		},
+		{
+			name:         "windows ps1 preserves extra args in order",
+			goos:         "windows",
+			executable:   "dr-foo.ps1",
+			args:         []string{"alpha", "beta"},
+			expectedName: "powershell.exe",
+			expectedArgs: []string{"-ExecutionPolicy", "Bypass", "-File", "dr-foo.ps1", "alpha", "beta"},
+		},
+		{
+			name:         "windows non-ps1 executable is unchanged",
+			goos:         "windows",
+			executable:   "dr-foo.exe",
+			args:         []string{PluginManifestFlag},
+			expectedName: "dr-foo.exe",
+			expectedArgs: []string{PluginManifestFlag},
+		},
+		{
+			name:         "windows extensionless executable is unchanged",
+			goos:         "windows",
+			executable:   "dr-foo",
+			args:         []string{PluginManifestFlag},
+			expectedName: "dr-foo",
+			expectedArgs: []string{PluginManifestFlag},
+		},
+		{
+			name:         "non-windows ps1 is not wrapped",
+			goos:         "linux",
+			executable:   "dr-foo.ps1",
+			args:         []string{PluginManifestFlag},
+			expectedName: "dr-foo.ps1",
+			expectedArgs: []string{PluginManifestFlag},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, cmdArgs := pluginCommandArgsFor(tt.goos, tt.executable, tt.args...)
+
+			assert.Equal(t, tt.expectedName, name)
+			assert.Equal(t, tt.expectedArgs, cmdArgs)
+		})
+	}
+}
+
 // TestExecutePluginExitCodes tests various exit codes are properly propagated
 func TestExecutePluginExitCodes(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "plugin-exitcode-test")

--- a/internal/plugin/validation.go
+++ b/internal/plugin/validation.go
@@ -216,7 +216,9 @@ func ExecPluginManifest(scriptPath string) (*PluginManifest, error) {
 		return nil, fmt.Errorf("failed to make script executable: %w", err)
 	}
 
-	cmd := exec.Command(scriptPath, PluginManifestFlag)
+	name, cmdArgs := pluginCommandArgs(scriptPath, PluginManifestFlag)
+
+	cmd := exec.Command(name, cmdArgs...)
 
 	var stdout, stderr bytes.Buffer
 


### PR DESCRIPTION
# RATIONALE

`ExecPluginManifest` (`internal/plugin/validation.go`) and `getManifest` (`internal/plugin/discover.go`) executed plugin scripts with a bare `exec.Command`/`exec.CommandContext` and no PowerShell wrapper. On Windows a `.ps1` is a text file, not a Win32 executable, so running it directly fails with *"%1 is not a valid Win32 application."* Since `isPluginScript` accepts `.ps1` as a valid plugin script on Windows, this breaks `dr self plugin package`/`publish` validation and PATH plugin discovery for any Windows-targeting plugin author.

Reported by a customer via bugbot. Tracks https://datarobot.atlassian.net/browse/CFX-6918 (epic CFX-6916, Windows Reliability).

## CHANGES

- Extract the PowerShell-wrapping decision from `buildPluginCommand` into a shared, goos-parameterized helper `pluginCommandArgs` / `pluginCommandArgsFor` (`internal/plugin/exec.go`).
- Use it in all three plugin-invocation sites: `buildPluginCommand`, `ExecPluginManifest` (`validation.go`), and `getManifest` (`discover.go`).
- Add `TestPluginCommandArgsFor` — a cross-platform test that exercises the Windows `.ps1` wrapping branch on Linux CI (the root cause was that Windows branches never ran in CI; see CFX-6919).

## TESTING

- `task test` / `task lint` pass on Linux and macOS.
- `TestPluginCommandArgsFor` covers the Windows PowerShell-wrapping path on any platform.
- Real-Windows coverage of these paths is provided by the new windows-latest unit-test leg from CFX-6919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784725599.437179 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized plugin subprocess invocation fix with shared helper and table tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Windows `.ps1` plugin scripts** were invoked with a bare `exec.Command`, which fails because PowerShell scripts are not Win32 executables. That broke PATH discovery (`getManifest`), packaging validation (`ExecPluginManifest`), while normal plugin runs already used PowerShell only inside `buildPluginCommand`.
> 
> The PR **centralizes** the Windows decision in `pluginCommandArgs` / `pluginCommandArgsFor` and routes **all three** invocation paths through it, so manifest fetch and validation match runtime execution. `buildPluginCommand` is simplified to a single `CommandContext` path after resolving name/args.
> 
> **`TestPluginCommandArgsFor`** exercises the Windows PowerShell wrapping branch on non-Windows CI via the `goos` test seam.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d089bc2fd1c67163301574dcf8c0b732db4d31ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->