### PR TITLE
feat(workload): add dr workload config + up commands

### DIFF
--- a/cmd/workload/cmd.go
+++ b/cmd/workload/cmd.go
@@ -15,6 +15,7 @@
 package workload
 
 import (
+	"github.com/datarobot/cli/cmd/workload/config"
 	"github.com/datarobot/cli/cmd/workload/create"
 	"github.com/datarobot/cli/cmd/workload/del"
 	"github.com/datarobot/cli/cmd/workload/endpoint"
@@ -24,6 +25,7 @@ import (
 	"github.com/datarobot/cli/cmd/workload/start"
 	"github.com/datarobot/cli/cmd/workload/status"
 	"github.com/datarobot/cli/cmd/workload/stop"
+	"github.com/datarobot/cli/cmd/workload/up"
 	"github.com/datarobot/cli/internal/features"
 	"github.com/spf13/cobra"
 )
@@ -53,6 +55,9 @@ Manage and monitor workloads in your deployment infrastructure.`,
 		start.Cmd(),
 		status.Cmd(),
 		stop.Cmd(),
+		// Porcelain: interactive setup + fused deploy on top of the verbs above.
+		config.Cmd(),
+		up.Cmd(),
 	)
 
 	return cmd

--- a/cmd/workload/config/cmd.go
+++ b/cmd/workload/config/cmd.go
@@ -1,0 +1,368 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config implements `dr workload config`: an interactive command that
+// selects or names a workload and writes the committed .datarobot/workload.yaml
+// that `dr workload up` consumes.
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/cmd/workload/internal/wlprompt"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/wlconfig"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+// workloadPickLimit caps how many existing workloads are fetched for the
+// interactive picker; more than this and the user should pass --workload-id.
+const workloadPickLimit = 100
+
+// Test seams: cmd_test.go reassigns these to bypass the network and the TUI.
+var (
+	listWorkloadsFn   = workload.ListWorkloads
+	runPickerFn       = runPicker
+	askFn             = wlprompt.Ask
+	isStdinTerminalFn = reader.IsStdinTerminal
+	promptBuildFn     = promptBuild
+)
+
+// configResult is the stable JSON shape emitted by --output-format json.
+type configResult struct {
+	WorkloadID string `json:"workloadId"`
+	Name       string `json:"name"`
+	Path       string `json:"path"`
+	// CreateOnUp is true when no existing workload was selected, so the
+	// workload is created on the first `dr workload up`.
+	CreateOnUp bool `json:"createOnUp"`
+}
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Configure a workload and write .datarobot/workload.yaml.",
+		Long: `Interactively select an existing workload or name a new one, then
+write the committed .datarobot/workload.yaml that 'dr workload up' reads.
+
+Selecting an existing workload records its id immediately. Naming a new
+workload records the name only; the workload itself is created on the
+first 'dr workload up' (so no empty placeholder workload is minted).
+
+For non-interactive use, pass --workload-id to bind an existing workload or
+--name to record a new one; either makes the command non-interactive on its
+own (no --yes needed). Bare --yes with neither flag is an error.
+
+Example:
+  dr workload config
+  dr workload config --workload-id 68b0c1d2e3f4a5b6c7d8e9f0
+  dr workload config --name my-app`,
+		Args:         cobra.NoArgs,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			return runConfig(cmd, outputFormat)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	cmd.Flags().String("dir", "", "Project directory (default: current directory).")
+	cmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts; requires --workload-id or --name.")
+	cmd.Flags().String("workload-id", "", "Bind an existing workload by id (non-interactive).")
+	cmd.Flags().String("name", "", "Name a new workload, created on first `dr workload up` (non-interactive).")
+
+	// Only the env var binds to viper; --yes is read directly from cobra so it
+	// never persists into drconfig.yaml.
+	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+
+	telemetry.TrackWith(cmd, func(cmd *cobra.Command, _ []string) map[string]any {
+		yesFlag, _ := cmd.Flags().GetBool("yes")
+
+		return map[string]any{
+			"yes":           yesFlag || viperx.GetBool("yes"),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}
+
+func runConfig(cmd *cobra.Command, outputFormat outputformat.OutputFormat) error {
+	dirFlag, _ := cmd.Flags().GetString("dir")
+	yesFlag, _ := cmd.Flags().GetBool("yes")
+	yes := yesFlag || viperx.GetBool("yes")
+	idFlag, _ := cmd.Flags().GetString("workload-id")
+	nameFlag, _ := cmd.Flags().GetString("name")
+
+	dir, err := wlprompt.ResolveDir(dirFlag, yes)
+	if err != nil {
+		return err
+	}
+
+	projectDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("resolve %s: %w", dir, err)
+	}
+
+	id, name, err := selectWorkload(yes, idFlag, nameFlag)
+	if err != nil {
+		return err
+	}
+
+	if name == "" {
+		name = filepath.Base(projectDir)
+	}
+
+	// Start from a fully-defaulted manifest so `up` can build and deploy with no
+	// further input, then let an interactive user adjust the build mode.
+	cfg := wlconfig.Default(name)
+	cfg.WorkloadID = id
+
+	preserveRecordedWorkloadID(cmd, projectDir, &cfg)
+
+	if !yes && isStdinTerminalFn() {
+		if err := promptBuildFn(cmd, &cfg); err != nil {
+			return err
+		}
+	}
+
+	if err := wlconfig.Save(projectDir, cfg); err != nil {
+		return err
+	}
+
+	return renderResult(cmd, outputFormat, cfg, wlconfig.Path(projectDir))
+}
+
+// promptBuild asks the one question that can't be defaulted well, how the image
+// comes to be, then the fields specific to that mode. Port and resources keep
+// their defaults; the written manifest is commented so the user can edit them.
+// A read error (Ctrl-C/EOF) aborts rather than silently accepting defaults.
+func promptBuild(cmd *cobra.Command, cfg *wlconfig.Config) error {
+	fmt.Fprintln(cmd.ErrOrStderr(), "Build mode: [1] use your Dockerfile   [2] DataRobot builds it (generated)   [3] deploy a pre-built image")
+
+	mode, err := wlprompt.AskWithDefault("Choose 1, 2, or 3", "1")
+	if err != nil {
+		return err
+	}
+
+	switch strings.TrimSpace(mode) {
+	case "2":
+		return promptGeneratedMode(cfg)
+	case "3":
+		return promptImageMode(cfg)
+	default:
+		return promptDockerfileMode(cfg)
+	}
+}
+
+// promptDockerfileMode configures provided-Dockerfile builds.
+func promptDockerfileMode(cfg *wlconfig.Config) error {
+	dockerfile, err := wlprompt.AskWithDefault("Dockerfile path", wlconfig.DefaultDockerfile)
+	if err != nil {
+		return err
+	}
+
+	cfg.Build.Dockerfile = dockerfile
+	cfg.Build.Image = ""
+	cfg.Build.ExecutionEnvironment = ""
+	cfg.Build.Entrypoint = nil
+
+	return nil
+}
+
+// promptGeneratedMode configures execution-environment builds.
+func promptGeneratedMode(cfg *wlconfig.Config) error {
+	ee, err := wlprompt.AskWithDefault("Execution environment (name)", wlconfig.DefaultExecutionEnvironment)
+	if err != nil {
+		return err
+	}
+
+	entry, err := wlprompt.AskWithDefault("Entrypoint", "uvicorn app:app --host 0.0.0.0 --port 8080")
+	if err != nil {
+		return err
+	}
+
+	cfg.Build.Dockerfile = ""
+	cfg.Build.Image = ""
+	cfg.Build.ExecutionEnvironment = ee
+	cfg.Build.Entrypoint = strings.Fields(entry)
+
+	return nil
+}
+
+// promptImageMode configures deployment of an existing container image
+// (Tutorial 2 style): image URI, optional entrypoint override, and the health
+// path since it is image-specific and gates the running transition.
+func promptImageMode(cfg *wlconfig.Config) error {
+	image, err := askFn("Image URI (e.g. registry/repo:tag)")
+	if err != nil {
+		return err
+	}
+
+	entry, err := wlprompt.AskWithDefault("Entrypoint (blank = image default)", "")
+	if err != nil {
+		return err
+	}
+
+	health, err := wlprompt.AskWithDefault("Health probe path", wlconfig.DefaultHealth)
+	if err != nil {
+		return err
+	}
+
+	cfg.Build.Image = image
+	cfg.Build.Dockerfile = ""
+	cfg.Build.ExecutionEnvironment = ""
+	cfg.Build.Entrypoint = strings.Fields(entry)
+	cfg.Build.Health = health
+
+	return nil
+}
+
+// preserveRecordedWorkloadID carries an existing manifest's workloadId into the
+// regenerated one. A re-run must not orphan the recorded workload: a draft
+// artifact allows only one workload, so dropping the id leads straight to a 409
+// on the next `up`. An explicitly chosen workload (non-empty cfg.WorkloadID)
+// wins.
+func preserveRecordedWorkloadID(cmd *cobra.Command, projectDir string, cfg *wlconfig.Config) {
+	if cfg.WorkloadID != "" {
+		return
+	}
+
+	prev, err := wlconfig.Load(projectDir)
+	if err != nil || prev.WorkloadID == "" {
+		return
+	}
+
+	cfg.WorkloadID = prev.WorkloadID
+
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"Keeping existing workload binding %s (remove the workloadId line from %s to detach).\n",
+		prev.WorkloadID, wlconfig.Path(projectDir))
+}
+
+// selectWorkload resolves which workload the config binds to. Passing
+// --workload-id or --name (with or without --yes) is a non-interactive request
+// and wins; otherwise, on an interactive terminal, the picker runs. An empty
+// returned id means "create a new workload named <name> on the first up".
+func selectWorkload(yes bool, idFlag, nameFlag string) (id, name string, err error) {
+	switch {
+	case idFlag != "":
+		return idFlag, nameFlag, nil
+	case nameFlag != "":
+		return "", nameFlag, nil
+	}
+
+	if yes || !isStdinTerminalFn() {
+		return "", "", errors.New("non-interactive: provide --workload-id (existing) or --name (new)")
+	}
+
+	workloads, err := listWorkloadsFn(workloadPickLimit, nil)
+	if err != nil {
+		return "", "", err
+	}
+
+	// With no existing workloads there is nothing to pick, and an empty picker
+	// is a dead end; go straight to naming a new one.
+	if len(workloads) == 0 {
+		return promptNewName()
+	}
+
+	item, err := runPickerFn(workloads)
+	if err != nil {
+		return "", "", err
+	}
+
+	if item.id == createNewID {
+		return promptNewName()
+	}
+
+	return item.id, item.name, nil
+}
+
+// promptNewName asks for a workload name and returns it as the "create new"
+// selection (empty id, so `up` creates it on first run).
+func promptNewName() (id, name string, err error) {
+	newName, err := askFn("Workload name")
+	if err != nil {
+		return "", "", err
+	}
+
+	return "", newName, nil
+}
+
+// runPicker runs the interactive workload picker and returns the chosen item.
+func runPicker(workloads []workload.Workload) (workloadItem, error) {
+	m := newPickerModel(workloads)
+
+	finalModel, err := tui.Run(m, tea.WithAltScreen())
+	if err != nil {
+		return workloadItem{}, err
+	}
+
+	picker, ok := tui.Unwrap(finalModel).(pickerModel)
+	if !ok {
+		return workloadItem{}, errors.New("unexpected inner model type returned from TUI")
+	}
+
+	if picker.selected == nil {
+		return workloadItem{}, errors.New("no workload selected")
+	}
+
+	return *picker.selected, nil
+}
+
+func renderResult(cmd *cobra.Command, outputFormat outputformat.OutputFormat, cfg wlconfig.Config, path string) error {
+	result := configResult{
+		WorkloadID: cfg.WorkloadID,
+		Name:       cfg.Name,
+		Path:       path,
+		CreateOnUp: cfg.WorkloadID == "",
+	}
+
+	if outputFormat == outputformat.OutputFormatJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+
+		return enc.Encode(result)
+	}
+
+	out := cmd.OutOrStdout()
+
+	if cfg.WorkloadID != "" {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Bound workload %s (%s).\n", cfg.WorkloadID, cfg.Name)
+	} else {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Recorded new workload %q; it is created on the first `dr workload up`.\n", cfg.Name)
+	}
+
+	fmt.Fprintf(cmd.ErrOrStderr(), "Wrote configuration. Run `dr workload up` to deploy.\n")
+	fmt.Fprintln(out, path)
+
+	return nil
+}

--- a/cmd/workload/config/cmd_test.go
+++ b/cmd/workload/config/cmd_test.go
@@ -1,0 +1,252 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/wlconfig"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestCmd builds the config command with auth bypassed and output captured.
+func newTestCmd(args []string) (*cobra.Command, *bytes.Buffer) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+
+	var out bytes.Buffer
+
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs(args)
+
+	return cmd, &out
+}
+
+// swapSelectionFns injects fakes for the network + TUI selection seams and
+// forces the interactive (terminal) path so the picker is reachable in tests.
+func swapSelectionFns(
+	t *testing.T,
+	list func(int, []string) ([]workload.Workload, error),
+	pick func([]workload.Workload) (workloadItem, error),
+	ask func(string) (string, error),
+) {
+	t.Helper()
+
+	origList, origPick, origAsk, origTerm, origPrompt := listWorkloadsFn, runPickerFn, askFn, isStdinTerminalFn, promptBuildFn
+
+	if list != nil {
+		listWorkloadsFn = list
+	}
+
+	if pick != nil {
+		runPickerFn = pick
+	}
+
+	if ask != nil {
+		askFn = ask
+	}
+
+	isStdinTerminalFn = func() bool { return true }
+	// Stub the build-mode prompt so interactive tests don't read real stdin.
+	promptBuildFn = func(*cobra.Command, *wlconfig.Config) error { return nil }
+
+	t.Cleanup(func() {
+		listWorkloadsFn, runPickerFn, askFn, isStdinTerminalFn, promptBuildFn = origList, origPick, origAsk, origTerm, origPrompt
+	})
+}
+
+// failPicker is a runPickerFn stub that fails the test if the picker is reached.
+func failPicker(t *testing.T) func([]workload.Workload) (workloadItem, error) {
+	return func([]workload.Workload) (workloadItem, error) {
+		t.Error("picker should not be invoked")
+
+		return workloadItem{}, nil
+	}
+}
+
+func TestConfig_YesWithWorkloadID(t *testing.T) {
+	dir := t.TempDir()
+
+	cmd, out := newTestCmd([]string{"--yes", "--dir", dir, "--workload-id", "wl-xyz"})
+	require.NoError(t, cmd.Execute())
+
+	cfg, err := wlconfig.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "wl-xyz", cfg.WorkloadID)
+	assert.Contains(t, out.String(), wlconfig.Path(dir))
+}
+
+func TestConfig_YesWithName(t *testing.T) {
+	dir := t.TempDir()
+
+	cmd, _ := newTestCmd([]string{"--yes", "--dir", dir, "--name", "my-app"})
+	require.NoError(t, cmd.Execute())
+
+	cfg, err := wlconfig.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "my-app", cfg.Name)
+	assert.Empty(t, cfg.WorkloadID)
+}
+
+func TestConfig_YesWithNeitherErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	cmd, _ := newTestCmd([]string{"--yes", "--dir", dir})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--workload-id")
+}
+
+func TestConfig_JSONOutput(t *testing.T) {
+	dir := t.TempDir()
+
+	cmd, out := newTestCmd([]string{"--yes", "--dir", dir, "--name", "app", "--output-format", "json"})
+	require.NoError(t, cmd.Execute())
+
+	var res configResult
+
+	require.NoError(t, json.Unmarshal(out.Bytes(), &res))
+	assert.Equal(t, "app", res.Name)
+	assert.True(t, res.CreateOnUp)
+	assert.Equal(t, wlconfig.Path(dir), res.Path)
+}
+
+func TestConfig_InteractivePickExisting(t *testing.T) {
+	dir := t.TempDir()
+
+	swapSelectionFns(t,
+		func(int, []string) ([]workload.Workload, error) {
+			return []workload.Workload{{ID: "wl-1", Name: "a", Status: "running"}}, nil
+		},
+		func([]workload.Workload) (workloadItem, error) {
+			return workloadItem{id: "wl-1", name: "a"}, nil
+		},
+		nil,
+	)
+
+	cmd, _ := newTestCmd([]string{"--dir", dir})
+	require.NoError(t, cmd.Execute())
+
+	cfg, err := wlconfig.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "wl-1", cfg.WorkloadID)
+	assert.Equal(t, "a", cfg.Name)
+}
+
+func TestConfig_InteractivePickCreateNew(t *testing.T) {
+	dir := t.TempDir()
+
+	swapSelectionFns(t,
+		func(int, []string) ([]workload.Workload, error) {
+			return []workload.Workload{{ID: "wl-1", Name: "a"}}, nil
+		},
+		func([]workload.Workload) (workloadItem, error) {
+			return workloadItem{id: createNewID}, nil
+		},
+		func(string) (string, error) { return "newapp", nil },
+	)
+
+	cmd, _ := newTestCmd([]string{"--dir", dir})
+	require.NoError(t, cmd.Execute())
+
+	cfg, err := wlconfig.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "newapp", cfg.Name)
+	assert.Empty(t, cfg.WorkloadID)
+}
+
+func TestConfig_WorkloadIDWithoutYesIsHonored(t *testing.T) {
+	dir := t.TempDir()
+
+	// Flags win even without --yes and must not touch the picker.
+	swapSelectionFns(t, nil, failPicker(t), nil)
+
+	cmd, _ := newTestCmd([]string{"--dir", dir, "--workload-id", "wl-flag"})
+	require.NoError(t, cmd.Execute())
+
+	cfg, err := wlconfig.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "wl-flag", cfg.WorkloadID)
+}
+
+func TestConfig_RerunPreservesRecordedWorkloadID(t *testing.T) {
+	dir := t.TempDir()
+
+	// A previous config+up recorded a workload id.
+	require.NoError(t, wlconfig.Save(dir, wlconfig.Config{WorkloadID: "wl-old", Name: "first"}))
+
+	// Re-running config with a new name must keep the binding: a draft artifact
+	// allows only one workload, so dropping the id causes a 409 on the next up.
+	cmd, _ := newTestCmd([]string{"--yes", "--dir", dir, "--name", "renamed"})
+	require.NoError(t, cmd.Execute())
+
+	cfg, err := wlconfig.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "wl-old", cfg.WorkloadID)
+	assert.Equal(t, "renamed", cfg.Name)
+}
+
+func TestConfig_RerunExplicitWorkloadIDOverrides(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, wlconfig.Save(dir, wlconfig.Config{WorkloadID: "wl-old", Name: "first"}))
+
+	cmd, _ := newTestCmd([]string{"--yes", "--dir", dir, "--workload-id", "wl-new"})
+	require.NoError(t, cmd.Execute())
+
+	cfg, err := wlconfig.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "wl-new", cfg.WorkloadID, "an explicit --workload-id rebinds")
+}
+
+func TestConfig_NonInteractiveWithoutFlagsErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	origTerm := isStdinTerminalFn
+	isStdinTerminalFn = func() bool { return false }
+
+	t.Cleanup(func() { isStdinTerminalFn = origTerm })
+
+	cmd, _ := newTestCmd([]string{"--dir", dir})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-interactive")
+}
+
+func TestConfig_InteractiveNoExistingWorkloadsPromptsName(t *testing.T) {
+	dir := t.TempDir()
+
+	// With zero existing workloads the picker is skipped entirely.
+	swapSelectionFns(t,
+		func(int, []string) ([]workload.Workload, error) { return nil, nil },
+		failPicker(t),
+		func(string) (string, error) { return "fresh", nil },
+	)
+
+	cmd, _ := newTestCmd([]string{"--dir", dir})
+	require.NoError(t, cmd.Execute())
+
+	cfg, err := wlconfig.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "fresh", cfg.Name)
+	assert.Empty(t, cfg.WorkloadID)
+}

--- a/cmd/workload/config/model.go
+++ b/cmd/workload/config/model.go
@@ -1,0 +1,172 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/datarobot/cli/internal/workload"
+)
+
+// createNewID is the sentinel id carried by the "create a new workload" row so
+// the picker can return it through the same list-item channel as real
+// workloads without a second out-of-band flag.
+const createNewID = "\x00create-new"
+
+// workloadItem is one row in the picker: either an existing workload or the
+// synthetic "create new" row pinned to the top of the list.
+type workloadItem struct {
+	id     string
+	name   string
+	status string
+}
+
+func (i workloadItem) Title() string {
+	if i.id == createNewID {
+		return "＋ Create a new workload"
+	}
+
+	return i.name
+}
+
+func (i workloadItem) Description() string {
+	if i.id == createNewID {
+		return "Name it now; it is created on the first `dr workload up`"
+	}
+
+	return i.status + " · " + i.id
+}
+
+func (i workloadItem) FilterValue() string {
+	// A non-empty value keeps the pinned "create new" row from being silently
+	// excluded when the user filters; it stays reachable by typing "create"/"new".
+	if i.id == createNewID {
+		return "create new workload"
+	}
+
+	return i.name
+}
+
+type workloadItemDelegate struct{}
+
+func (d workloadItemDelegate) Height() int                             { return 2 }
+func (d workloadItemDelegate) Spacing() int                            { return 1 }
+func (d workloadItemDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (d workloadItemDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	i, ok := listItem.(workloadItem)
+	if !ok {
+		return
+	}
+
+	accent := lipgloss.AdaptiveColor{Light: "#6124DF", Dark: "#9D7EDF"}
+
+	if index == m.Index() {
+		titleStyle := lipgloss.NewStyle().Foreground(accent).Bold(true)
+		descStyle := lipgloss.NewStyle().Foreground(accent).Faint(true)
+
+		fmt.Fprint(w, titleStyle.Render("▶ "+i.Title()))
+		fmt.Fprint(w, "\n")
+		fmt.Fprint(w, descStyle.Render("  "+i.Description()))
+
+		return
+	}
+
+	titleStyle := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#000000", Dark: "#FFFFFF"})
+	descStyle := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#666666", Dark: "#888888"}).Faint(true)
+
+	fmt.Fprint(w, titleStyle.Render("  "+i.Title()))
+	fmt.Fprint(w, "\n")
+	fmt.Fprint(w, descStyle.Render("  "+i.Description()))
+}
+
+// pickerModel is the TUI model that lets the user pick an existing workload or
+// the "create new" row.
+type pickerModel struct {
+	list     list.Model
+	selected *workloadItem
+}
+
+// newPickerModel builds the picker from the fetched workloads, pinning the
+// "create new" row to the top.
+func newPickerModel(workloads []workload.Workload) pickerModel {
+	items := make([]list.Item, 0, len(workloads)+1)
+	items = append(items, workloadItem{id: createNewID})
+
+	for _, w := range workloads {
+		items = append(items, workloadItem{id: w.ID, name: w.Name, status: w.Status})
+	}
+
+	delegate := workloadItemDelegate{}
+	l := list.New(items, delegate, 0, 0)
+
+	l.Title = "Select a workload"
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(true)
+	l.SetShowHelp(true)
+	l.Styles.Title = lipgloss.NewStyle().
+		Foreground(lipgloss.AdaptiveColor{Light: "#6124DF", Dark: "#9D7EDF"}).
+		Bold(true).
+		MarginLeft(2).
+		MarginBottom(1)
+
+	l.SetSize(80, 20)
+
+	return pickerModel{list: l}
+}
+
+func (m pickerModel) Init() tea.Cmd { return nil }
+
+func (m pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		listWidth := max(msg.Width-4, 60)
+		listHeight := max(msg.Height-8, 10)
+
+		m.list.SetSize(listWidth, listHeight)
+
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.list.FilterState() == list.Filtering {
+			var cmd tea.Cmd
+
+			m.list, cmd = m.list.Update(msg)
+
+			return m, cmd
+		}
+
+		if msg.String() == "enter" {
+			if item, ok := m.list.SelectedItem().(workloadItem); ok {
+				selected := item
+				m.selected = &selected
+
+				return m, tea.Quit
+			}
+		}
+	}
+
+	var cmd tea.Cmd
+
+	m.list, cmd = m.list.Update(msg)
+
+	return m, cmd
+}
+
+func (m pickerModel) View() string { return m.list.View() }

--- a/cmd/workload/internal/wlprompt/wlprompt.go
+++ b/cmd/workload/internal/wlprompt/wlprompt.go
@@ -1,0 +1,78 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package wlprompt holds the small stdin prompt helpers shared by the workload
+// porcelain commands (`config`, `up`). It mirrors the artifact-side dirprompt
+// helpers, which live in an internal package the workload commands cannot import.
+package wlprompt
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/datarobot/cli/internal/misc/reader"
+)
+
+// ResolveDir returns the project directory to operate on. A non-empty --dir
+// wins; otherwise --yes (non-interactive) defaults to the current directory,
+// and an interactive session is prompted with "." as the default.
+func ResolveDir(dirFlag string, yes bool) (string, error) {
+	if dirFlag != "" {
+		return dirFlag, nil
+	}
+
+	if yes {
+		return ".", nil
+	}
+
+	return AskWithDefault("Project directory", ".")
+}
+
+// Ask prompts for a required value on stderr and returns it trimmed, erroring
+// on an empty answer.
+func Ask(label string) (string, error) {
+	fmt.Fprintf(os.Stderr, "%s: ", label)
+
+	s, err := reader.ReadString()
+	if err != nil {
+		return "", err
+	}
+
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", errors.New(label + " is required")
+	}
+
+	return s, nil
+}
+
+// AskWithDefault prompts on stderr and returns defaultVal when the user just
+// presses Enter.
+func AskWithDefault(label, defaultVal string) (string, error) {
+	fmt.Fprintf(os.Stderr, "%s [%s]: ", label, defaultVal)
+
+	s, err := reader.ReadString()
+	if err != nil {
+		return "", err
+	}
+
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return defaultVal, nil
+	}
+
+	return s, nil
+}

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -1,0 +1,851 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package up implements `dr workload up`: a fused deploy verb driven by
+// .datarobot/workload.yaml. It creates the artifact and links the directory if
+// needed, then syncs -> builds -> optionally locks -> creates the workload ->
+// waits -> prints the URL, so `dr workload config` + `dr workload up` is the
+// whole flow.
+package up
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/datarobot/cli/cmd/internal/pollflags"
+	"github.com/datarobot/cli/cmd/workload/internal/wlprompt"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/datarobot/cli/internal/workload/wapi"
+	"github.com/datarobot/cli/internal/workload/wlconfig"
+	"github.com/spf13/cobra"
+)
+
+// Poll cadence defaults. The workload wait follows Marcus's diagram (5s / 10m,
+// overridable via --poll-interval/--poll-timeout). The build wait keeps the
+// build-oriented defaults (2s / 30m) since container builds run far longer.
+const (
+	workloadPollInterval = 5 * time.Second
+	workloadPollTimeout  = 10 * time.Minute
+)
+
+// Spec conventions. The group label is free; the container name must match
+// between the artifact spec and the workload runtime override.
+const (
+	defaultContainerGroup = "default"
+	primaryContainerName  = "primary"
+)
+
+// Readiness probe defaults for a created artifact (seconds).
+const (
+	probeInitialDelay     = 10
+	probePeriod           = 10
+	probeTimeout          = 5
+	probeFailureThreshold = 6
+)
+
+// Test seams: cmd_test.go reassigns these to drive the orchestrator without a
+// live server or a real sync.
+var (
+	getArtifactFn     = workload.GetArtifact
+	createArtifactFn  = workload.CreateArtifact
+	resolveEEFn       = workload.ResolveExecutionEnvironment
+	initProjectFn     = wapi.Initialize
+	runSyncFn         = defaultRunSync
+	triggerBuildFn    = workload.TriggerArtifactBuild
+	waitForBuildFn    = workload.WaitForBuild
+	lockArtifactFn    = workload.LockArtifact
+	createWorkloadFn  = workload.CreateWorkload
+	getWorkloadFn     = workload.GetWorkload
+	listWorkloadsFn   = workload.ListWorkloads
+	startWorkloadFn   = workload.StartWorkload
+	waitForWorkloadFn = workload.WaitForWorkload
+)
+
+// adoptListLimit caps the workload listing used to find the workload already
+// backing the linked draft artifact after a create 409.
+const adoptListLimit = 100
+
+// upResult is the stable JSON shape emitted by --output-format json.
+type upResult struct {
+	WorkloadID string `json:"workloadId"`
+	Status     string `json:"status"`
+	Endpoint   string `json:"endpoint"`
+}
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	var poll pollflags.Set
+
+	cmd := &cobra.Command{
+		Use:   "up",
+		Short: "Build and deploy the workload described by .datarobot/workload.yaml.",
+		Long: `Turn .datarobot/workload.yaml into a running workload with one command.
+
+For the code-build modes (your Dockerfile, or a DataRobot-generated build),
+'up' creates the artifact and links this directory if needed, syncs your
+code, builds the image, optionally locks the artifact (--lock), creates the
+workload with the manifest's resources, then blocks until it is running and
+prints the endpoint URL as the final stdout line.
+
+For a pre-built image manifest (build.image set), 'up' skips sync and build
+entirely: it creates the workload with the artifact inline in one call.
+
+Run 'dr workload config' first to generate the manifest. On a re-run, 'up'
+reaches the recorded workload and ensures it is running.
+
+By default 'up' blocks with progress; --detach returns immediately after
+the deploy is requested.
+
+Example:
+  dr workload up
+  dr workload up --lock
+  dr workload up --detach
+  dr workload up --yes --output-format json`,
+		Args:         cobra.NoArgs,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			return runUp(cmd, outputFormat, poll)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	cmd.Flags().String("dir", "", "Project directory (default: current directory).")
+	cmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts; use defaults.")
+	cmd.Flags().Bool("detach", false, "Return immediately after requesting the deploy; do not wait for running.")
+	cmd.Flags().Bool("lock", false, "Lock the artifact (immutable, versioned) before deploying.")
+
+	// Register only the poll cadence knobs (hidden). `up` blocks by default and
+	// is toggled by --detach, so pollflags' visible --wait flag is deliberately
+	// not used here: it would be dead and contradict --detach.
+	cmd.Flags().Var(pollflags.PositiveDuration(&poll.Interval, workloadPollInterval), "poll-interval", "Interval between workload status polls.")
+	cmd.Flags().Var(pollflags.PositiveDuration(&poll.Timeout, workloadPollTimeout), "poll-timeout", "Maximum time to wait for the workload to become running.")
+	_ = cmd.Flags().MarkHidden("poll-interval")
+	_ = cmd.Flags().MarkHidden("poll-timeout")
+
+	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+
+	telemetry.TrackWith(cmd, func(cmd *cobra.Command, _ []string) map[string]any {
+		yesFlag, _ := cmd.Flags().GetBool("yes")
+		detach, _ := cmd.Flags().GetBool("detach")
+		lock, _ := cmd.Flags().GetBool("lock")
+
+		return map[string]any{
+			"yes":           yesFlag || viperx.GetBool("yes"),
+			"detach":        detach,
+			"lock":          lock,
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}
+
+// upFlags is the parsed view of the command flags, folding the
+// DATAROBOT_CLI_NON_INTERACTIVE env override into Yes.
+type upFlags struct {
+	Yes    bool
+	Detach bool
+	Lock   bool
+}
+
+func parseUpFlags(cmd *cobra.Command) upFlags {
+	yesFlag, _ := cmd.Flags().GetBool("yes")
+	detach, _ := cmd.Flags().GetBool("detach")
+	lock, _ := cmd.Flags().GetBool("lock")
+
+	return upFlags{
+		Yes:    yesFlag || viperx.GetBool("yes"),
+		Detach: detach,
+		Lock:   lock,
+	}
+}
+
+func runUp(cmd *cobra.Command, outputFormat outputformat.OutputFormat, poll pollflags.Set) error {
+	flags := parseUpFlags(cmd)
+
+	dirFlag, _ := cmd.Flags().GetString("dir")
+
+	dir, err := wlprompt.ResolveDir(dirFlag, flags.Yes)
+	if err != nil {
+		return err
+	}
+
+	projectDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("resolve %s: %w", dir, err)
+	}
+
+	cfg, err := wlconfig.Load(projectDir)
+	if err != nil {
+		if errors.Is(err, wlconfig.ErrNotConfigured) {
+			return fmt.Errorf("no %s found; run `dr workload config` first", wlconfig.Path(projectDir))
+		}
+
+		return err
+	}
+
+	return orchestrate(cmd, projectDir, &cfg, flags, poll, outputFormat)
+}
+
+// orchestrate runs ensureLinked -> sync -> build -> deploy -> optional lock ->
+// wait -> render, keeping runUp's flag/config resolution separate from the flow.
+// Pre-built image manifests take the short path: no code, no sync, no build.
+func orchestrate(
+	cmd *cobra.Command,
+	projectDir string,
+	cfg *wlconfig.Config,
+	flags upFlags,
+	poll pollflags.Set,
+	outputFormat outputformat.OutputFormat,
+) error {
+	if cfg.BuildMode() == wlconfig.ModeImage {
+		return orchestrateImage(cmd, projectDir, cfg, flags, poll, outputFormat)
+	}
+
+	artifactID, art, err := ensureLinked(cmd, projectDir, cfg)
+	if err != nil {
+		return err
+	}
+
+	announce(cmd, "Syncing code")
+
+	result, err := runSyncFn(projectDir)
+	if err != nil {
+		return err
+	}
+
+	reportSyncConflicts(cmd, result)
+
+	announce(cmd, "Building image")
+
+	if err := buildAndWait(cmd, artifactID); err != nil {
+		return err
+	}
+
+	wl, err := deploy(cmd, projectDir, cfg, artifactID, art)
+	if err != nil {
+		return err
+	}
+
+	// Lock only after a successful deploy so a failed create cannot orphan a
+	// locked (undeletable) artifact.
+	if flags.Lock {
+		announce(cmd, "Locking artifact")
+
+		if _, err := lockArtifactFn(artifactID); err != nil {
+			return err
+		}
+	}
+
+	if !flags.Detach {
+		announce(cmd, "Waiting for workload to become running")
+
+		wl, err = waitForWorkloadFn(wl.ID, poll.Interval, poll.Timeout, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return renderUp(cmd, outputFormat, wl, flags.Detach)
+}
+
+// orchestrateImage is the pre-built-image path (Tutorial 2): create the
+// workload with the artifact inline in one call, optionally lock the artifact
+// the server minted, wait, render. No sync, no build, no project link.
+func orchestrateImage(
+	cmd *cobra.Command,
+	projectDir string,
+	cfg *wlconfig.Config,
+	flags upFlags,
+	poll pollflags.Set,
+	outputFormat outputformat.OutputFormat,
+) error {
+	wl, err := deployImage(cmd, projectDir, cfg)
+	if err != nil {
+		return err
+	}
+
+	// The inline-create response carries the id of the draft artifact the
+	// server created; locking it moves the workload into the production
+	// lifecycle (Tutorial 2, step 2).
+	if flags.Lock {
+		announce(cmd, "Locking artifact")
+
+		if _, err := lockArtifactFn(wl.ArtifactID); err != nil {
+			return err
+		}
+	}
+
+	if !flags.Detach {
+		announce(cmd, "Waiting for workload to become running")
+
+		wl, err = waitForWorkloadFn(wl.ID, poll.Interval, poll.Timeout, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return renderUp(cmd, outputFormat, wl, flags.Detach)
+}
+
+// deployImage creates the workload with the manifest's image inline on first
+// run, or reaches the recorded workload on a re-run.
+func deployImage(cmd *cobra.Command, projectDir string, cfg *wlconfig.Config) (*workload.Workload, error) {
+	if cfg.WorkloadID != "" {
+		return reachExistingWorkload(cmd, projectDir, cfg)
+	}
+
+	announce(cmd, "Creating workload from image "+cfg.Build.Image)
+
+	name := cfg.Name
+	if name == "" {
+		name = filepath.Base(projectDir)
+	}
+
+	wl, err := createWorkloadFn(buildImageCreatePayload(name, cfg))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := recordWorkloadID(projectDir, cfg, wl); err != nil {
+		return nil, err
+	}
+
+	return wl, nil
+}
+
+// buildImageCreatePayload assembles the one-call create for image mode: the
+// artifact (image, port, entrypoint, env, readiness probe) inline plus the
+// runtime resources, mirroring Tutorial 2's spec.
+func buildImageCreatePayload(name string, cfg *wlconfig.Config) map[string]any {
+	container := map[string]any{
+		"name":     primaryContainerName,
+		"imageUri": cfg.Build.Image,
+		"port":     cfg.Port(),
+		"primary":  true,
+		"readinessProbe": map[string]any{
+			"path": cfg.Health(),
+			"port": cfg.Port(),
+		},
+	}
+
+	if len(cfg.Build.Entrypoint) > 0 {
+		container["entrypoint"] = cfg.Build.Entrypoint
+	}
+
+	if env := envVarsPayload(cfg); env != nil {
+		container["environmentVars"] = env
+	}
+
+	payload := map[string]any{
+		"name": name,
+		"artifact": map[string]any{
+			"name": name + "-artifact",
+			"type": "service",
+			"spec": map[string]any{
+				"containerGroups": []any{
+					map[string]any{"name": defaultContainerGroup, "containers": []any{container}},
+				},
+			},
+		},
+		"runtime": runtimeBlock(cfg, primaryContainerName),
+	}
+
+	if cfg.Importance != "" {
+		payload["importance"] = cfg.Importance
+	}
+
+	return payload
+}
+
+// envVarsPayload renders the manifest's env map as the API's environmentVars
+// list, expanding ${VAR} references from the deploying shell so secrets can
+// stay out of the committed manifest. Keys are sorted for determinism.
+func envVarsPayload(cfg *wlconfig.Config) []any {
+	if len(cfg.Env) == 0 {
+		return nil
+	}
+
+	out := make([]any, 0, len(cfg.Env))
+
+	for _, k := range slices.Sorted(maps.Keys(cfg.Env)) {
+		out = append(out, map[string]any{"name": k, "value": os.Expand(cfg.Env[k], os.Getenv)})
+	}
+
+	return out
+}
+
+// ensureLinked returns the artifact to deploy, creating it and linking the
+// project directory from the manifest's build settings when the directory is not
+// linked yet. This is what lets `dr workload up` run with only `dr workload
+// config` before it, with no manual `dr artifact create` / `code init`.
+func ensureLinked(cmd *cobra.Command, projectDir string, cfg *wlconfig.Config) (string, *workload.Artifact, error) {
+	if !wapi.Exists(projectDir) {
+		return createAndLink(cmd, projectDir, cfg)
+	}
+
+	wcfg, err := wapi.LoadConfig(projectDir)
+	if err != nil {
+		return "", nil, err
+	}
+
+	art, err := getArtifactFn(wcfg.ArtifactID)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if art.IsLocked() {
+		return "", nil, fmt.Errorf("artifact %s is locked (immutable); `dr workload up` cannot redeploy through a locked artifact. Create a new artifact and workload to deploy changes", wcfg.ArtifactID)
+	}
+
+	return wcfg.ArtifactID, art, nil
+}
+
+// createAndLink creates a draft artifact from the manifest's build settings and
+// links the project directory to it.
+func createAndLink(cmd *cobra.Command, projectDir string, cfg *wlconfig.Config) (string, *workload.Artifact, error) {
+	announce(cmd, "Creating artifact ("+cfg.BuildMode()+" build)")
+
+	spec, err := buildArtifactSpec(cfg)
+	if err != nil {
+		return "", nil, err
+	}
+
+	art, err := createArtifactFn(spec)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if err := initProjectFn(projectDir, wapi.InitOptions{ArtifactID: art.ID}); err != nil {
+		return "", nil, fmt.Errorf("artifact %s created but linking %s failed: %w", art.ID, projectDir, err)
+	}
+
+	fmt.Fprintf(cmd.ErrOrStderr(), "  created artifact %s and linked %s\n", art.ID, projectDir)
+
+	return art.ID, art, nil
+}
+
+// buildArtifactSpec builds the CreateArtifact payload from the manifest, in
+// provided-Dockerfile or generated (execution-environment) mode.
+func buildArtifactSpec(cfg *wlconfig.Config) (map[string]any, error) {
+	dockerfile, err := dockerfileSpec(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	container := map[string]any{
+		"name":             primaryContainerName,
+		"imageUri":         "placeholder:latest",
+		"primary":          true,
+		"port":             cfg.Port(),
+		"imageBuildConfig": map[string]any{"dockerfile": dockerfile},
+		"readinessProbe": map[string]any{
+			"path":                cfg.Health(),
+			"port":                cfg.Port(),
+			"initialDelaySeconds": probeInitialDelay,
+			"periodSeconds":       probePeriod,
+			"timeoutSeconds":      probeTimeout,
+			"failureThreshold":    probeFailureThreshold,
+			"scheme":              "HTTP",
+		},
+	}
+
+	if env := envVarsPayload(cfg); env != nil {
+		container["environmentVars"] = env
+	}
+
+	return map[string]any{
+		"name": cfg.Name + "-artifact",
+		"type": "service",
+		"spec": map[string]any{
+			"containerGroups": []any{
+				map[string]any{"name": defaultContainerGroup, "containers": []any{container}},
+			},
+		},
+	}, nil
+}
+
+// dockerfileSpec returns the imageBuildConfig.dockerfile block for the manifest's
+// build mode, resolving the execution environment by name for generated mode.
+func dockerfileSpec(cfg *wlconfig.Config) (map[string]any, error) {
+	if cfg.BuildMode() == wlconfig.ModeProvided {
+		return map[string]any{"source": "provided", "path": cfg.Build.Dockerfile}, nil
+	}
+
+	eeName := wlconfig.DefaultExecutionEnvironment
+	if cfg.Build != nil && cfg.Build.ExecutionEnvironment != "" {
+		eeName = cfg.Build.ExecutionEnvironment
+	}
+
+	eeID, eeVer, err := resolveEEFn(eeName)
+	if err != nil {
+		return nil, err
+	}
+
+	spec := map[string]any{
+		"source":                        "generated",
+		"executionEnvironmentId":        eeID,
+		"executionEnvironmentVersionId": eeVer,
+	}
+
+	if cfg.Build != nil && len(cfg.Build.Entrypoint) > 0 {
+		spec["entrypoint"] = cfg.Build.Entrypoint
+	}
+
+	return spec, nil
+}
+
+// reportSyncConflicts surfaces auto-resolved sync conflicts. `up` runs the sync
+// engine with Yes:true (remote wins), so unlike interactive `dr artifact code
+// sync` the user is not prompted; at minimum we must tell them their working
+// copy was replaced and where the backups are.
+func reportSyncConflicts(cmd *cobra.Command, result *sync.Result) {
+	if result == nil || result.ConflictCount == 0 {
+		return
+	}
+
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"  %d conflicting file(s) auto-resolved (remote won); your versions were saved as:\n",
+		result.ConflictCount)
+
+	for _, copyPath := range result.ConflictCopies {
+		fmt.Fprintf(cmd.ErrOrStderr(), "    %s\n", copyPath)
+	}
+}
+
+// buildAndWait triggers a build for artifactID and blocks on each returned
+// build until it reaches a terminal status. On failure it prints the build log
+// tail, matching `dr artifact build create --wait`.
+func buildAndWait(cmd *cobra.Command, artifactID string) error {
+	resp, err := triggerBuildFn(artifactID)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.BuildIDs) == 0 {
+		return errors.New("no build IDs returned by server")
+	}
+
+	for _, id := range resp.BuildIDs {
+		fmt.Fprintf(cmd.ErrOrStderr(), "  waiting for build %s...\n", id)
+
+		build, werr := waitForBuildFn(artifactID, id, pollflags.DefaultPollInterval, pollflags.DefaultPollTimeout, nil)
+		if werr != nil {
+			printBuildFailure(cmd, build)
+
+			return werr
+		}
+	}
+
+	return nil
+}
+
+// printBuildFailure dumps the tail of a failed build's logs to stderr so the
+// user does not have to run a second command to see why the build failed.
+func printBuildFailure(cmd *cobra.Command, build *workload.Build) {
+	if build == nil {
+		return
+	}
+
+	summary, err := workload.BuildSummaryFor(build, workload.DefaultBuildLogTail)
+	if err != nil || len(summary.LogTail) == 0 {
+		return
+	}
+
+	fmt.Fprintf(cmd.ErrOrStderr(), "  --- last %d log line(s) for build %s ---\n", len(summary.LogTail), build.ID)
+
+	for _, entry := range summary.LogTail {
+		fmt.Fprintf(cmd.ErrOrStderr(), "  %s\n", entry.Message)
+	}
+}
+
+// deploy creates the workload on first run (recording its id back into the
+// manifest for idempotent re-runs) or reaches an already-created workload.
+func deploy(cmd *cobra.Command, projectDir string, cfg *wlconfig.Config, artifactID string, art *workload.Artifact) (*workload.Workload, error) {
+	if cfg.WorkloadID == "" {
+		return createWorkload(cmd, projectDir, cfg, artifactID, art)
+	}
+
+	return reachExistingWorkload(cmd, projectDir, cfg)
+}
+
+// createWorkload is the first-deploy path: create the workload from the linked
+// artifact and record its id so re-runs are idempotent.
+func createWorkload(cmd *cobra.Command, projectDir string, cfg *wlconfig.Config, artifactID string, art *workload.Artifact) (*workload.Workload, error) {
+	announce(cmd, "Creating workload")
+
+	name := cfg.Name
+	if name == "" {
+		name = filepath.Base(projectDir)
+	}
+
+	wl, err := createWorkloadFn(buildCreatePayload(name, artifactID, art, cfg))
+	if err != nil {
+		// The server allows only one workload per draft artifact. If that is
+		// what we hit, the manifest lost its workloadId (rewritten by an old
+		// config, hand-edited, fresh clone): adopt the existing workload
+		// instead of dead-ending on the 409.
+		wl = adoptWorkloadForArtifact(cmd, artifactID, err)
+		if wl == nil {
+			return nil, err
+		}
+	}
+
+	if err := recordWorkloadID(projectDir, cfg, wl); err != nil {
+		return nil, err
+	}
+
+	return wl, nil
+}
+
+// adoptWorkloadForArtifact recovers from the one-workload-per-draft-artifact
+// rule: on a create 409, find the workload already backing artifactID and
+// return it so the deploy continues with it. Returns nil when the error is not
+// that 409 or no backing workload is found (the caller keeps the original
+// error).
+func adoptWorkloadForArtifact(cmd *cobra.Command, artifactID string, createErr error) *workload.Workload {
+	var httpErr *drapi.HTTPError
+
+	if !errors.As(createErr, &httpErr) || httpErr.StatusCode != http.StatusConflict {
+		return nil
+	}
+
+	workloads, err := listWorkloadsFn(adoptListLimit, nil)
+	if err != nil {
+		return nil
+	}
+
+	for i := range workloads {
+		if workloads[i].ArtifactID != artifactID {
+			continue
+		}
+
+		announce(cmd, fmt.Sprintf("Adopting existing workload %s (%s); a draft artifact allows only one workload",
+			workloads[i].ID, workloads[i].Name))
+
+		return &workloads[i]
+	}
+
+	return nil
+}
+
+// recordWorkloadID writes the created workload's id back into the manifest so
+// re-runs are idempotent. On failure it tells the user how to record the id by
+// hand, so a blind retry does not create a duplicate.
+func recordWorkloadID(projectDir string, cfg *wlconfig.Config, wl *workload.Workload) error {
+	cfg.WorkloadID = wl.ID
+
+	if err := wlconfig.Save(projectDir, *cfg); err != nil {
+		return fmt.Errorf(
+			"workload %s was created but recording its id in %s failed: %w\nset `workloadId: %s` in that file before re-running to avoid creating a duplicate",
+			wl.ID, wlconfig.Path(projectDir), err, wl.ID)
+	}
+
+	return nil
+}
+
+// reachExistingWorkload is the re-deploy path. It brings a non-running workload
+// back up and is honest that a newly built image is not auto-applied to an
+// already-running workload.
+func reachExistingWorkload(cmd *cobra.Command, projectDir string, cfg *wlconfig.Config) (*workload.Workload, error) {
+	announce(cmd, "Reaching workload "+cfg.WorkloadID)
+
+	wl, err := getWorkloadFn(cfg.WorkloadID)
+	if err != nil {
+		var httpErr *drapi.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf(
+				"workload %s (recorded in %s) no longer exists; run `dr workload config` to bind or create another",
+				cfg.WorkloadID, wlconfig.Path(projectDir))
+		}
+
+		return nil, err
+	}
+
+	// Bring a stopped/suspended/interrupted workload back up, then re-fetch so
+	// we do not report the stale pre-start status.
+	if isStoppedLike(wl.Status) {
+		if _, serr := startWorkloadFn(cfg.WorkloadID); serr != nil {
+			return nil, serr
+		}
+
+		if refetched, rerr := getWorkloadFn(cfg.WorkloadID); rerr == nil {
+			wl = refetched
+		}
+	} else {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"  WARNING: workload %s already exists; updating a running workload in place is not automated yet, so it keeps serving its current artifact. Recreate the workload (or use a replace flow) to roll out changes.\n",
+			cfg.WorkloadID)
+	}
+
+	return wl, nil
+}
+
+// buildCreatePayload assembles the workload create request for the code-build
+// modes. The server requires a resource signal (resourceAllocation here); the
+// container name must match the artifact's primary container so the override
+// binds to it.
+func buildCreatePayload(name, artifactID string, art *workload.Artifact, cfg *wlconfig.Config) map[string]any {
+	containerName := primaryContainerName
+
+	if art != nil {
+		if n := workload.PrimaryContainerName(*art); n != "" {
+			containerName = n
+		}
+	}
+
+	payload := map[string]any{
+		"name":       name,
+		"artifactId": artifactID,
+		"runtime":    runtimeBlock(cfg, containerName),
+	}
+
+	if cfg != nil && cfg.Importance != "" {
+		payload["importance"] = cfg.Importance
+	}
+
+	return payload
+}
+
+// runtimeBlock renders the workload runtime with the manifest's resources,
+// falling back to the manifest defaults.
+func runtimeBlock(cfg *wlconfig.Config, containerName string) map[string]any {
+	replicas := wlconfig.DefaultReplicas
+	cpu := wlconfig.DefaultCPU
+	memory := wlconfig.DefaultMemory
+
+	if cfg != nil && cfg.Runtime != nil {
+		if cfg.Runtime.Replicas > 0 {
+			replicas = cfg.Runtime.Replicas
+		}
+
+		if cfg.Runtime.CPU > 0 {
+			cpu = cfg.Runtime.CPU
+		}
+
+		if cfg.Runtime.Memory != "" {
+			memory = cfg.Runtime.Memory
+		}
+	}
+
+	return map[string]any{
+		"containerGroups": []any{
+			map[string]any{
+				"name":         defaultContainerGroup,
+				"replicaCount": replicas,
+				"containers": []any{
+					map[string]any{
+						"name":               containerName,
+						"resourceAllocation": map[string]any{"cpu": cpu, "memory": memory},
+					},
+				},
+			},
+		},
+	}
+}
+
+func isStoppedLike(status string) bool {
+	switch status {
+	case workload.WorkloadStatusStopped,
+		workload.WorkloadStatusSuspended,
+		workload.WorkloadStatusInterrupted:
+		return true
+	}
+
+	return false
+}
+
+func renderUp(cmd *cobra.Command, outputFormat outputformat.OutputFormat, wl *workload.Workload, detached bool) error {
+	// A workload in a failed terminal state is not a success, on the detach
+	// path too where no wait ran to catch it: emit the record, then error.
+	failed := workload.IsWorkloadErrorStatus(wl.Status)
+
+	if outputFormat == outputformat.OutputFormatJSON {
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+
+		if err := enc.Encode(upResult{WorkloadID: wl.ID, Status: wl.Status, Endpoint: wl.Endpoint}); err != nil {
+			return err
+		}
+
+		if failed {
+			return fmt.Errorf("workload %s is in a failed state: %s", wl.ID, wl.Status)
+		}
+
+		return nil
+	}
+
+	if detached {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Workload %s is %s (deploy requested; not waiting). Check `dr workload status %s`.\n", wl.ID, wl.Status, wl.ID)
+	} else {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Workload %s is %s.\n", wl.ID, wl.Status)
+	}
+
+	if failed {
+		return fmt.Errorf("workload %s is in a failed state: %s", wl.ID, wl.Status)
+	}
+
+	// The bare endpoint URL is the last stdout line, matching the
+	// `dr workload endpoint` contract so scripts can capture it.
+	if wl.Endpoint == "" {
+		fmt.Fprintln(cmd.ErrOrStderr(), "No endpoint URL yet; check `dr workload status`.")
+
+		return nil
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), wl.Endpoint)
+
+	return nil
+}
+
+// announce prints a narrated phase line to stderr so stdout stays reserved for
+// the endpoint URL / JSON contract.
+func announce(cmd *cobra.Command, msg string) {
+	fmt.Fprintf(cmd.ErrOrStderr(), "==> %s\n", msg)
+}
+
+// defaultRunSync links the sync engine to projectDir and runs a full,
+// auto-resolving sync (remote wins on conflict, local copies preserved).
+func defaultRunSync(projectDir string) (*sync.Result, error) {
+	if !wapi.Exists(projectDir) {
+		return nil, errors.New("project not linked; `dr workload up` links it automatically, so this is unexpected")
+	}
+
+	engine, err := sync.New(projectDir, sync.Options{Yes: true})
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = engine.Close() }()
+
+	return engine.Run()
+}

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -1,0 +1,546 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/datarobot/cli/internal/workload/wapi"
+	"github.com/datarobot/cli/internal/workload/wlconfig"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validArtifactID is a dr_id-shaped id accepted by wapi.Initialize.
+const validArtifactID = "6a61e855fc6f074dbf0283f9"
+
+// fakes carries the seam overrides a test wants; nil fields fall back to safe
+// stubs so an unexpected call is caught rather than hitting the network.
+type fakes struct {
+	getArtifact     func(string) (*workload.Artifact, error)
+	createArtifact  func(any) (*workload.Artifact, error)
+	resolveEE       func(string) (string, string, error)
+	initProject     func(string, wapi.InitOptions) error
+	runSync         func(string) (*sync.Result, error)
+	triggerBuild    func(string) (*workload.BuildTriggerResponse, error)
+	waitForBuild    func(string, string, time.Duration, time.Duration, func(*workload.Build)) (*workload.Build, error)
+	lockArtifact    func(string) (*workload.Artifact, error)
+	createWorkload  func(any) (*workload.Workload, error)
+	getWorkload     func(string) (*workload.Workload, error)
+	listWorkloads   func(int, []string) ([]workload.Workload, error)
+	startWorkload   func(string) (*workload.WorkloadOperationResponse, error)
+	waitForWorkload func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
+}
+
+func installFakes(t *testing.T, f fakes) {
+	t.Helper()
+
+	origGetArt := getArtifactFn
+	origCreateArt := createArtifactFn
+	origResolveEE := resolveEEFn
+	origInit := initProjectFn
+	origSync := runSyncFn
+	origTrigger := triggerBuildFn
+	origWaitBuild := waitForBuildFn
+	origLock := lockArtifactFn
+	origCreate := createWorkloadFn
+	origGet := getWorkloadFn
+	origList := listWorkloadsFn
+	origStart := startWorkloadFn
+	origWaitWL := waitForWorkloadFn
+
+	t.Cleanup(func() {
+		getArtifactFn = origGetArt
+		createArtifactFn = origCreateArt
+		resolveEEFn = origResolveEE
+		initProjectFn = origInit
+		runSyncFn = origSync
+		triggerBuildFn = origTrigger
+		waitForBuildFn = origWaitBuild
+		lockArtifactFn = origLock
+		createWorkloadFn = origCreate
+		getWorkloadFn = origGet
+		listWorkloadsFn = origList
+		startWorkloadFn = origStart
+		waitForWorkloadFn = origWaitWL
+	})
+
+	fail := func(name string) { t.Errorf("unexpected call to %s", name) }
+
+	getArtifactFn = fnOr(f.getArtifact, func(string) (*workload.Artifact, error) { return &workload.Artifact{}, nil })
+	createArtifactFn = fnOr(f.createArtifact, func(any) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: "art-created"}, nil
+	})
+	resolveEEFn = fnOr(f.resolveEE, func(string) (string, string, error) { return "ee-1", "eev-1", nil })
+	initProjectFn = fnOr(f.initProject, func(string, wapi.InitOptions) error { return nil })
+	runSyncFn = fnOr(f.runSync, func(string) (*sync.Result, error) { return &sync.Result{}, nil })
+	triggerBuildFn = fnOr(f.triggerBuild, func(string) (*workload.BuildTriggerResponse, error) {
+		return &workload.BuildTriggerResponse{BuildIDs: []string{"b-1"}}, nil
+	})
+	waitForBuildFn = fnOr(f.waitForBuild, func(string, string, time.Duration, time.Duration, func(*workload.Build)) (*workload.Build, error) {
+		return &workload.Build{ID: "b-1", Status: workload.BuildStatusCompleted}, nil
+	})
+	lockArtifactFn = fnOr(f.lockArtifact, func(string) (*workload.Artifact, error) { fail("lockArtifact"); return nil, nil })
+	createWorkloadFn = fnOr(f.createWorkload, func(any) (*workload.Workload, error) { fail("createWorkload"); return nil, nil })
+	getWorkloadFn = fnOr(f.getWorkload, func(string) (*workload.Workload, error) { fail("getWorkload"); return nil, nil })
+	listWorkloadsFn = fnOr(f.listWorkloads, func(int, []string) ([]workload.Workload, error) { fail("listWorkloads"); return nil, nil })
+	startWorkloadFn = fnOr(f.startWorkload, func(string) (*workload.WorkloadOperationResponse, error) { fail("startWorkload"); return nil, nil })
+	waitForWorkloadFn = fnOr(f.waitForWorkload, func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		fail("waitForWorkload")
+
+		return nil, nil
+	})
+}
+
+// fnOr returns override when it is a non-nil func value, otherwise def.
+func fnOr[T any](override, def T) T {
+	if v := reflect.ValueOf(override); v.Kind() == reflect.Func && v.IsNil() {
+		return def
+	}
+
+	return override
+}
+
+func newTestCmd(args []string) (*cobra.Command, *bytes.Buffer) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+
+	var out bytes.Buffer
+
+	cmd.SetOut(&out)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs(args)
+
+	return cmd, &out
+}
+
+func newTestCmdWithErr(args []string) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+
+	var out, errBuf bytes.Buffer
+
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs(args)
+
+	return cmd, &out, &errBuf
+}
+
+// linkDir writes a real .wapi/ so ensureLinked takes the already-linked path.
+func linkDir(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{ArtifactID: validArtifactID}))
+}
+
+func TestUp_MissingConfigErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	installFakes(t, fakes{})
+
+	cmd, _ := newTestCmd([]string{"--yes", "--dir", dir})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dr workload config")
+}
+
+func TestUp_CreatesArtifactLinksAndDeploys(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, wlconfig.Save(dir, wlconfig.Default("my-app")))
+
+	var (
+		artifactSpec  map[string]any
+		linked        bool
+		createPayload map[string]any
+	)
+
+	installFakes(t, fakes{
+		createArtifact: func(spec any) (*workload.Artifact, error) {
+			artifactSpec, _ = spec.(map[string]any)
+
+			return &workload.Artifact{ID: "art-new"}, nil
+		},
+		initProject: func(string, wapi.InitOptions) error {
+			linked = true
+
+			return nil
+		},
+		createWorkload: func(payload any) (*workload.Workload, error) {
+			createPayload, _ = payload.(map[string]any)
+
+			return &workload.Workload{ID: "wl-1", Status: workload.WorkloadStatusSubmitted, Endpoint: "https://e/"}, nil
+		},
+		waitForWorkload: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return &workload.Workload{ID: "wl-1", Status: workload.WorkloadStatusRunning, Endpoint: "https://e/"}, nil
+		},
+	})
+
+	cmd, out := newTestCmd([]string{"--yes", "--dir", dir})
+	require.NoError(t, cmd.Execute())
+
+	assert.NotNil(t, artifactSpec, "up must create the artifact when not linked")
+	assert.True(t, linked, "up must link the project directory")
+	assert.NotNil(t, createPayload["runtime"], "workload create must include a runtime resource signal")
+	assert.Equal(t, "https://e/", strings.TrimSpace(out.String()))
+
+	cfg, err := wlconfig.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "wl-1", cfg.WorkloadID, "id is recorded for idempotent re-runs")
+}
+
+func TestBuildArtifactSpec_ProvidedDockerfile(t *testing.T) {
+	cfg := wlconfig.Default("app") // provided mode by default
+
+	spec, err := buildArtifactSpec(&cfg)
+	require.NoError(t, err)
+
+	df := dockerfileOf(t, spec)
+	assert.Equal(t, "provided", df["source"])
+	assert.Equal(t, wlconfig.DefaultDockerfile, df["path"])
+}
+
+func TestBuildArtifactSpec_GeneratedResolvesEE(t *testing.T) {
+	installFakes(t, fakes{
+		resolveEE: func(name string) (string, string, error) {
+			assert.Equal(t, "my-ee", name)
+
+			return "ee-9", "eev-9", nil
+		},
+	})
+
+	cfg := wlconfig.Config{
+		Name:  "app",
+		Build: &wlconfig.Build{ExecutionEnvironment: "my-ee", Entrypoint: []string{"uvicorn", "app:app"}, Port: 8080, Health: "/h"},
+	}
+
+	spec, err := buildArtifactSpec(&cfg)
+	require.NoError(t, err)
+
+	df := dockerfileOf(t, spec)
+	assert.Equal(t, "generated", df["source"])
+	assert.Equal(t, "ee-9", df["executionEnvironmentId"])
+	assert.Equal(t, "eev-9", df["executionEnvironmentVersionId"])
+}
+
+// dockerfileOf digs the imageBuildConfig.dockerfile map out of an artifact spec.
+func dockerfileOf(t *testing.T, spec map[string]any) map[string]any {
+	t.Helper()
+
+	s := spec["spec"].(map[string]any)
+	groups := s["containerGroups"].([]any)
+	group := groups[0].(map[string]any)
+	container := group["containers"].([]any)[0].(map[string]any)
+	ibc := container["imageBuildConfig"].(map[string]any)
+
+	return ibc["dockerfile"].(map[string]any)
+}
+
+func TestBuildCreatePayload_UsesManifestRuntime(t *testing.T) {
+	cfg := &wlconfig.Config{Runtime: &wlconfig.Runtime{Replicas: 3, CPU: 2, Memory: "1GB"}}
+
+	payload := buildCreatePayload("app", "art-1", nil, cfg)
+
+	runtime := payload["runtime"].(map[string]any)
+	group := runtime["containerGroups"].([]any)[0].(map[string]any)
+	assert.Equal(t, 3, group["replicaCount"])
+
+	container := group["containers"].([]any)[0].(map[string]any)
+	ra := container["resourceAllocation"].(map[string]any)
+	assert.InDelta(t, 2.0, ra["cpu"], 0.0001)
+	assert.Equal(t, "1GB", ra["memory"])
+}
+
+func TestUp_LockedArtifactFailsFast(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, wlconfig.Save(dir, wlconfig.Default("app")))
+	linkDir(t, dir)
+
+	installFakes(t, fakes{
+		getArtifact: func(string) (*workload.Artifact, error) {
+			return &workload.Artifact{Status: workload.ArtifactStatusLocked}, nil
+		},
+		runSync: func(string) (*sync.Result, error) {
+			t.Error("sync should not run on a locked artifact")
+
+			return nil, errors.New("unexpected")
+		},
+	})
+
+	cmd, _ := newTestCmd([]string{"--yes", "--dir", dir})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "locked")
+}
+
+func TestUp_LockFlagLocksAfterDeploy(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, wlconfig.Save(dir, wlconfig.Default("app")))
+
+	locked := false
+
+	installFakes(t, fakes{
+		createArtifact: func(any) (*workload.Artifact, error) { return &workload.Artifact{ID: "art-x"}, nil },
+		lockArtifact: func(id string) (*workload.Artifact, error) {
+			locked = true
+
+			assert.Equal(t, "art-x", id)
+
+			return &workload.Artifact{ID: id}, nil
+		},
+		createWorkload: func(any) (*workload.Workload, error) {
+			return &workload.Workload{ID: "wl-1", Endpoint: "https://e/"}, nil
+		},
+		waitForWorkload: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return &workload.Workload{ID: "wl-1", Status: workload.WorkloadStatusRunning, Endpoint: "https://e/"}, nil
+		},
+	})
+
+	cmd, _ := newTestCmd([]string{"--yes", "--dir", dir, "--lock"})
+	require.NoError(t, cmd.Execute())
+	assert.True(t, locked, "--lock must call LockArtifact")
+}
+
+func TestUp_DetachErroredWorkloadExitsNonZero(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, wlconfig.Save(dir, wlconfig.Config{WorkloadID: "wl-9", Name: "app"}))
+	linkDir(t, dir)
+
+	installFakes(t, fakes{
+		getWorkload: func(string) (*workload.Workload, error) {
+			return &workload.Workload{ID: "wl-9", Status: workload.WorkloadStatusErrored, Endpoint: "https://e/"}, nil
+		},
+	})
+
+	cmd, _ := newTestCmd([]string{"--yes", "--dir", dir, "--detach"})
+	err := cmd.Execute()
+	require.Error(t, err, "an errored workload must not exit 0 even with --detach")
+	assert.Contains(t, err.Error(), "failed state")
+}
+
+func TestUp_DeletedWorkloadGivesReconfigureHint(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, wlconfig.Save(dir, wlconfig.Config{WorkloadID: "wl-gone", Name: "app"}))
+	linkDir(t, dir)
+
+	installFakes(t, fakes{
+		getWorkload: func(string) (*workload.Workload, error) {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
+		},
+	})
+
+	cmd, _ := newTestCmd([]string{"--yes", "--dir", dir})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no longer exists")
+	assert.Contains(t, err.Error(), "dr workload config")
+}
+
+func TestUp_Create409AdoptsExistingWorkloadForArtifact(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, wlconfig.Save(dir, wlconfig.Default("my-app")))
+	linkDir(t, dir) // .wapi pins validArtifactID; manifest has no workloadId
+
+	installFakes(t, fakes{
+		createWorkload: func(any) (*workload.Workload, error) {
+			// The server's one-workload-per-draft-artifact rule.
+			return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
+		},
+		listWorkloads: func(int, []string) ([]workload.Workload, error) {
+			return []workload.Workload{
+				{ID: "wl-other", ArtifactID: "someone-elses-artifact"},
+				{ID: "wl-mine", Name: "my-app", ArtifactID: validArtifactID, Status: workload.WorkloadStatusRunning, Endpoint: "https://e/"},
+			}, nil
+		},
+		waitForWorkload: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			assert.Equal(t, "wl-mine", id)
+
+			return &workload.Workload{ID: "wl-mine", Status: workload.WorkloadStatusRunning, Endpoint: "https://e/"}, nil
+		},
+	})
+
+	cmd, out := newTestCmd([]string{"--yes", "--dir", dir})
+	require.NoError(t, cmd.Execute(), "409 must self-heal by adopting the artifact's existing workload")
+	assert.Equal(t, "https://e/", strings.TrimSpace(out.String()))
+
+	cfg, err := wlconfig.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "wl-mine", cfg.WorkloadID, "adopted id is recorded for the next run")
+}
+
+func TestUp_Create409WithNoMatchingWorkloadKeepsError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, wlconfig.Save(dir, wlconfig.Default("my-app")))
+	linkDir(t, dir)
+
+	installFakes(t, fakes{
+		createWorkload: func(any) (*workload.Workload, error) {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
+		},
+		listWorkloads: func(int, []string) ([]workload.Workload, error) {
+			return []workload.Workload{{ID: "wl-other", ArtifactID: "someone-elses-artifact"}}, nil
+		},
+	})
+
+	cmd, _ := newTestCmd([]string{"--yes", "--dir", dir})
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
+}
+
+func imageManifest(name string) wlconfig.Config {
+	return wlconfig.Config{
+		Name:       name,
+		Importance: "high",
+		Build:      &wlconfig.Build{Image: "repo/app:1", Entrypoint: []string{"python", "server.py"}, Port: 8080, Health: "/readyz"},
+		Runtime:    &wlconfig.Runtime{Replicas: 1, CPU: 1, Memory: "512MB"},
+		Env:        map[string]string{"MODEL": "azure/gpt-5-nano-2025-08-07"},
+	}
+}
+
+func TestUp_ImageModeSkipsLinkSyncAndBuild(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, wlconfig.Save(dir, imageManifest("agent-service")))
+
+	var payload map[string]any
+
+	installFakes(t, fakes{
+		// Everything code-related left as failing stubs via explicit overrides:
+		createArtifact: func(any) (*workload.Artifact, error) {
+			t.Error("image mode must not create a standalone artifact")
+
+			return nil, errors.New("unexpected")
+		},
+		initProject: func(string, wapi.InitOptions) error {
+			t.Error("image mode must not link the project")
+
+			return errors.New("unexpected")
+		},
+		runSync: func(string) (*sync.Result, error) {
+			t.Error("image mode must not sync")
+
+			return nil, errors.New("unexpected")
+		},
+		triggerBuild: func(string) (*workload.BuildTriggerResponse, error) {
+			t.Error("image mode must not build")
+
+			return nil, errors.New("unexpected")
+		},
+		createWorkload: func(p any) (*workload.Workload, error) {
+			payload, _ = p.(map[string]any)
+
+			return &workload.Workload{ID: "wl-img", ArtifactID: "art-inline", Status: workload.WorkloadStatusSubmitted, Endpoint: "https://e/"}, nil
+		},
+		waitForWorkload: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return &workload.Workload{ID: "wl-img", Status: workload.WorkloadStatusRunning, Endpoint: "https://e/"}, nil
+		},
+	})
+
+	cmd, out := newTestCmd([]string{"--yes", "--dir", dir})
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "https://e/", strings.TrimSpace(out.String()))
+
+	// Inline artifact, not artifactId (Tutorial 2 shape).
+	require.NotNil(t, payload)
+	assert.NotContains(t, payload, "artifactId")
+	assert.Equal(t, "high", payload["importance"])
+
+	art := payload["artifact"].(map[string]any)
+	container := art["spec"].(map[string]any)["containerGroups"].([]any)[0].(map[string]any)["containers"].([]any)[0].(map[string]any)
+	assert.Equal(t, "repo/app:1", container["imageUri"])
+	assert.Equal(t, []string{"python", "server.py"}, container["entrypoint"])
+	assert.NotNil(t, container["environmentVars"])
+	assert.NotNil(t, payload["runtime"], "resource signal is still required")
+
+	cfg, err := wlconfig.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "wl-img", cfg.WorkloadID)
+}
+
+func TestUp_ImageModeLockLocksInlineArtifact(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, wlconfig.Save(dir, imageManifest("agent-service")))
+
+	locked := ""
+
+	installFakes(t, fakes{
+		createWorkload: func(any) (*workload.Workload, error) {
+			return &workload.Workload{ID: "wl-img", ArtifactID: "art-inline", Endpoint: "https://e/"}, nil
+		},
+		lockArtifact: func(id string) (*workload.Artifact, error) {
+			locked = id
+
+			return &workload.Artifact{ID: id}, nil
+		},
+		waitForWorkload: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return &workload.Workload{ID: "wl-img", Status: workload.WorkloadStatusRunning, Endpoint: "https://e/"}, nil
+		},
+	})
+
+	cmd, _ := newTestCmd([]string{"--yes", "--dir", dir, "--lock"})
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, "art-inline", locked, "--lock must lock the artifact minted by the inline create")
+}
+
+func TestEnvVarsPayload_ExpandsShellVars(t *testing.T) {
+	t.Setenv("UP_TEST_SECRET", "sekret")
+
+	cfg := &wlconfig.Config{Env: map[string]string{
+		"B_TOKEN": "${UP_TEST_SECRET}",
+		"A_PLAIN": "value",
+	}}
+
+	env := envVarsPayload(cfg)
+	require.Len(t, env, 2)
+	assert.Equal(t, map[string]any{"name": "A_PLAIN", "value": "value"}, env[0])
+	assert.Equal(t, map[string]any{"name": "B_TOKEN", "value": "sekret"}, env[1])
+}
+
+func TestUp_ReportsAutoResolvedSyncConflicts(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, wlconfig.Save(dir, wlconfig.Default("app")))
+
+	installFakes(t, fakes{
+		createArtifact: func(any) (*workload.Artifact, error) { return &workload.Artifact{ID: "art-x"}, nil },
+		runSync: func(string) (*sync.Result, error) {
+			return &sync.Result{ConflictCount: 1, ConflictCopies: []string{"main.py.LOCAL.123"}}, nil
+		},
+		createWorkload: func(any) (*workload.Workload, error) {
+			return &workload.Workload{ID: "wl-1", Endpoint: "https://e/"}, nil
+		},
+		waitForWorkload: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return &workload.Workload{ID: "wl-1", Status: workload.WorkloadStatusRunning, Endpoint: "https://e/"}, nil
+		},
+	})
+
+	cmd, _, errBuf := newTestCmdWithErr([]string{"--yes", "--dir", dir})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, errBuf.String(), "auto-resolved")
+	assert.Contains(t, errBuf.String(), "main.py.LOCAL.123")
+}

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -64,6 +64,10 @@ type ContainerGroup struct {
 }
 
 type Container struct {
+	// Name is the container's identifier within its group. Workload runtime
+	// overrides (e.g. resourceAllocation) must reference the container by this
+	// name, so it is parsed for callers that build a runtime spec.
+	Name             string            `json:"name,omitempty"`
 	ImageBuildConfig *ImageBuildConfig `json:"imageBuildConfig,omitempty"`
 	// ImageURI is the resolved container image reference. Server-managed:
 	// before a successful build this is the placeholder from create; after
@@ -189,6 +193,28 @@ func GetPrimaryContainerImageURI(artifact Artifact) string {
 	}
 
 	return artifact.Spec.ContainerGroups[0].Containers[0].ImageURI
+}
+
+// PrimaryContainerName returns the name of the artifact's primary container,
+// falling back to the first container, then to "primary". Callers building a
+// workload runtime spec need this because resourceAllocation overrides are keyed
+// by container name and must match a container in the artifact.
+func PrimaryContainerName(artifact Artifact) string {
+	for _, group := range artifact.Spec.ContainerGroups {
+		for _, container := range group.Containers {
+			if container.Primary != nil && *container.Primary && container.Name != "" {
+				return container.Name
+			}
+		}
+	}
+
+	if len(artifact.Spec.ContainerGroups) > 0 &&
+		len(artifact.Spec.ContainerGroups[0].Containers) > 0 &&
+		artifact.Spec.ContainerGroups[0].Containers[0].Name != "" {
+		return artifact.Spec.ContainerGroups[0].Containers[0].Name
+	}
+
+	return "primary"
 }
 
 func GetArtifact(artifactID string) (*Artifact, error) {

--- a/internal/workload/artifact_test.go
+++ b/internal/workload/artifact_test.go
@@ -790,3 +790,25 @@ func TestLockArtifact_403AlreadyLockedPropagatesAsHTTPError(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, httpErr.StatusCode)
 	assert.Contains(t, err.Error(), "artifact is locked")
 }
