### PR TITLE
[APP-6736] implements `dr auth export` to emit canonical DataRobot env vars

### DIFF
--- a/cmd/auth/cmd.go
+++ b/cmd/auth/cmd.go
@@ -16,6 +16,7 @@ package auth
 
 import (
 	"github.com/datarobot/cli/cmd/auth/check"
+	"github.com/datarobot/cli/cmd/auth/export"
 	"github.com/datarobot/cli/cmd/auth/login"
 	"github.com/datarobot/cli/cmd/auth/logout"
 	"github.com/datarobot/cli/cmd/auth/seturl"
@@ -34,12 +35,14 @@ Manage your DataRobot credentials and connection settings:
   • Configure your DataRobot environment URL
   • Log in using OAuth authentication
   • Log out and clear stored credentials
+  • Export your credentials as environment variables
 
 🚀 Quick start: dr auth set-url && dr auth login`,
 	}
 
 	cmd.AddCommand(
 		check.Cmd(),
+		export.Cmd(),
 		login.Cmd(),
 		logout.Cmd(),
 		seturl.Cmd(),

--- a/cmd/auth/export/cmd.go
+++ b/cmd/auth/export/cmd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/outputformat"
 	internalShell "github.com/datarobot/cli/internal/shell"
 	"github.com/datarobot/cli/internal/version"
@@ -248,8 +249,13 @@ func resolveShell(requested string) (internalShell.Shell, error) {
 
 	detected, err := internalShell.DetectShell()
 	if err != nil {
+		log.Debug("auth export: shell detection failed, falling back to POSIX syntax",
+			"error", err, "shell", internalShell.Bash)
+
 		return internalShell.Bash, nil
 	}
+
+	log.Debug("auth export: detected shell", "shell", detected)
 
 	return internalShell.Shell(detected), nil
 }
@@ -305,6 +311,9 @@ directly by your shell. Errors and hints go to stderr.
 Credentials are resolved the same way the rest of the CLI resolves them:
   • the ` + endpointVar + ` and ` + tokenVar + ` environment variables, if both are set
   • otherwise the CLI config file written by '` + version.CliName + ` auth login'
+
+A project's .env file is never consulted — this exports the CLI's own
+credentials. Use '` + version.CliName + ` dotenv setup' to manage .env files.
 
 Unlike most commands, this one never starts a login flow and never calls the
 API, so it is safe to run from a shell startup file. Run '` + version.CliName + ` auth check' first

--- a/cmd/auth/export/cmd.go
+++ b/cmd/auth/export/cmd.go
@@ -1,0 +1,346 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package export renders the DataRobot credentials the CLI is currently using
+// as shell statements that set the canonical DataRobot environment variables,
+// so they can be sourced into the caller's shell session.
+package export
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/outputformat"
+	internalShell "github.com/datarobot/cli/internal/shell"
+	"github.com/datarobot/cli/internal/version"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+// The canonical DataRobot environment variables. Every DataRobot SDK, the
+// platform itself, and this CLI read this pair, so they are what we emit.
+const (
+	endpointVar = "DATAROBOT_ENDPOINT"
+	tokenVar    = "DATAROBOT_API_TOKEN"
+)
+
+// jsonEnvelopeKey is the top-level key used for `--output-format json`.
+const jsonEnvelopeKey = "environment"
+
+var (
+	errNoCredentials = errors.New("no DataRobot credentials configured")
+	errNoEndpoint    = errors.New("no DataRobot endpoint configured")
+	errNoToken       = errors.New("no DataRobot API token configured")
+)
+
+// credentials is the endpoint/token pair this command renders.
+type credentials struct {
+	Endpoint string
+	Token    string
+}
+
+// statementFunc renders a single "set this variable" statement for one shell.
+type statementFunc func(name, value string) string
+
+// canonicalEndpoint normalizes a configured DataRobot URL into the canonical
+// API endpoint form, e.g. "app.datarobot.com" becomes
+// "https://app.datarobot.com/api/v2". A URL that already carries a path is
+// preserved as-is (minus any trailing slash, query, or fragment) so that
+// self-managed installs serving the API under a custom prefix keep working.
+func canonicalEndpoint(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", errNoEndpoint
+	}
+
+	// Default to https so a bare hostname is accepted, matching
+	// config.SchemeHostOnly.
+	if !strings.Contains(trimmed, "://") {
+		trimmed = "https://" + trimmed
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", err
+	}
+
+	if parsed.Host == "" {
+		return "", config.ErrInvalidURL
+	}
+
+	path := strings.TrimRight(parsed.Path, "/")
+	if path == "" {
+		path = config.DRAPIURLSuffix
+	}
+
+	parsed.Path, parsed.RawQuery, parsed.Fragment = path, "", ""
+
+	return parsed.String(), nil
+}
+
+// rawCredentials returns the credentials the CLI would use, mirroring the
+// precedence in auth.EnsureAuthenticated: a complete pair of environment
+// variables wins over the CLI config file. Unlike EnsureAuthenticated, it never
+// contacts the API and never starts a login flow, so `dr auth export` stays
+// usable from shell startup files and non-interactive sessions.
+func rawCredentials() (credentials, error) {
+	if env := auth.GetEnvCredentials(); env.Endpoint != "" && env.Token != "" {
+		return credentials{Endpoint: env.Endpoint, Token: env.Token}, nil
+	}
+
+	creds := credentials{
+		Endpoint: viperx.GetString(config.DataRobotURL),
+		Token:    viperx.GetString(config.DataRobotAPIKey),
+	}
+
+	switch {
+	case creds.Endpoint == "" && creds.Token == "":
+		return creds, errNoCredentials
+	case creds.Endpoint == "":
+		return creds, errNoEndpoint
+	case creds.Token == "":
+		return creds, errNoToken
+	}
+
+	return creds, nil
+}
+
+// resolveCredentials returns the credentials to export, with the endpoint
+// normalized to its canonical form.
+func resolveCredentials() (credentials, error) {
+	creds, err := rawCredentials()
+	if err != nil {
+		return creds, err
+	}
+
+	endpoint, err := canonicalEndpoint(creds.Endpoint)
+	if err != nil {
+		return creds, err
+	}
+
+	creds.Endpoint = endpoint
+
+	return creds, nil
+}
+
+// printCredentialError explains on stderr why nothing was exported. stdout is
+// left empty so that `eval "$(dr auth export)"` cannot evaluate a partial or
+// non-executable result.
+func printCredentialError(w io.Writer, err error) {
+	switch {
+	case errors.Is(err, errNoEndpoint):
+		fmt.Fprintln(w, tui.BaseTextStyle.Render("❌ No DataRobot URL configured."))
+		fmt.Fprint(w, tui.BaseTextStyle.Render("Run "))
+		fmt.Fprint(w, tui.InfoStyle.Render(version.CliName+" auth set-url"))
+		fmt.Fprintln(w, tui.BaseTextStyle.Render(" to configure your DataRobot URL."))
+	case errors.Is(err, errNoToken), errors.Is(err, errNoCredentials):
+		fmt.Fprintln(w, tui.BaseTextStyle.Render("❌ No DataRobot credentials found."))
+		fmt.Fprint(w, tui.BaseTextStyle.Render("Run "))
+		fmt.Fprint(w, tui.InfoStyle.Render(version.CliName+" auth login"))
+		fmt.Fprintln(w, tui.BaseTextStyle.Render(" to authenticate."))
+	default:
+		fmt.Fprintln(w, tui.BaseTextStyle.Render("❌ Invalid DataRobot URL configured: "+err.Error()))
+		fmt.Fprint(w, tui.BaseTextStyle.Render("Run "))
+		fmt.Fprint(w, tui.InfoStyle.Render(version.CliName+" auth set-url"))
+		fmt.Fprintln(w, tui.BaseTextStyle.Render(" to fix it."))
+	}
+}
+
+// posixQuote wraps a value in single quotes and escapes any embedded single
+// quote, producing one literal word in sh, bash, zsh, and fish.
+func posixQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+// powerShellQuote wraps a value in single quotes, where an embedded quote is
+// escaped by doubling it.
+func powerShellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+// cmdEscape caret-escapes the cmd.exe metacharacters. `set NAME=value` has no
+// quoting form — surrounding quotes would become part of the value — so the
+// metacharacters have to be escaped individually.
+func cmdEscape(value string) string {
+	return strings.NewReplacer(
+		"^", "^^",
+		"&", "^&",
+		"<", "^<",
+		">", "^>",
+		"|", "^|",
+	).Replace(value)
+}
+
+func posixStatement(name, value string) string {
+	return "export " + name + "=" + posixQuote(value)
+}
+
+func fishStatement(name, value string) string {
+	return "set -gx " + name + " " + posixQuote(value)
+}
+
+func powerShellStatement(name, value string) string {
+	return "$env:" + name + " = " + powerShellQuote(value)
+}
+
+func cmdStatement(name, value string) string {
+	return "set " + name + "=" + cmdEscape(value)
+}
+
+// renderExports returns the statements that set both canonical variables in the
+// syntax of the given shell.
+func renderExports(sh internalShell.Shell, creds credentials) []string {
+	var statement statementFunc
+
+	switch sh {
+	case internalShell.Fish:
+		statement = fishStatement
+	case internalShell.PowerShell:
+		statement = powerShellStatement
+	case internalShell.Cmd:
+		statement = cmdStatement
+	case internalShell.Bash, internalShell.Zsh:
+		statement = posixStatement
+	default:
+		// Unrecognized shells (e.g. plain sh, dash, ksh) get POSIX syntax,
+		// which is correct for every Bourne-compatible shell.
+		statement = posixStatement
+	}
+
+	return []string{
+		statement(endpointVar, creds.Endpoint),
+		statement(tokenVar, creds.Token),
+	}
+}
+
+// resolveShell picks the syntax to emit. An explicit --shell wins; otherwise
+// the parent shell is detected. Detection failures fall back to POSIX syntax
+// instead of erroring, since that is the right answer for sh, bash, and zsh.
+func resolveShell(requested string) (internalShell.Shell, error) {
+	if requested != "" {
+		normalized := strings.ToLower(strings.TrimSpace(requested))
+		if !slices.Contains(internalShell.SupportedShells(), normalized) {
+			return "", fmt.Errorf("Unsupported shell %q: use one of %s.",
+				requested, strings.Join(internalShell.SupportedShells(), ", "))
+		}
+
+		return internalShell.Shell(normalized), nil
+	}
+
+	detected, err := internalShell.DetectShell()
+	if err != nil {
+		return internalShell.Bash, nil
+	}
+
+	return internalShell.Shell(detected), nil
+}
+
+func RunE(cmd *cobra.Command, _ []string) error {
+	shellFlag, err := cmd.Flags().GetString("shell")
+	if err != nil {
+		return err
+	}
+
+	sh, err := resolveShell(shellFlag)
+	if err != nil {
+		return err
+	}
+
+	creds, err := resolveCredentials()
+	if err != nil {
+		printCredentialError(cmd.ErrOrStderr(), err)
+
+		return cli.ErrSilent
+	}
+
+	if outputformat.GetFormat(cmd) == outputformat.OutputFormatJSON {
+		return outputformat.PrintJSONEnvelope(cmd.OutOrStdout(), jsonEnvelopeKey, map[string]string{
+			endpointVar: creds.Endpoint,
+			tokenVar:    creds.Token,
+		})
+	}
+
+	for _, statement := range renderExports(sh, creds) {
+		fmt.Fprintln(cmd.OutOrStdout(), statement)
+	}
+
+	return nil
+}
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "export",
+		Short:         "📤 Print shell statements that set the DataRobot environment variables",
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		Long: `Print the canonical DataRobot environment variables for the credentials the
+CLI is currently using:
+
+  ` + endpointVar + `=https://<your-install>/api/v2
+  ` + tokenVar + `=<token>
+
+Only the shell statements are written to stdout, so the output can be evaluated
+directly by your shell. Errors and hints go to stderr.
+
+Credentials are resolved the same way the rest of the CLI resolves them:
+  • the ` + endpointVar + ` and ` + tokenVar + ` environment variables, if both are set
+  • otherwise the CLI config file written by '` + version.CliName + ` auth login'
+
+Unlike most commands, this one never starts a login flow and never calls the
+API, so it is safe to run from a shell startup file. Run '` + version.CliName + ` auth check' first
+if you want the credentials validated.
+
+The syntax matches the detected parent shell; override it with --shell.
+
+⚠️  The output contains your API token in plain text. Avoid piping it into a
+    shared terminal, a log, or a file that is checked into version control.`,
+		Example: `  # bash / zsh
+  eval "$(` + version.CliName + ` auth export)"
+
+  # fish
+  ` + version.CliName + ` auth export | source
+
+  # PowerShell
+  ` + version.CliName + ` auth export | Out-String | Invoke-Expression
+
+  # cmd.exe
+  for /f "usebackq delims=" %i in (` + "`" + version.CliName + ` auth export --shell cmd` + "`" + `) do @%i
+
+  # save for later sourcing
+  ` + version.CliName + ` auth export --shell bash > ~/.datarobot-env && source ~/.datarobot-env
+
+  # machine-readable
+  ` + version.CliName + ` auth export --output-format json`,
+		RunE: RunE,
+	}
+
+	cmd.Flags().String("shell", "",
+		fmt.Sprintf("Shell syntax to emit (%s); defaults to the detected shell",
+			strings.Join(internalShell.SupportedShells(), ", ")))
+
+	_ = cmd.RegisterFlagCompletionFunc("shell", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return internalShell.SupportedShells(), cobra.ShellCompDirectiveNoFileComp
+	})
+
+	return cmd
+}

--- a/cmd/auth/export/cmd_test.go
+++ b/cmd/auth/export/cmd_test.go
@@ -1,0 +1,321 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package export
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/datarobot/cli/internal/cli"
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/outputformat"
+	internalShell "github.com/datarobot/cli/internal/shell"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// clearEnvCredentials removes the ambient DataRobot environment variables so a
+// developer's own shell cannot influence the result.
+func clearEnvCredentials(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("DATAROBOT_ENDPOINT", "")
+	t.Setenv("DATAROBOT_API_ENDPOINT", "")
+	t.Setenv("DATAROBOT_API_TOKEN", "")
+}
+
+func TestCanonicalEndpoint(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"bare host", "app.datarobot.com", "https://app.datarobot.com/api/v2", false},
+		{"scheme only", "https://app.datarobot.com", "https://app.datarobot.com/api/v2", false},
+		{"trailing slash", "https://app.datarobot.com/", "https://app.datarobot.com/api/v2", false},
+		{"already canonical", "https://app.datarobot.com/api/v2", "https://app.datarobot.com/api/v2", false},
+		{"custom api path", "https://dr.corp.example/dr/api/v2", "https://dr.corp.example/dr/api/v2", false},
+		{"strips query", "https://app.datarobot.com/api/v2?x=1", "https://app.datarobot.com/api/v2", false},
+		{"whitespace", "  https://app.datarobot.com  ", "https://app.datarobot.com/api/v2", false},
+		{"port preserved", "https://dr.corp.example:8443", "https://dr.corp.example:8443/api/v2", false},
+		{"empty", "", "", true},
+		{"no host", "https://", "", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := canonicalEndpoint(c.in)
+			if c.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestRenderExports(t *testing.T) {
+	creds := credentials{
+		Endpoint: "https://app.datarobot.com/api/v2",
+		Token:    "NjY2",
+	}
+
+	cases := []struct {
+		shell internalShell.Shell
+		want  []string
+	}{
+		{
+			internalShell.Bash,
+			[]string{
+				"export DATAROBOT_ENDPOINT='https://app.datarobot.com/api/v2'",
+				"export DATAROBOT_API_TOKEN='NjY2'",
+			},
+		},
+		{
+			internalShell.Zsh,
+			[]string{
+				"export DATAROBOT_ENDPOINT='https://app.datarobot.com/api/v2'",
+				"export DATAROBOT_API_TOKEN='NjY2'",
+			},
+		},
+		{
+			internalShell.Fish,
+			[]string{
+				"set -gx DATAROBOT_ENDPOINT 'https://app.datarobot.com/api/v2'",
+				"set -gx DATAROBOT_API_TOKEN 'NjY2'",
+			},
+		},
+		{
+			internalShell.PowerShell,
+			[]string{
+				"$env:DATAROBOT_ENDPOINT = 'https://app.datarobot.com/api/v2'",
+				"$env:DATAROBOT_API_TOKEN = 'NjY2'",
+			},
+		},
+		{
+			internalShell.Cmd,
+			[]string{
+				"set DATAROBOT_ENDPOINT=https://app.datarobot.com/api/v2",
+				"set DATAROBOT_API_TOKEN=NjY2",
+			},
+		},
+		{
+			internalShell.Shell("dash"),
+			[]string{
+				"export DATAROBOT_ENDPOINT='https://app.datarobot.com/api/v2'",
+				"export DATAROBOT_API_TOKEN='NjY2'",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(string(c.shell), func(t *testing.T) {
+			assert.Equal(t, c.want, renderExports(c.shell, creds))
+		})
+	}
+}
+
+func TestQuotingEscapesEmbeddedQuotes(t *testing.T) {
+	nasty := credentials{Endpoint: "https://h/api/v2", Token: "a'b&c"}
+
+	assert.Equal(t, `export DATAROBOT_API_TOKEN='a'\''b&c'`, renderExports(internalShell.Bash, nasty)[1])
+	assert.Equal(t, `$env:DATAROBOT_API_TOKEN = 'a''b&c'`, renderExports(internalShell.PowerShell, nasty)[1])
+	assert.Equal(t, `set DATAROBOT_API_TOKEN=a'b^&c`, renderExports(internalShell.Cmd, nasty)[1])
+}
+
+func TestResolveShell(t *testing.T) {
+	t.Run("explicit shell is normalized", func(t *testing.T) {
+		got, err := resolveShell("  FISH ")
+		require.NoError(t, err)
+		assert.Equal(t, internalShell.Fish, got)
+	})
+
+	t.Run("unsupported shell errors", func(t *testing.T) {
+		_, err := resolveShell("nushell")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nushell")
+	})
+
+	t.Run("empty shell is detected", func(t *testing.T) {
+		// Detection depends on the host environment; any non-empty result is
+		// acceptable as long as it never fails.
+		got, err := resolveShell("")
+		require.NoError(t, err)
+		assert.NotEmpty(t, string(got))
+	})
+}
+
+func TestResolveCredentials_PrefersCompleteEnvPair(t *testing.T) {
+	viperx.Reset()
+
+	t.Setenv("DATAROBOT_ENDPOINT", "env.datarobot.com")
+	t.Setenv("DATAROBOT_API_TOKEN", "env-token")
+
+	viperx.Set(config.DataRobotURL, "https://config.datarobot.com/api/v2")
+	viperx.Set(config.DataRobotAPIKey, "config-token")
+
+	defer viperx.Reset()
+
+	creds, err := resolveCredentials()
+	require.NoError(t, err)
+	assert.Equal(t, "https://env.datarobot.com/api/v2", creds.Endpoint)
+	assert.Equal(t, "env-token", creds.Token)
+}
+
+func TestResolveCredentials_FallsBackToConfig(t *testing.T) {
+	viperx.Reset()
+	clearEnvCredentials(t)
+
+	// A half-set environment must not be mixed with the config file.
+	t.Setenv("DATAROBOT_ENDPOINT", "env.datarobot.com")
+
+	viperx.Set(config.DataRobotURL, "https://config.datarobot.com/api/v2")
+	viperx.Set(config.DataRobotAPIKey, "config-token")
+
+	defer viperx.Reset()
+
+	creds, err := resolveCredentials()
+	require.NoError(t, err)
+	assert.Equal(t, "https://config.datarobot.com/api/v2", creds.Endpoint)
+	assert.Equal(t, "config-token", creds.Token)
+}
+
+func TestResolveCredentials_MissingValues(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		token    string
+		wantErr  error
+	}{
+		{"nothing configured", "", "", errNoCredentials},
+		{"no endpoint", "", "some-token", errNoEndpoint},
+		{"no token", "https://app.datarobot.com/api/v2", "", errNoToken},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			viperx.Reset()
+			clearEnvCredentials(t)
+
+			viperx.Set(config.DataRobotURL, c.endpoint)
+			viperx.Set(config.DataRobotAPIKey, c.token)
+
+			defer viperx.Reset()
+
+			_, err := resolveCredentials()
+			require.ErrorIs(t, err, c.wantErr)
+		})
+	}
+}
+
+func TestRunE_WritesSourceableStatements(t *testing.T) {
+	viperx.Reset()
+	clearEnvCredentials(t)
+
+	viperx.Set(config.DataRobotURL, "https://app.datarobot.com/api/v2")
+	viperx.Set(config.DataRobotAPIKey, "secret-token")
+
+	defer viperx.Reset()
+
+	var stdout, stderr bytes.Buffer
+
+	cmd := Cmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--shell", "bash"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t,
+		"export DATAROBOT_ENDPOINT='https://app.datarobot.com/api/v2'\n"+
+			"export DATAROBOT_API_TOKEN='secret-token'\n",
+		stdout.String())
+	assert.Empty(t, stderr.String())
+}
+
+func TestRunE_JSONOutput(t *testing.T) {
+	viperx.Reset()
+	clearEnvCredentials(t)
+
+	viperx.Set(config.DataRobotURL, "app.datarobot.com")
+	viperx.Set(config.DataRobotAPIKey, "secret-token")
+
+	defer viperx.Reset()
+
+	var stdout bytes.Buffer
+
+	var format outputformat.OutputFormat
+
+	cmd := Cmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	// The real --output-format flag is persistent on the root command; add it
+	// locally so the subcommand can be exercised standalone.
+	outputformat.AddFlag(cmd, &format)
+	cmd.SetArgs([]string{"--output-format", "json"})
+
+	require.NoError(t, cmd.Execute())
+
+	var payload struct {
+		Environment map[string]string `json:"environment"`
+	}
+
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
+	assert.Equal(t, map[string]string{
+		"DATAROBOT_ENDPOINT":  "https://app.datarobot.com/api/v2",
+		"DATAROBOT_API_TOKEN": "secret-token",
+	}, payload.Environment)
+}
+
+func TestRunE_NoCredentialsKeepsStdoutEmpty(t *testing.T) {
+	viperx.Reset()
+	clearEnvCredentials(t)
+
+	defer viperx.Reset()
+
+	var stdout, stderr bytes.Buffer
+
+	cmd := Cmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.ErrorIs(t, err, cli.ErrSilent)
+	assert.Empty(t, stdout.String())
+	assert.Contains(t, stderr.String(), "auth login")
+}
+
+func TestRunE_UnsupportedShell(t *testing.T) {
+	viperx.Reset()
+	clearEnvCredentials(t)
+
+	defer viperx.Reset()
+
+	var stdout, stderr bytes.Buffer
+
+	cmd := Cmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--shell", "nushell"})
+
+	require.Error(t, cmd.Execute())
+	assert.Empty(t, stdout.String())
+}

