### PR TITLE
fix(ci): disable PR Approved Image workflow

### DIFF
--- a/.github/workflows/image-on-pr-approval.yaml
+++ b/.github/workflows/image-on-pr-approval.yaml
@@ -4,6 +4,12 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Disabled: pull_request_review runs the workflow from the fork branch's HEAD,
+# not from main, so fixes here never reach existing fork PRs. Additionally,
+# fork PRs get a read-only GITHUB_TOKEN that can't push to org GHCR packages.
+# Replacing with an issue_comment-based approach. See CFX-7265.
+if: false
+
 concurrency:
   group: pr-image-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
Disabled `image-on-pr-approval.yaml` with `if: false`.

`pull_request_review` resolves the workflow from the fork branch HEAD, not main, so fixes never reach existing fork PRs. Combined with the read-only `GITHUB_TOKEN` for fork PRs, the workflow has never successfully published an image for its intended use case. Replacing with an `issue_comment`-based approach (CFX-7265).

@carsongee — disabled for now. if you really need this workflow to work, let us know

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1785882855.542729 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that stops a non-working workflow; no application runtime or deployment logic is modified.
> 
> **Overview**
> **Disables** the `PR Approved Image` GitHub Actions workflow by adding a workflow-level `if: false`, so approvals no longer trigger image builds.
> 
> The inline comment records why it was turned off: `pull_request_review` runs workflow definitions from the **fork branch HEAD** (so fixes on `main` never apply to open fork PRs), and fork PRs only get a **read-only** `GITHUB_TOKEN`, which blocks pushes to org GHCR. A follow-up will use an **`issue_comment`-based** flow (CFX-7265).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d04a46ede4fa5a54601df468864848482c97109. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->