+
+func TestPrimaryContainerName(t *testing.T) {
+	primary := true
+
+	t.Run("returns the name of the primary-flagged container", func(t *testing.T) {
+		art := Artifact{Spec: Spec{ContainerGroups: []ContainerGroup{
+			{Containers: []Container{{Name: "sidecar"}, {Name: "main", Primary: &primary}}},
+		}}}
+		assert.Equal(t, "main", PrimaryContainerName(art))
+	})
+
+	t.Run("falls back to the first container when none is flagged primary", func(t *testing.T) {
+		art := Artifact{Spec: Spec{ContainerGroups: []ContainerGroup{
+			{Containers: []Container{{Name: "only"}}},
+		}}}
+		assert.Equal(t, "only", PrimaryContainerName(art))
+	})
+
+	t.Run("falls back to \"primary\" when the artifact has no named container", func(t *testing.T) {
+		assert.Equal(t, "primary", PrimaryContainerName(Artifact{}))
+	})
+}

--- a/internal/workload/execenv.go
+++ b/internal/workload/execenv.go
@@ -1,0 +1,83 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"fmt"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// ExecutionEnvironment is the projection of the server's EE document the CLI
+// needs to build a generated-Dockerfile artifact spec.
+type ExecutionEnvironment struct {
+	ID                      string     `json:"id"`
+	Name                    string     `json:"name"`
+	LatestSuccessfulVersion *EEVersion `json:"latestSuccessfulVersion"`
+}
+
+// EEVersion is an execution environment version reference.
+type EEVersion struct {
+	ID string `json:"id"`
+}
+
+type executionEnvironmentList struct {
+	Data []ExecutionEnvironment `json:"data"`
+	Next string                 `json:"next"`
+}
+
+// ResolveExecutionEnvironment finds an execution environment by exact id or
+// name and returns its id and latest successful version id. `dr workload up`
+// uses it to fill the executionEnvironmentId/versionId of a generated-Dockerfile
+// artifact so the user names an EE without pasting ids.
+func ResolveExecutionEnvironment(nameOrID string) (id, versionID string, err error) {
+	pageURL, err := config.GetEndpointURL("/api/v2/executionEnvironments/?limit=100")
+	if err != nil {
+		return "", "", err
+	}
+
+	for pageURL != "" {
+		var list executionEnvironmentList
+
+		if err := drapi.GetJSON(pageURL, "execution environments", &list); err != nil {
+			return "", "", err
+		}
+
+		for _, ee := range list.Data {
+			if ee.ID != nameOrID && ee.Name != nameOrID {
+				continue
+			}
+
+			if ee.LatestSuccessfulVersion == nil {
+				return "", "", fmt.Errorf("execution environment %q has no successful version to build from", nameOrID)
+			}
+
+			return ee.ID, ee.LatestSuccessfulVersion.ID, nil
+		}
+
+		if list.Next == "" {
+			break
+		}
+
+		if err := drapi.AssertNextOnSameHost(list.Next); err != nil {
+			return "", "", err
+		}
+
+		pageURL = list.Next
+	}
+
+	return "", "", fmt.Errorf("execution environment %q not found; list options with `dr` against /executionEnvironments/", nameOrID)
+}

