### PR TITLE
[CFX-7139] fix(lint): resolve remaining gosec violations and remove exclusions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -90,7 +90,7 @@ linters:
       - linters: [forbidigo]
         path: "^main\\.go$|internal/telemetry/telemetry\\.go|internal/log/pkg\\.go|_test\\.go$"
       - linters: [gosec]
-        text: "G(101|104|115|122|204|301|304|306|602|703):"
+        text: "G(101|104|122|204|301|304|306|602|703):"
     generated: lax
     presets:
       - comments

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -90,7 +90,7 @@ linters:
       - linters: [forbidigo]
         path: "^main\\.go$|internal/telemetry/telemetry\\.go|internal/log/pkg\\.go|_test\\.go$"
       - linters: [gosec]
-        text: "G(101|104|122|204|301|304|306|703):"
+        text: "G(101|104|122|301|304|306|703):"
     generated: lax
     presets:
       - comments

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -90,7 +90,7 @@ linters:
       - linters: [forbidigo]
         path: "^main\\.go$|internal/telemetry/telemetry\\.go|internal/log/pkg\\.go|_test\\.go$"
       - linters: [gosec]
-        text: "G(101|104|122|301|304|306|703):"
+        text: "G(101|104|301|304|306):"
     generated: lax
     presets:
       - comments

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -90,7 +90,7 @@ linters:
       - linters: [forbidigo]
         path: "^main\\.go$|internal/telemetry/telemetry\\.go|internal/log/pkg\\.go|_test\\.go$"
       - linters: [gosec]
-        text: "G(101|104|122|204|301|304|306|602|703):"
+        text: "G(101|104|122|204|301|304|306|703):"
     generated: lax
     presets:
       - comments

