### PR TITLE
[CFX-7063] fix(cmd): add update hint to --version and --help output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,7 @@ using pre-built templates. Get from idea to production in minutes, not hours.
 
 🎯 ` + tui.BaseTextStyle.Render("Quick Start:") + `
   dr start             # Create your first AI app (start here!)
+  dr self update       # Update DataRobot CLI to latest version
   dr --help            # Show all available commands
 
 💡 ` + tui.BaseTextStyle.Render("New to AI development?") + ` Perfect! Run 'dr start' and we'll guide you through everything.`,
@@ -219,7 +220,7 @@ func init() {
 	RootCmd.CompletionOptions.DisableDefaultCmd = true
 
 	// Set custom version template to match our unified format
-	RootCmd.SetVersionTemplate(internalVersion.GetAppNameVersionText() + "\n")
+	RootCmd.SetVersionTemplate(internalVersion.GetAppNameVersionText() + "\n\nTo update: dr self update\n")
 
 	// Configure persistent flags
 	RootCmd.PersistentFlags().StringVar(&configFilePath, "config", "",
@@ -309,6 +310,7 @@ func init() {
 			_, _ = fmt.Fprint(cmd.OutOrStdout(), output)
 		} else if showVersion {
 			fmt.Fprintln(cmd.OutOrStdout(), internalVersion.GetAppNameVersionText())
+			fmt.Fprintln(cmd.OutOrStdout(), "\nTo update: dr self update")
 		} else {
 			// Use default help behavior but with customized template
 			RootCmd.SetHelpTemplate(CustomHelpTemplate)

--- a/cmd/self/cmd.go
+++ b/cmd/self/cmd.go
@@ -27,7 +27,7 @@ func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "self",
 		GroupID: "self",
-		Short:   "⚙️ Run DataRobot CLI utility commands",
+		Short:   "⚙️ Configure and update the DataRobot CLI",
 	}
 
 	cmd.AddCommand(


### PR DESCRIPTION
## Summary

The `dr self update` command is buried under the `self` command group (described as "⚙️ Run DataRobot CLI utility commands"), making it undiscoverable for users who check their CLI version and want to update. A user reported having to clone the repo and ask an LLM how to update (CFX-7063).

A reminder that the overall strategy for the CLI is "to automatically self-update whenever possible".

## Changes

- **`dr --version` output**: append `To update: dr self update` after the version text (both in the HelpFunc override and the version template)

- **`dr --help` Quick Start section**: added `dr self update # Update DataRobot CLI to latest version` to the existing bullet list

- **`dr self --help`**: updated the short description to say "Configure and update the DataRobot CLI"

## What is NOT changed

- `dr self version` output (text, JSON, `--short`) is untouched — it is consumed by smoke tests and the prerequisites system
- No new commands or flags added

## TODO
- Add output-format support to `dr self version`, make `json` the default, have `dr --version` explicitly pass `--output-format text`
- Add an automatic self check mechanism that polls in the backgruond whether an update is available, and to do the update for us. Probably only visible in interactive commands, or in --help...

## Testing

```sh
╰─ ❯ dr --help                                                                                                                                                                           3 
DataRobot CLI version: v0.2.78-7-gf497abad29d3a9b
────────────────────────────────────────────     
    🚀 Build AI Applications Faster              
                                                 

The DataRobot CLI helps you quickly set up, configure, and deploy AI applications
using pre-built templates. Get from idea to production in minutes, not hours.

✨ What you can do:
  • Choose from ready-made AI application templates
  • Set up your development environment quickly
  • Deploy to DataRobot with a single command
  • Manage environment variables and configurations

🎯 Quick Start:
  dr start             # Create your first AI app (start here!)
  dr self update       # Update DataRobot CLI to latest version
  dr --help            # Show all available commands

[snip]

Self Commands:
  self        ⚙️ Configure and update the DataRobot CLI
```

```
╰─ ❯ dr self version                                                                                                                                                                     3 
DataRobot CLI version: v0.2.78-7-gf497abad29d3a9b

╭ cli on  aj/update-hint-version-help via 🐹 v1.26.5 via 🐍 v3.14.6 (sdk_docs)  l/a as aj.alon@datarobot.com (AJ Alon) .......................................................👾 staging.dr
╰─ ❯ dr --version                                                                                                                                                                        3 
DataRobot CLI version: v0.2.78-7-gf497abad29d3a9b

To update: dr self update
```


Closes CFX-7063
<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784745111.847959 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UX changes to help and version strings; no command behavior, auth, or update logic modified.
> 
> **Overview**
> Makes the self-update path visible when users check their CLI version or read top-level help, addressing discoverability of `dr self update` (CFX-7063).
> 
> **`dr --version`** (and the version branch of the custom help handler) now prints a second line: `To update: dr self update`, via both `SetVersionTemplate` and the `--version` help path. Root **Quick Start** in `dr --help` adds a bullet for `dr self update`. The **`dr self`** group short description is reworded to *Configure and update the DataRobot CLI*.
> 
> `dr self version` output is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f497abad29d3a9b50db5f1c2361c1a370c55bcf4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->