--- a/cmd/dotenv/model_test.go
+++ b/cmd/dotenv/model_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/envbuilder"
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/datarobot/cli/tui"
 	"github.com/stretchr/testify/suite"
 )
@@ -165,7 +166,9 @@ func (suite *DotenvModelTestSuite) FinalModel(tm *teatest.TestModel) Model {
 		suite.T().Error(err)
 	}
 
-	finalModel := tm.FinalModel(suite.T())
+	// testutil.FinalModel, not tm.FinalModel — see its doc comment for the
+	// teatest race that otherwise hands back a nil model under load.
+	finalModel := testutil.FinalModel(suite.T(), tm)
 
 	// The model is wrapped in InterruptibleModel, so we need to unwrap it
 	if wrappedModel, ok := finalModel.(tui.InterruptibleModel); ok {

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -183,6 +183,9 @@ dr
 dr auth set-url https://app.datarobot.com
 dr auth login
 
+# Export credentials into the current shell session
+eval "$(dr auth export)"
+
 # Logout
 dr auth logout
 ```

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -199,6 +199,8 @@ The output syntax is chosen from the detected parent shell. Use `--shell` to ove
 
 The endpoint is normalized to its canonical `/api/v2` form, so a config or environment value of `app.datarobot.com` is exported as `https://app.datarobot.com/api/v2`. A URL that already has a path (self-managed installs serving the API under a custom prefix) is left alone.
 
+A project's `.env` file is never consulted — this exports the CLI's own credentials. Use [`dr dotenv setup`](dotenv.md) to manage `.env` files.
+
 **Machine-readable output:**
 
 ```bash

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -27,7 +27,7 @@ dr auth <command> [flags]
 
 ## Description
 
-The `auth` command provides authentication management for the DataRobot CLI. It handles login, logout, and URL configuration for connecting to your DataRobot instance.
+The `auth` command provides authentication management for the DataRobot CLI. It handles login, logout, URL configuration, and exporting credentials as environment variables for connecting to your DataRobot instance.
 
 ## Subcommands
 
@@ -152,6 +152,80 @@ Unset it and try again:
 
 > [!TIP]
 > Use `dr auth check` in CI/CD pipelines to verify credentials before running other commands.
+
+### `export`
+
+Print the canonical DataRobot environment variables for the credentials the CLI is currently using, as shell statements you can source into your session.
+
+```bash
+dr auth export [--shell <bash|zsh|fish|powershell|cmd>]
+```
+
+**Output:**
+
+```bash
+$ dr auth export
+export DATAROBOT_ENDPOINT='https://app.datarobot.com/api/v2'
+export DATAROBOT_API_TOKEN='<token>'
+```
+
+Only the statements go to stdout — every error, hint, and warning goes to stderr — so the output is always safe to evaluate.
+
+**Sourcing into your shell:**
+
+```bash
+# bash / zsh
+eval "$(dr auth export)"
+
+# fish
+dr auth export | source
+
+# PowerShell
+dr auth export | Out-String | Invoke-Expression
+
+# cmd.exe
+for /f "usebackq delims=" %i in (`dr auth export --shell cmd`) do @%i
+
+# Save for later sourcing
+dr auth export --shell bash > ~/.datarobot-env && source ~/.datarobot-env
+```
+
+The output syntax is chosen from the detected parent shell. Use `--shell` to override it — useful when generating a file for a different shell, or when detection fails (unrecognized shells fall back to POSIX `export` syntax).
+
+**Where credentials come from:**
+
+1. `DATAROBOT_ENDPOINT` (or `DATAROBOT_API_ENDPOINT`) and `DATAROBOT_API_TOKEN`, if both are set
+2. Otherwise the CLI config file written by `dr auth login`
+
+The endpoint is normalized to its canonical `/api/v2` form, so a config or environment value of `app.datarobot.com` is exported as `https://app.datarobot.com/api/v2`. A URL that already has a path (self-managed installs serving the API under a custom prefix) is left alone.
+
+**Machine-readable output:**
+
+```bash
+$ dr auth export --output-format json
+{
+  "environment": {
+    "DATAROBOT_API_TOKEN": "<token>",
+    "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2"
+  }
+}
+```
+
+**No credentials configured:**
+
+```bash
+$ dr auth export
+❌ No DataRobot credentials found.
+Run dr auth login to authenticate.
+```
+
+Nothing is written to stdout and the command exits non-zero, so `eval "$(dr auth export)"` cannot evaluate a partial result.
+
+> [!NOTE]
+> This command never starts a login flow and never calls the API, so it is safe to run from a shell startup file. It does not validate the credentials — run `dr auth check` for that.
+
+> [!WARNING]
+> The output contains your API token in plain text. Avoid piping it into a shared terminal, a log, or a file that is checked into version control.
 
 ### `set-url`
 
@@ -473,6 +547,12 @@ export DATAROBOT_API_TOKEN=your-api-token
 
 # Custom config file location
 export DATAROBOT_CLI_CONFIG=~/.config/datarobot/custom-config.yaml
+```
+
+To go the other way — take the credentials the CLI already has and put them in your shell environment for the DataRobot SDKs and other tools — use [`dr auth export`](#export):
+
+```bash
+eval "$(dr auth export)"
 ```
 
 ## Common issues

--- a/docs/user-guide/quick-reference.md
+++ b/docs/user-guide/quick-reference.md
@@ -21,6 +21,9 @@ dr auth logout
 
 # Check authentication status
 dr auth check
+
+# Export credentials into the current shell session
+eval "$(dr auth export)"
 ```
 
 ## Templates

--- a/internal/testutil/teatest.go
+++ b/internal/testutil/teatest.go
@@ -1,0 +1,69 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+)
+
+const (
+	// finalModelTimeout bounds how long FinalModel waits for teatest to publish
+	// the model after the program has reported that it finished.
+	finalModelTimeout = 5 * time.Second
+	// finalModelPollInterval is how often FinalModel re-checks in that window.
+	finalModelPollInterval = time.Millisecond
+)
+
+// FinalModel returns the model a teatest program ended with, retrying until
+// teatest has actually published it.
+//
+// teatest.TestModel runs the program on its own goroutine and, when it returns,
+// signals completion on doneCh *before* sending the final model on modelCh:
+//
+//	tm.doneCh <- true
+//	tm.modelCh <- m
+//
+// teatest's own TestModel.FinalModel waits on doneCh and then does a
+// *non-blocking* receive on modelCh, falling back to tm.model — which is never
+// assigned before the program finishes. A caller that lands between those two
+// sends therefore gets a nil model back, and any type assertion on it fails
+// ("final model is not of type X"). The window is tiny, so this only bites
+// under load: a shuffled or heavily parallel CI run.
+//
+// Calling TestModel.FinalModel again closes the gap, since its wait is
+// sync.Once-guarded and the second receive picks up the published model.
+func FinalModel(t *testing.T, tm *teatest.TestModel, opts ...teatest.FinalOpt) tea.Model {
+	t.Helper()
+
+	deadline := time.Now().Add(finalModelTimeout)
+
+	for {
+		if model := tm.FinalModel(t, opts...); model != nil {
+			return model
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("teatest did not publish a final model within %s", finalModelTimeout)
+
+			return nil
+		}
+
+		time.Sleep(finalModelPollInterval)
+	}
+}

