### PR TITLE
Add assist plugin v0.1.33

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.33",
+          "url": "assist/assist-0.1.33.tar.xz",
+          "sha256": "599450d4ea00e150e9958913ea12d687cddb4d610babe1e3b9a99e7257ce2778",
+          "releaseDate": "2026-08-03"
+        },
+        {
           "version": "0.1.32",
           "url": "assist/assist-0.1.32.tar.xz",
           "sha256": "687a41a9dc0e166608e388d18d0d4706190ce3b0d9655c2a522c093c1618c63d",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.33 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.33
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.33
- **SHA256:** `599450d4ea00e150e9958913ea12d687cddb4d610babe1e3b9a99e7257ce2778`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Index-only metadata update with no application or security logic changes; verify tarball URL and SHA256 match the published release.
> 
> **Overview**
> Registers **assist** **v0.1.33** in `docs/plugins/index.json` as the latest installable release for the CLI plugin catalog.
> 
> The new entry points at `assist/assist-0.1.33.tar.xz`, includes SHA256 `599450d4…`, and `releaseDate` **2026-08-03**, inserted ahead of **0.1.32** in the versions list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af9248d6f319b66c2853d86db52c2280f3f192c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->