### PR TITLE
[CFX-7139] fix(lint): enable errorlint and resolve violations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,7 @@ linters:
     - depguard
     - dupword
     - errname
-    # - errorlint # disabled until we can resolve lints
+    - errorlint
     - exhaustive
     # - godot # disabled until we can resolve lints
     # - godox # disabled until we can resolve lints

--- a/cmd/task/run/cmd.go
+++ b/cmd/task/run/cmd.go
@@ -15,6 +15,7 @@
 package run
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -141,7 +142,9 @@ Examples:
 			if err != nil { //nolint: nestif
 				exitCode := 1
 
-				if exitErr, ok := err.(*exec.ExitError); ok {
+				var exitErr *exec.ExitError
+
+				if errors.As(err, &exitErr) {
 					// Only propagate if '--exit-code' was requested
 					if opts.taskOpts.ExitCode {
 						if status, ok := exitErr.Sys().(interface{ ExitStatus() int }); ok {

--- a/cmd/templates/setup/loginModel.go
+++ b/cmd/templates/setup/loginModel.go
@@ -140,7 +140,7 @@ func (lm LoginModel) waitForAPIKey() tea.Cmd {
 
 		// Now shut down the server after key is received
 		if err := lm.server.Shutdown(context.Background()); err != nil {
-			return errMsg{fmt.Errorf("Error during shutdown: %v", err)}
+			return errMsg{fmt.Errorf("Error during shutdown: %w", err)}
 		}
 
 		// empty apiKey means we need to interrupt current auth flow
@@ -152,7 +152,7 @@ func (lm LoginModel) waitForAPIKey() tea.Cmd {
 
 		err := auth.WriteConfigFileSilent()
 		if err != nil {
-			return errMsg{fmt.Errorf("Error during writing config file: %v", err)}
+			return errMsg{fmt.Errorf("Error during writing config file: %w", err)}
 		}
 
 		return lm.SuccessCmd()

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -250,7 +250,7 @@ func WaitForAPIKeyCallback(ctx context.Context, datarobotHost string) (string, e
 	case apiKey := <-apiKeyChan:
 		// Now shut down the server after key is received
 		if err := server.Shutdown(ctx); err != nil {
-			return "", fmt.Errorf("Error during shutdown: %v", err)
+			return "", fmt.Errorf("Error during shutdown: %w", err)
 		}
 
 		// empty apiKey means we need to interrupt current auth flow


### PR DESCRIPTION
# RATIONALE

Enable the `errorlint` linter to catch common error-handling mistakes at compile time. This is the first PR in a stack to enable all disabled linters in `.golangci.yaml`.

## CHANGES

- **`cmd/task/run/cmd.go`**: Replaced type assertion `err.(*exec.ExitError)` with `errors.As(err, &exitErr)` to handle wrapped errors correctly. Added `"errors"` import.
- **`cmd/templates/setup/loginModel.go`**: Changed two `fmt.Errorf` calls from `%v` to `%w` for proper error wrapping.
- **`internal/auth/auth.go`**: Changed one `fmt.Errorf` call from `%v` to `%w` for proper error wrapping.
- **`.golangci.yaml`**: Uncommented `errorlint` and removed stale comment.

## TESTING

- `golangci-lint run ./...` passes with 0 issues
- `go vet ./...` passes
- Tests pass for modified packages

## NOTES

Part of a stack of PRs to enable disabled linters. Stack order: errorlint → godot → gosec → wrapcheck (godox excluded).

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784868140.511749 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, mechanical error-handling fixes with no behavior change intended beyond correct handling of wrapped errors.
> 
> **Overview**
> Turns on the **`errorlint`** linter in `.golangci.yaml` and fixes the violations it reported so CI stays clean.
> 
> **`dr run`** now uses **`errors.As`** instead of a direct `*exec.ExitError` type assertion when handling task runner failures, so wrapped exit errors still honor **`--exit-code`**. Login/auth shutdown and config-write paths switch **`fmt.Errorf`** from **`%v`** to **`%w`** so underlying errors remain in the chain for **`errors.Is` / `errors.As`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 756aac94fa913ee438d86b2a5ead03c3b339cbfa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->