### PR TITLE
[CFX-6904] dotenv setup always show Pulumi config screen

### DIFF
--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -196,9 +196,10 @@ This wizard will help you:
 			contents:       contents,
 			SuccessCmd:     tea.Quit,
 			ShowAllPrompts: showAllPrompts,
-			Yes:            yes,
 		}
-		m.ConfigureFromPulumiCheck(CheckPulumiSetup(repositoryRoot, variables))
+
+		needsPulumi, pulumiLoggedIn, needsPassphrase := CheckPulumiSetup(repositoryRoot, variables)
+		m.ConfigureFromPulumiCheck(needsPulumi, pulumiLoggedIn, needsPassphrase, yes)
 
 		finalModel, err := tui.Run(m, tea.WithAltScreen(), tea.WithContext(cmd.Context()))
 		if err != nil {

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -89,11 +89,11 @@ var EditCmd = &cobra.Command{
 		}
 
 		m := Model{
-			initialScreen: screen,
-			DotenvFile:    dotenvFile,
-			variables:     variables,
-			contents:      contents,
-			SuccessCmd:    tea.Quit,
+			screen:     screen,
+			DotenvFile: dotenvFile,
+			variables:  variables,
+			contents:   contents,
+			SuccessCmd: tea.Quit,
 		}
 		_, err = tui.Run(m, tea.WithAltScreen(), tea.WithContext(cmd.Context()))
 
@@ -190,20 +190,15 @@ This wizard will help you:
 		dotenvFileLines, _ := readDotenvFile(dotenvFile)
 		variables, contents := envbuilder.VariablesFromLines(dotenvFileLines)
 
-		needsPulumi, pulumiLoggedIn, needsPassphrase := CheckPulumiSetup(repositoryRoot, variables)
-
 		m := Model{
-			initialScreen:         wizardScreen,
-			DotenvFile:            dotenvFile,
-			variables:             variables,
-			contents:              contents,
-			SuccessCmd:            tea.Quit,
-			ShowAllPrompts:        showAllPrompts,
-			Yes:                   yes,
-			NeedsPulumiLogin:      needsPulumi,
-			PulumiAlreadyLoggedIn: pulumiLoggedIn,
-			NeedsPulumiPassphrase: needsPassphrase,
+			DotenvFile:     dotenvFile,
+			variables:      variables,
+			contents:       contents,
+			SuccessCmd:     tea.Quit,
+			ShowAllPrompts: showAllPrompts,
+			Yes:            yes,
 		}
+		m.ConfigureFromPulumiCheck(CheckPulumiSetup(repositoryRoot, variables))
 
 		finalModel, err := tui.Run(m, tea.WithAltScreen(), tea.WithContext(cmd.Context()))
 		if err != nil {

--- a/cmd/dotenv/helpers.go
+++ b/cmd/dotenv/helpers.go
@@ -119,11 +119,11 @@ func ValidateAndEditIfNeeded() error {
 
 	// Launch the edit flow
 	m := Model{
-		initialScreen: screen,
-		DotenvFile:    dotenv,
-		variables:     variables,
-		contents:      contents,
-		SuccessCmd:    tea.Quit,
+		screen:     screen,
+		DotenvFile: dotenv,
+		variables:  variables,
+		contents:   contents,
+		SuccessCmd: tea.Quit,
 	}
 
 	_, err = tui.Run(m, tea.WithAltScreen())

--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -299,6 +299,16 @@ func (m Model) handlePulumiUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
+	// Always capture window size on the outer model, even while a sub-model
+	// (e.g. the Pulumi flow) is active — otherwise width/height never get set
+	// when Init() starts directly on a screen with an active sub-model, and
+	// stay stuck at zero for the rest of the session (no SIGWINCH on Windows
+	// means no later WindowSizeMsg will ever arrive to fix it up).
+	if sizeMsg, ok := msg.(tea.WindowSizeMsg); ok {
+		m.width = sizeMsg.Width
+		m.height = sizeMsg.Height
+	}
+
 	// If Pulumi login sub-model is active, delegate to it
 	if m.pulumiModel != nil {
 		return m.handlePulumiUpdate(msg)

--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -42,7 +42,12 @@ const (
 type screens int
 
 const (
-	listScreen = screens(iota)
+	// unsetScreen is the zero value: a Model whose screen was never explicitly
+	// configured. Init() panics on it rather than silently behaving as
+	// listScreen, so a caller that forgets to set screen fails immediately
+	// instead of shipping a hard-to-diagnose "wrong screen shown" bug.
+	unsetScreen = screens(iota)
+	listScreen
 	editorScreen
 	wizardScreen
 	pulumiScreen
@@ -263,6 +268,8 @@ func (m Model) autoPopulateAndSave() (tea.Model, tea.Cmd) {
 
 func (m Model) Init() tea.Cmd {
 	switch m.screen {
+	case unsetScreen:
+		panic("dotenv.Model.screen was never configured before Init()")
 	case editorScreen:
 		return tea.Batch(openEditorCmd, tea.WindowSize())
 	case pulumiScreen:
@@ -275,7 +282,7 @@ func (m Model) Init() tea.Cmd {
 		return tea.Batch(m.loadVariables(), tea.WindowSize())
 	}
 
-	return tea.Batch(m.loadVariables(), tea.WindowSize())
+	panic(fmt.Sprintf("dotenv.Model.screen has unknown value %d", m.screen))
 }
 
 func (m Model) handlePulumiUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -395,6 +402,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 	}
 
 	switch m.screen {
+	case unsetScreen:
+		// Unreachable: Init() panics before Update() ever sees an unconfigured Model.
 	case pulumiScreen:
 		// Handled above via m.pulumiModel delegation
 	case listScreen:
@@ -480,6 +489,8 @@ func (m Model) View() string {
 	}
 
 	switch m.screen {
+	case unsetScreen:
+		// Unreachable: Init() panics before View() ever sees an unconfigured Model.
 	case pulumiScreen:
 		if m.pulumiModel != nil {
 			sb.WriteString(m.pulumiModel.View())

--- a/cmd/dotenv/model.go
+++ b/cmd/dotenv/model.go
@@ -49,27 +49,23 @@ const (
 )
 
 type Model struct {
-	screen                screens
-	initialScreen         screens
-	DotenvFile            string
-	variables             []envbuilder.Variable
-	err                   error
-	textarea              textarea.Model
-	contents              string
-	width                 int
-	height                int
-	SuccessCmd            tea.Cmd
-	prompts               []envbuilder.UserPrompt
-	currentPromptIndex    int
-	currentPrompt         promptModel
-	hasPrompts            *bool             // Cache whether prompts are available
-	ShowAllPrompts        bool              // When true, show all prompts regardless of defaults
-	Yes                   bool              // When true, auto-populate all prompts with defaults (or empty) without showing wizard
-	skippedPrompts        int               // Count of prompts skipped due to having defaults
-	pulumiModel           *pulumiLoginModel // Sub-model for Pulumi login flow, shown before wizard if needed
-	NeedsPulumiLogin      bool              // Set by callers before Init(); true when login or passphrase setup is needed
-	PulumiAlreadyLoggedIn bool              // Set by callers; when true, Pulumi screen skips backend selection
-	NeedsPulumiPassphrase bool              // Set by callers; when true, passphrase prompt is shown after login
+	screen             screens
+	DotenvFile         string
+	variables          []envbuilder.Variable
+	err                error
+	textarea           textarea.Model
+	contents           string
+	width              int
+	height             int
+	SuccessCmd         tea.Cmd
+	prompts            []envbuilder.UserPrompt
+	currentPromptIndex int
+	currentPrompt      promptModel
+	hasPrompts         *bool             // Cache whether prompts are available
+	ShowAllPrompts     bool              // When true, show all prompts regardless of defaults
+	Yes                bool              // When true, auto-populate all prompts with defaults (or empty) without showing wizard
+	skippedPrompts     int               // Count of prompts skipped due to having defaults
+	pulumiModel        *pulumiLoginModel // Sub-model for Pulumi login flow, shown before wizard if needed
 }
 
 type (
@@ -266,12 +262,17 @@ func (m Model) autoPopulateAndSave() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) Init() tea.Cmd {
-	if m.initialScreen == editorScreen {
+	switch m.screen {
+	case editorScreen:
 		return tea.Batch(openEditorCmd, tea.WindowSize())
-	}
-
-	if m.initialScreen == wizardScreen {
+	case pulumiScreen:
+		// Prompts are (re)loaded once the Pulumi flow completes and hands off
+		// to the wizard (see handlePulumiUpdate) — no need to load them now.
+		return tea.Batch(m.pulumiModel.Init(), tea.WindowSize())
+	case wizardScreen:
 		return tea.Batch(m.loadPrompts(), tea.WindowSize())
+	case listScreen:
+		return tea.Batch(m.loadVariables(), tea.WindowSize())
 	}
 
 	return tea.Batch(m.loadVariables(), tea.WindowSize())
@@ -280,10 +281,10 @@ func (m Model) Init() tea.Cmd {
 func (m Model) handlePulumiUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg.(type) {
 	case pulumiLoginCompleteMsg:
-		// Pulumi setup finished — reload prompts so the newly saved passphrase
-		// is picked up before the wizard starts.
+		// Pulumi setup finished — hand off to the wizard and reload prompts so
+		// the newly saved passphrase is picked up before it starts.
 		m.pulumiModel = nil
-		m.NeedsPulumiLogin = false
+		m.screen = wizardScreen
 
 		return m, m.loadPrompts()
 	}
@@ -352,16 +353,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 			return m, nil
 		}
 
-		// Check if Pulumi login/passphrase setup is needed before the wizard
-		// Skip interactive Pulumi screen in --yes mode (passphrase will be auto-generated if needed)
-		if m.NeedsPulumiLogin && !m.Yes {
-			plm := newPulumiLoginModel(m.PulumiAlreadyLoggedIn, m.NeedsPulumiPassphrase)
-			m.pulumiModel = &plm
-			m.screen = pulumiScreen
-
-			return m, plm.Init()
-		}
-
 		// If Yes is true, auto-populate all values and save without showing wizard
 		if m.Yes {
 			return m.autoPopulateAndSave()
@@ -387,6 +378,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 				Runes: []rune("ctrl+home"),
 			}
 		})
+	case errMsg:
+		m.err = msg.err
+
+		return m, nil
 	}
 
 	switch m.screen {
@@ -407,9 +402,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 			case keyOpenExternal:
 				return m, m.openInExternalEditor()
 			}
-		case errMsg:
-			m.err = msg.err
-			return m, nil
 		}
 	case editorScreen:
 		switch msg := msg.(type) {
@@ -468,6 +460,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 
 func (m Model) View() string {
 	var sb strings.Builder
+
+	if m.err != nil {
+		sb.WriteString(tui.ErrorStyle.Render("Error: " + m.err.Error()))
+		sb.WriteString("\n\n")
+		sb.WriteString(tui.BaseTextStyle.Render("Press ctrl+c to exit."))
+
+		return sb.String()
+	}
 
 	switch m.screen {
 	case pulumiScreen:

--- a/cmd/dotenv/model_test.go
+++ b/cmd/dotenv/model_test.go
@@ -16,6 +16,8 @@ package dotenv
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -179,7 +181,6 @@ func (suite *DotenvModelTestSuite) FinalModel(tm *teatest.TestModel) Model {
 func (suite *DotenvModelTestSuite) TestDotenvModel_Happy_Path() {
 	tm := suite.NewTestModel(Model{
 		screen:         wizardScreen,
-		initialScreen:  wizardScreen,
 		DotenvFile:     filepath.Join(suite.tempDir, ".env"),
 		ShowAllPrompts: true,
 	})
@@ -226,7 +227,6 @@ func (suite *DotenvModelTestSuite) TestDotenvModel_Happy_Path() {
 func (suite *DotenvModelTestSuite) TestDotenvModel_Branching_Path() {
 	tm := suite.NewTestModel(Model{
 		screen:         wizardScreen,
-		initialScreen:  wizardScreen,
 		DotenvFile:     filepath.Join(suite.tempDir, ".env"),
 		ShowAllPrompts: true,
 	})
@@ -284,7 +284,6 @@ func (suite *DotenvModelTestSuite) TestDotenvModel_Branching_Path() {
 func (suite *DotenvModelTestSuite) TestDotenvModel_Both_Path() {
 	tm := suite.NewTestModel(Model{
 		screen:         wizardScreen,
-		initialScreen:  wizardScreen,
 		DotenvFile:     filepath.Join(suite.tempDir, ".env"),
 		ShowAllPrompts: true,
 	})
@@ -356,7 +355,6 @@ func (suite *DotenvModelTestSuite) Test__loadPromptsFindsEnvValues() {
 	suite.T().Setenv("PULUMI_CONFIG_PASSPHRASE", "existing_passphrase")
 	tm := suite.NewTestModel(Model{
 		screen:         wizardScreen,
-		initialScreen:  wizardScreen,
 		DotenvFile:     filepath.Join(suite.tempDir, ".env"),
 		ShowAllPrompts: true,
 	})
@@ -427,7 +425,6 @@ func (suite *DotenvModelTestSuite) TestDotenvModel_SkipsPromptsWithDefaults() {
 	// The wizard should skip both and start directly at data_source.
 	tm := suite.NewTestModel(Model{
 		screen:         wizardScreen,
-		initialScreen:  wizardScreen,
 		DotenvFile:     filepath.Join(suite.tempDir, ".env"),
 		ShowAllPrompts: false, // Default behavior - skip prompts with defaults
 	})
@@ -470,10 +467,9 @@ func (suite *DotenvModelTestSuite) TestDotenvModel_Yes() {
 	// 3. The file is saved automatically
 	// 4. The model exits immediately without waiting for user confirmation
 	tm := suite.NewTestModel(Model{
-		screen:        wizardScreen,
-		initialScreen: wizardScreen,
-		DotenvFile:    filepath.Join(suite.tempDir, ".env"),
-		Yes:           true,
+		screen:     wizardScreen,
+		DotenvFile: filepath.Join(suite.tempDir, ".env"),
+		Yes:        true,
 	})
 
 	// Wait a moment for the async save operation to complete before quitting
@@ -526,4 +522,56 @@ func (suite *DotenvModelTestSuite) TestYes_ViperBinding() {
 	suite.T().Setenv("DATAROBOT_CLI_NON_INTERACTIVE", "false")
 
 	suite.False(viperx.GetBool("yes"), "Expected viper to read 'false' as false")
+}
+
+// TestDotenvModel_PulumiScreenShownFirst is a regression test for CFX-6904: when Pulumi
+// setup is needed, the passphrase screen must be the very first thing rendered — never
+// the "Environment Variables Menu" list screen — regardless of how long loading prompts
+// in the background takes. Deciding this asynchronously (via promptsLoadedMsg) used to
+// race with that load and could leave the wrong screen showing.
+func (suite *DotenvModelTestSuite) TestDotenvModel_PulumiScreenShownFirst() {
+	m := Model{
+		DotenvFile: filepath.Join(suite.tempDir, ".env"),
+	}
+	// loggedIn=true so the Pulumi sub-model starts directly on the passphrase
+	// prompt screen instead of the backend-selection screen.
+	m.ConfigureFromPulumiCheck(true, true, true)
+
+	tm := suite.NewTestModel(m)
+
+	var captured bytes.Buffer
+
+	teatest.WaitFor(
+		suite.T(), io.TeeReader(tm.Output(), &captured),
+		func(bts []byte) bool {
+			return bytes.Contains(bts, []byte("Pulumi Configuration Passphrase"))
+		},
+		teatest.WithCheckInterval(time.Millisecond*100),
+		teatest.WithDuration(time.Second*3),
+	)
+
+	suite.NotContains(captured.String(), "Environment Variables Menu",
+		"the Pulumi passphrase screen must be the first thing rendered, not the list screen")
+}
+
+// TestDotenvModel_ErrorSurfacedRegardlessOfScreen is a regression test for CFX-6904:
+// errMsg used to only be handled while m.screen == listScreen, so an error arriving on
+// any other screen (e.g. wizardScreen) was silently dropped and the model got stuck
+// re-rendering stale UI forever. errMsg must now be captured and surfaced regardless of
+// which screen is active.
+func (suite *DotenvModelTestSuite) TestDotenvModel_ErrorSurfacedRegardlessOfScreen() {
+	m := Model{
+		screen:     wizardScreen,
+		DotenvFile: filepath.Join(suite.tempDir, ".env"),
+	}
+
+	tm := suite.NewTestModel(m)
+
+	tm.Send(errMsg{err: errors.New("boom: something went wrong loading prompts")})
+
+	suite.WaitFor(tm, "Error: boom")
+
+	fm := suite.FinalModel(tm)
+	suite.Require().Error(fm.err)
+	suite.Contains(fm.err.Error(), "boom")
 }

--- a/cmd/dotenv/model_test.go
+++ b/cmd/dotenv/model_test.go
@@ -535,7 +535,7 @@ func (suite *DotenvModelTestSuite) TestDotenvModel_PulumiScreenShownFirst() {
 	}
 	// loggedIn=true so the Pulumi sub-model starts directly on the passphrase
 	// prompt screen instead of the backend-selection screen.
-	m.ConfigureFromPulumiCheck(true, true, true)
+	m.ConfigureFromPulumiCheck(true, true, true, false)
 
 	tm := suite.NewTestModel(m)
 
@@ -587,7 +587,7 @@ func (suite *DotenvModelTestSuite) TestDotenvModel_WindowSizeCapturedWhileOnPulu
 	m := Model{
 		DotenvFile: filepath.Join(suite.tempDir, ".env"),
 	}
-	m.ConfigureFromPulumiCheck(true, true, true)
+	m.ConfigureFromPulumiCheck(true, true, true, false)
 
 	// suite.NewTestModel sends an initial tea.WindowSizeMsg{300, 100} (via
 	// teatest.WithInitialTermSize) while the model still starts on pulumiScreen.

--- a/cmd/dotenv/model_test.go
+++ b/cmd/dotenv/model_test.go
@@ -575,3 +575,40 @@ func (suite *DotenvModelTestSuite) TestDotenvModel_ErrorSurfacedRegardlessOfScre
 	suite.Require().Error(fm.err)
 	suite.Contains(fm.err.Error(), "boom")
 }
+
+// TestDotenvModel_WindowSizeCapturedWhileOnPulumiScreen is a regression test: when
+// Init() starts on pulumiScreen, the tea.WindowSizeMsg used to be swallowed entirely by
+// the top-level "delegate to pulumiModel" guard in Update(), so m.width/m.height were
+// never set. Once the Pulumi flow completed and the user opened the editor from
+// listScreen, the textarea was built with negative width/height (m.width-14, m.height-13
+// with both still zero) and — with no SIGWINCH-driven resize on Windows to correct it —
+// stayed broken for the rest of the session.
+func (suite *DotenvModelTestSuite) TestDotenvModel_WindowSizeCapturedWhileOnPulumiScreen() {
+	m := Model{
+		DotenvFile: filepath.Join(suite.tempDir, ".env"),
+	}
+	m.ConfigureFromPulumiCheck(true, true, true)
+
+	// suite.NewTestModel sends an initial tea.WindowSizeMsg{300, 100} (via
+	// teatest.WithInitialTermSize) while the model still starts on pulumiScreen.
+	tm := suite.NewTestModel(m)
+
+	suite.WaitFor(tm, "Pulumi Configuration Passphrase")
+
+	// Skip the passphrase prompt, hand off to the wizard.
+	suite.Send(tm, "n")
+	suite.WaitFor(tm, "Interactive Setup")
+
+	// Jump straight to the list screen without completing every prompt.
+	suite.Send(tm, "esc")
+	suite.WaitFor(tm, "Environment Variables Menu")
+
+	// Open the built-in editor — this is where the stale zero width/height used to bite.
+	suite.Send(tm, "e")
+	suite.WaitFor(tm, "Edit Mode")
+
+	fm := suite.FinalModel(tm)
+
+	suite.Greater(fm.textarea.Width(), 100, "textarea width should reflect the real terminal size, not a clamped/zero fallback")
+	suite.Greater(fm.textarea.Height(), 50, "textarea height should reflect the real terminal size, not a clamped/zero fallback")
+}

--- a/cmd/dotenv/pulumiModel.go
+++ b/cmd/dotenv/pulumiModel.go
@@ -397,14 +397,17 @@ func CheckPulumiSetup(dir string, variables []envbuilder.Variable) (needsSetup, 
 	return needsPulumiSetup(prompts, loggedIn, passphraseSet), loggedIn, !passphraseSet
 }
 
-// ConfigureFromPulumiCheck sets the model's initial screen synchronously from the
-// result of CheckPulumiSetup, so the Pulumi passphrase screen — when needed — is the
-// very first thing rendered. Deciding this asynchronously (e.g. only once the wizard's
-// prompt-loading completes) races with that load and can leave the wrong screen showing
-// if it's slow or fails. Call this after constructing the Model (with Yes already set,
-// since --yes mode always skips the interactive Pulumi screen) and before Init().
-func (m *Model) ConfigureFromPulumiCheck(needsPulumi, loggedIn, needsPassphrase bool) {
-	if needsPulumi && !m.Yes {
+// ConfigureFromPulumiCheck sets the model's Yes flag and initial screen synchronously
+// from the result of CheckPulumiSetup, so the Pulumi passphrase screen — when needed —
+// is the very first thing rendered. Deciding this asynchronously (e.g. only once the
+// wizard's prompt-loading completes) races with that load and can leave the wrong
+// screen showing if it's slow or fails. yes mirrors --yes/non-interactive mode, which
+// always skips the interactive Pulumi screen. Call this after constructing the Model
+// and before Init(); it owns setting Yes, so callers don't need to set it separately.
+func (m *Model) ConfigureFromPulumiCheck(needsPulumi, loggedIn, needsPassphrase, yes bool) {
+	m.Yes = yes
+
+	if needsPulumi && !yes {
 		plm := newPulumiLoginModel(loggedIn, needsPassphrase)
 		m.pulumiModel = &plm
 		m.screen = pulumiScreen

--- a/cmd/dotenv/pulumiModel.go
+++ b/cmd/dotenv/pulumiModel.go
@@ -379,8 +379,8 @@ func isPulumiLoggedIn() bool {
 
 // CheckPulumiSetup returns whether the Pulumi setup screen should be shown,
 // whether the user is already logged in, and whether a passphrase needs to be
-// configured. Call this before starting the dotenv TUI and set the corresponding
-// Model fields.
+// configured. Call this before starting the dotenv TUI and pass the result to
+// ConfigureFromPulumiCheck.
 func CheckPulumiSetup(dir string, variables []envbuilder.Variable) (needsSetup, alreadyLoggedIn, needsPassphrase bool) {
 	prompts, err := envbuilder.GatherUserPrompts(dir, variables)
 	if err != nil {
@@ -395,6 +395,24 @@ func CheckPulumiSetup(dir string, variables []envbuilder.Variable) (needsSetup, 
 	passphraseSet := viperx.GetString(pulumiConfigPassphraseKey) != ""
 
 	return needsPulumiSetup(prompts, loggedIn, passphraseSet), loggedIn, !passphraseSet
+}
+
+// ConfigureFromPulumiCheck sets the model's initial screen synchronously from the
+// result of CheckPulumiSetup, so the Pulumi passphrase screen — when needed — is the
+// very first thing rendered. Deciding this asynchronously (e.g. only once the wizard's
+// prompt-loading completes) races with that load and can leave the wrong screen showing
+// if it's slow or fails. Call this after constructing the Model (with Yes already set,
+// since --yes mode always skips the interactive Pulumi screen) and before Init().
+func (m *Model) ConfigureFromPulumiCheck(needsPulumi, loggedIn, needsPassphrase bool) {
+	if needsPulumi && !m.Yes {
+		plm := newPulumiLoginModel(loggedIn, needsPassphrase)
+		m.pulumiModel = &plm
+		m.screen = pulumiScreen
+
+		return
+	}
+
+	m.screen = wizardScreen
 }
 
 // handlePulumiPassphraseNonInteractive checks if Pulumi passphrase needs to be

--- a/cmd/templates/setup/model.go
+++ b/cmd/templates/setup/model.go
@@ -418,7 +418,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		m.loadingMessage = ""
 		m.screen = dotenvScreen
 		m.dotenv.DotenvFile = filepath.Join(m.clone.Dir, ".env")
-		m.dotenv.ConfigureFromPulumiCheck(dotenv.CheckPulumiSetup(m.clone.Dir, nil))
+
+		needsPulumi, loggedIn, needsPassphrase := dotenv.CheckPulumiSetup(m.clone.Dir, nil)
+		m.dotenv.ConfigureFromPulumiCheck(needsPulumi, loggedIn, needsPassphrase, m.dotenv.Yes)
 		m.dotenvSetupCompleted = true
 
 		return m, m.dotenv.Init()
@@ -428,7 +430,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		m.list.Template = msg.template
 		m.template = msg.template
 		m.dotenv.DotenvFile = msg.dotenvFile
-		m.dotenv.ConfigureFromPulumiCheck(dotenv.CheckPulumiSetup(filepath.Dir(msg.dotenvFile), nil))
+
+		needsPulumi, loggedIn, needsPassphrase := dotenv.CheckPulumiSetup(filepath.Dir(msg.dotenvFile), nil)
+		m.dotenv.ConfigureFromPulumiCheck(needsPulumi, loggedIn, needsPassphrase, m.dotenv.Yes)
 		m.dotenvSetupCompleted = true
 
 		return m, m.dotenv.Init()

--- a/cmd/templates/setup/model.go
+++ b/cmd/templates/setup/model.go
@@ -418,7 +418,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		m.loadingMessage = ""
 		m.screen = dotenvScreen
 		m.dotenv.DotenvFile = filepath.Join(m.clone.Dir, ".env")
-		m.dotenv.NeedsPulumiLogin, m.dotenv.PulumiAlreadyLoggedIn, m.dotenv.NeedsPulumiPassphrase = dotenv.CheckPulumiSetup(m.clone.Dir, nil)
+		m.dotenv.ConfigureFromPulumiCheck(dotenv.CheckPulumiSetup(m.clone.Dir, nil))
 		m.dotenvSetupCompleted = true
 
 		return m, m.dotenv.Init()
@@ -428,7 +428,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint: cyclop
 		m.list.Template = msg.template
 		m.template = msg.template
 		m.dotenv.DotenvFile = msg.dotenvFile
-		m.dotenv.NeedsPulumiLogin, m.dotenv.PulumiAlreadyLoggedIn, m.dotenv.NeedsPulumiPassphrase = dotenv.CheckPulumiSetup(filepath.Dir(msg.dotenvFile), nil)
+		m.dotenv.ConfigureFromPulumiCheck(dotenv.CheckPulumiSetup(filepath.Dir(msg.dotenvFile), nil))
 		m.dotenvSetupCompleted = true
 
 		return m, m.dotenv.Init()


### PR DESCRIPTION
## RATIONALE

The Harness "Agentic app E2E tests" Windows pipeline has a "Run DR CLI tests" stage that drives `dr dotenv setup` with scripted keystrokes, expecting the "Pulumi Configuration Passphrase" screen to be the very first thing shown (it answers `n` to skip). The stage was flaky: some runs never showed that screen at all — instead the CLI's "Environment Variables Menu" was rendered/re-rendered repeatedly, so the scripted input went to the wrong screen and the stage failed (confirmed via Harness execution `o8jh7ZZoThijkiydUVvpTg`, run #379).

Root cause: `dotenv.Model` had two screen fields — `screen` (what `Update()`/`View()` actually read) and `initialScreen` (set by callers, but only ever consulted inside `Init()` to pick an async command). Since `screen` was left at its Go zero value (`listScreen`, i.e. "Environment Variables Menu"), and bubbletea renders the first frame from the model as originally constructed — before any async `Init()` command resolves — every `dr dotenv setup` briefly showed the wrong screen, regardless of intent. The decision to show the Pulumi screen was *also* made only asynchronously, inside the `promptsLoadedMsg` handler, racing a `filepath.Walk`-based prompt-discovery call that's slower and less predictable on Windows CI. When that load was slow, or errored, the model got stuck re-rendering "Environment Variables Menu" forever — errors from it were captured but never rendered anywhere.

A second caller with the identical bug was found during the fix: `cmd/templates/setup/model.go` embeds a `dotenv.Model` and drives the same Pulumi-screen decision via the same async path.

## CHANGES

- Collapsed `Model.screen`/`initialScreen` into a single field, always set explicitly at construction time (`cmd/dotenv/cmd.go`, `cmd/dotenv/helpers.go`) instead of relying on the `listScreen` zero-value + an async transition.
- Added an exported `Model.ConfigureFromPulumiCheck(needsPulumi, loggedIn, needsPassphrase bool)` method (`cmd/dotenv/pulumiModel.go`) that decides synchronously — right after `CheckPulumiSetup` runs — whether to start on the Pulumi screen, instead of deferring that decision to the async `promptsLoadedMsg` handler. This guarantees the passphrase screen, when needed, is the very first frame rendered, with no dependency on the prompt-discovery walk completing first.
- Updated both callers to use it: `cmd/dotenv/cmd.go`'s `SetupCmd`, and the embedded flow in `cmd/templates/setup/model.go` (which had the same latent race).
- Moved `errMsg` handling to the top level of `Update()` so an error is captured regardless of which screen is currently active (previously only handled while on `listScreen`), and now renders as a visible error banner in `View()` instead of being silently dropped.
- Removed the now-dead `NeedsPulumiLogin`/`PulumiAlreadyLoggedIn`/`NeedsPulumiPassphrase` exported fields on `Model`, superseded by `ConfigureFromPulumiCheck`.
- Added regression tests (`cmd/dotenv/model_test.go`): one asserting the Pulumi passphrase screen is always the first thing rendered (never "Environment Variables Menu"), one asserting an error is surfaced regardless of the active screen. Both were verified to fail (compile error) against the pre-fix code.



# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-frame TUI behavior for setup and template flows; risk is mitigated by focused regression tests but still affects interactive and scripted automation paths.
> 
> **Overview**
> Fixes flaky `dr dotenv setup` / template setup where the **Environment Variables Menu** could appear before the **Pulumi Configuration Passphrase** screen, breaking scripted CI input.
> 
> **Screen selection** no longer relies on `listScreen` as the zero value plus an async handoff after prompt loading. Callers set a single `screen` up front, and **`ConfigureFromPulumiCheck`** runs right after `CheckPulumiSetup` so the Pulumi flow is the first frame when needed (`--yes` still skips it). The old `NeedsPulumiLogin` / related exported fields are removed in favor of that helper; `cmd/templates/setup` uses the same path for embedded dotenv.
> 
> **Errors:** `errMsg` is handled at the top of `Update()` and shown in `View()` on any screen, so prompt-load failures are not dropped while on the wizard.
> 
> Regression tests cover “Pulumi first, never the list menu” and error display on non-list screens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5f1736d9c60fc3882b482e4007ab99c39a9b252. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->