### PR TITLE
[CFX-7139] fix(lint): enable gosec with exclusions for noisy rules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,7 +15,7 @@ linters:
     - exhaustive
     - godot
     # - godox # disabled until we can resolve lints
-    # - gosec # disabled until we can resolve lints
+    - gosec
     - loggercheck
     - misspell
     - nestif
@@ -89,6 +89,8 @@ linters:
     rules:
       - linters: [forbidigo]
         path: "^main\\.go$|internal/telemetry/telemetry\\.go|internal/log/pkg\\.go|_test\\.go$"
+      - linters: [gosec]
+        text: "G(101|104|115|122|204|301|304|306|602|703):"
     generated: lax
     presets:
       - comments

--- a/cmd/self/completion/install/cmd.go
+++ b/cmd/self/completion/install/cmd.go
@@ -509,7 +509,7 @@ func installPowerShell(_ *cobra.Command, _ bool) (string, func(*cobra.Command) e
 		}
 
 		// Append missing blocks to profile
-		f, err := os.OpenFile(profilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		f, err := os.OpenFile(profilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 		if err != nil {
 			return fmt.Errorf("Failed to open PowerShell profile: %w", err)
 		}
@@ -600,7 +600,7 @@ func ensureFpathInZshrc(zshrc, compDir string) error {
 	}
 
 	// Append to file
-	f, err := os.OpenFile(zshrc, os.O_APPEND|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(zshrc, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}
@@ -637,7 +637,7 @@ func ensureSourceInBashrc(bashrc, completionFile string) error {
 	}
 
 	// Append to file
-	f, err := os.OpenFile(bashrc, os.O_APPEND|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(bashrc, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}

--- a/cmd/templates/setup/loginModel.go
+++ b/cmd/templates/setup/loginModel.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -55,8 +56,9 @@ func startServer(apiKeyChan chan string, datarobotHost string) tea.Cmd {
 
 		mux := http.NewServeMux()
 		server := &http.Server{
-			Addr:    addr,
-			Handler: mux,
+			Addr:              addr,
+			Handler:           mux,
+			ReadHeaderTimeout: 10 * time.Second,
 		}
 
 		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/datarobot/cli/internal/assets"
 	"github.com/datarobot/cli/internal/config"
@@ -206,8 +207,9 @@ func WaitForAPIKeyCallback(ctx context.Context, datarobotHost string) (string, e
 
 	mux := http.NewServeMux()
 	server := &http.Server{
-		Addr:    addr,
-		Handler: mux,
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/workload/sync/diskspace_unix.go
+++ b/internal/workload/sync/diskspace_unix.go
@@ -30,6 +30,5 @@ func realAvailableBytes(path string) (int64, error) {
 		return 0, fmt.Errorf("statfs %s: %w", path, err)
 	}
 
-	//nolint:gosec // Bavail * Bsize fits in int64 on every supported FS.
 	return int64(st.Bavail * uint64(st.Bsize)), nil
 }

--- a/internal/workload/sync/synclock.go
+++ b/internal/workload/sync/synclock.go
@@ -38,7 +38,7 @@ func AcquireSyncLock(projectDir string) (*SyncLock, error) {
 
 	path := filepath.Join(wapiDir, syncLockFile)
 
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("open sync lock %s: %w", path, err)
 	}


### PR DESCRIPTION
# RATIONALE

Enable the `gosec` linter to catch security issues in production code. Noisy rules that predominantly flag test-file false positives are excluded. Critical rules are fixed in this PR; remaining rules will be addressed in follow-up PRs.

## CHANGES

### Enable gosec with exclusions
- **`.golangci.yaml`**: Uncommented `gosec`. Added exclusion rule for noisy rules: G101, G104, G115, G122, G204, G301, G304, G306, G602, G703. These are predominantly test-file false positives or require larger fixes planned for follow-up PRs.

### Fix critical gosec violations
- **G302** (file permissions): Tightened permissions from `0o644` to `0o600` in:
  - `cmd/self/completion/install/cmd.go` (3 locations: PowerShell profile, zshrc, bashrc)
  - `internal/workload/sync/synclock.go` (sync lock file)
- **G112** (Slowloris): Added `ReadHeaderTimeout: 10 * time.Second` to HTTP servers in:
  - `cmd/templates/setup/loginModel.go`
  - `internal/auth/auth.go`

### Cleanup
- Removed `//nolint:gosec` annotations that are now unused due to rule exclusions (including 1 pre-existing annotation in `internal/workload/sync/diskspace_unix.go`)

## TESTING

- `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 ./...` passes with 0 issues
- `go vet ./...` passes

## NOTES

**Stacked on top of #709 (errorlint) and #710 (godot).** This PR includes all changes from those PRs plus the gosec fixes. Reviewers should focus on the incremental gosec changes.

Remaining gosec rules to address in follow-up PRs:
- G115 (4): integer overflow - safe uintptr→int casts
- G602 (4): slice bounds checking
- G204 (5): subprocess launches (shell.go expected behavior)
- G122 (3): filesystem TOCTOU in filepath.Walk callbacks
- G703 (1): path traversal via taint analysis

Part of a stack: errorlint (#709) → godot (#710) → **gosec (this PR)** → wrapcheck (godox excluded).
<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1784867914.512809 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication HTTP servers and file permissions for shell profiles and sync locks; behavior is tightened but login/callback flows should be smoke-tested.
> 
> **Overview**
> Turns on **`gosec`** in `.golangci.yaml` (alongside already-enabled **`errorlint`** and **`godot`** in this stack) and adds a text exclusion for noisy rules so CI stays green while other findings are handled in follow-ups.
> 
> **Security fixes** for rules that are not excluded: shell completion installers and workload sync lock creation use **`0o600`** instead of **`0o644`** (G302). Localhost API-key callback servers in **`internal/auth`** and template setup login set **`ReadHeaderTimeout: 10s`** on `http.Server` (G112 / Slowloris). A stale **`//nolint:gosec`** on Unix disk-space code is removed now that G115 is excluded.
> 
> **Lint hygiene** in the same diff: widespread **godot** comment punctuation, **`errors.As`** for `*exec.ExitError` in **`cmd/task/run`**, and **`%w`** error wrapping in auth/login paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29cbeefab82c80cdc8c0bbd434d7f0d119baf399. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->