### PR TITLE
[CMPT-6969] feat(pipeline): add `dr pipeline clone` command

### DIFF
--- a/cmd/pipeline/clone/cmd.go
+++ b/cmd/pipeline/clone/cmd.go
@@ -1,0 +1,80 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clone
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/pipeline"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var (
+		outputFormat outputformat.OutputFormat
+		name         string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "clone <pipeline-id>",
+		Short: "Clone a pipeline into a new draft",
+		Long: `Clone an existing pipeline into a brand-new draft, copying over its source
+code, description, latest input params, and latest assigned image.
+
+The clone is named "Clone of <source name>" by default. Supply --name to use a
+custom label instead. If the name is already taken by another draft, a numeric
+suffix is appended automatically so repeated clones never fail.
+
+Example:
+  dr pipeline clone 507f1f77bcf86cd799439011
+  dr pipeline clone 507f1f77bcf86cd799439011 --name "My Clone"
+  dr pipeline clone 507f1f77bcf86cd799439011 --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			name = strings.TrimSpace(name)
+			if cmd.Flags().Changed("name") && name == "" {
+				return errors.New("--name must not be blank")
+			}
+
+			result, err := pipeline.ClonePipeline(args[0], name)
+			if err != nil {
+				return fmt.Errorf("clone pipeline: %w", err)
+			}
+
+			return pipeline.RenderCreateResponse(outputFormat, *result)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+	cmd.Flags().StringVar(&name, "name", "", "Optional display name for the clone; defaults to \"Clone of <source name>\"")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"pipeline_id":   telemetry.FirstArg(args),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/pipeline/clone/cmd_test.go
+++ b/cmd/pipeline/clone/cmd_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clone
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/cmd/pipeline/internal/testutil"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sample is a clone response: always a fresh draft, so Version/Status are
+// intentionally zero-valued (the server returns none for a draft, same as
+// POST /pipelines).
+func sample() pipeline.CreateResponse {
+	return pipeline.CreateResponse{
+		PipelineID: "p-2",
+		Name:       "Clone of wf",
+		Mode:       "draft",
+		TaskNames:  []string{"e1", "e2"},
+		CreatedAt:  time.Date(2026, 4, 30, 10, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestPrintCloneJSON(t *testing.T) {
+	output := testutil.CaptureStdout(t, func() {
+		require.NoError(t, pipeline.RenderCreateResponse(outputformat.OutputFormatJSON, sample()))
+	})
+
+	var parsed map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+	assert.Equal(t, "p-2", parsed["id"])
+	assert.Equal(t, "Clone of wf", parsed["name"])
+	assert.Equal(t, "draft", parsed["mode"])
+}
+
+func TestPrintCloneHuman(t *testing.T) {
+	output := testutil.CaptureStdout(t, func() {
+		require.NoError(t, pipeline.RenderCreateResponse(outputformat.OutputFormatText, sample()))
+	})
+
+	assert.Contains(t, output, "Clone of wf")
+	assert.Contains(t, output, "draft")
+	assert.Contains(t, output, "e1, e2")
+}
+
+func TestCmd_RejectsInvalidOutput(t *testing.T) {
+	cmd := Cmd()
+	cmd.SetArgs([]string{"abc", "--output-format", "yaml"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.PreRunE = nil
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output format")
+}
+
+func TestCmd_RejectsBlankName(t *testing.T) {
+	cmd := Cmd()
+	cmd.SetArgs([]string{"abc", "--name", "   "})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.PreRunE = nil
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--name must not be blank")
+}

--- a/cmd/pipeline/cmd.go
+++ b/cmd/pipeline/cmd.go
@@ -15,6 +15,7 @@
 package pipeline
 
 import (
+	"github.com/datarobot/cli/cmd/pipeline/clone"
 	"github.com/datarobot/cli/cmd/pipeline/create"
 	"github.com/datarobot/cli/cmd/pipeline/del"
 	"github.com/datarobot/cli/cmd/pipeline/get"
@@ -54,6 +55,7 @@ input payloads, runs, and recurring schedules.`,
 	cmd.AddCommand(
 		create.Cmd(),
 		get.Cmd(),
+		clone.Cmd(),
 		list.Cmd(),
 		update.Cmd(),
 		del.Cmd(),

--- a/docs/commands/pipeline.md
+++ b/docs/commands/pipeline.md
@@ -76,6 +76,7 @@ dr pipeline lock <pipeline-id>
 | `dr pipeline create`    | `POST   /api/v2/pipelines`           | Upload a Python file to register a new pipeline. |
 | `dr pipeline list`      | `GET    /api/v2/pipelines`           | Paginated list with mode filtering.              |
 | `dr pipeline get`       | `GET    /api/v2/pipelines/{id}`      | Pipeline detail including all versions.          |
+| `dr pipeline clone`     | `POST   /api/v2/pipelines/{id}/clone` | Clone a pipeline into a new draft (source, description, latest input, image). |
 | `dr pipeline update`    | `PATCH  /api/v2/pipelines/{id}`      | Re-upload a file to append a new version.        |
 | `dr pipeline delete`    | `DELETE /api/v2/pipelines/{id}`      | Remove a pipeline and all of its versions.       |
 | `dr pipeline lock`      | `PATCH  /api/v2/pipelines/{id}/mode` | Promote a draft to locked mode.                  |
@@ -542,8 +543,8 @@ If the task ID is not found, the command prints `Task not found: <task-id>` and 
 | Status | Cause                                                                          |
 |--------|--------------------------------------------------------------------------------|
 | `400`  | Invalid Python file or mismatched pipeline name.                               |
-| `404`  | The provided `<pipeline-id>`, version, or run does not exist.                  |
-| `409`  | Tried to update a `locked` pipeline, or cancel an already-terminal run.        |
+| `404`  | The provided `<pipeline-id>`, version, run, or task does not exist.            |
+| `409`  | Tried to update a `locked` pipeline; cancelled an already-terminal run; requested `run task result` before the task reached `COMPLETED`; or addressed a fan-out `run task` (`get`/`logs`/`result`) without `--node-id` (message lists the candidate node ids). |
 
 ## See also
 

--- a/internal/pipeline/clone_test.go
+++ b/internal/pipeline/clone_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClonePipeline_DefaultName(t *testing.T) {
+	installSkipAuth(t)
+
+	var (
+		gotMethod string
+		gotPath   string
+		gotBody   []byte
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id": "p-2",
+			"name": "Clone of wf",
+			"mode": "draft",
+			"taskNames": ["e1"],
+			"createdAt": "2026-04-29T10:00:00Z"
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	got, err := ClonePipeline("p-1", "")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v2/pipelines/p-1/clone", gotPath)
+
+	// No name override → the body must omit "name" entirely.
+	var payload map[string]any
+
+	require.NoError(t, json.Unmarshal(gotBody, &payload))
+
+	_, hasName := payload["name"]
+	assert.False(t, hasName, "empty name must be omitted from the request body")
+	assert.Equal(t, "p-2", got.PipelineID)
+	assert.Equal(t, "Clone of wf", got.Name)
+	assert.Equal(t, "draft", got.Mode)
+	// A clone is always a fresh draft, so the server returns no version/status
+	// (mirrors POST /pipelines). The fixture omits them deliberately.
+	assert.Zero(t, got.Version)
+	assert.Empty(t, got.Status)
+}
+
+func TestClonePipeline_NameOverride(t *testing.T) {
+	installSkipAuth(t)
+
+	var gotBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"p-3","name":"My Clone","mode":"draft","createdAt":"2026-04-29T10:00:00Z"}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	got, err := ClonePipeline("p-1", "My Clone")
+	require.NoError(t, err)
+
+	var payload map[string]any
+
+	require.NoError(t, json.Unmarshal(gotBody, &payload))
+	assert.Equal(t, "My Clone", payload["name"])
+	assert.Equal(t, "My Clone", got.Name)
+}
+
+func TestClonePipeline_404NotFound(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"Pipeline p-1 not found"}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := ClonePipeline("p-1", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 404")
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/internal/pipeline/clone_test.go
+++ b/internal/pipeline/clone_test.go
@@ -101,6 +101,33 @@ func TestClonePipeline_NameOverride(t *testing.T) {
 	assert.Equal(t, "My Clone", got.Name)
 }
 
+func TestClonePipeline_EscapesPipelineID(t *testing.T) {
+	installSkipAuth(t)
+
+	var gotRequestURI string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// RequestURI is the raw, undecoded wire target — unlike r.URL.Path it
+		// preserves %2F, so it is the only value that proves the id was escaped
+		// (a rewritten "p/1" would arrive here as ".../p/1/clone").
+		gotRequestURI = r.RequestURI
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"p-2","name":"Clone of wf","mode":"draft","createdAt":"2026-04-29T10:00:00Z"}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	// A reserved "/" in the id must be percent-encoded so it stays a single
+	// path segment instead of altering the request path.
+	_, err := ClonePipeline("p/1", "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/v2/pipelines/p%2F1/clone", gotRequestURI)
+}
+
 func TestClonePipeline_404NotFound(t *testing.T) {
 	installSkipAuth(t)
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -178,9 +178,15 @@ func ListPipelines(mode, search string, offset, limit int) (*DataPage[ListItem],
 	return &page, nil
 }
 
+// escapeID percent-encodes a caller-supplied pipeline id so reserved path
+// characters can't rewrite the request path (mirrors internal/workload/workload.go).
+func escapeID(id string) string {
+	return url.PathEscape(id)
+}
+
 // GetPipeline fetches a single pipeline from GET /api/v2/pipelines/{pipeline_id}.
 func GetPipeline(pipelineID string) (*Pipeline, error) {
-	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + pipelineID)
+	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + escapeID(pipelineID))
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +204,7 @@ func GetPipeline(pipelineID string) (*Pipeline, error) {
 // UpdatePipeline patches a draft pipeline. filePath is optional (empty = no file
 // re-upload); name, description, and imageID are each no-op when empty.
 func UpdatePipeline(pipelineID, filePath, imageID, name, description string) (*CreateResponse, error) {
-	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + pipelineID)
+	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + escapeID(pipelineID))
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +236,7 @@ func UpdatePipeline(pipelineID, filePath, imageID, name, description string) (*C
 // DeletePipeline issues DELETE /api/v2/pipelines/{pipeline_id}. The API
 // returns 204 on success.
 func DeletePipeline(pipelineID string) error {
-	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + pipelineID)
+	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + escapeID(pipelineID))
 	if err != nil {
 		return err
 	}
@@ -243,7 +249,7 @@ func DeletePipeline(pipelineID string) error {
 // create/update payload, with `mode` set to "locked" and `version`
 // pointing at the locked version.
 func LockPipeline(pipelineID string) (*CreateResponse, error) {
-	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + pipelineID + "/mode")
+	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + escapeID(pipelineID) + "/mode")
 	if err != nil {
 		return nil, err
 	}
@@ -270,11 +276,7 @@ type cloneRequest struct {
 // assigned image). An empty name lets the server default to
 // "Clone of <source name>". The response mirrors a create payload.
 func ClonePipeline(pipelineID, name string) (*CreateResponse, error) {
-	// Escape the caller-supplied id so reserved path characters can't alter
-	// the request path (mirrors internal/workload/workload.go).
-	escapedID := url.PathEscape(pipelineID)
-
-	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + escapedID + "/clone")
+	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + escapeID(pipelineID) + "/clone")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -258,6 +258,37 @@ func LockPipeline(pipelineID string) (*CreateResponse, error) {
 	return &result, nil
 }
 
+// cloneRequest is the JSON body for POST /api/v2/pipelines/{id}/clone. The
+// omitempty keeps the body as `{}` when no name override is supplied, letting
+// the server apply its default "Clone of <source name>" label.
+type cloneRequest struct {
+	Name string `json:"name,omitempty"`
+}
+
+// ClonePipeline issues POST /api/v2/pipelines/{pipeline_id}/clone to copy an
+// existing pipeline into a new draft (source, description, latest input, and
+// assigned image). An empty name lets the server default to
+// "Clone of <source name>". The response mirrors a create payload.
+func ClonePipeline(pipelineID, name string) (*CreateResponse, error) {
+	// Escape the caller-supplied id so reserved path characters can't alter
+	// the request path (mirrors internal/workload/workload.go).
+	escapedID := url.PathEscape(pipelineID)
+
+	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + escapedID + "/clone")
+	if err != nil {
+		return nil, err
+	}
+
+	var result CreateResponse
+
+	err = doJSON(http.MethodPost, endpoint, cloneRequest{Name: name}, "clone pipeline", &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
 // doMultipart performs a multipart/form-data request with a single "file" upload
 // and optional form fields, decoding the JSON response into out.
 func doMultipart(method, endpoint, filePath string, fields map[string]string, info string, out any) error {

--- a/internal/pipeline/pipeline_output.go
+++ b/internal/pipeline/pipeline_output.go
@@ -256,6 +256,18 @@ func printCreateResponseHuman(result CreateResponse) {
 		tasks = strings.Join(result.TaskNames, ", ")
 	}
 
+	// A fresh draft (clone, or a just-created pipeline) carries no version or
+	// status yet, so render a placeholder instead of a bare "0" / empty cell.
+	version := emptyValuePlaceholder
+	if result.Version > 0 {
+		version = strconv.Itoa(result.Version)
+	}
+
+	status := emptyValuePlaceholder
+	if result.Status != "" {
+		status = result.Status
+	}
+
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
 	fmt.Fprintf(w, "Pipeline ID:\t%s\n", result.PipelineID)
@@ -265,8 +277,8 @@ func printCreateResponseHuman(result CreateResponse) {
 		fmt.Fprintf(w, "Description:\t%s\n", *result.Description)
 	}
 
-	fmt.Fprintf(w, "Version:\t%d\n", result.Version)
-	fmt.Fprintf(w, "Status:\t%s\n", result.Status)
+	fmt.Fprintf(w, "Version:\t%s\n", version)
+	fmt.Fprintf(w, "Status:\t%s\n", status)
 	fmt.Fprintf(w, "Mode:\t%s\n", result.Mode)
 	fmt.Fprintf(w, "Tasks:\t%s\n", tasks)
 

--- a/internal/pipeline/pipeline_output_test.go
+++ b/internal/pipeline/pipeline_output_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,6 +27,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fieldValue returns the trailing value of the tabwriter line beginning with
+// label (the whitespace padding between label and value is normalised away), or
+// ("", false) when no such line exists.
+func fieldValue(out, label string) (string, bool) {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, label) {
+			return strings.TrimSpace(strings.TrimPrefix(line, label)), true
+		}
+	}
+
+	return "", false
+}
 
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
@@ -111,6 +125,59 @@ func TestRenderCreateResponse_Human_NoTasks(t *testing.T) {
 	})
 
 	assert.Contains(t, out, emptyValuePlaceholder)
