### PR TITLE
Add assist plugin v0.1.32

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.32",
+          "url": "assist/assist-0.1.32.tar.xz",
+          "sha256": "687a41a9dc0e166608e388d18d0d4706190ce3b0d9655c2a522c093c1618c63d",
+          "releaseDate": "2026-08-03"
+        },
+        {
           "version": "0.1.31",
           "url": "assist/assist-0.1.31.tar.xz",
           "sha256": "7650745f3606713d2032c941f9b5a52dabd6d7e6648d181c602ef35dd3260232",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.32 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.32
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.32
- **SHA256:** `687a41a9dc0e166608e388d18d0d4706190ce3b0d9655c2a522c093c1618c63d`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only registry update with no application or runtime code changes.
> 
> **Overview**
> Registers **assist** **v0.1.32** in `docs/plugins/index.json` as the newest entry in the plugin registry, with tarball URL, SHA256, and release date **2026-08-03**.
> 
> This follows the existing pattern for CLI plugin releases so `dr plugin install assist` can resolve and verify the new build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51e64981d7ced24207dc472c02cd9cab174e77ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->