### PR TITLE
feat(enclave): add enclave (outpost) management commands

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,6 @@ internal/workload/ @datarobot-oss/workload-cli
 cmd/pipeline/ @datarobot-oss/compute-services
 internal/pipeline/ @datarobot-oss/compute-services
 docs/commands/pipeline*.md @datarobot-oss/compute-services
+cmd/enclave/ @datarobot-oss/compute-services
+internal/enclave/ @datarobot-oss/compute-services
+docs/commands/enclave.md @datarobot-oss/compute-services

--- a/cmd/enclave/access/cmd.go
+++ b/cmd/enclave/access/cmd.go
@@ -1,0 +1,43 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package access
+
+import (
+	"github.com/datarobot/cli/cmd/enclave/access/grant"
+	"github.com/datarobot/cli/cmd/enclave/access/revoke"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "access",
+		Short: "Manage who can access an enclave.",
+		Long: `Manage enclave access: grant or revoke a role (owner, user, consumer) for a
+user, group, or organization.
+
+These commands are thin wrappers over the enclave sharedRoles API. They take
+effect only when the server has ENCLAVE_RBAC_ENABLED=true; otherwise the call
+succeeds but grants nothing. The caller must hold CAN_SHARE on the enclave
+(owner or admin), and where ENCLAVE_ADMIN_ONLY=true is set, must also be a
+sysadmin or org admin.`,
+	}
+
+	cmd.AddCommand(
+		grant.Cmd(),
+		revoke.Cmd(),
+	)
+
+	return cmd
+}

--- a/cmd/enclave/access/cmd.go
+++ b/cmd/enclave/access/cmd.go
@@ -29,9 +29,10 @@ user, group, or organization.
 
 These commands are thin wrappers over the enclave sharedRoles API. They take
 effect only when the server has ENCLAVE_RBAC_ENABLED=true; otherwise the call
