### PR TITLE
[CFX-6318] fix(auth): open the browser instead of routing users to the terminal

### DIFF
--- a/cmd/auth/login/cmd.go
+++ b/cmd/auth/login/cmd.go
@@ -24,15 +24,14 @@ import (
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
-	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
 func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop
-	// short-circuit if skip_auth is enabled. This allows users to avoid login prompts
+	// short-circuit if skip-auth is enabled. This allows users to avoid login prompts
 	// when authentication is intentionally disabled, say if the user is offline, or in
 	// a CI/CD environment, or in a script.
-	if viperx.GetBool("skip_auth") {
+	if viperx.GetBool(config.SkipAuthKey) {
 		err := errors.New("Login has been disabled via the '--skip-auth' flag.")
 		log.Error(err)
 
@@ -77,16 +76,10 @@ func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop
 	// Clear existing token and get new one
 	viperx.Set(config.DataRobotAPIKey, "")
 
-	var key string
+	noBrowser, _ := cmd.Flags().GetBool("no-browser")
 
-	auth.PrintAuthInstructions(auth.AuthCallbackURL(datarobotHost))
-
-	err = tui.RunWithSpinner("Waiting for browser authorization…", func() error {
-		var waitErr error
-
-		key, waitErr = auth.WaitForAPIKeyCallback(cmd.Context(), datarobotHost)
-
-		return waitErr
+	key, err := auth.RunBrowserLoginWith(cmd.Context(), datarobotHost, auth.LoginOptions{
+		NoBrowser: noBrowser,
 	})
 	if err != nil {
 		log.Error(err)
@@ -115,17 +108,26 @@ func RunE(cmd *cobra.Command, args []string) error { //nolint: cyclop
 }
 
 func Cmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "login [url]",
-		Short: "🔐 Log in to DataRobot using OAuth authentication.",
-		Long: `Log in to DataRobot using OAuth authentication in your browser.
+		Short: "🔐 Log in to DataRobot in your browser.",
+		Long: `Log in to DataRobot by authorizing the CLI in your browser.
 
 This command will:
   1. Open your default browser.
   2. Redirect you to the DataRobot login page.
-  3. Securely store your API key for future CLI operations.`,
+  3. Securely store your API key for future CLI operations.
+
+If the browser cannot be opened, the CLI prints a link to open yourself. Pass
+--no-browser to skip the browser launch entirely, which is useful over SSH.`,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE:          RunE,
 	}
+
+	// Read directly from cobra rather than binding to viper: this is a transient
+	// per-invocation flag and must never be persisted to drconfig.yaml.
+	cmd.Flags().Bool("no-browser", false, "print the login link instead of opening a browser")
+
+	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -234,7 +234,7 @@ func init() {
 	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
 	RootCmd.PersistentFlags().Bool("debug", false, "debug output")
 	RootCmd.PersistentFlags().Bool("all-commands", false, "display all available commands and their flags in tree format")
-	RootCmd.PersistentFlags().Bool("skip-auth", false, "skip authentication checks (for advanced users)")
+	RootCmd.PersistentFlags().Bool(config.SkipAuthKey, false, "skip authentication checks (for advanced users)")
 	RootCmd.PersistentFlags().Bool("force-interactive", false, "force setup wizards to run even if already completed")
 	RootCmd.PersistentFlags().Duration("plugin-discovery-timeout", 2*time.Second, "timeout for plugin discovery (0s disables)")
 	RootCmd.PersistentFlags().Duration("plugin-update-check-interval", internalPlugin.DefaultUpdateCheckInterval, "cooldown between plugin update checks (0s disables)")
@@ -258,7 +258,7 @@ func init() {
 
 	// Non-universal flags: bound to viper only.
 	_ = viperx.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config"))
-	_ = viperx.BindPFlag("skip-auth", RootCmd.PersistentFlags().Lookup("skip-auth"))
+	_ = viperx.BindPFlag(config.SkipAuthKey, RootCmd.PersistentFlags().Lookup(config.SkipAuthKey))
 	_ = viperx.BindPFlag("force-interactive", RootCmd.PersistentFlags().Lookup("force-interactive"))
 	_ = viperx.BindPFlag("plugin-discovery-timeout", RootCmd.PersistentFlags().Lookup("plugin-discovery-timeout"))
 	_ = viperx.BindPFlag("plugin-update-check-interval", RootCmd.PersistentFlags().Lookup("plugin-update-check-interval"))

--- a/cmd/templates/setup/loginModel.go
+++ b/cmd/templates/setup/loginModel.go
@@ -16,27 +16,19 @@ package setup
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net"
-	"net/http"
 	"strings"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
-	"github.com/datarobot/cli/internal/assets"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
-	"github.com/datarobot/cli/internal/misc/open"
-	"github.com/datarobot/cli/tui"
 )
 
 type LoginModel struct {
 	loginMessage string
-	server       *http.Server
+	flow         *auth.BrowserFlow
 	APIKeyChan   chan string
 	err          error
 	GetHostCmd   tea.Cmd
@@ -46,114 +38,49 @@ type LoginModel struct {
 type errMsg struct{ error } //nolint: errname
 
 type startedMsg struct {
-	server  *http.Server
+	flow    *auth.BrowserFlow
 	message string
 }
 
-func startServer(apiKeyChan chan string, datarobotHost string) tea.Cmd {
+// startLogin binds the callback listener, opens the browser, and renders either
+// the "browser is opening" hint or, when the browser could not be launched, the
+// link the user has to follow by hand.
+func startLogin(datarobotHost string) tea.Cmd {
 	return func() tea.Msg {
-		addr := "localhost:51164"
-
-		mux := http.NewServeMux()
-		server := &http.Server{
-			Addr:              addr,
-			Handler:           mux,
-			ReadHeaderTimeout: 10 * time.Second,
-		}
-
-		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			apiKey := r.URL.Query().Get("key")
-
-			// Response to browser
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			_ = assets.Write(w, "templates/success.html")
-
-			apiKeyChan <- apiKey // send the key to the main goroutine
-		})
-
-		listen, err := net.Listen("tcp", addr)
+		flow, err := auth.NewBrowserFlow(datarobotHost)
 		if err != nil {
-			// close previous auth server if address already in use
-			resp, err := http.Get("http://" + addr)
-			if err == nil {
-				resp.Body.Close()
-			}
-
-			listen, err = net.Listen("tcp", addr)
-			if err != nil {
-				return errMsg{err}
-			}
+			return errMsg{err}
 		}
 
-		// Start the server in a goroutine
-		go func() {
-			err := server.Serve(listen)
-			if !errors.Is(err, http.ErrServerClosed) {
-				log.Errorf("Server error: %v\n", err)
-			}
-		}()
-
-		authURL := datarobotHost + "/account/developer-tools?cliRedirect=true"
-
-		// Style the URL
-		urlStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.AdaptiveColor{Light: "#6124DF", Dark: "#9D7EDF"}).
-			Underline(true).
-			Bold(true)
-
-		// Create styled frame for the auth URL - use dynamic width based on URL length
-		// Add padding for borders and internal padding (2 + 2 + 4 for border chars)
-		urlWidth := len(authURL) + 6
-		urlFrameStyle := lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.AdaptiveColor{Light: "#6124DF", Dark: "#9D7EDF"}).
-			Padding(1, 2).
-			Width(urlWidth)
-
-		styledURL := urlStyle.Render(authURL)
-		urlBox := urlFrameStyle.Render(styledURL)
-
-		hint := tui.BaseTextStyle.
-			Faint(true).
-			Render("💡 If your browser didn't open automatically, click or copy the link above")
-
-		message := lipgloss.JoinVertical(
-			lipgloss.Left,
-			"",
-			urlBox,
-			"",
-			hint,
-			"",
-		)
-
-		open.Open(authURL)
+		openErr := flow.OpenBrowser()
+		if openErr != nil {
+			log.Debugf("Could not open the browser automatically: %v", openErr)
+		}
 
 		return startedMsg{
-			server:  server,
-			message: message,
+			flow:    flow,
+			message: auth.RenderBrowserPrompt(flow.AuthURL(), auth.BrowserStateFor(openErr)),
 		}
 	}
 }
 
+// waitForAPIKey blocks on the callback and persists the key once it arrives.
 func (lm LoginModel) waitForAPIKey() tea.Cmd {
 	return func() tea.Msg {
-		// Wait for the key from the handler
-		apiKey := <-lm.APIKeyChan
+		defer func() {
+			if closeErr := lm.flow.Close(); closeErr != nil {
+				log.Debugf("%v", closeErr)
+			}
+		}()
 
-		// Now shut down the server after key is received
-		if err := lm.server.Shutdown(context.Background()); err != nil {
-			return errMsg{fmt.Errorf("Error during shutdown: %w", err)}
-		}
-
-		// empty apiKey means we need to interrupt current auth flow
-		if apiKey == "" {
-			return errMsg{errors.New("Interrupt request received.")}
+		apiKey, err := lm.flow.Wait(context.Background())
+		if err != nil {
+			return errMsg{err}
 		}
 
 		viperx.Set(config.DataRobotAPIKey, apiKey)
 
-		err := auth.WriteConfigFileSilent()
-		if err != nil {
+		if err := auth.WriteConfigFileSilent(); err != nil {
 			return errMsg{fmt.Errorf("Error during writing config file: %w", err)}
 		}
 
@@ -167,19 +94,20 @@ func (lm LoginModel) Init() tea.Cmd {
 		return lm.GetHostCmd
 	}
 
-	return startServer(lm.APIKeyChan, datarobotHost)
+	return startLogin(datarobotHost)
 }
 
 func (lm LoginModel) Update(msg tea.Msg) (LoginModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case startedMsg:
 		lm.loginMessage = msg.message
-		lm.server = msg.server
+		lm.flow = msg.flow
 
 		return lm, lm.waitForAPIKey()
 
 	case errMsg:
 		lm.err = msg
+
 		return lm, nil
 
 	default:
@@ -198,4 +126,17 @@ func (lm LoginModel) View() string {
 	}
 
 	return sb.String()
+}
+
+// Close releases the callback listener. It is safe to call before the flow has
+// started, which happens when the user presses Esc to change the DataRobot URL
+// while the login screen is still initialising.
+func (lm LoginModel) Close() {
+	if lm.flow == nil {
+		return
+	}
+
+	if err := lm.flow.Close(); err != nil {
+		log.Debugf("%v", err)
+	}
 }

--- a/cmd/templates/setup/loginModel.go
+++ b/cmd/templates/setup/loginModel.go
@@ -29,7 +29,6 @@ import (
 type LoginModel struct {
 	loginMessage string
 	flow         *auth.BrowserFlow
-	APIKeyChan   chan string
 	err          error
 	GetHostCmd   tea.Cmd
 	SuccessCmd   tea.Cmd

--- a/cmd/templates/setup/loginModel_test.go
+++ b/cmd/templates/setup/loginModel_test.go
@@ -110,7 +110,7 @@ func (suite *LoginModelTestSuite) TestLoginModel_Init_Press_1() {
 	suite.WaitFor(tm, "US Cloud")
 	// US Cloud is already selected by default (first item)
 	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-	suite.WaitFor(tm, "If your browser didn't open automatically")
+	suite.WaitFor(tm, "Didn't open? Use this link:")
 	suite.Send(tm, "esc")
 
 	suite.Quit(tm)
@@ -132,7 +132,7 @@ func (suite *LoginModelTestSuite) TestLoginModel_Init_Press_2() {
 	// Navigate down to EU Cloud (second item)
 	tm.Send(tea.KeyMsg{Type: tea.KeyDown})
 	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-	suite.WaitFor(tm, "If your browser didn't open automatically")
+	suite.WaitFor(tm, "Didn't open? Use this link:")
 	suite.Send(tm, "esc")
 
 	suite.Quit(tm)
@@ -155,7 +155,7 @@ func (suite *LoginModelTestSuite) TestLoginModel_Init_Press_3() {
 	tm.Send(tea.KeyMsg{Type: tea.KeyDown})
 	tm.Send(tea.KeyMsg{Type: tea.KeyDown})
 	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-	suite.WaitFor(tm, "If your browser didn't open automatically")
+	suite.WaitFor(tm, "Didn't open? Use this link:")
 	suite.Send(tm, "esc")
 
 	suite.Quit(tm)
@@ -187,7 +187,7 @@ func (suite *LoginModelTestSuite) TestLoginModel_Init_Custom_URL() {
 	}
 
 	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
-	suite.WaitFor(tm, "If your browser didn't open automatically")
+	suite.WaitFor(tm, "Didn't open? Use this link:")
 	suite.Send(tm, "esc")
 
 	suite.Quit(tm)

--- a/cmd/templates/setup/model.go
+++ b/cmd/templates/setup/model.go
@@ -300,7 +300,6 @@ func NewModel(fromStartCommand bool) Model {
 
 		hostModel: hostpicker.New(),
 		login: LoginModel{
-			APIKeyChan: make(chan string, 1),
 			GetHostCmd: getHost,
 			SuccessCmd: authSuccess,
 		},

--- a/cmd/templates/setup/model.go
+++ b/cmd/templates/setup/model.go
@@ -37,6 +37,7 @@ import (
 	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/internal/state"
 	"github.com/datarobot/cli/tui"
+	"github.com/datarobot/cli/tui/hostpicker"
 )
 
 type screens int
@@ -69,7 +70,7 @@ type Model struct {
 	fromStartCommand     bool // true if invoked from dr start
 	skipDotenvSetup      bool // true if dotenv setup was already completed
 	dotenvSetupCompleted bool // tracks if dotenv was actually run (for state update)
-	hostModel            HostModel
+	hostModel            hostpicker.Model
 	login                LoginModel
 	list                 list.Model
 	clone                clone.Model
@@ -297,7 +298,7 @@ func NewModel(fromStartCommand bool) Model {
 		width:           80,
 		isAuthenticated: false,
 
-		hostModel: NewHostModel(),
+		hostModel: hostpicker.New(),
 		login: LoginModel{
 			APIKeyChan: make(chan string, 1),
 			GetHostCmd: getHost,
@@ -485,7 +486,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		m.hostModel, cmd = m.hostModel.Update(msg)
 	case loginScreen:
 		if keyMsg, ok := msg.(tea.KeyMsg); ok && keyMsg.String() == "esc" {
-			m.login.server.Close()
+			m.login.Close()
 			// Reset authentication flag when user goes back to change URL
 			m.isAuthenticated = false
 			cmd = getHost
@@ -581,14 +582,13 @@ func (m Model) View() string { //nolint: cyclop
 			Bold(true).
 			Render("🔐 Connect Your DataRobot Account")
 
-		subtitle := tui.BaseTextStyle.
-			Render("Opening your browser to securely authenticate...")
-
+		// No "opening your browser" subtitle here: LoginModel knows whether the
+		// browser actually opened and says so itself, so this screen must not claim
+		// it did.
 		content := lipgloss.JoinVertical(
 			lipgloss.Left,
 			title,
 			"",
-			subtitle,
 			m.login.View(),
 			"",
 			tui.BaseTextStyle.Faint(true).Render("💡 Press Esc to change DataRobot URL"),

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -64,8 +64,12 @@ dr auth login
 ```bash
 $ dr auth login
 ⠋ Opening your browser to sign in to DataRobot…
+
   Didn't open? Use this link:
-  https://app.datarobot.com/account/developer-tools?cliRedirect=true
+
+  ╭────────────────────────────────────────────────────────────────────╮
+  │ https://app.datarobot.com/account/developer-tools?cliRedirect=true │
+  ╰────────────────────────────────────────────────────────────────────╯
 ```
 
 **Stored Credentials:**
@@ -76,19 +80,20 @@ $ dr auth login
 
 **Troubleshooting:**
 
-If the browser cannot be opened, the CLI says so and promotes the link, which you can
-open on any machine that can reach DataRobot:
+If the browser cannot be opened, the CLI says so and the link becomes the instruction
+rather than a footnote. The layout is otherwise identical, so the two paths read as the
+same command:
 
 ```bash
 $ dr auth login
-⚠ Couldn't open your browser automatically.
-Open this link to finish signing in:
-
-╭────────────────────────────────────────────────────────────────────╮
-│ https://app.datarobot.com/account/developer-tools?cliRedirect=true │
-╰────────────────────────────────────────────────────────────────────╯
-
 ⠋ Waiting for authorization…
+
+  ⚠ Couldn't open your browser automatically.
+  Open this link to finish signing in:
+
+  ╭────────────────────────────────────────────────────────────────────╮
+  │ https://app.datarobot.com/account/developer-tools?cliRedirect=true │
+  ╰────────────────────────────────────────────────────────────────────╯
 ```
 
 If another `dr` process is already waiting on `localhost:51164`, the new one asks it to
@@ -517,14 +522,17 @@ machine that can reach both DataRobot and this machine's `localhost:51164`. Use
 
 ```bash
 $ dr auth login --no-browser
-Open this link to finish signing in:
-
-╭────────────────────────────────────────────────────────────────────╮
-│ https://app.datarobot.com/account/developer-tools?cliRedirect=true │
-╰────────────────────────────────────────────────────────────────────╯
-
 ⠋ Waiting for authorization…
+
+  Open this link to finish signing in:
+
+  ╭────────────────────────────────────────────────────────────────────╮
+  │ https://app.datarobot.com/account/developer-tools?cliRedirect=true │
+  ╰────────────────────────────────────────────────────────────────────╯
 ```
+
+`--no-browser` is not reported as a failure: it shows the same framed link as the error
+path, without the warning line.
 
 Run with `--debug` to see why the launch failed.
 

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -196,13 +196,13 @@ common case is a single keystroke:
 ```text
   DataRobot Environment
 
-▶ 🇺🇸 US Cloud
+▶ 🌎 US Cloud
   https://app.datarobot.com
 
-  🇪🇺 EU Cloud
+  🌍 EU Cloud
   https://app.eu.datarobot.com
 
-  🇯🇵 Japan Cloud
+  🌏 Japan Cloud
   https://app.jp.datarobot.com
 
   🏢 Custom/On-Prem

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -10,7 +10,7 @@ For most users, authentication is a two-step process:
 # 1. Set your DataRobot instance URL
 dr auth set-url [YOUR_DATA_ROBOT_INSTANCE_URL] # e.g. https://app.datarobot.com
 
-# 2. Log in (opens browser for OAuth)
+# 2. Log in (opens your browser to authorize the CLI)
 dr auth login
 ```
 
@@ -33,49 +33,66 @@ The `auth` command provides authentication management for the DataRobot CLI. It 
 
 ### `login`
 
-Authenticate with DataRobot using OAuth (Open Authorization). This is the recommended way to authenticate as it's secure and doesn't require you to manually copy API keys.
+Authenticate by authorizing the CLI in your browser, so you never have to copy an API key by hand.
 
 ```bash
 dr auth login
 ```
 
+**Options:**
+
+| Flag           | Description                                                |
+| -------------- | ---------------------------------------------------------- |
+| `--no-browser` | Print the login link instead of opening a browser (useful over SSH) |
+
 **What happens:**
 
-1. The CLI starts a temporary local web server (typically on port 8080).
-2. Your default web browser opens to DataRobot's authorization page.
+1. The CLI starts a temporary local web server on `localhost:51164`.
+2. Your default web browser opens to DataRobot's developer tools page.
 3. You log in to DataRobot (if not already logged in) and authorize the CLI.
-4. DataRobot sends an API key back to the CLI.
-5. The CLI securely stores the API key in your configuration file.
+4. DataRobot redirects back to the local server with your API key.
+5. The CLI stores the API key in your configuration file.
 
 > [!NOTE]
-> OAuth is a secure authentication method that allows the CLI to access DataRobot on your behalf without you needing to manually manage API keys.
+> Despite the name, this is not an OAuth grant: there is no `client_id`, no PKCE, and
+> no authorization-code exchange. DataRobot returns the API key directly to the local
+> callback server. The port is fixed at `51164` because the web app's redirect target
+> is part of the contract, so there is no fallback port.
 
 **Example:**
 
 ```bash
 $ dr auth login
-Opening browser for authentication...
-Waiting for authentication...
-✓ Successfully authenticated!
+⠋ Opening your browser to sign in to DataRobot…
+  Didn't open? Use this link:
+  https://app.datarobot.com/account/developer-tools?cliRedirect=true
 ```
 
 **Stored Credentials:**
 
 - Location: `~/.config/datarobot/drconfig.yaml` (Linux/macOS) or `%USERPROFILE%\.config\datarobot\drconfig.yaml` (Windows)
-- Format: Encrypted API key
+- Format: plaintext YAML, written with `0600` (owner read/write only). The token is
+  **not** encrypted — treat the file as a secret.
 
 **Troubleshooting:**
 
-If your browser doesn't open automatically, the CLI will display a URL to visit manually. For example:
+If the browser cannot be opened, the CLI says so and promotes the link, which you can
+open on any machine that can reach DataRobot:
 
 ```bash
 $ dr auth login
-Failed to open browser automatically.
-Please visit: https://app.datarobot.com/oauth/authorize?client_id=...
+⚠ Couldn't open your browser automatically.
+Open this link to finish signing in:
 
-# Port already in use
-# The CLI will try alternative ports automatically
+╭────────────────────────────────────────────────────────────────────╮
+│ https://app.datarobot.com/account/developer-tools?cliRedirect=true │
+╰────────────────────────────────────────────────────────────────────╯
+
+⠋ Waiting for authorization…
 ```
+
+If another `dr` process is already waiting on `localhost:51164`, the new one asks it to
+release the port and takes over. The wait times out after 5 minutes.
 
 ### `logout`
 
@@ -167,32 +184,41 @@ dr auth set-url [url]
 
 **Interactive mode:**
 
-If you run `dr auth set-url` without providing a URL, the CLI enters interactive mode and guides you through selecting your DataRobot instance:
+If you run `dr auth set-url` without providing a URL, the CLI shows a picker. Move with
+the arrow keys, confirm with Enter, cancel with Esc. US Cloud is preselected, so the
+common case is a single keystroke:
 
-```bash
-$ dr auth set-url
-🌐 DataRobot URL Configuration
+```text
+  DataRobot Environment
 
-Choose your DataRobot environment:
+▶ 🇺🇸 US Cloud
+  https://app.datarobot.com
 
-┌────────────────────────────────────────────────────────┐
-│  [1] 🇺🇸 US Cloud        https://app.datarobot.com      │
-│  [2] 🇪🇺 EU Cloud        https://app.eu.datarobot.com   │
-│  [3] 🇯🇵 Japan Cloud     https://app.jp.datarobot.com   │
-│      🏢 Custom          Enter your custom URL          │
-└────────────────────────────────────────────────────────┘
+  🇪🇺 EU Cloud
+  https://app.eu.datarobot.com
 
-🔗 Don't know which one? Check your DataRobot login page URL.
+  🇯🇵 Japan Cloud
+  https://app.jp.datarobot.com
 
-Enter your choice:
+  🏢 Custom/On-Prem
+  Enter your custom DataRobot URL
 ```
 
-**Quick selection:**
+Choosing **Custom/On-Prem** opens a text field for a self-managed instance URL.
+
+**Non-interactive terminals:**
+
+When stdin is not a terminal, or `DATAROBOT_CLI_NON_INTERACTIVE` is set, the picker is
+replaced by a plain numbered prompt read from stdin, so redirected input and scripted
+runs keep working:
 
 - Enter `1` for US cloud (`https://app.datarobot.com`)
 - Enter `2` for EU cloud (`https://app.eu.datarobot.com`)
 - Enter `3` for Japan cloud (`https://app.jp.datarobot.com`)
 - Type your custom URL for self-managed instances
+
+Passing the URL as an argument (below) avoids the prompt entirely and is the best option
+for scripts.
 
 **Direct mode:**
 
@@ -317,27 +343,18 @@ $ dr auth login
 ### Debug authentication issues
 
 ```bash
-# Use verbose flag for details
-$ dr auth login --verbose
-[INFO] Starting OAuth server on port 8080
-[INFO] Opening browser to: https://app.datarobot.com/oauth/...
-[INFO] Waiting for callback...
-[INFO] Received authorization code
-[INFO] Exchanging code for token...
-[INFO] Token saved successfully
-✓ Successfully authenticated!
-
-# Use debug flag for even more details
+# Use debug flag for details
 $ dr auth login --debug
 [DEBUG] Config file: /Users/username/.config/datarobot/drconfig.yaml
 [DEBUG] Current URL: https://app.datarobot.com
-[DEBUG] Starting server on: 127.0.0.1:8080
+[DEBUG] Could not open the browser automatically: ...
+[DEBUG] Successfully consumed API key from callback request
 ...
 ```
 
 ## How authentication works
 
-The authentication process uses OAuth, a secure standard for authorization. Here's what happens behind the scenes:
+The CLI hands the browser off to DataRobot and waits on a local callback:
 
 ```text
 ┌──────────┐
@@ -347,45 +364,52 @@ The authentication process uses OAuth, a secure standard for authorization. Here
      │ dr auth login
      │
      v
-┌─────────────────┐       ┌──────────────┐
-│  Local Server   │◄──────┤   Browser    │
-│  (Port 8080)    │       │              │
-└────┬────────────┘       └──────▲───────┘
-     │                            │
-     │                            │ Opens
-     │                            │
-     v                            │
-┌─────────────────┐               │
-│  DataRobot      │───────────────┘
-│  OAuth Server   │
-└────┬────────────┘
+┌──────────────────────┐       ┌──────────────┐
+│  Local Server        │◄──────┤   Browser    │
+│  (localhost:51164)   │       │              │
+└────┬─────────────────┘       └──────▲───────┘
+     │                                 │
+     │                                 │ Opens
+     │                                 │
+     v                                 │
+┌──────────────────────┐               │
+│  DataRobot           │───────────────┘
+│  /account/           │
+│  developer-tools     │
+└────┬─────────────────┘
      │
-     │ Returns API Key
+     │ Redirects to localhost:51164/?key=<apiKey>
      │
      v
-┌─────────────────┐
-│  Config File    │
-│  (~/.config/    │
+┌──────────────────┐
+│  Config File     │
+│  (~/.config/     │
 │   datarobot/     │
 │   drconfig.yaml) │
-└─────────────────┘
+└──────────────────┘
 ```
 
 **Step-by-step:**
 
 1. You run `dr auth login`
-2. CLI starts a local server to receive the authorization response
-3. Your browser opens to DataRobot's login page
+2. CLI binds `localhost:51164` **before** opening the browser, so a fast redirect cannot
+   arrive before the listener exists
+3. Your browser opens to DataRobot's developer tools page
 4. You log in and authorize the CLI
-5. DataRobot sends an API key to the local server
-6. CLI saves the key securely to your config file
-7. Browser and server close automatically
+5. DataRobot redirects to `http://localhost:51164/?key=<apiKey>`
+6. CLI saves the key to your config file (mode `0600`) and shuts the server down
 
-This process is secure because:
+Properties of this flow:
 
-- You authenticate directly with DataRobot (not the CLI)
-- The API key is transmitted securely
-- No passwords are stored locally
+- You authenticate directly with DataRobot, never handing credentials to the CLI
+- No password is stored locally
+- The callback listener is bound to localhost only
+
+> [!IMPORTANT]
+> The API key arrives as a URL query parameter and is stored in plaintext. There is no
+> `state` parameter, so any local process able to reach `localhost:51164` while a login
+> is in flight could deliver a key. Treat `drconfig.yaml` as a secret and prefer
+> `DATAROBOT_API_TOKEN` in shared or automated environments.
 
 ## Configuration file
 
@@ -398,21 +422,27 @@ After authentication, credentials are stored in:
 
 **Format:**
 
-```yaml
-datarobot:
-  endpoint: https://app.datarobot.com
-  token: <encrypted_key>
+Keys are flat and top-level; there is no `datarobot:` or `preferences:` nesting:
 
-# User preferences
-preferences:
-  default_timeout: 30
-  verify_ssl: true
+```yaml
+endpoint: https://app.datarobot.com/api/v2
+token: <plaintext_api_key>
+api-consumer-tracking-enabled: true
 ```
+
+Only allowlisted keys are ever written back (see `config.PersistableKeys`), so transient
+flags such as `--yes` never leak into the file.
 
 **Permissions:**
 
-- File is created with restricted permissions (0600)
-- Only the user who created it can read/write
+- Created with, and tightened on every write to, `0600` — owner read/write only
+- The token is stored in plaintext, so the file permissions are the only thing
+  protecting it
+
+> [!NOTE]
+> CLI versions before this fix created the file with `0644`, leaving the token readable
+> by other users on the machine. Any `dr` command that writes credentials now corrects
+> the mode automatically; you can also run `chmod 600` yourself, as shown below.
 
 ## Security best practices
 
@@ -434,7 +464,7 @@ chmod 600 ~/.config/datarobot/drconfig.yaml
 >
 > - `~/.config/datarobot/drconfig.yaml`
 > - API keys
-> - OAuth tokens
+> - The contents of any `.env` file containing `DATAROBOT_API_TOKEN`
 
 ### Use per-environment authentication
 
@@ -481,21 +511,30 @@ export DATAROBOT_CLI_CONFIG=~/.config/datarobot/custom-config.yaml
 
 **Problem:** Browser fails to open automatically.
 
-**Solution:**
+**Solution:** The CLI detects this and shows the link in a box — open it yourself, on any
+machine that can reach both DataRobot and this machine's `localhost:51164`. Use
+`--no-browser` to skip the launch attempt entirely:
 
 ```bash
-# Copy the URL from the output and open manually
-$ dr auth login
-Failed to open browser automatically.
-Please visit: https://app.datarobot.com/oauth/authorize?...
+$ dr auth login --no-browser
+Open this link to finish signing in:
+
+╭────────────────────────────────────────────────────────────────────╮
+│ https://app.datarobot.com/account/developer-tools?cliRedirect=true │
+╰────────────────────────────────────────────────────────────────────╯
+
+⠋ Waiting for authorization…
 ```
+
+Run with `--debug` to see why the launch failed.
 
 ### Port already in use
 
-**Problem:** Port 8080 is already in use.
+**Problem:** `localhost:51164` is already in use.
 
-**Solution:**
-The CLI automatically tries alternative ports (8081, 8082, etc.)
+**Solution:** If the holder is another `dr` login, the new process asks it to release the
+port and takes over automatically. If an unrelated process holds it, free that port —
+there is no fallback, because the redirect target is fixed on the DataRobot side.
 
 ### Invalid credentials
 

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -8,17 +8,16 @@ The CLI provides a reusable authentication mechanism that you can use with any c
 
 ### PreRunE hook
 
-Use the `auth.EnsureAuthenticatedE(ctx)` function in your command's `PreRunE` hook.
+Use `auth.EnsureAuthenticatedE` as your command's `PreRunE` hook. It already has the
+`func(*cobra.Command, []string) error` shape Cobra expects, so assign it directly.
 
 ```go
-import "github.com/datarobot/cli/cmd/auth"
+import "github.com/datarobot/cli/internal/auth"
 
 var MyCmd = &cobra.Command{
-    Use:   "mycommand",
-    Short: "My command description",
-    PreRunE: func(cmd *cobra.Command, _ []string) error {
-        return auth.EnsureAuthenticatedE(cmd.Context())
-    },
+    Use:     "mycommand",
+    Short:   "My command description",
+    PreRunE: auth.EnsureAuthenticatedE,
     Run: func(_ *cobra.Command, _ []string) {
         // Command implementation
         // Authentication is guaranteed to be valid here
@@ -37,19 +36,22 @@ The hook functions are outlined below.
 
 ### Direct call for non-command code
 
-For code that isn't a Cobra command, you can use `auth.EnsureAuthenticated()` directly.
+For code that isn't a Cobra command, call `auth.EnsureAuthenticated(ctx)` directly.
 
 ```go
-import "github.com/datarobot/cli/cmd/auth"
+import "github.com/datarobot/cli/internal/auth"
 
-func MyFunction() error {
+func MyFunction(ctx context.Context) error {
     // Ensure valid authentication before proceeding.
-    if !auth.EnsureAuthenticated() {
+    if !auth.EnsureAuthenticated(ctx) {
         return errors.New("authentication failed")
     }
 
     // Continue with authenticated operations.
-    apiKey := config.GetAPIKey()
+    apiKey, err := config.GetAPIKey(ctx)
+    if err != nil {
+        return err
+    }
     // ... use apiKey for API calls
 
     return nil
@@ -109,7 +111,35 @@ The `--skip-auth` flag is intended for advanced scenarios such as:
 
 ## Manual login
 
-You can still manually run `dr auth login` to refresh credentials or change accounts. The `LoginAction()` function provides the interactive login experience with confirmation prompts for overwriting existing credentials.
+You can still run `dr auth login` to refresh credentials or change accounts. Both that
+command and the implicit login inside `EnsureAuthenticated` go through
+`auth.RunBrowserLogin`, so the two present identically.
+
+### Browser login internals
+
+`auth.BrowserFlow` (`internal/auth/browserflow.go`) owns the callback listener and splits
+the login into three steps, which is what lets the blocking CLI path and the bubbletea
+setup wizard share one implementation:
+
+```go
+flow, err := auth.NewBrowserFlow(host) // binds localhost:51164
+defer flow.Close()
+
+openErr := flow.OpenBrowser()          // best effort; report the link if non-nil
+key, err := flow.Wait(ctx)             // serves until the callback arrives
+```
+
+Two rules matter when changing this code:
+
+- **Bind before opening the browser.** `NewBrowserFlow` binds the listener so a fast
+  redirect cannot arrive before anything is listening.
+- **Never claim the browser opened without checking.** `open.Open` returns an error;
+  pass it through `auth.BrowserStateFor` and let `auth.RenderBrowserPrompt` choose the
+  wording. Telling users to watch for a browser that never opened is the bug CFX-6318
+  fixed.
+
+`auth.RunBrowserLoginWith` accepts `LoginOptions{NoBrowser: true}` for `--no-browser`,
+which renders the link prominently without reporting a failure.
 
 ## Internal APIs
 
@@ -121,10 +151,18 @@ into `drconfig.yaml`. Outside `internal/config/...`, all viper access
 goes through the `internal/config/viperx` wrapper. See
 [Configuration](configuration.md) for the full contract.
 
+`drconfig.yaml` holds the API token in plaintext, so `config.UpdateConfigFile` writes it
+with mode `0600` **and** chmods it on every write. The chmod is not redundant:
+`os.WriteFile` only applies its perm argument when it creates the file, so a config left
+at `0644` by an older CLI would otherwise stay world-readable forever.
+
 - `WriteConfigFileSilent()`&mdash;writes only allowlisted keys
   (`config.PersistableKeys`) back to `drconfig.yaml` and returns an error.
 - `WriteConfigFile()`&mdash;writes the config file, prints a success
   message, and returns an error.
-- `SetURLAction()`&mdash;prompts for a DataRobot URL, optionally
-  overwrites an existing value, and returns a boolean indicating whether
-  the URL changed.
+- `SetURLAction()`&mdash;asks for a DataRobot URL and returns whether it changed. On an
+  interactive terminal it runs the `tui/hostpicker` list; otherwise it falls back to a
+  plain-text stdin prompt so piped input and the expect-based smoke tests keep working.
+- `config.SkipAuthKey`&mdash;the viper key for `--skip-auth`. Use the constant at every
+  bind and read site: viper does not treat `-` and `_` as equivalent for lookups, and
+  reading `"skip_auth"` silently ignored the bound flag.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -210,16 +210,23 @@ func WriteConfigFile() error {
 	return nil
 }
 
+// printSetURLPrompt draws the non-interactive environment menu.
+//
+// The region icons are the single-codepoint globes from tui/hostpicker rather
+// than country flags: a flag is a regional-indicator pair that Windows paints as
+// two letter boxes (4 columns) while every width calculation says 2, which both
+// hides the icon and knocks this hand-aligned box out of true. See the comment on
+// hostpicker's icon constants.
 func printSetURLPrompt() {
 	fmt.Println("🌐 DataRobot URL Configuration")
 	fmt.Println("")
 	fmt.Println("Choose your DataRobot environment:")
 	fmt.Println("")
 	fmt.Println("┌────────────────────────────────────────────────────────┐")
-	fmt.Println("│  [1] 🇺🇸 US Cloud        https://app.datarobot.com      │")
-	fmt.Println("│  [2] 🇪🇺 EU Cloud        https://app.eu.datarobot.com   │")
-	fmt.Println("│  [3] 🇯🇵 Japan Cloud     https://app.jp.datarobot.com   │")
-	fmt.Println("│      🏢 Custom          Enter your custom URL          │")
+	fmt.Printf("│  [1] %s US Cloud        https://app.datarobot.com      │\n", hostpicker.USRegionIcon)
+	fmt.Printf("│  [2] %s EU Cloud        https://app.eu.datarobot.com   │\n", hostpicker.EURegionIcon)
+	fmt.Printf("│  [3] %s Japan Cloud     https://app.jp.datarobot.com   │\n", hostpicker.JPRegionIcon)
+	fmt.Printf("│      %s Custom          Enter your custom URL          │\n", hostpicker.CustomRegionIcon)
 	fmt.Println("└────────────────────────────────────────────────────────┘")
 	fmt.Println("")
 	fmt.Println("🔗 Don't know which one? Check your DataRobot login page URL in your browser.")

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -18,38 +18,26 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
-	"net/http"
 	"os"
 	"strings"
-	"time"
+	"testing"
 
-	"github.com/datarobot/cli/internal/assets"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
-	"github.com/datarobot/cli/internal/misc/open"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/tui"
+	"github.com/datarobot/cli/tui/hostpicker"
 	"github.com/spf13/cobra"
 )
 
 // APIKeyCallbackFunc is a variable that holds the function for retrieving API keys.
 // This can be overridden in tests to mock the browser-based authentication flow.
-var APIKeyCallbackFunc = WaitForAPIKeyCallback
+var APIKeyCallbackFunc = RunBrowserLogin
 
 // AuthCallbackURL returns the DataRobot URL the user must visit to authorize the CLI.
 func AuthCallbackURL(datarobotHost string) string {
 	return datarobotHost + "/account/developer-tools?cliRedirect=true"
-}
-
-// PrintAuthInstructions prints the message instructing the user to visit the
-// given auth URL. It must be called before any TUI/bubbletea program starts
-// rendering, otherwise the output will be garbled or hidden.
-func PrintAuthInstructions(authURL string) {
-	fmt.Println("\n\nPlease visit this link to connect your DataRobot credentials to the CLI")
-	fmt.Println("(If you're prompted to log in, you may need to re-enter this URL):")
-	fmt.Printf("%s\n\n", authURL)
 }
 
 // ErrEnvCredentialsNotSet is returned when environment credentials are not fully configured.
@@ -111,7 +99,7 @@ func EnsureAuthenticatedE(cmd *cobra.Command, _ []string) error {
 // triggers the login flow automatically. Returns true if authentication
 // is valid or was successfully obtained.
 func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
-	if viperx.GetBool("skip_auth") {
+	if viperx.GetBool(config.SkipAuthKey) {
 		log.Warn("Authentication checks are disabled via the '--skip-auth' flag. This may cause API calls to fail.")
 
 		return true
@@ -180,8 +168,6 @@ func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
 	// Auto-retrieve new credentials without prompting
 	viperx.Set(config.DataRobotAPIKey, "")
 
-	PrintAuthInstructions(AuthCallbackURL(datarobotHost))
-
 	key, err := APIKeyCallbackFunc(ctx, datarobotHost)
 	if err != nil {
 		log.Error("Failed to retrieve API key.", "error", err)
@@ -199,74 +185,6 @@ func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
 	log.Info("Authentication successful")
 
 	return true
-}
-
-func WaitForAPIKeyCallback(ctx context.Context, datarobotHost string) (string, error) {
-	addr := "localhost:51164"
-	apiKeyChan := make(chan string, 1) // If we don't have a buffer of 1, this may hang.
-
-	mux := http.NewServeMux()
-	server := &http.Server{
-		Addr:              addr,
-		Handler:           mux,
-		ReadHeaderTimeout: 10 * time.Second,
-	}
-
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		apiKey := r.URL.Query().Get("key")
-
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_ = assets.Write(w, "templates/success.html")
-
-		apiKeyChan <- apiKey // send the key to the main goroutine
-	})
-
-	listen, err := net.Listen("tcp", addr)
-	if err != nil {
-		// close previous auth server if address already in use
-		resp, err := http.Get("http://" + addr)
-		if err == nil {
-			resp.Body.Close()
-		}
-
-		listen, err = net.Listen("tcp", addr)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	// Start the server in a goroutine
-	authURL := AuthCallbackURL(datarobotHost)
-
-	go func() {
-		open.Open(authURL)
-
-		err := server.Serve(listen)
-		if err != http.ErrServerClosed {
-			log.Errorf("Server error: %v\n", err)
-		}
-	}()
-
-	select {
-	// Wait for the key from the handler
-	case apiKey := <-apiKeyChan:
-		// Now shut down the server after key is received
-		if err := server.Shutdown(ctx); err != nil {
-			return "", fmt.Errorf("Error during shutdown: %w", err)
-		}
-
-		// empty apiKey means we need to interrupt current auth flow
-		if apiKey == "" {
-			return "", errors.New("Interrupt request received.")
-		}
-
-		log.Debug("Successfully consumed API key from API request")
-
-		return apiKey, nil
-	case <-ctx.Done():
-		log.Debug("Ctrl-C received, exiting auth wait")
-		return "", errors.New("Interrupt request received.")
-	}
 }
 
 func WriteConfigFileSilent() error {
@@ -326,44 +244,137 @@ func askForNewHost() bool {
 	return strings.ToLower(strings.TrimSpace(selectedOption)) == "y"
 }
 
+// SetURLAction asks the user which DataRobot environment to use and stores the
+// answer. It reports whether the configured URL changed.
+//
+// On an interactive terminal this is a TUI list (arrow keys plus Enter, US Cloud
+// preselected). On a terminal with DATAROBOT_CLI_NON_INTERACTIVE set it falls back
+// to the plain-text numbered prompt, which is what the expect based smoke tests
+// drive - they spawn a PTY and set that variable. With no terminal at all there is
+// nothing to prompt, so it prints the non-interactive instructions and gives up.
 func SetURLAction() bool {
+	// Every path below reads stdin, askForNewHost's overwrite prompt included, so
+	// this has to come first. Without a terminal no answer is coming: on Windows
+	// cancelreader discards a redirected stdin in favour of the real console and
+	// then blocks forever waiting for keystrokes. See internal/misc/reader.
 	if !reader.IsStdinTerminal() {
-		log.Error("No DataRobot URL configured and no terminal available to prompt for one. " +
-			"Run 'dr auth set-url <url>' or set DATAROBOT_ENDPOINT to configure it non-interactively.")
+		printURLUnchanged()
 
 		return false
 	}
 
-	if askForNewHost() {
-		for {
-			printSetURLPrompt()
+	if !askForNewHost() {
+		printURLUnchanged()
 
-			url, err := reader.ReadString()
-			if err != nil || url == "" {
-				break
-			}
-
-			err = config.SetURLToConfig(url)
-			if err != nil {
-				if errors.Is(err, config.ErrInvalidURL) {
-					fmt.Print("\nInvalid URL provided. Verify your URL and try again.\n\n")
-					continue
-				}
-
-				log.Error(err)
-
-				break
-			}
-
-			fmt.Println("Thank you for providing the URL. Validating it and retrieving your API key...")
-
-			return true
-		}
+		return false
 	}
 
-	fmt.Println("Exiting without changing the DataRobot URL.")
+	if interactiveURLPickerAvailable() {
+		return selectURLInteractively()
+	}
+
+	return readURLFromStdin()
+}
+
+// interactiveURLPickerAvailable reports whether the TUI picker can be shown.
+//
+// The testing.Testing() guard matches internal/misc/open: `go test` normally hands
+// the binary /dev/null for stdin, but under a PTY it would not, and a test that
+// launched the real picker would block until the suite timed out.
+func interactiveURLPickerAvailable() bool {
+	if testing.Testing() {
+		return false
+	}
+
+	return reader.IsStdinTerminal() && !reader.IsNonInteractive()
+}
+
+// selectURLInteractively runs the TUI environment picker.
+func selectURLInteractively() bool {
+	for {
+		url, ok, err := hostpicker.Select()
+		if err != nil {
+			log.Error("Failed to show the environment picker.", "error", err)
+			printURLUnchanged()
+
+			return false
+		}
+
+		if !ok {
+			// The user pressed Esc or Ctrl-C.
+			printURLUnchanged()
+
+			return false
+		}
+
+		err = config.SetURLToConfig(url)
+		if err == nil {
+			return true
+		}
+
+		if errors.Is(err, config.ErrInvalidURL) {
+			fmt.Println(tui.ErrorStyle.Render("Invalid URL provided. Verify your URL and try again."))
+
+			continue
+		}
+
+		log.Error(err)
+		printURLUnchanged()
+
+		return false
+	}
+}
+
+// readURLFromStdin is the non-interactive fallback: a numbered prompt read from
+// stdin, so DATAROBOT_CLI_NON_INTERACTIVE and the expect-based smoke tests keep
+// working.
+func readURLFromStdin() bool {
+	for {
+		printSetURLPrompt()
+
+		// reader.ReadString strips the newline, so an empty answer is "" - testing
+		// for "\n" here would send it to SetURLToConfig and loop on "Invalid URL".
+		url, err := reader.ReadString()
+		if err != nil || url == "" {
+			break
+		}
+
+		err = config.SetURLToConfig(url)
+		if err != nil {
+			if errors.Is(err, config.ErrInvalidURL) {
+				fmt.Print("\nInvalid URL provided. Verify your URL and try again.\n\n")
+				continue
+			}
+
+			log.Error(err)
+
+			break
+		}
+
+		fmt.Println("Thank you for providing the URL. Validating it and retrieving your API key...")
+
+		return true
+	}
+
+	printURLUnchanged()
 
 	return false
+}
+
+// printURLUnchanged explains that nothing was configured and how to proceed.
+//
+// The bare "Exiting without changing the DataRobot URL." this replaces left users
+// with no next step, which is especially unhelpful when the cause was redirected
+// stdin rather than a deliberate cancel.
+func printURLUnchanged() {
+	fmt.Println(tui.BaseTextStyle.Render("No DataRobot URL was configured."))
+	fmt.Print(tui.BaseTextStyle.Render("Set one non-interactively with "))
+	fmt.Println(tui.InfoStyle.Render("dr auth set-url <url>"))
+	fmt.Print(tui.BaseTextStyle.Render("or export "))
+	fmt.Print(tui.InfoStyle.Render("DATAROBOT_ENDPOINT"))
+	fmt.Print(tui.BaseTextStyle.Render(" and "))
+	fmt.Print(tui.InfoStyle.Render("DATAROBOT_API_TOKEN"))
+	fmt.Println(tui.BaseTextStyle.Render(" to skip the login entirely."))
 }
 
 func GetBaseURLOrAsk() string {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -368,14 +368,25 @@ func readURLFromStdin() bool {
 	return false
 }
 
-// printURLUnchanged explains that nothing was configured and how to proceed.
+// printURLUnchanged explains that the configured URL was left as it is and how to
+// proceed non-interactively.
 //
 // The bare "Exiting without changing the DataRobot URL." this replaces left users
 // with no next step, which is especially unhelpful when the cause was redirected
-// stdin rather than a deliberate cancel.
+// stdin rather than a deliberate cancel. The first line depends on whether a URL is
+// already configured: callers get here either because nothing was ever set or
+// because the user kept what was there (declining the overwrite prompt, cancelling
+// the picker), and "nothing configured" would be wrong in the latter case.
 func printURLUnchanged() {
-	fmt.Println(tui.BaseTextStyle.Render("No DataRobot URL was configured."))
-	fmt.Print(tui.BaseTextStyle.Render("Set one non-interactively with "))
+	if current := config.GetBaseURL(); len(current) > 0 {
+		fmt.Print(tui.BaseTextStyle.Render("Keeping the current DataRobot URL "))
+		fmt.Println(tui.InfoStyle.Render(current))
+		fmt.Print(tui.BaseTextStyle.Render("Change it non-interactively with "))
+	} else {
+		fmt.Println(tui.BaseTextStyle.Render("No DataRobot URL was configured."))
+		fmt.Print(tui.BaseTextStyle.Render("Set one non-interactively with "))
+	}
+
 	fmt.Println(tui.InfoStyle.Render("dr auth set-url <url>"))
 	fmt.Print(tui.BaseTextStyle.Render("or export "))
 	fmt.Print(tui.InfoStyle.Render("DATAROBOT_ENDPOINT"))

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -165,8 +165,8 @@ func TestEnsureAuthenticated_SkipAuth(t *testing.T) {
 	_, cleanup := setupTestEnvironment(t)
 	defer cleanup()
 
-	// Set skip_auth flag to true
-	viperx.Set("skip_auth", true)
+	// Set the skip-auth flag to true
+	viperx.Set(config.SkipAuthKey, true)
 
 	// Don't set any credentials
 	viperx.Set(config.DataRobotAPIKey, "")

--- a/internal/auth/browserflow.go
+++ b/internal/auth/browserflow.go
@@ -1,0 +1,317 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/datarobot/cli/internal/assets"
+	"github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/misc/open"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/tui"
+)
+
+// CallbackAddr is the address the DataRobot web app redirects back to after the
+// user authorizes the CLI. The port is part of the contract with the web app's
+// cliRedirect handler, so it cannot be changed unilaterally and has no fallback.
+const CallbackAddr = "localhost:51164"
+
+// DefaultLoginTimeout bounds how long the CLI waits for the browser callback.
+// Generous enough to cover an SSO round trip, short enough that a browser which
+// never opened does not hang the terminal indefinitely.
+const DefaultLoginTimeout = 5 * time.Minute
+
+// ErrLoginInterrupted is returned when the user aborts the login (Ctrl-C) or
+// another CLI process takes over the callback port.
+var ErrLoginInterrupted = errors.New("login was interrupted")
+
+// BrowserFlow owns the local HTTP listener that receives the API key after the
+// user authorizes the CLI in their browser.
+//
+// The three steps are deliberately separate so that both the blocking CLI path
+// and the bubbletea setup wizard can drive them from their own control flow:
+//
+//	flow, err := NewBrowserFlow(host)  // binds the listener
+//	defer flow.Close()
+//	openErr := flow.OpenBrowser()      // best effort; report the link if non-nil
+//	key, err := flow.Wait(ctx)         // serves until the callback arrives
+//
+// Binding before opening the browser matters: the listener must already exist
+// when the browser follows the redirect, otherwise a fast redirect races the
+// CLI and the callback is refused.
+type BrowserFlow struct {
+	authURL  string
+	listener net.Listener
+	server   *http.Server
+	keyCh    chan string
+	timeout  time.Duration
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// NewBrowserFlow binds the callback listener and prepares the browser login for
+// datarobotHost. The caller must Close the returned flow.
+func NewBrowserFlow(datarobotHost string) (*BrowserFlow, error) {
+	return newBrowserFlowOn(CallbackAddr, datarobotHost)
+}
+
+// newBrowserFlowOn is NewBrowserFlow with a configurable address so tests can
+// bind an ephemeral port instead of competing for the fixed production one.
+func newBrowserFlowOn(addr, datarobotHost string) (*BrowserFlow, error) {
+	listener, err := listenReclaimingPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	flow := &BrowserFlow{
+		authURL:  AuthCallbackURL(datarobotHost),
+		listener: listener,
+		keyCh:    make(chan string, 1),
+		timeout:  DefaultLoginTimeout,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", flow.handleCallback)
+
+	flow.server = &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	return flow, nil
+}
+
+// AuthURL is the DataRobot URL the user must visit to authorize the CLI.
+func (f *BrowserFlow) AuthURL() string {
+	return f.authURL
+}
+
+// localAddr reports the address the listener actually bound, which differs from
+// CallbackAddr only in tests.
+func (f *BrowserFlow) localAddr() string {
+	return f.listener.Addr().String()
+}
+
+// OpenBrowser launches the auth URL in the user's default browser.
+//
+// A non-nil error means the browser did not open and the caller must show the
+// user the link instead; it is never fatal to the login itself, because the user
+// can always follow the link by hand.
+func (f *BrowserFlow) OpenBrowser() error {
+	return open.Open(f.authURL)
+}
+
+// Wait serves the callback endpoint until the API key arrives, the user
+// interrupts, or DefaultLoginTimeout elapses.
+func (f *BrowserFlow) Wait(ctx context.Context) (string, error) {
+	go func() {
+		err := f.server.Serve(f.listener)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Debugf("Auth callback server stopped: %v", err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(ctx, f.timeout)
+	defer cancel()
+
+	select {
+	case apiKey := <-f.keyCh:
+		// An empty key is the sentinel another CLI process uses to ask us to give
+		// up the callback port.
+		if apiKey == "" {
+			return "", ErrLoginInterrupted
+		}
+
+		log.Debug("Successfully consumed API key from callback request")
+
+		return apiKey, nil
+
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return "", fmt.Errorf("timed out after %s waiting for browser authorization: %w", f.timeout, ctx.Err())
+		}
+
+		log.Debug("Login context cancelled, exiting auth wait")
+
+		return "", ErrLoginInterrupted
+	}
+}
+
+// Close shuts the callback server down. It is safe to call more than once.
+func (f *BrowserFlow) Close() error {
+	f.closeOnce.Do(func() {
+		// A fresh context: the login context is typically already cancelled by the
+		// time we get here (Ctrl-C), and Shutdown on a cancelled context would skip
+		// draining the in-flight response that renders the success page.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := f.server.Shutdown(ctx); err != nil {
+			f.closeErr = fmt.Errorf("failed to shut down auth callback server: %w", err)
+		}
+	})
+
+	return f.closeErr
+}
+
+// handleCallback receives the redirect from the DataRobot web app, which carries
+// the API key as the "key" query parameter.
+func (f *BrowserFlow) handleCallback(w http.ResponseWriter, r *http.Request) {
+	apiKey := r.URL.Query().Get("key")
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	if err := assets.Write(w, "templates/success.html"); err != nil {
+		log.Debugf("Failed to render auth success page: %v", err)
+	}
+
+	// Non-blocking: the channel holds one key and Wait may already have returned.
+	// A stray extra callback must not park this handler goroutine forever.
+	select {
+	case f.keyCh <- apiKey:
+	default:
+		log.Debug("Discarding duplicate auth callback; a key was already received")
+	}
+}
+
+// LoginOptions tunes the interactive browser login.
+type LoginOptions struct {
+	// NoBrowser skips launching a browser and shows the link instead. Useful over
+	// SSH or anywhere the CLI cannot reach a usable browser.
+	NoBrowser bool
+}
+
+// RunBrowserLogin opens the browser, tells the user what is happening, and blocks
+// until the DataRobot web app hands the API key back to the local listener.
+//
+// This is the single entry point for interactive login: both `dr auth login` and
+// the implicit login triggered by EnsureAuthenticated go through it, so the two
+// look the same. It binds the listener before opening the browser and only shows
+// the link as a fallback, which is the whole point of CFX-6318 - the browser is
+// the action being taken, not an instruction for the user to follow by hand.
+func RunBrowserLogin(ctx context.Context, datarobotHost string) (string, error) {
+	return RunBrowserLoginWith(ctx, datarobotHost, LoginOptions{})
+}
+
+// RunBrowserLoginWith is RunBrowserLogin with explicit options.
+func RunBrowserLoginWith(ctx context.Context, datarobotHost string, opts LoginOptions) (string, error) {
+	flow, err := NewBrowserFlow(datarobotHost)
+	if err != nil {
+		return "", err
+	}
+
+	// Close intentionally uses its own context rather than ctx: by the time we unwind
+	// here ctx is usually already cancelled, and Shutdown on a cancelled context would
+	// abandon the in-flight response that renders the success page in the browser.
+	defer func() { //nolint:contextcheck // Close is deliberately detached from ctx
+		if closeErr := flow.Close(); closeErr != nil {
+			log.Debugf("%v", closeErr)
+		}
+	}()
+
+	// The browser state drives the wording: when no browser opened, the link stops
+	// being a footnote and becomes the primary instruction.
+	state := BrowserSkipped
+
+	if !opts.NoBrowser {
+		openErr := flow.OpenBrowser()
+		if openErr != nil {
+			log.Debugf("Could not open the browser automatically: %v", openErr)
+		}
+
+		state = BrowserStateFor(openErr)
+	}
+
+	// RunWithSpinner renders "<spinner> <label>", and the label may span lines, so
+	// the prompt block rides along beneath the spinner without a second component.
+	label := SpinnerLabel(state) + RenderBrowserPrompt(flow.AuthURL(), state)
+
+	var apiKey string
+
+	wait := func() error {
+		var waitErr error
+
+		apiKey, waitErr = flow.Wait(ctx)
+
+		return waitErr
+	}
+
+	// tui.RunWithSpinner drops the label entirely when stdin is not a terminal, which
+	// would leave a piped or redirected invocation waiting in silence with no link to
+	// follow. Print it ourselves in that case; the animated spinner is only useful on
+	// a real terminal anyway.
+	if !reader.IsStdinTerminal() {
+		fmt.Fprintln(os.Stderr, label)
+
+		err = wait()
+	} else {
+		err = tui.RunWithSpinner(label, wait)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return apiKey, nil
+}
+
+// listenReclaimingPort binds addr, first asking any auth server left over from a
+// previous CLI run to release it.
+//
+// A keyless GET to the callback endpoint is the interrupt sentinel: the stale
+// process sees an empty key, aborts its own wait, and closes its listener.
+func listenReclaimingPort(addr string) (net.Listener, error) {
+	listener, listenErr := net.Listen("tcp", addr)
+	if listenErr == nil {
+		return listener, nil
+	}
+
+	log.Debugf("Auth callback port %s is busy, asking the previous process to release it", addr)
+
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	resp, err := client.Get("http://" + addr) //nolint:noctx // bounded by the client timeout
+	if err != nil {
+		log.Debugf("No auth server responded on %s: %v", addr, err)
+	} else {
+		_ = resp.Body.Close()
+	}
+
+	// The stale process needs a moment to unwind its wait and close the listener.
+	for attempt := range 10 {
+		listener, err := net.Listen("tcp", addr)
+		if err == nil {
+			return listener, nil
+		}
+
+		if attempt < 9 {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+
+	// Report the original failure, which describes why the port was unavailable in
+	// the first place, rather than the last retry's identical error.
+	return nil, fmt.Errorf("auth callback port %s is already in use: %w", addr, listenErr)
+}

--- a/internal/auth/browserflow.go
+++ b/internal/auth/browserflow.go
@@ -231,6 +231,15 @@ func RunBrowserLoginWith(ctx context.Context, datarobotHost string, opts LoginOp
 		}
 	}()
 
+	return runLoginWithFlow(ctx, flow, opts)
+}
+
+// runLoginWithFlow drives a flow whose listener is already bound: it opens the
+// browser, shows the user the link, and waits for the callback.
+//
+// Split out from RunBrowserLoginWith so tests can drive a flow on an ephemeral port
+// instead of competing for the fixed production one.
+func runLoginWithFlow(ctx context.Context, flow *BrowserFlow, opts LoginOptions) (string, error) {
 	// The browser state drives the wording: when no browser opened, the link stops
 	// being a footnote and becomes the primary instruction.
 	state := BrowserSkipped
@@ -258,12 +267,20 @@ func RunBrowserLoginWith(ctx context.Context, datarobotHost string, opts LoginOp
 		return waitErr
 	}
 
-	// tui.RunWithSpinner drops the label entirely when stdin is not a terminal, which
-	// would leave a piped or redirected invocation waiting in silence with no link to
-	// follow. Print it ourselves in that case; the animated spinner is only useful on
-	// a real terminal anyway.
-	if !reader.IsStdinTerminal() {
-		fmt.Fprintln(os.Stderr, label)
+	var err error
+
+	// The link is what this command exists to produce, so it goes to stdout - where
+	// the animated spinner renders its own copy (tui.Run hands bubbletea os.Stdout)
+	// and where callers that redirect the streams separately look for it. The Windows
+	// smoke test is one such caller; the expect-based Linux and macOS ones cannot tell
+	// the difference, because a PTY merges stdout and stderr.
+	//
+	// Printing it here rather than leaving it to tui.RunWithSpinner, which only shows
+	// the label while it animates: it drops the label outright without a terminal, and
+	// diverts it to stderr under DATAROBOT_CLI_NON_INTERACTIVE. Neither leaves the
+	// link on stdout, and the spinner is no use in either case anyway.
+	if !reader.IsStdinTerminal() || reader.IsNonInteractive() {
+		fmt.Fprintln(os.Stdout, label)
 
 		err = wait()
 	} else {

--- a/internal/auth/browserflow_test.go
+++ b/internal/auth/browserflow_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -256,4 +257,77 @@ func TestBrowserFlow_OpenBrowserIsNoOpUnderTest(t *testing.T) {
 
 func TestErrLoginInterrupted_IsNotDeadlineExceeded(t *testing.T) {
 	assert.NotErrorIs(t, ErrLoginInterrupted, context.DeadlineExceeded)
+}
+
+// captureStdoutStderr runs fn with both standard streams replaced by pipes and
+// returns what each received.
+//
+// The streams are swapped rather than injected because the login prompt is written
+// through os.Stdout/os.Stderr directly, which is the behaviour under test: the
+// Windows smoke test reads the two streams as separate files, so which one the link
+// lands on is a contract, not an implementation detail.
+func captureStdoutStderr(t *testing.T, fn func()) (stdout, stderr string) {
+	t.Helper()
+
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+
+	errR, errW, err := os.Pipe()
+	require.NoError(t, err)
+
+	oldOut, oldErr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = outW, errW
+
+	defer func() {
+		os.Stdout, os.Stderr = oldOut, oldErr
+	}()
+
+	// Drain concurrently: a prompt larger than the pipe buffer would otherwise block
+	// fn forever.
+	outCh, errCh := make(chan string, 1), make(chan string, 1)
+
+	go func() { outCh <- readAll(outR) }()
+	go func() { errCh <- readAll(errR) }()
+
+	fn()
+
+	require.NoError(t, outW.Close())
+	require.NoError(t, errW.Close())
+
+	return <-outCh, <-errCh
+}
+
+func readAll(r io.Reader) string {
+	b, _ := io.ReadAll(r)
+
+	return string(b)
+}
+
+// TestRunLoginWithFlow_PrintsLinkToStdout pins which stream carries the login link
+// when there is no terminal to animate a spinner on.
+//
+// It has to be stdout. The Windows smoke test launches `dr auth login` with
+// Start-Process, redirects the two streams to separate files, and polls only the
+// stdout one for "cliRedirect=true" - so a link on stderr fails the test while
+// looking correct to anyone watching a terminal. The expect-based Linux and macOS
+// tests cannot catch this: a PTY merges both streams into one.
+func TestRunLoginWithFlow_PrintsLinkToStdout(t *testing.T) {
+	flow := newTestFlow(t)
+
+	// Already cancelled, so Wait returns at once instead of holding the test for the
+	// full login timeout. The prompt is printed before the wait either way.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stdout, stderr := captureStdoutStderr(t, func() {
+		_, err := runLoginWithFlow(ctx, flow, LoginOptions{NoBrowser: true})
+		assert.ErrorIs(t, err, ErrLoginInterrupted)
+	})
+
+	assert.Contains(t, stdout, "cliRedirect=true",
+		"the smoke test polls stdout for this substring")
+	assert.Contains(t, stdout, flow.AuthURL(),
+		"the whole link must reach stdout unbroken")
+	assert.NotContains(t, stderr, "cliRedirect=true",
+		"the link must not be diverted to stderr, where redirected callers miss it")
 }

--- a/internal/auth/browserflow_test.go
+++ b/internal/auth/browserflow_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestFlow binds a flow on an ephemeral port so tests never collide with the
+// fixed production port (or with each other when run in parallel).
+func newTestFlow(t *testing.T) *BrowserFlow {
+	t.Helper()
+
+	flow, err := newBrowserFlowOn("127.0.0.1:0", "https://app.datarobot.com")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = flow.Close()
+	})
+
+	return flow
+}
+
+// callbackURL builds the URL the browser would be redirected to, using the port
+// the test flow actually bound.
+func callbackURL(t *testing.T, flow *BrowserFlow, query string) string {
+	t.Helper()
+
+	return "http://" + flow.localAddr() + "/" + query
+}
+
+func TestBrowserFlow_AuthURL(t *testing.T) {
+	flow := newTestFlow(t)
+
+	assert.Equal(t,
+		"https://app.datarobot.com/account/developer-tools?cliRedirect=true",
+		flow.AuthURL(),
+		"AuthURL must match AuthCallbackURL so the CLI and the wizard show the same link",
+	)
+}
+
+func TestBrowserFlow_WaitReturnsKeyFromCallback(t *testing.T) {
+	flow := newTestFlow(t)
+
+	keyCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		key, err := flow.Wait(context.Background())
+
+		keyCh <- key
+
+		errCh <- err
+	}()
+
+	resp := waitForCallback(t, callbackURL(t, flow, "?key=test-api-key"))
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html",
+		"the browser must receive the rendered success page")
+	assert.NotEmpty(t, body, "success.html should have been written to the response")
+
+	require.NoError(t, <-errCh)
+	assert.Equal(t, "test-api-key", <-keyCh)
+}
+
+func TestBrowserFlow_EmptyKeyIsInterrupt(t *testing.T) {
+	// A bare GET with no key is how a newly started CLI tells a stale auth server
+	// from a previous run to give up the port.
+	flow := newTestFlow(t)
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		_, err := flow.Wait(context.Background())
+		errCh <- err
+	}()
+
+	resp := waitForCallback(t, callbackURL(t, flow, ""))
+	require.NoError(t, resp.Body.Close())
+
+	err := <-errCh
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrLoginInterrupted)
+}
+
+func TestBrowserFlow_WaitHonoursContextCancellation(t *testing.T) {
+	flow := newTestFlow(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		_, err := flow.Wait(ctx)
+		errCh <- err
+	}()
+
+	cancel()
+
+	err := <-errCh
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrLoginInterrupted, "Ctrl-C should surface as an interrupt, not a timeout")
+}
+
+func TestBrowserFlow_WaitTimesOut(t *testing.T) {
+	// Before this change the wait was unbounded: a browser that never opened left
+	// the CLI blocked forever with no explanation.
+	flow := newTestFlow(t)
+	flow.timeout = 50 * time.Millisecond
+
+	_, err := flow.Wait(context.Background())
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.NotErrorIs(t, err, ErrLoginInterrupted,
+		"a timeout must be distinguishable from a user interrupt")
+}
+
+func TestBrowserFlow_ExtraCallbacksDoNotBlockHandlers(t *testing.T) {
+	// The key channel is buffered for exactly one key. Once Wait has returned and
+	// nobody is draining it, further callbacks must still be answered and dropped
+	// rather than parking HTTP handler goroutines forever.
+	flow := newTestFlow(t)
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		_, err := flow.Wait(context.Background())
+		errCh <- err
+	}()
+
+	first := waitForCallback(t, callbackURL(t, flow, "?key=first"))
+	require.NoError(t, first.Body.Close())
+	require.NoError(t, <-errCh)
+
+	// The first extra fills the now-empty buffer; the second has nowhere to go and
+	// is the one that would deadlock a naive blocking send.
+	for _, key := range []string{"extra-one", "extra-two", "extra-three"} {
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+
+			resp, err := http.Get(callbackURL(t, flow, "?key="+key)) //nolint:noctx // short-lived test request
+			if err == nil {
+				_ = resp.Body.Close()
+			}
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("callback %q blocked: the handler is leaking on a full channel", key)
+		}
+	}
+}
+
+func TestBrowserFlow_CloseIsIdempotent(t *testing.T) {
+	flow, err := newBrowserFlowOn("127.0.0.1:0", "https://app.datarobot.com")
+	require.NoError(t, err)
+
+	require.NoError(t, flow.Close())
+	assert.NoError(t, flow.Close(), "Close must be safe to call twice (defer plus explicit)")
+}
+
+func TestBrowserFlow_ReclaimsPortFromStaleServer(t *testing.T) {
+	// Two CLI runs must not deadlock on the fixed callback port: starting a second
+	// flow on the same address interrupts the first and takes over.
+	first, err := newBrowserFlowOn("127.0.0.1:0", "https://app.datarobot.com")
+	require.NoError(t, err)
+
+	addr := first.localAddr()
+
+	firstErrCh := make(chan error, 1)
+
+	// Mirror what real callers do: Close once Wait returns. Releasing the listener
+	// is what actually frees the port for the incoming process.
+	go func() {
+		defer func() {
+			_ = first.Close()
+		}()
+
+		_, waitErr := first.Wait(context.Background())
+		firstErrCh <- waitErr
+	}()
+
+	// No HTTP readiness probe here: any request to the callback server counts as a
+	// keyless callback and would itself interrupt the first flow. The port is held
+	// from construction, so the second flow's takeover retry absorbs the timing.
+	second, err := newBrowserFlowOn(addr, "https://app.datarobot.com")
+	require.NoError(t, err, "a second flow must be able to reclaim the port")
+
+	t.Cleanup(func() {
+		_ = second.Close()
+	})
+
+	select {
+	case waitErr := <-firstErrCh:
+		require.ErrorIs(t, waitErr, ErrLoginInterrupted, "the stale flow should report an interrupt")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the stale flow was never interrupted")
+	}
+}
+
+// waitForCallback issues the callback request, retrying briefly because Wait
+// starts the server asynchronously.
+func waitForCallback(t *testing.T, url string) *http.Response {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+
+	for {
+		resp, err := http.Get(url) //nolint:noctx,gosec // test-controlled localhost URL
+		if err == nil {
+			return resp
+		}
+
+		if time.Now().After(deadline) {
+			require.NoError(t, err, "callback server never became reachable at %s", url)
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestBrowserFlow_OpenBrowserIsNoOpUnderTest(t *testing.T) {
+	flow := newTestFlow(t)
+
+	// open.Open short-circuits under test, so this asserts the wiring compiles and
+	// reports success rather than that a browser actually launched.
+	assert.NoError(t, flow.OpenBrowser())
+}
+
+func TestErrLoginInterrupted_IsNotDeadlineExceeded(t *testing.T) {
+	assert.NotErrorIs(t, ErrLoginInterrupted, context.DeadlineExceeded)
+}

--- a/internal/auth/prompt.go
+++ b/internal/auth/prompt.go
@@ -15,7 +15,8 @@
 package auth
 
 import (
-	"github.com/charmbracelet/lipgloss"
+	"strings"
+
 	"github.com/datarobot/cli/tui"
 )
 
@@ -54,7 +55,31 @@ const (
 	browserOpenedHint = "Didn't open? Use this link:"
 	browserFailedHint = "⚠ Couldn't open your browser automatically."
 	browserManualHint = "Open this link to finish signing in:"
+
+	// promptIndent lines the prompt block up under the spinner's label rather than
+	// against the left edge of the terminal.
+	promptIndent = 2
 )
+
+// indentLines prefixes every line with n spaces.
+//
+// Done by hand rather than with a lipgloss padding style because that pads every
+// line out to the width of the widest one, leaving trailing whitespace on the
+// short hint lines that users would pick up when copying the link.
+func indentLines(s string, n int) string {
+	pad := strings.Repeat(" ", n)
+	lines := strings.Split(s, "\n")
+
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+
+		lines[i] = pad + line
+	}
+
+	return strings.Join(lines, "\n")
+}
 
 // SpinnerLabel returns the label for the wait spinner.
 //
@@ -67,37 +92,46 @@ func SpinnerLabel(state BrowserState) string {
 	return awaitingAuthLabel
 }
 
+// linkHint is the line introducing the link. It is a quiet aside when the browser
+// opened and an instruction when it did not.
+func linkHint(state BrowserState) string {
+	if state == BrowserOpened {
+		return tui.HintStyle.Render(browserOpenedHint)
+	}
+
+	return tui.BaseTextStyle.Render(browserManualHint)
+}
+
 // RenderBrowserPrompt returns the block shown beneath the spinner while the CLI
 // waits for the browser callback.
 //
-// When the browser opened the link is a quiet fallback. Otherwise it is promoted
-// into a bordered box, because it is then the only way for the user to continue.
+// Every state uses the same shape - a hint line, a blank line, then the link in a
+// bordered box - so that `dr auth login` and `dr auth login --no-browser` look
+// like the same command. Only the wording changes with the state.
 func RenderBrowserPrompt(authURL string, state BrowserState) string {
-	link := tui.InfoStyle.Underline(true).Render(authURL)
+	rows := make([]string, 0, 4)
 
-	if state == BrowserOpened {
-		return lipgloss.JoinVertical(
-			lipgloss.Left,
-			"",
-			tui.HintStyle.Render(browserOpenedHint),
-			link,
-			"",
-		)
-	}
-
-	lines := []string{""}
-
-	// A skipped browser is expected, so it gets no warning line.
+	// Only a genuine failure warrants a warning; --no-browser is a deliberate
+	// choice and must not be reported as something going wrong.
 	if state == BrowserFailed {
-		lines = append(lines, tui.ErrorStyle.Render(browserFailedHint))
+		rows = append(rows, tui.ErrorStyle.Render(browserFailedHint))
 	}
 
-	lines = append(lines,
-		tui.BaseTextStyle.Render(browserManualHint),
+	// The URL is deliberately unstyled. Styling text that lipgloss then wraps in a
+	// border makes it re-emit the content one character at a time with escapes in
+	// between, so the URL stops being a contiguous string: terminals no longer
+	// linkify it, copying it can pick up escapes, and anything matching on the
+	// output (the expect-based smoke tests) stops finding it. The border already
+	// draws the eye, so the text needs no help.
+	rows = append(rows,
+		linkHint(state),
 		"",
-		tui.NoteBoxStyle.Render(link),
-		"",
+		tui.NoteBoxStyle.Render(authURL),
 	)
 
-	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+	block := indentLines(strings.Join(rows, "\n"), promptIndent)
+
+	// A blank line separates the block from the spinner label it is appended to,
+	// and a trailing newline keeps it off whatever the caller prints next.
+	return "\n\n" + block + "\n"
 }

--- a/internal/auth/prompt.go
+++ b/internal/auth/prompt.go
@@ -1,0 +1,103 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/datarobot/cli/tui"
+)
+
+// BrowserState describes what happened when the CLI tried to open the browser.
+// It drives the wording of the wait prompt, which differs in kind between the
+// three cases: a browser that opened needs only a quiet fallback link, one that
+// failed needs an apology plus a prominent link, and one that was deliberately
+// skipped needs the prominent link without the apology.
+type BrowserState int
+
+const (
+	// BrowserOpened means the browser was launched successfully.
+	BrowserOpened BrowserState = iota
+	// BrowserFailed means the browser could not be launched.
+	BrowserFailed
+	// BrowserSkipped means the caller asked not to launch a browser (--no-browser).
+	BrowserSkipped
+)
+
+// BrowserStateFor maps the error from opening a browser onto a BrowserState.
+func BrowserStateFor(openErr error) BrowserState {
+	if openErr != nil {
+		return BrowserFailed
+	}
+
+	return BrowserOpened
+}
+
+// Labels shown while the CLI waits for the browser callback. The wording is
+// deliberately browser-first: opening the browser is the action being taken, and
+// the link is the fallback, not the instruction.
+const (
+	openingBrowserLabel = "Opening your browser to sign in to DataRobot…"
+	awaitingAuthLabel   = "Waiting for authorization…"
+
+	browserOpenedHint = "Didn't open? Use this link:"
+	browserFailedHint = "⚠ Couldn't open your browser automatically."
+	browserManualHint = "Open this link to finish signing in:"
+)
+
+// SpinnerLabel returns the label for the wait spinner.
+//
+// Only the opened case claims a browser is opening; the others would be lying.
+func SpinnerLabel(state BrowserState) string {
+	if state == BrowserOpened {
+		return openingBrowserLabel
+	}
+
+	return awaitingAuthLabel
+}
+
+// RenderBrowserPrompt returns the block shown beneath the spinner while the CLI
+// waits for the browser callback.
+//
+// When the browser opened the link is a quiet fallback. Otherwise it is promoted
+// into a bordered box, because it is then the only way for the user to continue.
+func RenderBrowserPrompt(authURL string, state BrowserState) string {
+	link := tui.InfoStyle.Underline(true).Render(authURL)
+
+	if state == BrowserOpened {
+		return lipgloss.JoinVertical(
+			lipgloss.Left,
+			"",
+			tui.HintStyle.Render(browserOpenedHint),
+			link,
+			"",
+		)
+	}
+
+	lines := []string{""}
+
+	// A skipped browser is expected, so it gets no warning line.
+	if state == BrowserFailed {
+		lines = append(lines, tui.ErrorStyle.Render(browserFailedHint))
+	}
+
+	lines = append(lines,
+		tui.BaseTextStyle.Render(browserManualHint),
+		"",
+		tui.NoteBoxStyle.Render(link),
+		"",
+	)
+
+	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+}

--- a/internal/auth/prompt_test.go
+++ b/internal/auth/prompt_test.go
@@ -37,15 +37,16 @@ func TestSpinnerLabel_OnlyClaimsOpeningWhenItActuallyOpened(t *testing.T) {
 	assert.Equal(t, awaitingAuthLabel, SpinnerLabel(BrowserSkipped))
 }
 
-func TestRenderBrowserPrompt_OpenedKeepsLinkAsQuietFallback(t *testing.T) {
+func TestRenderBrowserPrompt_OpenedFramesLinkAsQuietFallback(t *testing.T) {
 	out := RenderBrowserPrompt(testAuthURL, BrowserOpened)
+	plain := stripANSI(out)
 
-	assert.Contains(t, stripANSI(out), browserOpenedHint)
-	assert.Contains(t, stripANSI(out), testAuthURL)
+	assert.Contains(t, plain, browserOpenedHint)
+	assert.Contains(t, plain, testAuthURL)
+	assert.Contains(t, plain, "╭", "the link is boxed in every state so the paths look alike")
 
-	// No apology and no box: the browser did open, so the link is a footnote.
-	assert.NotContains(t, stripANSI(out), browserFailedHint)
-	assert.NotContains(t, out, "╭", "the link must not be boxed when the browser opened")
+	// The browser did open, so there is nothing to apologise for.
+	assert.NotContains(t, plain, browserFailedHint)
 }
 
 func TestRenderBrowserPrompt_FailedPromotesLinkAndSaysSo(t *testing.T) {
@@ -55,7 +56,7 @@ func TestRenderBrowserPrompt_FailedPromotesLinkAndSaysSo(t *testing.T) {
 	assert.Contains(t, plain, browserFailedHint, "the user must be told the browser did not open")
 	assert.Contains(t, plain, browserManualHint)
 	assert.Contains(t, plain, testAuthURL)
-	assert.Contains(t, out, "╭", "the link becomes the primary instruction and is boxed")
+	assert.Contains(t, plain, "╭")
 }
 
 func TestRenderBrowserPrompt_SkippedPromotesLinkWithoutWarning(t *testing.T) {
@@ -66,7 +67,80 @@ func TestRenderBrowserPrompt_SkippedPromotesLinkWithoutWarning(t *testing.T) {
 	assert.NotContains(t, plain, browserFailedHint)
 	assert.Contains(t, plain, browserManualHint)
 	assert.Contains(t, plain, testAuthURL)
-	assert.Contains(t, out, "╭")
+	assert.Contains(t, plain, "╭")
+}
+
+// TestRenderBrowserPrompt_AllStatesShareOneShape is the consistency guard: the
+// regular and --no-browser paths must be recognisably the same command, differing
+// only in wording. It compares the structure with the text stripped out.
+func TestRenderBrowserPrompt_AllStatesShareOneShape(t *testing.T) {
+	shapes := map[BrowserState]string{}
+
+	for _, state := range []BrowserState{BrowserOpened, BrowserFailed, BrowserSkipped} {
+		plain := stripANSI(RenderBrowserPrompt(testAuthURL, state))
+
+		// Every state: leading blank line, hint, blank line, three box lines.
+		assert.True(t, strings.HasPrefix(plain, "\n\n"),
+			"state %d must start with a blank line separating it from the spinner label", state)
+		assert.True(t, strings.HasSuffix(plain, "\n"),
+			"state %d must end with a newline", state)
+
+		var boxLines int
+
+		for line := range strings.SplitSeq(plain, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+
+			// Non-blank lines are indented as a block.
+			assert.True(t, strings.HasPrefix(line, strings.Repeat(" ", promptIndent)),
+				"state %d line %q must be indented by %d spaces", state, line, promptIndent)
+
+			if strings.ContainsAny(trimmed, "╭│╰") {
+				boxLines++
+			}
+		}
+
+		assert.Equal(t, 3, boxLines, "state %d must render a three-line bordered box", state)
+
+		shapes[state] = strings.Join(boxLinesOf(plain), "\n")
+	}
+
+	// The box itself is identical across states; only the hint above it differs.
+	assert.Equal(t, shapes[BrowserOpened], shapes[BrowserFailed])
+	assert.Equal(t, shapes[BrowserOpened], shapes[BrowserSkipped])
+}
+
+// TestRenderBrowserPrompt_URLStaysContiguousInRawOutput guards a subtle rendering
+// trap: styling text that lipgloss then wraps in a border makes it re-emit the
+// content one character at a time with escape sequences in between. The URL then
+// still *looks* right but is no longer a contiguous string, so terminals stop
+// linkifying it and anything matching on raw output - notably
+// smoke_test_scripts/expect_auth_login.exp, which waits for "cliRedirect=true" -
+// silently stops finding it.
+func TestRenderBrowserPrompt_URLStaysContiguousInRawOutput(t *testing.T) {
+	for _, state := range []BrowserState{BrowserOpened, BrowserFailed, BrowserSkipped} {
+		raw := RenderBrowserPrompt(testAuthURL, state)
+
+		assert.Contains(t, raw, testAuthURL,
+			"state %d: the URL must appear un-escaped in the raw output", state)
+		assert.Contains(t, raw, "cliRedirect=true",
+			"state %d: the smoke tests match this substring in raw terminal output", state)
+	}
+}
+
+// boxLinesOf returns just the bordered-box lines of a rendered prompt.
+func boxLinesOf(plain string) []string {
+	var out []string
+
+	for line := range strings.SplitSeq(plain, "\n") {
+		if strings.ContainsAny(line, "╭│╰") {
+			out = append(out, line)
+		}
+	}
+
+	return out
 }
 
 func TestRenderBrowserPrompt_LabelAndPromptComposeIntoMultilineSpinnerLabel(t *testing.T) {
@@ -76,10 +150,8 @@ func TestRenderBrowserPrompt_LabelAndPromptComposeIntoMultilineSpinnerLabel(t *t
 	label := SpinnerLabel(BrowserOpened) + RenderBrowserPrompt(testAuthURL, BrowserOpened)
 	lines := strings.Split(stripANSI(label), "\n")
 
-	// lipgloss pads every joined line to the width of the widest one, so compare
-	// content rather than the incidental trailing whitespace.
-	assert.Equal(t, openingBrowserLabel, strings.TrimRight(lines[0], " "),
-		"the spinner's own line must contain only the label")
+	assert.Equal(t, openingBrowserLabel, lines[0],
+		"the spinner's own line must contain only the label, with no padding")
 	assert.Greater(t, len(lines), 2, "the fallback link must render below the spinner line")
 	assert.Contains(t, stripANSI(label), testAuthURL)
 }

--- a/internal/auth/prompt_test.go
+++ b/internal/auth/prompt_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testAuthURL = "https://app.datarobot.com/account/developer-tools?cliRedirect=true"
+
+func TestBrowserStateFor(t *testing.T) {
+	assert.Equal(t, BrowserOpened, BrowserStateFor(nil))
+	assert.Equal(t, BrowserFailed, BrowserStateFor(errors.New("xdg-open: not found")))
+}
+
+func TestSpinnerLabel_OnlyClaimsOpeningWhenItActuallyOpened(t *testing.T) {
+	// Saying "Opening your browser" when no browser opened is the confusing part of
+	// CFX-6318, just inverted - it must not survive into the failure paths.
+	assert.Equal(t, openingBrowserLabel, SpinnerLabel(BrowserOpened))
+	assert.Equal(t, awaitingAuthLabel, SpinnerLabel(BrowserFailed))
+	assert.Equal(t, awaitingAuthLabel, SpinnerLabel(BrowserSkipped))
+}
+
+func TestRenderBrowserPrompt_OpenedKeepsLinkAsQuietFallback(t *testing.T) {
+	out := RenderBrowserPrompt(testAuthURL, BrowserOpened)
+
+	assert.Contains(t, stripANSI(out), browserOpenedHint)
+	assert.Contains(t, stripANSI(out), testAuthURL)
+
+	// No apology and no box: the browser did open, so the link is a footnote.
+	assert.NotContains(t, stripANSI(out), browserFailedHint)
+	assert.NotContains(t, out, "╭", "the link must not be boxed when the browser opened")
+}
+
+func TestRenderBrowserPrompt_FailedPromotesLinkAndSaysSo(t *testing.T) {
+	out := RenderBrowserPrompt(testAuthURL, BrowserFailed)
+	plain := stripANSI(out)
+
+	assert.Contains(t, plain, browserFailedHint, "the user must be told the browser did not open")
+	assert.Contains(t, plain, browserManualHint)
+	assert.Contains(t, plain, testAuthURL)
+	assert.Contains(t, out, "╭", "the link becomes the primary instruction and is boxed")
+}
+
+func TestRenderBrowserPrompt_SkippedPromotesLinkWithoutWarning(t *testing.T) {
+	// --no-browser is a deliberate choice, so it must not be reported as a failure.
+	out := RenderBrowserPrompt(testAuthURL, BrowserSkipped)
+	plain := stripANSI(out)
+
+	assert.NotContains(t, plain, browserFailedHint)
+	assert.Contains(t, plain, browserManualHint)
+	assert.Contains(t, plain, testAuthURL)
+	assert.Contains(t, out, "╭")
+}
+
+func TestRenderBrowserPrompt_LabelAndPromptComposeIntoMultilineSpinnerLabel(t *testing.T) {
+	// RunBrowserLoginWith concatenates these two and hands the result to
+	// tui.RunWithSpinner, which renders "<spinner> <label>". The prompt therefore
+	// has to begin on its own line or it would be glued to the spinner text.
+	label := SpinnerLabel(BrowserOpened) + RenderBrowserPrompt(testAuthURL, BrowserOpened)
+	lines := strings.Split(stripANSI(label), "\n")
+
+	// lipgloss pads every joined line to the width of the widest one, so compare
+	// content rather than the incidental trailing whitespace.
+	assert.Equal(t, openingBrowserLabel, strings.TrimRight(lines[0], " "),
+		"the spinner's own line must contain only the label")
+	assert.Greater(t, len(lines), 2, "the fallback link must render below the spinner line")
+	assert.Contains(t, stripANSI(label), testAuthURL)
+}
+
+// stripANSI removes lipgloss colour escapes so assertions can match plain text.
+// Styling is environment dependent (it varies with terminal colour support), so
+// tests assert on content, never on the escape sequences.
+func stripANSI(s string) string {
+	var (
+		out    strings.Builder
+		inEsc  bool
+		escSeq strings.Builder
+	)
+
+	for _, r := range s {
+		switch {
+		case r == 0x1b:
+			inEsc = true
+
+			escSeq.Reset()
+		case inEsc:
+			escSeq.WriteRune(r)
+			// CSI sequences end with a byte in the range @ to ~.
+			if r >= '@' && r <= '~' && escSeq.Len() > 1 {
+				inEsc = false
+			}
+		default:
+			out.WriteRune(r)
+		}
+	}
+
+	return out.String()
+}

--- a/internal/auth/skipauth_test.go
+++ b/internal/auth/skipauth_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSkipAuth_BoundFlagShortCircuits binds --skip-auth exactly as cmd/root.go
+// does and checks that EnsureAuthenticated honours it.
+//
+// The previous code bound the flag as "skip-auth" but read "skip_auth". Viper
+// lowercases keys yet does not treat "-" and "_" as interchangeable for lookups,
+// so the flag was silently ignored: DATAROBOT_CLI_SKIP_AUTH worked (AutomaticEnv
+// applies the "-" to "_" replacer when deriving env names) while the flag did
+// not. A user passing --skip-auth on a fresh install was still dragged into the
+// interactive login. Setting the viper key directly, as the older test did, could
+// not catch that - only going through a bound pflag can.
+func TestSkipAuth_BoundFlagShortCircuits(t *testing.T) {
+	_, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// No credentials at all: without the short circuit this would start a login.
+	viperx.Set(config.DataRobotAPIKey, "")
+	t.Setenv("DATAROBOT_API_TOKEN", "")
+	t.Setenv("DATAROBOT_ENDPOINT", "")
+	t.Setenv("DATAROBOT_API_ENDPOINT", "")
+
+	flags := pflag.NewFlagSet("root", pflag.ContinueOnError)
+	flags.Bool(config.SkipAuthKey, false, "skip authentication checks")
+
+	require.NoError(t, flags.Parse([]string{"--" + config.SkipAuthKey}))
+	require.NoError(t, viperx.BindPFlag(config.SkipAuthKey, flags.Lookup(config.SkipAuthKey)))
+
+	assert.True(t, viperx.GetBool(config.SkipAuthKey),
+		"the bound --skip-auth flag must be readable under the key it was bound to")
+
+	assert.True(t, EnsureAuthenticated(context.Background()),
+		"--skip-auth must short-circuit authentication without contacting DataRobot")
+}
+
+// TestSkipAuth_KeyMatchesFlagName guards the invariant that broke: the viper key
+// and the flag name are the same string.
+func TestSkipAuth_KeyMatchesFlagName(t *testing.T) {
+	flags := pflag.NewFlagSet("root", pflag.ContinueOnError)
+	flags.Bool("skip-auth", false, "skip authentication checks")
+
+	assert.NotNil(t, flags.Lookup(config.SkipAuthKey),
+		"config.SkipAuthKey must name the --skip-auth flag exactly; underscores do not resolve")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,10 @@ import (
 
 var configFileName = "drconfig.yaml"
 
+// configFileMode is the permission drconfig.yaml must have: it stores the API
+// token in plaintext, so it is owner-only.
+const configFileMode = 0o600
+
 // GetConfigDir returns the config directory, respecting XDG_CONFIG_HOME if set.
 // Falls back to ~/.config/datarobot if XDG_CONFIG_HOME is not set.
 func GetConfigDir() (string, error) {
@@ -108,7 +112,10 @@ func CreateConfigFileDirIfNotExists() error {
 		return fmt.Errorf("Failed to create config file directory: %w", err)
 	}
 
-	f, err := os.Create(defaultConfigFilePath)
+	// Create with 0600 rather than os.Create's 0666&^umask: this file holds the API
+	// token. os.WriteFile in UpdateConfigFile cannot fix the mode later, because its
+	// perm argument only applies when it creates the file itself.
+	f, err := os.OpenFile(defaultConfigFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, configFileMode)
 	if err != nil {
 		return fmt.Errorf("Failed to create config file: %w", err)
 	}

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -20,6 +20,14 @@ const (
 
 	APIConsumerTrackingEnabled = "api-consumer-tracking-enabled"
 
+	// SkipAuthKey is the viper key behind the --skip-auth persistent flag.
+	//
+	// It must match the flag name exactly: viper lowercases keys but does not treat
+	// "-" and "_" as equivalent for lookups, so reading "skip_auth" silently missed
+	// the bound flag and only ever saw DATAROBOT_CLI_SKIP_AUTH. Use this constant at
+	// every bind and read site so the two cannot drift apart again.
+	SkipAuthKey = "skip-auth"
+
 	// DefaultLLMID is the config key for the user's default LLM ID. The value is
 	// either an LLM Gateway model id or a DataRobot deployment id.
 	DefaultLLMID = "default-llm-id"

--- a/internal/config/perms_test.go
+++ b/internal/config/perms_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// drconfig.yaml stores the API token in plaintext, so it must never be readable
+// by other users on the machine. These tests are POSIX-only: os.Chmod on Windows
+// only toggles the read-only bit and mode bits are not meaningful there.
+
+func TestCreateConfigFile_IsOwnerOnly(t *testing.T) {
+	testutil.SetTestHomeDir(t, t.TempDir())
+	viperx.Reset()
+
+	require.NoError(t, CreateConfigFileDirIfNotExists())
+
+	dir, err := GetConfigDir()
+	require.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(dir, configFileName))
+	require.NoError(t, err)
+
+	assert.Equal(t, os.FileMode(configFileMode), info.Mode().Perm(),
+		"a freshly created config must be 0600, not os.Create's 0666&^umask")
+}
+
+func TestUpdateConfigFile_TightensPreExistingLoosePermissions(t *testing.T) {
+	// Configs created by earlier CLI versions are 0644. os.WriteFile cannot fix that
+	// on its own - its perm argument is ignored for an existing file - so the write
+	// path has to chmod explicitly or the token stays world-readable forever.
+	testutil.SetTestHomeDir(t, t.TempDir())
+	viperx.Reset()
+
+	dir, err := GetConfigDir()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	configFile := filepath.Join(dir, configFileName)
+	require.NoError(t, os.WriteFile(configFile, []byte("endpoint: https://app.datarobot.com/api/v2\n"), 0o644))
+
+	// Sanity check that the fixture really is loose before the write.
+	info, err := os.Stat(configFile)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o644), info.Mode().Perm(), "fixture should start world-readable")
+
+	viperx.Set(DataRobotAPIKey, "secret-token")
+	viperx.Set(DataRobotURL, "https://app.datarobot.com/api/v2")
+
+	require.NoError(t, ReadConfigFile(configFile))
+	require.NoError(t, UpdateConfigFile(DataRobotAPIKey))
+
+	info, err = os.Stat(configFile)
+	require.NoError(t, err)
+
+	assert.Equal(t, os.FileMode(configFileMode), info.Mode().Perm(),
+		"writing credentials must tighten a pre-existing 0644 config to 0600")
+
+	// The token must actually have been persisted; a permissions-only pass would
+	// make this test vacuous.
+	contents, err := os.ReadFile(configFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(contents), "secret-token")
+}
+
+func TestConfigFileMode_IsOwnerOnly(t *testing.T) {
+	assert.Zero(t, configFileMode&0o077, "no group or other permission bits may be set")
+}

--- a/internal/config/write.go
+++ b/internal/config/write.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/datarobot/cli/internal/log"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
@@ -81,8 +82,19 @@ func UpdateConfigFile(keys ...string) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	if err := os.WriteFile(configFile, out, 0o600); err != nil {
+	if err := os.WriteFile(configFile, out, configFileMode); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	// os.WriteFile only applies its perm argument when it creates the file, so a
+	// config left at 0644 by an earlier CLI version would keep the API token
+	// world-readable forever. Tighten it explicitly on every write.
+	//
+	// Best effort: on Windows os.Chmod only toggles the read-only bit, and a config
+	// owned by another user is not ours to re-permission. Neither case should fail
+	// the write, so log and carry on.
+	if err := os.Chmod(configFile, configFileMode); err != nil {
+		log.Debugf("Could not set %s to %#o: %v", configFile, configFileMode, err)
 	}
 
 	return nil

--- a/internal/drapi/client_test.go
+++ b/internal/drapi/client_test.go
@@ -47,14 +47,14 @@ func resetTokenCache(t *testing.T) {
 func withSkipAuth(t *testing.T, value string) string {
 	t.Helper()
 
-	prevSkip := viperx.GetBool("skip_auth")
+	prevSkip := viperx.GetBool(config.SkipAuthKey)
 	prevKey := viperx.GetString(config.DataRobotAPIKey)
 
-	viperx.Set("skip_auth", true)
+	viperx.Set(config.SkipAuthKey, true)
 	viperx.Set(config.DataRobotAPIKey, value)
 
 	t.Cleanup(func() {
-		viperx.Set("skip_auth", prevSkip)
+		viperx.Set(config.SkipAuthKey, prevSkip)
 		viperx.Set(config.DataRobotAPIKey, prevKey)
 	})
 

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -60,7 +60,7 @@ func SetToken(value string) {
 // is in viper without contacting the server, so local development against
 // stub APIs that don't implement /version/ still works.
 func resolveToken() (string, error) {
-	if viperx.GetBool("skip_auth") {
+	if viperx.GetBool(config.SkipAuthKey) {
 		return viperx.GetString(config.DataRobotAPIKey), nil
 	}
 

--- a/internal/drapi/llms_test.go
+++ b/internal/drapi/llms_test.go
@@ -66,7 +66,7 @@ func setupRoutedServer(t *testing.T, catalog, deployments routeResponse) {
 	viperx.Set(config.DataRobotAPIKey, "test-token")
 	// skip_auth trusts the viper token directly; without it resolveToken makes a
 	// server-side verification request the routed handler would 404.
-	viperx.Set("skip_auth", true)
+	viperx.Set(config.SkipAuthKey, true)
 
 	t.Cleanup(func() {
 		srv.Close()
@@ -121,7 +121,7 @@ func TestGetDeployedLLMs_Pagination(t *testing.T) {
 	viperx.Reset()
 	viperx.Set(config.DataRobotURL, srv.URL)
 	viperx.Set(config.DataRobotAPIKey, "test-token")
-	viperx.Set("skip_auth", true)
+	viperx.Set(config.SkipAuthKey, true)
 
 	t.Cleanup(func() {
 		srv.Close()
@@ -214,7 +214,7 @@ func TestGetDeployedLLMs_SendsFilterAndLimit(t *testing.T) {
 	viperx.Reset()
 	viperx.Set(config.DataRobotURL, srv.URL)
 	viperx.Set(config.DataRobotAPIKey, "test-token")
-	viperx.Set("skip_auth", true)
+	viperx.Set(config.SkipAuthKey, true)
 
 	t.Cleanup(func() {
 		srv.Close()

--- a/internal/misc/open/open.go
+++ b/internal/misc/open/open.go
@@ -12,25 +12,86 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package open launches URLs in the user's default browser.
 package open
 
 import (
+	"errors"
+	"fmt"
+	"net/url"
 	"os/exec"
 	"runtime"
+	"strings"
 	"testing"
 )
 
-func Open(url string) {
-	if testing.Testing() {
-		return
+// ErrUnsupportedURL is returned when a URL is not a plain http(s) URL and so is
+// not safe to hand to a platform launcher.
+var ErrUnsupportedURL = errors.New("only http and https URLs can be opened in a browser")
+
+// browserCommand returns the executable and arguments that open rawURL in the
+// default browser on goos.
+//
+// The URL is validated first: it is passed to an external launcher, so anything
+// that is not a plain http(s) URL (a file:// path, a javascript: payload, a
+// leading dash that a launcher might read as a flag) is rejected rather than
+// forwarded.
+func browserCommand(goos, rawURL string) (string, []string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", nil, fmt.Errorf("%w: %q is not a valid URL", ErrUnsupportedURL, rawURL)
 	}
 
-	switch runtime.GOOS {
-	case "darwin":
-		_ = exec.Command("open", url).Run()
-	case "windows":
-		_ = exec.Command("start", url).Run()
-	default:
-		_ = exec.Command("xdg-open", url).Run()
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", nil, fmt.Errorf("%w: got scheme %q", ErrUnsupportedURL, parsed.Scheme)
 	}
+
+	if parsed.Host == "" {
+		return "", nil, fmt.Errorf("%w: %q has no host", ErrUnsupportedURL, rawURL)
+	}
+
+	// A launcher may treat a leading dash as one of its own flags, and no
+	// legitimate URL contains whitespace at this point.
+	if strings.HasPrefix(rawURL, "-") || strings.ContainsAny(rawURL, " \t\n\r") {
+		return "", nil, fmt.Errorf("%w: %q contains unsupported characters", ErrUnsupportedURL, rawURL)
+	}
+
+	switch goos {
+	case "darwin":
+		return "open", []string{rawURL}, nil
+	case "windows":
+		// "start" is a cmd.exe builtin with no executable on disk, so
+		// exec.Command("start", url) can never succeed. rundll32 is a real
+		// binary, needs no shell quoting for "&" in query strings, and opens no
+		// console window.
+		return "rundll32.exe", []string{"url.dll,FileProtocolHandler", rawURL}, nil
+	default:
+		return "xdg-open", []string{rawURL}, nil
+	}
+}
+
+// Open launches rawURL in the user's default browser.
+//
+// It returns an error when the URL is unsupported or the platform launcher is
+// missing or exits non-zero, so callers can fall back to showing the user the
+// link instead of waiting on a browser that never opened.
+func Open(rawURL string) error {
+	if testing.Testing() {
+		return nil
+	}
+
+	name, args, err := browserCommand(runtime.GOOS, rawURL)
+	if err != nil {
+		return err
+	}
+
+	// The executable name is a constant per platform and rawURL is validated by
+	// browserCommand above, so no untrusted input reaches the command line.
+	cmd := exec.Command(name, args...)
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to open browser via %s: %w", name, err)
+	}
+
+	return nil
 }

--- a/internal/misc/open/open_test.go
+++ b/internal/misc/open/open_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package open
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrowserCommand_PerPlatform(t *testing.T) {
+	const url = "https://app.datarobot.com/account/developer-tools?cliRedirect=true"
+
+	tests := map[string]struct {
+		goos     string
+		wantName string
+		wantArgs []string
+	}{
+		"macOS uses open": {
+			goos:     "darwin",
+			wantName: "open",
+			wantArgs: []string{url},
+		},
+		// "start" is a cmd.exe builtin with no executable on disk, so
+		// exec.Command("start", url) always fails. rundll32 is a real binary and
+		// needs no shell quoting for "&" in query strings.
+		"Windows uses rundll32, not the cmd builtin": {
+			goos:     "windows",
+			wantName: "rundll32.exe",
+			wantArgs: []string{"url.dll,FileProtocolHandler", url},
+		},
+		"Linux uses xdg-open": {
+			goos:     "linux",
+			wantName: "xdg-open",
+			wantArgs: []string{url},
+		},
+		"other Unix falls back to xdg-open": {
+			goos:     "freebsd",
+			wantName: "xdg-open",
+			wantArgs: []string{url},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotName, gotArgs, err := browserCommand(tc.goos, url)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantName, gotName)
+			assert.Equal(t, tc.wantArgs, gotArgs)
+		})
+	}
+}
+
+func TestBrowserCommand_RejectsNonHTTPURLs(t *testing.T) {
+	// The URL is handed to a platform launcher, so anything that is not a plain
+	// http(s) URL is rejected rather than passed through.
+	tests := map[string]string{
+		"empty":               "",
+		"file scheme":         "file:///etc/passwd",
+		"javascript scheme":   "javascript:alert(1)",
+		"no scheme":           "app.datarobot.com",
+		"shell metacharacter": "https://app.datarobot.com/;rm -rf /",
+		"leading dash":        "-oProxyCommand=evil",
+		"not a URL":           "://",
+	}
+
+	for name, url := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := browserCommand("darwin", url)
+
+			require.Error(t, err, "browserCommand(%q) should be rejected", url)
+		})
+	}
+}
+
+func TestBrowserCommand_AllowsHTTPAndHTTPS(t *testing.T) {
+	for _, url := range []string{
+		"http://localhost:51164/?key=abc",
+		"https://app.eu.datarobot.com/account/developer-tools?cliRedirect=true",
+		"https://datarobot.example.com:8443/account/developer-tools?cliRedirect=true&x=1",
+	} {
+		t.Run(url, func(t *testing.T) {
+			name, args, err := browserCommand("darwin", url)
+
+			require.NoError(t, err)
+			assert.Equal(t, "open", name)
+			assert.Equal(t, []string{url}, args)
+		})
+	}
+}
+
+func TestOpen_NoOpUnderTest(t *testing.T) {
+	// The testing.Testing() guard keeps the suite from launching real browsers.
+	// A malformed URL still returns nil here because the guard short-circuits
+	// before validation - that is intentional, validation is covered above.
+	assert.NoError(t, Open("https://app.datarobot.com"))
+}

--- a/internal/pipeline/transport_test.go
+++ b/internal/pipeline/transport_test.go
@@ -34,14 +34,14 @@ import (
 func installSkipAuth(t *testing.T) {
 	t.Helper()
 
-	prevSkip := viperx.GetBool("skip_auth")
+	prevSkip := viperx.GetBool(config.SkipAuthKey)
 	prevTok := viperx.GetString(config.DataRobotAPIKey)
 
-	viperx.Set("skip_auth", true)
+	viperx.Set(config.SkipAuthKey, true)
 	viperx.Set(config.DataRobotAPIKey, "test-token")
 
 	t.Cleanup(func() {
-		viperx.Set("skip_auth", prevSkip)
+		viperx.Set(config.SkipAuthKey, prevSkip)
 		viperx.Set(config.DataRobotAPIKey, prevTok)
 	})
 }

--- a/internal/plugin/exec.go
+++ b/internal/plugin/exec.go
@@ -78,7 +78,7 @@ func ExecutePlugin(ctx context.Context, manifest PluginManifest, executable stri
 		return 1
 	}
 
-	skipAuth := viperx.GetBool("skip-auth")
+	skipAuth := viperx.GetBool(config.SkipAuthKey)
 
 	if manifest.Authentication && !skipAuth {
 		userAgent := fmt.Sprintf("DataRobot CLI plugin: %s (version %s)", manifest.Name, manifest.Version)

--- a/internal/plugin/exec_test.go
+++ b/internal/plugin/exec_test.go
@@ -590,7 +590,7 @@ func TestTraverseChildren_PostPluginFlagsInvisibleToCore(t *testing.T) {
 
 func TestExecutePluginSkipAuthBypassesAuthCheck(t *testing.T) {
 	viperx.Reset()
-	viperx.Set("skip-auth", true)
+	viperx.Set(config.SkipAuthKey, true)
 
 	// Deliberately leave no credentials configured — if auth were attempted it would fail.
 	os.Unsetenv("DATAROBOT_ENDPOINT")

--- a/internal/workload/testhelpers_test.go
+++ b/internal/workload/testhelpers_test.go
@@ -27,14 +27,14 @@ import (
 func installSkipAuth(t *testing.T) {
 	t.Helper()
 
-	prevSkip := viperx.GetBool("skip_auth")
+	prevSkip := viperx.GetBool(config.SkipAuthKey)
 	prevTok := viperx.GetString(config.DataRobotAPIKey)
 
-	viperx.Set("skip_auth", true)
+	viperx.Set(config.SkipAuthKey, true)
 	viperx.Set(config.DataRobotAPIKey, "test-token")
 
 	t.Cleanup(func() {
-		viperx.Set("skip_auth", prevSkip)
+		viperx.Set(config.SkipAuthKey, prevSkip)
 		viperx.Set(config.DataRobotAPIKey, prevTok)
 	})
 }

--- a/smoke_test_scripts/expect_auth_login.exp
+++ b/smoke_test_scripts/expect_auth_login.exp
@@ -7,9 +7,11 @@ set env(TERM) dumb
 
 # Force non-interactive mode so the CLI skips the animated Bubble Tea spinner
 # (which otherwise burns CPU redrawing every frame) and prints a single static
-# "Waiting for browser authorization…" line instead. Ctrl-C is delivered as a
-# real SIGINT, which cancels the root context and unblocks the auth wait via the
-# normal signal path (fast, deterministic exit).
+# status line plus the auth link instead. It also keeps the set-url fallback on
+# the plain-text numbered prompt this script types into, rather than the Bubble
+# Tea list picker used on a real terminal. Ctrl-C is delivered as a real SIGINT,
+# which cancels the root context and unblocks the auth wait via the normal
+# signal path (fast, deterministic exit).
 set env(DATAROBOT_CLI_NON_INTERACTIVE) 1
 
 spawn dr auth login

--- a/smoke_test_scripts/expect_auth_setURL.exp
+++ b/smoke_test_scripts/expect_auth_setURL.exp
@@ -27,4 +27,28 @@ expect {
 expect "Check your DataRobot login page"
 send -- "https://app.datarobot.com\r\n"
 
-expect eof
+# Setting the URL writes the config and then hands straight over to the login
+# flow, which blocks waiting for a browser callback that never comes in a test.
+# Interrupt it as soon as the auth link appears, the same way
+# expect_auth_login.exp does; SIGINT cancels the root context and unblocks the
+# wait immediately. Without this the script sits here until the login times out.
+expect {
+    "cliRedirect=true" {
+        send -- "\x03"
+    }
+    timeout {
+        puts "WARN: auth link never appeared; interrupting anyway"
+        send -- "\x03"
+    }
+}
+
+# The endpoint is already persisted by this point, so the harness's config
+# assertion holds regardless of how the login ends.
+expect {
+    eof {}
+    timeout {
+        puts "WARN: process did not exit after interrupt; forcing close"
+        close
+        wait
+    }
+}

--- a/smoke_test_scripts/expect_auth_setURL.exp
+++ b/smoke_test_scripts/expect_auth_setURL.exp
@@ -5,13 +5,20 @@ set timeout 10
 # Use TERM=dumb to prevent terminal color probing which causes OSC sequences
 set env(TERM) dumb
 
+# Force non-interactive mode so set-url uses the plain-text numbered prompt that
+# this script drives. On a real terminal it now shows a Bubble Tea list picker
+# instead, which expects arrow keys rather than a typed URL.
+set env(DATAROBOT_CLI_NON_INTERACTIVE) 1
+
 set datarobot_cli_config [lindex $argv 0]; # Grab the first command line parameter
 
 spawn dr auth set-url --config $datarobot_cli_config
 
-# If we get an overwrite prompt be sure to say yes to it first
+# If a URL is already configured we get an overwrite prompt; say yes to it first.
+# This must match internal/auth.askForNewHost. When no URL is configured the
+# prompt never appears, so fall through on timeout.
 expect {
-    "Do you want to login with a different account" {
+    "do you want to overwrite it?" {
         send -- "y\r\n"
     }
     timeout

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -332,10 +332,14 @@ for ($i = 0; $i -lt 20; $i++) {
     if ($auth_proc.HasExited) { break }
 }
 
+# Whether the process was still running tells a hang apart from an early exit, so
+# capture it before the kill below makes it moot.
+$auth_still_running = -not $auth_proc.HasExited
+
 # No browser round-trip happens in tests, so stop the waiting process. Guard the
 # kill: the process may exit between the check and the Kill() call, which would
 # otherwise throw under $ErrorActionPreference = "Stop".
-if (-not $auth_proc.HasExited) {
+if ($auth_still_running) {
     try {
         $auth_proc.Kill()
         $auth_proc.WaitForExit()
@@ -344,12 +348,35 @@ if (-not $auth_proc.HasExited) {
     }
 }
 
-Remove-Item $auth_out, $auth_err -Force -ErrorAction SilentlyContinue
-
 if ($auth_url_shown) {
+    Remove-Item $auth_out, $auth_err -Force -ErrorAction SilentlyContinue
     Write-SuccessMsg "Assertion passed: 'dr auth login' displayed the OAuth redirect URL."
 } else {
+    # Dump both streams before deleting them. Without this the failure says only
+    # "the URL was not on stdout", which cannot distinguish the three causes that
+    # look identical from here: the link went to stderr instead, the process never
+    # got as far as printing it (a browser launcher that blocks would do that), or
+    # it exited early with an error.
     Write-ErrorMsg "Assertion failed: 'dr auth login' did not display the auth URL (cliRedirect=true)."
+    Write-InfoMsg "Process still running when polling gave up: $auth_still_running"
+
+    foreach ($stream in @(@{ Name = "stdout"; Path = $auth_out }, @{ Name = "stderr"; Path = $auth_err })) {
+        Write-InfoMsg "--- dr auth login $($stream.Name) ---"
+
+        if (Test-Path $stream.Path) {
+            $content = Get-Content $stream.Path -Raw
+
+            if ([string]::IsNullOrWhiteSpace($content)) {
+                Write-Host "(empty)"
+            } else {
+                Write-Host $content
+            }
+        } else {
+            Write-Host "(file never created)"
+        }
+    }
+
+    Remove-Item $auth_out, $auth_err -Force -ErrorAction SilentlyContinue
 }
 Write-End
 

--- a/tui/hostpicker/hostpicker.go
+++ b/tui/hostpicker/hostpicker.go
@@ -89,28 +89,49 @@ type Model struct {
 	SuccessCmd  func(string) tea.Cmd
 }
 
+// Region icons are single-codepoint globes, not country flags.
+//
+// Flag emoji are pairs of regional-indicator letters, and Windows deliberately
+// ships no flag glyphs in Segoe UI Emoji - it renders the pair as two letter
+// boxes instead. That is not a font the user can install, so flags are invisible
+// or wrong in PowerShell, Windows Terminal, and the VS Code terminal no matter
+// what. Worse, the pair measures as width 2 (lipgloss.Width) but paints 4
+// columns, so it silently breaks alignment as well.
+//
+// The globes are one codepoint, measure and paint as width 2, and are present in
+// Segoe UI Emoji, so they render everywhere the rest of the CLI's emoji do.
+//
+// Exported so the plain-text fallback menu in internal/auth renders the same
+// icons; keeping two copies is how they would drift back to flags.
+const (
+	USRegionIcon     = "🌎" // Americas
+	EURegionIcon     = "🌍" // Europe / Africa
+	JPRegionIcon     = "🌏" // Asia
+	CustomRegionIcon = "🏢"
+)
+
 func New() Model {
 	items := []list.Item{
 		item{
-			title:       "🇺🇸 US Cloud",
+			title:       USRegionIcon + " US Cloud",
 			description: "https://app.datarobot.com",
 			url:         "https://app.datarobot.com",
 			isCustom:    false,
 		},
 		item{
-			title:       "🇪🇺 EU Cloud",
+			title:       EURegionIcon + " EU Cloud",
 			description: "https://app.eu.datarobot.com",
 			url:         "https://app.eu.datarobot.com",
 			isCustom:    false,
 		},
 		item{
-			title:       "🇯🇵 Japan Cloud",
+			title:       JPRegionIcon + " Japan Cloud",
 			description: "https://app.jp.datarobot.com",
 			url:         "https://app.jp.datarobot.com",
 			isCustom:    false,
 		},
 		item{
-			title:       "🏢 Custom/On-Prem",
+			title:       CustomRegionIcon + " Custom/On-Prem",
 			description: "Enter your custom DataRobot URL",
 			url:         "",
 			isCustom:    true,
@@ -253,7 +274,7 @@ func (m Model) View() string {
 		title := lipgloss.NewStyle().
 			Foreground(lipgloss.AdaptiveColor{Light: "#6124DF", Dark: "#9D7EDF"}).
 			Bold(true).
-			Render("🏢 Custom DataRobot URL")
+			Render(CustomRegionIcon + " Custom DataRobot URL")
 
 		sb.WriteString(title)
 		sb.WriteString("\n\n")

--- a/tui/hostpicker/hostpicker.go
+++ b/tui/hostpicker/hostpicker.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package setup
+package hostpicker
 
 import (
 	"fmt"
@@ -26,24 +26,24 @@ import (
 	"github.com/datarobot/cli/tui"
 )
 
-type hostItem struct {
+type item struct {
 	title       string
 	description string
 	url         string
 	isCustom    bool
 }
 
-func (i hostItem) Title() string       { return i.title }
-func (i hostItem) Description() string { return i.description }
-func (i hostItem) FilterValue() string { return i.title }
+func (i item) Title() string       { return i.title }
+func (i item) Description() string { return i.description }
+func (i item) FilterValue() string { return i.title }
 
-type hostItemDelegate struct{}
+type itemDelegate struct{}
 
-func (d hostItemDelegate) Height() int                             { return 2 }
-func (d hostItemDelegate) Spacing() int                            { return 1 }
-func (d hostItemDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
-func (d hostItemDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
-	i, ok := listItem.(hostItem)
+func (d itemDelegate) Height() int                             { return 2 }
+func (d itemDelegate) Spacing() int                            { return 1 }
+func (d itemDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	i, ok := listItem.(item)
 	if !ok {
 		return
 	}
@@ -81,7 +81,7 @@ func (d hostItemDelegate) Render(w io.Writer, m list.Model, index int, listItem 
 	}
 }
 
-type HostModel struct {
+type Model struct {
 	list        list.Model
 	customInput textinput.Model
 	showCustom  bool
@@ -89,27 +89,27 @@ type HostModel struct {
 	SuccessCmd  func(string) tea.Cmd
 }
 
-func NewHostModel() HostModel {
+func New() Model {
 	items := []list.Item{
-		hostItem{
+		item{
 			title:       "🇺🇸 US Cloud",
 			description: "https://app.datarobot.com",
 			url:         "https://app.datarobot.com",
 			isCustom:    false,
 		},
-		hostItem{
+		item{
 			title:       "🇪🇺 EU Cloud",
 			description: "https://app.eu.datarobot.com",
 			url:         "https://app.eu.datarobot.com",
 			isCustom:    false,
 		},
-		hostItem{
+		item{
 			title:       "🇯🇵 Japan Cloud",
 			description: "https://app.jp.datarobot.com",
 			url:         "https://app.jp.datarobot.com",
 			isCustom:    false,
 		},
-		hostItem{
+		item{
 			title:       "🏢 Custom/On-Prem",
 			description: "Enter your custom DataRobot URL",
 			url:         "",
@@ -117,7 +117,7 @@ func NewHostModel() HostModel {
 		},
 	}
 
-	delegate := hostItemDelegate{}
+	delegate := itemDelegate{}
 	l := list.New(items, delegate, 0, 0)
 	l.Title = "DataRobot Environment"
 	l.SetShowStatusBar(false)
@@ -137,7 +137,7 @@ func NewHostModel() HostModel {
 	customInput.CharLimit = 256
 	customInput.Width = 50
 
-	return HostModel{
+	return Model{
 		list:        l,
 		customInput: customInput,
 		showCustom:  false,
@@ -145,11 +145,11 @@ func NewHostModel() HostModel {
 	}
 }
 
-func (m HostModel) Init() tea.Cmd {
+func (m Model) Init() tea.Cmd {
 	return nil
 }
 
-func (m HostModel) handleCustomInput(msg tea.KeyMsg) (HostModel, tea.Cmd) {
+func (m Model) handleCustomInput(msg tea.KeyMsg) (Model, tea.Cmd) {
 	switch msg.String() {
 	case tea.KeyEnter.String():
 		url := strings.TrimSpace(m.customInput.Value())
@@ -173,12 +173,12 @@ func (m HostModel) handleCustomInput(msg tea.KeyMsg) (HostModel, tea.Cmd) {
 	return m, cmd
 }
 
-func (m HostModel) handleListMode(msg tea.KeyMsg) (HostModel, tea.Cmd) {
+func (m Model) handleListMode(msg tea.KeyMsg) (Model, tea.Cmd) {
 	if msg.String() != "enter" {
 		return m, nil
 	}
 
-	selectedItem, ok := m.list.SelectedItem().(hostItem)
+	selectedItem, ok := m.list.SelectedItem().(item)
 	if !ok {
 		return m, nil
 	}
@@ -199,7 +199,7 @@ func (m HostModel) handleListMode(msg tea.KeyMsg) (HostModel, tea.Cmd) {
 	return m, nil
 }
 
-func (m HostModel) Update(msg tea.Msg) (HostModel, tea.Cmd) {
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	var cmd tea.Cmd
 
 	switch msg := msg.(type) {
@@ -245,7 +245,7 @@ func (m HostModel) Update(msg tea.Msg) (HostModel, tea.Cmd) {
 	return m, cmd
 }
 
-func (m HostModel) View() string {
+func (m Model) View() string {
 	if m.showCustom {
 		// Custom URL input view
 		var sb strings.Builder

--- a/tui/hostpicker/hostpicker_test.go
+++ b/tui/hostpicker/hostpicker_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package setup
+package hostpicker
 
 import (
 	"bytes"
@@ -33,20 +33,20 @@ type HostModelTestSuite struct {
 	suite.Suite
 }
 
-// hostModelWrapper wraps HostModel to satisfy tea.Model interface.
+// hostModelWrapper wraps Model to satisfy tea.Model interface.
 type hostModelWrapper struct {
-	HostModel
+	Model
 }
 
 func (w hostModelWrapper) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	model, cmd := w.HostModel.Update(msg)
-	w.HostModel = model
+	model, cmd := w.Model.Update(msg)
+	w.Model = model
 
 	return w, cmd
 }
 
-func (suite *HostModelTestSuite) NewTestModel(m HostModel) *teatest.TestModel {
-	wrapper := hostModelWrapper{HostModel: m}
+func (suite *HostModelTestSuite) NewTestModel(m Model) *teatest.TestModel {
+	wrapper := hostModelWrapper{Model: m}
 
 	return teatest.NewTestModel(suite.T(), wrapper, teatest.WithInitialTermSize(300, 100))
 }
@@ -70,7 +70,7 @@ func (suite *HostModelTestSuite) Quit(tm *teatest.TestModel) {
 }
 
 func (suite *HostModelTestSuite) TestHostModel_Init() {
-	m := NewHostModel()
+	m := New()
 
 	suite.Equal(80, m.width)
 	suite.False(m.showCustom)
@@ -82,7 +82,7 @@ func (suite *HostModelTestSuite) TestHostModel_Init() {
 }
 
 func (suite *HostModelTestSuite) TestHostModel_SelectUSCloud() {
-	m := NewHostModel()
+	m := New()
 
 	var capturedURL string
 
@@ -120,7 +120,7 @@ func (suite *HostModelTestSuite) TestHostModel_SelectUSCloud() {
 }
 
 func (suite *HostModelTestSuite) TestHostModel_SelectEUCloud() {
-	m := NewHostModel()
+	m := New()
 
 	var capturedURL string
 
@@ -159,7 +159,7 @@ func (suite *HostModelTestSuite) TestHostModel_SelectEUCloud() {
 }
 
 func (suite *HostModelTestSuite) TestHostModel_SelectJapanCloud() {
-	m := NewHostModel()
+	m := New()
 
 	var capturedURL string
 
@@ -199,7 +199,7 @@ func (suite *HostModelTestSuite) TestHostModel_SelectJapanCloud() {
 }
 
 func (suite *HostModelTestSuite) TestHostModel_NavigateToCustom() {
-	m := NewHostModel()
+	m := New()
 
 	tm := suite.NewTestModel(m)
 
@@ -223,7 +223,7 @@ func (suite *HostModelTestSuite) TestHostModel_NavigateToCustom() {
 }
 
 func (suite *HostModelTestSuite) TestHostModel_CustomURLInput() {
-	m := NewHostModel()
+	m := New()
 
 	var capturedURL string
 
@@ -278,7 +278,7 @@ func (suite *HostModelTestSuite) TestHostModel_CustomURLInput() {
 }
 
 func (suite *HostModelTestSuite) TestHostModel_CustomURLEscape() {
-	m := NewHostModel()
+	m := New()
 
 	tm := suite.NewTestModel(m)
 
@@ -313,7 +313,7 @@ func (suite *HostModelTestSuite) TestHostModel_CustomURLEscape() {
 }
 
 func (suite *HostModelTestSuite) TestHostModel_CustomURLEmptySubmit() {
-	m := NewHostModel()
+	m := New()
 
 	var capturedURL string
 
@@ -360,7 +360,7 @@ func (suite *HostModelTestSuite) TestHostModel_CustomURLEmptySubmit() {
 }
 
 func (suite *HostModelTestSuite) TestHostModel_WindowResize() {
-	m := NewHostModel()
+	m := New()
 
 	// Send window resize message
 	msg := tea.WindowSizeMsg{
@@ -374,7 +374,7 @@ func (suite *HostModelTestSuite) TestHostModel_WindowResize() {
 }
 
 func (suite *HostModelTestSuite) TestHostModel_ListNavigation() {
-	m := NewHostModel()
+	m := New()
 
 	tm := suite.NewTestModel(m)
 
@@ -409,7 +409,7 @@ func (suite *HostModelTestSuite) TestHostModel_ListNavigation() {
 }
 
 func (suite *HostModelTestSuite) TestHostModel_ViewListMode() {
-	m := NewHostModel()
+	m := New()
 	m.showCustom = false
 
 	view := m.View()
@@ -420,7 +420,7 @@ func (suite *HostModelTestSuite) TestHostModel_ViewListMode() {
 }
 
 func (suite *HostModelTestSuite) TestHostModel_ViewCustomMode() {
-	m := NewHostModel()
+	m := New()
 	m.showCustom = true
 
 	view := m.View()
@@ -432,7 +432,7 @@ func (suite *HostModelTestSuite) TestHostModel_ViewCustomMode() {
 }
 
 func (suite *HostModelTestSuite) TestHostModel_InitReturnsNil() {
-	m := NewHostModel()
+	m := New()
 
 	cmd := m.Init()
 

--- a/tui/hostpicker/icons_test.go
+++ b/tui/hostpicker/icons_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostpicker
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isRegionalIndicator reports whether r is one of the letters used to build flag
+// emoji (U+1F1E6..U+1F1FF).
+func isRegionalIndicator(r rune) bool {
+	return r >= 0x1F1E6 && r <= 0x1F1FF
+}
+
+// TestRegionIcons_NoFlagEmoji is the guard against reintroducing country flags.
+//
+// Flags are pairs of regional-indicator letters. Windows ships no flag glyphs in
+// Segoe UI Emoji and paints the pair as two letter boxes instead, so a flag is
+// invisible or wrong in PowerShell, Windows Terminal, and the VS Code terminal
+// regardless of the user's font. There is no capability check that fixes this;
+// the only fix is not to use them.
+func TestRegionIcons_NoFlagEmoji(t *testing.T) {
+	for _, icon := range []string{USRegionIcon, EURegionIcon, JPRegionIcon, CustomRegionIcon} {
+		for _, r := range icon {
+			assert.False(t, isRegionalIndicator(r),
+				"icon %q contains regional indicator %U; flags do not render on Windows", icon, r)
+		}
+	}
+}
+
+// TestRegionIcons_AreSingleCodepointAndWidthTwo pins the property that keeps the
+// hand-aligned menu in internal/auth.printSetURLPrompt true.
+//
+// A flag measures as width 2 but paints 4 columns on Windows, so alignment breaks
+// silently. A single-codepoint emoji measures and paints the same everywhere.
+func TestRegionIcons_AreSingleCodepointAndWidthTwo(t *testing.T) {
+	for _, icon := range []string{USRegionIcon, EURegionIcon, JPRegionIcon, CustomRegionIcon} {
+		assert.Equal(t, 1, utf8.RuneCountInString(icon),
+			"icon %q must be a single codepoint so its measured width matches what terminals paint", icon)
+		assert.Equal(t, 2, lipgloss.Width(icon), "icon %q must measure two columns", icon)
+	}
+}
+
+// TestRegionIcons_AreDistinct catches a copy-paste that would give two regions the
+// same globe.
+func TestRegionIcons_AreDistinct(t *testing.T) {
+	seen := map[string]bool{}
+
+	for _, icon := range []string{USRegionIcon, EURegionIcon, JPRegionIcon, CustomRegionIcon} {
+		assert.False(t, seen[icon], "icon %q is used for more than one entry", icon)
+		seen[icon] = true
+	}
+}
+
+// TestNew_ItemTitlesUseTheRegionIcons ties the list items to the constants, so the
+// checks above actually cover what the user sees.
+func TestNew_ItemTitlesUseTheRegionIcons(t *testing.T) {
+	items := New().list.Items()
+	require.Len(t, items, 4)
+
+	wantPrefixes := []string{USRegionIcon, EURegionIcon, JPRegionIcon, CustomRegionIcon}
+
+	for i, li := range items {
+		entry, ok := li.(item)
+		require.True(t, ok)
+
+		assert.True(t, len(entry.title) > 0 && entry.title[:len(wantPrefixes[i])] == wantPrefixes[i],
+			"item %d title %q must start with %q", i, entry.title, wantPrefixes[i])
+
+		for _, r := range entry.title {
+			assert.False(t, isRegionalIndicator(r),
+				"item %d title %q contains a flag codepoint", i, entry.title)
+		}
+	}
+}
+
+// compile-time assurance that the list package is the one New() builds against.
+var _ = list.Item(item{})

--- a/tui/hostpicker/select.go
+++ b/tui/hostpicker/select.go
@@ -1,0 +1,102 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostpicker
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/tui"
+)
+
+// chosenMsg carries the URL the user selected.
+type chosenMsg struct{ url string }
+
+// standaloneModel adapts Model, which is designed to be embedded in a larger
+// wizard, into a program that can run on its own and then exit.
+//
+// It owns the two behaviours the embedded model deliberately leaves to its
+// parent: turning a selection into a quit, and treating Esc in list mode as
+// "cancel" rather than as the custom-input "go back".
+type standaloneModel struct {
+	picker   Model
+	url      string
+	chosen   bool
+	quitting bool
+}
+
+func newStandaloneModel() standaloneModel {
+	picker := New()
+	picker.SuccessCmd = func(url string) tea.Cmd {
+		return func() tea.Msg { return chosenMsg{url: url} }
+	}
+
+	return standaloneModel{picker: picker}
+}
+
+func (m standaloneModel) Init() tea.Cmd {
+	return m.picker.Init()
+}
+
+func (m standaloneModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case chosenMsg:
+		m.url = msg.url
+		m.chosen = true
+		m.quitting = true
+
+		return m, tea.Quit
+
+	case tea.KeyMsg:
+		// Esc inside the custom-URL field means "back to the list"; the embedded
+		// model handles that itself. Only Esc in list mode cancels the picker.
+		if msg.Type == tea.KeyEsc && !m.picker.showCustom {
+			m.quitting = true
+
+			return m, tea.Quit
+		}
+	}
+
+	var cmd tea.Cmd
+
+	m.picker, cmd = m.picker.Update(msg)
+
+	return m, cmd
+}
+
+func (m standaloneModel) View() string {
+	if m.quitting {
+		return ""
+	}
+
+	return m.picker.View()
+}
+
+// Select runs the environment picker as its own program and returns the URL the
+// user chose.
+//
+// ok is false when the user cancelled with Esc or Ctrl-C. Callers must check it
+// before using the URL; a cancel is a normal outcome, not an error.
+func Select() (url string, ok bool, err error) {
+	finalModel, err := tui.Run(newStandaloneModel())
+	if err != nil {
+		return "", false, err
+	}
+
+	final, isStandalone := tui.Unwrap(finalModel).(standaloneModel)
+	if !isStandalone {
+		return "", false, nil
+	}
+
+	return final.url, final.chosen, nil
+}

--- a/tui/hostpicker/select_test.go
+++ b/tui/hostpicker/select_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostpicker
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// drive feeds messages into the standalone model and returns the final state.
+//
+// It stands in for the bubbletea runtime: a model communicates by returning a
+// tea.Cmd, so any command produced by an Update is executed and its message fed
+// back in, otherwise selections (which travel as a chosenMsg) never arrive.
+func drive(t *testing.T, msgs ...tea.Msg) standaloneModel {
+	t.Helper()
+
+	m := newStandaloneModel()
+	m.Init()
+
+	for _, msg := range msgs {
+		m = step(t, m, msg)
+	}
+
+	return m
+}
+
+func step(t *testing.T, m standaloneModel, msg tea.Msg) standaloneModel {
+	t.Helper()
+
+	next, cmd := m.Update(msg)
+
+	updated, ok := next.(standaloneModel)
+	require.True(t, ok, "Update must return a standaloneModel")
+
+	if cmd == nil {
+		return updated
+	}
+
+	// One level of command resolution is enough for this model; it never batches.
+	if produced := cmd(); produced != nil {
+		return step(t, updated, produced)
+	}
+
+	return updated
+}
+
+func TestStandalone_EnterSelectsHighlightedCloud(t *testing.T) {
+	// US Cloud is the first item, so Enter with no navigation picks it. That is the
+	// one-keystroke path for the common case.
+	m := drive(t, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.True(t, m.chosen, "Enter should record a choice")
+	assert.Equal(t, "https://app.datarobot.com", m.url)
+}
+
+func TestStandalone_NavigateThenEnterSelectsEUCloud(t *testing.T) {
+	m := drive(t,
+		tea.KeyMsg{Type: tea.KeyDown},
+		tea.KeyMsg{Type: tea.KeyEnter},
+	)
+
+	assert.True(t, m.chosen)
+	assert.Equal(t, "https://app.eu.datarobot.com", m.url)
+}
+
+func TestStandalone_EscInListModeCancels(t *testing.T) {
+	m := drive(t, tea.KeyMsg{Type: tea.KeyEsc})
+
+	assert.False(t, m.chosen, "Esc in list mode must cancel rather than choose")
+	assert.Empty(t, m.url)
+	assert.True(t, m.quitting)
+}
+
+func TestStandalone_EscInCustomModeGoesBackWithoutCancelling(t *testing.T) {
+	// Esc has two meanings: leave the custom-URL field, or cancel the picker. Inside
+	// the field it must only back out to the list.
+	m := drive(t,
+		tea.KeyMsg{Type: tea.KeyDown},
+		tea.KeyMsg{Type: tea.KeyDown},
+		tea.KeyMsg{Type: tea.KeyDown},
+		tea.KeyMsg{Type: tea.KeyEnter}, // opens the custom URL input
+		tea.KeyMsg{Type: tea.KeyEsc},   // back to the list
+	)
+
+	assert.False(t, m.quitting, "Esc inside the custom field must not quit the picker")
+	assert.False(t, m.chosen)
+
+	// A second Esc, now back in list mode, cancels.
+	final := step(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+
+	assert.True(t, final.quitting)
+	assert.False(t, final.chosen)
+}
+
+func TestStandalone_CustomURLIsReturned(t *testing.T) {
+	m := drive(t,
+		tea.KeyMsg{Type: tea.KeyDown},
+		tea.KeyMsg{Type: tea.KeyDown},
+		tea.KeyMsg{Type: tea.KeyDown},
+		tea.KeyMsg{Type: tea.KeyEnter},
+		tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("https://dr.internal.example.com")},
+		tea.KeyMsg{Type: tea.KeyEnter},
+	)
+
+	assert.True(t, m.chosen)
+	assert.Equal(t, "https://dr.internal.example.com", m.url)
+}
+
+func TestStandalone_ViewRendersPicker(t *testing.T) {
+	// Give it a size so the list has room to render its items.
+	sized := drive(t, tea.WindowSizeMsg{Width: 100, Height: 40})
+
+	view := sized.View()
+
+	assert.Contains(t, view, "US Cloud")
+	assert.Contains(t, view, "EU Cloud")
+}
+
+func TestStandalone_ViewIsEmptyOnceQuitting(t *testing.T) {
+	// Leaving the list rendered after selection would duplicate it above whatever
+	// the caller prints next.
+	m := drive(t, tea.KeyMsg{Type: tea.KeyEnter})
+
+	assert.Empty(t, m.View())
+}


### PR DESCRIPTION
# RATIONALE

UX research (P4, week of 2026-05-26) found `dr auth` "routed the user to the terminal" instead of opening a browser on a fresh install. Tracing the fresh-install path turned up four separate causes, plus two adjacent bugs.

Jira: [CFX-6318](https://datarobot.atlassian.net/browse/CFX-6318)

## CHANGES

**Flow change** — fresh install, before → after:

| Before | After |
| --- | --- |
| ASCII `[1] US / [2] EU / [3] JP` menu read off stdin | TUI list picker, US Cloud preselected (one keystroke) |
| `Please visit this link…` printed **before** the browser was touched | Browser opened first; link shown as a labelled fallback |
| `open.Open` errors discarded — silent no-op on Windows | Returns an error; failure is reported with the link promoted into a box |
| No spinner, no timeout — bare URL then blocked forever | Spinner in both paths, 5-minute bound |

Root causes: the env picker ran from the `EnsureAuthenticatedE` `PreRunE` on ~70 commands, so it fired before any TUI could render (the wizard's picker was unreachable on a fresh install); and Windows ran `exec.Command("start", url)`, but `start` is a `cmd.exe` builtin with no executable, so it always failed silently.

**Code:**
- `open.Open` returns an error; Windows uses `rundll32 url.dll,FileProtocolHandler`; non-`http(s)` URLs rejected before reaching a platform launcher.
- New `internal/auth.BrowserFlow` replaces the two duplicate `localhost:51164` callback servers (`internal/auth` + `cmd/templates/setup`). Binds *before* opening the browser so a fast redirect can't beat the listener; bounds the wait; drops stray callbacks instead of parking handlers.
- `RunBrowserLogin` is the single entry point for interactive login, so `dr auth login` and the implicit login look identical. Wording follows what actually happened — only a browser that really opened gets "Opening your browser…".
- `HostModel` → `tui/hostpicker` with a blocking `Select()`. Real picker on a TTY; plain-text prompt retained for piped stdin, CI, and the expect smoke tests.
- Adds `dr auth login --no-browser` for SSH/headless.

**Two bugs found while tracing this flow:**
- **`--skip-auth` was silently ignored.** `cmd/root.go` bound `"skip-auth"`; three read sites read `"skip_auth"`. Viper doesn't treat `-`/`_` as equivalent for lookups, so only `DATAROBOT_CLI_SKIP_AUTH` worked — a user passing `--skip-auth` on a fresh install was still dragged into this exact auth flow. Now behind `config.SkipAuthKey`. Several tests had enshrined the wrong spelling, which is why it stayed invisible.
- **`drconfig.yaml` was world-readable (`0644`).** `os.Create` sets `0644` and `os.WriteFile`'s perm arg is ignored for an existing file, so the deliberate `0600` in `write.go` never took effect on the plaintext API token. Now created `0600` and chmod'ed on every write to repair existing configs.

`docs/commands/auth.md` was substantially wrong about this flow (port 8080 with 8081/8082 fallback, an OAuth code exchange, an "encrypted" token, nested YAML). Corrected, and documented that the `?key=` handoff has no `state` parameter.

## TESTING

`task lint` 0 issues · full `-race` suite clean · both auth expect scripts pass (set-url 9.6s, login 0.66s).

Verified against the real binary: end-to-end callback (200, success page, token persisted, `0600`), TUI picker over a PTY (arrow-down+Enter persisted EU Cloud), `--no-browser`, non-TTY, and `--skip-auth` — the last confirmed broken on `main` in a throwaway worktree and fixed here.

## NOTES

- **The Windows `rundll32` change is unverified** — can't be exercised on macOS. Needs the Windows smoke workflow or a manual run. Per `AGENTS.md`, if that workflow's composite action needs touching, `@main` pinning means this PR's own CI won't exercise it.
- **The protocol is still unhardened, deliberately.** The API key arrives as a GET query param with no `state` parameter, so any local process reachable at `localhost:51164` during a login could deliver a key. Documented but left alone — deserves a security-reviewed ticket, not a ride-along on a UX fix.
- One rendering trap worth knowing: styling text that lipgloss then wraps in a border makes it re-emit content one character at a time, which broke the smoke test's `cliRedirect=true` match. The URL is now intentionally unstyled, with a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Before: 
<img width="1060" height="372" alt="image" src="https://github.com/user-attachments/assets/a83cfb4b-fd91-4a5f-a608-4c94715930f2" />

After:
<img width="730" height="376" alt="image" src="https://github.com/user-attachments/assets/7d08f641-2031-4290-b741-0c15ca64b201" />

<img width="944" height="298" alt="image" src="https://github.com/user-attachments/assets/56ad6a0d-d860-451e-98cb-29d98f03a3b2" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b819b707a3bdc763011650f5c15e4d33924f87c0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->