--- a/smoke_test_scripts/COVERAGE.md
+++ b/smoke_test_scripts/COVERAGE.md
@@ -44,6 +44,8 @@ Legend: ✅ Covered · ⚠️ Partial · ❌ Not covered · ⏭️ Intentionally
 | `dr auth setURL` (interactive) | ✅ | ⚠️ | Windows sets config directly |
 | Config file updated with correct endpoint | ✅ | ✅ | |
 | `dr auth login` (interactive) | ✅ | ⚠️ | Windows falls back to `dr auth check` |
+| `dr auth export` emits both canonical variables | ✅ | ✅ | `--shell bash` / `--shell powershell` |
+| Exported statements populate the shell when sourced | ✅ | ✅ | `eval` / `Invoke-Expression` |
 | **Templates** | | | |
 | `dr templates setup` (interactive clone) | ✅ | ⏭️ | Skipped on Windows (no `expect`) |
 | Cloned directory exists after setup | ✅ | ⏭️ | |

--- a/smoke_test_scripts/run_smoke_test.sh
+++ b/smoke_test_scripts/run_smoke_test.sh
@@ -166,6 +166,32 @@ start_timer "dr auth login (expect)"
 expect ./smoke_test_scripts/expect_auth_login.exp
 stop_timer
 
+start_timer "dr auth export"
+# Only the shell statements may reach stdout, otherwise `eval` breaks.
+auth_export_output=$(dr auth export --shell bash)
+if [[ "$auth_export_output" == *"export DATAROBOT_ENDPOINT="* && "$auth_export_output" == *"export DATAROBOT_API_TOKEN="* ]]; then
+  echo "✅ Assertion passed: 'dr auth export' emitted both canonical variables."
+else
+  echo "❌ Assertion failed: 'dr auth export' did not emit both canonical variables."
+  # Redact values so no token reaches CI logs.
+  echo "$auth_export_output" | sed 's/=.*/=<redacted>/'
+  exit 1
+fi
+
+# Sourcing the output must actually populate the current shell. Run in a
+# subshell so the token does not leak into the rest of the suite's environment.
+(
+  eval "$auth_export_output"
+  if [[ "$DATAROBOT_ENDPOINT" == "${testing_url}/api/v2" && -n "$DATAROBOT_API_TOKEN" ]]; then
+    echo "✅ Assertion passed: eval of 'dr auth export' set the canonical variables."
+  else
+    echo "❌ Assertion failed: eval of 'dr auth export' did not set the canonical variables."
+    echo "DATAROBOT_ENDPOINT=${DATAROBOT_ENDPOINT}"
+    exit 1
+  fi
+) || exit 1
+stop_timer
+
 start_timer "dr templates setup + dotenv"
 if [ "$url_accessible" -eq 0 ]; then
   echo "ℹ️ URL (${testing_url}) is not accessible so skipping 'dr templates setup' test."