-succeeds but grants nothing. The caller must hold CAN_SHARE on the enclave
-(owner or admin), and where ENCLAVE_ADMIN_ONLY=true is set, must also be a
-sysadmin or org admin.`,
+succeeds but grants nothing. The caller must hold CAN_SHARE on the enclave;
+system administrators may manage any enclave.
+
+To control who may create enclaves at all, see "dr enclave permission".`,
 	}
 
 	cmd.AddCommand(

--- a/cmd/enclave/access/cmd.go
+++ b/cmd/enclave/access/cmd.go
@@ -17,15 +17,16 @@ package access
 import (
 	"github.com/datarobot/cli/cmd/enclave/access/grant"
 	"github.com/datarobot/cli/cmd/enclave/access/revoke"
+	"github.com/datarobot/cli/cmd/enclave/access/show"
 	"github.com/spf13/cobra"
 )
 
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "access",
-		Short: "Manage who can access an enclave.",
-		Long: `Manage enclave access: grant or revoke a role (owner, user, consumer) for a
-user, group, or organization.
+		Short: "Inspect and manage who can access an enclave.",
+		Long: `Inspect enclave access with "show", or grant/revoke a role (owner, user,
+consumer) for a user, group, or organization.
 
 These commands are thin wrappers over the enclave sharedRoles API. They take
 effect only when the server has ENCLAVE_RBAC_ENABLED=true; otherwise the call
@@ -36,6 +37,7 @@ To control who may create enclaves at all, see "dr enclave permission".`,
 	}
 
 	cmd.AddCommand(
+		show.Cmd(),
 		grant.Cmd(),
 		revoke.Cmd(),
 	)

--- a/cmd/enclave/access/cmd.go
+++ b/cmd/enclave/access/cmd.go
@@ -16,6 +16,7 @@ package access
 
 import (
 	"github.com/datarobot/cli/cmd/enclave/access/grant"
+	"github.com/datarobot/cli/cmd/enclave/access/list"
 	"github.com/datarobot/cli/cmd/enclave/access/revoke"
 	"github.com/datarobot/cli/cmd/enclave/access/show"
 	"github.com/spf13/cobra"
@@ -25,8 +26,9 @@ func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "access",
 		Short: "Inspect and manage who can access an enclave.",
-		Long: `Inspect enclave access with "show", or grant/revoke a role (owner, user,
-consumer) for a user, group, or organization.
+		Long: `See who an enclave is shared with ("list"), what a given user effectively
+holds ("show"), or grant/revoke a role (owner, user, consumer) for a user, group,
+or organization.
 
 These commands are thin wrappers over the enclave sharedRoles API. They take
 effect only when the server has ENCLAVE_RBAC_ENABLED=true; otherwise the call
@@ -37,6 +39,7 @@ To control who may create enclaves at all, see "dr enclave permission".`,
 	}
 
 	cmd.AddCommand(
+		list.Cmd(),
 		show.Cmd(),
 		grant.Cmd(),
 		revoke.Cmd(),

--- a/cmd/enclave/access/grant/cmd.go
+++ b/cmd/enclave/access/grant/cmd.go
@@ -54,8 +54,7 @@ organization with --org to cover every user in it.
 
 Takes effect only with ENCLAVE_RBAC_ENABLED=true on the server; otherwise the
 call succeeds but grants nothing. The caller must hold CAN_SHARE on the
-enclave (owner or admin), and where ENCLAVE_ADMIN_ONLY=true, must also be a
-sysadmin or org admin.
+enclave; system administrators may manage any enclave.
 
 Example:
   dr enclave access grant 3fa85f64-5717-4562-b3fc-2c963f66afa6 --role user --user alice@corp.io

--- a/cmd/enclave/access/grant/cmd.go
+++ b/cmd/enclave/access/grant/cmd.go
@@ -1,0 +1,116 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grant
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	var (
+		role   string
+		user   string
+		userID string
+		group  string
+		org    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "grant <enclave-id> --role <owner|user|consumer> <recipient>",
+		Short: "Grant a role on an enclave to a recipient.",
+		Long: `Grant a role on an enclave to a single recipient.
+
+The role is one of:
+  owner      full control, including sharing and deletion
+  user       deploy workloads and view the enclave
+  consumer   view only
+
+Choose exactly one recipient:
+  --user <username>   a user, by username
+  --user-id <id>      a user, by DataRobot user id
+  --group <id>        a group
+  --org <id>          an entire organization (all its users)
+
+There is no separate "all users in a tenant" subject; grant the tenant's
+organization with --org to cover every user in it.
+
+Takes effect only with ENCLAVE_RBAC_ENABLED=true on the server; otherwise the
+call succeeds but grants nothing. The caller must hold CAN_SHARE on the
+enclave (owner or admin), and where ENCLAVE_ADMIN_ONLY=true, must also be a
+sysadmin or org admin.
+
+Example:
+  dr enclave access grant 3fa85f64-5717-4562-b3fc-2c963f66afa6 --role user --user alice@corp.io
+  dr enclave access grant 3fa85f64-5717-4562-b3fc-2c963f66afa6 --role user --org 656f0000000000000000abcd`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			serverRole, err := enclave.ParseRole(role)
+			if err != nil {
+				return err
+			}
+
+			recipient, err := enclave.ResolveRecipient(user, userID, group, org)
+			if err != nil {
+				return err
+			}
+
+			if err := enclave.GrantAccess(args[0], serverRole, recipient); err != nil {
+				return err
+			}
+
+			return enclave.RenderAccessChange(outputFormat, enclave.AccessChange{
+				EnclaveID:     args[0],
+				Action:        "granted",
+				Role:          serverRole,
+				RecipientType: recipient.Type,
+				Recipient:     recipient.Value(),
+			})
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	cmd.Flags().StringVar(&role, "role", "", "Role to grant: owner, user, or consumer (required)")
+	_ = cmd.MarkFlagRequired("role")
+
+	cmd.Flags().StringVar(&user, "user", "", "Grant a user by username")
+	cmd.Flags().StringVar(&userID, "user-id", "", "Grant a user by DataRobot user id")
+	cmd.Flags().StringVar(&group, "group", "", "Grant a group by id")
+	cmd.Flags().StringVar(&org, "org", "", "Grant an entire organization by id (all its users)")
+	cmd.MarkFlagsMutuallyExclusive("user", "user-id", "group", "org")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		recipientType, _ := enclave.RecipientTypeOf(user, userID, group, org)
+
+		return map[string]any{
+			"enclave_id":     telemetry.FirstArg(args),
+			"role":           role,
+			"recipient_type": recipientType,
+			"output_format":  string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/enclave/access/grant/cmd.go
+++ b/cmd/enclave/access/grant/cmd.go
@@ -34,7 +34,7 @@ func Cmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "grant <enclave-id> --role <owner|user|consumer> <recipient>",
+		Use:   "grant <enclave-id>",
 		Short: "Grant a role on an enclave to a recipient.",
 		Long: `Grant a role on an enclave to a single recipient.
 

--- a/cmd/enclave/access/grant/cmd_test.go
+++ b/cmd/enclave/access/grant/cmd_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grant
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--role", "user", "--user", "alice"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_RequiresRole(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"enc-1", "--user", "alice"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "role")
+}
+
+func TestCmd_RejectsMultipleRecipients(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"enc-1", "--role", "user", "--user", "alice", "--org", "org-1"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/enclave/access/list/cmd.go
+++ b/cmd/enclave/access/list/cmd.go
@@ -1,0 +1,74 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:     "list <enclave-id>",
+		Aliases: []string{"ls"},
+		Short:   "List who has access to an enclave.",
+		Long: `List the users, groups, and organizations an enclave is shared with, and the
+role each holds.
+
+This is the "did my grant land?" view. "dr enclave access show" answers only for
+a single subject, and for a system administrator it answers from the bypass
+(always the full set), so neither reveals what the enclave is actually shared
+with.
+
+An empty result means nothing has been shared yet — including the case where the
+enclave was registered before enclave RBAC was enabled and so never received its
+owner grant.
+
+Requires CAN_VIEW on the enclave; system administrators may list any enclave.
+
+Example:
+  dr enclave access list 3fa85f64-5717-4562-b3fc-2c963f66afa6
+  dr enclave access list 3fa85f64-5717-4562-b3fc-2c963f66afa6 --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			roles, err := enclave.ListSharedRoles(args[0])
+			if err != nil {
+				return err
+			}
+
+			return enclave.RenderSharedRoles(outputFormat, roles)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"enclave_id":    telemetry.FirstArg(args),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/enclave/access/list/cmd_test.go
+++ b/cmd/enclave/access/list/cmd_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresEnclaveID(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_RejectsExtraArgs(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"enc-1", "enc-2"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_HasLsAlias(t *testing.T) {
+	assert.Contains(t, Cmd().Aliases, "ls")
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/enclave/access/revoke/cmd.go
+++ b/cmd/enclave/access/revoke/cmd.go
@@ -45,8 +45,7 @@ Choose exactly one recipient:
 
 Takes effect only with ENCLAVE_RBAC_ENABLED=true on the server; otherwise the
 call succeeds but changes nothing. The caller must hold CAN_SHARE on the
-enclave (owner or admin), and where ENCLAVE_ADMIN_ONLY=true, must also be a
-sysadmin or org admin.
+enclave; system administrators may manage any enclave.
 
 Example:
   dr enclave access revoke 3fa85f64-5717-4562-b3fc-2c963f66afa6 --user alice@corp.io

--- a/cmd/enclave/access/revoke/cmd.go
+++ b/cmd/enclave/access/revoke/cmd.go
@@ -1,0 +1,97 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package revoke
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	var (
+		user   string
+		userID string
+		group  string
+		org    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "revoke <enclave-id> <recipient>",
+		Short: "Revoke a recipient's access to an enclave.",
+		Long: `Revoke a recipient's access to an enclave, whatever role they currently hold.
+
+Choose exactly one recipient:
+  --user <username>   a user, by username
+  --user-id <id>      a user, by DataRobot user id
+  --group <id>        a group
+  --org <id>          an entire organization (all its users)
+
+Takes effect only with ENCLAVE_RBAC_ENABLED=true on the server; otherwise the
+call succeeds but changes nothing. The caller must hold CAN_SHARE on the
+enclave (owner or admin), and where ENCLAVE_ADMIN_ONLY=true, must also be a
+sysadmin or org admin.
+
+Example:
+  dr enclave access revoke 3fa85f64-5717-4562-b3fc-2c963f66afa6 --user alice@corp.io
+  dr enclave access revoke 3fa85f64-5717-4562-b3fc-2c963f66afa6 --org 656f0000000000000000abcd`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			recipient, err := enclave.ResolveRecipient(user, userID, group, org)
+			if err != nil {
+				return err
+			}
+
+			if err := enclave.RevokeAccess(args[0], recipient); err != nil {
+				return err
+			}
+
+			return enclave.RenderAccessChange(outputFormat, enclave.AccessChange{
+				EnclaveID:     args[0],
+				Action:        "revoked",
+				RecipientType: recipient.Type,
+				Recipient:     recipient.Value(),
+			})
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	cmd.Flags().StringVar(&user, "user", "", "Revoke a user by username")
+	cmd.Flags().StringVar(&userID, "user-id", "", "Revoke a user by DataRobot user id")
+	cmd.Flags().StringVar(&group, "group", "", "Revoke a group by id")
+	cmd.Flags().StringVar(&org, "org", "", "Revoke an entire organization by id")
+	cmd.MarkFlagsMutuallyExclusive("user", "user-id", "group", "org")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		recipientType, _ := enclave.RecipientTypeOf(user, userID, group, org)
+
+		return map[string]any{
+			"enclave_id":     telemetry.FirstArg(args),
+			"recipient_type": recipientType,
+			"output_format":  string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/enclave/access/revoke/cmd.go
+++ b/cmd/enclave/access/revoke/cmd.go
@@ -33,7 +33,7 @@ func Cmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "revoke <enclave-id> <recipient>",
+		Use:   "revoke <enclave-id>",
 		Short: "Revoke a recipient's access to an enclave.",
 		Long: `Revoke a recipient's access to an enclave, whatever role they currently hold.
 

--- a/cmd/enclave/access/revoke/cmd_test.go
+++ b/cmd/enclave/access/revoke/cmd_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package revoke
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--user", "alice"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_RejectsMultipleRecipients(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"enc-1", "--user", "alice", "--group", "grp-1"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/enclave/access/show/cmd.go
+++ b/cmd/enclave/access/show/cmd.go
@@ -1,0 +1,86 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package show
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	var userID string
+
+	cmd := &cobra.Command{
+		Use:   "show <enclave-id>",
+		Short: "Show effective permissions on an enclave.",
+		Long: `Show the effective permissions you hold on an enclave, and where they come from.
+
+Permissions are the atomic rights the server checks:
+  CAN_VIEW     see the enclave
+  CAN_UPDATE   deactivate / reactivate it
+  CAN_DELETE   delete it
+  CAN_SHARE    grant roles on it to others
+  CAN_DEPLOY   schedule workloads onto it
+
+An empty list means no access — which is the usual reason a workload fails to
+schedule with "not permitted to deploy".
+
+The reported source matters when the list is full: a system administrator and a
+server with enclave RBAC disabled both hold everything without any grant, and
+that is indistinguishable from genuinely being the owner unless it is spelled
+out.
+
+Pass --user-id to inspect another user instead of yourself (for example, to see
+why they cannot deploy). That requires a system administrator.
+
+Example:
+  dr enclave access show 3fa85f64-5717-4562-b3fc-2c963f66afa6
+  dr enclave access show 3fa85f64-5717-4562-b3fc-2c963f66afa6 --output-format json
+  dr enclave access show 3fa85f64-5717-4562-b3fc-2c963f66afa6 --user-id 656f0000000000000000abcd`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			permissions, err := enclave.GetEnclavePermissions(args[0], userID)
+			if err != nil {
+				return err
+			}
+
+			return enclave.RenderEnclavePermissions(outputFormat, *permissions)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	cmd.Flags().StringVar(&userID, "user-id", "",
+		"Inspect another user by DataRobot user id (system administrators only)")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"enclave_id":    telemetry.FirstArg(args),
+			"for_other":     userID != "",
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/enclave/access/show/cmd_test.go
+++ b/cmd/enclave/access/show/cmd_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package show
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresEnclaveID(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_RejectsExtraArgs(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"enc-1", "enc-2"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_HasUserIDFlag(t *testing.T) {
+	assert.NotNil(t, Cmd().Flags().Lookup("user-id"))
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/enclave/cmd.go
+++ b/cmd/enclave/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/datarobot/cli/cmd/enclave/del"
 	"github.com/datarobot/cli/cmd/enclave/get"
 	"github.com/datarobot/cli/cmd/enclave/list"
+	"github.com/datarobot/cli/cmd/enclave/reactivate"
 	"github.com/datarobot/cli/cmd/enclave/register"
 	"github.com/datarobot/cli/internal/features"
 	"github.com/spf13/cobra"
@@ -45,6 +46,7 @@ the installer reports in from the cluster; there is no manual activate step.`,
 		get.Cmd(),
 		list.Cmd(),
 		deactivate.Cmd(),
+		reactivate.Cmd(),
 		del.Cmd(),
 		access.Cmd(),
 	)

--- a/cmd/enclave/cmd.go
+++ b/cmd/enclave/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/datarobot/cli/cmd/enclave/del"
 	"github.com/datarobot/cli/cmd/enclave/get"
 	"github.com/datarobot/cli/cmd/enclave/list"
+	"github.com/datarobot/cli/cmd/enclave/permission"
 	"github.com/datarobot/cli/cmd/enclave/reactivate"
 	"github.com/datarobot/cli/cmd/enclave/register"
 	"github.com/datarobot/cli/internal/features"
@@ -49,6 +50,7 @@ the installer reports in from the cluster; there is no manual activate step.`,
 		reactivate.Cmd(),
 		del.Cmd(),
 		access.Cmd(),
+		permission.Cmd(),
 	)
 
 	return cmd

--- a/cmd/enclave/cmd.go
+++ b/cmd/enclave/cmd.go
@@ -1,0 +1,53 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enclave
+
+import (
+	"github.com/datarobot/cli/cmd/enclave/access"
+	"github.com/datarobot/cli/cmd/enclave/deactivate"
+	"github.com/datarobot/cli/cmd/enclave/del"
+	"github.com/datarobot/cli/cmd/enclave/get"
+	"github.com/datarobot/cli/cmd/enclave/list"
+	"github.com/datarobot/cli/cmd/enclave/register"
+	"github.com/datarobot/cli/internal/features"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "enclave",
+		Aliases: []string{"enclaves", "outpost", "outposts"},
+		GroupID: "core",
+		Short:   "🏛️  Enclave (outpost) management commands",
+		Long: `Manage enclaves — remote outpost clusters that run your DataRobot workloads.
+
+Register a new enclave to receive its one-shot installation secrets, then
+inspect, deactivate, or delete it. An enclave becomes active on its own once
+the installer reports in from the cluster; there is no manual activate step.`,
+	}
+
+	features.SetGate(cmd, "enclave")
+
+	cmd.AddCommand(
+		register.Cmd(),
+		get.Cmd(),
+		list.Cmd(),
+		deactivate.Cmd(),
+		del.Cmd(),
+		access.Cmd(),
+	)
+
+	return cmd
+}

--- a/cmd/enclave/deactivate/cmd.go
+++ b/cmd/enclave/deactivate/cmd.go
@@ -1,0 +1,66 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deactivate
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:   "deactivate <enclave-id>",
+		Short: "Deactivate an enclave.",
+		Long: `Deactivate an enclave (outpost) so it stops accepting new workloads.
+
+The enclave record is preserved; this only changes its status. Use
+'dr enclave delete' to remove it entirely.
+
+By default, output is human-readable. Use --output-format json for machine-parseable output.
+
+Example:
+  dr enclave deactivate 3fa85f64-5717-4562-b3fc-2c963f66afa6
+  dr enclave deactivate 3fa85f64-5717-4562-b3fc-2c963f66afa6 --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			e, err := enclave.DeactivateEnclave(args[0])
+			if err != nil {
+				return err
+			}
+
+			return enclave.RenderEnclave(outputFormat, *e)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"enclave_id":    telemetry.FirstArg(args),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/enclave/deactivate/cmd_test.go
+++ b/cmd/enclave/deactivate/cmd_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deactivate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/enclave/del/cmd.go
+++ b/cmd/enclave/del/cmd.go
@@ -1,0 +1,128 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package del implements the `dr enclave delete` verb. The directory is named
+// `del` rather than `delete` because the latter shadows Go's built-in delete()
+// function in importing files.
+package del
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/datarobot/cli/cmd/helpers"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <enclave-id>",
+		Short: "Delete an enclave.",
+		Long: `Delete an enclave (outpost) by id.
+
+This removes the enclave record from your tenant. To take an enclave out of
+service without removing it, use 'dr enclave deactivate' instead.
+
+Without --yes the command asks for confirmation.
+
+Example:
+  dr enclave delete 3fa85f64-5717-4562-b3fc-2c963f66afa6
+  dr enclave delete 3fa85f64-5717-4562-b3fc-2c963f66afa6 --yes`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			confirmed, err := confirmDelete(cmd, args[0])
+			if err != nil || !confirmed {
+				return err
+			}
+
+			if err := enclave.DeleteEnclave(args[0]); err != nil {
+				return handleDeleteError(err, args[0])
+			}
+
+			fmt.Println(tui.BaseTextStyle.Render("Deleted enclave: " + args[0]))
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt.")
+
+	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
+	// flag itself is read directly from cmd.Flags() so an explicit --yes does
+	// not leak into viper.AllSettings() and persist to drconfig.yaml.
+	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+
+	telemetry.TrackWith(cmd, func(cmd *cobra.Command, args []string) map[string]any {
+		yesFlag, _ := cmd.Flags().GetBool("yes")
+
+		return map[string]any{
+			"enclave_id": telemetry.FirstArg(args),
+			"yes":        yesFlag || viperx.GetBool("yes"),
+		}
+	})
+
+	return cmd
+}
+
+// confirmDelete returns (true, nil) when the deletion may proceed: either
+// --yes / DATAROBOT_CLI_NON_INTERACTIVE was given, or the user confirmed
+// interactively. A declined prompt is (false, nil) so the command exits 0
+// as a no-op.
+func confirmDelete(cmd *cobra.Command, enclaveID string) (bool, error) {
+	yesFlag, _ := cmd.Flags().GetBool("yes")
+	if yesFlag || viperx.GetBool("yes") {
+		return true, nil
+	}
+
+	if !reader.IsStdinTerminal() {
+		return false, errors.New("confirmation required: pass --yes (or set DATAROBOT_CLI_NON_INTERACTIVE=1) to delete without a prompt")
+	}
+
+	confirmed, err := helpers.Confirm(cmd.OutOrStdout(), cmd.InOrStdin(),
+		"Delete enclave "+enclaveID+"? [y/N] ")
+	if err != nil {
+		return false, err
+	}
+
+	if !confirmed {
+		fmt.Println(tui.DimStyle.Render("Aborted."))
+	}
+
+	return confirmed, nil
+}
+
+// handleDeleteError converts a 404 into a friendly informational message
+// (returns nil) so the user does not see a stack-trace-style HTTP error
+// for what is effectively a no-op.
+func handleDeleteError(err error, enclaveID string) error {
+	var httpErr *drapi.HTTPError
+
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		fmt.Println(tui.DimStyle.Render("No enclave found with id: " + enclaveID))
+
+		return nil
+	}
+
+	return err
+}

--- a/cmd/enclave/del/cmd.go
+++ b/cmd/enclave/del/cmd.go
@@ -19,21 +19,24 @@ package del
 
 import (
 	"errors"
-	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/datarobot/cli/cmd/helpers"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/enclave"
 	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
-	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
 func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
 	cmd := &cobra.Command{
 		Use:   "delete <enclave-id>",
 		Short: "Delete an enclave.",
@@ -44,41 +47,57 @@ service without removing it, use 'dr enclave deactivate' instead.
 
 Without --yes the command asks for confirmation.
 
+Deleting an enclave that is already gone, and declining the prompt, are both
+no-ops that exit 0. Use --output-format json to tell them apart from a real
+deletion: the result carries "deleted" plus a "reason" when it is false.
+
 Example:
   dr enclave delete 3fa85f64-5717-4562-b3fc-2c963f66afa6
-  dr enclave delete 3fa85f64-5717-4562-b3fc-2c963f66afa6 --yes`,
+  dr enclave delete 3fa85f64-5717-4562-b3fc-2c963f66afa6 --yes
+  dr enclave delete 3fa85f64-5717-4562-b3fc-2c963f66afa6 --yes --output-format json`,
 		Args:         cobra.ExactArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			confirmed, err := confirmDelete(cmd, args[0])
-			if err != nil || !confirmed {
+			outputFormat = outputformat.GetFormat(cmd)
+			enclaveID := args[0]
+
+			confirmed, err := confirmDelete(cmd, outputFormat, enclaveID)
+			if err != nil {
 				return err
 			}
 
-			if err := enclave.DeleteEnclave(args[0]); err != nil {
-				return handleDeleteError(err, args[0])
+			if !confirmed {
+				return enclave.RenderDeletion(outputFormat, enclave.DeletionResult{
+					EnclaveID: enclaveID,
+					Reason:    enclave.DeletionReasonAborted,
+				})
 			}
 
-			fmt.Println(tui.BaseTextStyle.Render("Deleted enclave: " + args[0]))
+			if err := enclave.DeleteEnclave(enclaveID); err != nil {
+				return handleDeleteError(err, outputFormat, enclaveID)
+			}
 
-			return nil
+			return enclave.RenderDeletion(outputFormat, enclave.DeletionResult{
+				EnclaveID: enclaveID,
+				Deleted:   true,
+			})
 		},
 	}
 
-	cmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt.")
+	outputformat.AddFlag(cmd, &outputFormat)
+	cmd.Flags().BoolP(cli.YesFlagName, "y", false, "Skip the confirmation prompt.")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
 	// flag itself is read directly from cmd.Flags() so an explicit --yes does
 	// not leak into viper.AllSettings() and persist to drconfig.yaml.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, reader.NonInteractiveEnv)
 
 	telemetry.TrackWith(cmd, func(cmd *cobra.Command, args []string) map[string]any {
-		yesFlag, _ := cmd.Flags().GetBool("yes")
-
 		return map[string]any{
-			"enclave_id": telemetry.FirstArg(args),
-			"yes":        yesFlag || viperx.GetBool("yes"),
+			"enclave_id":    telemetry.FirstArg(args),
+			"yes":           cli.IsNonInteractive(cmd),
+			"output_format": string(outputFormat),
 		}
 	})
 
@@ -89,39 +108,41 @@ Example:
 // --yes / DATAROBOT_CLI_NON_INTERACTIVE was given, or the user confirmed
 // interactively. A declined prompt is (false, nil) so the command exits 0
 // as a no-op.
-func confirmDelete(cmd *cobra.Command, enclaveID string) (bool, error) {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	if yesFlag || viperx.GetBool("yes") {
+func confirmDelete(cmd *cobra.Command, format outputformat.OutputFormat, enclaveID string) (bool, error) {
+	if cli.IsNonInteractive(cmd) {
 		return true, nil
 	}
 
 	if !reader.IsStdinTerminal() {
-		return false, errors.New("confirmation required: pass --yes (or set DATAROBOT_CLI_NON_INTERACTIVE=1) to delete without a prompt")
+		return false, errors.New("confirmation required: pass --yes (or set " +
+			reader.NonInteractiveEnv + "=1) to delete without a prompt")
 	}
 
-	confirmed, err := helpers.Confirm(cmd.OutOrStdout(), cmd.InOrStdin(),
+	return helpers.Confirm(promptWriter(cmd, format), cmd.InOrStdin(),
 		"Delete enclave "+enclaveID+"? [y/N] ")
-	if err != nil {
-		return false, err
-	}
-
-	if !confirmed {
-		fmt.Println(tui.DimStyle.Render("Aborted."))
-	}
-
-	return confirmed, nil
 }
 
-// handleDeleteError converts a 404 into a friendly informational message
-// (returns nil) so the user does not see a stack-trace-style HTTP error
-// for what is effectively a no-op.
-func handleDeleteError(err error, enclaveID string) error {
+// promptWriter keeps the confirmation prompt off stdout in JSON mode, so the
+// only thing a caller parsing stdout sees is the DeletionResult document.
+func promptWriter(cmd *cobra.Command, format outputformat.OutputFormat) io.Writer {
+	if format == outputformat.OutputFormatJSON {
+		return cmd.ErrOrStderr()
+	}
+
+	return cmd.OutOrStdout()
+}
+
+// handleDeleteError turns a 404 into an already-gone result (exit 0) so the
+// user does not see a stack-trace-style HTTP error for what is effectively a
+// no-op. Every other error propagates.
+func handleDeleteError(err error, format outputformat.OutputFormat, enclaveID string) error {
 	var httpErr *drapi.HTTPError
 
 	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-		fmt.Println(tui.DimStyle.Render("No enclave found with id: " + enclaveID))
-
-		return nil
+		return enclave.RenderDeletion(format, enclave.DeletionResult{
+			EnclaveID: enclaveID,
+			Reason:    enclave.DeletionReasonNotFound,
+		})
 	}
 
 	return err

--- a/cmd/enclave/del/cmd_test.go
+++ b/cmd/enclave/del/cmd_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package del
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{})
+
+	require.Error(t, cmd.Execute())
+}
+
+// In tests stdin is not a terminal, so without --yes the command must stop
+// with the confirmation-required guidance before any network call.
+func TestCmd_RequiresYesWhenNonInteractive(t *testing.T) {
+	t.Setenv(reader.NonInteractiveEnv, "")
+
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"3fa85f64-5717-4562-b3fc-2c963f66afa6"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "confirmation required")
+	assert.Contains(t, err.Error(), "--yes")
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/enclave/del/cmd_test.go
+++ b/cmd/enclave/del/cmd_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,4 +48,35 @@ func TestCmd_RequiresYesWhenNonInteractive(t *testing.T) {
 
 func TestCmd_HasTelemetry(t *testing.T) {
 	assert.Contains(t, Cmd().Annotations, "telemetry")
+}
+
+// Every spelling reader.IsNonInteractive() accepts must count as consent. A
+// plain viper.GetBool (cast.ToBool) rejects "yes"/"y"/"t", which would fail a
+// CI run that sets DATAROBOT_CLI_NON_INTERACTIVE=yes; cli.IsNonInteractive is
+// the canonical check that does not.
+func TestConfirmDelete_HonorsTruthyNonInteractiveSpellings(t *testing.T) {
+	for _, value := range []string{"1", "t", "T", "true", "TRUE", "True", "y", "Y", "yes", "YES", "Yes"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv(reader.NonInteractiveEnv, value)
+
+			cmd := Cmd()
+
+			confirmed, err := confirmDelete(cmd, outputformat.OutputFormatText, "enc-1")
+			require.NoError(t, err)
+			assert.True(t, confirmed, "DATAROBOT_CLI_NON_INTERACTIVE=%s must count as consent", value)
+		})
+	}
+}
+
+// --output-format is a persistent root flag, so it parses either way; the
+// command needs its own flag for the format to actually reach the renderer.
+func TestCmd_HasOutputFormatFlag(t *testing.T) {
+	assert.NotNil(t, Cmd().Flags().Lookup("output-format"))
+}
+
+func TestCmd_JSONKeepsThePromptOffStdout(t *testing.T) {
+	cmd := Cmd()
+
+	assert.Equal(t, cmd.ErrOrStderr(), promptWriter(cmd, outputformat.OutputFormatJSON))
+	assert.Equal(t, cmd.OutOrStdout(), promptWriter(cmd, outputformat.OutputFormatText))
 }

--- a/cmd/enclave/get/cmd.go
+++ b/cmd/enclave/get/cmd.go
@@ -1,0 +1,66 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:   "get <enclave-id>",
+		Short: "Display details of an enclave.",
+		Long: `Display details of a single enclave (outpost).
+
+Shows the enclave's ID, name, status, and dispatch URL. The dispatch URL is
+populated once the enclave activates; until then it is shown as "—".
+
+By default, output is human-readable. Use --output-format json for machine-parseable output.
+
+Example:
+  dr enclave get 3fa85f64-5717-4562-b3fc-2c963f66afa6
+  dr enclave get 3fa85f64-5717-4562-b3fc-2c963f66afa6 --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			e, err := enclave.GetEnclave(args[0])
+			if err != nil {
+				return err
+			}
+
+			return enclave.RenderEnclave(outputFormat, *e)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"enclave_id":    telemetry.FirstArg(args),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/enclave/get/cmd_test.go
+++ b/cmd/enclave/get/cmd_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/enclave/list/cmd.go
+++ b/cmd/enclave/list/cmd.go
@@ -1,0 +1,64 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List enclaves.",
+		Long: `List the enclaves (outposts) registered to your DataRobot tenant.
+
+For each enclave the listing shows its ID, name, status, and dispatch URL.
+
+By default, output is a human-readable table. Use --output-format json for machine-parseable output.
+
+Example:
+  dr enclave list
+  dr enclave list --output-format json`,
+		Args:         cobra.NoArgs,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			enclaves, err := enclave.ListEnclaves()
+			if err != nil {
+				return err
+			}
+
+			return enclave.RenderEnclaves(outputFormat, enclaves)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		return map[string]any{
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/enclave/list/cmd_test.go
+++ b/cmd/enclave/list/cmd_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RejectsArgs(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"unexpected"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/enclave/permission/cmd.go
+++ b/cmd/enclave/permission/cmd.go
@@ -16,16 +16,18 @@ package permission
 
 import (
 	"github.com/datarobot/cli/cmd/enclave/permission/grant"
+	"github.com/datarobot/cli/cmd/enclave/permission/list"
 	"github.com/datarobot/cli/cmd/enclave/permission/revoke"
+	"github.com/datarobot/cli/cmd/enclave/permission/show"
 	"github.com/spf13/cobra"
 )
 
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "permission",
-		Short: "Manage who can create enclaves.",
-		Long: `Manage collection-level enclave permissions — capabilities that are not tied to
-any single enclave.
+		Short: "Inspect and manage who can create enclaves.",
+		Long: `Inspect ("show", "list") or manage ("grant", "revoke") collection-level enclave
+permissions — capabilities that are not tied to any single enclave.
 
 Today the only such permission is "create": the right to register a new
 enclave. A system administrator grants it to org admins and other users, so
@@ -40,6 +42,8 @@ a system administrator.`,
 	}
 
 	cmd.AddCommand(
+		list.Cmd(),
+		show.Cmd(),
 		grant.Cmd(),
 		revoke.Cmd(),
 	)

--- a/cmd/enclave/permission/cmd.go
+++ b/cmd/enclave/permission/cmd.go
@@ -1,0 +1,48 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package permission
+
+import (
+	"github.com/datarobot/cli/cmd/enclave/permission/grant"
+	"github.com/datarobot/cli/cmd/enclave/permission/revoke"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "permission",
+		Short: "Manage who can create enclaves.",
+		Long: `Manage collection-level enclave permissions — capabilities that are not tied to
+any single enclave.
+
+Today the only such permission is "create": the right to register a new
+enclave. A system administrator grants it to org admins and other users, so
+that creating enclaves is delegated as a permission rather than inferred from a
+role.
+
+Use "dr enclave access" instead to manage access to an existing enclave.
+
+These commands take effect only when the server has ENCLAVE_RBAC_ENABLED=true;
+otherwise the call succeeds but changes nothing. Granting and revoking require
+a system administrator.`,
+	}
+
+	cmd.AddCommand(
+		grant.Cmd(),
+		revoke.Cmd(),
+	)
+
+	return cmd
+}

--- a/cmd/enclave/permission/grant/cmd.go
+++ b/cmd/enclave/permission/grant/cmd.go
@@ -1,0 +1,108 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grant
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	var (
+		permission string
+		userID     string
+		group      string
+		org        string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "grant --permission create <recipient>",
+		Short: "Grant a collection-level enclave permission to a recipient.",
+		Long: `Grant a collection-level enclave permission to a single recipient.
+
+The permission is:
+  create   register new enclaves
+
+Choose exactly one recipient:
+  --user-id <id>   a user, by DataRobot user id
+  --group <id>     a group
+  --org <id>       an entire organization (all its users)
+
+Recipients are named by id only — unlike "dr enclave access", there is no
+--user <username> form. There is also no separate "all users in a tenant"
+subject; grant the tenant's organization with --org to cover every user in it.
+
+Takes effect only with ENCLAVE_RBAC_ENABLED=true on the server; otherwise the
+call succeeds but grants nothing. Granting requires a system administrator.
+
+Example:
+  dr enclave permission grant --permission create --org 656f0000000000000000abcd
+  dr enclave permission grant --permission create --user-id 656f0000000000000000abce`,
+		Args:         cobra.NoArgs,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			name, err := enclave.ParsePermission(permission)
+			if err != nil {
+				return err
+			}
+
+			recipient, err := enclave.ResolveRecipientByID(userID, group, org)
+			if err != nil {
+				return err
+			}
+
+			if err := enclave.GrantCreatePermission(recipient); err != nil {
+				return err
+			}
+
+			return enclave.RenderPermissionChange(outputFormat, enclave.PermissionChange{
+				Permission:    name,
+				Action:        "granted",
+				RecipientType: recipient.Type,
+				Recipient:     recipient.Value(),
+			})
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	cmd.Flags().StringVar(&permission, "permission", "", "Permission to grant: create (required)")
+	_ = cmd.MarkFlagRequired("permission")
+
+	cmd.Flags().StringVar(&userID, "user-id", "", "Grant a user by DataRobot user id")
+	cmd.Flags().StringVar(&group, "group", "", "Grant a group by id")
+	cmd.Flags().StringVar(&org, "org", "", "Grant an entire organization by id (all its users)")
+	cmd.MarkFlagsMutuallyExclusive("user-id", "group", "org")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		recipientType, _ := enclave.RecipientTypeByIDOf(userID, group, org)
+
+		return map[string]any{
+			"permission":     permission,
+			"recipient_type": recipientType,
+			"output_format":  string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/enclave/permission/grant/cmd.go
+++ b/cmd/enclave/permission/grant/cmd.go
@@ -33,7 +33,7 @@ func Cmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "grant --permission create <recipient>",
+		Use:   "grant",
 		Short: "Grant a collection-level enclave permission to a recipient.",
 		Long: `Grant a collection-level enclave permission to a single recipient.
 

--- a/cmd/enclave/permission/grant/cmd_test.go
+++ b/cmd/enclave/permission/grant/cmd_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grant
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresPermission(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--org", "org-1"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission")
+}
+
+func TestCmd_RejectsUnknownPermission(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--permission", "deploy", "--org", "org-1"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create")
+}
+
+func TestCmd_RejectsMultipleRecipients(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--permission", "create", "--org", "org-1", "--group", "grp-1"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_RejectsUsernameSelector(t *testing.T) {
+	// The createAccess endpoint identifies recipients by id only, so --user is
+	// deliberately not offered here (unlike "dr enclave access").
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--permission", "create", "--user", "alice@corp.io"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_TakesNoPositionalArgs(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"enc-1", "--permission", "create", "--org", "org-1"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/enclave/permission/list/cmd.go
+++ b/cmd/enclave/permission/list/cmd.go
@@ -1,0 +1,70 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List who may create enclaves.",
+		Long: `List the users, groups, and organizations granted the enclave create
+permission.
+
+This is the "did my grant land?" view for "dr enclave permission grant".
+"dr enclave permission show" answers only for a single subject, and for a system
+administrator it answers from the bypass, so neither reveals who has actually
+been granted the permission.
+
+An empty result means nobody has been granted it — note that system
+administrators may create enclaves regardless and so do not appear here.
+
+Requires a system administrator, matching grant and revoke.
+
+Example:
+  dr enclave permission list
+  dr enclave permission list --output-format json`,
+		Args:         cobra.NoArgs,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			holders, err := enclave.ListCreateAccess()
+			if err != nil {
+				return err
+			}
+
+			return enclave.RenderCreateAccess(outputFormat, holders)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		return map[string]any{"output_format": string(outputFormat)}
+	})
+
+	return cmd
+}

--- a/cmd/enclave/permission/list/cmd_test.go
+++ b/cmd/enclave/permission/list/cmd_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_TakesNoPositionalArgs(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"extra"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_HasLsAlias(t *testing.T) {
+	assert.Contains(t, Cmd().Aliases, "ls")
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/enclave/permission/revoke/cmd.go
+++ b/cmd/enclave/permission/revoke/cmd.go
@@ -1,0 +1,109 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package revoke
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	var (
+		permission string
+		userID     string
+		group      string
+		org        string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "revoke --permission create <recipient>",
+		Short: "Revoke a collection-level enclave permission from a recipient.",
+		Long: `Revoke a collection-level enclave permission from a single recipient.
+
+The permission is:
+  create   register new enclaves
+
+Choose exactly one recipient:
+  --user-id <id>   a user, by DataRobot user id
+  --group <id>     a group
+  --org <id>       an entire organization
+
+Recipients are named by id only — unlike "dr enclave access", there is no
+--user <username> form. Revoking a recipient's permission does not affect
+enclaves they already own, nor any permission granted to them by way of a
+different subject (for example, an organization-wide grant).
+
+Takes effect only with ENCLAVE_RBAC_ENABLED=true on the server; otherwise the
+call succeeds but changes nothing. Revoking requires a system administrator.
+
+Example:
+  dr enclave permission revoke --permission create --org 656f0000000000000000abcd
+  dr enclave permission revoke --permission create --user-id 656f0000000000000000abce`,
+		Args:         cobra.NoArgs,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			name, err := enclave.ParsePermission(permission)
+			if err != nil {
+				return err
+			}
+
+			recipient, err := enclave.ResolveRecipientByID(userID, group, org)
+			if err != nil {
+				return err
+			}
+
+			if err := enclave.RevokeCreatePermission(recipient); err != nil {
+				return err
+			}
+
+			return enclave.RenderPermissionChange(outputFormat, enclave.PermissionChange{
+				Permission:    name,
+				Action:        "revoked",
+				RecipientType: recipient.Type,
+				Recipient:     recipient.Value(),
+			})
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	cmd.Flags().StringVar(&permission, "permission", "", "Permission to revoke: create (required)")
+	_ = cmd.MarkFlagRequired("permission")
+
+	cmd.Flags().StringVar(&userID, "user-id", "", "Revoke from a user by DataRobot user id")
+	cmd.Flags().StringVar(&group, "group", "", "Revoke from a group by id")
+	cmd.Flags().StringVar(&org, "org", "", "Revoke from an entire organization by id")
+	cmd.MarkFlagsMutuallyExclusive("user-id", "group", "org")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		recipientType, _ := enclave.RecipientTypeByIDOf(userID, group, org)
+
+		return map[string]any{
+			"permission":     permission,
+			"recipient_type": recipientType,
+			"output_format":  string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/enclave/permission/revoke/cmd.go
+++ b/cmd/enclave/permission/revoke/cmd.go
@@ -33,7 +33,7 @@ func Cmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "revoke --permission create <recipient>",
+		Use:   "revoke",
 		Short: "Revoke a collection-level enclave permission from a recipient.",
 		Long: `Revoke a collection-level enclave permission from a single recipient.
 

--- a/cmd/enclave/permission/revoke/cmd_test.go
+++ b/cmd/enclave/permission/revoke/cmd_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package revoke
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresPermission(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--org", "org-1"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission")
+}
+
+func TestCmd_RejectsUnknownPermission(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--permission", "deploy", "--org", "org-1"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create")
+}
+
+func TestCmd_RejectsMultipleRecipients(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--permission", "create", "--user-id", "u-1", "--org", "org-1"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/enclave/permission/show/cmd.go
+++ b/cmd/enclave/permission/show/cmd.go
@@ -1,0 +1,77 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package show
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	var userID string
+
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Show your collection-level enclave permissions.",
+		Long: `Show whether you may create enclaves, and where that comes from.
+
+Collection-level permissions are not tied to any single enclave. Today there is
+one: CAN_CREATE, the right to register a new enclave. Use "dr enclave access
+show" for permissions on a specific enclave.
+
+The reported source matters: a system administrator may create enclaves
+regardless of grants, and a server with enclave RBAC disabled enforces nothing —
+both are indistinguishable from holding CAN_CREATE unless spelled out.
+
+Pass --user-id to inspect another user. That requires a system administrator.
+
+Example:
+  dr enclave permission show
+  dr enclave permission show --user-id 656f0000000000000000abcd
+  dr enclave permission show --output-format json`,
+		Args:         cobra.NoArgs,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			permissions, err := enclave.GetCollectionPermissions(userID)
+			if err != nil {
+				return err
+			}
+
+			return enclave.RenderCollectionPermissions(outputFormat, *permissions)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	cmd.Flags().StringVar(&userID, "user-id", "",
+		"Inspect another user by DataRobot user id (system administrators only)")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		return map[string]any{
+			"for_other":     userID != "",
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/enclave/permission/show/cmd_test.go
+++ b/cmd/enclave/permission/show/cmd_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package show
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_TakesNoPositionalArgs(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"enc-1"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_HasUserIDFlag(t *testing.T) {
+	assert.NotNil(t, Cmd().Flags().Lookup("user-id"))
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/enclave/reactivate/cmd.go
+++ b/cmd/enclave/reactivate/cmd.go
@@ -1,0 +1,64 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reactivate
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	cmd := &cobra.Command{
+		Use:   "reactivate <enclave-id>",
+		Short: "Reactivate a deactivated enclave.",
+		Long: `Return a manually deactivated enclave (outpost) to service so it accepts
+workloads again. This is the inverse of 'dr enclave deactivate'.
+
+By default, output is human-readable. Use --output-format json for machine-parseable output.
+
+Example:
+  dr enclave reactivate 3fa85f64-5717-4562-b3fc-2c963f66afa6
+  dr enclave reactivate 3fa85f64-5717-4562-b3fc-2c963f66afa6 --output-format json`,
+		Args:         cobra.ExactArgs(1),
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			e, err := enclave.ReactivateEnclave(args[0])
+			if err != nil {
+				return err
+			}
+
+			return enclave.RenderEnclave(outputFormat, *e)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+		return map[string]any{
+			"enclave_id":    telemetry.FirstArg(args),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/enclave/reactivate/cmd_test.go
+++ b/cmd/enclave/reactivate/cmd_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reactivate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCmd_RequiresArg(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/enclave/register/cmd.go
+++ b/cmd/enclave/register/cmd.go
@@ -1,0 +1,86 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package register
+
+import (
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/enclave"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	var outputFormat outputformat.OutputFormat
+
+	var (
+		name   string
+		labels []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "register",
+		Short: "Register a new enclave.",
+		Long: `Register a new enclave (outpost) with your DataRobot tenant.
+
+Registration returns the enclave's ID and status along with its one-shot
+installation secrets — the credentials the installer materializes as
+Kubernetes Secrets on the enclave cluster. Those secrets are shown only once
+and are never persisted server-side, so capture them from this command's
+output (use --output-format json to save them programmatically).
+
+After the installer applies the secrets and reports in, the enclave activates
+on its own; there is no separate activate command.
+
+Example:
+  dr enclave register --name my-enclave
+  dr enclave register --name my-enclave --label team=research --label env=prod
+  dr enclave register --name my-enclave --output-format json`,
+		Args:         cobra.NoArgs,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			parsedLabels, err := enclave.ParseLabels(labels)
+			if err != nil {
+				return err
+			}
+
+			result, err := enclave.RegisterEnclave(name, parsedLabels)
+			if err != nil {
+				return err
+			}
+
+			return enclave.RenderRegistration(outputFormat, *result)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+
+	cmd.Flags().StringVar(&name, "name", "", "Name for the new enclave (required)")
+	_ = cmd.MarkFlagRequired("name")
+	cmd.Flags().StringArrayVar(&labels, "label", nil,
+		"Label to attach as key=value (repeatable)")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		return map[string]any{
+			"label_count":   len(labels),
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}

--- a/cmd/enclave/register/cmd_test.go
+++ b/cmd/enclave/register/cmd_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package register
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --name is required, so an invocation without it must fail before any
+// network call. PreRunE (auth) is cleared so the required-flag check is what
+// stops execution.
+func TestCmd_RequiresName(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name")
+}
+
+func TestCmd_RejectsPositionalArgs(t *testing.T) {
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--name", "e", "unexpected"})
+
+	require.Error(t, cmd.Execute())
+}
+
+func TestCmd_HasTelemetry(t *testing.T) {
+	assert.Contains(t, Cmd().Annotations, "telemetry")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/datarobot/cli/cmd/component"
 	"github.com/datarobot/cli/cmd/dependencies"
 	"github.com/datarobot/cli/cmd/dotenv"
+	"github.com/datarobot/cli/cmd/enclave"
 	llmgateway "github.com/datarobot/cli/cmd/llm-gateway"
 	"github.com/datarobot/cli/cmd/pipeline"
 	"github.com/datarobot/cli/cmd/plugin"
@@ -282,6 +283,7 @@ func init() {
 		component.Cmd(),
 		dependencies.Cmd(),
 		dotenv.Cmd(),
+		enclave.Cmd(),
 		llmgateway.Cmd(),
 		run.Cmd(),
 		self.Cmd(),

--- a/cmd/root_factory.go
+++ b/cmd/root_factory.go
@@ -37,6 +37,7 @@ import (
 	"github.com/datarobot/cli/cmd/component"
 	"github.com/datarobot/cli/cmd/dependencies"
 	"github.com/datarobot/cli/cmd/dotenv"
+	"github.com/datarobot/cli/cmd/enclave"
 	llmgateway "github.com/datarobot/cli/cmd/llm-gateway"
 	"github.com/datarobot/cli/cmd/pipeline"
 	"github.com/datarobot/cli/cmd/plugin"
@@ -592,6 +593,7 @@ func (f *RootFactory) addSubcommands(adder *cli.CommandAdder) {
 		component.Cmd(),
 		dependencies.Cmd(),
 		dotenv.Cmd(),
+		enclave.Cmd(),
 		llmgateway.Cmd(),
 		run.Cmd(),
 		self.Cmd(),

--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/cmd/artifact"
+	"github.com/datarobot/cli/cmd/enclave"
 	"github.com/datarobot/cli/cmd/workload"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -142,6 +143,39 @@ func TestTelemetryWiring_AllArtifactCommandsTracked(t *testing.T) {
 		t.Run("dr "+path, func(t *testing.T) {
 			cmd := findCommandByPath(artifactRoot, path)
 			require.NotNilf(t, cmd, "command %q not found in artifact subtree", path)
+
+			assert.Containsf(t, cmd.Annotations, "telemetry",
+				"command %q must be wired to telemetry via telemetry.Track / TrackWith", path)
+		})
+	}
+}
+
+// expectedEnclaveTrackedCommands enumerates leaf commands under `dr enclave`
+// that must be wired to fire a telemetry event. Like the workload subtree,
+// `dr enclave` is hidden from the live RootCmd by cli.CommandAdder when
+// DATAROBOT_CLI_FEATURE_ENCLAVE is unset (the default in CI), so this test
+// walks a freshly-built subtree produced by enclave.Cmd().
+var expectedEnclaveTrackedCommands = []string{
+	"enclave register",
+	"enclave get",
+	"enclave list",
+	"enclave deactivate",
+	"enclave delete",
+	"enclave access grant",
+	"enclave access revoke",
+}
+
+// TestTelemetryWiring_AllEnclaveCommandsTracked walks the enclave subtree
+// (built via enclave.Cmd() to bypass the feature-gate filter in
+// cli.CommandAdder) and asserts each entry has the "telemetry" annotation set
+// by telemetry.Track / TrackWith.
+func TestTelemetryWiring_AllEnclaveCommandsTracked(t *testing.T) {
+	enclaveRoot := enclave.Cmd()
+
+	for _, path := range expectedEnclaveTrackedCommands {
+		t.Run("dr "+path, func(t *testing.T) {
+			cmd := findCommandByPath(enclaveRoot, path)
+			require.NotNilf(t, cmd, "command %q not found in enclave subtree", path)
 
 			assert.Containsf(t, cmd.Annotations, "telemetry",
 				"command %q must be wired to telemetry via telemetry.Track / TrackWith", path)

--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -160,6 +160,7 @@ var expectedEnclaveTrackedCommands = []string{
 	"enclave get",
 	"enclave list",
 	"enclave deactivate",
+	"enclave reactivate",
 	"enclave delete",
 	"enclave access grant",
 	"enclave access revoke",

--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -164,6 +164,12 @@ var expectedEnclaveTrackedCommands = []string{
 	"enclave delete",
 	"enclave access grant",
 	"enclave access revoke",
+	"enclave access list",
+	"enclave access show",
+	"enclave permission grant",
+	"enclave permission revoke",
+	"enclave permission list",
+	"enclave permission show",
 }
 
 // TestTelemetryWiring_AllEnclaveCommandsTracked walks the enclave subtree

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -60,6 +60,7 @@ These flags are available for all commands:
 | [`pipeline`](pipeline.md)         | Manage pipelines via the pipelines API (feature-gated).     |
 | [`artifact`](artifact.md)         | Build and manage workload artifacts (feature-gated).        |
 | [`workload`](workload.md)         | Deploy and manage workloads from artifacts (feature-gated). |
+| [`enclave`](enclave.md)           | Register and manage enclaves (outposts) (feature-gated).    |
 | [`dependencies`](dependencies.md) | Check and install template dependencies (advanced).         |
 
 ### Command tree
@@ -160,6 +161,23 @@ dr
 │   ├── status         Show a workload's status
 │   ├── endpoint       Print a workload's endpoint URL
 │   └── logs           Show a workload's container logs
+├── enclave            Enclave management (alias: enclaves, outpost(s), feature-gated)
+│   ├── register       Register an enclave, returning one-shot install secrets
+│   ├── get            Display details of an enclave
+│   ├── list           List enclaves
+│   ├── deactivate     Take an active enclave out of scheduling
+│   ├── reactivate     Return a deactivated enclave to service
+│   ├── delete         Delete an enclave
+│   ├── access         Manage who can access one enclave
+│   │   ├── grant      Grant a role (owner|user|consumer) on an enclave
+│   │   ├── revoke     Revoke a recipient's role on an enclave
+│   │   ├── list       List who holds a role on an enclave
+│   │   └── show       Show effective permissions on an enclave
+│   └── permission     Manage who can create enclaves
+│       ├── grant      Allow a recipient to create enclaves
+│       ├── revoke     Stop a recipient from creating enclaves
+│       ├── list       List who may create enclaves
+│       └── show       Show your collection-level permissions
 └── self               CLI utility commands
     ├── completion     Shell completion
     │   ├── install    Install completions interactively

--- a/docs/commands/enclave.md
+++ b/docs/commands/enclave.md
@@ -50,22 +50,26 @@ Pin a workload to an enclave with [`dr workload create --enclave <name>`](worklo
 
 | Command                        | Endpoint                                          | Purpose                                          |
 | ------------------------------ | ------------------------------------------------- | ------------------------------------------------ |
-| `dr enclave register`          | `POST   /api/v2/outposts`                         | Register an enclave, returning install secrets.  |
-| `dr enclave get`               | `GET    /api/v2/outposts/{id}`                    | Show a single enclave.                           |
-| `dr enclave list`              | `GET    /api/v2/outposts`                         | List the enclaves you can see.                   |
-| `dr enclave deactivate`        | `POST   /api/v2/outposts/{id}/deactivate`         | Take an active enclave out of scheduling.        |
-| `dr enclave reactivate`        | `POST   /api/v2/outposts/{id}/reactivate`         | Return a deactivated enclave to service.         |
-| `dr enclave delete`            | `DELETE /api/v2/outposts/{id}`                    | Delete an enclave.                               |
-| `dr enclave access grant`      | `PATCH  /api/v2/outposts/{id}/sharedRoles`        | Grant a role on one enclave.                     |
-| `dr enclave access revoke`     | `PATCH  /api/v2/outposts/{id}/sharedRoles`        | Revoke a recipient's role on one enclave.        |
-| `dr enclave access list`       | `GET    /api/v2/outposts/{id}/sharedRoles`        | List who holds a role on one enclave.            |
-| `dr enclave access show`       | `GET    /api/v2/outposts/{id}/permissions`        | Show effective permissions on one enclave.       |
-| `dr enclave permission grant`  | `PATCH  /api/v2/outposts/createAccess`            | Allow a recipient to create enclaves.            |
-| `dr enclave permission revoke` | `PATCH  /api/v2/outposts/createAccess`            | Stop a recipient from creating enclaves.         |
-| `dr enclave permission list`   | `GET    /api/v2/outposts/createAccess`            | List who may create enclaves.                    |
-| `dr enclave permission show`   | `GET    /api/v2/outposts/permissions`             | Show your own collection-level permissions.      |
+| `dr enclave register`          | `POST   /api/v2/enclaves`                         | Register an enclave, returning install secrets.  |
+| `dr enclave get`               | `GET    /api/v2/enclaves/{id}`                    | Show a single enclave.                           |
+| `dr enclave list`              | `GET    /api/v2/enclaves`                         | List the enclaves you can see.                   |
+| `dr enclave deactivate`        | `POST   /api/v2/enclaves/{id}/deactivate`         | Take an active enclave out of scheduling.        |
+| `dr enclave reactivate`        | `POST   /api/v2/enclaves/{id}/reactivate`         | Return a deactivated enclave to service.         |
+| `dr enclave delete`            | `DELETE /api/v2/enclaves/{id}`                    | Delete an enclave.                               |
+| `dr enclave access grant`      | `PATCH  /api/v2/enclaves/{id}/sharedRoles`        | Grant a role on one enclave.                     |
+| `dr enclave access revoke`     | `PATCH  /api/v2/enclaves/{id}/sharedRoles`        | Revoke a recipient's role on one enclave.        |
+| `dr enclave access list`       | `GET    /api/v2/enclaves/{id}/sharedRoles`        | List who holds a role on one enclave.            |
+| `dr enclave access show`       | `GET    /api/v2/enclaves/{id}/permissions`        | Show effective permissions on one enclave.       |
+| `dr enclave permission grant`  | `PATCH  /api/v2/enclaves/createAccess`            | Allow a recipient to create enclaves.            |
+| `dr enclave permission revoke` | `PATCH  /api/v2/enclaves/createAccess`            | Stop a recipient from creating enclaves.         |
+| `dr enclave permission list`   | `GET    /api/v2/enclaves/createAccess`            | List who may create enclaves.                    |
+| `dr enclave permission show`   | `GET    /api/v2/enclaves/permissions`             | Show your own collection-level permissions.      |
 
-All paths are served under the `/covalent` prefix on your DataRobot host.
+All paths are served at the root of your DataRobot host. They are new: the API
+previously sat behind a `/covalent` prefix, and its access routes answered under
+`/outposts`. Those spellings still work server-side as deprecated aliases, but
+the CLI calls only the paths above, so `dr enclave` needs a DataRobot whose
+Covalent carries that change — it landed just after Covalent 11.12.0.
 
 ## Subcommands
 

--- a/docs/commands/enclave.md
+++ b/docs/commands/enclave.md
@@ -1,0 +1,238 @@
+# `dr enclave` - Enclave management
+
+Register and operate enclaves — remote outpost clusters that run your DataRobot workloads on infrastructure you control. The `dr enclave` group wraps the Covalent Enclaves API, with one subcommand per operation. It is also available under the aliases `enclaves`, `outpost`, and `outposts`.
+
+## Synopsis
+
+```bash
+dr enclave <command> [flags]
+```
+
+## Description
+
+An **enclave** is a Kubernetes cluster registered with your DataRobot tenant that workloads can be scheduled onto. `register` returns the enclave's id together with its one-shot installation secrets; the installer materializes those as Kubernetes Secrets on the cluster, reports in, and the enclave activates on its own — there is no manual activate step.
+
+`deactivate` takes an active enclave out of scheduling while keeping the record, and `reactivate` puts it back; `delete` removes it for good.
+
+Two separate things govern who can do what:
+
+- **Per-enclave access** (`dr enclave access`) — the `owner`, `user`, and `consumer` roles on one enclave. Deploying a workload onto an enclave requires at least the `user` role.
+- **Collection-level permission** (`dr enclave permission`) — who may create enclaves at all, independent of any single one.
+
+DataRobot system administrators bypass both and always have full access.
+
+> [!NOTE]
+> The `enclave` command is currently behind a feature gate. Enable it by exporting `DATAROBOT_CLI_FEATURE_ENCLAVE=true` before running any `dr enclave` subcommand. See [Feature gates](../development/feature-gates.md) for details.
+>
+> The access and permission subcommands need `ENCLAVE_RBAC_ENABLED` on the server. Where it is off, grants and revokes are accepted as no-ops and every caller shows as fully permitted.
+
+## Quick start
+
+```bash
+export DATAROBOT_CLI_FEATURE_ENCLAVE=true
+
+# Register an enclave and capture its one-shot installation secrets
+dr enclave register --name my-enclave --output-format json > enclave.json
+
+# Watch for it to come up on its own once the installer reports in
+dr enclave list
+
+# Let an entire organization deploy onto it
+dr enclave access grant <enclave-id> --role user --org <org-id>
+
+# Check what you can do with it
+dr enclave access show <enclave-id>
+```
+
+Pin a workload to an enclave with [`dr workload create --enclave <name>`](workload.md).
+
+## Command groups
+
+| Command                        | Endpoint                                          | Purpose                                          |
+| ------------------------------ | ------------------------------------------------- | ------------------------------------------------ |
+| `dr enclave register`          | `POST   /api/v2/outposts`                         | Register an enclave, returning install secrets.  |
+| `dr enclave get`               | `GET    /api/v2/outposts/{id}`                    | Show a single enclave.                           |
+| `dr enclave list`              | `GET    /api/v2/outposts`                         | List the enclaves you can see.                   |
+| `dr enclave deactivate`        | `POST   /api/v2/outposts/{id}/deactivate`         | Take an active enclave out of scheduling.        |
+| `dr enclave reactivate`        | `POST   /api/v2/outposts/{id}/reactivate`         | Return a deactivated enclave to service.         |
+| `dr enclave delete`            | `DELETE /api/v2/outposts/{id}`                    | Delete an enclave.                               |
+| `dr enclave access grant`      | `PATCH  /api/v2/outposts/{id}/sharedRoles`        | Grant a role on one enclave.                     |
+| `dr enclave access revoke`     | `PATCH  /api/v2/outposts/{id}/sharedRoles`        | Revoke a recipient's role on one enclave.        |
+| `dr enclave access list`       | `GET    /api/v2/outposts/{id}/sharedRoles`        | List who holds a role on one enclave.            |
+| `dr enclave access show`       | `GET    /api/v2/outposts/{id}/permissions`        | Show effective permissions on one enclave.       |
+| `dr enclave permission grant`  | `PATCH  /api/v2/outposts/createAccess`            | Allow a recipient to create enclaves.            |
+| `dr enclave permission revoke` | `PATCH  /api/v2/outposts/createAccess`            | Stop a recipient from creating enclaves.         |
+| `dr enclave permission list`   | `GET    /api/v2/outposts/createAccess`            | List who may create enclaves.                    |
+| `dr enclave permission show`   | `GET    /api/v2/outposts/permissions`             | Show your own collection-level permissions.      |
+
+All paths are served under the `/covalent` prefix on your DataRobot host.
+
+## Subcommands
+
+### `register`
+
+Register a new enclave with your tenant. The response carries the enclave id and status along with its **one-shot installation secrets** — they are shown only once and never persisted server-side, so capture them here. `--output-format json` writes them in a form you can feed to the installer; the default text output prints the equivalent `kubectl create secret generic` command for each one.
+
+```bash
+dr enclave register --name my-enclave
+dr enclave register --name my-enclave --label team=research --label env=prod
+dr enclave register --name my-enclave --output-format json
+```
+
+| Flag      | Description                                                     |
+| --------- | --------------------------------------------------------------- |
+| `--name`  | Name for the new enclave (required).                            |
+| `--label` | Attach a `key=value` label. Repeatable.                         |
+
+Creating an enclave requires the collection-level `create` permission (see [`permission grant`](#permission-grant)) or system administrator rights.
+
+### `get`
+
+Show one enclave by id.
+
+```bash
+dr enclave get <enclave-id>
+```
+
+### `list`
+
+List the enclaves you can see. With RBAC enabled this is only those you hold a role on; system administrators see every enclave in the tenant.
+
+```bash
+dr enclave list
+dr enclave list --output-format json
+```
+
+### `deactivate`
+
+Take an active enclave out of scheduling without deleting it. Only an `ACTIVE` enclave can be deactivated; anything else returns a conflict.
+
+```bash
+dr enclave deactivate <enclave-id>
+```
+
+### `reactivate`
+
+Return a deactivated enclave to service.
+
+```bash
+dr enclave reactivate <enclave-id>
+```
+
+### `delete`
+
+Delete an enclave. Prompts for confirmation unless `--yes` is given.
+
+```bash
+dr enclave delete <enclave-id>
+dr enclave delete <enclave-id> --yes
+```
+
+| Flag        | Description                    |
+| ----------- | ------------------------------ |
+| `-y, --yes` | Skip the confirmation prompt.  |
+
+## Access on one enclave
+
+`dr enclave access` manages the roles held on a single enclave. Every subcommand names the enclave by id.
+
+The three roles:
+
+| Role       | Grants                                                          |
+| ---------- | --------------------------------------------------------------- |
+| `owner`    | Full control, including sharing the enclave with others.        |
+| `user`     | View and deploy onto the enclave.                               |
+| `consumer` | View only — **not** enough to deploy.                           |
+
+A recipient is exactly one of `--user` (by username), `--user-id`, `--group`, or `--org`.
+
+### `access grant`
+
+```bash
+dr enclave access grant <enclave-id> --role user --org <org-id>
+dr enclave access grant <enclave-id> --role consumer --user alice@corp.io
+dr enclave access grant <enclave-id> --role owner --user-id <datarobot-user-id>
+```
+
+| Flag        | Description                                        |
+| ----------- | -------------------------------------------------- |
+| `--role`    | `owner`, `user`, or `consumer` (required).         |
+| `--user`    | Grant a user by username.                          |
+| `--user-id` | Grant a user by DataRobot user id.                 |
+| `--group`   | Grant a group by id.                               |
+| `--org`     | Grant an entire organization by id.                |
+
+### `access revoke`
+
+Remove a recipient's role. Takes the same recipient flags as `grant`.
+
+```bash
+dr enclave access revoke <enclave-id> --org <org-id>
+```
+
+### `access list`
+
+List the recipients holding a role on the enclave, and which role each holds.
+
+```bash
+dr enclave access list <enclave-id>
+```
+
+### `access show`
+
+Show the effective permissions on the enclave — what the subject can actually do, after roles, organization membership, and any administrator bypass are resolved. Defaults to you; pass `--user-id` to inspect somebody else (system administrators only).
+
+```bash
+dr enclave access show <enclave-id>
+dr enclave access show <enclave-id> --user-id <datarobot-user-id>
+```
+
+## Permission to create enclaves
+
+`dr enclave permission` governs who may create enclaves at all. It targets no single enclave, so these commands take no enclave id. Recipients are named by id: `--user-id`, `--group`, or `--org`.
+
+### `permission grant`
+
+```bash
+dr enclave permission grant --permission create --org <org-id>
+dr enclave permission grant --permission create --user-id <datarobot-user-id>
+```
+
+| Flag           | Description                                  |
+| -------------- | -------------------------------------------- |
+| `--permission` | Permission to grant: `create` (required).    |
+| `--user-id`    | Grant a user by DataRobot user id.           |
+| `--group`      | Grant a group by id.                         |
+| `--org`        | Grant an entire organization by id.          |
+
+### `permission revoke`
+
+```bash
+dr enclave permission revoke --permission create --org <org-id>
+```
+
+### `permission list`
+
+List the recipients who have been granted the create permission. An empty result means nobody holds it; system administrators do not appear, because they bypass the permission rather than holding it.
+
+```bash
+dr enclave permission list
+```
+
+### `permission show`
+
+Show whether a subject may create enclaves, and where that comes from. Defaults to you; `--user-id` inspects somebody else (system administrators only).
+
+```bash
+dr enclave permission show
+dr enclave permission show --user-id <datarobot-user-id>
+```
+
+## Output formats
+
+Every subcommand accepts `--output-format` (`text` or `json`). `text` is the default and is meant for reading; `json` is the one to use in scripts, and the only practical way to capture `register`'s installation secrets.
+
+## See also
+
+- [`dr workload`](workload.md) — deploy workloads, and pin one to an enclave with `--enclave <name>`
+- [Feature gates](../development/feature-gates.md) — enabling `DATAROBOT_CLI_FEATURE_ENCLAVE`

--- a/docs/commands/enclave.md
+++ b/docs/commands/enclave.md
@@ -130,11 +130,25 @@ Delete an enclave. Prompts for confirmation unless `--yes` is given.
 ```bash
 dr enclave delete <enclave-id>
 dr enclave delete <enclave-id> --yes
+dr enclave delete <enclave-id> --yes --output-format json
 ```
 
 | Flag        | Description                    |
 | ----------- | ------------------------------ |
 | `-y, --yes` | Skip the confirmation prompt.  |
+
+Deleting an enclave that is already gone, and declining the prompt, are both
+no-ops that exit 0. `--output-format json` is how a script tells them apart from
+a real deletion:
+
+```json
+{ "enclaveId": "<enclave-id>", "deleted": true }
+{ "enclaveId": "<enclave-id>", "deleted": false, "reason": "not found" }
+{ "enclaveId": "<enclave-id>", "deleted": false, "reason": "aborted" }
+```
+
+In JSON mode the confirmation prompt is written to stderr, so stdout carries
+nothing but the result document.
 
 ## Access on one enclave
 

--- a/internal/enclave/enclave.go
+++ b/internal/enclave/enclave.go
@@ -1,0 +1,184 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package enclave talks to the public Outposts API under /covalent/api/v2/outposts.
+// The platform calls these resources "outposts" on the wire; the CLI and the
+// RBAC layer surface them as "enclaves", so the command tree and this package
+// use the enclave name while the request paths stay /outposts.
+package enclave
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// Enclave statuses as serialized by the server (OutpostStatus StrEnum). CREATED
+// is a transient pre-registration state the public API never returns on its own.
+const (
+	StatusCreated    = "CREATED"
+	StatusRegistered = "REGISTERED"
+	StatusActive     = "ACTIVE"
+	StatusDrain      = "DRAIN"
+	StatusDown       = "DOWN"
+	StatusMaint      = "MAINT"
+)
+
+// basePath is the collection route. The server route is "/outposts" (no
+// trailing slash); requests must match it exactly to avoid a 307 redirect.
+const basePath = "/covalent/api/v2/outposts"
+
+// Enclave is the projection of an outpost record returned by GET /outposts and
+// GET /outposts/{id}. Those responses are serialized snake_case (no alias
+// generator on the server schema), hence the dispatch_url tag.
+type Enclave struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DispatchURL string `json:"dispatch_url"`
+	Status      string `json:"status"`
+}
+
+// InstallationSecret is one K8s Secret's literal contents the installer must
+// materialize on the enclave cluster. Returned only by register and never
+// persisted server-side, so the register command output is the sole place it
+// ever appears.
+type InstallationSecret struct {
+	Data map[string]string `json:"data"`
+}
+
+// RegistrationResult is the POST /outposts response. Unlike the GET schema it
+// is serialized camelCase (the server schema sets explicit aliases).
+type RegistrationResult struct {
+	EnclaveID           string                        `json:"outpostId"`
+	Name                string                        `json:"name"`
+	Status              string                        `json:"status"`
+	InstallationSecrets map[string]InstallationSecret `json:"installationSecrets"`
+}
+
+type registerRequest struct {
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// escapeID percent-encodes a user-supplied enclave id so it always stays a
+// single URL path segment.
+func escapeID(id string) string {
+	return url.PathEscape(id)
+}
+
+// RegisterEnclave registers a new enclave (outpost) and returns the created
+// record together with its one-shot installation secrets. The server replies
+// 201 with the full registration document inline. A name already registered
+// for the tenant yields a 409.
+func RegisterEnclave(name string, labels map[string]string) (*RegistrationResult, error) {
+	url, err := config.GetEndpointURL(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var result RegistrationResult
+
+	if err := drapi.PostJSON(url, "enclave", registerRequest{Name: name, Labels: labels}, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// GetEnclave fetches a single enclave by id.
+func GetEnclave(enclaveID string) (*Enclave, error) {
+	url, err := config.GetEndpointURL(basePath + "/" + escapeID(enclaveID))
+	if err != nil {
+		return nil, err
+	}
+
+	var enclave Enclave
+
+	if err := drapi.GetJSON(url, "enclave", &enclave); err != nil {
+		return nil, err
+	}
+
+	return &enclave, nil
+}
+
+// ListEnclaves returns every enclave visible to the caller. The endpoint
+// responds with a bare JSON array (not a paginated envelope).
+func ListEnclaves() ([]Enclave, error) {
+	url, err := config.GetEndpointURL(basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var enclaves []Enclave
+
+	if err := drapi.GetJSON(url, "enclaves", &enclaves); err != nil {
+		return nil, err
+	}
+
+	return enclaves, nil
+}
+
+// DeactivateEnclave marks an enclave inactive and returns the updated record.
+// The endpoint takes no request body and replies 200 with the enclave.
+func DeactivateEnclave(enclaveID string) (*Enclave, error) {
+	url, err := config.GetEndpointURL(basePath + "/" + escapeID(enclaveID) + "/deactivate")
+	if err != nil {
+		return nil, err
+	}
+
+	var enclave Enclave
+
+	// No body param server-side; send an empty object so the request carries
+	// valid JSON matching the application/json content type.
+	if err := drapi.PostJSON(url, "enclave", struct{}{}, &enclave); err != nil {
+		return nil, err
+	}
+
+	return &enclave, nil
+}
+
+// DeleteEnclave deletes an enclave. The server replies 204 on success and 404
+// when no enclave with the id exists.
+func DeleteEnclave(enclaveID string) error {
+	url, err := config.GetEndpointURL(basePath + "/" + escapeID(enclaveID))
+	if err != nil {
+		return err
+	}
+
+	return drapi.DeleteJSON(url, "enclave", nil, nil)
+}
+
+// ParseLabels turns repeated key=value flag values into a labels map, rejecting
+// malformed entries and empty keys.
+func ParseLabels(values []string) (map[string]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+
+	labels := make(map[string]string, len(values))
+
+	for _, v := range values {
+		key, value, found := strings.Cut(v, "=")
+		if !found || key == "" {
+			return nil, fmt.Errorf("invalid label %q: expected key=value", v)
+		}
+
+		labels[key] = value
+	}
+
+	return labels, nil
+}

--- a/internal/enclave/enclave.go
+++ b/internal/enclave/enclave.go
@@ -151,6 +151,24 @@ func DeactivateEnclave(enclaveID string) (*Enclave, error) {
 	return &enclave, nil
 }
 
+// ReactivateEnclave returns a manually deactivated enclave to service and
+// returns the updated record. Like deactivate, the endpoint takes no request
+// body and replies 200 with the enclave.
+func ReactivateEnclave(enclaveID string) (*Enclave, error) {
+	url, err := config.GetEndpointURL(basePath + "/" + escapeID(enclaveID) + "/reactivate")
+	if err != nil {
+		return nil, err
+	}
+
+	var enclave Enclave
+
+	if err := drapi.PostJSON(url, "enclave", struct{}{}, &enclave); err != nil {
+		return nil, err
+	}
+
+	return &enclave, nil
+}
+
 // DeleteEnclave deletes an enclave. The server replies 204 on success and 404
 // when no enclave with the id exists.
 func DeleteEnclave(enclaveID string) error {

--- a/internal/enclave/enclave.go
+++ b/internal/enclave/enclave.go
@@ -12,10 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package enclave talks to the public Outposts API under /covalent/api/v2/outposts.
-// The platform calls these resources "outposts" on the wire; the CLI and the
-// RBAC layer surface them as "enclaves", so the command tree and this package
-// use the enclave name while the request paths stay /outposts.
+// Package enclave talks to the public Enclaves API at /api/v2/enclaves.
+//
+// Both halves of that path are new in CMPT-7347 (covalent-cloud-server#681,
+// merged 2026-09-04, so the first release after v11.12.0). The API used to sit
+// behind a /covalent ingress prefix, and its RBAC and lifecycle routes used to
+// answer under /outposts; it is now registered at the canonical DataRobot path,
+// so a single base path covers the whole surface.
+//
+// The old spellings still answer server-side as deprecated aliases, but this
+// package uses only the new ones -- against a Covalent older than that change
+// every enclave command 404s.
 package enclave
 
 import (
@@ -27,7 +34,7 @@ import (
 	"github.com/datarobot/cli/internal/drapi"
 )
 
-// Enclave statuses as serialized by the server (OutpostStatus StrEnum). CREATED
+// Enclave statuses as serialized by the server (EnclaveStatus StrEnum). CREATED
 // is a transient pre-registration state the public API never returns on its own.
 const (
 	StatusCreated    = "CREATED"
@@ -38,12 +45,13 @@ const (
 	StatusMaint      = "MAINT"
 )
 
-// basePath is the collection route. The server route is "/outposts" (no
-// trailing slash); requests must match it exactly to avoid a 307 redirect.
-const basePath = "/covalent/api/v2/outposts"
+// basePath is the collection route, and the prefix every sub-resource hangs off.
+// There is no trailing slash; requests must match the route exactly to avoid a
+// 307 redirect.
+const basePath = "/api/v2/enclaves"
 
-// Enclave is the projection of an outpost record returned by GET /outposts and
-// GET /outposts/{id}. Those responses are serialized snake_case (no alias
+// Enclave is the projection of an enclave record returned by GET /enclaves and
+// GET /enclaves/{id}. Those responses are serialized snake_case (no alias
 // generator on the server schema), hence the dispatch_url tag.
 type Enclave struct {
 	ID          string `json:"id"`
@@ -60,10 +68,10 @@ type InstallationSecret struct {
 	Data map[string]string `json:"data"`
 }
 
-// RegistrationResult is the POST /outposts response. Unlike the GET schema it
+// RegistrationResult is the POST /enclaves response. Unlike the GET schema it
 // is serialized camelCase (the server schema sets explicit aliases).
 type RegistrationResult struct {
-	EnclaveID           string                        `json:"outpostId"`
+	EnclaveID           string                        `json:"enclaveId"`
 	Name                string                        `json:"name"`
 	Status              string                        `json:"status"`
 	InstallationSecrets map[string]InstallationSecret `json:"installationSecrets"`
@@ -80,10 +88,10 @@ func escapeID(id string) string {
 	return url.PathEscape(id)
 }
 
-// RegisterEnclave registers a new enclave (outpost) and returns the created
-// record together with its one-shot installation secrets. The server replies
-// 201 with the full registration document inline. A name already registered
-// for the tenant yields a 409.
+// RegisterEnclave registers a new enclave and returns the created record
+// together with its one-shot installation secrets. The server replies 201 with
+// the full registration document inline. A name already registered for the
+// tenant yields a 409.
 func RegisterEnclave(name string, labels map[string]string) (*RegistrationResult, error) {
 	url, err := config.GetEndpointURL(basePath)
 	if err != nil {

--- a/internal/enclave/enclave_test.go
+++ b/internal/enclave/enclave_test.go
@@ -102,14 +102,14 @@ func TestRegisterEnclave(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/covalent/api/v2/outposts", r.URL.Path)
+		assert.Equal(t, "/api/v2/enclaves", r.URL.Path)
 
 		raw, _ := io.ReadAll(r.Body)
 		assert.NoError(t, json.Unmarshal(raw, &gotBody))
 
 		w.WriteHeader(http.StatusCreated)
 		_, _ = w.Write([]byte(`{
-			"outpostId": "abc-123",
+			"enclaveId": "abc-123",
 			"name": "my-enclave",
 			"status": "REGISTERED",
 			"installationSecrets": {
@@ -161,7 +161,7 @@ func TestGetEnclave(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/covalent/api/v2/outposts/abc-123", r.URL.Path)
+		assert.Equal(t, "/api/v2/enclaves/abc-123", r.URL.Path)
 
 		_, _ = w.Write([]byte(`{
 			"id": "abc-123",
@@ -198,7 +198,7 @@ func TestGetEnclaveEscapesID(t *testing.T) {
 
 	_, err := GetEnclave("a/b?c")
 	require.NoError(t, err)
-	assert.Equal(t, "/covalent/api/v2/outposts/a%2Fb%3Fc", gotPath)
+	assert.Equal(t, "/api/v2/enclaves/a%2Fb%3Fc", gotPath)
 }
 
 func TestListEnclaves(t *testing.T) {
@@ -206,7 +206,7 @@ func TestListEnclaves(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/covalent/api/v2/outposts", r.URL.Path)
+		assert.Equal(t, "/api/v2/enclaves", r.URL.Path)
 
 		_, _ = w.Write([]byte(`[
 			{"id": "1", "name": "a", "dispatch_url": "", "status": "REGISTERED"},
@@ -229,7 +229,7 @@ func TestDeactivateEnclave(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/covalent/api/v2/outposts/abc-123/deactivate", r.URL.Path)
+		assert.Equal(t, "/api/v2/enclaves/abc-123/deactivate", r.URL.Path)
 
 		_, _ = w.Write([]byte(`{"id": "abc-123", "name": "n", "status": "DRAIN"}`))
 	}))
@@ -247,7 +247,7 @@ func TestReactivateEnclave(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Equal(t, "/covalent/api/v2/outposts/abc-123/reactivate", r.URL.Path)
+		assert.Equal(t, "/api/v2/enclaves/abc-123/reactivate", r.URL.Path)
 
 		_, _ = w.Write([]byte(`{"id": "abc-123", "name": "n", "status": "ACTIVE"}`))
 	}))
@@ -265,7 +265,7 @@ func TestDeleteEnclave(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
-		assert.Equal(t, "/covalent/api/v2/outposts/abc-123", r.URL.Path)
+		assert.Equal(t, "/api/v2/enclaves/abc-123", r.URL.Path)
 
 		w.WriteHeader(http.StatusNoContent)
 	}))

--- a/internal/enclave/enclave_test.go
+++ b/internal/enclave/enclave_test.go
@@ -1,0 +1,274 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enclave
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// installSkipAuth configures viper so drapi.AuthorizeRequest does not attempt
+// to verify a token over the network.
+func installSkipAuth(t *testing.T) {
+	t.Helper()
+
+	prevSkip := viperx.GetBool("skip_auth")
+	prevTok := viperx.GetString(config.DataRobotAPIKey)
+
+	viperx.Set("skip_auth", true)
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+
+	t.Cleanup(func() {
+		viperx.Set("skip_auth", prevSkip)
+		viperx.Set(config.DataRobotAPIKey, prevTok)
+	})
+}
+
+// installEndpoint redirects config.GetEndpointURL to the given test server URL.
+func installEndpoint(t *testing.T, url string) {
+	t.Helper()
+
+	prev := viperx.GetString(config.DataRobotURL)
+
+	viperx.Set(config.DataRobotURL, url)
+
+	t.Cleanup(func() {
+		viperx.Set(config.DataRobotURL, prev)
+	})
+}
+
+func TestParseLabels(t *testing.T) {
+	t.Run("nil for no values", func(t *testing.T) {
+		labels, err := ParseLabels(nil)
+		require.NoError(t, err)
+		assert.Nil(t, labels)
+	})
+
+	t.Run("parses key=value pairs", func(t *testing.T) {
+		labels, err := ParseLabels([]string{"team=research", "env=prod"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"team": "research", "env": "prod"}, labels)
+	})
+
+	t.Run("keeps = in value", func(t *testing.T) {
+		labels, err := ParseLabels([]string{"cfg=a=b"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"cfg": "a=b"}, labels)
+	})
+
+	t.Run("rejects missing =", func(t *testing.T) {
+		_, err := ParseLabels([]string{"noequals"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected key=value")
+	})
+
+	t.Run("rejects empty key", func(t *testing.T) {
+		_, err := ParseLabels([]string{"=value"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected key=value")
+	})
+}
+
+func TestRegisterEnclave(t *testing.T) {
+	installSkipAuth(t)
+
+	var gotBody registerRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/covalent/api/v2/outposts", r.URL.Path)
+
+		raw, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(raw, &gotBody))
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{
+			"outpostId": "abc-123",
+			"name": "my-enclave",
+			"status": "REGISTERED",
+			"installationSecrets": {
+				"drauth-service-registration-controller": {
+					"data": {"hydraClientId": "cid", "hydraClientSecret": "csecret"}
+				}
+			}
+		}`))
+	}))
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	result, err := RegisterEnclave("my-enclave", map[string]string{"team": "research"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-enclave", gotBody.Name)
+	assert.Equal(t, map[string]string{"team": "research"}, gotBody.Labels)
+
+	assert.Equal(t, "abc-123", result.EnclaveID)
+	assert.Equal(t, "REGISTERED", result.Status)
+	require.Contains(t, result.InstallationSecrets, "drauth-service-registration-controller")
+	assert.Equal(t, "cid",
+		result.InstallationSecrets["drauth-service-registration-controller"].Data["hydraClientId"])
+}
+
+func TestRegisterEnclaveConflict(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"detail": "already exists"}`))
+	}))
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := RegisterEnclave("dup", nil)
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.True(t, errors.As(err, &httpErr))
+	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
+}
+
+func TestGetEnclave(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/covalent/api/v2/outposts/abc-123", r.URL.Path)
+
+		_, _ = w.Write([]byte(`{
+			"id": "abc-123",
+			"name": "my-enclave",
+			"dispatch_url": "https://enclave.example.com",
+			"status": "ACTIVE"
+		}`))
+	}))
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	e, err := GetEnclave("abc-123")
+	require.NoError(t, err)
+	assert.Equal(t, "abc-123", e.ID)
+	assert.Equal(t, "my-enclave", e.Name)
+	assert.Equal(t, "https://enclave.example.com", e.DispatchURL)
+	assert.Equal(t, "ACTIVE", e.Status)
+}
+
+func TestGetEnclaveEscapesID(t *testing.T) {
+	installSkipAuth(t)
+
+	var gotPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.EscapedPath()
+
+		_, _ = w.Write([]byte(`{"id": "x", "name": "n", "status": "ACTIVE"}`))
+	}))
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := GetEnclave("a/b?c")
+	require.NoError(t, err)
+	assert.Equal(t, "/covalent/api/v2/outposts/a%2Fb%3Fc", gotPath)
+}
+
+func TestListEnclaves(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/covalent/api/v2/outposts", r.URL.Path)
+
+		_, _ = w.Write([]byte(`[
+			{"id": "1", "name": "a", "dispatch_url": "", "status": "REGISTERED"},
+			{"id": "2", "name": "b", "dispatch_url": "https://b", "status": "ACTIVE"}
+		]`))
+	}))
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	enclaves, err := ListEnclaves()
+	require.NoError(t, err)
+	require.Len(t, enclaves, 2)
+	assert.Equal(t, "a", enclaves[0].Name)
+	assert.Equal(t, "ACTIVE", enclaves[1].Status)
+}
+
+func TestDeactivateEnclave(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/covalent/api/v2/outposts/abc-123/deactivate", r.URL.Path)
+
+		_, _ = w.Write([]byte(`{"id": "abc-123", "name": "n", "status": "DRAIN"}`))
+	}))
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	e, err := DeactivateEnclave("abc-123")
+	require.NoError(t, err)
+	assert.Equal(t, "DRAIN", e.Status)
+}
+
+func TestDeleteEnclave(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, "/covalent/api/v2/outposts/abc-123", r.URL.Path)
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	require.NoError(t, DeleteEnclave("abc-123"))
+}
+
+func TestDeleteEnclaveNotFound(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	err := DeleteEnclave("missing")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.True(t, errors.As(err, &httpErr))
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+}

--- a/internal/enclave/enclave_test.go
+++ b/internal/enclave/enclave_test.go
@@ -16,7 +16,6 @@ package enclave
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -31,17 +30,22 @@ import (
 
 // installSkipAuth configures viper so drapi.AuthorizeRequest does not attempt
 // to verify a token over the network.
+//
+// The key has to be config.SkipAuthKey ("skip-auth"), not "skip_auth": the
+// underscore spelling does not resolve to the --skip-auth flag, so viper
+// answers false, resolveToken falls through to config.GetAPIKey, and every
+// request is preceded by a GET /version/ probe against the test server.
 func installSkipAuth(t *testing.T) {
 	t.Helper()
 
-	prevSkip := viperx.GetBool("skip_auth")
+	prevSkip := viperx.GetBool(config.SkipAuthKey)
 	prevTok := viperx.GetString(config.DataRobotAPIKey)
 
-	viperx.Set("skip_auth", true)
+	viperx.Set(config.SkipAuthKey, true)
 	viperx.Set(config.DataRobotAPIKey, "test-token")
 
 	t.Cleanup(func() {
-		viperx.Set("skip_auth", prevSkip)
+		viperx.Set(config.SkipAuthKey, prevSkip)
 		viperx.Set(config.DataRobotAPIKey, prevTok)
 	})
 }
@@ -101,7 +105,7 @@ func TestRegisterEnclave(t *testing.T) {
 		assert.Equal(t, "/covalent/api/v2/outposts", r.URL.Path)
 
 		raw, _ := io.ReadAll(r.Body)
-		require.NoError(t, json.Unmarshal(raw, &gotBody))
+		assert.NoError(t, json.Unmarshal(raw, &gotBody))
 
 		w.WriteHeader(http.StatusCreated)
 		_, _ = w.Write([]byte(`{
@@ -148,7 +152,7 @@ func TestRegisterEnclaveConflict(t *testing.T) {
 
 	var httpErr *drapi.HTTPError
 
-	require.True(t, errors.As(err, &httpErr))
+	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
 }
 
@@ -287,6 +291,6 @@ func TestDeleteEnclaveNotFound(t *testing.T) {
 
 	var httpErr *drapi.HTTPError
 
-	require.True(t, errors.As(err, &httpErr))
+	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
 }

--- a/internal/enclave/enclave_test.go
+++ b/internal/enclave/enclave_test.go
@@ -238,6 +238,24 @@ func TestDeactivateEnclave(t *testing.T) {
 	assert.Equal(t, "DRAIN", e.Status)
 }
 
+func TestReactivateEnclave(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/covalent/api/v2/outposts/abc-123/reactivate", r.URL.Path)
+
+		_, _ = w.Write([]byte(`{"id": "abc-123", "name": "n", "status": "ACTIVE"}`))
+	}))
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	e, err := ReactivateEnclave("abc-123")
+	require.NoError(t, err)
+	assert.Equal(t, "ACTIVE", e.Status)
+}
+
 func TestDeleteEnclave(t *testing.T) {
 	installSkipAuth(t)
 

--- a/internal/enclave/output.go
+++ b/internal/enclave/output.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/charmbracelet/lipgloss"
@@ -91,6 +92,35 @@ func RenderPermissionChange(format outputformat.OutputFormat, change PermissionC
 		fmt.Printf("granted enclave %s permission to %s\n", change.Permission, recipient)
 	} else {
 		fmt.Printf("revoked enclave %s permission from %s\n", change.Permission, recipient)
+	}
+
+	return nil
+}
+
+// RenderEnclavePermissions prints the effective permissions on an enclave. Text
+// mode explains *why* the set is what it is, since a full set from the sys-admin
+// bypass or from RBAC being off looks identical to being an owner.
+func RenderEnclavePermissions(format outputformat.OutputFormat, p EnclavePermissions) error {
+	if format == outputformat.OutputFormatJSON {
+		return printJSON(p)
+	}
+
+	fmt.Printf("Enclave:     %s\n", p.EnclaveID)
+	fmt.Printf("Subject:     %s\n", p.SubjectUserID)
+
+	if len(p.Permissions) == 0 {
+		fmt.Printf("Permissions: %s (no access)\n", emptyValuePlaceholder)
+	} else {
+		fmt.Printf("Permissions: %s\n", strings.Join(p.Permissions, ", "))
+	}
+
+	switch {
+	case !p.RBACEnabled:
+		fmt.Println("Source:      enclave RBAC is disabled server-side — nothing is enforced")
+	case p.ViaSysAdmin:
+		fmt.Println("Source:      system administrator (bypasses enclave permissions)")
+	default:
+		fmt.Println("Source:      granted permissions")
 	}
 
 	return nil

--- a/internal/enclave/output.go
+++ b/internal/enclave/output.go
@@ -336,17 +336,17 @@ func kubectlLiterals(data map[string]string) string {
 
 	sort.Strings(keys)
 
-	out := ""
+	var out strings.Builder
 
 	for i, k := range keys {
 		if i > 0 {
-			out += " "
+			out.WriteString(" ")
 		}
 
-		out += fmt.Sprintf("--from-literal=%s=%s", k, data[k])
+		fmt.Fprintf(&out, "--from-literal=%s=%s", k, data[k])
 	}
 
-	return out
+	return out.String()
 }
 
 // RenderCollectionPermissions prints whether the subject may create enclaves, and

--- a/internal/enclave/output.go
+++ b/internal/enclave/output.go
@@ -123,6 +123,61 @@ func RenderEnclavePermissions(format outputformat.OutputFormat, p EnclavePermiss
 		fmt.Println("Source:      granted permissions")
 	}
 
+	// Only worth printing when it differs from the effective set: under a bypass the
+	// effective set is always full, so this is the only way to see whether the
+	// subject was granted anything at all.
+	if p.RBACEnabled && p.ViaSysAdmin {
+		if len(p.GrantedPermissions) == 0 {
+			fmt.Printf("Granted:     %s (no grants of its own)\n", emptyValuePlaceholder)
+		} else {
+			fmt.Printf("Granted:     %s\n", strings.Join(p.GrantedPermissions, ", "))
+		}
+	}
+
+	return nil
+}
+
+// RenderSharedRoles prints who holds which role on an enclave.
+func RenderSharedRoles(format outputformat.OutputFormat, roles []SharedRole) error {
+	if format == outputformat.OutputFormatJSON {
+		if roles == nil {
+			roles = []SharedRole{}
+		}
+
+		return outputformat.PrintJSONEnvelope(os.Stdout, "sharedRoles", roles)
+	}
+
+	if len(roles) == 0 {
+		fmt.Println("This enclave is not shared with anyone.")
+
+		return nil
+	}
+
+	cellStyle := tui.BaseTextStyle.Padding(0, 1)
+
+	t := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(tui.TableBorderStyle).
+		StyleFunc(func(row, _ int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return cellStyle.Bold(true)
+			}
+
+			return cellStyle
+		}).
+		Headers("RECIPIENT TYPE", "NAME", "ID", "ROLE")
+
+	for _, r := range roles {
+		name := r.Name
+		if name == "" {
+			name = emptyValuePlaceholder
+		}
+
+		t.Row(r.ShareRecipientType, name, r.ID, r.Role)
+	}
+
+	fmt.Fprintln(os.Stdout, t.Render())
+
 	return nil
 }
 

--- a/internal/enclave/output.go
+++ b/internal/enclave/output.go
@@ -1,0 +1,237 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enclave
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/lipgloss/table"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/tui"
+)
+
+const emptyValuePlaceholder = "—"
+
+func printJSON(v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+
+	return nil
+}
+
+// AccessChange is the stable JSON shape emitted after a grant/revoke, and the
+// data backing the text confirmation line.
+type AccessChange struct {
+	EnclaveID     string `json:"enclaveId"`
+	Action        string `json:"action"`         // granted | revoked
+	Role          string `json:"role,omitempty"` // set for grant only
+	RecipientType string `json:"recipientType"`
+	Recipient     string `json:"recipient"`
+}
+
+// RenderAccessChange prints the outcome of a grant/revoke. Text mode prints a
+// one-line confirmation; JSON mode emits the AccessChange document.
+func RenderAccessChange(format outputformat.OutputFormat, change AccessChange) error {
+	if format == outputformat.OutputFormatJSON {
+		return printJSON(change)
+	}
+
+	recipient := change.RecipientType + " " + change.Recipient
+
+	if change.Action == "granted" {
+		fmt.Printf("granted %s on enclave %s to %s\n", change.Role, change.EnclaveID, recipient)
+	} else {
+		fmt.Printf("revoked access on enclave %s from %s\n", change.EnclaveID, recipient)
+	}
+
+	return nil
+}
+
+// RenderEnclave renders a single enclave (get / deactivate result).
+func RenderEnclave(format outputformat.OutputFormat, e Enclave) error {
+	if format == outputformat.OutputFormatJSON {
+		return printJSON(e)
+	}
+
+	printEnclaveDetails(e)
+
+	return nil
+}
+
+// RenderEnclaves renders the list result as a table (text) or JSON envelope.
+func RenderEnclaves(format outputformat.OutputFormat, enclaves []Enclave) error {
+	if format == outputformat.OutputFormatJSON {
+		if enclaves == nil {
+			enclaves = []Enclave{}
+		}
+
+		return outputformat.PrintJSONEnvelope(os.Stdout, "enclaves", enclaves)
+	}
+
+	printEnclavesTable(enclaves)
+
+	return nil
+}
+
+// RenderRegistration renders the register result. Text mode prints the created
+// enclave plus its one-shot installation secrets with a warning that they are
+// shown only once; JSON mode emits the whole document so scripts keep the
+// secrets. Because the server never persists the secrets, this output is the
+// only place they can be captured.
+func RenderRegistration(format outputformat.OutputFormat, result RegistrationResult) error {
+	if format == outputformat.OutputFormatJSON {
+		return printJSON(result)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "ID:\t%s\n", result.EnclaveID)
+	fmt.Fprintf(w, "Name:\t%s\n", result.Name)
+	fmt.Fprintf(w, "Status:\t%s\n", result.Status)
+
+	w.Flush()
+
+	printInstallationSecrets(result.InstallationSecrets)
+
+	return nil
+}
+
+func printEnclaveDetails(e Enclave) {
+	dispatch := e.DispatchURL
+	if dispatch == "" {
+		dispatch = emptyValuePlaceholder
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "ID:\t%s\n", e.ID)
+	fmt.Fprintf(w, "Name:\t%s\n", e.Name)
+	fmt.Fprintf(w, "Status:\t%s\n", e.Status)
+	fmt.Fprintf(w, "Dispatch URL:\t%s\n", dispatch)
+
+	w.Flush()
+}
+
+func printEnclavesTable(enclaves []Enclave) {
+	if len(enclaves) == 0 {
+		fmt.Println("No enclaves found.")
+
+		return
+	}
+
+	cellStyle := tui.BaseTextStyle.Padding(0, 1)
+
+	headers := []string{"ENCLAVE ID", "NAME", "STATUS", "DISPATCH URL"}
+
+	t := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(tui.TableBorderStyle).
+		StyleFunc(func(row, _ int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return cellStyle.Bold(true)
+			}
+
+			return cellStyle
+		}).
+		Headers(headers...)
+
+	for _, e := range enclaves {
+		dispatch := e.DispatchURL
+		if dispatch == "" {
+			dispatch = emptyValuePlaceholder
+		}
+
+		t.Row(e.ID, e.Name, e.Status, dispatch)
+	}
+
+	fmt.Fprintln(os.Stdout, t.Render())
+}
+
+// printInstallationSecrets renders each returned secret and its key/value data
+// under a shown-once warning, followed by a kubectl hint for materializing it.
+func printInstallationSecrets(secrets map[string]InstallationSecret) {
+	if len(secrets) == 0 {
+		return
+	}
+
+	fmt.Println()
+	fmt.Println(tui.BaseTextStyle.Bold(true).Render("Installation secrets (shown once — save them now):"))
+
+	names := make([]string, 0, len(secrets))
+
+	for name := range secrets {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	for _, name := range names {
+		fmt.Printf("\n  %s\n", tui.BaseTextStyle.Bold(true).Render(name))
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+		keys := make([]string, 0, len(secrets[name].Data))
+
+		for k := range secrets[name].Data {
+			keys = append(keys, k)
+		}
+
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			fmt.Fprintf(w, "    %s:\t%s\n", k, secrets[name].Data[k])
+		}
+
+		w.Flush()
+
+		fmt.Println(tui.DimStyle.Render(
+			"    Create on the enclave cluster with:\n" +
+				"      kubectl create secret generic " + name + " \\\n" +
+				"        " + kubectlLiterals(secrets[name].Data)))
+	}
+}
+
+// kubectlLiterals renders the --from-literal flags for a secret's data in a
+// stable key order, joined for a single-line continuation.
+func kubectlLiterals(data map[string]string) string {
+	keys := make([]string, 0, len(data))
+
+	for k := range data {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	out := ""
+
+	for i, k := range keys {
+		if i > 0 {
+			out += " "
+		}
+
+		out += fmt.Sprintf("--from-literal=%s=%s", k, data[k])
+	}
+
+	return out
+}

--- a/internal/enclave/output.go
+++ b/internal/enclave/output.go
@@ -68,6 +68,34 @@ func RenderAccessChange(format outputformat.OutputFormat, change AccessChange) e
 	return nil
 }
 
+// PermissionChange is the stable JSON shape emitted after a collection-level
+// permission grant/revoke, and the data backing the text confirmation line.
+type PermissionChange struct {
+	Permission    string `json:"permission"`
+	Action        string `json:"action"` // granted | revoked
+	RecipientType string `json:"recipientType"`
+	Recipient     string `json:"recipient"`
+}
+
+// RenderPermissionChange prints the outcome of a permission grant/revoke. Text
+// mode prints a one-line confirmation; JSON mode emits the PermissionChange
+// document. There is no enclave id — the permission spans the collection.
+func RenderPermissionChange(format outputformat.OutputFormat, change PermissionChange) error {
+	if format == outputformat.OutputFormatJSON {
+		return printJSON(change)
+	}
+
+	recipient := change.RecipientType + " " + change.Recipient
+
+	if change.Action == "granted" {
+		fmt.Printf("granted enclave %s permission to %s\n", change.Permission, recipient)
+	} else {
+		fmt.Printf("revoked enclave %s permission from %s\n", change.Permission, recipient)
+	}
+
+	return nil
+}
+
 // RenderEnclave renders a single enclave (get / deactivate result).
 func RenderEnclave(format outputformat.OutputFormat, e Enclave) error {
 	if format == outputformat.OutputFormatJSON {

--- a/internal/enclave/output.go
+++ b/internal/enclave/output.go
@@ -348,3 +348,79 @@ func kubectlLiterals(data map[string]string) string {
 
 	return out
 }
+
+// RenderCollectionPermissions prints whether the subject may create enclaves, and
+// where that comes from.
+func RenderCollectionPermissions(
+	format outputformat.OutputFormat, p CollectionPermissions,
+) error {
+	if format == outputformat.OutputFormatJSON {
+		return printJSON(p)
+	}
+
+	fmt.Printf("Subject:     %s\n", p.SubjectUserID)
+
+	if len(p.Permissions) == 0 {
+		fmt.Printf("Permissions: %s (may not create enclaves)\n", emptyValuePlaceholder)
+	} else {
+		fmt.Printf("Permissions: %s\n", strings.Join(p.Permissions, ", "))
+	}
+
+	switch {
+	case !p.RBACEnabled:
+		fmt.Println("Source:      enclave RBAC is disabled server-side — nothing is enforced")
+	case p.ViaSysAdmin:
+		fmt.Println("Source:      system administrator (bypasses enclave permissions)")
+	default:
+		fmt.Println("Source:      granted permissions")
+	}
+
+	if p.RBACEnabled && p.ViaSysAdmin {
+		if len(p.GrantedPermissions) == 0 {
+			fmt.Printf("Granted:     %s (no grants of its own)\n", emptyValuePlaceholder)
+		} else {
+			fmt.Printf("Granted:     %s\n", strings.Join(p.GrantedPermissions, ", "))
+		}
+	}
+
+	return nil
+}
+
+// RenderCreateAccess prints who may create enclaves.
+func RenderCreateAccess(format outputformat.OutputFormat, holders []CreateAccessHolder) error {
+	if format == outputformat.OutputFormatJSON {
+		if holders == nil {
+			holders = []CreateAccessHolder{}
+		}
+
+		return outputformat.PrintJSONEnvelope(os.Stdout, "createAccess", holders)
+	}
+
+	if len(holders) == 0 {
+		fmt.Println("Nobody has been granted the enclave create permission.")
+
+		return nil
+	}
+
+	cellStyle := tui.BaseTextStyle.Padding(0, 1)
+
+	t := table.New().
+		Border(lipgloss.RoundedBorder()).
+		BorderStyle(tui.TableBorderStyle).
+		StyleFunc(func(row, _ int) lipgloss.Style {
+			if row == table.HeaderRow {
+				return cellStyle.Bold(true)
+			}
+
+			return cellStyle
+		}).
+		Headers("RECIPIENT TYPE", "ID", "PERMISSIONS")
+
+	for _, h := range holders {
+		t.Row(h.ShareRecipientType, h.ID, strings.Join(h.Permissions, ", "))
+	}
+
+	fmt.Fprintln(os.Stdout, t.Render())
+
+	return nil
+}

--- a/internal/enclave/output.go
+++ b/internal/enclave/output.go
@@ -358,13 +358,16 @@ func printInstallationSecrets(secrets map[string]InstallationSecret) {
 
 		fmt.Println(tui.DimStyle.Render(
 			"    Create on the enclave cluster with:\n" +
-				"      kubectl create secret generic " + name + " \\\n" +
+				"      kubectl create secret generic " + posixQuote(name) + " \\\n" +
 				"        " + kubectlLiterals(secrets[name].Data)))
 	}
 }
 
 // kubectlLiterals renders the --from-literal flags for a secret's data in a
-// stable key order, joined for a single-line continuation.
+// stable key order, joined for a single-line continuation. Each key=value is
+// shell-quoted as one word: the data is server-supplied and lands in a command
+// the operator pastes into a shell, so whitespace or metacharacters in a value
+// (a PEM body, say) must not split the word or reach the shell as syntax.
 func kubectlLiterals(data map[string]string) string {
 	keys := make([]string, 0, len(data))
 
@@ -381,10 +384,16 @@ func kubectlLiterals(data map[string]string) string {
 			out.WriteString(" ")
 		}
 
-		fmt.Fprintf(&out, "--from-literal=%s=%s", k, data[k])
+		out.WriteString("--from-literal=" + posixQuote(k+"="+data[k]))
 	}
 
 	return out.String()
+}
+
+// posixQuote wraps a value in single quotes and escapes any embedded single
+// quote, producing one literal word in sh, bash, zsh, and fish.
+func posixQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
 }
 
 // RenderCollectionPermissions prints whether the subject may create enclaves, and

--- a/internal/enclave/output.go
+++ b/internal/enclave/output.go
@@ -192,6 +192,44 @@ func RenderEnclave(format outputformat.OutputFormat, e Enclave) error {
 	return nil
 }
 
+// Deletion outcomes reported by `dr enclave delete` when nothing was removed.
+// Both are exit-0 no-ops rather than errors, so they need a spelling a script
+// can branch on.
+const (
+	DeletionReasonNotFound = "not found"
+	DeletionReasonAborted  = "aborted"
+)
+
+// DeletionResult is the stable JSON shape emitted by `dr enclave delete`, and
+// the data backing its text confirmation line. It covers every exit-0 path:
+// the enclave was deleted, it was already gone, or the operator declined the
+// confirmation prompt.
+type DeletionResult struct {
+	EnclaveID string `json:"enclaveId"`
+	Deleted   bool   `json:"deleted"`
+	Reason    string `json:"reason,omitempty"` // set only when Deleted is false
+}
+
+// RenderDeletion prints the outcome of a delete. Text mode prints a one-line
+// confirmation; JSON mode emits the DeletionResult, so a script can tell a real
+// deletion from an already-gone or declined no-op without parsing prose.
+func RenderDeletion(format outputformat.OutputFormat, result DeletionResult) error {
+	if format == outputformat.OutputFormatJSON {
+		return printJSON(result)
+	}
+
+	switch {
+	case result.Deleted:
+		fmt.Println(tui.BaseTextStyle.Render("Deleted enclave: " + result.EnclaveID))
+	case result.Reason == DeletionReasonNotFound:
+		fmt.Println(tui.DimStyle.Render("No enclave found with id: " + result.EnclaveID))
+	default:
+		fmt.Println(tui.DimStyle.Render("Aborted."))
+	}
+
+	return nil
+}
+
 // RenderEnclaves renders the list result as a table (text) or JSON envelope.
 func RenderEnclaves(format outputformat.OutputFormat, enclaves []Enclave) error {
 	if format == outputformat.OutputFormatJSON {

--- a/internal/enclave/output_test.go
+++ b/internal/enclave/output_test.go
@@ -107,3 +107,34 @@ func TestRenderDeletion_Text(t *testing.T) {
 		})
 	}
 }
+
+func TestPosixQuote(t *testing.T) {
+	assert.Equal(t, `'plain'`, posixQuote("plain"))
+	assert.Equal(t, `'a b'`, posixQuote("a b"))
+	assert.Equal(t, `'it'\''s'`, posixQuote("it's"))
+	assert.Equal(t, `''`, posixQuote(""))
+}
+
+// Secret data is server-supplied and lands in a command the operator pastes
+// into a shell, so every key=value must survive as exactly one literal word.
+func TestKubectlLiterals_QuotesServerData(t *testing.T) {
+	got := kubectlLiterals(map[string]string{
+		"token": "$(whoami)",
+		"cert":  "-----BEGIN CERT-----\nline two\n",
+	})
+
+	// Sorted by key, each key=value wrapped as a single quoted word.
+	assert.Equal(t,
+		"--from-literal='cert=-----BEGIN CERT-----\nline two\n' "+
+			"--from-literal='token=$(whoami)'",
+		got)
+
+	// The substitution is inert because the whole word is single-quoted; a
+	// bare $(...) here would run on paste.
+	assert.Contains(t, got, `'token=$(whoami)'`)
+}
+
+func TestKubectlLiterals_EscapesEmbeddedQuote(t *testing.T) {
+	got := kubectlLiterals(map[string]string{"k": "it's"})
+	assert.Equal(t, `--from-literal='k=it'\''s'`, got)
+}

--- a/internal/enclave/output_test.go
+++ b/internal/enclave/output_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enclave
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+
+	os.Stdout = old
+
+	var buf bytes.Buffer
+
+	_, _ = io.Copy(&buf, r)
+
+	return buf.String()
+}
+
+// The delete result is a contract for scripts: it must distinguish a real
+// deletion from the two exit-0 no-ops (already gone, prompt declined).
+func TestRenderDeletion_JSON(t *testing.T) {
+	cases := map[string]struct {
+		result      DeletionResult
+		wantDeleted bool
+		wantReason  any
+	}{
+		"deleted": {
+			result:      DeletionResult{EnclaveID: "enc-1", Deleted: true},
+			wantDeleted: true,
+			wantReason:  nil, // omitempty: absent on success
+		},
+		"not found": {
+			result:      DeletionResult{EnclaveID: "enc-1", Reason: DeletionReasonNotFound},
+			wantDeleted: false,
+			wantReason:  DeletionReasonNotFound,
+		},
+		"aborted": {
+			result:      DeletionResult{EnclaveID: "enc-1", Reason: DeletionReasonAborted},
+			wantDeleted: false,
+			wantReason:  DeletionReasonAborted,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				require.NoError(t, RenderDeletion(outputformat.OutputFormatJSON, tc.result))
+			})
+
+			var back map[string]any
+
+			require.NoError(t, json.Unmarshal([]byte(out), &back))
+			assert.Equal(t, "enc-1", back["enclaveId"])
+			assert.Equal(t, tc.wantDeleted, back["deleted"])
+			assert.Equal(t, tc.wantReason, back["reason"])
+		})
+	}
+}
+
+func TestRenderDeletion_Text(t *testing.T) {
+	cases := map[string]struct {
+		result DeletionResult
+		want   string
+	}{
+		"deleted":   {DeletionResult{EnclaveID: "enc-1", Deleted: true}, "Deleted enclave: enc-1"},
+		"not found": {DeletionResult{EnclaveID: "enc-1", Reason: DeletionReasonNotFound}, "No enclave found with id: enc-1"},
+		"aborted":   {DeletionResult{EnclaveID: "enc-1", Reason: DeletionReasonAborted}, "Aborted."},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			out := captureStdout(t, func() {
+				require.NoError(t, RenderDeletion(outputformat.OutputFormatText, tc.result))
+			})
+
+			assert.Contains(t, out, tc.want)
+		})
+	}
+}

--- a/internal/enclave/permissions.go
+++ b/internal/enclave/permissions.go
@@ -15,6 +15,7 @@
 package enclave
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -85,12 +86,12 @@ func ResolveRecipientByID(userID, group, org string) (Recipient, error) {
 	}
 
 	if count == 0 {
-		return Recipient{}, fmt.Errorf(
+		return Recipient{}, errors.New(
 			"a recipient is required: pass exactly one of --user-id, --group, or --org")
 	}
 
 	if count > 1 {
-		return Recipient{}, fmt.Errorf(
+		return Recipient{}, errors.New(
 			"only one recipient may be given: pass exactly one of --user-id, --group, or --org")
 	}
 
@@ -115,7 +116,7 @@ func RecipientTypeByIDOf(userID, group, org string) (string, bool) {
 // ENCLAVE_RBAC_ENABLED server-side; when disabled the endpoint is a 204 no-op.
 func updateCreateAccess(operation string, r Recipient) error {
 	if r.ID == "" {
-		return fmt.Errorf(
+		return errors.New(
 			"the enclave create permission is granted by id: use --user-id, --group, or --org")
 	}
 

--- a/internal/enclave/permissions.go
+++ b/internal/enclave/permissions.go
@@ -156,8 +156,12 @@ type EnclavePermissions struct {
 	EnclaveID     string   `json:"enclaveId"`
 	SubjectUserID string   `json:"subjectUserId"`
 	Permissions   []string `json:"permissions"`
-	RBACEnabled   bool     `json:"rbacEnabled"`
-	ViaSysAdmin   bool     `json:"viaSysAdmin"`
+	// GrantedPermissions is what the subject was actually granted. It differs from
+	// Permissions when the answer came from a bypass, which is the only way to tell
+	// whether a share landed.
+	GrantedPermissions []string `json:"grantedPermissions"`
+	RBACEnabled        bool     `json:"rbacEnabled"`
+	ViaSysAdmin        bool     `json:"viaSysAdmin"`
 }
 
 // GetEnclavePermissions fetches the effective permissions on an enclave. An empty
@@ -181,4 +185,29 @@ func GetEnclavePermissions(enclaveID, userID string) (*EnclavePermissions, error
 	}
 
 	return &permissions, nil
+}
+
+// SharedRole is one recipient of an enclave and the role they hold on it.
+type SharedRole struct {
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	ShareRecipientType string `json:"shareRecipientType"`
+	Role               string `json:"role"`
+}
+
+// ListSharedRoles returns who holds which role on the enclave. An empty result
+// means nothing has been shared yet (or the server has RBAC disabled).
+func ListSharedRoles(enclaveID string) ([]SharedRole, error) {
+	endpoint, err := config.GetEndpointURL(basePath + "/" + escapeID(enclaveID) + sharedRolesSuffix)
+	if err != nil {
+		return nil, err
+	}
+
+	var roles []SharedRole
+
+	if err := drapi.GetJSON(endpoint, "enclave shared roles", &roles); err != nil {
+		return nil, err
+	}
+
+	return roles, nil
 }

--- a/internal/enclave/permissions.go
+++ b/internal/enclave/permissions.go
@@ -25,7 +25,7 @@ import (
 )
 
 // createAccessPath is the collection-level permission sub-resource:
-// PATCH /covalent/api/v2/outposts/createAccess. Unlike sharedRoles it targets no
+// PATCH /api/v2/enclaves/createAccess. Unlike sharedRoles it targets no
 // single enclave — it governs who may create them.
 const createAccessPath = "/createAccess"
 
@@ -146,7 +146,7 @@ func RevokeCreatePermission(r Recipient) error {
 }
 
 // permissionsSuffix is the effective-permissions sub-resource on an enclave:
-// GET /covalent/api/v2/outposts/{id}/permissions.
+// GET /api/v2/enclaves/{id}/permissions.
 const permissionsSuffix = "/permissions"
 
 // EnclavePermissions is the effective permission set a subject holds on an

--- a/internal/enclave/permissions.go
+++ b/internal/enclave/permissions.go
@@ -211,3 +211,58 @@ func ListSharedRoles(enclaveID string) ([]SharedRole, error) {
 
 	return roles, nil
 }
+
+// CollectionPermissions is what a subject may do that is not tied to a single
+// enclave (today: create one), plus how that answer was reached.
+type CollectionPermissions struct {
+	SubjectUserID      string   `json:"subjectUserId"`
+	Permissions        []string `json:"permissions"`
+	GrantedPermissions []string `json:"grantedPermissions"`
+	RBACEnabled        bool     `json:"rbacEnabled"`
+	ViaSysAdmin        bool     `json:"viaSysAdmin"`
+}
+
+// CreateAccessHolder is a recipient that may create enclaves.
+type CreateAccessHolder struct {
+	ShareRecipientType string   `json:"shareRecipientType"`
+	ID                 string   `json:"id"`
+	Permissions        []string `json:"permissions"`
+}
+
+// GetCollectionPermissions reports whether a subject may create enclaves. An empty
+// userID means the calling user; naming another requires a system administrator.
+func GetCollectionPermissions(userID string) (*CollectionPermissions, error) {
+	path := basePath + permissionsSuffix
+	if userID != "" {
+		path += "?userId=" + url.QueryEscape(userID)
+	}
+
+	endpoint, err := config.GetEndpointURL(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var permissions CollectionPermissions
+
+	if err := drapi.GetJSON(endpoint, "enclave permissions", &permissions); err != nil {
+		return nil, err
+	}
+
+	return &permissions, nil
+}
+
+// ListCreateAccess returns who may create enclaves. System administrators only.
+func ListCreateAccess() ([]CreateAccessHolder, error) {
+	endpoint, err := config.GetEndpointURL(basePath + createAccessPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var holders []CreateAccessHolder
+
+	if err := drapi.GetJSON(endpoint, "enclave create access", &holders); err != nil {
+		return nil, err
+	}
+
+	return holders, nil
+}

--- a/internal/enclave/permissions.go
+++ b/internal/enclave/permissions.go
@@ -1,0 +1,143 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enclave
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// createAccessPath is the collection-level permission sub-resource:
+// PATCH /covalent/api/v2/outposts/createAccess. Unlike sharedRoles it targets no
+// single enclave — it governs who may create them.
+const createAccessPath = "/createAccess"
+
+// Operations accepted by the createAccess endpoint.
+const (
+	operationGrant  = "grant"
+	operationRevoke = "revoke"
+)
+
+// PermissionCreate is the user-facing name of the collection-level permission
+// that allows registering new enclaves (server: CAN_CREATE).
+const PermissionCreate = "create"
+
+// createAccessUpdate is the PATCH body (server EnclaveCreateAccessRequest).
+// The endpoint identifies recipients by id only — there is no username form, so
+// users must be named with their DataRobot user id.
+type createAccessUpdate struct {
+	Operation          string `json:"operation"`
+	ShareRecipientType string `json:"shareRecipientType"`
+	ID                 string `json:"id"`
+}
+
+// ParsePermission maps a user-facing permission name to its canonical form.
+// Only "create" exists today; the flag is kept so further collection-level
+// permissions can be added without changing the command surface.
+func ParsePermission(value string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case PermissionCreate:
+		return PermissionCreate, nil
+	default:
+		return "", fmt.Errorf("invalid permission %q: the only supported permission is create", value)
+	}
+}
+
+// ResolveRecipientByID validates that exactly one id-based recipient selector
+// was provided. The createAccess endpoint takes an id, so these commands offer
+// no --user (username) form — hence a distinct error message from
+// ResolveRecipient, naming only the flags that actually exist here.
+func ResolveRecipientByID(userID, group, org string) (Recipient, error) {
+	var (
+		chosen Recipient
+		count  int
+	)
+
+	if userID != "" {
+		chosen = Recipient{Type: RecipientUser, ID: userID}
+		count++
+	}
+
+	if group != "" {
+		chosen = Recipient{Type: RecipientGroup, ID: group}
+		count++
+	}
+
+	if org != "" {
+		chosen = Recipient{Type: RecipientOrg, ID: org}
+		count++
+	}
+
+	if count == 0 {
+		return Recipient{}, fmt.Errorf(
+			"a recipient is required: pass exactly one of --user-id, --group, or --org")
+	}
+
+	if count > 1 {
+		return Recipient{}, fmt.Errorf(
+			"only one recipient may be given: pass exactly one of --user-id, --group, or --org")
+	}
+
+	return chosen, nil
+}
+
+// RecipientTypeByIDOf reports the recipient subject type implied by the id-based
+// selector flags, for telemetry. It returns ("", false) when no selector or more
+// than one is set, so callers get a best-effort label without duplicating
+// ResolveRecipientByID's validation.
+func RecipientTypeByIDOf(userID, group, org string) (string, bool) {
+	r, err := ResolveRecipientByID(userID, group, org)
+	if err != nil {
+		return "", false
+	}
+
+	return r.Type, true
+}
+
+// updateCreateAccess PATCHes a grant or revoke of the create permission for the
+// given recipient. The server replies 204 on success. Requires
+// ENCLAVE_RBAC_ENABLED server-side; when disabled the endpoint is a 204 no-op.
+func updateCreateAccess(operation string, r Recipient) error {
+	if r.ID == "" {
+		return fmt.Errorf(
+			"the enclave create permission is granted by id: use --user-id, --group, or --org")
+	}
+
+	url, err := config.GetEndpointURL(basePath + createAccessPath)
+	if err != nil {
+		return err
+	}
+
+	body := createAccessUpdate{
+		Operation:          operation,
+		ShareRecipientType: r.Type,
+		ID:                 r.ID,
+	}
+
+	return drapi.PatchJSON(url, "enclave", body, nil)
+}
+
+// GrantCreatePermission allows the recipient to create (register) enclaves.
+func GrantCreatePermission(r Recipient) error {
+	return updateCreateAccess(operationGrant, r)
+}
+
+// RevokeCreatePermission withdraws the recipient's ability to create enclaves.
+func RevokeCreatePermission(r Recipient) error {
+	return updateCreateAccess(operationRevoke, r)
+}

--- a/internal/enclave/permissions.go
+++ b/internal/enclave/permissions.go
@@ -16,6 +16,7 @@ package enclave
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/datarobot/cli/internal/config"
@@ -118,7 +119,8 @@ func updateCreateAccess(operation string, r Recipient) error {
 			"the enclave create permission is granted by id: use --user-id, --group, or --org")
 	}
 
-	url, err := config.GetEndpointURL(basePath + createAccessPath)
+	// Named endpoint, not url: the net/url package is imported in this file.
+	endpoint, err := config.GetEndpointURL(basePath + createAccessPath)
 	if err != nil {
 		return err
 	}
@@ -129,7 +131,7 @@ func updateCreateAccess(operation string, r Recipient) error {
 		ID:                 r.ID,
 	}
 
-	return drapi.PatchJSON(url, "enclave", body, nil)
+	return drapi.PatchJSON(endpoint, "enclave", body, nil)
 }
 
 // GrantCreatePermission allows the recipient to create (register) enclaves.
@@ -140,4 +142,43 @@ func GrantCreatePermission(r Recipient) error {
 // RevokeCreatePermission withdraws the recipient's ability to create enclaves.
 func RevokeCreatePermission(r Recipient) error {
 	return updateCreateAccess(operationRevoke, r)
+}
+
+// permissionsSuffix is the effective-permissions sub-resource on an enclave:
+// GET /covalent/api/v2/outposts/{id}/permissions.
+const permissionsSuffix = "/permissions"
+
+// EnclavePermissions is the effective permission set a subject holds on an
+// enclave, plus how that set was reached. RBACEnabled=false or ViaSysAdmin=true
+// both yield the full set without any grant, which is otherwise
+// indistinguishable from genuinely being an owner.
+type EnclavePermissions struct {
+	EnclaveID     string   `json:"enclaveId"`
+	SubjectUserID string   `json:"subjectUserId"`
+	Permissions   []string `json:"permissions"`
+	RBACEnabled   bool     `json:"rbacEnabled"`
+	ViaSysAdmin   bool     `json:"viaSysAdmin"`
+}
+
+// GetEnclavePermissions fetches the effective permissions on an enclave. An empty
+// userID means the calling user; naming another user requires a system
+// administrator server-side.
+func GetEnclavePermissions(enclaveID, userID string) (*EnclavePermissions, error) {
+	path := basePath + "/" + escapeID(enclaveID) + permissionsSuffix
+	if userID != "" {
+		path += "?userId=" + url.QueryEscape(userID)
+	}
+
+	endpoint, err := config.GetEndpointURL(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var permissions EnclavePermissions
+
+	if err := drapi.GetJSON(endpoint, "enclave permissions", &permissions); err != nil {
+		return nil, err
+	}
+
+	return &permissions, nil
 }

--- a/internal/enclave/permissions_test.go
+++ b/internal/enclave/permissions_test.go
@@ -15,6 +15,7 @@
 package enclave
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,4 +73,27 @@ func TestUpdateCreateAccess_RequiresAnID(t *testing.T) {
 	err = RevokeCreatePermission(Recipient{Type: RecipientUser, Username: "alice@corp.io"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--user-id")
+}
+
+func TestRenderEnclavePermissions_JSONRoundTrip(t *testing.T) {
+	// The JSON shape is a contract for scripts; keep the keys stable.
+	p := EnclavePermissions{
+		EnclaveID:     "enc-1",
+		SubjectUserID: "u-1",
+		Permissions:   []string{"CAN_VIEW", "CAN_DEPLOY"},
+		RBACEnabled:   true,
+		ViaSysAdmin:   false,
+	}
+
+	data, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	var back map[string]any
+
+	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, "enc-1", back["enclaveId"])
+	assert.Equal(t, "u-1", back["subjectUserId"])
+	assert.Equal(t, true, back["rbacEnabled"])
+	assert.Equal(t, false, back["viaSysAdmin"])
+	assert.Len(t, back["permissions"], 2)
 }

--- a/internal/enclave/permissions_test.go
+++ b/internal/enclave/permissions_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enclave
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePermission(t *testing.T) {
+	for _, in := range []string{"create", "CREATE", " Create "} {
+		got, err := ParsePermission(in)
+		require.NoError(t, err)
+		assert.Equal(t, PermissionCreate, got)
+	}
+}
+
+func TestParsePermission_RejectsUnknown(t *testing.T) {
+	_, err := ParsePermission("deploy")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create")
+}
+
+func TestResolveRecipientByID(t *testing.T) {
+	r, err := ResolveRecipientByID("", "", "org-1")
+	require.NoError(t, err)
+	assert.Equal(t, RecipientOrg, r.Type)
+	assert.Equal(t, "org-1", r.Value())
+
+	r, err = ResolveRecipientByID("u-1", "", "")
+	require.NoError(t, err)
+	assert.Equal(t, RecipientUser, r.Type)
+
+	r, err = ResolveRecipientByID("", "g-1", "")
+	require.NoError(t, err)
+	assert.Equal(t, RecipientGroup, r.Type)
+}
+
+func TestResolveRecipientByID_Errors(t *testing.T) {
+	// The error must name only the flags these commands actually offer — no --user.
+	_, err := ResolveRecipientByID("", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--user-id")
+	assert.NotContains(t, err.Error(), "--user,")
+
+	_, err = ResolveRecipientByID("u-1", "", "org-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only one recipient")
+}
+
+func TestUpdateCreateAccess_RequiresAnID(t *testing.T) {
+	// A username-only recipient cannot be used: the createAccess endpoint takes
+	// an id. Fail before issuing the request rather than sending an empty id.
+	err := GrantCreatePermission(Recipient{Type: RecipientUser, Username: "alice@corp.io"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--user-id")
+
+	err = RevokeCreatePermission(Recipient{Type: RecipientUser, Username: "alice@corp.io"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--user-id")
+}

--- a/internal/enclave/sharing.go
+++ b/internal/enclave/sharing.go
@@ -15,6 +15,7 @@
 package enclave
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -144,12 +145,12 @@ func ResolveRecipient(user, userID, group, org string) (Recipient, error) {
 	}
 
 	if count == 0 {
-		return Recipient{}, fmt.Errorf(
+		return Recipient{}, errors.New(
 			"a recipient is required: pass exactly one of --user, --user-id, --group, or --org")
 	}
 
 	if count > 1 {
-		return Recipient{}, fmt.Errorf(
+		return Recipient{}, errors.New(
 			"only one recipient may be given: pass exactly one of --user, --user-id, --group, or --org")
 	}
 

--- a/internal/enclave/sharing.go
+++ b/internal/enclave/sharing.go
@@ -24,7 +24,7 @@ import (
 )
 
 // sharedRolesSuffix is appended to an enclave's path to reach the sharedRoles
-// sub-resource: PATCH /covalent/api/v2/outposts/{id}/sharedRoles.
+// sub-resource: PATCH /api/v2/enclaves/{id}/sharedRoles.
 const sharedRolesSuffix = "/sharedRoles"
 
 // updateRolesOperation is the only operation the sharedRoles endpoint accepts.

--- a/internal/enclave/sharing.go
+++ b/internal/enclave/sharing.go
@@ -1,0 +1,196 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enclave
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// sharedRolesSuffix is appended to an enclave's path to reach the sharedRoles
+// sub-resource: PATCH /covalent/api/v2/outposts/{id}/sharedRoles.
+const sharedRolesSuffix = "/sharedRoles"
+
+// updateRolesOperation is the only operation the sharedRoles endpoint accepts.
+const updateRolesOperation = "updateRoles"
+
+// Server SharingRole values the CLI grants. NO_ROLE is the removal sentinel
+// sent by revoke.
+const (
+	RoleOwner    = "OWNER"
+	RoleUser     = "USER"
+	RoleConsumer = "CONSUMER"
+	roleNone     = "NO_ROLE"
+)
+
+// Recipient subject types (server SubjectType values, lowercase on the wire).
+const (
+	RecipientUser  = "user"
+	RecipientGroup = "group"
+	RecipientOrg   = "organization"
+)
+
+// sharedRole is one entry in a sharedRoles update: a recipient plus the role
+// to set. Exactly one of Username (users only) or ID (users/groups/orgs) is
+// populated, matching the server's oneof of GrantAccessControlWithUsername /
+// GrantAccessControlWithId.
+type sharedRole struct {
+	ShareRecipientType string `json:"shareRecipientType"`
+	Role               string `json:"role"`
+	Username           string `json:"username,omitempty"`
+	ID                 string `json:"id,omitempty"`
+}
+
+// sharedRolesUpdate is the PATCH body (server SharedRolesUpdateRequest).
+type sharedRolesUpdate struct {
+	Operation string       `json:"operation"`
+	Roles     []sharedRole `json:"roles"`
+}
+
+// Recipient identifies who a grant/revoke targets: a subject type plus exactly
+// one of a username (users only) or an id (users, groups, or organizations).
+type Recipient struct {
+	Type     string
+	Username string
+	ID       string
+}
+
+// Value returns the recipient's identifying string — its username when granted
+// by username, otherwise its id.
+func (r Recipient) Value() string {
+	if r.Username != "" {
+		return r.Username
+	}
+
+	return r.ID
+}
+
+// Describe renders "<type> <value>" for confirmation messages, e.g.
+// "organization 656f0000000000000000abcd".
+func (r Recipient) Describe() string {
+	return r.Type + " " + r.Value()
+}
+
+// toSharedRole builds the wire entry for this recipient at the given role.
+func (r Recipient) toSharedRole(role string) sharedRole {
+	entry := sharedRole{ShareRecipientType: r.Type, Role: role}
+
+	if r.Username != "" {
+		entry.Username = r.Username
+	} else {
+		entry.ID = r.ID
+	}
+
+	return entry
+}
+
+// ParseRole maps a user-facing role name (owner|user|consumer, case-insensitive)
+// to the server SharingRole value. Unknown names are rejected.
+func ParseRole(value string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "owner":
+		return RoleOwner, nil
+	case "user":
+		return RoleUser, nil
+	case "consumer":
+		return RoleConsumer, nil
+	default:
+		return "", fmt.Errorf("invalid role %q: use one of owner, user, consumer", value)
+	}
+}
+
+// ResolveRecipient validates that exactly one recipient selector was provided
+// and returns the corresponding Recipient. The flags mirror the command
+// surface: --user (username), --user-id / --group / --org (id).
+func ResolveRecipient(user, userID, group, org string) (Recipient, error) {
+	var (
+		chosen Recipient
+		count  int
+	)
+
+	if user != "" {
+		chosen = Recipient{Type: RecipientUser, Username: user}
+		count++
+	}
+
+	if userID != "" {
+		chosen = Recipient{Type: RecipientUser, ID: userID}
+		count++
+	}
+
+	if group != "" {
+		chosen = Recipient{Type: RecipientGroup, ID: group}
+		count++
+	}
+
+	if org != "" {
+		chosen = Recipient{Type: RecipientOrg, ID: org}
+		count++
+	}
+
+	if count == 0 {
+		return Recipient{}, fmt.Errorf(
+			"a recipient is required: pass exactly one of --user, --user-id, --group, or --org")
+	}
+
+	if count > 1 {
+		return Recipient{}, fmt.Errorf(
+			"only one recipient may be given: pass exactly one of --user, --user-id, --group, or --org")
+	}
+
+	return chosen, nil
+}
+
+// RecipientTypeOf reports the recipient subject type implied by the given
+// selector flags, for telemetry. It returns ("", false) when no selector or
+// more than one is set, so callers get a best-effort label without duplicating
+// ResolveRecipient's validation.
+func RecipientTypeOf(user, userID, group, org string) (string, bool) {
+	r, err := ResolveRecipient(user, userID, group, org)
+	if err != nil {
+		return "", false
+	}
+
+	return r.Type, true
+}
+
+// UpdateSharedRoles PATCHes the given role changes onto an enclave. The server
+// replies 204 on success. Requires ENCLAVE_RBAC_ENABLED server-side; when
+// disabled the endpoint is a 204 no-op.
+func UpdateSharedRoles(enclaveID string, roles []sharedRole) error {
+	url, err := config.GetEndpointURL(basePath + "/" + escapeID(enclaveID) + sharedRolesSuffix)
+	if err != nil {
+		return err
+	}
+
+	body := sharedRolesUpdate{Operation: updateRolesOperation, Roles: roles}
+
+	return drapi.PatchJSON(url, "enclave", body, nil)
+}
+
+// GrantAccess grants role (a server SharingRole such as OWNER/USER/CONSUMER) to
+// the recipient on the enclave.
+func GrantAccess(enclaveID, role string, r Recipient) error {
+	return UpdateSharedRoles(enclaveID, []sharedRole{r.toSharedRole(role)})
+}
+
+// RevokeAccess removes the recipient's access to the enclave by sending the
+// NO_ROLE removal sentinel.
+func RevokeAccess(enclaveID string, r Recipient) error {
+	return UpdateSharedRoles(enclaveID, []sharedRole{r.toSharedRole(roleNone)})
+}

--- a/internal/enclave/sharing_test.go
+++ b/internal/enclave/sharing_test.go
@@ -110,7 +110,7 @@ func TestGrantAccessSendsPatch(t *testing.T) {
 		gotPath = r.URL.Path
 
 		raw, _ := io.ReadAll(r.Body)
-		require.NoError(t, json.Unmarshal(raw, &gotBody))
+		assert.NoError(t, json.Unmarshal(raw, &gotBody))
 
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -134,7 +134,7 @@ func TestGrantAccessByUsernameOmitsID(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		raw, _ := io.ReadAll(r.Body)
-		require.NoError(t, json.Unmarshal(raw, &gotBody))
+		assert.NoError(t, json.Unmarshal(raw, &gotBody))
 
 		// Assert the raw body carries username and no id key for a username grant.
 		assert.Contains(t, string(raw), `"username":"alice@corp.io"`)
@@ -163,7 +163,7 @@ func TestRevokeAccessSendsNoRole(t *testing.T) {
 		assert.Equal(t, http.MethodPatch, r.Method)
 
 		raw, _ := io.ReadAll(r.Body)
-		require.NoError(t, json.Unmarshal(raw, &gotBody))
+		assert.NoError(t, json.Unmarshal(raw, &gotBody))
 
 		w.WriteHeader(http.StatusNoContent)
 	}))

--- a/internal/enclave/sharing_test.go
+++ b/internal/enclave/sharing_test.go
@@ -121,7 +121,7 @@ func TestGrantAccessSendsPatch(t *testing.T) {
 	err := GrantAccess("abc-123", RoleUser, Recipient{Type: RecipientOrg, ID: "org-1"})
 	require.NoError(t, err)
 
-	assert.Equal(t, "/covalent/api/v2/outposts/abc-123/sharedRoles", gotPath)
+	assert.Equal(t, "/api/v2/enclaves/abc-123/sharedRoles", gotPath)
 	assert.Equal(t, "updateRoles", gotBody.Operation)
 	require.Len(t, gotBody.Roles, 1)
 	assert.Equal(t, sharedRole{ShareRecipientType: RecipientOrg, Role: RoleUser, ID: "org-1"}, gotBody.Roles[0])

--- a/internal/enclave/sharing_test.go
+++ b/internal/enclave/sharing_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enclave
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRole(t *testing.T) {
+	cases := map[string]string{
+		"owner":      RoleOwner,
+		"USER":       RoleUser,
+		" Consumer ": RoleConsumer,
+	}
+
+	for in, want := range cases {
+		got, err := ParseRole(in)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	}
+
+	_, err := ParseRole("admin")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "owner, user, consumer")
+}
+
+func TestResolveRecipient(t *testing.T) {
+	t.Run("user by username", func(t *testing.T) {
+		r, err := ResolveRecipient("alice@corp.io", "", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, Recipient{Type: RecipientUser, Username: "alice@corp.io"}, r)
+		assert.Equal(t, "alice@corp.io", r.Value())
+	})
+
+	t.Run("user by id", func(t *testing.T) {
+		r, err := ResolveRecipient("", "uid-1", "", "")
+		require.NoError(t, err)
+		assert.Equal(t, Recipient{Type: RecipientUser, ID: "uid-1"}, r)
+		assert.Equal(t, "uid-1", r.Value())
+	})
+
+	t.Run("group", func(t *testing.T) {
+		r, err := ResolveRecipient("", "", "grp-1", "")
+		require.NoError(t, err)
+		assert.Equal(t, RecipientGroup, r.Type)
+	})
+
+	t.Run("org", func(t *testing.T) {
+		r, err := ResolveRecipient("", "", "", "org-1")
+		require.NoError(t, err)
+		assert.Equal(t, RecipientOrg, r.Type)
+		assert.Equal(t, "organization org-1", r.Describe())
+	})
+
+	t.Run("none is an error", func(t *testing.T) {
+		_, err := ResolveRecipient("", "", "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "recipient is required")
+	})
+
+	t.Run("more than one is an error", func(t *testing.T) {
+		_, err := ResolveRecipient("alice", "", "grp-1", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only one recipient")
+	})
+}
+
+func TestRecipientTypeOf(t *testing.T) {
+	typ, ok := RecipientTypeOf("", "", "", "org-1")
+	assert.True(t, ok)
+	assert.Equal(t, RecipientOrg, typ)
+
+	_, ok = RecipientTypeOf("", "", "", "")
+	assert.False(t, ok)
+
+	_, ok = RecipientTypeOf("alice", "uid", "", "")
+	assert.False(t, ok)
+}
+
+func TestGrantAccessSendsPatch(t *testing.T) {
+	installSkipAuth(t)
+
+	var (
+		gotBody sharedRolesUpdate
+		gotPath string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+
+		gotPath = r.URL.Path
+
+		raw, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(raw, &gotBody))
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	err := GrantAccess("abc-123", RoleUser, Recipient{Type: RecipientOrg, ID: "org-1"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/covalent/api/v2/outposts/abc-123/sharedRoles", gotPath)
+	assert.Equal(t, "updateRoles", gotBody.Operation)
+	require.Len(t, gotBody.Roles, 1)
+	assert.Equal(t, sharedRole{ShareRecipientType: RecipientOrg, Role: RoleUser, ID: "org-1"}, gotBody.Roles[0])
+}
+
+func TestGrantAccessByUsernameOmitsID(t *testing.T) {
+	installSkipAuth(t)
+
+	var gotBody sharedRolesUpdate
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(raw, &gotBody))
+
+		// Assert the raw body carries username and no id key for a username grant.
+		assert.Contains(t, string(raw), `"username":"alice@corp.io"`)
+		assert.NotContains(t, string(raw), `"id"`)
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	err := GrantAccess("abc-123", RoleOwner, Recipient{Type: RecipientUser, Username: "alice@corp.io"})
+	require.NoError(t, err)
+
+	require.Len(t, gotBody.Roles, 1)
+	assert.Equal(t, "alice@corp.io", gotBody.Roles[0].Username)
+	assert.Empty(t, gotBody.Roles[0].ID)
+}
+
+func TestRevokeAccessSendsNoRole(t *testing.T) {
+	installSkipAuth(t)
+
+	var gotBody sharedRolesUpdate
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+
+		raw, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(raw, &gotBody))
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	err := RevokeAccess("abc-123", Recipient{Type: RecipientOrg, ID: "org-1"})
+	require.NoError(t, err)
+
+	require.Len(t, gotBody.Roles, 1)
+	assert.Equal(t, roleNone, gotBody.Roles[0].Role)
+	assert.Equal(t, "org-1", gotBody.Roles[0].ID)
+}


### PR DESCRIPTION
# RATIONALE

Covalent ships a public Enclaves API at `/api/v2/enclaves`. This adds first-class CLI support so operators can register and manage enclaves and control who may use them, instead of hand-rolling `curl` calls. It mirrors the existing `dr workload` command tree in layout, output handling, and telemetry wiring.

There is no public `activate` verb — an enclave activates itself when its installer reports in — so no `activate` command is provided (documented in `--help`). Manually deactivated enclaves can be returned to service with `reactivate`.

**Server floor.** The client calls only the canonical paths, which are new in CMPT-7347 ([covalent-cloud-server#681](https://github.com/datarobot/covalent-cloud-server/pull/681), merged 2026-09-04, so the first Covalent release after 11.12.0). Before that change the API sat behind a `/covalent` ingress prefix and its RBAC/lifecycle routes answered under `/outposts`; both old spellings survive server-side as hidden deprecated aliases, so nothing forces the CLI to keep using them — and referencing only the new paths means those aliases can be retired without touching the CLI again.

## CHANGES

New feature-gated `dr enclave` command tree (gated behind `DATAROBOT_CLI_FEATURE_ENCLAVE`, mirroring `dr workload`):

**Lifecycle**

- `dr enclave register --name <n> [--label k=v]` — surfaces the one-shot installation secrets (shown once, never persisted server-side; `--output-format json` to capture them)
- `dr enclave get <id>` / `dr enclave list`
- `dr enclave deactivate <id>` — takes an enclave out of service
- `dr enclave reactivate <id>` — returns a manually deactivated enclave to service (inverse of `deactivate`)
- `dr enclave delete <id> [--yes]` — confirmation prompt + friendly 404

**Per-enclave access** (`dr enclave access`)

- `grant <id> --role <owner|user|consumer> <recipient>` / `revoke <id> <recipient>` — the latter sends the `NO_ROLE` removal sentinel
- `list <id>` — who the enclave is shared with and the role each holds
- `show <id> [--user-id]` — the caller's effective permissions, and whether the answer came from a grant, the system-admin bypass, or RBAC being off

**Collection-level permission** (`dr enclave permission`)

- `grant` / `revoke --permission create` for a user / group / organization
- `list` — who has been granted the create permission
- `show [--user-id]` — whether the caller may create enclaves, and why

`access` commands wrap the `sharedRoles` PATCH endpoint, mapping `owner|user|consumer` → `OWNER|USER|CONSUMER`, with exactly-one recipient selection (`--user` / `--user-id` / `--group` / `--org`) enforced via `MarkFlagsMutuallyExclusive` plus a required-one check. `permission` recipients are id-based only (`--user-id` / `--group` / `--org`), because `createAccess` identifies subjects by id. `--help` calls out the server dependencies (`ENCLAVE_RBAC_ENABLED`, `CAN_SHARE`, `ENCLAVE_ADMIN_ONLY`).

Every command supports `--output-format json`.

Layout:

- `internal/enclave/` — API client (`enclave.go`), sharing client (`sharing.go`), permission client (`permissions.go`), output rendering (`output.go`)
- `cmd/enclave/**` — parent group + per-verb packages (`register`, `get`, `list`, `deactivate`, `reactivate`, `del`, `access/{grant,revoke,list,show}`, `permission/{grant,revoke,list,show}`)
- Registered in `cmd/root.go`; telemetry-wiring assertions added in `cmd/telemetry_wiring_test.go`
- `docs/commands/enclave.md` — command reference, including the command → endpoint table

One `basePath` const covers the whole surface, with the sub-resource paths composed off it, so there is a single place to change if the API moves again.

## TESTING

- `go build ./...` and `go vet ./...` clean; `golangci-lint run` reports **0 issues** on the pinned v2.11.4 (`golangci-lint fmt` produces no diff)
- Unit tests: httptest-backed client (register incl. 409, get + id-escaping, list, deactivate, reactivate, delete + 404, sharedRoles grant/revoke body + path, permission/createAccess), role/recipient parsing, flag/arg validation, telemetry wiring
- `go test -race ./internal/enclave/... ./cmd/enclave/...` green; full `go test -race ./...` green apart from `cmd/dotenv`'s pulumi-login tests, which fail the same way on `main` in this environment
- **Not** re-verified against a deployed environment: the canonical paths need a Covalent carrying covalent-cloud-server#681, which is merged to `main` but not in a release yet. Worth an end-to-end pass (register → share → `access show` / `access list` → `permission grant` → `permission list`) once it deploys, before this merges.

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1788962851.879019 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New commands can grant/revoke enclave access and delete enclaves, and registration output exposes one-shot credentials; impact is limited by feature gating and server-side RBAC, but operator mistakes could affect who can deploy or create outposts.
> 
> **Overview**
> Adds a feature-gated **`dr enclave`** command group (enable with `DATAROBOT_CLI_FEATURE_ENCLAVE`) for registering and operating remote outpost clusters via `/api/v2/enclaves`, wired into the root CLI with CODEOWNERS and command docs.
> 
> **Lifecycle:** `register` (one-shot install secrets + optional labels), `get`/`list`, `deactivate`/`reactivate`, and `delete` with interactive confirmation or `--yes` / `DATAROBOT_CLI_NON_INTERACTIVE`, including a friendly 404 on delete.
> 
> **Sharing & RBAC:** `dr enclave access` wraps `sharedRoles` (grant/revoke roles, list shares, show effective permissions with RBAC/sys-admin source hints). `dr enclave permission` manages collection-level **create** access via `createAccess` (id-only recipients). All support `--output-format json`.
> 
> New **`internal/enclave`** holds the HTTP client, sharing/permission helpers, and text/JSON rendering (including kubectl hints for registration secrets). Telemetry wiring tests cover a subset of leaf commands; unit tests cover clients and flag validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c90d82fee8356388a50c06081dd3dc3b396e636. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->