--- a/internal/workload/wlconfig/config.go
+++ b/internal/workload/wlconfig/config.go
@@ -1,0 +1,393 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package wlconfig reads and writes .datarobot/workload.yaml, the committed
+// manifest that `dr workload config` generates and `dr workload up` consumes to
+// build a container image and deploy it as a workload. It intentionally mirrors
+// the "Git to Workload" manifest shape (name/importance/build/runtime).
+package wlconfig
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/datarobot/cli/internal/fsutil"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// DirName is the DataRobot project directory that holds the committed
+	// workload manifest.
+	DirName = ".datarobot"
+
+	// FileName is the committed workload manifest inside DirName.
+	FileName = "workload.yaml"
+)
+
+// Build modes, discriminated by which fields are set.
+const (
+	// ModeProvided builds the user's own Dockerfile server-side.
+	ModeProvided = "provided"
+	// ModeGenerated builds from an execution environment (no Dockerfile).
+	ModeGenerated = "generated"
+	// ModeImage deploys an existing container image; no code, no build.
+	ModeImage = "image"
+)
+
+// Defaults used by Default() and the generated manifest.
+const (
+	DefaultImportance = "low"
+	DefaultDockerfile = "./Dockerfile"
+	DefaultPort       = 8080
+	DefaultHealth     = "/health"
+	DefaultReplicas   = 1
+	DefaultCPU        = 0.5
+	DefaultMemory     = "512MB"
+	// DefaultExecutionEnvironment is the EE name `up` resolves for generated
+	// mode when the manifest names none.
+	DefaultExecutionEnvironment = "[DataRobot] Python 3.12 Applications Base"
+)
+
+// ErrNotConfigured is returned by Load when no workload.yaml exists yet, so
+// callers (e.g. `dr workload up`) can point the user at `dr workload config`.
+var ErrNotConfigured = errors.New("workload not configured: .datarobot/workload.yaml not found")
+
+// Config is the parsed workload manifest.
+type Config struct {
+	WorkloadID string   `yaml:"workloadId,omitempty"`
+	Name       string   `yaml:"name,omitempty"`
+	Importance string   `yaml:"importance,omitempty"`
+	Build      *Build   `yaml:"build,omitempty"`
+	Runtime    *Runtime `yaml:"runtime,omitempty"`
+	// Env is injected into the container as environment variables. Values may
+	// reference the deploying shell's environment as ${VAR}; `up` expands them
+	// at deploy time so secrets never live in this committed file.
+	Env map[string]string `yaml:"env,omitempty"`
+}
+
+// Build describes how the container image is produced. Exactly one mode is
+// active: a non-empty Image deploys that pre-built image (no build); otherwise
+// a non-empty Dockerfile selects provided mode; otherwise `up` uses generated
+// mode with ExecutionEnvironment + Entrypoint.
+type Build struct {
+	Image                string   `yaml:"image,omitempty"`
+	Dockerfile           string   `yaml:"dockerfile,omitempty"`
+	ExecutionEnvironment string   `yaml:"executionEnvironment,omitempty"`
+	Entrypoint           []string `yaml:"entrypoint,omitempty"`
+	Port                 int      `yaml:"port,omitempty"`
+	Health               string   `yaml:"health,omitempty"`
+}
+
+// Runtime describes the deployed workload's resources.
+type Runtime struct {
+	Replicas int     `yaml:"replicas,omitempty"`
+	CPU      float64 `yaml:"cpu,omitempty"`
+	Memory   string  `yaml:"memory,omitempty"`
+}
+
+// Default returns a fully-populated provided-Dockerfile manifest for name, so
+// `dr workload up` can build and deploy with no further input.
+func Default(name string) Config {
+	return Config{
+		Name:       name,
+		Importance: DefaultImportance,
+		Build:      &Build{Dockerfile: DefaultDockerfile, Port: DefaultPort, Health: DefaultHealth},
+		Runtime:    &Runtime{Replicas: DefaultReplicas, CPU: DefaultCPU, Memory: DefaultMemory},
+	}
+}
+
+// BuildMode reports which build mode the manifest selects. Image wins over
+// Dockerfile so a user switching modes only has to add the image line.
+func (c Config) BuildMode() string {
+	switch {
+	case c.Build != nil && c.Build.Image != "":
+		return ModeImage
+	case c.Build != nil && c.Build.Dockerfile != "":
+		return ModeProvided
+	default:
+		return ModeGenerated
+	}
+}
+
+// Port returns the configured container port or the default.
+func (c Config) Port() int {
+	if c.Build != nil && c.Build.Port > 0 {
+		return c.Build.Port
+	}
+
+	return DefaultPort
+}
+
+// Health returns the configured probe path or the default.
+func (c Config) Health() string {
+	if c.Build != nil && c.Build.Health != "" {
+		return c.Build.Health
+	}
+
+	return DefaultHealth
+}
+
+// Dir returns the .datarobot directory for projectDir.
+func Dir(projectDir string) string {
+	return filepath.Join(projectDir, DirName)
+}
+
+// Path returns the absolute path to the manifest for projectDir.
+func Path(projectDir string) string {
+	return filepath.Join(Dir(projectDir), FileName)
+}
+
+// Exists reports whether projectDir already has a committed manifest.
+func Exists(projectDir string) bool {
+	return fsutil.FileExists(Path(projectDir))
+}
+
+// Load reads and parses the manifest, returning ErrNotConfigured when absent.
+func Load(projectDir string) (Config, error) {
+	path := Path(projectDir)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Config{}, ErrNotConfigured
+		}
+
+		return Config{}, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var cfg Config
+
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return Config{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	return cfg, nil
+}
+
+// Save atomically writes cfg to the manifest as a commented, self-documenting
+// file (regenerated each write, so `up`'s workloadId write-back keeps the
+// comments intact).
+func Save(projectDir string, cfg Config) error {
+	dir := Dir(projectDir)
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
+
+	return atomicWriteFile(Path(projectDir), Marshal(cfg))
+}
+
+// Marshal renders cfg as the commented manifest. Fields fall back to defaults so
+// a partial Config still produces a runnable file.
+func Marshal(cfg Config) []byte {
+	b := cfg.withDefaults()
+
+	var sb strings.Builder
+
+	sb.WriteString("# DataRobot workload manifest, generated by `dr workload config`.\n")
+	sb.WriteString("# `dr workload up` reads this to deploy a workload: it builds a container\n")
+	sb.WriteString("# image from this repo (or takes your pre-built one) and creates everything\n")
+	sb.WriteString("# else automatically.\n\n")
+
+	if b.WorkloadID != "" {
+		fmt.Fprintf(&sb, "workloadId: %s\n", b.WorkloadID)
+	}
+
+	fmt.Fprintf(&sb, "name: %s\n", b.Name)
+	fmt.Fprintf(&sb, "importance: %s   # low | moderate | high | critical\n\n", b.Importance)
+
+	sb.WriteString("build:\n")
+	writeBuildSection(&sb, b)
+
+	sb.WriteString("\nruntime:\n")
+	fmt.Fprintf(&sb, "  replicas: %d\n", b.Runtime.Replicas)
+	fmt.Fprintf(&sb, "  cpu: %s        # cores (fractional allowed)\n", formatFloat(b.Runtime.CPU))
+	fmt.Fprintf(&sb, "  memory: %s   # B/KB/MB/GB\n", b.Runtime.Memory)
+
+	writeEnvSection(&sb, b)
+
+	return []byte(sb.String())
+}
+
+// writeBuildSection renders the active build mode, with the other modes' fields
+// shown as commented hints.
+func writeBuildSection(sb *strings.Builder, c Config) {
+	switch c.BuildMode() {
+	case ModeImage:
+		sb.WriteString("  # Pre-built image mode: deploy an existing container image, no build step.\n")
+		fmt.Fprintf(sb, "  image: %s\n", c.Build.Image)
+
+		if len(c.Build.Entrypoint) > 0 {
+			fmt.Fprintf(sb, "  entrypoint: [%s]\n", quoteList(c.Build.Entrypoint))
+		}
+
+		sb.WriteString("  # Or build from this repo instead: remove `image` and set either\n")
+		sb.WriteString("  # `dockerfile: ./Dockerfile` or `executionEnvironment` + `entrypoint`.\n")
+	case ModeProvided:
+		sb.WriteString("  # Provided-Dockerfile mode: DataRobot builds your Dockerfile from this repo.\n")
+		fmt.Fprintf(sb, "  dockerfile: %s\n", c.Build.Dockerfile)
+		sb.WriteString("  # Other modes: replace `dockerfile` with one of:\n")
+		fmt.Fprintf(sb, "  #   executionEnvironment: %q   # + entrypoint: [...]\n", DefaultExecutionEnvironment)
+		sb.WriteString("  #   image: registry/repo:tag                              # deploy a pre-built image\n")
+	default:
+		sb.WriteString("  # Generated mode: DataRobot builds an image from an execution environment.\n")
+		fmt.Fprintf(sb, "  executionEnvironment: %q\n", c.Build.ExecutionEnvironment)
+		fmt.Fprintf(sb, "  entrypoint: [%s]\n", quoteList(c.Build.Entrypoint))
+		sb.WriteString("  # Other modes: replace the two lines above with one of:\n")
+		sb.WriteString("  #   dockerfile: ./Dockerfile     # build your own Dockerfile\n")
+		sb.WriteString("  #   image: registry/repo:tag     # deploy a pre-built image\n")
+	}
+
+	fmt.Fprintf(sb, "  port: %d          # container listen port (>= 1024)\n", c.Build.Port)
+	fmt.Fprintf(sb, "  health: %s      # HTTP readiness/liveness path\n", c.Build.Health)
+}
+
+// writeEnvSection renders the container environment variables, or a commented
+// example when none are set.
+func writeEnvSection(sb *strings.Builder, c Config) {
+	sb.WriteString("\n# Container environment variables; ${VAR} expands from your shell at deploy\n")
+	sb.WriteString("# time, so secrets never live in this committed file.\n")
+
+	if len(c.Env) == 0 {
+		sb.WriteString("# env:\n")
+		sb.WriteString("#   MY_SETTING: value\n")
+		sb.WriteString("#   MY_SECRET: ${MY_SECRET}\n")
+
+		return
+	}
+
+	sb.WriteString("env:\n")
+
+	for _, k := range slices.Sorted(maps.Keys(c.Env)) {
+		fmt.Fprintf(sb, "  %s: %q\n", k, c.Env[k])
+	}
+}
+
+// withDefaults returns a copy of cfg with empty fields filled from Default, so
+// Marshal never emits a blank required field.
+func (c Config) withDefaults() Config {
+	out := c
+
+	if out.Name == "" {
+		out.Name = "my-app"
+	}
+
+	if out.Importance == "" {
+		out.Importance = DefaultImportance
+	}
+
+	out.Build = buildWithDefaults(out.Build)
+	out.Runtime = runtimeWithDefaults(out.Runtime)
+
+	return out
+}
+
+func buildWithDefaults(b *Build) *Build {
+	out := Build{}
+	if b != nil {
+		out = *b
+	}
+
+	if out.Image == "" && out.Dockerfile == "" && out.ExecutionEnvironment == "" {
+		out.Dockerfile = DefaultDockerfile
+	}
+
+	if out.Port == 0 {
+		out.Port = DefaultPort
+	}
+
+	if out.Health == "" {
+		out.Health = DefaultHealth
+	}
+
+	return &out
+}
+
+func runtimeWithDefaults(r *Runtime) *Runtime {
+	out := Runtime{}
+	if r != nil {
+		out = *r
+	}
+
+	if out.Replicas == 0 {
+		out.Replicas = DefaultReplicas
+	}
+
+	if out.CPU == 0 {
+		out.CPU = DefaultCPU
+	}
+
+	if out.Memory == "" {
+		out.Memory = DefaultMemory
+	}
+
+	return &out
+}
+
+func formatFloat(f float64) string {
+	return strconv.FormatFloat(f, 'g', -1, 64)
+}
+
+func quoteList(items []string) string {
+	quoted := make([]string, len(items))
+
+	for i, s := range items {
+		quoted[i] = strconv.Quote(s)
+	}
+
+	return strings.Join(quoted, ", ")
+}
+
+// atomicWriteFile writes data via a temp file + rename so readers never observe
+// a half-written manifest.
+func atomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+
+	tmp, err := os.CreateTemp(dir, ".workload-*.yaml.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file in %s: %w", dir, err)
+	}
+
+	tmpName := tmp.Name()
+
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+
+		return fmt.Errorf("write %s: %w", tmpName, err)
+	}
+
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+
+		return fmt.Errorf("chmod %s: %w", tmpName, err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", tmpName, err)
+	}
+
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename %s to %s: %w", tmpName, path, err)
+	}
+
+	return nil
+}

