### PR TITLE
[CFX-6921] Add cmd.exe support to shell detection

### DIFF
--- a/cmd/self/completion/cmd.go
+++ b/cmd/self/completion/cmd.go
@@ -93,6 +93,14 @@ PowerShell:
 				return cmd.Root().GenFishCompletion(os.Stdout, true)
 			case internalShell.PowerShell:
 				return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+			case internalShell.Cmd:
+				// cmd.exe has no completion-script mechanism. Keep stdout clean
+				// (no bogus script) and explain on stderr.
+				cmd.SilenceUsage = true
+
+				fmt.Fprintln(os.Stderr, "cmd.exe does not support shell completion scripts.")
+
+				return nil
 			default:
 				cmd.SilenceUsage = true
 				return fmt.Errorf("Unsupported shell %q.", args[0])

--- a/cmd/self/completion/cmd_test.go
+++ b/cmd/self/completion/cmd_test.go
@@ -26,7 +26,7 @@ import (
 func TestSupportedShells(t *testing.T) {
 	shells := internalShell.SupportedShells()
 
-	expected := []string{"bash", "zsh", "fish", "powershell"}
+	expected := []string{"bash", "zsh", "fish", "powershell", "cmd"}
 
 	if len(shells) != len(expected) {
 		t.Errorf("expected %d shells, got %d", len(expected), len(shells))
@@ -48,7 +48,7 @@ func TestCmd(t *testing.T) {
 		return
 	}
 
-	if cmd.Use != "completion [bash|zsh|fish|powershell]" {
+	if cmd.Use != "completion [bash|zsh|fish|powershell|cmd]" {
 		t.Errorf("unexpected Use: %s", cmd.Use)
 	}
 
@@ -131,6 +131,8 @@ func TestCompletionGeneration(t *testing.T) {
 				err = rootCmd.GenFishCompletion(&buf, true)
 			case internalShell.PowerShell:
 				err = rootCmd.GenPowerShellCompletionWithDesc(&buf)
+			case internalShell.Cmd:
+				// cmd.exe has no completion generator; not exercised here.
 			}
 
 			if err != nil {

--- a/cmd/self/completion/install/cmd.go
+++ b/cmd/self/completion/install/cmd.go
@@ -113,6 +113,17 @@ func runInstall(rootCmd *cobra.Command, specifiedShell string, force, yes, dryRu
 
 	shellType := internalShell.Shell(shell)
 
+	if shellType == internalShell.Cmd {
+		// cmd.exe has no completion-script mechanism, so there is nothing to
+		// install. Surface a clear message rather than the generic error.
+		fmt.Println(infoStyle.Render("cmd.exe does not support shell completion scripts; nothing to install."))
+		return nil
+	}
+
+	return installForShell(rootCmd, shell, shellType, force, yes, dryRun)
+}
+
+func installForShell(rootCmd *cobra.Command, shell string, shellType internalShell.Shell, force, yes, dryRun bool) error {
 	installPath, installFunc, err := getInstallFunc(rootCmd, shellType, force)
 	if err != nil {
 		return err
@@ -222,6 +233,10 @@ func getInstallFunc(rootCmd *cobra.Command, shellType internalShell.Shell, force
 	case internalShell.PowerShell:
 		path, fn := installPowerShell(rootCmd, force)
 		return path, fn, nil
+	case internalShell.Cmd:
+		// cmd.exe has no completion-script mechanism; callers short-circuit
+		// before reaching here, so this is a defensive guard.
+		return "", nil, errors.New("cmd.exe does not support shell completion scripts.")
 	default:
 		return "", nil, fmt.Errorf("Unsupported shell: %s.", shellType)
 	}
@@ -599,6 +614,8 @@ func showActivationInstructions(shell internalShell.Shell) {
 		fmt.Println()
 		fmt.Println("  2. Or reload your profile in the current session:")
 		fmt.Println(infoStyle.Render("     . $PROFILE"))
+	case internalShell.Cmd:
+		// cmd.exe has no completions to activate; callers short-circuit earlier.
 	}
 
 	fmt.Println()

--- a/cmd/self/completion/uninstall/cmd.go
+++ b/cmd/self/completion/uninstall/cmd.go
@@ -191,6 +191,9 @@ func performUninstall(shell internalShell.Shell) error {
 		removed = uninstallFish()
 	case internalShell.PowerShell:
 		removed = uninstallPowerShell()
+	case internalShell.Cmd:
+		// cmd.exe has no completions to remove.
+		return nil
 	default:
 		return fmt.Errorf("Unsupported shell: %s.", shell)
 	}
@@ -276,6 +279,9 @@ func getUninstallPaths(shell internalShell.Shell) []string {
 		}
 
 		return paths
+	case internalShell.Cmd:
+		// cmd.exe has no completions on disk.
+		return nil
 	default:
 		return []string{}
 	}

--- a/cmd/self/update/cmd.go
+++ b/cmd/self/update/cmd.go
@@ -102,6 +102,7 @@ with your default shell.
 				command    string
 				executable string
 				backup     string
+				execCmd    *exec.Cmd
 			)
 
 			switch runtime.GOOS {
@@ -114,13 +115,17 @@ with your default shell.
 				if err != nil {
 					return err
 				}
+
+				// The install command is a PowerShell one-liner, so it must run
+				// under PowerShell regardless of the detected shell (e.g. cmd.exe,
+				// which uses /C and cannot run `irm ... | iex`).
+				execCmd = exec.Command("powershell", "-NoProfile", "-Command", command)
 			case "darwin", "linux":
 				command = "curl -fsSL https://raw.githubusercontent.com/datarobot-oss/cli/main/install.sh | sh"
+				execCmd = exec.Command(shell, "-c", command)
 			default:
 				return fmt.Errorf("could not determine OS: %s", runtime.GOOS)
 			}
-
-			execCmd := exec.Command(shell, "-c", command)
 
 			execCmd.Stdout = os.Stdout
 			execCmd.Stderr = os.Stderr

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -37,6 +37,7 @@ const (
 	Zsh        Shell = "zsh"
 	Fish       Shell = "fish"
 	PowerShell Shell = "powershell"
+	Cmd        Shell = "cmd"
 )
 
 func SupportedShells() []string {
@@ -45,6 +46,7 @@ func SupportedShells() []string {
 		string(Zsh),
 		string(Fish),
 		string(PowerShell),
+		string(Cmd),
 	}
 }
 
@@ -53,11 +55,16 @@ func SupportedShells() []string {
 // its process name as "pwsh" (or "pwsh.exe" on Windows), but the CLI uses the
 // constant "powershell" for all PowerShell variants.
 func normalizeShellName(name string) string {
-	if name == "pwsh" {
+	switch name {
+	case "pwsh":
 		return string(PowerShell)
+	case "cmd.exe":
+		// $SHELL (rare on Windows) may carry the .exe suffix; the parent-process
+		// path already strips it, so canonicalize here for the fallback case.
+		return string(Cmd)
+	default:
+		return name
 	}
-
-	return name
 }
 
 // isSupportedShell reports whether name is one of the shells the CLI supports
@@ -111,8 +118,19 @@ func parentProcessNameWindows(ppid int) string {
 		return ""
 	}
 
-	// Output: "powershell.exe","12345","Console","1","4,000 K"
-	line := strings.TrimSpace(string(out))
+	return parseTasklistName(string(out))
+}
+
+// parseTasklistName extracts the lowercase process name (without the .exe
+// suffix) from a single tasklist CSV row. The expected format is:
+//
+//	"powershell.exe","12345","Console","1","4,000 K"
+//
+// It returns an empty string when the row cannot be parsed. This is split out
+// from parentProcessNameWindows so the CSV parsing can be unit-tested on any
+// platform (tasklist itself only exists on Windows).
+func parseTasklistName(output string) string {
+	line := strings.TrimSpace(output)
 
 	idx := strings.Index(line, ",")
 	if idx <= 0 {

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -48,6 +48,8 @@ func TestNormalizeShellName(t *testing.T) {
 		{input: "bash", expected: "bash"},
 		{input: "zsh", expected: "zsh"},
 		{input: "fish", expected: "fish"},
+		{input: "cmd", expected: "cmd"},
+		{input: "cmd.exe", expected: "cmd"},
 	}
 
 	for _, tt := range tests {
@@ -130,6 +132,7 @@ func TestIsSupportedShell(t *testing.T) {
 		{name: "zsh", want: true},
 		{name: "fish", want: true},
 		{name: "powershell", want: true},
+		{name: "cmd", want: true},
 		{name: "ruby", want: false},
 		{name: "python", want: false},
 		{name: "sh", want: false},
@@ -186,13 +189,14 @@ func TestSupportedShells(t *testing.T) {
 	assert.Contains(t, supported, string(Zsh))
 	assert.Contains(t, supported, string(Fish))
 	assert.Contains(t, supported, string(PowerShell))
-	assert.Len(t, supported, 4)
+	assert.Contains(t, supported, string(Cmd))
+	assert.Len(t, supported, 5)
 }
 
 // TestResolveShell_SpecifiedShell verifies that an explicitly provided shell name
 // is returned unchanged without invoking detection.
 func TestResolveShell_SpecifiedShell(t *testing.T) {
-	shells := []string{"bash", "zsh", "fish", "powershell"}
+	shells := []string{"bash", "zsh", "fish", "powershell", "cmd"}
 
 	for _, shell := range shells {
 		t.Run(shell, func(t *testing.T) {
@@ -244,11 +248,67 @@ func TestNormalizeShellName_EdgeCases(t *testing.T) {
 		// Only "pwsh" maps to "powershell"; other PowerShell names are unchanged
 		{input: "pwsh.exe", want: "pwsh.exe"},
 		{input: "powershell.exe", want: "powershell.exe"},
+		// "cmd.exe" (as it may appear in $SHELL) canonicalizes to "cmd"
+		{input: "cmd.exe", want: "cmd"},
+		{input: "cmd", want: "cmd"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			assert.Equal(t, tt.want, normalizeShellName(tt.input))
+		})
+	}
+}
+
+// TestParseTasklistName exercises the CSV parsing used to read the parent
+// process name from tasklist output on Windows. tasklist only exists on
+// Windows, but the parsing is pure and must behave identically everywhere.
+func TestParseTasklistName(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name:   "cmd.exe",
+			output: `"cmd.exe","12345","Console","1","4,000 K"`,
+			want:   "cmd",
+		},
+		{
+			name:   "powershell.exe",
+			output: `"powershell.exe","12345","Console","1","4,000 K"`,
+			want:   "powershell",
+		},
+		{
+			name:   "pwsh.exe",
+			output: `"pwsh.exe","12345","Console","1","4,000 K"`,
+			want:   "pwsh",
+		},
+		{
+			name:   "trailing newline",
+			output: "\"cmd.exe\",\"12345\",\"Console\",\"1\",\"4,000 K\"\r\n",
+			want:   "cmd",
+		},
+		{
+			name:   "mixed case is lowercased",
+			output: `"CMD.EXE","12345","Console","1","4,000 K"`,
+			want:   "cmd",
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   "",
+		},
+		{
+			name:   "no comma",
+			output: `"cmd.exe"`,
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseTasklistName(tt.output))
 		})
 	}
 }


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->
Tested on windows locally.


<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1785163387.326099 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted Windows/shell UX changes with defensive no-ops for cmd completions; the update path change is a bugfix for cmd users.
> 
> **Overview**
> Adds **cmd.exe** as a recognized shell so Windows parent-process detection (via `tasklist`) and name normalization (`cmd.exe` → `cmd`) behave consistently with other shells.
> 
> Completion **generate / install / uninstall** paths treat `cmd` as supported but **no-op with clear messaging**, since cmd has no completion-script mechanism—stdout stays clean on `completion cmd`.
> 
> **`self update` on Windows** now always runs the install one-liner through **PowerShell** (`powershell -NoProfile -Command`), fixing failures when the detected shell is cmd (which cannot run `irm ... | iex` via `cmd /C`).
> 
> Refactors Windows `tasklist` CSV parsing into **`parseTasklistName`** for cross-platform unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455a4a7dcd29f3c62cd3841e2303fa3396a3888b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->