### PR TITLE
[CFX-4533] Improve plugin docs and add package-level docstrings

### DIFF
--- a/cmd/plugin/doc.go
+++ b/cmd/plugin/doc.go
@@ -1,0 +1,20 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package plugin wires up the `dr plugin` parent command and its
+// subcommands (list, install, uninstall, update, version). It also
+// registers discovered plugins as top-level commands on the root command
+// during CLI startup, including the automatic pre-run update check for
+// managed plugins.
+package plugin

--- a/cmd/plugin/install/doc.go
+++ b/cmd/plugin/install/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package install implements the `dr plugin install` subcommand, which
+// installs a plugin from the remote registry, a local .tar.xz archive,
+// or an HTTP/HTTPS URL. It also lists available plugins and versions
+// from the registry.
+package install

--- a/cmd/plugin/list/cmd.go
+++ b/cmd/plugin/list/cmd.go
@@ -137,8 +137,9 @@ func runList(cmd *cobra.Command, _ []string) error {
 		fmt.Println("No plugins discovered.")
 		fmt.Println()
 		fmt.Println("Plugins are discovered from:")
-		fmt.Println("  1. Project-local .dr/plugins/ directory")
-		fmt.Println("  2. Executables named 'dr-*' in PATH")
+		fmt.Println("  1. Managed plugin directories (~/.config/datarobot/plugins/)")
+		fmt.Println("  2. Project-local .dr/plugins/ directory")
+		fmt.Println("  3. Executables named 'dr-*' in PATH")
 
 		return nil
 	}

--- a/cmd/plugin/list/doc.go
+++ b/cmd/plugin/list/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package list implements the `dr plugin list` subcommand, which displays
+// all plugins discovered at CLI startup in a table or as JSON.
+package list

--- a/cmd/plugin/shared/doc.go
+++ b/cmd/plugin/shared/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package shared contains helpers reused across the `dr plugin`
+// subcommands, including registry URL normalization and the
+// backup-install-validate-rollback update cycle.
+package shared

--- a/cmd/plugin/uninstall/doc.go
+++ b/cmd/plugin/uninstall/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package uninstall implements the `dr plugin uninstall` subcommand, which
+// removes a managed plugin (one previously installed via `dr plugin install`).
+package uninstall

--- a/cmd/plugin/update/doc.go
+++ b/cmd/plugin/update/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package update implements the `dr plugin update` subcommand, which
+// upgrades one or all installed managed plugins to their latest available
+// version from the registry.
+package update

--- a/cmd/plugin/version/doc.go
+++ b/cmd/plugin/version/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package version implements the `dr plugin version` subcommand, which
+// prints the version of a discovered plugin as reported in its manifest.
+package version

--- a/docs/commands/plugins.md
+++ b/docs/commands/plugins.md
@@ -183,7 +183,7 @@ Either way, the check is not repeated until the configured cooldown interval has
 ### Configuring the update check
 
 ```bash
-# Change the cooldown interval (default 24h)
+# Change the cooldown interval (default 1h)
 # Accepts Go duration strings: 30m, 6h, 48h, 0s
 dr --plugin-update-check-interval 6h assist
 

--- a/docs/commands/plugins.md
+++ b/docs/commands/plugins.md
@@ -228,10 +228,13 @@ A plugin is an executable that:
 
 ### Plugin discovery
 
-The CLI discovers plugins from:
+The CLI discovers plugins from, in priority order:
 
-1. Project-local `.dr/plugins/` directory (highest priority).
-2. All directories on your `PATH`.
+1. **Managed plugin directories** (highest priority) — plugins installed via `dr plugin install`.
+   - Primary: `$XDG_CONFIG_HOME/datarobot/plugins/` (or `~/.config/datarobot/plugins/` when `XDG_CONFIG_HOME` is not set).
+   - Additional directories from `$XDG_CONFIG_DIRS` if set (e.g., `/etc/xdg/datarobot/plugins` for system-wide plugins).
+2. **Project-local** `.dr/plugins/` directory.
+3. **All directories on your `PATH`**.
 
 If multiple executables declare the same manifest `name`, the CLI uses only the first discovered plugin.
 

--- a/docs/development/plugins.md
+++ b/docs/development/plugins.md
@@ -22,7 +22,7 @@ At CLI startup, plugins are discovered from the following locations, in priority
    - Additional directories from `$XDG_CONFIG_DIRS` if set (e.g., `/etc/xdg/datarobot/plugins` for system-wide plugins).
    - The primary directory always takes precedence: if the same plugin name exists in multiple locations, the first discovered one wins and later ones are skipped.
 2. **Project-local** `.dr/plugins/` directory.
-3. **Every directory on your `PATH``.
+3. **Every directory on your `PATH`**.
 
 Only files whose filename begins with `dr-` are considered.
 