--- a/internal/workload/wlconfig/config_test.go
+++ b/internal/workload/wlconfig/config_test.go
@@ -1,0 +1,208 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wlconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefault_IsFullyPopulatedProvidedMode(t *testing.T) {
+	cfg := Default("app")
+
+	assert.Equal(t, "app", cfg.Name)
+	assert.Equal(t, ModeProvided, cfg.BuildMode())
+	require.NotNil(t, cfg.Build)
+	assert.Equal(t, DefaultDockerfile, cfg.Build.Dockerfile)
+	assert.Equal(t, DefaultPort, cfg.Build.Port)
+	require.NotNil(t, cfg.Runtime)
+	assert.InDelta(t, DefaultCPU, cfg.Runtime.CPU, 0.0001)
+}
+
+func TestSaveLoadRoundTrip_Default(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Default("my-app")
+
+	require.NoError(t, Save(dir, cfg))
+
+	got, err := Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, cfg, got)
+}
+
+func TestSave_WritesCommentedManifest(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, Save(dir, Default("app")))
+
+	data, err := os.ReadFile(Path(dir))
+	require.NoError(t, err)
+
+	s := string(data)
+	assert.Contains(t, s, "# DataRobot workload manifest")
+	assert.Contains(t, s, "name: app")
+	assert.Contains(t, s, "build:")
+	assert.Contains(t, s, "dockerfile: ./Dockerfile")
+	assert.Contains(t, s, "runtime:")
+	assert.Contains(t, s, "cpu: 0.5")
+}
+
+func TestSave_WorkloadIDWriteBackKeepsManifest(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Default("app")
+
+	require.NoError(t, Save(dir, cfg))
+
+	// Simulate `up` recording the id after create.
+	cfg.WorkloadID = "wl-1"
+	require.NoError(t, Save(dir, cfg))
+
+	data, err := os.ReadFile(Path(dir))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "workloadId: wl-1")
+	assert.Contains(t, string(data), "dockerfile:", "manifest fields survive the write-back")
+
+	got, err := Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "wl-1", got.WorkloadID)
+	assert.Equal(t, "app", got.Name)
+}
+
+func TestSave_IsAtomicAndLeavesNoTempFile(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, Save(dir, Default("app")))
+
+	entries, err := os.ReadDir(Dir(dir))
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".tmp", "temp file should be renamed away")
+	}
+}
+
+func TestBuildMode(t *testing.T) {
+	assert.Equal(t, ModeProvided, Config{Build: &Build{Dockerfile: "./Dockerfile"}}.BuildMode())
+	assert.Equal(t, ModeGenerated, Config{Build: &Build{ExecutionEnvironment: "ee"}}.BuildMode())
+	assert.Equal(t, ModeGenerated, Config{}.BuildMode())
+	assert.Equal(t, ModeImage, Config{Build: &Build{Image: "repo/app:1"}}.BuildMode())
+	assert.Equal(t, ModeImage, Config{Build: &Build{Image: "repo/app:1", Dockerfile: "./Dockerfile"}}.BuildMode(),
+		"image wins over dockerfile so switching modes only needs the image line")
+}
+
+func TestSaveLoadRoundTrip_ImageModeWithEnv(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Name:       "agent-service",
+		Importance: "high",
+		Build:      &Build{Image: "otkachnlp/fastapi-server-example:latest", Entrypoint: []string{"python", "server.py"}, Port: 8080, Health: "/readyz"},
+		Runtime:    &Runtime{Replicas: 1, CPU: 1, Memory: "512MB"},
+		Env: map[string]string{
+			"MODEL":               "azure/gpt-5-nano-2025-08-07",
+			"DATAROBOT_API_TOKEN": "${DATAROBOT_API_TOKEN}",
+		},
+	}
+
+	require.NoError(t, Save(dir, cfg))
+
+	got, err := Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, cfg, got)
+	assert.Equal(t, ModeImage, got.BuildMode())
+}
+
+func TestMarshal_ImageModeSection(t *testing.T) {
+	cfg := Config{
+		Name:  "app",
+		Build: &Build{Image: "repo/app:1", Entrypoint: []string{"python", "server.py"}, Port: 8080, Health: "/readyz"},
+	}
+
+	s := string(Marshal(cfg))
+	assert.Contains(t, s, "image: repo/app:1")
+	assert.Contains(t, s, `"python", "server.py"`)
+	assert.Contains(t, s, "health: /readyz")
+	// No active dockerfile/EE lines; they may appear only as commented hints.
+	assert.NotContains(t, s, "\n  dockerfile:")
+	assert.NotContains(t, s, "\n  executionEnvironment:")
+}
+
+func TestWithDefaults_ImageModeDoesNotInjectDockerfile(t *testing.T) {
+	cfg := Config{Name: "app", Build: &Build{Image: "repo/app:1"}}
+
+	out := cfg.withDefaults()
+	assert.Empty(t, out.Build.Dockerfile)
+	assert.Equal(t, ModeImage, out.BuildMode())
+}
+
+func TestMarshal_EnvSectionRendersSorted(t *testing.T) {
+	cfg := Config{Name: "app", Env: map[string]string{"B_VAR": "2", "A_VAR": "1"}}
+
+	s := string(Marshal(cfg))
+	assert.Contains(t, s, "env:\n  A_VAR: \"1\"\n  B_VAR: \"2\"\n")
+}
+
+func TestMarshal_GeneratedModeShowsEEAndEntrypoint(t *testing.T) {
+	cfg := Config{
+		Name:  "app",
+		Build: &Build{ExecutionEnvironment: "my-ee", Entrypoint: []string{"uvicorn", "app:app"}, Port: 9000, Health: "/h"},
+	}
+
+	s := string(Marshal(cfg))
+	assert.Contains(t, s, `executionEnvironment: "my-ee"`)
+	assert.Contains(t, s, `"uvicorn", "app:app"`)
+	// The dockerfile line appears only as a commented alternative.
+	assert.NotContains(t, s, "\n  dockerfile:")
+}
+
+func TestLoad_MissingReturnsErrNotConfigured(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := Load(dir)
+	require.ErrorIs(t, err, ErrNotConfigured)
+	assert.False(t, Exists(dir))
+}
+
+func TestLoad_ParsesManifest(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, DirName), 0o755))
+
+	manifest := "name: svc\nimportance: high\nbuild:\n  dockerfile: ./Dockerfile\n  port: 9000\nruntime:\n  cpu: 2\n  memory: 1GB\n"
+	require.NoError(t, os.WriteFile(Path(dir), []byte(manifest), 0o644))
+
+	cfg, err := Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "svc", cfg.Name)
+	assert.Equal(t, "high", cfg.Importance)
+	assert.Equal(t, 9000, cfg.Build.Port)
+	assert.InDelta(t, 2.0, cfg.Runtime.CPU, 0.0001)
+	assert.Equal(t, "1GB", cfg.Runtime.Memory)
+}
+
+func TestLoad_MalformedYAMLErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, DirName), 0o755))
+	require.NoError(t, os.WriteFile(Path(dir), []byte("name: [unterminated\n"), 0o644))
+
+	_, err := Load(dir)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrNotConfigured)
+	assert.Contains(t, err.Error(), "parse")
+}

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -95,6 +95,36 @@ func knownWorkloadStatuses() []string {
 	}
 }
 
