### PR TITLE
[CFX-7064] Add --output-format to dr self version with text as default

### DIFF
--- a/.cursor/bugbot-cmd.md
+++ b/.cursor/bugbot-cmd.md
@@ -16,6 +16,14 @@ Follow the standard file naming pattern: `cmd.go` for command logic, `model.go` 
 
 Text and JSON output must contain identical data with consistent field naming (camelCase for JSON).
 
+### JSON output purity
+
+When a command is invoked with `--output-format json` (or the deprecated `-o json` / `--format json`), **stdout must contain only valid JSON** — nothing else. This guarantees `dr <cmd> --output-format json | jq .` and `dr <cmd> --output-format json 2>&1 | jq .` both parse.
+
+All non-JSON diagnostics must go to **stderr**, never stdout.
+
+Prefer `outputformat.PrintJSONEnvelope` for structured output so the payload is always a single JSON object.
+
 ## Pagination Safety
 
 Validate that pagination never crosses host boundaries.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,31 +142,38 @@ For full details, see [docs/development/configuration.md](docs/development/confi
 All PRs are reviewed against **bugbot rules** in [.cursor/BUGBOT.md](.cursor/BUGBOT.md). Rules are organized by risk level:
 
 **High-Risk** (catches silent failures, data corruption, poor error handling):
+
 - **Concurrency** — Goroutine panic recovery, loop variable capture, WaitGroup pairing, channel closure
 - **Error Handling** — Wrapping errors with context, user-facing messages, not silently ignoring errors
 - **Security** — Input validation, security boundaries, threat models
 - **Testing** — Race detector, error path coverage, test seams
 
 **Resource & Operations** (prevents hangs, leaks, platform bugs):
+
 - **Resources** — Lock lifecycle, timeouts, cleanup, disk space checks
 - **Paths** — Validation, normalization, Unicode, symlinks
 - **Cross-Platform** — Build tags, case sensitivity, line endings, symlink handling
 
 **Design** (prevents tight coupling, premature abstraction):
+
 - **Architecture** — Code organization, separation of concerns, dependency injection, phase orchestration
 - **Package APIs** — Contracts between packages, documentation, limitations
 
 **Quality** (consistency and maintainability):
+
 - **Testing** — Test coverage, mocking, pagination tests
-- **Commands** — Table rendering, file organization, output formatting
+- **Commands** — Table rendering, file organization, output formatting, JSON output purity
 
 **CI & Workflows** (informational callouts, not correctness bugs):
+
 - **Composite Actions** — Changes to `.github/actions/*/action.yaml` can't be validated by their own PR's CI
 
 **When working on code**, apply these quick principles:
+
 - **Concurrency**: Recover from panics, capture loop variables, pair WaitGroups, close channels safely
 - **Errors**: Wrap with context, specialize messages (404 vs 500), log before returning
 - **Commands**: Use `lipgloss/table` + `tui.TableBorderStyle`, consistent styling, test output formatting
+- **JSON output purity**: When `--output-format json` is set, stdout must contain only valid JSON. All deprecation warnings, logs, usage, and update hints go to stderr
 - **Platforms**: Add build tags, match signatures, test on target platforms
 
 Refer to [.cursor/BUGBOT.md](.cursor/BUGBOT.md) for detailed rules and examples during PR review.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"github.com/datarobot/cli/cmd/pipeline"
 	"github.com/datarobot/cli/cmd/plugin"
 	"github.com/datarobot/cli/cmd/self"
+	selfversion "github.com/datarobot/cli/cmd/self/version"
 	"github.com/datarobot/cli/cmd/start"
 	"github.com/datarobot/cli/cmd/task"
 	"github.com/datarobot/cli/cmd/task/run"
@@ -309,7 +310,16 @@ func init() {
 
 			_, _ = fmt.Fprint(cmd.OutOrStdout(), output)
 		} else if showVersion {
-			fmt.Fprintln(cmd.OutOrStdout(), internalVersion.GetAppNameVersionText())
+			// Route through self version with explicit --output-format text
+			versionCmd := selfversion.Cmd()
+			versionCmd.SetArgs([]string{"--output-format", "text"})
+			versionCmd.SetOut(cmd.OutOrStdout())
+			versionCmd.SetErr(cmd.ErrOrStderr())
+
+			if err := versionCmd.Execute(); err != nil {
+				fmt.Fprintln(cmd.ErrOrStderr(), err)
+			}
+
 			fmt.Fprintln(cmd.OutOrStdout(), "\nTo update: dr self update")
 		} else {
 			// Use default help behavior but with customized template

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -312,15 +312,20 @@ func init() {
 		} else if showVersion {
 			// Route through self version with explicit --output-format text
 			versionCmd := selfversion.Cmd()
+			// Suppress automatic error/usage output from cobra to prevent double-printing.
+			// Error handling is done explicitly below.
+			versionCmd.SilenceErrors = true
+			versionCmd.SilenceUsage = true
 			versionCmd.SetArgs([]string{"--output-format", "text"})
 			versionCmd.SetOut(cmd.OutOrStdout())
 			versionCmd.SetErr(cmd.ErrOrStderr())
 
 			if err := versionCmd.Execute(); err != nil {
 				fmt.Fprintln(cmd.ErrOrStderr(), err)
+			} else {
+				// Only print the update hint on success
+				fmt.Fprintln(cmd.OutOrStdout(), "\nTo update: dr self update")
 			}
-
-			fmt.Fprintln(cmd.OutOrStdout(), "\nTo update: dr self update")
 		} else {
 			// Use default help behavior but with customized template
 			RootCmd.SetHelpTemplate(CustomHelpTemplate)

--- a/cmd/self/version/cmd.go
+++ b/cmd/self/version/cmd.go
@@ -60,15 +60,16 @@ func Cmd() *cobra.Command {
 	cmd.Flags().VarP(
 		&options.outputFormat,
 		"output-format",
-		"o",
+		"",
 		fmt.Sprintf("Output format (%s, %s)", outputformat.OutputFormatJSON, outputformat.OutputFormatText),
 	)
 
 	// Deprecated: use --output-format instead. Kept for backward compat with smoke test scripts.
+	// The -o shorthand is retained here for backwards compatibility with existing scripts.
 	cmd.Flags().VarP(
 		&options.legacyFormat,
 		"format",
-		"f",
+		"o",
 		fmt.Sprintf("Output format (deprecated, use --output-format) (%s, %s)", outputformat.OutputFormatJSON, outputformat.OutputFormatText),
 	)
 

--- a/cmd/self/version/cmd.go
+++ b/cmd/self/version/cmd.go
@@ -18,60 +18,35 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/datarobot/cli/internal/outputformat"
 	internalVersion "github.com/datarobot/cli/internal/version"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
-
-type Format string
-
-var _ pflag.Value = (*Format)(nil)
-
-const (
-	FormatJSON Format = "json"
-	FormatText Format = "text"
-)
-
-func (vf *Format) String() string {
-	if vf == nil {
-		return ""
-	}
-
-	return string(*vf)
-}
-
-func (vf *Format) Set(s string) error {
-	switch s {
-	case string(FormatJSON), string(FormatText):
-		*vf = Format(s)
-		return nil
-	}
-
-	return fmt.Errorf("Invalid format %q (must be %q or %q).",
-		s, FormatJSON, FormatText)
-}
-
-// Type is used by the shell completion generator
-func (vf *Format) Type() string {
-	return "version.Format"
-}
 
 type versionOptions struct {
-	format Format
-	short  bool
+	outputFormat outputformat.OutputFormat
+	legacyFormat outputformat.OutputFormat
+	short        bool
 }
 
 func Cmd() *cobra.Command {
 	var options versionOptions
 
-	options.format = FormatText
+	options.outputFormat = outputformat.OutputFormatJSON
 
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "📋 Show " + internalVersion.AppName + " version information",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			info, err := getVersion(options)
+			format := outputformat.GetFormat(cmd)
+
+			// Backward compat: --format takes precedence if explicitly set
+			if legacyFlag := cmd.Flags().Lookup("format"); legacyFlag != nil && legacyFlag.Changed {
+				format = options.legacyFormat
+			}
+
+			info, err := getVersion(format, options.short)
 			if err != nil {
 				return err
 			}
@@ -83,27 +58,38 @@ func Cmd() *cobra.Command {
 	}
 
 	cmd.Flags().VarP(
-		&options.format,
-		"format",
-		"f",
-		fmt.Sprintf("Output format (options: %s, %s)", FormatJSON, FormatText),
+		&options.outputFormat,
+		"output-format",
+		"o",
+		fmt.Sprintf("Output format (%s, %s)", outputformat.OutputFormatJSON, outputformat.OutputFormatText),
 	)
 
-	cmd.Flags().BoolVarP(&options.short, "short", "s", false, "Short format")
+	// Deprecated: use --output-format instead. Kept for backward compat with smoke test scripts.
+	cmd.Flags().VarP(
+		&options.legacyFormat,
+		"format",
+		"f",
+		fmt.Sprintf("Output format (deprecated, use --output-format) (%s, %s)", outputformat.OutputFormatJSON, outputformat.OutputFormatText),
+	)
 
-	_ = cmd.RegisterFlagCompletionFunc("format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-		return []string{string(FormatJSON), string(FormatText)}, cobra.ShellCompDirectiveNoFileComp
+	_ = cmd.Flags().MarkHidden("format")
+	_ = cmd.Flags().MarkDeprecated("format", "use --output-format instead")
+
+	cmd.Flags().BoolVarP(&options.short, "short", "s", false, "Print just the version number (text format only)")
+
+	_ = cmd.RegisterFlagCompletionFunc("output-format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{string(outputformat.OutputFormatJSON), string(outputformat.OutputFormatText)}, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	return cmd
 }
 
-func getVersion(opts versionOptions) (string, error) {
-	if opts.short {
+func getVersion(format outputformat.OutputFormat, short bool) (string, error) {
+	if short && format == outputformat.OutputFormatText {
 		return internalVersion.Version, nil
 	}
 
-	if opts.format == FormatJSON {
+	if format == outputformat.OutputFormatJSON {
 		b, err := json.Marshal(internalVersion.Info)
 		if err != nil {
 			return "", fmt.Errorf("Failed to marshal version info to JSON: %w", err)

--- a/cmd/self/version/cmd.go
+++ b/cmd/self/version/cmd.go
@@ -32,7 +32,7 @@ type versionOptions struct {
 func Cmd() *cobra.Command {
 	var options versionOptions
 
-	options.outputFormat = outputformat.OutputFormatJSON
+	options.outputFormat = outputformat.OutputFormatText
 
 	cmd := &cobra.Command{
 		Use:   "version",

--- a/cmd/self/version/cmd_test.go
+++ b/cmd/self/version/cmd_test.go
@@ -41,14 +41,11 @@ func runVersionCmd(t *testing.T, args ...string) string {
 	return outBuf.String()
 }
 
-func TestVersionDefaultJSON(t *testing.T) {
+func TestVersionDefaultText(t *testing.T) {
 	output := runVersionCmd(t)
 
-	var info internalVersion.InfoData
-
-	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &info), "default output should be valid JSON")
-	assert.Equal(t, internalVersion.Version, info.Version)
-	assert.NotEmpty(t, info.Runtime)
+	assert.Contains(t, output, internalVersion.AppName, "default output should contain app name")
+	assert.Contains(t, output, internalVersion.Version, "default output should contain version")
 }
 
 func TestVersionOutputFormatText(t *testing.T) {
@@ -74,15 +71,10 @@ func TestVersionShortText(t *testing.T) {
 	assert.Equal(t, internalVersion.Version, strings.TrimSpace(output), "--short should return just the version number")
 }
 
-func TestVersionShortJSONIgnored(t *testing.T) {
+func TestVersionShortDefault(t *testing.T) {
 	output := runVersionCmd(t, "--short")
 
-	// --short is ignored in JSON mode; should still get full JSON
-	var info internalVersion.InfoData
-
-	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &info), "output should be valid JSON")
-	assert.Equal(t, internalVersion.Version, info.Version)
-	assert.NotEmpty(t, info.Runtime)
+	assert.Equal(t, internalVersion.Version, strings.TrimSpace(output), "--short with default (text) should return just the version number")
 }
 
 func TestVersionLegacyFormatJSON(t *testing.T) {

--- a/cmd/self/version/cmd_test.go
+++ b/cmd/self/version/cmd_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	internalVersion "github.com/datarobot/cli/internal/version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runVersionCmd(t *testing.T, args ...string) string {
+	t.Helper()
+
+	cmd := Cmd()
+
+	outBuf := new(bytes.Buffer)
+
+	cmd.SetOut(outBuf)
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs(args)
+
+	require.NoError(t, cmd.Execute())
+
+	return outBuf.String()
+}
+
+func TestVersionDefaultJSON(t *testing.T) {
+	output := runVersionCmd(t)
+
+	var info internalVersion.InfoData
+
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &info), "default output should be valid JSON")
+	assert.Equal(t, internalVersion.Version, info.Version)
+	assert.NotEmpty(t, info.Runtime)
+}
+
+func TestVersionOutputFormatText(t *testing.T) {
+	output := runVersionCmd(t, "--output-format", "text")
+
+	assert.Contains(t, output, internalVersion.AppName, "text output should contain app name")
+	assert.Contains(t, output, internalVersion.Version, "text output should contain version")
+}
+
+func TestVersionOutputFormatJSON(t *testing.T) {
+	output := runVersionCmd(t, "--output-format", "json")
+
+	var info internalVersion.InfoData
+
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &info))
+	assert.Equal(t, internalVersion.Version, info.Version)
+	assert.NotEmpty(t, info.Runtime)
+}
+
+func TestVersionShortText(t *testing.T) {
+	output := runVersionCmd(t, "--output-format", "text", "--short")
+
+	assert.Equal(t, internalVersion.Version, strings.TrimSpace(output), "--short should return just the version number")
+}
+
+func TestVersionShortJSONIgnored(t *testing.T) {
+	output := runVersionCmd(t, "--short")
+
+	// --short is ignored in JSON mode; should still get full JSON
+	var info internalVersion.InfoData
+
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &info), "output should be valid JSON")
+	assert.Equal(t, internalVersion.Version, info.Version)
+	assert.NotEmpty(t, info.Runtime)
+}
+
+func TestVersionLegacyFormatJSON(t *testing.T) {
+	cmd := Cmd()
+
+	outBuf := new(bytes.Buffer)
+
+	cmd.SetOut(outBuf)
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{"--format", "json"})
+
+	require.NoError(t, cmd.Execute())
+
+	// pflag prints a deprecation warning to the same output buffer; find the JSON line
+	var jsonLine string
+
+	for _, line := range strings.Split(outBuf.String(), "\n") {
+		line = strings.TrimSpace(line)
+
+		if strings.HasPrefix(line, "{") {
+			jsonLine = line
+			break
+		}
+	}
+
+	require.NotEmpty(t, jsonLine, "should find JSON output among deprecation warnings")
+
+	var info internalVersion.InfoData
+
+	require.NoError(t, json.Unmarshal([]byte(jsonLine), &info), "--format json should produce valid JSON")
+	assert.Equal(t, internalVersion.Version, info.Version)
+}
+
+func TestVersionLegacyFormatText(t *testing.T) {
+	output := runVersionCmd(t, "--format", "text")
+
+	assert.Contains(t, output, internalVersion.AppName, "--format text should produce text output with app name")
+	assert.Contains(t, output, internalVersion.Version, "--format text should produce text output with version")
+}
+
+func TestVersionInvalidFormat(t *testing.T) {
+	cmd := Cmd()
+
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.SetErr(new(bytes.Buffer))
+	cmd.SetArgs([]string{"--output-format", "yaml"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}

--- a/docs/commands/self.md
+++ b/docs/commands/self.md
@@ -8,7 +8,7 @@ For most users, common CLI management tasks are straightforward:
 
 ```bash
 # Check CLI version
-dr self version
+dr self version --output-format text
 
 # Update to latest version
 dr self update
@@ -147,16 +147,20 @@ dr self version
 
 **Options:**
 
-- `-f, --format`&mdash;output format (`text` or `json`)
+- `-o, --output-format`&mdash;output format (`text` or `json`, default: `json`)
+- `-s, --short`&mdash;print just the version number (text format only)
 
 **Examples:**
 
 ```bash
-# Show version (default text format)
+# Show version (default JSON format)
 dr self version
 
-# Show version in JSON format
-dr self version --format json
+# Show version in text format
+dr self version --output-format text
+
+# Show just the version number
+dr self version --output-format text --short
 ```
 
 ## Global options
@@ -181,7 +185,7 @@ Installing DataRobot CLI...
 ### Check CLI version
 
 ```bash
-$ dr self version
+$ dr self version --output-format text
 DataRobot CLI version: v0.2.55
 ```
 
@@ -214,7 +218,7 @@ $ dr self completion bash | sudo tee /etc/bash_completion.d/dr
 ### Get version in JSON
 
 ```bash
-$ dr self version --format json
+$ dr self version
 {
   "version": "v0.2.55",
   "commit": "abc1234def5678",

--- a/docs/commands/self.md
+++ b/docs/commands/self.md
@@ -8,7 +8,7 @@ For most users, common CLI management tasks are straightforward:
 
 ```bash
 # Check CLI version
-dr self version --output-format text
+dr self version
 
 # Update to latest version
 dr self update
@@ -147,20 +147,20 @@ dr self version
 
 **Options:**
 
-- `-o, --output-format`&mdash;output format (`text` or `json`, default: `json`)
+- `-o, --output-format`&mdash;output format (`text` or `json`, default: `text`)
 - `-s, --short`&mdash;print just the version number (text format only)
 
 **Examples:**
 
 ```bash
-# Show version (default JSON format)
+# Show version (default text format)
 dr self version
 
-# Show version in text format
-dr self version --output-format text
+# Show version in JSON format
+dr self version --output-format json
 
 # Show just the version number
-dr self version --output-format text --short
+dr self version --short
 ```
 
 ## Global options
@@ -185,7 +185,7 @@ Installing DataRobot CLI...
 ### Check CLI version
 
 ```bash
-$ dr self version --output-format text
+$ dr self version
 DataRobot CLI version: v0.2.55
 ```
 
@@ -218,7 +218,7 @@ $ dr self completion bash | sudo tee /etc/bash_completion.d/dr
 ### Get version in JSON
 
 ```bash
-$ dr self version
+$ dr self version --output-format json
 {
   "version": "v0.2.55",
   "commit": "abc1234def5678",

--- a/docs/development/flags.md
+++ b/docs/development/flags.md
@@ -91,6 +91,22 @@ if format == outputformat.OutputFormatJSON {
 
 The envelope format is `{"<key>": <data>}`, which ensures output is always a JSON object (never a bare array). This makes the output forward-compatible for adding metadata, pagination, or warnings without breaking callers.
 
+### JSON output purity
+
+When the effective format is JSON, **stdout must contain only valid JSON**. Anything that would break `dr <cmd> --output-format json | jq .` (or `... 2>&1 | jq .`) is a bug.
+
+All non-JSON diagnostics belong on **stderr**, never stdout:
+
+- Cobra deprecation warnings (e.g. from `MarkDeprecated` / the legacy `-o`/`--format` shorthand)
+- Usage/help printed on error
+- Log lines, warnings, progress messages, update hints
+
+Concretely:
+
+- Write JSON via `fmt.Fprintln(cmd.OutOrStdout(), payload)` or `outputformat.PrintJSONEnvelope(os.Stdout, ...)` — never mix in non-JSON `fmt.Fprintln(cmd.OutOrStdout(), ...)` calls on the JSON path.
+- Return errors from `RunE` so cobra routes them to stderr; do not print errors to stdout.
+- If you need to emit a deprecation/notice alongside JSON output, write it to `cmd.ErrOrStderr()`.
+
 ## Universal flags (forwarded to plugins)
 
 Some root flags must be forwarded to plugin subprocesses as `DATAROBOT_CLI_*` environment variables so plugins can honour them (e.g. `--debug` → `DATAROBOT_CLI_DEBUG=1`). These are called **universal flags**.


### PR DESCRIPTION
## RATIONALE

`dr self version` had a custom `--format` flag inconsistent with the rest of the CLI, which uses `--output-format` from `internal/outputformat`. This change aligns the version command with the standard pattern. Text remains the default; `--output-format json` is opt-in. The `dr --version` flag explicitly passes `--output-format text`.

JSON was considered as the default but rejected as too much of a breaking change for users and scripts that run `dr self version` without explicit flags.

Follow-up to CFX-7063 (dr self update discoverability).

## CHANGES

**`cmd/self/version/cmd.go`**
- Refactored to use `internal/outputformat` and the `--output-format` global flag.
- Default remains `text`.
- `--format`/`-f` kept as hidden, deprecated alias for backward compat. `-o` is shorthand
- `--short`/`-s` now only applies in text mode.
- SilenceUsage and SilenceErrors
- warnings, etc. go to stderr so that `jq` can parse stdout properly

**`cmd/root.go`**:
`SetHelpFunc` version case now routes through `self version` with explicit `--output-format text` instead of printing directly.

**`docs/commands/self.md`**:
Updated examples from `--format` to `--output-format`.

**`cmd/self/version/cmd_test.go`**:
New test file covering default text, `--output-format text/json`, `--short` (text + default), `--format` backward compat, and invalid format error.

## TESTING

- `task lint` passes with 0 issues
- `go test ./cmd/self/version/... -v` — all 8 tests pass
- `go test ./cmd/ -run TestVersionFlag -v` — existing version flag test passes
- Smoke test scripts using `--format=json` remain backward compatible via deprecated alias

## RELATED

- [CFX-7063](https://datarobot.atlassian.net/browse/CFX-7063) — dr self update discoverability
- [CFX-7064](https://datarobot.atlassian.net/browse/CFX-7064) — This ticket

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI flag and help-path changes only; backward compatibility is preserved via deprecated `--format` with tests.
> 
> **Overview**
> **`dr self version`** now uses the shared **`internal/outputformat`** pattern with **`-o, --output-format`** (`text` default, `json` opt-in) instead of a bespoke **`--format`** flag. The old **`-f, --format`** remains as a hidden, deprecated alias (explicit **`--format`** still wins for backward compat), and **`--short`** applies only in text mode.
> 
> **`dr --version`** no longer prints version text directly; it executes **`self version`** with **`--output-format text`**, then prints the update hint.
> 
> Docs in **`docs/commands/self.md`** and new **`cmd/self/version/cmd_test.go`** cover the new flag, short output, legacy **`--format`**, and invalid format errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d58cdcd42e1cadc0bbf34ce7181504370138086. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->