### PR TITLE
[CFX-6647] fix(completion, windows): warn Windows users when execution policy blocks PowerShell profile

### DIFF
--- a/cmd/self/completion/install/cmd.go
+++ b/cmd/self/completion/install/cmd.go
@@ -519,6 +519,8 @@ func installPowerShell(_ *cobra.Command, _ bool) (string, func(*cobra.Command) e
 			return fmt.Errorf("Failed to write to PowerShell profile: %w", err)
 		}
 
+		warnIfExecutionPolicyRestricted()
+
 		return nil
 	}
 

--- a/cmd/self/completion/install/cmd.go
+++ b/cmd/self/completion/install/cmd.go
@@ -482,6 +482,8 @@ func installPowerShell(_ *cobra.Command, _ bool) (string, func(*cobra.Command) e
 		return "", func(*cobra.Command) error { return err }
 	}
 
+	shellExe := powerShellExeForProfile()
+
 	installFunc := func(rootCmd *cobra.Command) error {
 		// Ensure the directory exists
 		profileDir := filepath.Dir(profilePath)
@@ -519,12 +521,33 @@ func installPowerShell(_ *cobra.Command, _ bool) (string, func(*cobra.Command) e
 			return fmt.Errorf("Failed to write to PowerShell profile: %w", err)
 		}
 
-		warnIfExecutionPolicyRestricted()
+		warnIfExecutionPolicyRestricted(shellExe)
 
 		return nil
 	}
 
 	return profilePath, installFunc
+}
+
+// powerShellExeForProfile returns the PowerShell binary name that matches the
+// profile path chosen by powerShellProfilePath. PS Core (pwsh) and Windows
+// PowerShell (powershell) maintain separate execution policy settings, so the
+// warning check must query the same shell that will actually load the profile.
+func powerShellExeForProfile() string {
+	if runtime.GOOS != "windows" {
+		return "powershell"
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "powershell"
+	}
+
+	if fsutil.DirExists(filepath.Join(homeDir, "Documents", "PowerShell")) {
+		return "pwsh"
+	}
+
+	return "powershell"
 }
 
 func powerShellProfilePath() (string, error) {

--- a/cmd/self/completion/install/cmd_test.go
+++ b/cmd/self/completion/install/cmd_test.go
@@ -505,10 +505,16 @@ func TestInstallPowerShell(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
+	// On Windows, os.UserHomeDir() reads USERPROFILE, not HOME.
+	// Set both so the test isolates the profile path on all platforms.
 	origHome := os.Getenv("HOME")
+	origUserProfile := os.Getenv("USERPROFILE")
 
 	os.Setenv("HOME", tmpDir)
+	os.Setenv("USERPROFILE", tmpDir)
+
 	defer os.Setenv("HOME", origHome)
+	defer os.Setenv("USERPROFILE", origUserProfile)
 
 	profilePath, installFn := installPowerShell(rootCmd, false)
 
@@ -540,7 +546,7 @@ func TestInstallPowerShell(t *testing.T) {
 	}
 }
 
-// Helper function
+// Helper function.
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }

--- a/cmd/self/completion/install/cmd_test.go
+++ b/cmd/self/completion/install/cmd_test.go
@@ -445,7 +445,102 @@ func TestEnsureSourceInBashrcNotFound(t *testing.T) {
 	}
 }
 