+// IsTerminalWorkloadStatus reports whether a "wait until running" poll loop
+// should stop: running is terminal success; errored and terminated are terminal
+// failures. Every other status is non-terminal so the loop keeps polling. That
+// deliberately includes the steady non-running states (stopped, suspended,
+// interrupted): WaitForWorkload only runs after the caller has created or
+// started the workload, so those states are transient on the way up, not a
+// reason to bail. A workload that never leaves them surfaces via the timeout
+// rather than a spurious "settled" error on the first, still-stale poll.
+func IsTerminalWorkloadStatus(s string) bool {
+	switch s {
+	case WorkloadStatusRunning,
+		WorkloadStatusErrored,
+		WorkloadStatusTerminated:
+		return true
+	}
+
+	return false
+}
+
+// IsWorkloadErrorStatus reports whether s is a terminal failure a caller should
+// surface as an error rather than a settled state.
+func IsWorkloadErrorStatus(s string) bool {
+	switch s {
+	case WorkloadStatusErrored, WorkloadStatusTerminated:
+		return true
+	}
+
+	return false
+}
+
 // Workload is the projection of the server's workload document the CLI
 // renders. Server-side extras (owners, permissions, creator, stats) are
 // deliberately not parsed so they cannot leak into scripted output.
@@ -221,6 +251,50 @@ func GetWorkload(workloadID string) (*Workload, error) {
 	}
 
 	return &workload, nil