--- a/cmd/artifact/build/internal/buildargs/buildargs.go
+++ b/cmd/artifact/build/internal/buildargs/buildargs.go
@@ -36,7 +36,7 @@ import (
 func ResolveOptional(args []string) (string, error) {
 	explicit := ""
 	if len(args) == 1 {
-		explicit = args[0]
+		explicit = args[0] //nolint:gosec // bounded by if len(args)==1 check above
 	}
 
 	id, _, err := workload.ResolveArtifactID(explicit)
@@ -59,9 +59,9 @@ func ResolvePositional(args []string) (string, string, error) {
 			return "", "", err
 		}
 
-		return artifactID, args[0], nil
+		return artifactID, args[0], nil //nolint:gosec // bounded by case 1: len(args)==1
 	case 2:
-		artifactID, _, err := workload.ResolveArtifactID(args[0])
+		artifactID, _, err := workload.ResolveArtifactID(args[0]) //nolint:gosec // bounded by case 2: len(args)==2
 		if err != nil {
 			return "", "", err
 		}

--- a/cmd/dotenv/template.go
+++ b/cmd/dotenv/template.go
@@ -131,7 +131,7 @@ func backup(dotenvFile string) error {
 	}
 
 	// Write to backup location
-	if err := os.WriteFile(backupPath, content, 0o644); err != nil {
+	if err := os.WriteFile(backupPath, content, 0o644); err != nil { //nolint:gosec // backup path is internally constructed
 		return fmt.Errorf("Failed to write backup file: %w", err)
 	}
 

--- a/cmd/llm-gateway/list/cmd.go
+++ b/cmd/llm-gateway/list/cmd.go
@@ -104,7 +104,7 @@ func toLLMOutputs(llms []drapi.LLM, selectedID string) []LLMOutput {
 }
 
 func terminalWidth() int {
-	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	w, _, err := term.GetSize(int(os.Stdout.Fd())) //nolint:gosec // uintptr and int are same size on supported platforms
 	if err != nil || w <= 0 {
 		return 120
 	}

--- a/cmd/self/plugin/package/cmd.go
+++ b/cmd/self/plugin/package/cmd.go
@@ -215,7 +215,7 @@ func createArchive(sourceDir, archivePath string) error {
 			return nil
 		}
 
-		file, err := os.Open(path)
+		file, err := os.Open(path) //nolint:gosec // low TOCTOU risk for plugin packaging
 		if err != nil {
 			return err
 		}

--- a/cmd/self/plugin/publish/cmd.go
+++ b/cmd/self/plugin/publish/cmd.go
@@ -200,7 +200,7 @@ func createArchive(sourceDir, archivePath string) error {
 			return nil
 		}
 
-		file, err := os.Open(path)
+		file, err := os.Open(path) //nolint:gosec // low TOCTOU risk for plugin publishing
 		if err != nil {
 			return err
 		}

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -195,7 +195,7 @@ func (m Model) execQuickstartScript() tea.Cmd {
 	}
 
 	// Regular quickstart script execution
-	cmd := exec.Command(m.quickstartScriptPath)
+	cmd := exec.Command(m.quickstartScriptPath) //nolint:gosec // subprocess launched with validated input
 
 	return tea.ExecProcess(cmd, func(e error) tea.Msg {
 		return startScriptCompleteMsg{err: e}

--- a/internal/misc/reader/reader.go
+++ b/internal/misc/reader/reader.go
@@ -78,7 +78,7 @@ func AskYesNo() bool {
 // IsStdinTerminal reports whether stdin is connected to an interactive terminal.
 // Returns false when stdin is a pipe, a file redirect, or otherwise non-interactive.
 func IsStdinTerminal() bool {
-	return term.IsTerminal(int(os.Stdin.Fd()))
+	return term.IsTerminal(int(os.Stdin.Fd())) //nolint:gosec // uintptr and int are same size on supported platforms
 }
 
 // NonInteractiveEnv is the env var users set to force non-interactive mode

--- a/internal/plugin/discover.go
+++ b/internal/plugin/discover.go
@@ -214,7 +214,7 @@ func discoverPathDirsParallel(ctx context.Context, pathDirs []string, baseSeen m
 
 	for i, dr := range dirResults {
 		for _, e := range dr.errs {
-			log.Debug("Plugin discovery error", "dir", pathDirs[i], "error", e)
+			log.Debug("Plugin discovery error", "dir", pathDirs[i], "error", e) //nolint:gosec // dirResults has len(pathDirs) entries
 		}
 
 		conflicts = append(conflicts, dr.conflicts...)

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -106,7 +106,7 @@ func parentProcessNameWindows(ppid int) string {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	out, err := exec.CommandContext(ctx, "tasklist", "/FI", "PID eq "+strconv.Itoa(ppid), "/NH", "/FO", "CSV").Output()
+	out, err := exec.CommandContext(ctx, "tasklist", "/FI", "PID eq "+strconv.Itoa(ppid), "/NH", "/FO", "CSV").Output() //nolint:gosec // subprocess launched with validated input
 	if err != nil {
 		return ""
 	}
@@ -147,7 +147,7 @@ func parentProcessName() string {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	out, err := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(ppid), "-o", "comm=").Output()
+	out, err := exec.CommandContext(ctx, "ps", "-p", strconv.Itoa(ppid), "-o", "comm=").Output() //nolint:gosec // subprocess launched with validated input
 	if err != nil {
 		return ""
 	}

--- a/internal/task/runner.go
+++ b/internal/task/runner.go
@@ -91,7 +91,7 @@ func (r *Runner) ListTasks() ([]Task, error) {
 		args = append(args, "-t", r.opts.Taskfile)
 	}
 
-	cmd := exec.Command(r.opts.BinaryName, args...)
+	cmd := exec.Command(r.opts.BinaryName, args...) //nolint:gosec // subprocess launched with validated input
 
 	cmd.Dir = r.opts.Dir
 
@@ -169,7 +169,7 @@ func (r *Runner) Run(tasks []string, opts RunOpts) error {
 		args = append(args, opts.TaskArgs...)
 	}
 
-	cmd := exec.Command(r.opts.BinaryName, args...)
+	cmd := exec.Command(r.opts.BinaryName, args...) //nolint:gosec // subprocess launched with validated input
 
 	cmd.Dir = r.opts.Dir
 

--- a/internal/telemetry/os_windows.go
+++ b/internal/telemetry/os_windows.go
@@ -22,7 +22,7 @@ import (
 
 // osVersion retrieves the Windows OS version via RtlGetVersion (ntdll.dll).
 // Returns an empty string if detection fails.
-// example output: "10.0.22621"
+// example output: "10.0.22621".
 func osVersion() string {
 	info := windows.RtlGetVersion()
 

--- a/internal/tls/tls_windows.go
+++ b/internal/tls/tls_windows.go
@@ -17,6 +17,7 @@
 package tls
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -50,7 +51,7 @@ func ExportWindowsCerts(dest string) error {
 	pem := strings.TrimSpace(string(out))
 
 	if pem == "" {
-		return fmt.Errorf("no certificates found in Windows cert store")
+		return errors.New("no certificates found in Windows cert store")
 	}
 
 	if err := os.WriteFile(dest, []byte(pem+"\n"), 0o600); err != nil {

--- a/internal/workload/sync/diskspace_unix.go
+++ b/internal/workload/sync/diskspace_unix.go
@@ -30,5 +30,5 @@ func realAvailableBytes(path string) (int64, error) {
 		return 0, fmt.Errorf("statfs %s: %w", path, err)
 	}
 
-	return int64(st.Bavail * uint64(st.Bsize)), nil
+	return int64(st.Bavail * uint64(st.Bsize)), nil //nolint:gosec // Bavail * Bsize fits in int64 on every supported FS.
 }

--- a/internal/workload/sync/rollback.go
+++ b/internal/workload/sync/rollback.go
@@ -173,7 +173,7 @@ func restoreFromDir(rollDir, projectDir string) error {
 			return fmt.Errorf("mkdir restore parent: %w", err)
 		}
 
-		in, err := os.Open(p)
+		in, err := os.Open(p) //nolint:gosec // low TOCTOU risk for backup restore
 		if err != nil {
 			return fmt.Errorf("open backup %s: %w", p, err)
 		}

--- a/internal/workload/sync/synclock_unix.go
+++ b/internal/workload/sync/synclock_unix.go
@@ -23,9 +23,9 @@ import (
 )
 
 func tryLockExclusive(f *os.File) error {
-	return unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	return unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB) //nolint:gosec // uintptr and int are same size on supported platforms
 }
 
 func unlockExclusive(f *os.File) error {
-	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
+	return unix.Flock(int(f.Fd()), unix.LOCK_UN) //nolint:gosec // uintptr and int are same size on supported platforms
 }


### PR DESCRIPTION
# RATIONALE

Resolve all remaining gosec violations that were temporarily excluded in PR #711. Each lint type is fixed in its own commit for reviewability.

Ref: CFX-7139

## CHANGES

### Commit 1: G115 integer overflow (5 fixes)
Add //nolint:gosec annotations for uintptr→int and uint64→int64 conversions that are safe on supported platforms. Remove G115 from exclusion regex.

### Commit 2: G602 slice bounds (4 fixes)
Add //nolint:gosec annotations for slice accesses provably safe due to prior length guards. Remove G602 from exclusion regex.

### Commit 3: Windows-specific godot + perfsprint (2 fixes)
Fix 2 lint issues only visible with GOOS=windows:
- godot: add period to comment in os_windows.go
- perfsprint: replace fmt.Errorf with errors.New in tls_windows.go

### Commit 4: G204 subprocess (5 nolint annotations)
Add //nolint:gosec for 5 'tainted input' subprocess launches in shell.go, runner.go, and start/model.go. The remaining 20 G204 findings are handled by config presets. Remove G204 from exclusion regex.

### Commit 5: G122 + G703 cleanup (4 nolint annotations)
Add //nolint:gosec for 3 filepath.Walk TOCTOU findings (G122) and 1 path traversal finding (G703) - all low-risk false positives for CLI operations. Remove G122 and G703 from exclusion regex.

## TESTING

- `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 ./...` passes with 0 issues on darwin, linux, and windows
- `go vet ./...` passes

## NOTES

Remaining gosec exclusions: G101, G104, G301, G304, G306 (noisy test false positives).

Part of CFX-7139: enabling all disabled linters. Stack: errorlint (#709) → godot (#710) → gosec (#711, this PR) → wrapcheck (follow-up).

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1785176486.274109 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and annotation-only changes with no functional logic modifications; remaining gosec exclusions are unchanged noisy categories.
> 
> **Overview**
> Tightens **gosec** enforcement by dropping blanket suppressions for **G115**, **G602**, **G204**, **G122**, and **G703** in `.golangci.yaml`, leaving only **G101**, **G104**, **G301**, **G304**, and **G306** excluded.
> 
> Previously suppressed findings are now addressed with targeted `//nolint:gosec` comments (bounded slice/arg access, safe `uintptr`→`int` conversions, CLI subprocess launches, low-risk `filepath.Walk` / backup opens). **Windows-only** lint fixes: godot punctuation on a telemetry comment and `errors.New` instead of `fmt.Errorf` when exporting certs.
> 
> No runtime behavior change—lint hygiene and documented false positives only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58e1afc17a3c89c3e7b214e2df2d48c94fb66b0e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->