-// Helper function.
+func TestMissingPowerShellBlocks(t *testing.T) {
+	t.Run("empty content returns all blocks", func(t *testing.T) {
+		result := missingPowerShellBlocks("")
+		if !contains(result, "dr completion powershell") {
+			t.Error("expected dr completion block")
+		}
+
+		if !contains(result, "# datarobot alias completion") {
+			t.Error("expected datarobot alias block")
+		}
+	})
+
+	t.Run("existing dr block skips dr but includes alias", func(t *testing.T) {
+		existing := "dr completion powershell | Out-String | Invoke-Expression\n"
+
+		result := missingPowerShellBlocks(existing)
+		if contains(result, "# dr completion") {
+			t.Error("should not include dr block header when already present")
+		}
+
+		if !contains(result, "# datarobot alias completion") {
+			t.Error("expected datarobot alias block")
+		}
+	})
+
+	t.Run("existing alias block skips alias", func(t *testing.T) {
+		existing := "# datarobot alias completion\nif (Get-Command datarobot -ErrorAction SilentlyContinue) {\n"
+
+		result := missingPowerShellBlocks(existing)
+		if contains(result, "# datarobot alias completion") {
+			t.Error("should not include datarobot alias block when already present")
+		}
+
+		if !contains(result, "dr completion powershell") {
+			t.Error("expected dr completion block")
+		}
+	})
+
+	t.Run("all blocks present returns empty", func(t *testing.T) {
+		existing := "dr completion powershell | Out-String | Invoke-Expression\n# datarobot alias completion\n"
+
+		result := missingPowerShellBlocks(existing)
+		if result != "" {
+			t.Errorf("expected empty result when all blocks present, got: %s", result)
+		}
+	})
+}
+
+func TestInstallPowerShell(t *testing.T) {
+	rootCmd := &cobra.Command{
+		Use:   "dr",
+		Short: "DataRobot CLI.",
+	}
+
+	tmpDir, err := os.MkdirTemp("", "test-powershell-profile-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	origHome := os.Getenv("HOME")
+
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	profilePath, installFn := installPowerShell(rootCmd, false)
+
+	if profilePath == "" {
+		t.Error("expected non-empty profile path")
+	}
+
+	if installFn == nil {
+		t.Fatal("expected non-nil install function")
+	}
+
+	if err := installFn(rootCmd); err != nil {
+		t.Fatalf("installPowerShell failed: %v", err)
+	}
+
+	if !fsutil.FileExists(profilePath) {
+		t.Fatalf("expected profile to exist at %s", profilePath)
+	}
+
+	data, err := os.ReadFile(profilePath)
+	if err != nil {
+		t.Fatalf("failed to read profile: %v", err)
+	}
+
+	content := string(data)
+
+	if !contains(content, "dr completion powershell") {
+		t.Error("profile should contain dr completion block")
+	}
+}
+
+// Helper function
 func contains(s, substr string) bool {
 	return strings.Contains(s, substr)
 }

--- a/cmd/self/completion/install/exec_policy_other.go
+++ b/cmd/self/completion/install/exec_policy_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package install
+
+func warnIfExecutionPolicyRestricted() {}

--- a/cmd/self/completion/install/exec_policy_other.go
+++ b/cmd/self/completion/install/exec_policy_other.go
@@ -1,5 +1,19 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build !windows
 
 package install
 
-func warnIfExecutionPolicyRestricted() {}
+func warnIfExecutionPolicyRestricted(_ string) {}

--- a/cmd/self/completion/install/exec_policy_windows.go
+++ b/cmd/self/completion/install/exec_policy_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package install
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const policyWarning = `  ⚠  PowerShell execution policy is set to %s.
+     The completion profile was written but will not load on the next
+     PowerShell launch.
+
+     Run this command to fix it:
+       Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+`
+
+func warnIfExecutionPolicyRestricted() {
+	out, err := exec.Command("powershell", "-Command", "Get-ExecutionPolicy -Scope CurrentUser").Output()
+	if err != nil {
+		return
+	}
+
+	policy := strings.TrimSpace(string(out))
+
+	if policy == "Restricted" || policy == "Undefined" {
+		fmt.Fprintf(os.Stderr, policyWarning, policy)
+	}
+}

--- a/cmd/self/completion/install/exec_policy_windows.go
+++ b/cmd/self/completion/install/exec_policy_windows.go
@@ -37,7 +37,7 @@ func warnIfExecutionPolicyRestricted(shellExe string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	out, err := exec.CommandContext(ctx, shellExe, "-Command", "Get-ExecutionPolicy").Output()
+	out, err := exec.CommandContext(ctx, shellExe, "-NoProfile", "-NonInteractive", "-Command", "Get-ExecutionPolicy").Output()
 	if err != nil {
 		return
 	}

--- a/cmd/self/completion/install/exec_policy_windows.go
+++ b/cmd/self/completion/install/exec_policy_windows.go
@@ -1,12 +1,28 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build windows
 
 package install
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 const policyWarning = `  ⚠  PowerShell execution policy is set to %s.
@@ -17,15 +33,18 @@ const policyWarning = `  ⚠  PowerShell execution policy is set to %s.
        Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
 `
 
-func warnIfExecutionPolicyRestricted() {
-	out, err := exec.Command("powershell", "-Command", "Get-ExecutionPolicy -Scope CurrentUser").Output()
+func warnIfExecutionPolicyRestricted(shellExe string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, shellExe, "-Command", "Get-ExecutionPolicy").Output()
 	if err != nil {
 		return
 	}
 
 	policy := strings.TrimSpace(string(out))
 
-	if policy == "Restricted" || policy == "Undefined" {
+	if policy == "Restricted" {
 		fmt.Fprintf(os.Stderr, policyWarning, policy)
 	}
 }

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -25,6 +25,7 @@ function Write-InfoMsg {
     Write-Host $Message
 }
 
+# Prints a section header banner centered around the given message.
 function Write-Delimiter {
     param([string]$Message)
     Write-Host ""
@@ -35,6 +36,7 @@ function Write-Delimiter {
     Write-Host ("=" * 20)
 }
 
+# Prints a closing END banner to delimit test sections.
 function Write-End {
     Write-Host ("=" * 20) -NoNewline
     Write-Host " END " -NoNewline
@@ -51,6 +53,7 @@ function Test-URLAccessible {
     }
 }
 
+# Installs PowerShell completions under a given execution policy and asserts warning behavior, profile contents, and policy preservation.
 function Test-DRCompletionInstallWithExecutionPolicy {
     param(
         [string]$TestName,
@@ -59,9 +62,11 @@ function Test-DRCompletionInstallWithExecutionPolicy {
         [bool]$ExpectWarning
     )
 
+    # Save the current policy so it can be restored after the test, then apply the policy under test.
     $originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
     Set-ExecutionPolicy $Policy -Scope CurrentUser -Force
 
+    # Run the installer and fail fast if it exits non-zero.
     $installOutput = (dr self completion install powershell --yes 2>&1 | Out-String)
     $installExitCode = $LASTEXITCODE
     if ($installExitCode -ne 0) {
@@ -69,6 +74,7 @@ function Test-DRCompletionInstallWithExecutionPolicy {
         Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCode"
     }
 
+    # Assert the installer warned (or did not warn) about the execution policy fix command.
     $fixCommand = "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser"
     $hasWarning = $installOutput -match $fixCommand
 
@@ -84,8 +90,7 @@ function Test-DRCompletionInstallWithExecutionPolicy {
 
     Write-SuccessMsg "Assertion passed [$TestName]: warning behavior correct"
 
-    # Match the order used by the Go installer: prefer PowerShell Core if the
-    # directory exists, otherwise fall back to Windows PowerShell.
+    # Resolve the PowerShell profile path, preferring PowerShell Core over Windows PowerShell (matches the Go installer).
     $documentsPath = "$env:USERPROFILE\Documents"
     $psCoreDir = Join-Path $documentsPath "PowerShell"
     $windowsPsDir = Join-Path $documentsPath "WindowsPowerShell"
@@ -96,6 +101,7 @@ function Test-DRCompletionInstallWithExecutionPolicy {
         $profilePath = Join-Path $windowsPsDir "Microsoft.PowerShell_profile.ps1"
     }
 
+    # Assert the profile exists and contains the dr completion block.
     if (-not (Test-Path $profilePath)) {
         Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
         Write-ErrorMsg "Assertion failed: PowerShell profile was not found at $profilePath"
@@ -109,6 +115,7 @@ function Test-DRCompletionInstallWithExecutionPolicy {
 
     Write-SuccessMsg "Assertion passed: profile contains completion block"
 
+    # Assert the execution policy was not modified by the installer.
     $actualPolicy = Get-ExecutionPolicy -Scope CurrentUser
     if ($actualPolicy -ne $ExpectedPolicy) {
         Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
@@ -117,6 +124,7 @@ function Test-DRCompletionInstallWithExecutionPolicy {
 
     Write-SuccessMsg "Assertion passed [$TestName]: execution policy remains '$actualPolicy'"
 
+    # Restore the original execution policy.
     Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
 }
 

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -51,39 +51,6 @@ function Test-URLAccessible {
     }
 }
 
-function Get-DRCompletionProfilePath {
-    # Match the order used by the Go installer: prefer PowerShell Core if the
-    # directory exists, otherwise fall back to Windows PowerShell.
-    $documentsPath = "$env:USERPROFILE\Documents"
-    $psCoreDir = Join-Path $documentsPath "PowerShell"
-    $windowsPsDir = Join-Path $documentsPath "WindowsPowerShell"
-
-    if (Test-Path $psCoreDir) {
-        return Join-Path $psCoreDir "Microsoft.PowerShell_profile.ps1"
-    }
-    return Join-Path $windowsPsDir "Microsoft.PowerShell_profile.ps1"
-}
-
-function Test-DRCompletionProfile {
-    param(
-        [string]$ProfilePath,
-        [string]$OriginalPolicy
-    )
-
-    if (-not (Test-Path $ProfilePath)) {
-        Set-ExecutionPolicy $OriginalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "Assertion failed: PowerShell profile was not found at $ProfilePath"
-    }
-
-    $profileContent = Get-Content $ProfilePath -Raw
-    if ($profileContent -notmatch "dr completion powershell") {
-        Set-ExecutionPolicy $OriginalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "Assertion failed: profile does not contain completion block"
-    }
-
-    Write-SuccessMsg "Assertion passed: profile contains completion block"
-}
-
 function Test-DRCompletionInstallWithExecutionPolicy {
     param(
         [string]$TestName,
@@ -117,8 +84,30 @@ function Test-DRCompletionInstallWithExecutionPolicy {
 
     Write-SuccessMsg "Assertion passed [$TestName]: warning behavior correct"
 
-    $profilePath = Get-DRCompletionProfilePath
-    Test-DRCompletionProfile -ProfilePath $profilePath -OriginalPolicy $originalPolicy
+    # Match the order used by the Go installer: prefer PowerShell Core if the
+    # directory exists, otherwise fall back to Windows PowerShell.
+    $documentsPath = "$env:USERPROFILE\Documents"
+    $psCoreDir = Join-Path $documentsPath "PowerShell"
+    $windowsPsDir = Join-Path $documentsPath "WindowsPowerShell"
+
+    if (Test-Path $psCoreDir) {
+        $profilePath = Join-Path $psCoreDir "Microsoft.PowerShell_profile.ps1"
+    } else {
+        $profilePath = Join-Path $windowsPsDir "Microsoft.PowerShell_profile.ps1"
+    }
+
+    if (-not (Test-Path $profilePath)) {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed: PowerShell profile was not found at $profilePath"
+    }
+
+    $profileContent = Get-Content $profilePath -Raw
+    if ($profileContent -notmatch "dr completion powershell") {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed: profile does not contain completion block"
+    }
+
+    Write-SuccessMsg "Assertion passed: profile contains completion block"
 
     $actualPolicy = Get-ExecutionPolicy -Scope CurrentUser
     if ($actualPolicy -ne $ExpectedPolicy) {

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -51,6 +51,86 @@ function Test-URLAccessible {
     }
 }
 
+function Get-DRCompletionProfilePath {
+    # Match the order used by the Go installer: prefer PowerShell Core if the
+    # directory exists, otherwise fall back to Windows PowerShell.
+    $documentsPath = "$env:USERPROFILE\Documents"
+    $psCoreDir = Join-Path $documentsPath "PowerShell"
+    $windowsPsDir = Join-Path $documentsPath "WindowsPowerShell"
+
+    if (Test-Path $psCoreDir) {
+        return Join-Path $psCoreDir "Microsoft.PowerShell_profile.ps1"
+    }
+    return Join-Path $windowsPsDir "Microsoft.PowerShell_profile.ps1"
+}
+
+function Test-DRCompletionProfile {
+    param(
+        [string]$ProfilePath,
+        [string]$OriginalPolicy
+    )
+
+    if (-not (Test-Path $ProfilePath)) {
+        Set-ExecutionPolicy $OriginalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed: PowerShell profile was not found at $ProfilePath"
+    }
+
+    $profileContent = Get-Content $ProfilePath -Raw
+    if ($profileContent -notmatch "dr completion powershell") {
+        Set-ExecutionPolicy $OriginalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed: profile does not contain completion block"
+    }
+
+    Write-SuccessMsg "Assertion passed: profile contains completion block"
+}
+
+function Test-DRCompletionInstallWithExecutionPolicy {
+    param(
+        [string]$TestName,
+        [string]$Policy,
+        [string]$ExpectedPolicy,
+        [bool]$ExpectWarning
+    )
+
+    $originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
+    Set-ExecutionPolicy $Policy -Scope CurrentUser -Force
+
+    $installOutput = (dr self completion install powershell --yes 2>&1 | Out-String)
+    $installExitCode = $LASTEXITCODE
+    if ($installExitCode -ne 0) {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCode"
+    }
+
+    $fixCommand = "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser"
+    $hasWarning = $installOutput -match $fixCommand
+
+    if ($ExpectWarning -and -not $hasWarning) {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed [$TestName]: installer did not warn user with the execution policy fix command"
+    }
+
+    if (-not $ExpectWarning -and $hasWarning) {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed [$TestName]: installer warned about execution policy when policy was already permissive"
+    }
+
+    Write-SuccessMsg "Assertion passed [$TestName]: warning behavior correct"
+
+    $profilePath = Get-DRCompletionProfilePath
+    Test-DRCompletionProfile -ProfilePath $profilePath -OriginalPolicy $originalPolicy
+
+    $actualPolicy = Get-ExecutionPolicy -Scope CurrentUser
+    if ($actualPolicy -ne $ExpectedPolicy) {
+        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed [$TestName]: expected execution policy to be $ExpectedPolicy, but it is '$actualPolicy'"
+    }
+
+    Write-SuccessMsg "Assertion passed [$TestName]: execution policy remains '$actualPolicy'"
+
+    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+}
+
 # Main execution
 Write-Host 'Running smoke tests for Windows...'
 
@@ -155,105 +235,13 @@ Write-End
 # default Restricted policy and print the exact command to fix it, but it should
 # not modify the policy itself.
 Write-Delimiter "Testing dr self completion install (Restricted execution policy)"
-
-$originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
-
-# Simulate a fresh Windows machine where the default execution policy is Restricted.
-Set-ExecutionPolicy Restricted -Scope CurrentUser -Force
-
-# Run the completion installer and capture its output so we can verify the warning.
-$installOutput = (dr self completion install powershell --yes 2>&1 | Out-String)
-$installExitCode = $LASTEXITCODE
-if ($installExitCode -ne 0) {
-    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCode"
-}
-
-# Verify the installer warned the user with the exact fix command.
-if ($installOutput -notmatch "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser") {
-    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: installer did not warn user with the execution policy fix command"
-}
-Write-SuccessMsg "Assertion passed: installer warned about Restricted execution policy"
-
-# Verify the completion profile was written.
-$profilePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
-if (-not (Test-Path $profilePath)) {
-    $profilePath = "$env:USERPROFILE\Documents\PowerShell\Microsoft.PowerShell_profile.ps1"
-}
-if (-not (Test-Path $profilePath)) {
-    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: PowerShell profile was not created"
-}
-$profileContent = Get-Content $profilePath -Raw
-if ($profileContent -notmatch "dr completion powershell") {
-    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: profile does not contain completion block"
-}
-Write-SuccessMsg "Assertion passed: profile written and contains completion block"
-
-# Verify the policy remains unchanged (warn-only behavior; the fix is left to the user).
-$policy = Get-ExecutionPolicy -Scope CurrentUser
-if ($policy -ne "Restricted") {
-    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: expected execution policy to remain Restricted (warn-only), but it is '$policy'"
-}
-Write-SuccessMsg "Assertion passed: execution policy remains '$policy' (installer only warned)"
-
-# Restore the original policy so the rest of the smoke test is not affected.
-Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+Test-DRCompletionInstallWithExecutionPolicy -TestName "Restricted" -Policy "Restricted" -ExpectedPolicy "Restricted" -ExpectWarning $true
 Write-End
 
 # Test completion install under a permissive execution policy.
 # The installer should complete silently without warning the user.
 Write-Delimiter "Testing dr self completion install (permissive execution policy)"
-
-$originalPolicyPermissive = Get-ExecutionPolicy -Scope CurrentUser
-
-# Simulate a machine where the user has already relaxed the execution policy.
-Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-
-# Run the completion installer and capture its output.
-$installOutputPermissive = (dr self completion install powershell --yes 2>&1 | Out-String)
-$installExitCodePermissive = $LASTEXITCODE
-if ($installExitCodePermissive -ne 0) {
-    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCodePermissive"
-}
-
-# Verify the installer did NOT warn about execution policy.
-if ($installOutputPermissive -match "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser") {
-    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: installer warned about execution policy when policy was already permissive"
-}
-Write-SuccessMsg "Assertion passed: installer did not warn when execution policy is permissive"
-
-# Verify the completion profile exists and contains the completion block.
-$profilePathPermissive = "$env:USERPROFILE\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
-if (-not (Test-Path $profilePathPermissive)) {
-    $profilePathPermissive = "$env:USERPROFILE\Documents\PowerShell\Microsoft.PowerShell_profile.ps1"
-}
-if (-not (Test-Path $profilePathPermissive)) {
-    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: PowerShell profile was not found"
-}
-$profileContentPermissive = Get-Content $profilePathPermissive -Raw
-if ($profileContentPermissive -notmatch "dr completion powershell") {
-    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: profile does not contain completion block"
-}
-Write-SuccessMsg "Assertion passed: profile contains completion block"
-
-# Verify the policy remains unchanged.
-$policyPermissive = Get-ExecutionPolicy -Scope CurrentUser
-if ($policyPermissive -ne "RemoteSigned") {
-    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: expected execution policy to remain RemoteSigned, but it is '$policyPermissive'"
-}
-Write-SuccessMsg "Assertion passed: execution policy remains '$policyPermissive'"
-
-# Restore the original policy.
-Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+Test-DRCompletionInstallWithExecutionPolicy -TestName "RemoteSigned" -Policy "RemoteSigned" -ExpectedPolicy "RemoteSigned" -ExpectWarning $false
 Write-End
 
 # Test dr run command

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -204,6 +204,58 @@ Write-SuccessMsg "Assertion passed: execution policy remains '$policy' (installe
 Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
 Write-End
 
+# Test completion install under a permissive execution policy.
+# The installer should complete silently without warning the user.
+Write-Delimiter "Testing dr self completion install (permissive execution policy)"
+
+$originalPolicyPermissive = Get-ExecutionPolicy -Scope CurrentUser
+
+# Simulate a machine where the user has already relaxed the execution policy.
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+
+# Run the completion installer and capture its output.
+$installOutputPermissive = (dr self completion install powershell --yes 2>&1 | Out-String)
+$installExitCodePermissive = $LASTEXITCODE
+if ($installExitCodePermissive -ne 0) {
+    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCodePermissive"
+}
+
+# Verify the installer did NOT warn about execution policy.
+if ($installOutputPermissive -match "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser") {
+    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: installer warned about execution policy when policy was already permissive"
+}
+Write-SuccessMsg "Assertion passed: installer did not warn when execution policy is permissive"
+
+# Verify the completion profile exists and contains the completion block.
+$profilePathPermissive = "$env:USERPROFILE\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
+if (-not (Test-Path $profilePathPermissive)) {
+    $profilePathPermissive = "$env:USERPROFILE\Documents\PowerShell\Microsoft.PowerShell_profile.ps1"
+}
+if (-not (Test-Path $profilePathPermissive)) {
+    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: PowerShell profile was not found"
+}
+$profileContentPermissive = Get-Content $profilePathPermissive -Raw
+if ($profileContentPermissive -notmatch "dr completion powershell") {
+    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: profile does not contain completion block"
+}
+Write-SuccessMsg "Assertion passed: profile contains completion block"
+
+# Verify the policy remains unchanged.
+$policyPermissive = Get-ExecutionPolicy -Scope CurrentUser
+if ($policyPermissive -ne "RemoteSigned") {
+    Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: expected execution policy to remain RemoteSigned, but it is '$policyPermissive'"
+}
+Write-SuccessMsg "Assertion passed: execution policy remains '$policyPermissive'"
+
+# Restore the original policy.
+Set-ExecutionPolicy $originalPolicyPermissive -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+Write-End
+
 # Test dr run command
 Write-Delimiter "Testing dr run command"
 dr run

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -151,10 +151,9 @@ if (Test-Path $completion_file) {
 Write-End
 
 # Test completion install under a fresh-machine execution policy.
-# This intentionally exposes the bug: dr self completion install writes a
-# profile that PowerShell refuses to load when the default Restricted policy
-# is in effect. The CLI does not yet fix the policy, so the assertion below
-# expects the policy to remain Restricted after install.
+# The installer should warn the user that the profile will not load under the
+# default Restricted policy and print the exact command to fix it, but it should
+# not modify the policy itself.
 Write-Delimiter "Testing dr self completion install (Restricted execution policy)"
 
 $originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
@@ -162,12 +161,20 @@ $originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
 # Simulate a fresh Windows machine where the default execution policy is Restricted.
 Set-ExecutionPolicy Restricted -Scope CurrentUser -Force
 
-# Run the completion installer. This is the exact user path that is broken.
-dr self completion install powershell --yes
-if ($LASTEXITCODE -ne 0) {
+# Run the completion installer and capture its output so we can verify the warning.
+$installOutput = (dr self completion install powershell --yes 2>&1 | Out-String)
+$installExitCode = $LASTEXITCODE
+if ($installExitCode -ne 0) {
     Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "dr self completion install powershell --yes failed"
+    Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCode"
 }
+
+# Verify the installer warned the user with the exact fix command.
+if ($installOutput -notmatch "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser") {
+    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: installer did not warn user with the execution policy fix command"
+}
+Write-SuccessMsg "Assertion passed: installer warned about Restricted execution policy"
 
 # Verify the completion profile was written.
 $profilePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
@@ -185,14 +192,13 @@ if ($profileContent -notmatch "dr completion powershell") {
 }
 Write-SuccessMsg "Assertion passed: profile written and contains completion block"
 
-# Verify the bug: the installer does NOT change the execution policy, so a
-# fresh machine remains Restricted and the profile will not load next session.
+# Verify the policy remains unchanged (warn-only behavior; the fix is left to the user).
 $policy = Get-ExecutionPolicy -Scope CurrentUser
 if ($policy -ne "Restricted") {
     Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-    Write-ErrorMsg "Assertion failed: expected execution policy to remain Restricted (proving the bug), but it is '$policy'"
+    Write-ErrorMsg "Assertion failed: expected execution policy to remain Restricted (warn-only), but it is '$policy'"
 }
-Write-SuccessMsg "Assertion passed: execution policy remains '$policy' after install, confirming the bug"
+Write-SuccessMsg "Assertion passed: execution policy remains '$policy' (installer only warned)"
 
 # Restore the original policy so the rest of the smoke test is not affected.
 Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -5,21 +5,12 @@ $DR_API_TOKEN = $args[0]
 
 $ErrorActionPreference = "Stop"
 
-$global:XFailCount = 0
-
 function Write-ErrorMsg {
     param([string]$Message)
     Write-Host "[ERROR] " -NoNewline -ForegroundColor Red
     Write-Host $Message
     Write-Host ""
     exit 1
-}
-
-function Write-XFailMsg {
-    param([string]$Message)
-    Write-Host "[XFAIL] " -NoNewline -ForegroundColor Yellow
-    Write-Host $Message
-    $global:XFailCount++
 }
 
 function Write-SuccessMsg {
@@ -34,7 +25,6 @@ function Write-InfoMsg {
     Write-Host $Message
 }
 
-# Prints a section header banner centered around the given message.
 function Write-Delimiter {
     param([string]$Message)
     Write-Host ""
@@ -45,7 +35,6 @@ function Write-Delimiter {
     Write-Host ("=" * 20)
 }
 
-# Prints a closing END banner to delimit test sections.
 function Write-End {
     Write-Host ("=" * 20) -NoNewline
     Write-Host " END " -NoNewline
@@ -60,130 +49,6 @@ function Test-URLAccessible {
     } catch {
         return $false
     }
-}
-
-# Installs PowerShell completions under a given execution policy and asserts warning behavior, profile contents, and policy preservation.
-function Test-DRCompletionInstallWithExecutionPolicy {
-    param(
-        [string]$TestName,
-        [string]$Policy,
-        [string]$ExpectedPolicy,
-        [bool]$ExpectWarning
-    )
-
-    # Guard: Get-ExecutionPolicy may not be available on every PowerShell
-    # build (e.g. some Windows Server 2025 runner images fail to auto-load
-    # the Microsoft.PowerShell.Security module).  Skip gracefully instead of
-    # crashing the entire smoke-test suite.
-    try {
-        $null = Get-ExecutionPolicy -ErrorAction Stop
-    } catch {
-        Write-InfoMsg "Skipping [$TestName]: Get-ExecutionPolicy cmdlet not available on this system."
-
-        return
-    }
-
-    # Save the current effective policy so it can be restored after the test.
-    # Use -Scope Process for Set-ExecutionPolicy so we don't touch the registry
-    # (some CI runners lock down CurrentUser/Machine policy via Group Policy).
-    # Get-ExecutionPolicy (no -Scope) returns the effective policy, which
-    # correctly reflects the Process-scope override.
-    $originalPolicy = Get-ExecutionPolicy
-
-    try {
-        Set-ExecutionPolicy $Policy -Scope Process -Force -ErrorAction Stop
-    } catch {
-        Write-InfoMsg "Skipping [$TestName]: unable to set execution policy to $Policy."
-
-        return
-    }
-
-    # Resolve the PowerShell profile path, preferring PowerShell Core over Windows PowerShell (matches the Go installer).
-    $documentsPath = "$env:USERPROFILE\Documents"
-    $psCoreDir = Join-Path $documentsPath "PowerShell"
-    $windowsPsDir = Join-Path $documentsPath "WindowsPowerShell"
-
-    if (Test-Path $psCoreDir) {
-        $profilePath = Join-Path $psCoreDir "Microsoft.PowerShell_profile.ps1"
-    } else {
-        $profilePath = Join-Path $windowsPsDir "Microsoft.PowerShell_profile.ps1"
-    }
-
-    # Clean up any existing profile from a previous test so each run starts fresh.
-    if (Test-Path $profilePath) {
-        Remove-Item $profilePath -Force -ErrorAction SilentlyContinue
-    }
-
-    # Run the installer with --force so each invocation performs a real install.
-    # Relax EAP to "Continue" so stderr lines from the native command are
-    # captured, not thrown (same pattern as the --debug test above).
-    $prevEAP = $ErrorActionPreference
-    $ErrorActionPreference = "Continue"
-    $installOutput = (dr self completion install powershell --yes --force 2>&1 | Out-String)
-    $installExitCode = $LASTEXITCODE
-    $ErrorActionPreference = $prevEAP
-    if ($installExitCode -ne 0) {
-        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "dr self completion install powershell --yes --force failed with exit code $installExitCode"
-    }
-
-    # Assert the installer warned (or did not warn) about the execution policy fix command.
-    $fixCommand = "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser"
-    $hasWarning = $installOutput -match $fixCommand
-
-    if ($ExpectWarning -and -not $hasWarning) {
-        # XFAIL: when testing Restricted policy without the Phase 2 Go fix,
-        # the warning is expected to be absent. Track as an expected failure
-        # and return early — the remaining assertions (profile, policy) are
-        # not meaningful when the warning behavior isn't yet implemented.
-        # Remove this branch when Phase 2 lands.
-        $isXFail = $ExpectWarning -and ($Policy -eq "Restricted")
-
-        if ($isXFail) {
-            Write-XFailMsg "Assertion xfail [$TestName]: installer did not warn user with the execution policy fix command (expected: Phase 2 not yet merged)"
-            Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
-            if (Test-Path $profilePath) { Remove-Item $profilePath -Force -ErrorAction SilentlyContinue }
-
-            return
-        }
-
-        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "Assertion failed [$TestName]: installer did not warn user with the execution policy fix command"
-    }
-
-    if (-not $ExpectWarning -and $hasWarning) {
-        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "Assertion failed [$TestName]: installer warned about execution policy when policy was already permissive"
-    }
-
-    Write-SuccessMsg "Assertion passed [$TestName]: warning behavior correct"
-
-    # Assert the profile exists and contains the dr completion block.
-    if (-not (Test-Path $profilePath)) {
-        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "Assertion failed: PowerShell profile was not found at $profilePath"
-    }
-
-    $profileContent = Get-Content $profilePath -Raw
-    if ($profileContent -notmatch "dr completion powershell") {
-        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "Assertion failed: profile does not contain completion block"
-    }
-
-    Write-SuccessMsg "Assertion passed: profile contains completion block"
-
-    # Assert the execution policy was not modified by the installer.
-    $actualPolicy = Get-ExecutionPolicy
-    if ($actualPolicy -ne $ExpectedPolicy) {
-        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "Assertion failed [$TestName]: expected execution policy to be $ExpectedPolicy, but it is '$actualPolicy'"
-    }
-
-    Write-SuccessMsg "Assertion passed [$TestName]: execution policy remains '$actualPolicy'"
-
-    # Restore the original execution policy and clean up the profile.
-    Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
-    if (Test-Path $profilePath) { Remove-Item $profilePath -Force -ErrorAction SilentlyContinue }
 }
 
 # Main execution
@@ -286,17 +151,51 @@ if (Test-Path $completion_file) {
 Write-End
 
 # Test completion install under a fresh-machine execution policy.
-# The installer should warn the user that the profile will not load under the
-# default Restricted policy and print the exact command to fix it, but it should
-# not modify the policy itself.
+# This intentionally exposes the bug: dr self completion install writes a
+# profile that PowerShell refuses to load when the default Restricted policy
+# is in effect. The CLI does not yet fix the policy, so the assertion below
+# expects the policy to remain Restricted after install.
 Write-Delimiter "Testing dr self completion install (Restricted execution policy)"
-Test-DRCompletionInstallWithExecutionPolicy -TestName "Restricted" -Policy "Restricted" -ExpectedPolicy "Restricted" -ExpectWarning $true
-Write-End
 
-# Test completion install under a permissive execution policy.
-# The installer should complete silently without warning the user.
-Write-Delimiter "Testing dr self completion install (permissive execution policy)"
-Test-DRCompletionInstallWithExecutionPolicy -TestName "RemoteSigned" -Policy "RemoteSigned" -ExpectedPolicy "RemoteSigned" -ExpectWarning $false
+$originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
+
+# Simulate a fresh Windows machine where the default execution policy is Restricted.
+Set-ExecutionPolicy Restricted -Scope CurrentUser -Force
+
+# Run the completion installer. This is the exact user path that is broken.
+dr self completion install powershell --yes
+if ($LASTEXITCODE -ne 0) {
+    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "dr self completion install powershell --yes failed"
+}
+
+# Verify the completion profile was written.
+$profilePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1"
+if (-not (Test-Path $profilePath)) {
+    $profilePath = "$env:USERPROFILE\Documents\PowerShell\Microsoft.PowerShell_profile.ps1"
+}
+if (-not (Test-Path $profilePath)) {
+    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: PowerShell profile was not created"
+}
+$profileContent = Get-Content $profilePath -Raw
+if ($profileContent -notmatch "dr completion powershell") {
+    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: profile does not contain completion block"
+}
+Write-SuccessMsg "Assertion passed: profile written and contains completion block"
+
+# Verify the bug: the installer does NOT change the execution policy, so a
+# fresh machine remains Restricted and the profile will not load next session.
+$policy = Get-ExecutionPolicy -Scope CurrentUser
+if ($policy -ne "Restricted") {
+    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-ErrorMsg "Assertion failed: expected execution policy to remain Restricted (proving the bug), but it is '$policy'"
+}
+Write-SuccessMsg "Assertion passed: execution policy remains '$policy' after install, confirming the bug"
+
+# Restore the original policy so the rest of the smoke test is not affected.
+Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
 Write-End
 
 # Test dr run command
@@ -383,14 +282,6 @@ if (-not $url_accessible) {
     Write-InfoMsg "Testing template setup would require interactive input..."
     Write-InfoMsg "Skipping template clone test on Windows (requires interactive expect-like tool)"
     Write-End
-}
-
-if ($global:XFailCount -gt 0) {
-    Write-Host ""
-    Write-Host ("=" * 20) -NoNewline
-    Write-Host " XFAIL SUMMARY " -NoNewline -ForegroundColor Yellow
-    Write-Host ("=" * 20)
-    Write-Host "$global:XFailCount expected failure(s) (xfail) -- these will pass after Phase 2 (CFX-6647 Go fix) is merged."
 }
 
 Write-SuccessMsg "Smoke tests for Windows completed successfully."

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -62,33 +62,32 @@ function Test-DRCompletionInstallWithExecutionPolicy {
         [bool]$ExpectWarning
     )
 
-    # Save the current policy so it can be restored after the test, then apply the policy under test.
-    $originalPolicy = Get-ExecutionPolicy -Scope CurrentUser
-    Set-ExecutionPolicy $Policy -Scope CurrentUser -Force
+    # Guard: Get-ExecutionPolicy may not be available on every PowerShell
+    # build (e.g. some Windows Server 2025 runner images fail to auto-load
+    # the Microsoft.PowerShell.Security module).  Skip gracefully instead of
+    # crashing the entire smoke-test suite.
+    try {
+        $null = Get-ExecutionPolicy -ErrorAction Stop
+    } catch {
+        Write-InfoMsg "Skipping [$TestName]: Get-ExecutionPolicy cmdlet not available on this system."
 
-    # Run the installer and fail fast if it exits non-zero.
-    $installOutput = (dr self completion install powershell --yes 2>&1 | Out-String)
-    $installExitCode = $LASTEXITCODE
-    if ($installExitCode -ne 0) {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "dr self completion install powershell --yes failed with exit code $installExitCode"
+        return
     }
 
-    # Assert the installer warned (or did not warn) about the execution policy fix command.
-    $fixCommand = "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser"
-    $hasWarning = $installOutput -match $fixCommand
+    # Save the current effective policy so it can be restored after the test.
+    # Use -Scope Process for Set-ExecutionPolicy so we don't touch the registry
+    # (some CI runners lock down CurrentUser/Machine policy via Group Policy).
+    # Get-ExecutionPolicy (no -Scope) returns the effective policy, which
+    # correctly reflects the Process-scope override.
+    $originalPolicy = Get-ExecutionPolicy
 
-    if ($ExpectWarning -and -not $hasWarning) {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "Assertion failed [$TestName]: installer did not warn user with the execution policy fix command"
+    try {
+        Set-ExecutionPolicy $Policy -Scope Process -Force -ErrorAction Stop
+    } catch {
+        Write-InfoMsg "Skipping [$TestName]: unable to set execution policy to $Policy."
+
+        return
     }
-
-    if (-not $ExpectWarning -and $hasWarning) {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
-        Write-ErrorMsg "Assertion failed [$TestName]: installer warned about execution policy when policy was already permissive"
-    }
-
-    Write-SuccessMsg "Assertion passed [$TestName]: warning behavior correct"
 
     # Resolve the PowerShell profile path, preferring PowerShell Core over Windows PowerShell (matches the Go installer).
     $documentsPath = "$env:USERPROFILE\Documents"
@@ -101,31 +100,68 @@ function Test-DRCompletionInstallWithExecutionPolicy {
         $profilePath = Join-Path $windowsPsDir "Microsoft.PowerShell_profile.ps1"
     }
 
+    # Clean up any existing profile from a previous test so each run starts fresh.
+    if (Test-Path $profilePath) {
+        Remove-Item $profilePath -Force -ErrorAction SilentlyContinue
+    }
+
+    # Run the installer with --force so each invocation performs a real install.
+    # Relax EAP to "Continue" so stderr lines from the native command are
+    # captured, not thrown (same pattern as the --debug test above).
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    $installOutput = (dr self completion install powershell --yes --force 2>&1 | Out-String)
+    $installExitCode = $LASTEXITCODE
+    $ErrorActionPreference = $prevEAP
+    if ($installExitCode -ne 0) {
+        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "dr self completion install powershell --yes --force failed with exit code $installExitCode"
+    }
+
+    # Assert the installer warned (or did not warn) about the execution policy fix command.
+    $fixCommand = "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser"
+    $hasWarning = $installOutput -match $fixCommand
+
+    if ($ExpectWarning -and -not $hasWarning) {
+        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed [$TestName]: installer did not warn user with the execution policy fix command"
+    }
+
+    if (-not $ExpectWarning -and $hasWarning) {
+        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
+        Write-ErrorMsg "Assertion failed [$TestName]: installer warned about execution policy when policy was already permissive"
+    }
+
+    Write-SuccessMsg "Assertion passed [$TestName]: warning behavior correct"
+
     # Assert the profile exists and contains the dr completion block.
+    # Restricted policy blocks *loading* the profile, not writing it, so the
+    # installer should still create the profile even under Restricted.
     if (-not (Test-Path $profilePath)) {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
         Write-ErrorMsg "Assertion failed: PowerShell profile was not found at $profilePath"
     }
 
     $profileContent = Get-Content $profilePath -Raw
     if ($profileContent -notmatch "dr completion powershell") {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
         Write-ErrorMsg "Assertion failed: profile does not contain completion block"
     }
 
     Write-SuccessMsg "Assertion passed: profile contains completion block"
 
     # Assert the execution policy was not modified by the installer.
-    $actualPolicy = Get-ExecutionPolicy -Scope CurrentUser
+    $actualPolicy = Get-ExecutionPolicy
     if ($actualPolicy -ne $ExpectedPolicy) {
-        Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+        Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
         Write-ErrorMsg "Assertion failed [$TestName]: expected execution policy to be $ExpectedPolicy, but it is '$actualPolicy'"
     }
 
     Write-SuccessMsg "Assertion passed [$TestName]: execution policy remains '$actualPolicy'"
 
-    # Restore the original execution policy.
-    Set-ExecutionPolicy $originalPolicy -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    # Restore the original execution policy and clean up the profile.
+    Set-ExecutionPolicy $originalPolicy -Scope Process -Force -ErrorAction SilentlyContinue
+    if (Test-Path $profilePath) { Remove-Item $profilePath -Force -ErrorAction SilentlyContinue }
 }
 
 # Main execution


### PR DESCRIPTION
# RATIONALE

On a fresh Windows machine, the default PowerShell execution policy is `Restricted`, which blocks all `.ps1` files on disk -- including the profile that `dr self completion install` writes. The user gets a cryptic error on their next PowerShell launch with no indication of the root cause or the fix.

We don't change the policy on the user's behalf (consistent with the behavior of package managers Scoop and Chocolatey), but we should at least tell them what's wrong and exactly how to fix it.

Followupt to #607 

## CHANGES

After writing the PowerShell completion profile in `installPowerShell()`, we check the effective execution policy and warn if it would prevent the profile from loading.

**New files:**
- `cmd/self/completion/install/exec_policy_windows.go` -- `warnIfExecutionPolicyRestricted(shellExe)` shells out to the correct PowerShell binary (`pwsh` or `powershell`) to read the effective `Get-ExecutionPolicy` (no `-Scope`), prints warning to stderr when the effective policy is `Restricted`. Uses `exec.CommandContext` with a 3s timeout.
- `cmd/self/completion/install/exec_policy_other.go` -- no-op stub for non-Windows

**Modified files:**
- `cmd/self/completion/install/cmd.go` -- adds `powerShellExeForProfile()` helper to determine which shell the profile targets (PS Core vs Windows PowerShell), calls `warnIfExecutionPolicyRestricted(shellExe)` after profile write succeeds
- `cmd/self/completion/install/cmd_test.go` -- adds `TestMissingPowerShellBlocks` (4 sub-cases) and `TestInstallPowerShell` (end-to-end temp profile install). Test now sets both `HOME` and `USERPROFILE` for cross-platform home dir isolation.
- `smoke_test_scripts/windows/run_smoke_test.ps1` -- aligns with merged #607 quality (Process scope, try/catch guards, `--force`, profile cleanup, EAP relaxation) and removes xfail logic since Phase 2 warning is now implemented

### Review fixes incorporated

- **Bugbot + chasdr:** Policy check now queries the same shell the profile targets (`pwsh` for PS Core, `powershell` for 5.1) instead of always using `powershell.exe`. PS7 and 5.1 maintain separate execution policies.

- **chasdr:** Dropped `-Scope CurrentUser` from `Get-ExecutionPolicy` to check the **effective** policy (resolves scope precedence: MachinePolicy > UserPolicy > Process > CurrentUser > LocalMachine) instead of reading an unset CurrentUser as `Undefined`.

- **Bugbot:** Added 3s `context.WithTimeout` to prevent CLI hang if PowerShell subprocess hangs.

- **Bugbot:** `TestInstallPowerShell` now sets `USERPROFILE` on Windows (`os.UserHomeDir()` reads `USERPROFILE`, not `HOME`).

- **chasdr (#607):** Restricted smoke test case now asserts profile IS created (Restricted blocks *loading*, not *writing*).

## Smoke test flow

```mermaid
sequenceDiagram
    participant CI as CI Runner (pwsh)
    participant PS as PowerShell 5.1
    participant CLI as dr CLI
    participant FS as File System
    participant REG as Registry/Policy

    CI->>PS: task smoke-test-windows (PSModulePath=)
    PS->>PS: Get-ExecutionPolicy guard (skip if unavailable)
    PS->>PS: Save $originalPolicy (effective)
    PS->>REG: Set-ExecutionPolicy $Policy -Scope Process
    Note over REG: Restricted or RemoteSigned<br/>Process scope = no registry changes
    PS->>FS: Clean up existing profile
    PS->>CLI: dr self completion install powershell --yes --force
    Note over CLI: 1. Write completion blocks to profile<br/>2. warnIfExecutionPolicyRestricted()
    CLI-->>PS: stderr warning if effective policy = Restricted
    PS->>FS: Assert profile exists + contains dr completion
    PS->>PS: Assert effective policy still matches $ExpectedPolicy
    Note over PS: This proves installer didn't mutate policy
    PS->>REG: Restore $originalPolicy -Scope Process
    PS->>CI: exit 0
```

## TESTING

- `task delint` -- 0 issues
- `task lint` -- 0 issues
- `task test` (with `-race`) -- all passing
- Smoke test: exercises install under both `Restricted` and `RemoteSigned` policies. The Restricted case now asserts the warning IS emitted and the profile IS created. The RemoteSigned case asserts no warning and profile is created.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to completion install UX on Windows; subprocess policy check is best-effort with timeout and does not modify execution policy.
> 
> **Overview**
> After a successful PowerShell completion profile write, the installer now checks whether **Restricted** execution policy would prevent that profile from loading on the next launch, and prints a stderr warning with **`Set-ExecutionPolicy RemoteSigned -Scope CurrentUser`** when needed—without changing policy on the user’s behalf.
> 
> On Windows, **`powerShellExeForProfile()`** picks **`pwsh`** vs **`powershell`** to match the profile path (PS Core vs 5.1), and **`warnIfExecutionPolicyRestricted`** runs **`Get-ExecutionPolicy`** (effective policy, 3s timeout) on that binary. Non-Windows builds use a no-op stub.
> 
> Unit tests cover **`missingPowerShellBlocks`** and end-to-end **`installPowerShell`** (including **`HOME`** / **`USERPROFILE`**). The Windows smoke script drops Phase 2 xfail handling and now **requires** the warning under Restricted while still asserting the profile is written.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b301ee3a48621a440545fed82e8bfbc65e7397f0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->