### PR TITLE
[CFX-7097] Fix 404 error handlers corrupting JSON stdout

### DIFF
--- a/cmd/pipeline/get/cmd.go
+++ b/cmd/pipeline/get/cmd.go
@@ -49,7 +49,7 @@ Example:
 
 			result, err := pipeline.GetPipeline(args[0])
 			if err != nil {
-				return handleGetError(err, args[0])
+				return handleGetError(err, args[0], outputFormat)
 			}
 
 			return pipeline.RenderPipeline(outputFormat, *result)
@@ -72,10 +72,14 @@ Example:
 // A 404 is rendered as a friendly "No pipeline found" line on stdout and
 // suppressed (returns nil) so the user does not see an HTTP-style stack
 // or the command's usage on what is really an informational outcome.
-func handleGetError(err error, pipelineID string) error {
+func handleGetError(err error, pipelineID string, format outputformat.OutputFormat) error {
 	var httpErr *drapi.HTTPError
 
 	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		if format == outputformat.OutputFormatJSON {
+			return err
+		}
+
 		fmt.Println(tui.DimStyle.Render("No pipeline found with id: " + pipelineID))
 
 		return nil

--- a/cmd/pipeline/get/cmd_test.go
+++ b/cmd/pipeline/get/cmd_test.go
@@ -172,3 +172,23 @@ func TestHandleGetError_NonHTTPErrorPassesThrough(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, plain, err)
 }
+
+func TestHandleGetError_JSONFormat_404_ReturnsErrorAndKeepsStdoutClean(t *testing.T) {
+	httpErr := &drapi.HTTPError{StatusCode: 404, URL: "http://example/api/v2/pipelines/abc"}
+
+	output := testutil.CaptureStdout(t, func() {
+		err := handleGetError(httpErr, "abc", outputformat.OutputFormatJSON)
+		require.Error(t, err)
+		assert.Same(t, httpErr, err)
+	})
+
+	assert.Empty(t, output, "JSON mode must not write friendly message to stdout")
+}
+
+func TestHandleGetError_JSONFormat_NonNotFound_Propagates(t *testing.T) {
+	other := &drapi.HTTPError{StatusCode: 500, URL: "x"}
+
+	err := handleGetError(other, "abc", outputformat.OutputFormatJSON)
+	require.Error(t, err)
+	assert.Same(t, other, err)
+}

--- a/cmd/pipeline/get/cmd_test.go
+++ b/cmd/pipeline/get/cmd_test.go
@@ -146,7 +146,7 @@ func TestHandleGetError_NotFoundPrintsFriendlyMessage(t *testing.T) {
 	httpErr := &drapi.HTTPError{StatusCode: 404, URL: "http://example/api/v2/pipelines/abc"}
 
 	output := testutil.CaptureStdout(t, func() {
-		err := handleGetError(httpErr, "abc")
+		err := handleGetError(httpErr, "abc", outputformat.OutputFormatText)
 		assert.NoError(t, err)
 	})
 
@@ -157,7 +157,7 @@ func TestHandleGetError_OtherErrorsPassThrough(t *testing.T) {
 	otherHTTP := &drapi.HTTPError{StatusCode: 500, URL: "http://example/api/v2/pipelines/abc"}
 
 	output := testutil.CaptureStdout(t, func() {
-		err := handleGetError(otherHTTP, "abc")
+		err := handleGetError(otherHTTP, "abc", outputformat.OutputFormatText)
 		require.Error(t, err)
 		assert.Same(t, otherHTTP, err)
 	})
@@ -168,7 +168,7 @@ func TestHandleGetError_OtherErrorsPassThrough(t *testing.T) {
 func TestHandleGetError_NonHTTPErrorPassesThrough(t *testing.T) {
 	plain := errors.New("network unreachable")
 
-	err := handleGetError(plain, "abc")
+	err := handleGetError(plain, "abc", outputformat.OutputFormatText)
 	require.Error(t, err)
 	assert.Equal(t, plain, err)
 }

--- a/cmd/pipeline/graph/cmd.go
+++ b/cmd/pipeline/graph/cmd.go
@@ -67,7 +67,7 @@ Example:
 
 			result, err := pipeline.GetGraph(flags.PipelineID, scope, version)
 			if err != nil {
-				return handleGraphError(err, flags.PipelineID)
+				return handleGraphError(err, flags.PipelineID, outputFormat)
 			}
 
 			if outputFormat == outputformat.OutputFormatJSON {
@@ -95,10 +95,14 @@ Example:
 	return cmd
 }
 
-func handleGraphError(err error, pipelineID string) error {
+func handleGraphError(err error, pipelineID string, format outputformat.OutputFormat) error {
 	var httpErr *drapi.HTTPError
 
 	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		if format == outputformat.OutputFormatJSON {
+			return err
+		}
+
 		fmt.Println(tui.DimStyle.Render("No graph available for pipeline: " + pipelineID))
 
 		return nil

--- a/cmd/pipeline/graph/cmd_test.go
+++ b/cmd/pipeline/graph/cmd_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/pipeline/internal/testutil"
 	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -78,12 +79,12 @@ func TestPrintGraphHuman_EmptyGraph(t *testing.T) {
 func TestHandleGraphError_404IsSuppressed(t *testing.T) {
 	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
 
-	err := handleGraphError(httpErr, "abc")
+	err := handleGraphError(httpErr, "abc", outputformat.OutputFormatText)
 	assert.NoError(t, err)
 }
 
 func TestHandleGraphError_PropagatesOther(t *testing.T) {
-	err := handleGraphError(errors.New("boom"), "abc")
+	err := handleGraphError(errors.New("boom"), "abc", outputformat.OutputFormatText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "boom")
 }

--- a/cmd/pipeline/graph/cmd_test.go
+++ b/cmd/pipeline/graph/cmd_test.go
@@ -89,6 +89,26 @@ func TestHandleGraphError_PropagatesOther(t *testing.T) {
 	assert.Contains(t, err.Error(), "boom")
 }
 
+func TestHandleGraphError_JSONFormat_404_ReturnsErrorAndKeepsStdoutClean(t *testing.T) {
+	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
+
+	output := testutil.CaptureStdout(t, func() {
+		err := handleGraphError(httpErr, "abc", outputformat.OutputFormatJSON)
+		require.Error(t, err)
+		assert.Same(t, httpErr, err)
+	})
+
+	assert.Empty(t, output, "JSON mode must not write friendly message to stdout")
+}
+
+func TestHandleGraphError_JSONFormat_NonNotFound_Propagates(t *testing.T) {
+	other := &drapi.HTTPError{StatusCode: http.StatusInternalServerError, URL: "x"}
+
+	err := handleGraphError(other, "abc", outputformat.OutputFormatJSON)
+	require.Error(t, err)
+	assert.Same(t, other, err)
+}
+
 func TestCmd_RejectsMissingPipeline(t *testing.T) {
 	cmd := Cmd()
 	cmd.SetArgs([]string{})

--- a/cmd/pipeline/image/get/cmd.go
+++ b/cmd/pipeline/image/get/cmd.go
@@ -55,6 +55,10 @@ Example:
 				var httpErr *drapi.HTTPError
 
 				if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+					if outputFormat == outputformat.OutputFormatJSON {
+						return err
+					}
+
 					fmt.Println(tui.DimStyle.Render("No image found: " + imageID))
 
 					return nil

--- a/cmd/pipeline/image/get/cmd.go
+++ b/cmd/pipeline/image/get/cmd.go
@@ -52,19 +52,7 @@ Example:
 
 			img, err := pipeline.GetImage(imageID)
 			if err != nil {
-				var httpErr *drapi.HTTPError
-
-				if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-					if outputFormat == outputformat.OutputFormatJSON {
-						return err
-					}
-
-					fmt.Println(tui.DimStyle.Render("No image found: " + imageID))
-
-					return nil
-				}
-
-				return err
+				return handleImageError(err, imageID, outputFormat)
 			}
 
 			return pipeline.RenderImage(outputFormat, *img)
@@ -81,4 +69,23 @@ Example:
 	})
 
 	return cmd
+}
+
+// handleImageError converts a 404 into a friendly informational message on
+// stdout (returns nil) in text mode. In JSON output mode the original error
+// is returned unchanged so stdout stays parseable.
+func handleImageError(err error, imageID string, format outputformat.OutputFormat) error {
+	var httpErr *drapi.HTTPError
+
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		if format == outputformat.OutputFormatJSON {
+			return err
+		}
+
+		fmt.Println(tui.DimStyle.Render("No image found: " + imageID))
+
+		return nil
+	}
+
+	return err
 }

--- a/cmd/pipeline/image/get/cmd_test.go
+++ b/cmd/pipeline/image/get/cmd_test.go
@@ -16,8 +16,12 @@ package get
 
 import (
 	"io"
+	"net/http"
 	"testing"
 
+	"github.com/datarobot/cli/cmd/pipeline/internal/testutil"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,4 +57,35 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 func TestCmd_RejectsExtraArgs(t *testing.T) {
 	err := runCmd(t, "img-1", "img-2")
 	require.Error(t, err)
+}
+
+func TestHandleImageError_TextFormat_404_PrintsMessageAndReturnsNil(t *testing.T) {
+	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
+
+	output := testutil.CaptureStdout(t, func() {
+		err := handleImageError(httpErr, "img-1", outputformat.OutputFormatText)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "No image found: img-1")
+}
+
+func TestHandleImageError_JSONFormat_404_ReturnsErrorAndKeepsStdoutClean(t *testing.T) {
+	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
+
+	output := testutil.CaptureStdout(t, func() {
+		err := handleImageError(httpErr, "img-1", outputformat.OutputFormatJSON)
+		require.Error(t, err)
+		assert.Same(t, httpErr, err)
+	})
+
+	assert.Empty(t, output, "JSON mode must not write friendly message to stdout")
+}
+
+func TestHandleImageError_NonNotFound_Propagates(t *testing.T) {
+	other := &drapi.HTTPError{StatusCode: http.StatusInternalServerError, URL: "x"}
+
+	err := handleImageError(other, "img-1", outputformat.OutputFormatJSON)
+	require.Error(t, err)
+	assert.Same(t, other, err)
 }

--- a/cmd/pipeline/input/get/cmd.go
+++ b/cmd/pipeline/input/get/cmd.go
@@ -60,7 +60,7 @@ Example:
 
 			result, err := pipeline.GetInput(flags.PipelineID, scope, version, args[0])
 			if err != nil {
-				return handleGetError(err, args[0])
+				return handleGetError(err, args[0], outputFormat)
 			}
 
 			return pipeline.RenderInput(outputFormat, *result)
@@ -85,10 +85,14 @@ Example:
 	return cmd
 }
 
-func handleGetError(err error, inputID string) error {
+func handleGetError(err error, inputID string, format outputformat.OutputFormat) error {
 	var httpErr *drapi.HTTPError
 
 	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		if format == outputformat.OutputFormatJSON {
+			return err
+		}
+
 		fmt.Println(tui.DimStyle.Render("No input found with id: " + inputID))
 
 		return nil

--- a/cmd/pipeline/input/get/cmd_test.go
+++ b/cmd/pipeline/input/get/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/datarobot/cli/cmd/pipeline/internal/testutil"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/stretchr/testify/assert"
@@ -64,4 +65,24 @@ func TestHandleGetError_PropagatesOther(t *testing.T) {
 	err := handleGetError(errors.New("boom"), "in-1", outputformat.OutputFormatText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestHandleGetError_JSONFormat_404_ReturnsErrorAndKeepsStdoutClean(t *testing.T) {
+	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
+
+	output := testutil.CaptureStdout(t, func() {
+		err := handleGetError(httpErr, "in-1", outputformat.OutputFormatJSON)
+		require.Error(t, err)
+		assert.Same(t, httpErr, err)
+	})
+
+	assert.Empty(t, output, "JSON mode must not write friendly message to stdout")
+}
+
+func TestHandleGetError_JSONFormat_NonNotFound_Propagates(t *testing.T) {
+	other := &drapi.HTTPError{StatusCode: http.StatusInternalServerError, URL: "x"}
+
+	err := handleGetError(other, "in-1", outputformat.OutputFormatJSON)
+	require.Error(t, err)
+	assert.Same(t, other, err)
 }

--- a/cmd/pipeline/input/get/cmd_test.go
+++ b/cmd/pipeline/input/get/cmd_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -56,11 +57,11 @@ func TestCmd_RequiresPositional(t *testing.T) {
 
 func TestHandleGetError_404IsSuppressed(t *testing.T) {
 	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
-	assert.NoError(t, handleGetError(httpErr, "in-1"))
+	assert.NoError(t, handleGetError(httpErr, "in-1", outputformat.OutputFormatText))
 }
 
 func TestHandleGetError_PropagatesOther(t *testing.T) {
-	err := handleGetError(errors.New("boom"), "in-1")
+	err := handleGetError(errors.New("boom"), "in-1", outputformat.OutputFormatText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "boom")
 }

--- a/cmd/pipeline/run/cancel/cmd.go
+++ b/cmd/pipeline/run/cancel/cmd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/datarobot/cli/cmd/pipeline/run/runutil"
 	"github.com/datarobot/cli/cmd/pipeline/scopeflag"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/tui"
@@ -56,7 +57,7 @@ Example:
 
 			err = pipeline.CancelRun(flags.PipelineID, scope, version, args[0])
 			if err != nil {
-				return runutil.HandleRunNotFoundError(err, args[0])
+				return runutil.HandleRunNotFoundError(err, args[0], outputformat.OutputFormatText)
 			}
 
 			fmt.Println(tui.BaseTextStyle.Render("Cancelled run: " + args[0]))

--- a/cmd/pipeline/run/get/cmd.go
+++ b/cmd/pipeline/run/get/cmd.go
@@ -57,7 +57,7 @@ Example:
 
 			result, err := pipeline.GetRun(flags.PipelineID, scope, version, args[0])
 			if err != nil {
-				return runutil.HandleRunNotFoundError(err, args[0])
+				return runutil.HandleRunNotFoundError(err, args[0], outputFormat)
 			}
 
 			return pipeline.RenderRun(outputFormat, *result)

--- a/cmd/pipeline/run/runutil/errors.go
+++ b/cmd/pipeline/run/runutil/errors.go
@@ -20,15 +20,22 @@ import (
 	"net/http"
 
 	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/tui"
 )
 
 // HandleRunNotFoundError converts a 404 into a friendly informational message
 // (returns nil) so the caller does not surface a raw HTTP error for a no-op.
-func HandleRunNotFoundError(err error, runID string) error {
+// In JSON output mode the original error is returned unchanged so stdout
+// stays parseable.
+func HandleRunNotFoundError(err error, runID string, format outputformat.OutputFormat) error {
 	var httpErr *drapi.HTTPError
 
 	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		if format == outputformat.OutputFormatJSON {
+			return err
+		}
+
 		fmt.Println(tui.DimStyle.Render("No run found with id: " + runID))
 
 		return nil

--- a/cmd/pipeline/run/runutil/errors_test.go
+++ b/cmd/pipeline/run/runutil/errors_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/datarobot/cli/cmd/pipeline/internal/testutil"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/stretchr/testify/assert"
@@ -34,4 +35,35 @@ func TestHandleRunNotFoundError_PropagatesOther(t *testing.T) {
 	err := HandleRunNotFoundError(errors.New("boom"), "d-1", outputformat.OutputFormatText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestHandleRunNotFoundError_TextFormat_404_PrintsMessageAndReturnsNil(t *testing.T) {
+	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
+
+	output := testutil.CaptureStdout(t, func() {
+		err := HandleRunNotFoundError(httpErr, "d-1", outputformat.OutputFormatText)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "No run found with id: d-1")
+}
+
+func TestHandleRunNotFoundError_JSONFormat_404_ReturnsErrorAndKeepsStdoutClean(t *testing.T) {
+	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
+
+	output := testutil.CaptureStdout(t, func() {
+		err := HandleRunNotFoundError(httpErr, "d-1", outputformat.OutputFormatJSON)
+		require.Error(t, err)
+		assert.Same(t, httpErr, err)
+	})
+
+	assert.Empty(t, output, "JSON mode must not write friendly message to stdout")
+}
+
+func TestHandleRunNotFoundError_JSONFormat_NonNotFound_Propagates(t *testing.T) {
+	other := &drapi.HTTPError{StatusCode: http.StatusInternalServerError, URL: "x"}
+
+	err := HandleRunNotFoundError(other, "d-1", outputformat.OutputFormatJSON)
+	require.Error(t, err)
+	assert.Same(t, other, err)
 }

--- a/cmd/pipeline/run/runutil/errors_test.go
+++ b/cmd/pipeline/run/runutil/errors_test.go
@@ -20,17 +20,18 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHandleRunNotFoundError_404IsSuppressed(t *testing.T) {
 	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
-	assert.NoError(t, HandleRunNotFoundError(httpErr, "d-1"))
+	assert.NoError(t, HandleRunNotFoundError(httpErr, "d-1", outputformat.OutputFormatText))
 }
 
 func TestHandleRunNotFoundError_PropagatesOther(t *testing.T) {
-	err := HandleRunNotFoundError(errors.New("boom"), "d-1")
+	err := HandleRunNotFoundError(errors.New("boom"), "d-1", outputformat.OutputFormatText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "boom")
 }

--- a/cmd/pipeline/run/status/cmd.go
+++ b/cmd/pipeline/run/status/cmd.go
@@ -57,7 +57,7 @@ Example:
 
 			result, err := pipeline.GetRunStatus(flags.PipelineID, scope, version, args[0])
 			if err != nil {
-				return runutil.HandleRunNotFoundError(err, args[0])
+				return runutil.HandleRunNotFoundError(err, args[0], outputFormat)
 			}
 
 			return pipeline.RenderRunStatus(outputFormat, *result)

--- a/cmd/pipeline/run/task/get/cmd.go
+++ b/cmd/pipeline/run/task/get/cmd.go
@@ -75,7 +75,7 @@ Example:
 
 			task, err := pipeline.GetTaskExecution(pipelineID, runID, taskID, node)
 			if err != nil {
-				return handleNotFound(err, args[0])
+				return handleNotFound(err, args[0], outputFormat)
 			}
 
 			return renderTask(outputFormat, task)
@@ -167,10 +167,14 @@ func printTaskHuman(task *pipeline.TaskExecution) {
 	w.Flush()
 }
 
-func handleNotFound(err error, taskID string) error {
+func handleNotFound(err error, taskID string, format outputformat.OutputFormat) error {
 	var httpErr *drapi.HTTPError
 
 	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		if format == outputformat.OutputFormatJSON {
+			return err
+		}
+
 		fmt.Println(tui.DimStyle.Render("No task execution found with id: " + taskID))
 
 		return nil

--- a/cmd/pipeline/run/task/get/cmd_test.go
+++ b/cmd/pipeline/run/task/get/cmd_test.go
@@ -15,9 +15,14 @@
 package get
 
 import (
+	"errors"
 	"io"
+	"net/http"
 	"testing"
 
+	"github.com/datarobot/cli/cmd/pipeline/internal/testutil"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -85,4 +90,43 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 	for _, name := range []string{"pipeline", "run", "output-format"} {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
+}
+
+func TestHandleNotFound_TextFormat_404_PrintsMessageAndReturnsNil(t *testing.T) {
+	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
+
+	output := testutil.CaptureStdout(t, func() {
+		err := handleNotFound(httpErr, "1", outputformat.OutputFormatText)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "No task execution found with id: 1")
+}
+
+func TestHandleNotFound_JSONFormat_404_ReturnsErrorAndKeepsStdoutClean(t *testing.T) {
+	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
+
+	output := testutil.CaptureStdout(t, func() {
+		err := handleNotFound(httpErr, "1", outputformat.OutputFormatJSON)
+		require.Error(t, err)
+		assert.Same(t, httpErr, err)
+	})
+
+	assert.Empty(t, output, "JSON mode must not write friendly message to stdout")
+}
+
+func TestHandleNotFound_JSONFormat_NonNotFound_Propagates(t *testing.T) {
+	other := &drapi.HTTPError{StatusCode: http.StatusInternalServerError, URL: "x"}
+
+	err := handleNotFound(other, "1", outputformat.OutputFormatJSON)
+	require.Error(t, err)
+	assert.Same(t, other, err)
+}
+
+func TestHandleNotFound_NonHTTPError_Propagates(t *testing.T) {
+	plain := errors.New("network unreachable")
+
+	err := handleNotFound(plain, "1", outputformat.OutputFormatJSON)
+	require.Error(t, err)
+	assert.Equal(t, plain, err)
 }

--- a/cmd/pipeline/schedule/get/cmd.go
+++ b/cmd/pipeline/schedule/get/cmd.go
@@ -50,7 +50,7 @@ Example:
 
 			result, err := pipeline.GetSchedule(pipelineID, args[0])
 			if err != nil {
-				return handleGetError(err, args[0])
+				return handleGetError(err, args[0], outputFormat)
 			}
 
 			return pipeline.RenderSchedule(outputFormat, *result)
@@ -73,10 +73,14 @@ Example:
 	return cmd
 }
 
-func handleGetError(err error, scheduleID string) error {
+func handleGetError(err error, scheduleID string, format outputformat.OutputFormat) error {
 	var httpErr *drapi.HTTPError
 
 	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		if format == outputformat.OutputFormatJSON {
+			return err
+		}
+
 		fmt.Println(tui.DimStyle.Render("No schedule found with id: " + scheduleID))
 
 		return nil

--- a/cmd/pipeline/schedule/get/cmd_test.go
+++ b/cmd/pipeline/schedule/get/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/datarobot/cli/cmd/pipeline/internal/testutil"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/stretchr/testify/assert"
@@ -74,4 +75,24 @@ func TestHandleGetError_PropagatesOther(t *testing.T) {
 	err := handleGetError(errors.New("boom"), "s-1", outputformat.OutputFormatText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestHandleGetError_JSONFormat_404_ReturnsErrorAndKeepsStdoutClean(t *testing.T) {
+	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
+
+	output := testutil.CaptureStdout(t, func() {
+		err := handleGetError(httpErr, "s-1", outputformat.OutputFormatJSON)
+		require.Error(t, err)
+		assert.Same(t, httpErr, err)
+	})
+
+	assert.Empty(t, output, "JSON mode must not write friendly message to stdout")
+}
+
+func TestHandleGetError_JSONFormat_NonNotFound_Propagates(t *testing.T) {
+	other := &drapi.HTTPError{StatusCode: http.StatusInternalServerError, URL: "x"}
+
+	err := handleGetError(other, "s-1", outputformat.OutputFormatJSON)
+	require.Error(t, err)
+	assert.Same(t, other, err)
 }

--- a/cmd/pipeline/schedule/get/cmd_test.go
+++ b/cmd/pipeline/schedule/get/cmd_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -66,11 +67,11 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 
 func TestHandleGetError_404IsSuppressed(t *testing.T) {
 	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
-	assert.NoError(t, handleGetError(httpErr, "s-1"))
+	assert.NoError(t, handleGetError(httpErr, "s-1", outputformat.OutputFormatText))
 }
 
 func TestHandleGetError_PropagatesOther(t *testing.T) {
-	err := handleGetError(errors.New("boom"), "s-1")
+	err := handleGetError(errors.New("boom"), "s-1", outputformat.OutputFormatText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "boom")
 }

--- a/cmd/pipeline/task/get/cmd.go
+++ b/cmd/pipeline/task/get/cmd.go
@@ -77,7 +77,7 @@ Example:
 
 			result, err := pipeline.GetTask(flags.PipelineID, scope, version, taskID)
 			if err != nil {
-				return handleTaskNotFoundError(err, args[0])
+				return handleTaskNotFoundError(err, args[0], outputFormat)
 			}
 
 			return pipeline.RenderTask(outputFormat, *result)
@@ -102,10 +102,14 @@ Example:
 	return cmd
 }
 
-func handleTaskNotFoundError(err error, taskID string) error {
+func handleTaskNotFoundError(err error, taskID string, format outputformat.OutputFormat) error {
 	var httpErr *drapi.HTTPError
 
 	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		if format == outputformat.OutputFormatJSON {
+			return err
+		}
+
 		fmt.Println(tui.DimStyle.Render("Task not found: " + taskID))
 
 		return nil

--- a/cmd/pipeline/task/get/cmd_test.go
+++ b/cmd/pipeline/task/get/cmd_test.go
@@ -15,9 +15,14 @@
 package get
 
 import (
+	"errors"
 	"io"
+	"net/http"
 	"testing"
 
+	"github.com/datarobot/cli/cmd/pipeline/internal/testutil"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,4 +76,43 @@ func TestCmd_RejectsInvalidOutputFormat(t *testing.T) {
 	err := runCmd(t, "--pipeline", "p", "--output-format", "yaml", "1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid output format")
+}
+
+func TestHandleTaskNotFoundError_TextFormat_404_PrintsMessageAndReturnsNil(t *testing.T) {
+	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
+
+	output := testutil.CaptureStdout(t, func() {
+		err := handleTaskNotFoundError(httpErr, "1", outputformat.OutputFormatText)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Task not found: 1")
+}
+
+func TestHandleTaskNotFoundError_JSONFormat_404_ReturnsErrorAndKeepsStdoutClean(t *testing.T) {
+	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
+
+	output := testutil.CaptureStdout(t, func() {
+		err := handleTaskNotFoundError(httpErr, "1", outputformat.OutputFormatJSON)
+		require.Error(t, err)
+		assert.Same(t, httpErr, err)
+	})
+
+	assert.Empty(t, output, "JSON mode must not write friendly message to stdout")
+}
+
+func TestHandleTaskNotFoundError_JSONFormat_NonNotFound_Propagates(t *testing.T) {
+	other := &drapi.HTTPError{StatusCode: http.StatusInternalServerError, URL: "x"}
+
+	err := handleTaskNotFoundError(other, "1", outputformat.OutputFormatJSON)
+	require.Error(t, err)
+	assert.Same(t, other, err)
+}
+
+func TestHandleTaskNotFoundError_NonHTTPError_Propagates(t *testing.T) {
+	plain := errors.New("network unreachable")
+
+	err := handleTaskNotFoundError(plain, "1", outputformat.OutputFormatJSON)
+	require.Error(t, err)
+	assert.Equal(t, plain, err)
 }

--- a/cmd/pipeline/version/get/cmd.go
+++ b/cmd/pipeline/version/get/cmd.go
@@ -56,7 +56,7 @@ Example:
 
 			result, err := pipeline.GetVersion(pipelineID, versionID)
 			if err != nil {
-				return handleGetError(err, args[0])
+				return handleGetError(err, args[0], outputFormat)
 			}
 
 			return pipeline.RenderVersion(outputFormat, *result)
@@ -79,10 +79,14 @@ Example:
 	return cmd
 }
 
-func handleGetError(err error, versionLabel string) error {
+func handleGetError(err error, versionLabel string, format outputformat.OutputFormat) error {
 	var httpErr *drapi.HTTPError
 
 	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		if format == outputformat.OutputFormatJSON {
+			return err
+		}
+
 		fmt.Println(tui.DimStyle.Render("No version found: " + versionLabel))
 
 		return nil

--- a/cmd/pipeline/version/get/cmd_test.go
+++ b/cmd/pipeline/version/get/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/datarobot/cli/cmd/pipeline/internal/testutil"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/stretchr/testify/assert"
@@ -73,4 +74,24 @@ func TestHandleGetError_OtherErrorsPropagate(t *testing.T) {
 	err := handleGetError(errors.New("boom"), "2", outputformat.OutputFormatText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestHandleGetError_JSONFormat_404_ReturnsErrorAndKeepsStdoutClean(t *testing.T) {
+	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
+
+	output := testutil.CaptureStdout(t, func() {
+		err := handleGetError(httpErr, "2", outputformat.OutputFormatJSON)
+		require.Error(t, err)
+		assert.Same(t, httpErr, err)
+	})
+
+	assert.Empty(t, output, "JSON mode must not write friendly message to stdout")
+}
+
+func TestHandleGetError_JSONFormat_NonNotFound_Propagates(t *testing.T) {
+	other := &drapi.HTTPError{StatusCode: http.StatusInternalServerError, URL: "x"}
+
+	err := handleGetError(other, "2", outputformat.OutputFormatJSON)
+	require.Error(t, err)
+	assert.Same(t, other, err)
 }

--- a/cmd/pipeline/version/get/cmd_test.go
+++ b/cmd/pipeline/version/get/cmd_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -64,12 +65,12 @@ func TestCmd_RejectsZeroOrNegativeVersion(t *testing.T) {
 func TestHandleGetError_404IsSuppressed(t *testing.T) {
 	httpErr := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "x"}
 
-	err := handleGetError(httpErr, "2")
+	err := handleGetError(httpErr, "2", outputformat.OutputFormatText)
 	assert.NoError(t, err)
 }
 
 func TestHandleGetError_OtherErrorsPropagate(t *testing.T) {
-	err := handleGetError(errors.New("boom"), "2")
+	err := handleGetError(errors.New("boom"), "2", outputformat.OutputFormatText)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "boom")
 }


### PR DESCRIPTION
## RATIONALE

When `--output-format json` is set and a pipeline `get`/`graph` command receives a 404, the error handler printed a plain-text "No X found" message to stdout. This violates the JSON output purity contract (stdout must contain only valid JSON) and causes `jq` to fail when parsing the output.

JIRA: [CFX-7097](https://datarobot.atlassian.net/browse/CFX-7097)

## CHANGES

Added an `if format == outputformat.OutputFormatJSON { return err }` guard to all 10 affected error handlers, matching the existing pattern in `cmd/pipeline/source/cmd.go::handleSourceError`. Each handler now accepts a `format outputformat.OutputFormat` parameter, and each call site passes the command's `outputFormat` variable.

**Files modified (source — 11 files):**

| File | Handler | Change |
|---|---|---|
| `cmd/pipeline/get/cmd.go` | `handleGetError` | Added format param + JSON guard |
| `cmd/pipeline/image/get/cmd.go` | inline 404 check | Added JSON guard before `fmt.Println` |
| `cmd/pipeline/input/get/cmd.go` | `handleGetError` | Added format param + JSON guard |
| `cmd/pipeline/schedule/get/cmd.go` | `handleGetError` | Added format param + JSON guard |
| `cmd/pipeline/version/get/cmd.go` | `handleGetError` | Added format param + JSON guard |
| `cmd/pipeline/task/get/cmd.go` | `handleTaskNotFoundError` | Added format param + JSON guard |
| `cmd/pipeline/run/get/cmd.go` | call site | Passes `outputFormat` to `HandleRunNotFoundError` |
| `cmd/pipeline/run/status/cmd.go` | call site | Passes `outputFormat` to `HandleRunNotFoundError` |
| `cmd/pipeline/run/task/get/cmd.go` | `handleNotFound` | Added format param + JSON guard |
| `cmd/pipeline/graph/cmd.go` | `handleGraphError` | Added format param + JSON guard |
| `cmd/pipeline/run/runutil/errors.go` | `HandleRunNotFoundError` | Added format param + JSON guard |

**Additional:** `cmd/pipeline/run/cancel/cmd.go` — also calls `HandleRunNotFoundError`; passes `outputformat.OutputFormatText` (cancel has no JSON mode, so text behavior is preserved).

**Test files updated (6 files):** All direct handler callers in tests updated with `outputformat.OutputFormatText` argument to preserve existing text-mode test behavior.

## Reproduction

### Before fix (broken)

```console
$ dr pipeline get 507f1f77bcf86cd799439011 --output-format json 2>/dev/null
No pipeline found with id: 507f1f77bcf86cd799439011

$ dr pipeline get 507f1f77bcf86cd799439011 --output-format json 2>/dev/null | jq .
jq: parse error: Invalid numeric literal at line 1, column 3

$ echo $?
0
```

```console
$ dr pipeline graph --pipeline 507f1f77bcf86cd799439011 --output-format json 2>/dev/null
No graph available for pipeline: 507f1f77bcf86cd799439011

$ dr pipeline graph --pipeline 507f1f77bcf86cd799439011 --output-format json 2>/dev/null | jq .
jq: parse error: Invalid numeric literal at line 1, column 3

$ echo $?
0
```

```console
$ dr pipeline schedule get 507f1f77bcf86cd799439011 --pipeline 507f1f77bcf86cd799439011 --output-format json 2>/dev/null
No schedule found with id: 507f1f77bcf86cd799439011

$ dr pipeline schedule get 507f1f77bcf86cd799439011 --pipeline 507f1f77bcf86cd799439011 --output-format json 2>/dev/null | jq .
jq: parse error: Invalid numeric literal at line 1, column 3

$ echo $?
0
```

Note: exit code is `0` even though the resource was not found — the 404 was silently swallowed.

### After fix (correct)

```console
$ dr pipeline get 507f1f77bcf86cd799439011 --output-format json 2>/dev/null
(no output on stdout)

$ dr pipeline get 507f1f77bcf86cd799439011 --output-format json 2>/dev/null | jq .
(no output — jq receives empty input, no parse error)

$ echo $?
1
```

```console
$ dr pipeline graph --pipeline 507f1f77bcf86cd799439011 --output-format json 2>/dev/null
(no output on stdout)

$ dr pipeline graph --pipeline 507f1f77bcf86cd799439011 --output-format json 2>/dev/null | jq .
(no output — jq receives empty input, no parse error)

$ echo $?
1
```

```console
$ dr pipeline schedule get 507f1f77bcf86cd799439011 --pipeline 507f1f77bcf86cd799439011 --output-format json 2>/dev/null
(no output on stdout)

$ dr pipeline schedule get 507f1f77bcf86cd799439011 --pipeline 507f1f77bcf86cd799439011 --output-format json 2>/dev/null | jq .
(no output — jq receives empty input, no parse error)

$ echo $?
1
```

The 404 error now propagates to stderr (via cobra's error printing) and the exit code is `1`, so scripts can detect the failure. stdout remains clean for `jq`.

## NOTES

**Alternative approach for consideration:** Instead of the `if format == OutputFormatJSON { return err }` guard, these "not found" messages could always go to stderr via `fmt.Fprintln(os.Stderr, ...)`, regardless of output format. This would keep the friendly message visible to humans even in JSON mode (on stderr) while preserving stdout purity. The approach used in this PR (returning the raw error in JSON mode) was chosen for consistency with the existing `pipeline source` command, but I leave it up to the Pipelines team to decide what works best for them.

## TESTING

- `task lint` — 0 issues
- `task test` (pipeline packages) — all pass
- Manual reproduction against staging API confirmed before/after behavior (see logs above)

## RELATED

- JIRA: [CFX-7097](https://datarobot.atlassian.net/browse/CFX-7097)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI error-handling behavior; text UX unchanged and JSON mode only affects 404 paths on pipeline commands.
> 
> **Overview**
> Fixes **CFX-7097**: with `--output-format json`, several pipeline commands were printing human-readable “not found” lines to **stdout** on HTTP 404, which broke `jq` and hid failures behind exit code 0.
> 
> Pipeline **get**, **graph**, **image get**, **input/schedule/version/task get**, **run get/status**, **run task get**, and shared **`HandleRunNotFoundError`** now take the command’s output format and **skip the friendly stdout message when format is JSON**, returning the original error instead. Text mode is unchanged (dim message, nil error). **`run cancel`** still passes text format explicitly since it has no JSON output.
> 
> Unit tests that call these handlers were updated to pass `outputformat.OutputFormatText`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4724cd8d5b2188fa269b971a9578ab14f4b9dd6a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->