+}
+
+// WaitForWorkload polls GetWorkload on interval until the workload reaches a
+// terminal status (see IsTerminalWorkloadStatus) or deadline expires. It
+// returns the final Workload in every non-poll-error case so callers can render
+// it:
+//   - running: success, nil error.
+//   - errored/terminated: the final workload alongside a failure error.
+//   - timeout: the last-seen workload alongside a timeout error (this covers a
+//     workload stuck in a non-running steady state such as stopped).
+//
+// onTick may be nil and is invoked after each poll for debug-only observation,
+// mirroring WaitForBuild.
+func WaitForWorkload(
+	workloadID string,
+	interval, timeout time.Duration,
+	onTick func(*Workload),
+) (*Workload, error) {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		wl, err := GetWorkload(workloadID)
+		if err != nil {
+			return nil, fmt.Errorf("poll workload %s: %w", workloadID, err)
+		}
+
+		if onTick != nil {
+			onTick(wl)
+		}
+
+		if IsTerminalWorkloadStatus(wl.Status) {
+			if IsWorkloadErrorStatus(wl.Status) {
+				return wl, fmt.Errorf("workload %s ended with status %s; run 'dr workload logs %s' to inspect", workloadID, wl.Status, workloadID)
+			}
+
+			return wl, nil
+		}
+
+		if time.Now().After(deadline) {
+			return wl, fmt.Errorf("timeout waiting for workload %s after %s", workloadID, timeout)
+		}
+
+		time.Sleep(interval)
+	}
 }
 
 type WorkloadList struct {

--- a/internal/workload/workload_test.go
+++ b/internal/workload/workload_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -418,4 +419,140 @@ func TestNewWorkloadOutput_FormatsTimestampsRFC3339(t *testing.T) {
 	assert.Equal(t, "2026-06-10T08:00:00Z", out.CreatedAt)
 	assert.Equal(t, "2026-06-10T08:05:00Z", out.UpdatedAt)
 	assert.Equal(t, "https://e/", out.Endpoint)
+}
+
+func TestIsTerminalWorkloadStatus(t *testing.T) {
+	terminal := []string{
+		WorkloadStatusRunning,
+		WorkloadStatusErrored,
+		WorkloadStatusTerminated,
+	}
+
+	nonTerminal := []string{
+		WorkloadStatusSubmitted,
+		WorkloadStatusProvisioning,
+		WorkloadStatusLaunching,
+		WorkloadStatusStopping,
+		WorkloadStatusStopped,
+		WorkloadStatusSuspended,
+		WorkloadStatusInterrupted,
+		WorkloadStatusUnknown,
+	}
+
+	for _, s := range terminal {
+		assert.True(t, IsTerminalWorkloadStatus(s), "%s should be terminal", s)
+	}
+
+	for _, s := range nonTerminal {
+		assert.False(t, IsTerminalWorkloadStatus(s), "%s should not be terminal", s)
+	}
+}
+
+func TestIsWorkloadErrorStatus(t *testing.T) {
+	for _, s := range []string{WorkloadStatusErrored, WorkloadStatusTerminated} {
+		assert.True(t, IsWorkloadErrorStatus(s), "%s should be an error status", s)
+	}
+
+	steady := []string{
+		WorkloadStatusRunning,
+		WorkloadStatusStopped,
+		WorkloadStatusSuspended,
+		WorkloadStatusInterrupted,
+		WorkloadStatusUnknown,
+	}
+
+	for _, s := range steady {
+		assert.False(t, IsWorkloadErrorStatus(s), "%s should not be an error status", s)
+	}
+}
+
+func TestWaitForWorkload_RunningReturnsNil(t *testing.T) {
+	installSkipAuth(t)
+
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		page := atomic.AddInt32(&hits, 1)
+
+		status := WorkloadStatusLaunching
+		if page >= 2 {
+			status = WorkloadStatusRunning
+		}
+
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", status))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	var ticks int
+
+	wl, err := WaitForWorkload("wl-1", time.Millisecond, time.Second, func(*Workload) {
+		ticks++
+	})
+	require.NoError(t, err)
+	assert.Equal(t, WorkloadStatusRunning, wl.Status)
+	assert.GreaterOrEqual(t, ticks, 2)
+}
+
+func TestWaitForWorkload_ErroredReturnsError(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", WorkloadStatusErrored))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkload("wl-1", time.Millisecond, time.Second, nil)
+	require.Error(t, err)
+	require.NotNil(t, wl, "errored returns final Workload alongside error")
+	assert.Equal(t, WorkloadStatusErrored, wl.Status)
+	assert.Contains(t, err.Error(), WorkloadStatusErrored)
+}
+
+func TestWaitForWorkload_PollsThroughStoppedUntilRunning(t *testing.T) {
+	installSkipAuth(t)
+
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		page := atomic.AddInt32(&hits, 1)
+
+		// A just-started workload can still report 'stopped' on the first poll;
+		// WaitForWorkload must keep polling rather than treat it as terminal.
+		status := WorkloadStatusStopped
+		if page >= 2 {
+			status = WorkloadStatusRunning
+		}
+
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", status))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkload("wl-1", time.Millisecond, time.Second, nil)
+	require.NoError(t, err)
+	assert.Equal(t, WorkloadStatusRunning, wl.Status)
+}
+
+func TestWaitForWorkload_Timeout(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", WorkloadStatusProvisioning))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := WaitForWorkload("wl-1", 5*time.Millisecond, 25*time.Millisecond, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
 }


### PR DESCRIPTION
# RATIONALE

A first deploy through the Workload API today is 9 commands, 2 hand-written YAML specs, and 3 copy-pasted IDs across the `dr artifact` and `dr workload` trees, and the user personally drives the internal state machine (draft artifact, code init, sync, build, lock, workload create, status polling). Every comparable CLI (fly, railway, gcloud run, compose) ships this as 1-2 commands.

This PR adds two feature-gated porcelain commands that compress the whole flow to `config` then `up`, while leaving every existing command untouched (the plumbing stays, for scripting and Terraform/Pulumi parity):

```bash
dr workload config   # generate .datarobot/workload.yaml (pick or name a workload, choose build mode)
dr workload up       # manifest -> running workload, prints the endpoint URL
```

All three build modes were validated end to end against staging (details in TESTING).

## CHANGES

- New `dr workload config`: interactive picker (existing workload or create new) plus a 3-way build-mode prompt; writes a commented, fully-defaulted `.datarobot/workload.yaml`; non-interactive via `--yes --workload-id <id>` or `--yes --name <name>`; re-runs preserve the recorded `workloadId`
- New `dr workload up`: one command from manifest to running workload: creates and links the artifact when the directory is not linked yet, syncs code, builds, optional `--lock`, creates the workload (resources, importance, env from the manifest), waits for `running`, prints the endpoint URL as the final stdout line; `--detach`, `--output-format json`
- Self-healing: on the server's one-workload-per-draft-artifact 409, `up` adopts the existing workload and records its id instead of dead-ending
- New `internal/workload/wlconfig` (manifest schema + commented marshal), `ResolveExecutionEnvironment` (EE by name, no pasted IDs), `WaitForWorkload` + terminal-status classification, `Container.Name` + `PrimaryContainerName`
- Everything is gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD`; no existing command changes behavior

## EXAMPLES

### Quick start (any repo with a Dockerfile)

```bash
export DATAROBOT_CLI_FEATURE_WORKLOAD=true
dr workload config --name my-app --yes
dr workload up --yes
```

```
==> Creating artifact (provided build)
  created artifact 6a61f765... and linked /Users/me/my-app
==> Syncing code
==> Building image
  waiting for build 6a61f77a...
==> Creating workload
==> Waiting for workload to become running
Workload 6a61f77a8d8c0166aa516e5d is running.
https://staging.datarobot.com/api/v2/endpoints/workloads/6a61f77a8d8c0166aa516e5d/
```

The URL is the last stdout line, so `URL=$(dr workload up --yes)` composes in scripts.

### The generated manifest

`config` writes a self-documenting file; every later tweak is an edit here, then `up`:

```yaml
name: my-app
importance: low   # low | moderate | high | critical

build:
  # Provided-Dockerfile mode: DataRobot builds your Dockerfile from this repo.
  dockerfile: ./Dockerfile
  # Other modes: replace `dockerfile` with one of:
  #   executionEnvironment: "[DataRobot] Python 3.12 Applications Base"   # + entrypoint: [...]
  #   image: registry/repo:tag                              # deploy a pre-built image
  port: 8080          # container listen port (>= 1024)
  health: /health      # HTTP readiness/liveness path

runtime:
  replicas: 1
  cpu: 0.5        # cores (fractional allowed)
  memory: 512MB   # B/KB/MB/GB

# Container environment variables; ${VAR} expands from your shell at deploy
# time, so secrets never live in this committed file.
# env:
#   MY_SETTING: value
#   MY_SECRET: ${MY_SECRET}
```

### Build mode 2: generated (no Dockerfile)

DataRobot generates the image from an execution environment, resolved by name (no pasted EE ids). Requires dependency files (`pyproject.toml`/`uv.lock` or `requirements.txt`) so the build can install them:

```yaml
build:
  executionEnvironment: "[DataRobot] Python 3.12 Applications Base"
  entrypoint: ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]
  port: 8080
  health: /health
