### PR TITLE
Add assist plugin v0.1.34

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.34",
+          "url": "assist/assist-0.1.34.tar.xz",
+          "sha256": "bbeec0796302b1ef586187cea371d15cab99f2bea0815a64ce9c86df6647dbf6",
+          "releaseDate": "2026-08-03"
+        },
+        {
           "version": "0.1.32",
           "url": "assist/assist-0.1.32.tar.xz",
           "sha256": "687a41a9dc0e166608e388d18d0d4706190ce3b0d9655c2a522c093c1618c63d",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.34 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.34
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.34
- **SHA256:** `bbeec0796302b1ef586187cea371d15cab99f2bea0815a64ce9c86df6647dbf6`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1785769093.530149 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Index-only metadata update with no application logic changes; verify the SHA256 matches the published artifact before merge.
> 
> **Overview**
> Registers **assist** **v0.1.34** as the newest entry in `docs/plugins/index.json`, so `dr plugin install assist` can resolve and download that release.
> 
> The new record includes the tarball path (`assist/assist-0.1.34.tar.xz`), SHA256 checksum, and release date, inserted ahead of **0.1.32** in the `versions` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83263efcb46f66c3e44dda5e3ee5d1f31c6a7e7a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->