--- a/smoke_test_scripts/windows/run_smoke_test.ps1
+++ b/smoke_test_scripts/windows/run_smoke_test.ps1
@@ -353,6 +353,39 @@ if ($auth_url_shown) {
 }
 Write-End
 
+# Test auth export
+#
+# Verifies the PowerShell rendering and that piping it to Invoke-Expression
+# actually populates $env:. Values are never echoed, so no token reaches the
+# CI log.
+Write-Delimiter "Testing dr auth export"
+
+$auth_export_output = (dr auth export --shell powershell) -join "`n"
+
+if ($auth_export_output -match '\$env:DATAROBOT_ENDPOINT = ' -and
+    $auth_export_output -match '\$env:DATAROBOT_API_TOKEN = ') {
+    Write-SuccessMsg "Assertion passed: 'dr auth export' emitted both canonical variables."
+} else {
+    Write-ErrorMsg "Assertion failed: 'dr auth export' did not emit both canonical variables."
+}
+
+# Snapshot and restore so the token does not leak into the rest of the suite.
+$saved_endpoint = $env:DATAROBOT_ENDPOINT
+$saved_token = $env:DATAROBOT_API_TOKEN
+
+$auth_export_output | Invoke-Expression
+
+if ($env:DATAROBOT_ENDPOINT -eq "${testing_url}/api/v2" -and -not [string]::IsNullOrEmpty($env:DATAROBOT_API_TOKEN)) {
+    Write-SuccessMsg "Assertion passed: Invoke-Expression of 'dr auth export' set the canonical variables."
+} else {
+    Write-Host "DATAROBOT_ENDPOINT=$($env:DATAROBOT_ENDPOINT)"
+    Write-ErrorMsg "Assertion failed: Invoke-Expression of 'dr auth export' did not set the canonical variables."
+}
+
+$env:DATAROBOT_ENDPOINT = $saved_endpoint
+$env:DATAROBOT_API_TOKEN = $saved_token
+Write-End
+
 # Test templates (if URL is accessible)
 if (-not $url_accessible) {
     Write-InfoMsg "URL (${testing_url}) is not accessible so skipping 'dr templates setup' test."

--- a/tui/logo_animation_test.go
+++ b/tui/logo_animation_test.go
@@ -22,6 +22,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -222,7 +223,9 @@ func TestLogoAnimationIntegrationSkipViaKeypress(t *testing.T) {
 
 	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
 
-	fm := tm.FinalModel(t)
+	// testutil.FinalModel, not tm.FinalModel — see its doc comment for the
+	// teatest race that otherwise hands back a nil model under load.
+	fm := testutil.FinalModel(t, tm)
 	result, ok := fm.(LogoAnimationModel)
 	require.True(t, ok, "final model is not LogoAnimationModel")
 	assert.True(t, result.Done)


### PR DESCRIPTION
## RATIONALE

Adds `dr auth export`, which prints the credentials the CLI is currently
using as shell statements that set `DATAROBOT_ENDPOINT` and
`DATAROBOT_API_TOKEN`, so they can be sourced straight into the session:

```
eval "$(dr auth export)"
```

This makes it easier to use `dr auth login` with DataRobot SDKs that expect environment variables.

## NOTES

Only the statements go to stdout — errors and hints go to stderr — so the
output is always safe to evaluate, and a missing-credentials run leaves
stdout empty and exits non-zero. Syntax follows the detected parent shell
(bash/zsh, fish, PowerShell, cmd.exe) and can be forced with `--shell`;
`--output-format json` emits the pair as an envelope instead.

Credentials resolve the same way the rest of the CLI resolves them — a
complete `DATAROBOT_ENDPOINT`/`DATAROBOT_API_TOKEN` env pair, else the config
file from `dr auth login` — with the endpoint normalized to its canonical
`/api/v2` form. Unlike other commands it never calls the API or starts a
login flow, so it is usable from shell startup files.

Covered by unit tests and by smoke tests on both bash and PowerShell that
assert the output actually populates the shell when sourced.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

### Resolved race condition in tests

This was a flake in the test harness, not in the dotenv model or the CFX-6904 change.

Root cause — teatest.TestModel runs the program on its own goroutine and, on exit, does:

tm.doneCh <- true   // FinalModel's wait unblocks here
tm.modelCh <- m     // ...but the model is published only after

TestModel.FinalModel waits on doneCh, then does a non-blocking receive on modelCh, falling back to tm.model — which is nil until the program finishes. A caller that lands between those two sends gets nil, and nil.(Model) fails with exactly Final model is not of type Model. The window is sub-microsecond, so it only opens under a loaded/shuffled CI run — and it applies to every test using the shared helper, not just the window-size one.

Fix — added internal/testutil/teatest.go with a FinalModel helper that re-calls TestModel.FinalModel until the model is published (its wait is sync.Once-guarded, so retries cost nothing), with a 5s bound and a clear t.Fatalf if it never arrives. Routed the dotenv suite helper (cmd/dotenv/model_test.go:171) and tui/logo_animation_test.go:227, which had the same latent race, through it.

Verification — the failure reproduces on this machine only under contention (6 concurrent go test -race invocations). Running that stress with temporary instrumentation in the helper caught teatest returning a nil model on one run — in TestDotenvModel_Branching_Path, confirming it isn't specific to the test CI happened to hit — which the retry absorbed, with zero failures. After removing the instrumentation: task lint clean, and ./cmd/dotenv ./tui pass under -race -shuffle 1785843468118572986 -count=2.

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1785658718.329329 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The command writes API tokens to stdout in plain text (documented), but it only reads existing CLI/env credentials and does not change auth storage or network behavior.
> 
> **Overview**
> Adds **`dr auth export`**, a new `auth` subcommand that prints **`DATAROBOT_ENDPOINT`** and **`DATAROBOT_API_TOKEN`** as shell assignments so users can run `eval "$(dr auth export)"` (or equivalent on fish/PowerShell/cmd).
> 
> Credentials follow the same precedence as the rest of the CLI (full env pair first, else login config), with endpoints normalized to canonical `/api/v2` form. The command **does not** call the API or start OAuth; on failure it writes hints to **stderr** and leaves **stdout** empty for safe `eval`. Output supports **`--shell`**, auto-detected shell syntax, and **`--output-format json`**.
> 
> The `auth` command tree and user/docs are updated; **unit tests** cover quoting, resolution, and CLI behavior; **Unix and Windows smoke tests** verify emitted variables and that sourcing/`Invoke-Expression` actually sets the env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a7214043cfd34f145423fd053e7246ca413f3b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->