```

### Build mode 3: pre-built image (Tutorial 2 pattern)

No code, no sync, no build: `up` creates the workload with the artifact inline in one call. `--lock` afterwards locks the artifact the server minted:

```yaml
name: agent-service
importance: high
build:
  image: otkachnlp/fastapi-server-example:latest
  entrypoint: ["python", "server.py"]
  port: 8080
  health: /readyz
runtime:
  replicas: 1
  cpu: 1
  memory: 512MB
env:
  MODEL: azure/gpt-5-nano-2025-08-07
  DATAROBOT_ENDPOINT: https://staging.datarobot.com/api/v2
  DATAROBOT_API_TOKEN: ${DATAROBOT_API_TOKEN}
```

```
==> Creating workload from image otkachnlp/fastapi-server-example:latest
==> Waiting for workload to become running
Workload 6a61f47a1611893b5ca5c485 is running.
https://staging.datarobot.com/api/v2/endpoints/workloads/6a61f47a1611893b5ca5c485/
```

### Re-runs and recovery

`up` records the workload id back into the manifest, so re-runs reach the same workload (stopped ones are started; errored ones fail loudly with a recovery hint). If the manifest ever loses its id while the draft artifact already backs a workload, `up` self-heals:

```
==> Creating workload
==> Adopting existing workload 6a61fb951534cb471fde9815 (c2w-demo); a draft artifact allows only one workload
Workload 6a61fb951534cb471fde9815 is running.
```

### CI usage

```bash
dr workload up --yes --output-format json
# {"workloadId": "...", "status": "running", "endpoint": "https://..."}
```

## TESTING

- `task lint`: 0 issues; `go test -race`: all 19 touched packages pass (new tests cover status classification, manifest round-trip and marshal, all three payload shapes, 409 adoption, locked-artifact fast-fail, detach-on-errored non-zero exit, sync-conflict reporting)
- Staging end to end, one deploy per mode, endpoints verified serving:
  - provided Dockerfile: workload `6a61f77a...`, `GET /health -> 200`, manifest env var visible in the app response
  - generated EE: workload `6a61ea01...`, `GET /version -> 200`
  - pre-built image (Tutorial 2 image incl. env + `${VAR}` token expansion, verified server-side): workload `6a61f47a...`, `GET /readyz -> 200`

## TODO

Follow-ups deliberately left out of this PR to keep it reviewable:

- **Richer interactive `config`**: prompt for env vars (the pre-built image tutorial needs three of them), resources (cpu/memory/replicas), importance, and per-mode extras; an EE picker fed from `/executionEnvironments/` instead of a free-text name; possibly a `--full` walkthrough vs the current minimal default
- **Preflight validation in `up`**: fail before creating anything on unset `${VAR}` env references, generated mode without dependency files (today it surfaces as the server's "cannot detect any runtime" 422 after a sync), and obvious probe mismatches
- **In-place rollout to a running workload**: wire the replacement flow (Tutorial 4) so `up` ships a new image without recreating the workload; today it warns and keeps serving the current artifact
- **Errored-workload recovery**: interactive offer to delete and recreate the recorded workload instead of erroring with manual instructions
- **Dev loop**: `dr workload dev` (draft hot-reload) and `promote`, which the server already supports
- **Semantic exit codes** (usage/auth/not-found/timeout) instead of a blanket exit 1
- **Resource model**: bundles and GPU are not expressible in `runtime` yet
- **Credential injection**: an opt-in way to pass the CLI's own endpoint/token to the container instead of hand-written env entries

## NOTES

- Applying a newly built image to an already-running workload is not automated yet (needs the Tutorial 4 replacement flow); `up` prints a prominent WARNING instead of pretending
- `--lock` runs after a successful deploy and `up` fails fast on an already-locked artifact (locking is one-way)
- `${VAR}` env values expand from the deploying shell; an unset variable currently expands to empty (client-side validation is a planned follow-up)
- Generated mode without dependency files fails with the server's "cannot detect any runtime" 422; a client-side preflight is a planned follow-up

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new deploy orchestration drives many workload/artifact APIs and can mutate remote state (sync, lock, create); behavior is well-tested but re-runs do not roll out new images to already-running workloads.
> 
> **Overview**
> Adds **porcelain** workload commands on top of the existing `dr workload` verbs: **`dr workload config`** writes **`.datarobot/workload.yaml`**, and **`dr workload up`** deploys from it in one flow.
> 
> **`config`** picks or names a workload (TUI list or `--workload-id` / `--name`), optionally walks build mode (Dockerfile, generated EE, or pre-built image), preserves an existing **`workloadId`** on re-run, and saves a commented manifest via new **`internal/workload/wlconfig`**.
> 
> **`up`** loads the manifest and orchestrates by mode: code paths **create/link artifact**, **sync** (remote wins, conflicts reported), **build**, **create or reach workload** (writes **`workloadId`** back), optional **`--lock`**, **`WaitForWorkload`**, endpoint on stdout; image mode skips sync/build and uses an **inline artifact** create. It **fails on locked artifacts**, **adopts** on draft-artifact **409**, starts stopped workloads, and **warns** when a running workload won’t pick up a new build.
> 
> Supporting changes: **`ResolveExecutionEnvironment`**, **`PrimaryContainerName`** / **`Container.Name`**, shared **`wlprompt`**, plus broad unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72fbbf7373e34186e33516450609061af4b3247c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->