+}
+
+func TestRenderCreateResponse_Human_DraftPlaceholders(t *testing.T) {
+	// A fresh draft (e.g. a clone, or POST /pipelines) returns no version or
+	// status; the human output must show the placeholder for those two fields
+	// specifically rather than a bare "0" / empty cell.
+	result := CreateResponse{
+		PipelineID: "p-2",
+		Name:       "Clone of wf",
+		Version:    0,
+		Status:     "",
+		Mode:       "draft",
+		TaskNames:  []string{"e1"},
+	}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderCreateResponse(outputformat.OutputFormatText, result))
+	})
+
+	got, ok := fieldValue(out, "Version:")
+	require.True(t, ok, "Version field must be rendered")
+	assert.Equal(t, emptyValuePlaceholder, got, "zero version must render as placeholder")
+
+	got, ok = fieldValue(out, "Status:")
+	require.True(t, ok, "Status field must be rendered")
+	assert.Equal(t, emptyValuePlaceholder, got, "empty status must render as placeholder")
+
+	// A populated field must NOT be turned into a placeholder.
+	got, ok = fieldValue(out, "Tasks:")
+	require.True(t, ok, "Tasks field must be rendered")
+	assert.Equal(t, "e1", got)
+}
+
+func TestRenderCreateResponse_Human_LockedKeepsValues(t *testing.T) {
+	// Guard the other direction: a locked pipeline with a real version/status
+	// must render those values verbatim, not the draft placeholder.
+	result := CreateResponse{
+		PipelineID: "p-9",
+		Name:       "locked_wf",
+		Version:    3,
+		Status:     "READY",
+		Mode:       "locked",
+	}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, RenderCreateResponse(outputformat.OutputFormatText, result))
+	})
+
+	got, _ := fieldValue(out, "Version:")
+	assert.Equal(t, "3", got)
+
+	got, _ = fieldValue(out, "Status:")
+	assert.Equal(t, "READY", got)
 }
 
 // ── RenderPipeline ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `dr pipeline clone <pipeline-id> [--name]`, mirroring the new pipelines-api endpoint `POST /api/v2/pipelines/{id}/clone`. Clones a pipeline into a new **draft**, copying its source code, description, latest input params, and assigned image. The name defaults to `Clone of <source name>` and is overridable via `--name`; the server auto-suffixes on collision so repeated clones never fail.

