### PR TITLE
[CFX-7422] fix(ci): skip PR image publish for fork PRs

### DIFF
--- a/.github/workflows/image-on-pr-approval.yaml
+++ b/.github/workflows/image-on-pr-approval.yaml
@@ -62,6 +62,11 @@ jobs:
 
   publish-image:
     needs: check-approval
+    # Fork PRs get a read-only GITHUB_TOKEN on pull_request_review events
+    # (no _target variant exists), so GHCR denies the org package write
+    # regardless of the permissions: block below. Skip to avoid a misleading
+    # red X. See CFX-7265.
+    if: needs.check-approval.outputs.is_fork == 'false'
     runs-on: ubuntu-latest
     name: Build and Push PR Image
     timeout-minutes: 20


### PR DESCRIPTION
## What & why

The `PR Approved Image` workflow (`.github/workflows/image-on-pr-approval.yaml`, added in #701) is designed to publish a Docker image to `ghcr.io/datarobot-oss/cli` when a maintainer approves a PR. However, it has never actually worked for its primary use case: **fork-originated PRs**.

### Symptom

Every time a maintainer approves a fork PR, the `publish-image` job fails at the Docker push step:

```
#11 ERROR: failed to push ghcr.io/datarobot-oss/cli:pr-734: denied: installation not allowed to Write organization package
ERROR: failed to build: failed to solve: failed to push ghcr.io/datarobot-oss/cli:pr-734: denied: installation not allowed to Write organization package
```

This has been observed on PRs #686, #723, and most recently #734.

### Root cause

This is a hard GitHub platform restriction, not a permissions misconfiguration. The workflow triggers on `pull_request_review`, which has no `_target` variant. For fork PRs, GitHub silently caps `GITHUB_TOKEN` to read-only regardless of the job's declared `permissions: { packages: write }` block. The token simply cannot write to organization-owned GHCR packages for fork-PR commits.

PR #723 previously fixed the secondary masking bug (an unhandled 403 from `createCommitStatus` burying the real error), but the underlying push failure was left as-is and tracked in [CFX-7265](https://datarobot.atlassian.net/browse/CFX-7265).

## Fix

Skip the `publish-image` job when `is_fork == 'true'` (the `is_fork` output is already computed by the `check-approval` job). The job shows a neutral skip instead of a misleading red X. A proper fix (PAT or GitHub App token with org `packages:write` scope) requires org-admin provisioning and is tracked separately in CFX-7265.

## How to test

Approve a fork PR and confirm the `publish-image` job skips with a neutral icon instead of failing. Approve a same-org branch PR and confirm the job still runs and pushes normally.

## Related

- [CFX-7265](https://datarobot.atlassian.net/browse/CFX-7265)
- #701 (original workflow)
- #723 (commit-status 403 fix)
- #734 (most recent fork PR to hit this)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow gating only; no application, auth, or runtime behavior changes.
> 
> **Overview**
> The **PR Approved Image** workflow’s `publish-image` job now runs only when `needs.check-approval.outputs.is_fork == 'false'`, using the fork flag already set in `check-approval`.
> 
> Fork PRs on `pull_request_review` keep a read-only `GITHUB_TOKEN`, so GHCR pushes fail even with `packages: write`. Skipping the job avoids a false red failure; same-repo PRs still build and push as before. Comments point to CFX-7265 for a token-based fix later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eac5d2a3ffe20158db2ba72033fba1d4e830b1d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->