### PR TITLE
make workload up more resilient

### DIFF
--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -80,6 +80,7 @@ var (
 	triggerBuildFn    = workload.TriggerArtifactBuild
 	waitForBuildFn    = workload.WaitForBuild
 	lockArtifactFn    = workload.LockArtifact
+	patchContainerFn  = workload.PatchPrimaryContainer
 	createWorkloadFn  = workload.CreateWorkload
 	getWorkloadFn     = workload.GetWorkload
 	listWorkloadsFn   = workload.ListWorkloads
@@ -256,6 +257,18 @@ func orchestrate( //nolint: cyclop
 		phaseComplete(cmd, linkDetail, time.Since(start))
 	} else {
 		phaseComplete(cmd, "Artifact ready", time.Since(start))
+
+		// The artifact already existed; reconcile its spec (probe, port, env)
+		// with the current workload.yaml so edits take effect without
+		// deleting and recreating.
+		if !art.IsLocked() {
+			err = runPhase(cmd, "Applying config to artifact", func() error {
+				return reconcileArtifactSpec(artifactID, cfg)
+			})
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	// Phase: sync code -------------------------------------------------------
@@ -277,23 +290,32 @@ func orchestrate( //nolint: cyclop
 	reportSyncConflicts(cmd, syncResult)
 
 	// Phase: build image -----------------------------------------------------
-	var failedBuild *workload.Build
+	codeChanged := syncResult == nil ||
+		syncResult.UploadedCount > 0 ||
+		syncResult.DeletedCount > 0 ||
+		syncResult.OldVersion == ""
 
-	start = time.Now()
+	if codeChanged {
+		var failedBuild *workload.Build
 
-	err = tui.RunWithSpinner("Building image (this may take a minute)", func() error {
-		b, e := buildAndWait(artifactID)
-		failedBuild = b
+		start = time.Now()
 
-		return e
-	})
-	if err != nil {
-		printBuildFailure(cmd, failedBuild)
+		err = tui.RunWithSpinner("Building image (this may take a minute)", func() error {
+			b, e := buildAndWait(artifactID)
+			failedBuild = b
 
-		return err
+			return e
+		})
+		if err != nil {
+			printBuildFailure(cmd, failedBuild)
+
+			return err
+		}
+
+		phaseComplete(cmd, "Image built", time.Since(start))
+	} else {
+		phaseComplete(cmd, "Image up to date (no code changes)", 0)
 	}
-
-	phaseComplete(cmd, "Image built", time.Since(start))
 
 	// Phase: deploy workload -------------------------------------------------
 	var (
@@ -313,7 +335,7 @@ func orchestrate( //nolint: cyclop
 		return err
 	}
 
-	phaseComplete(cmd, fmt.Sprintf("Launched workload %s", wl.ID), time.Since(start))
+	phaseComplete(cmd, "Launched workload "+wl.ID, time.Since(start))
 
 	if deployWarning != "" {
 		fmt.Fprintf(cmd.ErrOrStderr(), "    %s\n", tui.HintStyle.Render(deployWarning))
@@ -379,7 +401,7 @@ func orchestrateImage(
 		return err
 	}
 
-	phaseComplete(cmd, fmt.Sprintf("Launched workload %s", wl.ID), time.Since(start))
+	phaseComplete(cmd, "Launched workload "+wl.ID, time.Since(start))
 
 	if deployWarning != "" {
 		fmt.Fprintf(cmd.ErrOrStderr(), "    %s\n", tui.HintStyle.Render(deployWarning))
@@ -784,8 +806,8 @@ func reachExistingWorkload(projectDir string, cfg *wlconfig.Config) (*workload.W
 		return nil, "", err
 	}
 
-	// Bring a stopped/suspended/interrupted workload back up, then re-fetch so
-	// we do not report the stale pre-start status.
+	// Bring a stopped/suspended/interrupted/errored workload back up, then
+	// re-fetch so we do not report the stale pre-start status.
 	if isStoppedLike(wl.Status) {
 		if _, serr := startWorkloadFn(cfg.WorkloadID); serr != nil {
 			return nil, "", serr
@@ -872,7 +894,8 @@ func isStoppedLike(status string) bool {
 	switch status {
 	case workload.WorkloadStatusStopped,
 		workload.WorkloadStatusSuspended,
-		workload.WorkloadStatusInterrupted:
+		workload.WorkloadStatusInterrupted,
+		workload.WorkloadStatusErrored:
 		return true
 	}
 
@@ -932,8 +955,12 @@ var (
 )
 
 func phaseComplete(cmd *cobra.Command, msg string, elapsed time.Duration) {
-	dur := durationStyle.Render(fmt.Sprintf("(%s)", elapsed.Truncate(100*time.Millisecond)))
-	fmt.Fprintf(cmd.ErrOrStderr(), "  %s %s %s\n", checkStyle.Render("✓"), msg, dur)
+	if elapsed > 0 {
+		dur := durationStyle.Render(fmt.Sprintf("(%s)", elapsed.Truncate(100*time.Millisecond)))
+		fmt.Fprintf(cmd.ErrOrStderr(), "  %s %s %s\n", checkStyle.Render("✓"), msg, dur)
+	} else {
+		fmt.Fprintf(cmd.ErrOrStderr(), "  %s %s\n", checkStyle.Render("✓"), msg)
+	}
 }
 
 // runPhase wraps a function in a spinner, times it, and prints a ✓ completion
@@ -949,6 +976,31 @@ func runPhase(cmd *cobra.Command, label string, fn func() error) error {
 	phaseComplete(cmd, label, time.Since(start))
 
 	return nil
+}
+
+// reconcileArtifactSpec patches the primary container's readiness probe, port,
+// and env vars on the existing draft artifact so they match the current
+// workload.yaml. This lets a user fix a misconfigured probe path and re-run
+// `dr workload up` without deleting and recreating the artifact.
+func reconcileArtifactSpec(artifactID string, cfg *wlconfig.Config) error {
+	updates := map[string]any{
+		"port": cfg.Port(),
+		"readinessProbe": map[string]any{
+			"path":                cfg.Health(),
+			"port":                cfg.Port(),
+			"initialDelaySeconds": probeInitialDelay,
+			"periodSeconds":       probePeriod,
+			"timeoutSeconds":      probeTimeout,
+			"failureThreshold":    probeFailureThreshold,
+			"scheme":              "HTTP",
+		},
+	}
+
+	if env := envVarsPayload(cfg); env != nil {
+		updates["environmentVars"] = env
+	}
+
+	return patchContainerFn(artifactID, updates)
 }
 
 // defaultRunSync links the sync engine to projectDir and runs a full,

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -48,6 +48,7 @@ type fakes struct {
 	triggerBuild    func(string) (*workload.BuildTriggerResponse, error)
 	waitForBuild    func(string, string, time.Duration, time.Duration, func(*workload.Build)) (*workload.Build, error)
 	lockArtifact    func(string) (*workload.Artifact, error)
+	patchContainer  func(string, map[string]any) error
 	createWorkload  func(any) (*workload.Workload, error)
 	getWorkload     func(string) (*workload.Workload, error)
 	listWorkloads   func(int, []string) ([]workload.Workload, error)
@@ -66,6 +67,7 @@ func installFakes(t *testing.T, f fakes) {
 	origTrigger := triggerBuildFn
 	origWaitBuild := waitForBuildFn
 	origLock := lockArtifactFn
+	origPatch := patchContainerFn
 	origCreate := createWorkloadFn
 	origGet := getWorkloadFn
 	origList := listWorkloadsFn
@@ -81,6 +83,7 @@ func installFakes(t *testing.T, f fakes) {
 		triggerBuildFn = origTrigger
 		waitForBuildFn = origWaitBuild
 		lockArtifactFn = origLock
+		patchContainerFn = origPatch
 		createWorkloadFn = origCreate
 		getWorkloadFn = origGet
 		listWorkloadsFn = origList
@@ -104,6 +107,7 @@ func installFakes(t *testing.T, f fakes) {
 		return &workload.Build{ID: "b-1", Status: workload.BuildStatusCompleted}, nil
 	})
 	lockArtifactFn = fnOr(f.lockArtifact, func(string) (*workload.Artifact, error) { fail("lockArtifact"); return nil, nil })
+	patchContainerFn = fnOr(f.patchContainer, func(string, map[string]any) error { return nil })
 	createWorkloadFn = fnOr(f.createWorkload, func(any) (*workload.Workload, error) { fail("createWorkload"); return nil, nil })
 	getWorkloadFn = fnOr(f.getWorkload, func(string) (*workload.Workload, error) { fail("getWorkload"); return nil, nil })
 	listWorkloadsFn = fnOr(f.listWorkloads, func(int, []string) ([]workload.Workload, error) { fail("listWorkloads"); return nil, nil })
@@ -331,6 +335,9 @@ func TestUp_DetachErroredWorkloadExitsNonZero(t *testing.T) {
 	installFakes(t, fakes{
 		getWorkload: func(string) (*workload.Workload, error) {
 			return &workload.Workload{ID: "wl-9", Status: workload.WorkloadStatusErrored, Endpoint: "https://e/"}, nil
+		},
+		startWorkload: func(string) (*workload.WorkloadOperationResponse, error) {
+			return &workload.WorkloadOperationResponse{}, nil
 		},
 	})
 

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -362,6 +362,112 @@ func CreateArtifact(payload any) (*Artifact, error) {
 	return &artifact, nil
 }
 
+// PatchPrimaryContainer applies the key-value pairs from updates to the primary
+// container in the artifact's raw spec, then PATCHes the artifact. Only draft
+// artifacts are editable; locked artifacts will get a 403 from the server.
+// This follows the same GET-modify-PATCH pattern as PatchArtifactCodeRef.
+func PatchPrimaryContainer(artifactID string, updates map[string]any) error {
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/")
+	if err != nil {
+		return err
+	}
+
+	var raw map[string]any
+
+	if err := drapi.GetJSON(url, "artifact", &raw); err != nil {
+		return fmt.Errorf("fetch artifact for spec update: %w", err)
+	}
+
+	container, err := findPrimaryContainerRaw(raw)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range updates {
+		container[k] = v
+	}
+
+	body := map[string]any{"spec": raw["spec"]}
+
+	return drapi.PatchJSON(url, "artifact", body, nil)
+}
+
+// findPrimaryContainerRaw returns the raw map of the primary container in the
+// artifact spec, falling back to containerGroups[0].containers[0]. Mirrors the
+// selection logic in ExtractCodeRef / assignToPrimaryContainer.
+func findPrimaryContainerRaw(raw map[string]any) (map[string]any, error) {
+	groups, err := extractContainerGroups(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	if c := searchPrimaryContainer(groups); c != nil {
+		return c, nil
+	}
+
+	return fallbackFirstContainer(groups)
+}
+
+func extractContainerGroups(raw map[string]any) ([]any, error) {
+	spec, ok := raw["spec"].(map[string]any)
+	if !ok {
+		return nil, errors.New("artifact: spec missing or wrong type")
+	}
+
+	groups, ok := spec["containerGroups"].([]any)
+	if !ok || len(groups) == 0 {
+		return nil, errors.New("artifact: spec.containerGroups missing or empty")
+	}
+
+	return groups, nil
+}
+
+func searchPrimaryContainer(groups []any) map[string]any {
+	for _, g := range groups {
+		group, ok := g.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		containers, ok := group["containers"].([]any)
+		if !ok {
+			continue
+		}
+
+		for _, c := range containers {
+			container, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			if isPrimaryContainer(container) {
+				return container
+			}
+		}
+	}
+
+	return nil
+}
+
+func fallbackFirstContainer(groups []any) (map[string]any, error) {
+	firstGroup, ok := groups[0].(map[string]any)
+	if !ok {
+		return nil, errors.New("artifact: spec.containerGroups[0] wrong type")
+	}
+
+	containers, ok := firstGroup["containers"].([]any)
+	if !ok || len(containers) == 0 {
+		return nil, errors.New("artifact: spec.containerGroups[0].containers missing or empty")
+	}
+
+	first, ok := containers[0].(map[string]any)
+	if !ok {
+		return nil, errors.New("artifact: spec.containerGroups[0].containers[0] wrong type")
+	}
+
+	return first, nil
+}
+
 func PatchArtifactCodeRef(artifactID, catalogID, catalogVersionID string) error {
 	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/")
 	if err != nil {


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->
This iteration is making workload up better, to avoid rebuilding images for example. Or get stuck if there was another errored workload.
<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core `workload up` orchestration (build gating, artifact PATCH, workload restart on error) but stays within the CLI deploy path with test seam updates.
> 
> **Overview**
> **`dr workload up`** is more idempotent on repeat runs: it reconciles an existing draft artifact’s primary container (port, readiness probe, env) from `workload.yaml` via a new **GET → patch → PATCH** helper, and **skips the image build** when sync reports no uploaded/deleted files and a prior code version exists.
> 
> Re-deploying a recorded workload now treats **errored** status like stopped/suspended/interrupted and calls **start** before continuing; detach tests expect that path. Progress lines can omit elapsed time when there is nothing to measure (e.g. “image up to date”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 143617caa338c7ea02cdc4cdfb912a51f5b42dbe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->