> Depended on the pipelines-api clone endpoint (datarobot/pipelines-api#234), which has now **merged** — this is ready to merge/release once it reaches the target environment.

## Changes

- **`internal/pipeline`**: `ClonePipeline(pipelineID, name)` → `POST .../clone` with a JSON body (`name` omitempty), mirroring `LockPipeline`.
- **`cmd/pipeline/clone`**: cobra subcommand following the **write-command** pattern — returns `fmt.Errorf("clone pipeline: %w", err)` and renders via `RenderCreateResponse`. No read-command friendly-404 handler, so JSON stdout is never corrupted (consistent with #707).
- **Tests**: `internal/pipeline/clone_test.go` (httptest: default name omits body key, `--name` override, 404) + `cmd/pipeline/clone/cmd_test.go` (JSON/human render, invalid-output + blank-name rejection).
- **`docs/commands/pipeline.md`**: clone row.

## Test

`go build ./...`, `go vet`, `gofmt` clean; `go test ./cmd/pipeline/clone/... ./internal/pipeline/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI and API client for a new write endpoint; no changes to auth or existing pipeline flows beyond registering a subcommand.
> 
> **Overview**
> Adds **`dr pipeline clone <pipeline-id>`** so users can duplicate an existing pipeline into a new **draft** via `POST /api/v2/pipelines/{id}/clone`, copying source, description, latest input, and image as described in the command help.
> 
> The client sends an optional **`--name`** in JSON (`name` omitted when unset so the API can default to `Clone of <source>`); whitespace-only `--name` is rejected locally. Success output reuses **`RenderCreateResponse`** (same shape as create/lock). The subcommand is registered under `dr pipeline`, includes auth, output format, and telemetry, and is documented in the pipeline command table.
> 
> **`internal/pipeline.ClonePipeline`** mirrors **`LockPipeline`**’s JSON POST pattern. Tests cover default vs override name, 404 handling, rendering, and flag validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc6277a1c7203eda22043fcf4f955a697c14d82b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