--- a/internal/plugin/doc.go
+++ b/internal/plugin/doc.go
@@ -1,0 +1,38 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package plugin implements the core plugin system for the DataRobot CLI.
+//
+// Plugins are external executables named dr-* that extend the CLI with
+// additional top-level commands. This package provides:
+//
+//   - Discovery: scans managed plugin directories, the project-local
+//     .dr/plugins/ directory, and PATH for plugin executables, querying
+//     each for a JSON manifest via the --dr-plugin-manifest flag.
+//   - Execution: runs a discovered plugin as a subprocess, forwarding
+//     arguments verbatim, setting plugin-specific environment variables,
+//     and optionally enforcing DataRobot authentication beforehand.
+//   - Remote registry: fetches and parses the plugin registry, resolves
+//     semantic-version constraints, and downloads/installs plugins from
+//     the registry, local archives, or HTTP URLs with SHA256 verification.
+//   - Dependency checking: reads a plugin's versions.yaml and verifies
+//     that required external tools are present before installation and
+//     before each invocation.
+//   - Update checking: periodically checks the registry for newer versions
+//     of managed plugins, with a configurable cooldown to avoid redundant
+//     network requests.
+//
+// See the plugin system documentation at docs/development/plugins.md for
+// the manifest protocol, environment variables, and packaging workflow.
+package plugin


### PR DESCRIPTION
# RATIONALE

CFX-4533 is an open task to improve the plugin documentation. While reviewing the existing docs, several inaccuracies and gaps were found:

1. The user-facing plugin discovery docs omitted managed plugin directories (the highest-priority discovery tier).
2. The update check cooldown default was documented as 24h but the code uses 1h.
3. A markdown formatting bug broke bold rendering on the PATH line in the development docs.
4. The "No plugins discovered" runtime message in `dr plugin list` also omitted managed plugin directories.
5. None of the plugin-related Go packages had package-level docstrings (`// Package ...`), making them invisible to `go doc` and pkg.go.dev.

Closing this in order to close ye olde PBMP-7726.

## CHANGES

- **`docs/commands/plugins.md`**: Fixed plugin discovery section to include managed plugin directories as the highest-priority tier (matching the development docs and `internal/plugin/discover.go`).
- **`docs/commands/plugins.md`**: Fixed update check cooldown default from "24h" to "1h" (matching `DefaultUpdateCheckInterval` in `internal/plugin/updatecheck.go`).
- **`docs/development/plugins.md`**: Fixed markdown bold delimiter on the PATH discovery line.
- **`cmd/plugin/list/cmd.go`**: Added managed plugin directories to the "No plugins discovered" message.
- **8 new `doc.go` files**: Added package-level docstrings to `internal/plugin`, `cmd/plugin`, and all `cmd/plugin/*` subpackages (`list`, `install`, `uninstall`, `update`, `version`, `shared`), following the existing convention used by `internal/validate` and `internal/workload/sync`.

## TESTING

- `task lint` passes (0 issues).
- `go test ./internal/plugin/... ./cmd/plugin/...` passes.
- `go doc ./internal/plugin` renders the new package comment correctly.

## RELATED

- [CFX-4533](https://datarobot.atlassian.net/browse/CFX-4533)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, help text, and package comments only; no changes to discovery, install, or update behavior.
> 
> **Overview**
> Aligns **plugin documentation and UX copy** with actual discovery behavior and code defaults, and adds **`go doc` package comments** for plugin-related packages.
> 
> **User-facing docs** (`docs/commands/plugins.md`): plugin discovery now documents **managed plugin directories** as the highest-priority tier (with XDG paths), matching runtime behavior; the automatic update-check cooldown example default is corrected from **24h to 1h**.
> 
> **Development docs** (`docs/development/plugins.md`): fixes broken **bold markdown** on the PATH discovery bullet.
> 
> **CLI message** (`dr plugin list`): when no plugins are found, the hint list is updated to the same three-tier order—managed dirs, `.dr/plugins/`, then `dr-*` on PATH.
> 
> **New `doc.go` files** for `internal/plugin`, `cmd/plugin`, and subpackages (`install`, `list`, `uninstall`, `update`, `version`, `shared`) describe each package’s role; no runtime logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8006cad89fe68808c09d4400590ac828994d05e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->