### PR TITLE
[CFX-7138] fix(lint): resolve Windows-only lint violations found via GOOS cross-lint

### DIFF
--- a/internal/telemetry/os_windows.go
+++ b/internal/telemetry/os_windows.go
@@ -22,7 +22,7 @@ import (
 
 // osVersion retrieves the Windows OS version via RtlGetVersion (ntdll.dll).
 // Returns an empty string if detection fails.
-// example output: "10.0.22621"
+// example output: "10.0.22621".
 func osVersion() string {
 	info := windows.RtlGetVersion()
 

--- a/internal/tls/tls_windows.go
+++ b/internal/tls/tls_windows.go
@@ -17,6 +17,7 @@
 package tls
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -50,7 +51,7 @@ func ExportWindowsCerts(dest string) error {
 	pem := strings.TrimSpace(string(out))
 
 	if pem == "" {
-		return fmt.Errorf("no certificates found in Windows cert store")
+		return errors.New("no certificates found in Windows cert store")
 	}
 
 	if err := os.WriteFile(dest, []byte(pem+"\n"), 0o600); err != nil {


### PR DESCRIPTION
# RATIONALE

Linters such as `godot` and `perfsprint` skip platform-specific files (`*_windows.go`) when run on a different OS. CI only runs `golangci-lint` on `ubuntu-latest`, and local macOS dev never analyzes Windows-only files. Running `GOOS=windows golangci-lint run` surfaced two violations that were invisible to both.

Tracked in [CFX-7138](https://datarobot.atlassian.net/browse/CFX-7138).

## CHANGES

- **`internal/telemetry/os_windows.go`**: Added trailing period to `// example output` comment (godot).
- **`internal/tls/tls_windows.go`**: Replaced `fmt.Errorf` with no formatting verbs with `errors.New` (perfsprint).

## TESTING

- `GOOS=windows golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...` passes with 0 issues
- `golangci-lint run ./...` (macOS) passes with 0 issues
- `GOOS=windows go build ./...` passes
- `go build ./...` passes
- `go test ./internal/telemetry/...` passes

## NOTES

These violations were found by running `GOOS=windows golangci-lint run ./...` on macOS. The broader fix to prevent this class of issue (running lint across all target platforms in CI) is tracked in CFX-7138.

## RELATED

- CFX-7138: Linters skip platform-specific files (build tags) when run on a different OS
- PR #710: fix(lint): enable godot and add periods to comments

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1785176453.735549 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and error-construction style only; no runtime or security behavior change.
> 
> **Overview**
> Fixes **godot** and **perfsprint** issues in Windows build-tagged files that only show up when lint runs with `GOOS=windows` (they are skipped on Linux CI and local non-Windows runs).
> 
> In `internal/telemetry/os_windows.go`, the `// example output` comment now ends with a period. In `internal/tls/tls_windows.go`, the empty-cert-store error uses `errors.New` instead of `fmt.Errorf` with no format verbs, with `errors` added to imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf43adfc5d11aaac18f222388b77509313e8f7c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->