### PR TITLE
fix(ci): swallow commit-status 403 on fork PR approvals

### DIFF
--- a/.github/workflows/image-on-pr-approval.yaml
+++ b/.github/workflows/image-on-pr-approval.yaml
@@ -107,9 +107,9 @@ jobs:
 
       # Best-effort: pull_request_review has no "_target" variant, so on a fork PR
       # GitHub silently caps GITHUB_TOKEN to read-only here regardless of the
-      # `permissions:` block above, and this call 403s. Swallow that so it doesn't
-      # mask the real build failure (from the "Build and push PR image" step) behind
-      # an unrelated unhandled-error stack trace.
+      # `permissions:` block above, and this call 403s. Swallow only that expected
+      # 403 so it doesn't mask the real build failure (from the "Build and push PR
+      # image" step) behind an unrelated stack trace; re-throw anything else.
       - name: Set commit status with image name
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -129,5 +129,9 @@ jobs:
                 target_url: `${context.payload.repository.html_url}/actions/runs/${context.runId}`,
               });
             } catch (err) {
-              core.warning(`Could not set commit status (expected for fork PRs, which get a read-only token here): ${err.message}`);
+              if (err.status === 403) {
+                core.warning(`Could not set commit status (expected for fork PRs, which get a read-only token here): ${err.message}`);
+              } else {
+                throw err;
+              }
             }

--- a/.github/workflows/image-on-pr-approval.yaml
+++ b/.github/workflows/image-on-pr-approval.yaml
@@ -105,20 +105,29 @@ jobs:
           tags: "${{ steps.tags.outputs.pr_tag }} ${{ steps.tags.outputs.immutable_tag }}"
           revision: ${{ needs.check-approval.outputs.sha }}
 
+      # Best-effort: pull_request_review has no "_target" variant, so on a fork PR
+      # GitHub silently caps GITHUB_TOKEN to read-only here regardless of the
+      # `permissions:` block above, and this call 403s. Swallow that so it doesn't
+      # mask the real build failure (from the "Build and push PR image" step) behind
+      # an unrelated unhandled-error stack trace.
       - name: Set commit status with image name
         if: always()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const success = '${{ steps.build.outcome }}' === 'success';
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ needs.check-approval.outputs.sha }}',
-              state: success ? 'success' : 'failure',
-              context: 'PR Image',
-              description: success
-                ? 'ghcr.io/datarobot-oss/cli:${{ steps.tags.outputs.pr_tag }}'
-                : 'Failed to publish PR image',
-              target_url: `${context.payload.repository.html_url}/actions/runs/${context.runId}`,
-            });
+            try {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: '${{ needs.check-approval.outputs.sha }}',
+                state: success ? 'success' : 'failure',
+                context: 'PR Image',
+                description: success
+                  ? 'ghcr.io/datarobot-oss/cli:${{ steps.tags.outputs.pr_tag }}'
+                  : 'Failed to publish PR image',
+                target_url: `${context.payload.repository.html_url}/actions/runs/${context.runId}`,
+              });
+            } catch (err) {
+              core.warning(`Could not set commit status (expected for fork PRs, which get a read-only token here): ${err.message}`);
+            }


### PR DESCRIPTION
# RATIONALE

Investigating https://github.com/datarobot-oss/cli/actions/runs/30467883388/job/90630326802?pr=686 (PR #686), which failed with two errors:

1. **Root cause (not fixed here):** the fork branch for PR #686 predates #701, which added `.github/actions/build-push-docker-image`. Checking out that PR's exact head SHA means the composite action doesn't exist yet at that commit, so `uses: ./.github/actions/build-push-docker-image` fails to resolve. This needs the PR author to rebase onto `main`, not a workflow fix.
2. **Masking bug (fixed here):** the `Set commit status with image name` step then itself throws an unhandled `403 Resource not accessible by integration` when calling `createCommitStatus`. `pull_request_review` has no `_target` variant, so on a fork PR GitHub silently caps `GITHUB_TOKEN` to read-only regardless of the job's `permissions:` block — this is an unavoidable GitHub limitation, not something fixable via permissions. The unhandled exception buries the real build failure under a second, unrelated stack trace.

## CHANGES

- Wrap the `createCommitStatus` call in `image-on-pr-approval.yaml` in try/catch, logging `core.warning` instead of throwing when the status write fails (expected for fork PRs).
- Add a comment explaining why this call is best-effort only.

## RELATED

- Surfaced by CI run on #686

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to error handling on an optional commit status step; no application or security logic affected.
> 
> **Overview**
> Makes the **PR Image** commit status step in `image-on-pr-approval.yaml` best-effort so fork PR approvals no longer fail the job when status writes are impossible.
> 
> On `pull_request_review`, GitHub keeps `GITHUB_TOKEN` read-only for fork PRs even with `statuses: write`, so `createCommitStatus` can return **403**. The workflow now wraps that call in **try/catch**, logs a **warning** for status **403** only, and rethrows other errors. A short comment documents why the step is not guaranteed to succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6840df1d9f695910e0ca39aead0c3641beee9d81. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->