### PR TITLE
[APP-6754] fix(auth export): better errors for bad DATAROBOT_ENDPOINT

### DIFF
--- a/cmd/auth/check/cmd.go
+++ b/cmd/auth/check/cmd.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,13 +32,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func checkCLICredentials() bool {
+func checkCLICredentials(w io.Writer) bool {
 	allValid := true
 
 	// Check environment variables first (same pattern as EnsureAuthenticated)
 	creds, err := auth.VerifyEnvCredentials(context.Background())
 	if err == nil {
-		fmt.Println(tui.BaseTextStyle.Render("✅ Environment variable authentication is valid."))
+		fmt.Fprintln(w, tui.BaseTextStyle.Render("✅ Environment variable authentication is valid."))
 
 		return true
 	}
@@ -47,16 +48,28 @@ func checkCLICredentials() bool {
 		if errors.Is(err, context.DeadlineExceeded) {
 			envDatarobotHost, _ := config.SchemeHostOnly(creds.Endpoint)
 
-			fmt.Print(tui.BaseTextStyle.Render("❌ Connection to "))
-			fmt.Print(tui.InfoStyle.Render(envDatarobotHost))
-			fmt.Println(tui.BaseTextStyle.Render(" timed out. Check your network and try again."))
+			fmt.Fprint(w, tui.BaseTextStyle.Render("❌ Connection to "))
+			fmt.Fprint(w, tui.InfoStyle.Render(envDatarobotHost))
+			fmt.Fprintln(w, tui.BaseTextStyle.Render(" timed out. Check your network and try again."))
 
 			return false
 		}
 
-		fmt.Println(tui.BaseTextStyle.Render("❌ DATAROBOT_API_TOKEN environment variable is invalid or expired."))
-		fmt.Println(tui.BaseTextStyle.Render("Unset it and try again:"))
-		auth.PrintUnsetTokenInstructions()
+		// Distinguish a malformed DATAROBOT_ENDPOINT from an invalid token so
+		// the user fixes the right thing. A quoted endpoint (e.g. from running
+		// `$(dr auth export)` instead of `eval "$(dr auth export)"`) fails here
+		// and must not be reported as a token problem.
+		if epErr := auth.EndpointProblem(creds.Endpoint); epErr != nil {
+			fmt.Fprintln(w, tui.BaseTextStyle.Render("❌ DATAROBOT_ENDPOINT environment variable is invalid: "+epErr.Error()))
+			fmt.Fprintln(w, tui.BaseTextStyle.Render("Set it to a valid DataRobot URL and try again."))
+		} else {
+			fmt.Fprintln(w, tui.BaseTextStyle.Render("❌ DATAROBOT_API_TOKEN environment variable is invalid or expired."))
+			fmt.Fprintln(w, tui.BaseTextStyle.Render("Unset it and try again:"))
+			fmt.Fprint(w, tui.InfoStyle.Render("  unset DATAROBOT_API_TOKEN"))
+			fmt.Fprint(w, tui.BaseTextStyle.Render(" (or "))
+			fmt.Fprint(w, tui.InfoStyle.Render("Remove-Item Env:\\DATAROBOT_API_TOKEN"))
+			fmt.Fprintln(w, tui.BaseTextStyle.Render(" on Windows)"))
+		}
 
 		return false
 	}
@@ -64,10 +77,10 @@ func checkCLICredentials() bool {
 	// Fall back to config file credentials
 	datarobotHost := config.GetBaseURL()
 	if datarobotHost == "" {
-		fmt.Println(tui.BaseTextStyle.Render("❌ No DataRobot URL configured."))
-		fmt.Print(tui.BaseTextStyle.Render("Run "))
-		fmt.Print(tui.InfoStyle.Render("dr auth set-url"))
-		fmt.Println(tui.BaseTextStyle.Render(" to configure your DataRobot URL."))
+		fmt.Fprintln(w, tui.BaseTextStyle.Render("❌ No DataRobot URL configured."))
+		fmt.Fprint(w, tui.BaseTextStyle.Render("Run "))
+		fmt.Fprint(w, tui.InfoStyle.Render("dr auth set-url"))
+		fmt.Fprintln(w, tui.BaseTextStyle.Render(" to configure your DataRobot URL."))
 
 		allValid = false
 	}
@@ -75,19 +88,19 @@ func checkCLICredentials() bool {
 	_, err = config.GetAPIKey(context.Background())
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			fmt.Print(tui.BaseTextStyle.Render("❌ Connection to "))
-			fmt.Print(tui.InfoStyle.Render(datarobotHost))
-			fmt.Println(tui.BaseTextStyle.Render(" timed out. Check your network and try again."))
+			fmt.Fprint(w, tui.BaseTextStyle.Render("❌ Connection to "))
+			fmt.Fprint(w, tui.InfoStyle.Render(datarobotHost))
+			fmt.Fprintln(w, tui.BaseTextStyle.Render(" timed out. Check your network and try again."))
 		} else {
-			fmt.Println(tui.BaseTextStyle.Render("❌ No valid API key found in CLI config."))
-			fmt.Print(tui.BaseTextStyle.Render("Run "))
-			fmt.Print(tui.InfoStyle.Render("dr auth login"))
-			fmt.Println(tui.BaseTextStyle.Render(" to authenticate."))
+			fmt.Fprintln(w, tui.BaseTextStyle.Render("❌ No valid API key found in CLI config."))
+			fmt.Fprint(w, tui.BaseTextStyle.Render("Run "))
+			fmt.Fprint(w, tui.InfoStyle.Render("dr auth login"))
+			fmt.Fprintln(w, tui.BaseTextStyle.Render(" to authenticate."))
 		}
 
 		allValid = false
 	} else {
-		fmt.Println(tui.BaseTextStyle.Render("✅ CLI authentication is valid."))
+		fmt.Fprintln(w, tui.BaseTextStyle.Render("✅ CLI authentication is valid."))
 	}
 
 	return allValid
@@ -222,7 +235,7 @@ func RunE(_ *cobra.Command, _ []string) error {
 	// If not, check the CLI credentials only
 	repoRoot, err := repo.FindRepoRoot()
 	if err != nil {
-		if checkCLICredentials() {
+		if checkCLICredentials(os.Stdout) {
 			return nil
 		}
 
@@ -233,7 +246,7 @@ func RunE(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	if checkCLICredentials() {
+	if checkCLICredentials(os.Stdout) {
 		return nil
 	}
 

--- a/cmd/auth/check/cmd.go
+++ b/cmd/auth/check/cmd.go
@@ -59,7 +59,7 @@ func checkCLICredentials(w io.Writer) bool {
 		// the user fixes the right thing. A quoted endpoint (e.g. from running
 		// `$(dr auth export)` instead of `eval "$(dr auth export)"`) fails here
 		// and must not be reported as a token problem.
-		if epErr := auth.EndpointProblem(creds.Endpoint); epErr != nil {
+		if epErr := auth.ValidateEndpoint(creds.Endpoint); epErr != nil {
 			fmt.Fprintln(w, tui.BaseTextStyle.Render("❌ DATAROBOT_ENDPOINT environment variable is invalid: "+epErr.Error()))
 			fmt.Fprintln(w, tui.BaseTextStyle.Render("Set it to a valid DataRobot URL and try again."))
 		} else {

--- a/cmd/auth/check/cmd_test.go
+++ b/cmd/auth/check/cmd_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckCLICredentials_QuotedEndpointNamesEndpointNotToken(t *testing.T) {
+	// Reproduces the `$(dr auth export)` footgun: DATAROBOT_ENDPOINT carries
+	// literal surrounding quotes. config.VerifyToken fails fast at url.Parse
+	// (no network), so checkCLICredentials must report the endpoint as invalid
+	// rather than misattributing the failure to the token.
+	t.Setenv("DATAROBOT_ENDPOINT", "'https://staging.datarobot.com/api/v2'")
+	t.Setenv("DATAROBOT_API_TOKEN", "dummy-token")
+
+	var buf bytes.Buffer
+
+	valid := checkCLICredentials(&buf)
+
+	require.False(t, valid)
+	assert.Contains(t, buf.String(), "DATAROBOT_ENDPOINT environment variable is invalid")
+	assert.NotContains(t, buf.String(), "DATAROBOT_API_TOKEN environment variable is invalid or expired")
+}

--- a/cmd/auth/export/cmd.go
+++ b/cmd/auth/export/cmd.go
@@ -53,10 +53,19 @@ var (
 	errNoToken       = errors.New("no DataRobot API token configured")
 )
 
+// Human-readable labels for where the exported credentials came from, surfaced
+// both in error messages and in the JSON envelope's "source" metadata.
+const (
+	sourceEnv    = "DATAROBOT_ENDPOINT environment variable"
+	sourceConfig = "drconfig.yaml"
+)
+
 // credentials is the endpoint/token pair this command renders.
 type credentials struct {
 	Endpoint string
 	Token    string
+	// Source names where the credentials were read from, for diagnostics.
+	Source string
 }
 
 // statementFunc renders a single "set this variable" statement for one shell.
@@ -69,6 +78,7 @@ type statementFunc func(name, value string) string
 // self-managed installs serving the API under a custom prefix keep working.
 func canonicalEndpoint(raw string) (string, error) {
 	trimmed := strings.TrimSpace(raw)
+
 	if trimmed == "" {
 		return "", errNoEndpoint
 	}
@@ -105,12 +115,13 @@ func canonicalEndpoint(raw string) (string, error) {
 // usable from shell startup files and non-interactive sessions.
 func rawCredentials() (credentials, error) {
 	if env := auth.GetEnvCredentials(); env.Endpoint != "" && env.Token != "" {
-		return credentials{Endpoint: env.Endpoint, Token: env.Token}, nil
+		return credentials{Endpoint: env.Endpoint, Token: env.Token, Source: sourceEnv}, nil
 	}
 
 	creds := credentials{
 		Endpoint: viperx.GetString(config.DataRobotURL),
 		Token:    viperx.GetString(config.DataRobotAPIKey),
+		Source:   sourceConfig,
 	}
 
 	switch {
@@ -145,8 +156,9 @@ func resolveCredentials() (credentials, error) {
 
 // printCredentialError explains on stderr why nothing was exported. stdout is
 // left empty so that `eval "$(dr auth export)"` cannot evaluate a partial or
-// non-executable result.
-func printCredentialError(w io.Writer, err error) {
+// non-executable result. creds carries the credential source so the user can
+// locate a bad value; sh selects a shell-appropriate remediation hint.
+func printCredentialError(w io.Writer, err error, creds credentials, sh internalShell.Shell) {
 	switch {
 	case errors.Is(err, errNoEndpoint):
 		fmt.Fprintln(w, tui.BaseTextStyle.Render("❌ No DataRobot URL configured."))
@@ -159,7 +171,18 @@ func printCredentialError(w io.Writer, err error) {
 		fmt.Fprint(w, tui.InfoStyle.Render(version.CliName+" auth login"))
 		fmt.Fprintln(w, tui.BaseTextStyle.Render(" to authenticate."))
 	default:
-		fmt.Fprintln(w, tui.BaseTextStyle.Render("❌ Invalid DataRobot URL configured: "+err.Error()))
+		fmt.Fprintln(w, tui.BaseTextStyle.Render("❌ Invalid DataRobot URL from "+creds.Source+": "+err.Error()))
+
+		// The most common cause of a quoted DATAROBOT_ENDPOINT is running
+		// `$(dr auth export)` instead of `eval "$(dr auth export)"`: command
+		// substitution bakes the output's single quotes into the value. Hint
+		// at the correct invocation for POSIX shells where that footgun exists.
+		// PowerShell/cmd have their own patterns (see --help) and are handled
+		// in a separate PR.
+		if creds.Source == sourceEnv && (sh == internalShell.Bash || sh == internalShell.Zsh) {
+			fmt.Fprintln(w, tui.BaseTextStyle.Render("If you ran `$(dr auth export)`, use `eval \"$(dr auth export)\"` instead."))
+		}
+
 		fmt.Fprint(w, tui.BaseTextStyle.Render("Run "))
 		fmt.Fprint(w, tui.InfoStyle.Render(version.CliName+" auth set-url"))
 		fmt.Fprintln(w, tui.BaseTextStyle.Render(" to fix it."))
@@ -273,16 +296,19 @@ func RunE(cmd *cobra.Command, _ []string) error {
 
 	creds, err := resolveCredentials()
 	if err != nil {
-		printCredentialError(cmd.ErrOrStderr(), err)
+		printCredentialError(cmd.ErrOrStderr(), err, creds, sh)
 
 		return cli.ErrSilent
 	}
 
 	if outputformat.GetFormat(cmd) == outputformat.OutputFormatJSON {
-		return outputformat.PrintJSONEnvelope(cmd.OutOrStdout(), jsonEnvelopeKey, map[string]string{
-			endpointVar: creds.Endpoint,
-			tokenVar:    creds.Token,
-		})
+		return outputformat.PrintJSONEnvelopeWithMeta(cmd.OutOrStdout(), jsonEnvelopeKey,
+			map[string]string{
+				endpointVar: creds.Endpoint,
+				tokenVar:    creds.Token,
+			},
+			map[string]any{"source": creds.Source},
+		)
 	}
 
 	for _, statement := range renderExports(sh, creds) {

--- a/cmd/auth/export/cmd.go
+++ b/cmd/auth/export/cmd.go
@@ -179,13 +179,23 @@ func printCredentialError(w io.Writer, err error, creds credentials, sh internal
 		// at the correct invocation for POSIX shells where that footgun exists.
 		// PowerShell/cmd have their own patterns (see --help) and are handled
 		// in a separate PR.
-		if creds.Source == sourceEnv && (sh == internalShell.Bash || sh == internalShell.Zsh) {
-			fmt.Fprintln(w, tui.BaseTextStyle.Render("If you ran `$(dr auth export)`, use `eval \"$(dr auth export)\"` instead."))
-		}
+		if creds.Source == sourceEnv {
+			if sh == internalShell.Bash || sh == internalShell.Zsh {
+				fmt.Fprintln(w, tui.BaseTextStyle.Render("If you ran `$(dr auth export)`, use `eval \"$(dr auth export)\"` instead."))
+			}
 
-		fmt.Fprint(w, tui.BaseTextStyle.Render("Run "))
-		fmt.Fprint(w, tui.InfoStyle.Render(version.CliName+" auth set-url"))
-		fmt.Fprintln(w, tui.BaseTextStyle.Render(" to fix it."))
+			// Env vars take precedence over drconfig.yaml, so `dr auth set-url`
+			// cannot self-heal this; the user must unset the poisoned vars.
+			fmt.Fprintln(w, tui.BaseTextStyle.Render("Unset the invalid variable(s) and try again:"))
+			fmt.Fprint(w, tui.InfoStyle.Render("  unset DATAROBOT_ENDPOINT DATAROBOT_API_TOKEN"))
+			fmt.Fprint(w, tui.BaseTextStyle.Render(" (or "))
+			fmt.Fprint(w, tui.InfoStyle.Render("Remove-Item Env:\\DATAROBOT_ENDPOINT, Env:\\DATAROBOT_API_TOKEN"))
+			fmt.Fprintln(w, tui.BaseTextStyle.Render(" on Windows)"))
+		} else {
+			fmt.Fprint(w, tui.BaseTextStyle.Render("Run "))
+			fmt.Fprint(w, tui.InfoStyle.Render(version.CliName+" auth set-url"))
+			fmt.Fprintln(w, tui.BaseTextStyle.Render(" to fix it."))
+		}
 	}
 }
 

--- a/cmd/auth/export/cmd_test.go
+++ b/cmd/auth/export/cmd_test.go
@@ -53,6 +53,8 @@ func TestCanonicalEndpoint(t *testing.T) {
 		{"strips query", "https://app.datarobot.com/api/v2?x=1", "https://app.datarobot.com/api/v2", false},
 		{"whitespace", "  https://app.datarobot.com  ", "https://app.datarobot.com/api/v2", false},
 		{"port preserved", "https://dr.corp.example:8443", "https://dr.corp.example:8443/api/v2", false},
+		{"single-quoted url is rejected", "'https://app.datarobot.com/api/v2'", "", true},
+		{"double-quoted url is rejected", `"https://app.datarobot.com/api/v2"`, "", true},
 		{"empty", "", "", true},
 		{"no host", "https://", "", true},
 	}
@@ -275,6 +277,7 @@ func TestRunE_JSONOutput(t *testing.T) {
 
 	var payload struct {
 		Environment map[string]string `json:"environment"`
+		Source      string            `json:"source"`
 	}
 
 	require.NoError(t, json.Unmarshal(stdout.Bytes(), &payload))
@@ -282,6 +285,60 @@ func TestRunE_JSONOutput(t *testing.T) {
 		"DATAROBOT_ENDPOINT":  "https://app.datarobot.com/api/v2",
 		"DATAROBOT_API_TOKEN": "secret-token",
 	}, payload.Environment)
+	assert.Equal(t, "drconfig.yaml", payload.Source)
+}
+
+func TestRunE_QuotedEnvEndpointFailsWithEvalHint(t *testing.T) {
+	viperx.Reset()
+	clearEnvCredentials(t)
+
+	// Reproduces the real footgun: `$(dr auth export)` (no eval) bakes the
+	// output's single quotes into DATAROBOT_ENDPOINT. The CLI must NOT strip
+	// them; it must fail and point the user at `eval "$(dr auth export)"`.
+	t.Setenv("DATAROBOT_ENDPOINT", "'https://staging.datarobot.com/api/v2'")
+	t.Setenv("DATAROBOT_API_TOKEN", "token")
+
+	defer viperx.Reset()
+
+	var stdout, stderr bytes.Buffer
+
+	cmd := Cmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--shell", "bash"})
+
+	err := cmd.Execute()
+	require.ErrorIs(t, err, cli.ErrSilent)
+	assert.Empty(t, stdout.String())
+	assert.Contains(t, stderr.String(), "DATAROBOT_ENDPOINT environment variable")
+	assert.NotContains(t, stderr.String(), "drconfig.yaml")
+	assert.Contains(t, stderr.String(), `eval "$(dr auth export)"`)
+}
+
+func TestRunE_QuotedConfigEndpointNamesSourceWithoutEvalHint(t *testing.T) {
+	viperx.Reset()
+	clearEnvCredentials(t)
+
+	// A quoted endpoint coming from the config file (not env) still fails and
+	// names drconfig.yaml as the source, but does NOT show the `eval` hint
+	// (that hint is specific to the env `$(...)` misuse).
+	viperx.Set(config.DataRobotURL, "'https://staging.datarobot.com/api/v2'")
+	viperx.Set(config.DataRobotAPIKey, "token")
+
+	defer viperx.Reset()
+
+	var stdout, stderr bytes.Buffer
+
+	cmd := Cmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--shell", "bash"})
+
+	err := cmd.Execute()
+	require.ErrorIs(t, err, cli.ErrSilent)
+	assert.Empty(t, stdout.String())
+	assert.Contains(t, stderr.String(), "drconfig.yaml")
+	assert.NotContains(t, stderr.String(), `eval "$(dr auth export)"`)
 }
 
 func TestRunE_NoCredentialsKeepsStdoutEmpty(t *testing.T) {

--- a/cmd/auth/export/cmd_test.go
+++ b/cmd/auth/export/cmd_test.go
@@ -313,6 +313,8 @@ func TestRunE_QuotedEnvEndpointFailsWithEvalHint(t *testing.T) {
 	assert.Contains(t, stderr.String(), "DATAROBOT_ENDPOINT environment variable")
 	assert.NotContains(t, stderr.String(), "drconfig.yaml")
 	assert.Contains(t, stderr.String(), `eval "$(dr auth export)"`)
+	assert.Contains(t, stderr.String(), "unset DATAROBOT_ENDPOINT")
+	assert.NotContains(t, stderr.String(), "auth set-url")
 }
 
 func TestRunE_QuotedConfigEndpointNamesSourceWithoutEvalHint(t *testing.T) {
@@ -339,6 +341,8 @@ func TestRunE_QuotedConfigEndpointNamesSourceWithoutEvalHint(t *testing.T) {
 	assert.Empty(t, stdout.String())
 	assert.Contains(t, stderr.String(), "drconfig.yaml")
 	assert.NotContains(t, stderr.String(), `eval "$(dr auth export)"`)
+	assert.Contains(t, stderr.String(), "auth set-url")
+	assert.NotContains(t, stderr.String(), "unset DATAROBOT_ENDPOINT")
 }
 
 func TestRunE_NoCredentialsKeepsStdoutEmpty(t *testing.T) {

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -209,9 +209,12 @@ $ dr auth export --output-format json
   "environment": {
     "DATAROBOT_API_TOKEN": "<token>",
     "DATAROBOT_ENDPOINT": "https://app.datarobot.com/api/v2"
-  }
+  },
+  "source": "drconfig.yaml"
 }
 ```
+
+The `source` field names where the credentials were read from: `drconfig.yaml` (the CLI config file) or `DATAROBOT_ENDPOINT environment variable` (when the env pair takes precedence).
 
 **No credentials configured:**
 
@@ -222,6 +225,17 @@ Run dr auth login to authenticate.
 ```
 
 Nothing is written to stdout and the command exits non-zero, so `eval "$(dr auth export)"` cannot evaluate a partial result.
+
+**Malformed endpoint:**
+
+```bash
+$ dr auth export
+❌ Invalid DataRobot URL from DATAROBOT_ENDPOINT environment variable: parse "'https://app.datarobot.com/api/v2'": first path segment in URL cannot contain colon
+If you ran `$(dr auth export)`, use `eval "$(dr auth export)"` instead.
+Run dr auth set-url to fix it.
+```
+
+Surrounding quotes are not stripped from `DATAROBOT_ENDPOINT` — the DataRobot Python and R SDKs read it verbatim, so stripping would let the CLI silently succeed where other SDKs fail. The most common cause is running `$(dr auth export)` instead of `eval "$(dr auth export)"`, which bakes the output's single quotes into the value; the hint is shown for bash/zsh. The same endpoint-vs-token distinction is applied in `dr auth check` and the shared `EnsureAuthenticated` flow.
 
 > [!NOTE]
 > This command never starts a login flow and never calls the API, so it is safe to run from a shell startup file. It does not validate the credentials — run `dr auth check` for that.

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -232,8 +232,11 @@ Nothing is written to stdout and the command exits non-zero, so `eval "$(dr auth
 $ dr auth export
 ❌ Invalid DataRobot URL from DATAROBOT_ENDPOINT environment variable: parse "'https://app.datarobot.com/api/v2'": first path segment in URL cannot contain colon
 If you ran `$(dr auth export)`, use `eval "$(dr auth export)"` instead.
-Run dr auth set-url to fix it.
+Unset the invalid variable(s) and try again:
+  unset DATAROBOT_ENDPOINT DATAROBOT_API_TOKEN (or Remove-Item Env:\DATAROBOT_ENDPOINT, Env:\DATAROBOT_API_TOKEN on Windows)
 ```
+
+When the bad value comes from the environment, the hint recommends `unset` because env vars take precedence over `drconfig.yaml` — `dr auth set-url` only writes the config file and cannot clear poisoned env vars. For a malformed endpoint sourced from `drconfig.yaml`, the error suggests `dr auth set-url` instead.
 
 Surrounding quotes are not stripped from `DATAROBOT_ENDPOINT` — the DataRobot Python and R SDKs read it verbatim, so stripping would let the CLI silently succeed where other SDKs fail. The most common cause is running `$(dr auth export)` instead of `eval "$(dr auth export)"`, which bakes the output's single quotes into the value; the hint is shown for bash/zsh. The same endpoint-vs-token distinction is applied in `dr auth check` and the shared `EnsureAuthenticated` flow.
 

--- a/docs/development/flags.md
+++ b/docs/development/flags.md
@@ -91,6 +91,18 @@ if format == outputformat.OutputFormatJSON {
 
 The envelope format is `{"<key>": <data>}`, which ensures output is always a JSON object (never a bare array). This makes the output forward-compatible for adding metadata, pagination, or warnings without breaking callers.
 
+### PrintJSONEnvelopeWithMeta
+
+When you need top-level metadata siblings alongside the primary data key (for example, a `source` field naming where data came from), use `outputformat.PrintJSONEnvelopeWithMeta`:
+
+```go
+return outputformat.PrintJSONEnvelopeWithMeta(cmd.OutOrStdout(), "items", outputs,
+    map[string]any{"source": "drconfig.yaml"},
+)
+```
+
+This yields `{"items": <data>, "source": "drconfig.yaml"}`. It is otherwise identical to `PrintJSONEnvelope`; a metadata key that collides with the primary data key is not overwritten.
+
 ### JSON output purity
 
 When the effective format is JSON, **stdout must contain only valid JSON**. Anything that would break `dr <cmd> --output-format json | jq .` (or `... 2>&1 | jq .`) is a bug.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -71,6 +71,12 @@ type EnvCredentials struct {
 
 // GetEnvCredentials reads DATAROBOT_ENDPOINT and DATAROBOT_API_TOKEN from environment.
 // Falls back to DATAROBOT_API_ENDPOINT if DATAROBOT_ENDPOINT is not set.
+//
+// Values are returned verbatim; surrounding quotes are NOT stripped. The
+// DataRobot Python and R SDKs read these variables the same way, so stripping
+// here would let the CLI silently succeed where other SDKs fail. Callers that
+// need to report why env credentials failed should use EndpointProblem to
+// distinguish a malformed endpoint from an invalid token.
 func GetEnvCredentials() EnvCredentials {
 	endpoint := os.Getenv("DATAROBOT_ENDPOINT")
 	if endpoint == "" {
@@ -81,6 +87,22 @@ func GetEnvCredentials() EnvCredentials {
 		Endpoint: endpoint,
 		Token:    os.Getenv("DATAROBOT_API_TOKEN"),
 	}
+}
+
+// EndpointProblem returns a non-nil error when endpoint is not a usable
+// DataRobot URL (for example, it is wrapped in literal surrounding quotes that
+// make url.Parse fail). It lets callers distinguish a malformed
+// DATAROBOT_ENDPOINT from an expired/invalid token when reporting why
+// environment credentials failed verification. An empty endpoint returns nil
+// (that case is ErrEnvCredentialsNotSet, handled by the caller).
+func EndpointProblem(endpoint string) error {
+	if endpoint == "" {
+		return nil
+	}
+
+	_, err := config.SchemeHostOnly(endpoint)
+
+	return err
 }
 
 // VerifyEnvCredentials checks if environment variable credentials are valid.
@@ -154,9 +176,15 @@ func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
 
 		skipAuthFlow = true
 	} else if creds.Token != "" {
-		fmt.Println(tui.BaseTextStyle.Render("Your DATAROBOT_API_TOKEN environment variable"))
-		fmt.Println(tui.BaseTextStyle.Render("contains an expired or invalid token. Unset it:"))
-		PrintUnsetTokenInstructions()
+		if epErr := EndpointProblem(creds.Endpoint); epErr != nil {
+			fmt.Println(tui.BaseTextStyle.Render("Your DATAROBOT_ENDPOINT environment variable is invalid:"))
+			fmt.Println(tui.BaseTextStyle.Render(epErr.Error()))
+			fmt.Println(tui.BaseTextStyle.Render("Set it to a valid DataRobot URL and try again."))
+		} else {
+			fmt.Println(tui.BaseTextStyle.Render("Your DATAROBOT_API_TOKEN environment variable"))
+			fmt.Println(tui.BaseTextStyle.Render("contains an expired or invalid token. Unset it:"))
+			PrintUnsetTokenInstructions()
+		}
 
 		skipAuthFlow = true
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -75,7 +75,7 @@ type EnvCredentials struct {
 // Values are returned verbatim; surrounding quotes are NOT stripped. The
 // DataRobot Python and R SDKs read these variables the same way, so stripping
 // here would let the CLI silently succeed where other SDKs fail. Callers that
-// need to report why env credentials failed should use EndpointProblem to
+// need to report why env credentials failed should use ValidateEndpoint to
 // distinguish a malformed endpoint from an invalid token.
 func GetEnvCredentials() EnvCredentials {
 	endpoint := os.Getenv("DATAROBOT_ENDPOINT")
@@ -89,13 +89,13 @@ func GetEnvCredentials() EnvCredentials {
 	}
 }
 
-// EndpointProblem returns a non-nil error when endpoint is not a usable
+// ValidateEndpoint returns a non-nil error when endpoint is not a usable
 // DataRobot URL (for example, it is wrapped in literal surrounding quotes that
 // make url.Parse fail). It lets callers distinguish a malformed
 // DATAROBOT_ENDPOINT from an expired/invalid token when reporting why
 // environment credentials failed verification. An empty endpoint returns nil
 // (that case is ErrEnvCredentialsNotSet, handled by the caller).
-func EndpointProblem(endpoint string) error {
+func ValidateEndpoint(endpoint string) error {
 	if endpoint == "" {
 		return nil
 	}
@@ -176,7 +176,7 @@ func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
 
 		skipAuthFlow = true
 	} else if creds.Token != "" {
-		if epErr := EndpointProblem(creds.Endpoint); epErr != nil {
+		if epErr := ValidateEndpoint(creds.Endpoint); epErr != nil {
 			fmt.Println(tui.BaseTextStyle.Render("Your DATAROBOT_ENDPOINT environment variable is invalid:"))
 			fmt.Println(tui.BaseTextStyle.Render(epErr.Error()))
 			fmt.Println(tui.BaseTextStyle.Render("Set it to a valid DataRobot URL and try again."))

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -336,7 +336,7 @@ func TestGetEnvCredentials(t *testing.T) {
 	})
 }
 
-func TestEndpointProblem(t *testing.T) {
+func TestValidateEndpoint(t *testing.T) {
 	cases := []struct {
 		name     string
 		endpoint string
@@ -352,7 +352,7 @@ func TestEndpointProblem(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			err := EndpointProblem(c.endpoint)
+			err := ValidateEndpoint(c.endpoint)
 			if c.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -321,6 +321,45 @@ func TestGetEnvCredentials(t *testing.T) {
 		assert.Empty(t, creds.Endpoint)
 		assert.Empty(t, creds.Token)
 	})
+
+	t.Run("preserves surrounding quotes verbatim", func(t *testing.T) {
+		// GetEnvCredentials must NOT strip quotes. The DataRobot PySDK and RSDK
+		// read these variables verbatim, so stripping here would let the CLI
+		// silently succeed where other SDKs fail.
+		t.Setenv("DATAROBOT_ENDPOINT", "'https://staging.datarobot.com/api/v2'")
+		t.Setenv("DATAROBOT_API_TOKEN", "'secret-token'")
+
+		creds := GetEnvCredentials()
+
+		assert.Equal(t, "'https://staging.datarobot.com/api/v2'", creds.Endpoint)
+		assert.Equal(t, "'secret-token'", creds.Token)
+	})
+}
+
+func TestEndpointProblem(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		wantErr  bool
+	}{
+		{"empty returns nil", "", false},
+		{"valid url", "https://app.datarobot.com/api/v2", false},
+		{"bare host", "app.datarobot.com", false},
+		{"single quoted", "'https://staging.datarobot.com/api/v2'", true},
+		{"double quoted", `"https://staging.datarobot.com/api/v2"`, true},
+		{"mismatched quotes", `'https://staging.datarobot.com/api/v2"`, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := EndpointProblem(c.endpoint)
+			if c.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestVerifyEnvCredentials(t *testing.T) {

--- a/internal/outputformat/format.go
+++ b/internal/outputformat/format.go
@@ -117,3 +117,23 @@ func PrintJSONEnvelope(w io.Writer, key string, data any) error {
 
 	return enc.Encode(payload)
 }
+
+// PrintJSONEnvelopeWithMeta is like PrintJSONEnvelope but attaches the given
+// top-level metadata siblings alongside the primary data key. For example,
+// passing meta {"source": "drconfig.yaml"} yields
+// {"<key>": <data>, "source": "drconfig.yaml"}. Keys in meta that collide with
+// the primary data key are not overwritten.
+func PrintJSONEnvelopeWithMeta(w io.Writer, key string, data any, meta map[string]any) error {
+	payload := map[string]any{key: data}
+
+	for k, v := range meta {
+		if _, ok := payload[k]; !ok {
+			payload[k] = v
+		}
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	return enc.Encode(payload)
+}


### PR DESCRIPTION
# RATIONALE

`dr auth export` failed with a bare `url.Parse` error when DATAROBOT_ENDPOINT carried literal surrounding quotes.

As a note, since this is a new feature in the CLI:

```sh
╰─ ❯ dr auth export
export DATAROBOT_ENDPOINT='https://staging.datarobot.com/api/v2'
export DATAROBOT_API_TOKEN='[snip]'
```

which means you can now pipe these export statements wherever you need them, .envrc, shell profile, etc. Just to lead, you might think the quotes there are weird. The quotes there are fine -- they are POSIX quotes. Good for if someone does something silly like set `DATAROBOT_ENDPOINT='US Prod'`.

What had happened was: I accidentally ran in a zsh script: `$(dr auth export)`, instead of `eval "$(dr auth export)"`. This bakes the output's single quotes into the env var.

```sh
╰─ ❯ eval "$(dr auth export)"

╰─ ❯ env | grep DATAROBOT    
DATAROBOT_ENDPOINT=https://staging.datarobot.com/api/v2
DATAROBOT_API_TOKEN=[snip]

╰─ ❯ $(dr auth export)

╰─ ❯ env | grep DATAROBOT
DATAROBOT_ENDPOINT='https://staging.datarobot.com/api/v2'
DATAROBOT_API_TOKEN='[snip]'
```

Now that's not good.

## Endpoint parse failures
I also found that some other code (`auth check`, `EnsureAuthenticated`) misattributed the endpoint parse failure to the token. They now name the endpoint instead.

`dr auth check` (with the quoted env from above):

```sh
❌ DATAROBOT_ENDPOINT environment variable is invalid: parse "'https://staging.datarobot.com/api/v2'": first path segment in URL cannot contain colon
Set it to a valid DataRobot URL and try again.
```

`EnsureAuthenticated` (any command that goes through it, e.g. `dr auth set-url`):

```sh
Your DATAROBOT_ENDPOINT environment variable is invalid:
parse "'https://staging.datarobot.com/api/v2'": first path segment in URL cannot contain colon
Unset the invalid variable(s)...
```

## CHANGES

Do NOT strip quotes: the DataRobot PySDK and RSDK read `DATAROBOT_ENDPOINT` verbatim, so stripping would let the CLI silently succeed where other SDKs fail.

Add `auth.ValidateEndpoint` to detect a malformed endpoint and distinguish it from an invalid token. `auth export`, `auth check`, and EnsureAuthenticated now name DATAROBOT_ENDPOINT (and its source: env var vs drconfig.yaml) when the endpoint is the problem, instead of blaming the token.

Updated `dr auth export` to hint at `eval "$(dr auth export)"` for bash/zsh when the bad value came from the environment (the hint keys on source=env + shell=bash/zsh, not on detecting quotes; PowerShell/cmd are out of scope here — see `--help` for their patterns). So, given a bad environment as defined above:

```sh
╰─ ❯ dr auth export
❌ Invalid DataRobot URL from DATAROBOT_ENDPOINT environment variable: parse "'https://staging.datarobot.com/api/v2'": first path segment in URL cannot contain colon
If you ran `$(dr auth export)`, use `eval "$(dr auth export)"` instead.
Run dr auth set-url to fix it.
```

- Track the credential source and surface it in the invalid-URL error and as a `source` field in the `--output-format json` envelope (outputformat.PrintJSONEnvelopeWithMeta).

```
// credentials from the config file:
{
  "environment": {
    "DATAROBOT_API_TOKEN": "NmE2…",
    "DATAROBOT_ENDPOINT": "https://staging.datarobot.com/api/v2"
  },
  "source": "drconfig.yaml"
}

// credentials from the environment:
{
  "environment": {
    "DATAROBOT_API_TOKEN": "NmE2…",
    "DATAROBOT_ENDPOINT": "https://staging.datarobot.com/api/v2"
  },
  "source": "DATAROBOT_ENDPOINT environment variable"
}
```

### JSON output on error

On a malformed endpoint, `--output-format json` emits **no JSON on stdout**; the human-readable error above goes to stderr and the process exits non-zero (stdout stays empty so `eval`/piping can't evaluate a partial result). A machine-readable JSON error envelope is a follow-up, not in this PR.

## Known limitation: env-precedence stuck state

If `$(dr auth export)` poisons both `DATAROBOT_ENDPOINT` and `DATAROBOT_API_TOKEN` with quotes, **every** command going through `EnsureAuthenticated` blocks (env vars, when set, take precedence over the config file and are not silently ignored). `dr auth set-url` cannot self-heal this — it only writes the config file, not the shell environment. Recovery is `unset DATAROBOT_ENDPOINT DATAROBOT_API_TOKEN`. Tracked as CFX-7424 (design follow-up: possibly fall back to config when the env *endpoint* is specifically malformed).

## TESTING

- `task lint` (0 issues), `task test` (all green), lefthook pre-commit passed.
- New tests: `TestValidateEndpoint`; `TestRunE_QuotedEnvEndpointFailsWithEvalHint`; `TestRunE_QuotedConfigEndpointNamesSourceWithoutEvalHint`; `TestCheckCLICredentials_QuotedEndpointNamesEndpointNotToken`; `TestGetEnvCredentials` "preserves surrounding quotes verbatim"; quoted `canonicalEndpoint` cases now expect errors.
- Manual repro: `DATAROBOT_ENDPOINT="'https://staging.datarobot.com/api/v2'" DATAROBOT_API_TOKEN=dummy ./dist/dr auth export --shell bash` fails with the `eval` hint; `dr auth check` (from a non-repo dir) names `DATAROBOT_ENDPOINT`, not the token.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->


<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1785889628.604889 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared authentication and credential resolution paths used by many commands, but changes are mostly diagnostic messaging and stricter URL validation rather than new auth behavior.
> 
> **Overview**
> Fixes misleading auth diagnostics when **`DATAROBOT_ENDPOINT`** contains literal quotes (often from running **`$(dr auth export)`** instead of **`eval "$(dr auth export)"`**). The CLI **does not strip** surrounding quotes so behavior stays aligned with the Python and R SDKs.
> 
> Adds **`auth.EndpointProblem`** so **`dr auth export`**, **`dr auth check`**, and **`EnsureAuthenticated`** can blame a bad endpoint instead of an invalid token. Export errors now include **where credentials came from** (env vs **`drconfig.yaml`**), bash/zsh get an **`eval`** hint when the bad value is from the environment, and **`--output-format json`** adds a top-level **`source`** field via **`PrintJSONEnvelopeWithMeta`**. Quoted URLs are rejected during endpoint normalization rather than silently fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86cb4941afd7a2239aa31dc69b0e6e799c424ab9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
