### PR TITLE
[CFX-7138] fix(lint): run golangci-lint once per target GOOS

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -30,6 +30,7 @@ jobs:
       deps: ${{ steps.changes.outputs.deps }}
       install_sh: ${{ steps.changes.outputs.install_sh }}
       test_config: ${{ steps.changes.outputs.test_config }}
+      lint_config: ${{ steps.changes.outputs.lint_config }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -67,10 +68,21 @@ jobs:
               - 'Taskfile.yaml'
               - '.github/workflows/pr-checks.yaml'
               - '.github/actions/setup/**'
+            # Re-run the lint job when the lint tooling itself changes, so a PR
+            # that only touches the Taskfile / golangci config still gets its
+            # lint behaviour validated (CFX-7138).
+            lint_config:
+              - 'Taskfile.yaml'
+              - '.golangci.yaml'
+              - '.github/workflows/pr-checks.yaml'
+              - '.github/actions/setup/**'
 
   lint:
     needs: detect-changes
-    if: needs.detect-changes.outputs.go_code == 'true'
+    if: needs.detect-changes.outputs.go_code == 'true' || needs.detect-changes.outputs.lint_config == 'true'
+    # CFX-7138: `task lint` runs golangci-lint once per GOOS in
+    # LINT_GOOS_TARGETS (linux/darwin/windows), so a single Ubuntu runner still
+    # covers every build-constrained file — no 3-OS runner matrix needed.
     runs-on: ubuntu-latest
     name: Lint Code
     timeout-minutes: 15
@@ -97,7 +109,9 @@ jobs:
             tmp/bin/golangci-lint
             tmp/bin/goreleaser
             ~/.cache/golangci-lint
-          key: golangci-lint-${{ runner.os }}-${{ steps.golangci-version.outputs.version }}-${{ hashFiles('**/*.go', 'go.sum', '.golangci.yaml') }}
+          # Taskfile.yaml is in the key so changing LINT_GOOS_TARGETS (CFX-7138)
+          # invalidates a cache built for a different set of GOOS targets.
+          key: golangci-lint-${{ runner.os }}-${{ steps.golangci-version.outputs.version }}-${{ hashFiles('**/*.go', 'go.sum', '.golangci.yaml', 'Taskfile.yaml') }}
           restore-keys: |
             golangci-lint-${{ runner.os }}-${{ steps.golangci-version.outputs.version }}-
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,16 +77,39 @@ func example() {
 - `go mod tidy -diff` - checks if go.mod/go.sum need updates
 - `gofumpt -l -d` - lists formatting issues and shows diffs
 - `go vet` - checks for suspicious constructs
-- `golangci-lint run` - comprehensive linting checks (includes wsl, revive, staticcheck)
+- `golangci-lint run` - comprehensive linting checks (includes wsl, revive, staticcheck), run once per target GOOS
 - `goreleaser check` - validates release configuration
 
 **`task delint`** (auto-fixes):
 - `go mod tidy` - fixes go.mod/go.sum
 - `go fmt` - fixes basic formatting
 - `gofumpt -l -w` - fixes aggressive Go formatting
-- `golangci-lint run --fix` - fixes linting issues where possible
+- `golangci-lint run --fix` - fixes linting issues where possible, run once per target GOOS
 
 All code must pass `task lint` before submitting.
+
+### Cross-Platform Linting
+
+`golangci-lint` only analyzes files selected by the build constraints of the platform
+it runs on. Without help, `*_windows.go` (and any `//go:build` file) would only ever be
+linted on that OS — so a violation in a Windows-only file ships undetected from a macOS
+laptop and from Linux CI alike (CFX-7138).
+
+To close that gap, `lint`, `delint`, and `precommit` all route their `golangci-lint run`
+through the internal `lint-goos` task, which loops over the `LINT_GOOS_TARGETS` variable
+in `Taskfile.yaml` (`linux darwin windows` — kept in sync with the `goos` lists in
+`goreleaser.yaml`). Output is labelled per leg, e.g. `🧹 Linting (GOOS=windows)…`.
+
+Practical notes:
+- Expect `task lint` to fail on a file your own OS never compiles. That is the point.
+  `task delint` can auto-fix those files from any host.
+- The overhead is small (~1s per extra GOOS on a warm cache); each GOOS gets its own
+  golangci-lint analysis cache.
+- **When adding a new release platform, add it to `LINT_GOOS_TARGETS`.**
+- `go mod tidy`, `golangci-lint fmt`, and `goreleaser check` stay single-run — they are
+  GOOS-independent (the formatter walks files directly and is not build-constrained).
+- CI needs no OS matrix for lint: the single `ubuntu-latest` lint job covers all targets
+  because it just calls `task lint`.
 
 ### Git Hooks (Lefthook)
 
@@ -96,7 +119,7 @@ automatically by `task install-tools` and wired up by `task dev-init`.
 Hooks run automatically on `git commit`. Run manually with `task precommit`.
 Bypass with `LEFTHOOK=0 git commit` (use sparingly). Configured hooks:
 
-- **`task precommit`**: formats via gofumpt, verifies Go files are formatted, runs `go mod tidy`, `go vet`, and `golangci-lint run --new-from-rev HEAD` (new changes only), verifies golangci-lint config, and checks go.mod/go.sum are tidy
+- **`task precommit`**: formats via gofumpt, verifies Go files are formatted, runs `go mod tidy`, `go vet`, and `golangci-lint run --new-from-rev HEAD` (new changes only, once per target GOOS), verifies golangci-lint config, and checks go.mod/go.sum are tidy
 - **`task dupcheck`**: duplicate code detection via jscpd (threshold and exclusions in `.jscpd.json`)
 
 Both hooks reuse Taskfile tasks so there is a single source of truth for quality checks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,10 +95,15 @@ it runs on. Without help, `*_windows.go` (and any `//go:build` file) would only 
 linted on that OS — so a violation in a Windows-only file ships undetected from a macOS
 laptop and from Linux CI alike (CFX-7138).
 
-To close that gap, `lint`, `delint`, and `precommit` all route their `golangci-lint run`
-through the internal `lint-goos` task, which loops over the `LINT_GOOS_TARGETS` variable
-in `Taskfile.yaml` (`linux darwin windows` — kept in sync with the `goos` lists in
-`goreleaser.yaml`). Output is labelled per leg, e.g. `🧹 Linting (GOOS=windows)…`.
+To close that gap, `lint` and `delint` route their `golangci-lint run` through the internal
+`lint-goos` task, which loops over the `LINT_GOOS_TARGETS` variable in `Taskfile.yaml`
+(`linux darwin windows` — kept in sync with the `goos` lists in `goreleaser.yaml`). Output
+is labelled per leg, e.g. `🧹 Linting (GOOS=windows)…`.
+
+`precommit` deliberately stays **host-GOOS only**. It runs on every commit, and looping all
+targets there costs ~4-6s of interactive latency for little benefit — `task lint` and CI
+already enforce every target, so a cross-platform violation is caught before merge either
+way.
 
 Practical notes:
 - Expect `task lint` to fail on a file your own OS never compiles. That is the point.
@@ -119,7 +124,7 @@ automatically by `task install-tools` and wired up by `task dev-init`.
 Hooks run automatically on `git commit`. Run manually with `task precommit`.
 Bypass with `LEFTHOOK=0 git commit` (use sparingly). Configured hooks:
 
-- **`task precommit`**: formats via gofumpt, verifies Go files are formatted, runs `go mod tidy`, `go vet`, and `golangci-lint run --new-from-rev HEAD` (new changes only, once per target GOOS), verifies golangci-lint config, and checks go.mod/go.sum are tidy
+- **`task precommit`**: formats via gofumpt, verifies Go files are formatted, runs `go mod tidy`, `go vet`, and `golangci-lint run --new-from-rev HEAD` (new changes only, host GOOS only — see [Cross-Platform Linting](#cross-platform-linting)), verifies golangci-lint config, and checks go.mod/go.sum are tidy
 - **`task dupcheck`**: duplicate code detection via jscpd (threshold and exclusions in `.jscpd.json`)
 
 Both hooks reuse Taskfile tasks so there is a single source of truth for quality checks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,12 @@ task lint
    task test
 
    # Run linters
+   #
+   # `task lint` runs golangci-lint once per target GOOS (linux, darwin,
+   # windows), so build-constrained files such as *_windows.go are checked no
+   # matter which OS you develop on. Do not be surprised by a failure in a file
+   # your own platform never compiles — `task delint` can auto-fix it from any
+   # host. See "Cross-Platform Linting" in AGENTS.md.
    task lint
 
    # Check for duplicate code

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -212,9 +212,11 @@ tasks:
       - go mod tidy
       - echo "🧹 Vetting…"
       - go vet ./...
-      - task: lint-goos
-        vars:
-          LINT_ARGS: "--new-from-rev HEAD"
+      # CFX-7138: deliberately host-GOOS only. The commit hook runs on every
+      # commit, and looping all targets here costs ~4-6s of interactive latency
+      # for little benefit — `task lint` and CI already enforce every GOOS.
+      - echo "🧹 Linting new changes…"
+      - "{{.BIN_DIR}}/golangci-lint run --new-from-rev HEAD ./..."
       - echo "🧹 Verifying golangci-lint config…"
       - "{{.BIN_DIR}}/golangci-lint config verify"
       - echo "🧹 Checking go.mod/go.sum are tidy…"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -13,6 +13,11 @@ vars:
   GOLANGCI_LINT_VERSION: "v2.11.4"
   LEFTHOOK_VERSION: "v2.1.10"
   JSCPD_VERSION: "5.0.12"
+  # CFX-7138: GOOS targets to lint. golangci-lint only analyzes files selected by
+  # the host build constraints, so platform-specific files (*_windows.go,
+  # //go:build linux, …) escape enforcement unless the linter is re-run per
+  # target. Keep in sync with the goos lists in goreleaser.yaml.
+  LINT_GOOS_TARGETS: "linux darwin windows"
 
 dotenv: [".env"]
 
@@ -93,8 +98,7 @@ tasks:
       - "{{.BIN_DIR}}/golangci-lint fmt --diff"
       - echo "🧹 Vetting…"
       - go vet ./...
-      - echo "🧹 Linting…"
-      - "{{.BIN_DIR}}/golangci-lint run ./..."
+      - task: lint-goos
       - echo "🧹 Checking GoReleaser config…"
       - "{{.BIN_DIR}}/goreleaser check"
 
@@ -107,8 +111,24 @@ tasks:
       - go mod tidy
       - echo "🧹 Formatting files…"
       - "{{.BIN_DIR}}/golangci-lint fmt"
-      - echo "🧹 Fixing lint issues…"
-      - "{{.BIN_DIR}}/golangci-lint run --fix ./..."
+      - task: lint-goos
+        vars:
+          LINT_ARGS: "--fix"
+
+  # CFX-7138: run golangci-lint once per target GOOS so build-constrained files
+  # (*_windows.go, //go:build linux, …) are enforced no matter which OS the
+  # linter runs on. Without this, a macOS dev only lints the darwin/!windows
+  # files and CI (ubuntu) only the linux/!windows ones, so windows-only files
+  # are linted by nobody. Callers pass LINT_ARGS to select the mode.
+  lint-goos:
+    internal: true
+    silent: true
+    deps: [install-tools]
+    cmds:
+      - for: { var: LINT_GOOS_TARGETS, split: " " }
+        cmd: |
+          echo "🧹 Linting (GOOS={{.ITEM}})…"
+          GOOS={{.ITEM}} {{.BIN_DIR}}/golangci-lint run {{.LINT_ARGS}} ./...
 
   run:
     silent: true
@@ -192,8 +212,9 @@ tasks:
       - go mod tidy
       - echo "🧹 Vetting…"
       - go vet ./...
-      - echo "🧹 Linting new changes…"
-      - "{{.BIN_DIR}}/golangci-lint run --new-from-rev HEAD ./..."
+      - task: lint-goos
+        vars:
+          LINT_ARGS: "--new-from-rev HEAD"
       - echo "🧹 Verifying golangci-lint config…"
       - "{{.BIN_DIR}}/golangci-lint config verify"
       - echo "🧹 Checking go.mod/go.sum are tidy…"


### PR DESCRIPTION
# RATIONALE

`golangci-lint` only analyzes files selected by the **build constraints of the platform it runs on**. This repo lints exactly once, on the host GOOS:

- `Taskfile.yaml` — `golangci-lint run ./...`, no `GOOS` set
- `.golangci.yaml` — no `build-tags` key
- `.github/workflows/pr-checks.yaml` — the `lint` job is `ubuntu-latest` only

So of the 12 build-constrained files in this repo, a macOS dev lints the darwin/`!windows` set, CI lints the linux/`!windows` set, and the six **windows-only files are linted by nobody**.

That gap has already shipped real violations:

- `internal/telemetry/os_darwin.go` was fixed by #710 (linted on macOS) while its sibling `internal/telemetry/os_linux.go` was missed and needed a manual follow-up (`471ae910`).
- #712 later found two more (`os_windows.go` godot, `tls_windows.go` perfsprint) that only surfaced because someone ran `GOOS=windows golangci-lint run` by hand.

This makes that class of escape impossible rather than relying on someone remembering to check manually.

## CHANGES

**`Taskfile.yaml`**
- New `LINT_GOOS_TARGETS: "linux darwin windows"` var (kept in sync with the `goos` lists in `goreleaser.yaml`).
- New internal `lint-goos` task that loops those targets; callers pass `LINT_ARGS` to select the mode.
- `lint` and `delint` route their `golangci-lint run` through it. **`delint` matters as much as `lint`** — without it a macOS dev cannot `--fix` a `*_windows.go` violation at all.
- **`precommit` deliberately stays host-GOOS only.** The hook runs on every commit and the loop added ~4-6s of interactive latency there for little benefit — `task lint` and CI already enforce every target, so a cross-platform violation is still caught before merge.

Left **single-run** because they are GOOS-independent: `go mod tidy`, `goreleaser check`, `golangci-lint config verify`, and `golangci-lint fmt`. The formatter was checked empirically rather than assumed — it walks files directly and *does* see `tls_windows.go` from macOS, so it needs no loop.

**`.github/workflows/pr-checks.yaml`**
- No runner matrix. The single `ubuntu-latest` lint job already just calls `task lint`, so it now covers all three targets — same reasoning as the `build` job's *"cross-compile all platforms on a single Ubuntu runner (cheaper than 3-OS matrix)"*. A 3-OS lint matrix would cost macOS/Windows runner minutes, require reworking Linux-only assumptions in that job (`grep -oP`, `~/.cache/golangci-lint`, `tmp/bin/golangci-lint` without `.exe`), and still not help local `task lint`.
- Closed a second-order gap: the `lint` job was gated on `go_code` only, so a PR touching only `Taskfile.yaml`/`.golangci.yaml` (**like this one**) would never re-run lint. Added a `lint_config` paths-filter mirroring the existing `test_config` pattern from CFX-6919.
- Added `Taskfile.yaml` to the golangci cache key so changing `LINT_GOOS_TARGETS` invalidates a cache built for a different target set.

**Docs** — new "Cross-Platform Linting" section in `AGENTS.md` (incl. *"when adding a new release platform, add it to `LINT_GOOS_TARGETS`"*), plus a pointer in `CONTRIBUTING.md` so contributors understand why `task lint` can fail on a file their own OS never compiles.

## TESTING

Rather than just confirming the tree is green, I re-introduced both historical bugs from the ticket and confirmed the old behaviour misses them and the new behaviour catches them:

| Test | Host-only lint (old) | `task lint` (new) |
| --- | --- | --- |
| `os_windows.go` godot — the #712 bug | `0 issues.` | **fails** on the `GOOS=windows` leg |
| `os_linux.go` godot — the `471ae910` bug | `0 issues.` | **fails** on the `GOOS=linux` leg |

- `task delint` fixed the Windows-only file from macOS and left the tree clean — impossible before this change.
- `task lint` on a clean tree: three legs, `0 issues.` each, exit 0.
- `task precommit`: green, and unchanged in cost (host GOOS only, by design).
- `task test`: fully green, no failures.
- `lint-goos` is `internal: true`, so `task --list` is unchanged.

**Cost:** ~1.0s per extra GOOS on a warm cache (each GOOS keeps its own golangci-lint analysis cache), so roughly +2s on `task lint`.

## NOTES

GOARCH is deliberately **not** looped — a sweep found zero arch-constrained files (no `*_amd64.go` / `*_arm64.go` / `*_riscv64.go`, and no `//go:build` line mentions an arch). Only `GOOS` is a real gap today.

All three targets are already clean, so this is purely preventive and should land green.

## RELATED

- CFX-7138
- Follows #710 and #712, which fixed the symptoms this PR addresses the cause of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1785944996.059239 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to lint tasks, CI gating, and documentation; no application runtime, auth, or data paths are modified.
> 
> **Overview**
> **Cross-platform lint coverage** so build-tagged files (e.g. `*_windows.go`) are checked on every dev machine and in CI, not only on the host OS.
> 
> `Taskfile.yaml` adds `LINT_GOOS_TARGETS` (`linux darwin windows`) and an internal **`lint-goos`** task that runs `GOOS=<target> golangci-lint run` for each target. **`lint`** and **`delint`** now call `lint-goos` instead of a single `golangci-lint run` (with `--fix` passed via `LINT_ARGS`). **`precommit`** keeps its single host-GOOS run to stay fast. GOOS-independent steps (`go mod tidy`, `fmt`, `goreleaser check`) stay single-run.
> 
> **PR checks** mirror the existing `test_config` pattern: a **`lint_config`** paths filter and lint job condition so PRs that only change `Taskfile.yaml`, `.golangci.yaml`, or workflow setup still run lint. The golangci cache key now includes **`Taskfile.yaml`** so changes to `LINT_GOOS_TARGETS` invalidate stale analysis caches. Still one **`ubuntu-latest`** lint job—no OS matrix.
> 
> **`AGENTS.md`** documents cross-platform linting; **`CONTRIBUTING.md`** points contributors at it when running `task lint`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f028f6770c1e69c5933602da41a85f3471dfeda. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
