### PR TITLE
[RAPTOR-18983][RAPTOR-18974] refactor(workload): move state under .datarobot and port up internals

### DIFF
--- a/cmd/artifact/build/cmd.go
+++ b/cmd/artifact/build/cmd.go
@@ -31,7 +31,7 @@ artifacts.
 
 When run inside a directory linked via 'dr artifact code init', the
 <artifact-id> argument may be omitted on every subcommand and is read from
-.wapi/config.json.`,
+.datarobot/wapi/config.json.`,
 	}
 
 	cmd.AddCommand(

--- a/cmd/artifact/build/cmd.go
+++ b/cmd/artifact/build/cmd.go
@@ -31,7 +31,7 @@ artifacts.
 
 When run inside a directory linked via 'dr artifact code init', the
 <artifact-id> argument may be omitted on every subcommand and is read from
-.datarobot/wapi/config.json.`,
+.datarobot/workload/config.json.`,
 	}
 
 	cmd.AddCommand(

--- a/cmd/artifact/build/create/cmd.go
+++ b/cmd/artifact/build/create/cmd.go
@@ -38,7 +38,7 @@ func Cmd() *cobra.Command {
 		Long: `Trigger a new container image build for an artifact.
 
 The artifact-id argument is optional when run inside a directory linked
-via 'dr artifact code init': the id is read from .wapi/config.json.
+via 'dr artifact code init': the id is read from .datarobot/wapi/config.json.
 
 By default the command prints the new build IDs (one per line) and
 exits. With --wait it polls each build until it reaches a terminal

--- a/cmd/artifact/build/create/cmd.go
+++ b/cmd/artifact/build/create/cmd.go
@@ -38,7 +38,7 @@ func Cmd() *cobra.Command {
 		Long: `Trigger a new container image build for an artifact.
 
 The artifact-id argument is optional when run inside a directory linked
-via 'dr artifact code init': the id is read from .datarobot/wapi/config.json.
+via 'dr artifact code init': the id is read from .datarobot/workload/config.json.
 
 By default the command prints the new build IDs (one per line) and
 exits. With --wait it polls each build until it reaches a terminal

--- a/cmd/artifact/build/get/cmd.go
+++ b/cmd/artifact/build/get/cmd.go
@@ -37,7 +37,7 @@ func Cmd() *cobra.Command {
 		Long: `Get a build by id.
 
 When invoked with one positional argument the artifact-id is read from
-.wapi/config.json in the current directory. When invoked with two, the
+.datarobot/wapi/config.json in the current directory. When invoked with two, the
 first argument is the artifact-id and the second is the build-id.
 
 With --wait the command polls the build until it reaches a terminal
@@ -46,7 +46,7 @@ of the raw Build object. If the build is already terminal, --wait
 returns immediately.
 
 Examples:
-  dr artifact build get b-xyz-456                # uses .wapi/ artifact id
+  dr artifact build get b-xyz-456                # uses the linked artifact id
   dr artifact build get art-abc-123 b-xyz-456
   dr artifact build get art-abc-123 b-xyz-456 --wait
   dr artifact build get art-abc-123 b-xyz-456 --output-format json`,

--- a/cmd/artifact/build/get/cmd.go
+++ b/cmd/artifact/build/get/cmd.go
@@ -37,7 +37,7 @@ func Cmd() *cobra.Command {
 		Long: `Get a build by id.
 
 When invoked with one positional argument the artifact-id is read from
-.datarobot/wapi/config.json in the current directory. When invoked with two, the
+.datarobot/workload/config.json in the current directory. When invoked with two, the
 first argument is the artifact-id and the second is the build-id.
 
 With --wait the command polls the build until it reaches a terminal

--- a/cmd/artifact/build/internal/buildargs/buildargs.go
+++ b/cmd/artifact/build/internal/buildargs/buildargs.go
@@ -14,9 +14,9 @@
 
 // Package buildargs centralizes the positional argument shape shared by
 // `dr artifact build get` and `dr artifact build logs`. Both accept either
-// one positional (build-id, with the artifact-id read from .wapi/config.json)
-// or two positionals (artifact-id, build-id). Keeping the dispatch in one
-// place prevents the two leaves from drifting.
+// one positional (build-id, with the artifact-id read from the linked
+// project's config.json) or two positionals (artifact-id, build-id). Keeping
+// the dispatch in one place prevents the two leaves from drifting.
 
 package buildargs
 
@@ -29,10 +29,10 @@ import (
 // ResolveOptional maps cobra args to a single artifactID for commands that
 // accept an optional artifact-id (0 or 1 positional).
 //
-//   - 0 args -> artifact-id is read from .wapi.
-//   - 1 arg  -> args[0]=artifact-id (overrides .wapi).
+//   - 0 args -> artifact-id is read from the linked project.
+//   - 1 arg  -> args[0]=artifact-id (overrides the linked project).
 //
-// Returns an error if .wapi is required but missing.
+// Returns an error if the linked project is required but missing.
 func ResolveOptional(args []string) (string, error) {
 	explicit := ""
 	if len(args) == 1 {
@@ -46,11 +46,12 @@ func ResolveOptional(args []string) (string, error) {
 
 // ResolvePositional maps cobra args to (artifactID, buildID).
 //
-//   - 1 arg  -> arg is the build-id; artifact-id is read from .wapi.
-//   - 2 args -> args[0]=artifact-id, args[1]=build-id (overrides .wapi).
+//   - 1 arg  -> arg is the build-id; artifact-id is read from the linked project.
+//   - 2 args -> args[0]=artifact-id, args[1]=build-id (overrides the linked
+//     project).
 //
-// Returns an error if the wrong arity is given or .wapi is required but
-// missing.
+// Returns an error if the wrong arity is given or the linked project is
+// required but missing.
 func ResolvePositional(args []string) (string, string, error) {
 	switch len(args) {
 	case 1:

--- a/cmd/artifact/build/internal/buildargs/buildargs_test.go
+++ b/cmd/artifact/build/internal/buildargs/buildargs_test.go
@@ -38,7 +38,7 @@ func TestResolvePositional_OneArgNoWAPIFails(t *testing.T) {
 
 	_, _, err := ResolvePositional([]string{"b-1"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no .wapi project")
+	assert.Contains(t, err.Error(), "no linked project")
 }
 
 func TestResolvePositional_WrongArity(t *testing.T) {
@@ -64,5 +64,5 @@ func TestResolveOptional_NoArgsNoWAPIFails(t *testing.T) {
 
 	_, err := ResolveOptional([]string{})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no .wapi project")
+	assert.Contains(t, err.Error(), "no linked project")
 }

--- a/cmd/artifact/build/logs/cmd.go
+++ b/cmd/artifact/build/logs/cmd.go
@@ -46,7 +46,7 @@ func Cmd() *cobra.Command {
 		Long: `Fetch the structured log stream for a build.
 
 When invoked with one positional argument the artifact-id is read from
-.wapi/config.json in the current directory. When invoked with two, the
+.datarobot/wapi/config.json in the current directory. When invoked with two, the
 first argument is the artifact-id and the second is the build-id.
 
 The server emits one structured JSON record per line; the default

--- a/cmd/artifact/build/logs/cmd.go
+++ b/cmd/artifact/build/logs/cmd.go
@@ -46,7 +46,7 @@ func Cmd() *cobra.Command {
 		Long: `Fetch the structured log stream for a build.
 
 When invoked with one positional argument the artifact-id is read from
-.datarobot/wapi/config.json in the current directory. When invoked with two, the
+.datarobot/workload/config.json in the current directory. When invoked with two, the
 first argument is the artifact-id and the second is the build-id.
 
 The server emits one structured JSON record per line; the default

--- a/cmd/artifact/code/checkout/checkout.go
+++ b/cmd/artifact/code/checkout/checkout.go
@@ -200,7 +200,7 @@ type preflightResult struct {
 func preflight(dir, verArg string, deps Deps) (preflightResult, error) {
 	cfg, err := wapi.LoadConfig(dir)
 	if err != nil {
-		return preflightResult{}, fmt.Errorf("read .wapi/config.json: %w", err)
+		return preflightResult{}, fmt.Errorf("read %s: %w", wapi.ConfigPath(dir), err)
 	}
 
 	if cfg.CatalogID == nil || *cfg.CatalogID == "" {
@@ -225,7 +225,7 @@ func preflight(dir, verArg string, deps Deps) (preflightResult, error) {
 
 func prepareCheckoutsParent(parent string, totalSize int64) error {
 	if err := os.MkdirAll(parent, checkoutDirPerm); err != nil {
-		return fmt.Errorf("create .wapi/.checkouts dir: %w", err)
+		return fmt.Errorf("create checkouts dir %s: %w", parent, err)
 	}
 
 	if err := sync.EnsureSpaceFor(parent, totalSize); err != nil {

--- a/cmd/artifact/code/checkout/cmd.go
+++ b/cmd/artifact/code/checkout/cmd.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/datarobot/cli/cmd/artifact/code/internal/dirprompt"
+	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi/filesapi"
@@ -64,8 +65,10 @@ func cmdWithDeps(deps Deps) *cobra.Command {
 		SilenceUsage: true,
 		Args:         cobra.MaximumNArgs(1),
 		Long: `Download a specific catalog version into
-'.datarobot/wapi/.checkouts/<version-id>/' for read-only inspection. The
-working directory and the sync state are never modified.
+'.datarobot/workload/.checkouts/<version-id>/' for read-only inspection. Your
+working directory is never touched, and neither is the record of what the
+project is linked to or last synced. The snapshot and a history entry are
+written under the state directory.
 
 The version argument may be a full version ID or any unique prefix.
 If omitted (and --yes is not set), you will be prompted.
@@ -112,7 +115,7 @@ func runCheckout(cmd *cobra.Command, args []string, outputFormat outputformat.Ou
 		return err
 	}
 
-	wapi.EnsureMigrated(dir)
+	format.StateNotice(cmd.ErrOrStderr(), wapi.EnsureMigrated(dir))
 
 	if !wapi.Exists(dir) {
 		return errors.New("not linked to an artifact. Run 'dr artifact code init <id>' first")

--- a/cmd/artifact/code/checkout/cmd.go
+++ b/cmd/artifact/code/checkout/cmd.go
@@ -63,9 +63,9 @@ func cmdWithDeps(deps Deps) *cobra.Command {
 		Short:        "Download a version snapshot for read-only inspection.",
 		SilenceUsage: true,
 		Args:         cobra.MaximumNArgs(1),
-		Long: `Download a specific catalog version into '.wapi/.checkouts/<version-id>/'
-for read-only inspection. The working directory and '.wapi/' sync state
-are never modified.
+		Long: `Download a specific catalog version into
+'.datarobot/wapi/.checkouts/<version-id>/' for read-only inspection. The
+working directory and the sync state are never modified.
 
 The version argument may be a full version ID or any unique prefix.
 If omitted (and --yes is not set), you will be prompted.
@@ -111,6 +111,8 @@ func runCheckout(cmd *cobra.Command, args []string, outputFormat outputformat.Ou
 	if err != nil {
 		return err
 	}
+
+	wapi.EnsureMigrated(dir)
 
 	if !wapi.Exists(dir) {
 		return errors.New("not linked to an artifact. Run 'dr artifact code init <id>' first")

--- a/cmd/artifact/code/checkout/cmd_test.go
+++ b/cmd/artifact/code/checkout/cmd_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	gosync "sync"
 	"testing"
@@ -183,6 +184,25 @@ func TestCheckout_NotLinked(t *testing.T) {
 	assert.Contains(t, err.Error(), "not linked")
 }
 
+// The state directory moving out from under a project is the sort of thing a
+// user notices, so the migration is not allowed to happen behind their back.
+// This pins the wiring from the command through to stderr; the wording itself
+// is the wapi package's business.
+func TestCheckout_ReportsStateMigration(t *testing.T) {
+	dir := t.TempDir()
+	legacy := filepath.Join(dir, wapi.LegacyDirName)
+
+	require.NoError(t, os.Mkdir(legacy, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(legacy, "config.json"), []byte(`{"artifactId":"art-abc-123"}`), 0o600))
+
+	cmd, buf := newTestCmd(t, dir, Deps{}, []string{"abcdef12"})
+	_ = cmd.Execute()
+
+	assert.Contains(t, buf.String(), wapi.LegacyDirName)
+	assert.Contains(t, buf.String(), path.Join(wapi.RootDirName, wapi.StateDirName))
+	assert.NoDirExists(t, legacy, "and the move actually happened")
+}
+
 func TestCheckout_NoCatalog(t *testing.T) {
 	cmd, _ := newTestCmd(t, initLinkedDir(t, ""), Deps{}, []string{"abcdef12"})
 	err := cmd.Execute()
@@ -210,7 +230,7 @@ func TestCheckout_HappyPath_FullID(t *testing.T) {
 
 	out := buf.String()
 	assert.Contains(t, out, "Downloading version "+verA)
-	assert.Contains(t, out, "Checked out to: "+filepath.Join(".datarobot", "wapi", ".checkouts", verA))
+	assert.Contains(t, out, "Checked out to: "+filepath.Join(wapi.RootDirName, wapi.StateDirName, ".checkouts", verA))
 	assert.Contains(t, out, "read-only snapshot")
 
 	checkoutDir := wapi.CheckoutDir(dir, verA)

--- a/cmd/artifact/code/checkout/cmd_test.go
+++ b/cmd/artifact/code/checkout/cmd_test.go
@@ -210,7 +210,7 @@ func TestCheckout_HappyPath_FullID(t *testing.T) {
 
 	out := buf.String()
 	assert.Contains(t, out, "Downloading version "+verA)
-	assert.Contains(t, out, "Checked out to: "+filepath.Join(".wapi", ".checkouts", verA))
+	assert.Contains(t, out, "Checked out to: "+filepath.Join(".datarobot", "wapi", ".checkouts", verA))
 	assert.Contains(t, out, "read-only snapshot")
 
 	checkoutDir := wapi.CheckoutDir(dir, verA)
@@ -226,7 +226,7 @@ func TestCheckout_HappyPath_FullID(t *testing.T) {
 	assert.Equal(t, verA, meta.VersionID)
 	assert.Equal(t, 2, meta.FileCount)
 
-	historyData, err := os.ReadFile(filepath.Join(dir, ".wapi", "history.log"))
+	historyData, err := os.ReadFile(filepath.Join(wapi.Dir(dir), "history.log"))
 	require.NoError(t, err)
 
 	lines := bytes.Split(bytes.TrimRight(historyData, "\n"), []byte("\n"))

--- a/cmd/artifact/code/cmd.go
+++ b/cmd/artifact/code/cmd.go
@@ -29,19 +29,19 @@ func Cmd() *cobra.Command {
 		Long: `Manage the local-to-remote synchronization of code for an existing
 DataRobot artifact.
 
-These commands maintain a '.wapi/' state directory at the project root
-that tracks which artifact, catalog, and version a directory is bound
-to. The model is conceptually similar to '.git/' — local work happens
-in the project root, while '.wapi/' captures the remote binding and
-last-synced state used to detect drift on each operation.
+These commands maintain a '.datarobot/wapi/' state directory at the
+project root that tracks which artifact, catalog, and version a directory
+is bound to. The model is conceptually similar to '.git/' — local work
+happens in the project root, while '.datarobot/wapi/' captures the remote
+binding and last-synced state used to detect drift on each operation.
 
 Subcommands:
   init       Link a directory to an existing artifact and lay down the
-             '.wapi/' state. Required before any other 'code' command.
+             state directory. Required before any other 'code' command.
   sync       Push local edits and pull remote changes.
   versions   List catalog versions for the linked artifact.
-  checkout   Download a prior version into '.wapi/.checkouts/' for
-             read-only inspection.
+  checkout   Download a prior version into
+             '.datarobot/wapi/.checkouts/' for read-only inspection.
 
 Artifacts must already exist before running 'init'. Create them via
 'dr artifact create' or in the DataRobot UI — these commands

--- a/cmd/artifact/code/cmd.go
+++ b/cmd/artifact/code/cmd.go
@@ -29,10 +29,10 @@ func Cmd() *cobra.Command {
 		Long: `Manage the local-to-remote synchronization of code for an existing
 DataRobot artifact.
 
-These commands maintain a '.datarobot/wapi/' state directory at the
+These commands maintain a '.datarobot/workload/' state directory at the
 project root that tracks which artifact, catalog, and version a directory
 is bound to. The model is conceptually similar to '.git/' — local work
-happens in the project root, while '.datarobot/wapi/' captures the remote
+happens in the project root, while '.datarobot/workload/' captures the remote
 binding and last-synced state used to detect drift on each operation.
 
 Subcommands:
@@ -41,7 +41,7 @@ Subcommands:
   sync       Push local edits and pull remote changes.
   versions   List catalog versions for the linked artifact.
   checkout   Download a prior version into
-             '.datarobot/wapi/.checkouts/' for read-only inspection.
+             '.datarobot/workload/.checkouts/' for read-only inspection.
 
 Artifacts must already exist before running 'init'. Create them via
 'dr artifact create' or in the DataRobot UI — these commands

--- a/cmd/artifact/code/codesync/cmd.go
+++ b/cmd/artifact/code/codesync/cmd.go
@@ -24,6 +24,7 @@ import (
 	"io"
 
 	"github.com/datarobot/cli/cmd/artifact/code/internal/dirprompt"
+	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
@@ -45,6 +46,7 @@ type engineRunner interface {
 	Execute(*sync.SyncPlan) (*sync.Result, error)
 	Close() error
 	StaleRollbackRestored() bool
+	StateMigrationNotice() string
 	Fetcher() display.ContentFetcher
 }
 
@@ -184,6 +186,8 @@ func runSync(cmd *cobra.Command, outputFormat outputformat.OutputFormat, deps De
 	if err != nil {
 		return err
 	}
+
+	format.StateNotice(cmd.ErrOrStderr(), engine.StateMigrationNotice())
 
 	if engine.StaleRollbackRestored() {
 		fmt.Fprintln(cmd.ErrOrStderr(), tui.DimStyle.Render("Recovered from interrupted sync. Working tree restored."))

--- a/cmd/artifact/code/codesync/cmd_test.go
+++ b/cmd/artifact/code/codesync/cmd_test.go
@@ -33,13 +33,14 @@ import (
 // flag to assert the cmd's branch decisions (dry-run, diff, conflict
 // prompt, JSON output).
 type fakeEngine struct {
-	plan       *sync.SyncPlan
-	planErr    error
-	result     *sync.Result
-	executeErr error
-	stale      bool
-	fetcher    display.ContentFetcher
-	closeErr   error
+	plan          *sync.SyncPlan
+	planErr       error
+	result        *sync.Result
+	executeErr    error
+	stale         bool
+	migrationNote string
+	fetcher       display.ContentFetcher
+	closeErr      error
 
 	executed bool
 	closed   bool
@@ -60,6 +61,8 @@ func (f *fakeEngine) Close() error {
 }
 
 func (f *fakeEngine) StaleRollbackRestored() bool { return f.stale }
+
+func (f *fakeEngine) StateMigrationNotice() string { return f.migrationNote }
 
 func (f *fakeEngine) Fetcher() display.ContentFetcher { return f.fetcher }
 

--- a/cmd/artifact/code/codesync/cmd_test.go
+++ b/cmd/artifact/code/codesync/cmd_test.go
@@ -91,7 +91,7 @@ func stubReader(lines ...string) func() (string, error) {
 	}
 }
 
-// linkProject seeds a minimal .wapi/ directory so the cmd's
+// linkProject seeds a minimal state directory so the cmd's
 // "not linked" preflight passes.
 func linkProject(t *testing.T, dir string) {
 	t.Helper()
@@ -126,8 +126,8 @@ func runWithDeps(t *testing.T, deps Deps, flags map[string]string, extraArgs ...
 }
 
 // TestCmd_NotLinked confirms the command refuses to run when the
-// target directory has no .wapi/, with the expected hint pointing at
-// `code init`.
+// target directory has no state directory, with the expected hint pointing
+// at `code init`.
 func TestCmd_NotLinked(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/artifact/code/init/cmd.go
+++ b/cmd/artifact/code/init/cmd.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/datarobot/cli/cmd/artifact/code/internal/dirprompt"
+	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
@@ -43,7 +44,7 @@ func Cmd() *cobra.Command {
 		Long: `Link a local project directory to an existing DataRobot
 artifact in your deployment infrastructure.
 
-This command creates a '.datarobot/wapi/' state directory at the project
+This command creates a '.datarobot/workload/' state directory at the project
 root and records which artifact, catalog, and version the directory is
 bound to. Subsequent 'sync' invocations use this state to push local edits
 and pull remote changes.
@@ -102,7 +103,7 @@ func runInit(cmd *cobra.Command, args []string, outputFormat outputformat.Output
 		return err
 	}
 
-	wapi.EnsureMigrated(dir)
+	format.StateNotice(cmd.ErrOrStderr(), wapi.EnsureMigrated(dir))
 
 	if wapi.Exists(dir) {
 		return reportAlreadyLinked(dir)

--- a/cmd/artifact/code/init/cmd.go
+++ b/cmd/artifact/code/init/cmd.go
@@ -43,10 +43,10 @@ func Cmd() *cobra.Command {
 		Long: `Link a local project directory to an existing DataRobot
 artifact in your deployment infrastructure.
 
-This command creates a '.wapi/' state directory at the project root and
-records which artifact, catalog, and version the directory is bound to.
-Subsequent 'sync' invocations use this state to push local edits and
-pull remote changes.
+This command creates a '.datarobot/wapi/' state directory at the project
+root and records which artifact, catalog, and version the directory is
+bound to. Subsequent 'sync' invocations use this state to push local edits
+and pull remote changes.
 
 The artifact must already exist before running 'init'. Create it via
 'dr artifact create' or in the DataRobot UI.
@@ -101,6 +101,8 @@ func runInit(cmd *cobra.Command, args []string, outputFormat outputformat.Output
 	if err != nil {
 		return err
 	}
+
+	wapi.EnsureMigrated(dir)
 
 	if wapi.Exists(dir) {
 		return reportAlreadyLinked(dir)

--- a/cmd/artifact/code/init/cmd_test.go
+++ b/cmd/artifact/code/init/cmd_test.go
@@ -114,7 +114,7 @@ func TestRunE_ExistingCodeArtifact_EndToEnd(t *testing.T) {
 	assert.Equal(t, wapi.ManifestVersion, manifest.Version)
 	assert.Empty(t, manifest.Files)
 
-	historyData, err := os.ReadFile(filepath.Join(tmp, wapi.DirName, wapi.HistoryFile))
+	historyData, err := os.ReadFile(filepath.Join(wapi.Dir(tmp), wapi.HistoryFile))
 	require.NoError(t, err)
 
 	lines := strings.Split(strings.TrimSpace(string(historyData)), "\n")
@@ -163,7 +163,7 @@ func TestRunE_LockedArtifact(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "artifact is locked")
 
-	assert.False(t, wapi.Exists(tmp), ".wapi/ must not be created when artifact is locked")
+	assert.False(t, wapi.Exists(tmp), "state dir must not be created when artifact is locked")
 }
 
 func TestRunE_NotFound(t *testing.T) {
@@ -309,7 +309,7 @@ func TestRunE_NonInteractiveEnvVar(t *testing.T) {
 	cmd := newTestCmd(t, tmp, false, []string{"art-empty-001"})
 
 	require.NoError(t, cmd.Execute())
-	assert.True(t, wapi.Exists(tmp), ".wapi/ must be created in non-interactive mode via env var")
+	assert.True(t, wapi.Exists(tmp), "state dir must be created in non-interactive mode via env var")
 }
 
 // TestCmd_DoesNotClobberGlobalYesViper guards against re-introducing the

--- a/cmd/artifact/code/init/display.go
+++ b/cmd/artifact/code/init/display.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/datarobot/cli/tui"
 )
 
@@ -86,10 +87,12 @@ func printLinkedEmptyArtifact(name, artifactID string) {
 }
 
 func printAlreadyLinked(artifactID, dir string) {
+	stateDir := wapi.Dir(dir)
+
 	fmt.Println(tui.ErrorStyle.Render(
-		fmt.Sprintf("Already linked to artifact %s; .wapi/ exists at %s.", artifactID, dir),
+		fmt.Sprintf("Already linked to artifact %s; state exists at %s.", artifactID, stateDir),
 	))
-	fmt.Println(tui.DimStyle.Render("Delete .wapi/ to re-init."))
+	fmt.Println(tui.DimStyle.Render(fmt.Sprintf("Delete %s to re-init.", stateDir)))
 }
 
 func shortVer(s string) string {

--- a/cmd/artifact/code/init/display_test.go
+++ b/cmd/artifact/code/init/display_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -69,8 +70,8 @@ func TestPrintAlreadyLinked_IncludesPath(t *testing.T) {
 		printAlreadyLinked("art-abc-123", "/tmp/proj")
 	})
 
-	assert.Contains(t, out, "Already linked to artifact art-abc-123; .wapi/ exists at /tmp/proj.")
-	assert.Contains(t, out, "Delete .wapi/ to re-init.")
+	assert.Contains(t, out, "Already linked to artifact art-abc-123; state exists at "+wapi.Dir("/tmp/proj")+".")
+	assert.Contains(t, out, "Delete "+wapi.Dir("/tmp/proj")+" to re-init.")
 }
 
 func TestRenderInitResult_TextWithCodeRef(t *testing.T) {

--- a/cmd/artifact/code/internal/format/format.go
+++ b/cmd/artifact/code/internal/format/format.go
@@ -15,7 +15,24 @@
 // Package format provides display helpers shared across workload-code commands.
 package format
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+
+	"github.com/datarobot/cli/tui"
+)
+
+// StateNotice prints an incidental note about the state directory to w, dimmed
+// like the other housekeeping chatter. An empty notice prints nothing, so a
+// caller can pass wapi.EnsureMigrated's result straight through. Send it to
+// stderr: it is never part of a command's data output.
+func StateNotice(w io.Writer, notice string) {
+	if notice == "" {
+		return
+	}
+
+	fmt.Fprintln(w, tui.DimStyle.Render(notice))
+}
 
 // Bytes renders n in base-1024 units, capping at PB to avoid suffix overflow.
 func Bytes(n int64) string {

--- a/cmd/artifact/code/internal/format/format_test.go
+++ b/cmd/artifact/code/internal/format/format_test.go
@@ -15,6 +15,7 @@
 package format
 
 import (
+	"bytes"
 	"math"
 	"strings"
 	"testing"
@@ -59,4 +60,22 @@ func TestBytes_NoPanicAtExtreme(t *testing.T) {
 
 	got = Bytes(math.MaxInt64)
 	assert.True(t, strings.HasSuffix(got, " PB"), "expected PB suffix at MaxInt64, got %q", got)
+}
+
+// An empty notice must print nothing at all, not a blank line: callers pass
+// wapi.EnsureMigrated's result straight through on every command, and the
+// common case is that there was nothing to migrate.
+func TestStateNotice(t *testing.T) {
+	t.Parallel()
+
+	var quiet bytes.Buffer
+
+	StateNotice(&quiet, "")
+	assert.Empty(t, quiet.String())
+
+	var loud bytes.Buffer
+
+	StateNotice(&loud, "Moved local state.")
+	assert.Contains(t, loud.String(), "Moved local state.")
+	assert.True(t, strings.HasSuffix(loud.String(), "\n"), "the notice is one line, terminated")
 }

--- a/cmd/artifact/code/versions/cmd.go
+++ b/cmd/artifact/code/versions/cmd.go
@@ -62,8 +62,8 @@ func cmdWithDeps(deps Deps) *cobra.Command {
 project directory is linked to.
 
 The output marks the version that the artifact's codeRef currently
-points to with '*', and reports which version the local '.wapi/'
-state was last synced to.
+points to with '*', and reports which version the local
+'.datarobot/wapi/' state was last synced to.
 
 By default output is a human-readable table; use --output-format json
 for machine-parseable output.
@@ -108,7 +108,14 @@ func runVersions(cmd *cobra.Command, outputFormat outputformat.OutputFormat, dep
 		return fmt.Errorf("invalid --limit %d: must be positive", limit)
 	}
 
-	cfg, err := loadProjectConfig(dirFlag)
+	absDir, err := resolveProjectDir(dirFlag)
+	if err != nil {
+		return err
+	}
+
+	wapi.EnsureMigrated(absDir)
+
+	cfg, err := loadProjectConfig(absDir)
 	if err != nil {
 		return err
 	}
@@ -121,7 +128,7 @@ func runVersions(cmd *cobra.Command, outputFormat outputformat.OutputFormat, dep
 	return render(cmd.OutOrStdout(), outputFormat, v)
 }
 
-func loadProjectConfig(dirFlag string) (wapi.Config, error) {
+func resolveProjectDir(dirFlag string) (string, error) {
 	dir := dirFlag
 	if dir == "" {
 		dir = "."
@@ -129,16 +136,20 @@ func loadProjectConfig(dirFlag string) (wapi.Config, error) {
 
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
-		return wapi.Config{}, fmt.Errorf("resolve dir %s: %w", dir, err)
+		return "", fmt.Errorf("resolve dir %s: %w", dir, err)
 	}
 
+	return absDir, nil
+}
+
+func loadProjectConfig(absDir string) (wapi.Config, error) {
 	if !wapi.Exists(absDir) {
 		return wapi.Config{}, errors.New("not linked to an artifact. Run 'dr artifact code init <id>' first")
 	}
 
 	cfg, err := wapi.LoadConfig(absDir)
 	if err != nil {
-		return wapi.Config{}, fmt.Errorf("read .wapi/config.json: %w", err)
+		return wapi.Config{}, fmt.Errorf("read %s: %w", wapi.ConfigPath(absDir), err)
 	}
 
 	if cfg.CatalogID == nil || *cfg.CatalogID == "" {

--- a/cmd/artifact/code/versions/cmd.go
+++ b/cmd/artifact/code/versions/cmd.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"path/filepath"
 
+	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/drapi/filesapi"
@@ -63,7 +64,7 @@ project directory is linked to.
 
 The output marks the version that the artifact's codeRef currently
 points to with '*', and reports which version the local
-'.datarobot/wapi/' state was last synced to.
+'.datarobot/workload/' state was last synced to.
 
 By default output is a human-readable table; use --output-format json
 for machine-parseable output.
@@ -113,7 +114,7 @@ func runVersions(cmd *cobra.Command, outputFormat outputformat.OutputFormat, dep
 		return err
 	}
 
-	wapi.EnsureMigrated(absDir)
+	format.StateNotice(cmd.ErrOrStderr(), wapi.EnsureMigrated(absDir))
 
 	cfg, err := loadProjectConfig(absDir)
 	if err != nil {

--- a/cmd/artifact/code/versions/cmd_test.go
+++ b/cmd/artifact/code/versions/cmd_test.go
@@ -163,7 +163,7 @@ func TestVersions_NotLinked(t *testing.T) {
 }
 
 func TestVersions_NoCatalog(t *testing.T) {
-	// init creates .wapi/ with no catalogId set.
+	// init creates the state dir with no catalogId set.
 	dir := t.TempDir()
 	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{ArtifactID: "art-abc-123"}))
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -370,7 +370,7 @@ For detailed documentation on each command, see:
 - **[artifact](artifact.md)**&mdash;build and manage the container artifacts that back workloads (feature-gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`).
   - `create` / `get` / `list` / `lock` / `delete`&mdash;the draft-to-locked artifact lifecycle.
   - `build`&mdash;`create` / `get` / `list` / `logs` for container image builds.
-  - `code`&mdash;`init` / `sync` / `versions` / `checkout` to sync local code with an artifact via a `.wapi/` state directory.
+  - `code`&mdash;`init` / `sync` / `versions` / `checkout` to sync local code with an artifact via a `.datarobot/wapi/` state directory.
 
 - **[workload](workload.md)**&mdash;deploy and operate workloads created from artifacts (alias `wl`; feature-gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`).
   - `create` / `get` / `list` / `delete`&mdash;the workload lifecycle.

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -370,7 +370,7 @@ For detailed documentation on each command, see:
 - **[artifact](artifact.md)**&mdash;build and manage the container artifacts that back workloads (feature-gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`).
   - `create` / `get` / `list` / `lock` / `delete`&mdash;the draft-to-locked artifact lifecycle.
   - `build`&mdash;`create` / `get` / `list` / `logs` for container image builds.
-  - `code`&mdash;`init` / `sync` / `versions` / `checkout` to sync local code with an artifact via a `.datarobot/wapi/` state directory.
+  - `code`&mdash;`init` / `sync` / `versions` / `checkout` to sync local code with an artifact via a `.datarobot/workload/` state directory.
 
 - **[workload](workload.md)**&mdash;deploy and operate workloads created from artifacts (alias `wl`; feature-gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`).
   - `create` / `get` / `list` / `delete`&mdash;the workload lifecycle.

--- a/docs/commands/artifact.md
+++ b/docs/commands/artifact.md
@@ -21,7 +21,7 @@ Each container in the spec is one of two kinds:
 - **Prebuilt**: set `imageUri` to an existing image. There is nothing to build.
 - **Built from source**: set `imageBuildConfig`, push your code with `dr artifact code sync`, and produce an image with `dr artifact build create`. The Dockerfile is either one you provide (`./Dockerfile`) or one the server generates from a base environment.
 
-The `code` subcommands keep a local directory in sync with an artifact's source. They store a `.wapi/` state directory at the project root, much like `.git/`: local work happens in the project root while `.wapi/` records the remote binding and last-synced state. Once a directory is linked with `dr artifact code init`, the `build` and `code` subcommands read the artifact id from `.wapi/config.json`, so you can leave it off.
+The `code` subcommands keep a local directory in sync with an artifact's source. They store a `.datarobot/wapi/` state directory at the project root, much like `.git/`: local work happens in the project root while `.datarobot/wapi/` records the remote binding and last-synced state. Once a directory is linked with `dr artifact code init`, the `build` and `code` subcommands read the artifact id from `.datarobot/wapi/config.json`, so you can leave it off. A project linked by an older CLI keeps its state in a root `.wapi/`; the next command that touches state relocates it.
 
 A locked, fully built artifact is what you hand to `dr workload create` to deploy. See [`dr workload`](workload.md).
 
@@ -149,7 +149,7 @@ dr artifact delete <artifact-id> [--yes]
 
 ### `build`
 
-Trigger and inspect container image builds for an artifact. Inside a linked directory the `<artifact-id>` argument can be omitted; it is read from `.wapi/config.json`.
+Trigger and inspect container image builds for an artifact. Inside a linked directory the `<artifact-id>` argument can be omitted; it is read from `.datarobot/wapi/config.json`.
 
 ```bash
 dr artifact build create [<artifact-id>] [--wait]             # trigger a build
@@ -171,11 +171,11 @@ dr artifact code versions [--dir <path>] [--limit N]
 dr artifact code checkout [<ver>] [--dir <path>] [--clean]
 ```
 
-- `init` creates the `.wapi/` state directory and binds it to an existing draft artifact. The artifact must already exist (`dr artifact create` or the DataRobot UI); these commands manage an artifact's code, not its lifecycle.
+- `init` creates the `.datarobot/wapi/` state directory and binds it to an existing draft artifact. The artifact must already exist (`dr artifact create` or the DataRobot UI); these commands manage an artifact's code, not its lifecycle.
 - `sync` computes a three-way diff against the last synced state and applies it in one versioned step. Conflicts resolve to the remote copy, and your version is kept as a `*.LOCAL.<timestamp>` file. Preview with `--dry-run`, or use `--diff` to also see per-file diffs. Both exit before any remote write.
 - For Python projects, the image build requires a `uv.lock` next to `pyproject.toml`. When your project has `pyproject.toml` but no `uv.lock`, `sync` generates one automatically by running your local `uv lock` (your uv configuration, private indexes, and credentials apply) and uploads it with the rest of your code — commit the generated file to your repo. If `uv` is not installed or lock generation fails, sync still completes and prints what to do (`uv lock`, then re-sync); the image build will fail until a lock file is added. This also happens on `--dry-run`/`--diff`, so the preview matches what a real sync would upload. An existing `uv.lock` is never modified, and sync warns if your `.wapiignore` excludes it.
 - `versions` lists the artifact's catalog versions, marking the one the artifact currently points at (`*`) and noting the one you last synced.
-- `checkout` downloads a version into `.wapi/.checkouts/<version-id>/` for read-only inspection; your working directory is left untouched. `--clean` removes checkout directories instead of downloading.
+- `checkout` downloads a version into `.datarobot/wapi/.checkouts/<version-id>/` for read-only inspection; your working directory is left untouched. `--clean` removes checkout directories instead of downloading.
 
 ## Shared flags
 

--- a/docs/commands/artifact.md
+++ b/docs/commands/artifact.md
@@ -21,7 +21,7 @@ Each container in the spec is one of two kinds:
 - **Prebuilt**: set `imageUri` to an existing image. There is nothing to build.
 - **Built from source**: set `imageBuildConfig`, push your code with `dr artifact code sync`, and produce an image with `dr artifact build create`. The Dockerfile is either one you provide (`./Dockerfile`) or one the server generates from a base environment.
 
-The `code` subcommands keep a local directory in sync with an artifact's source. They store a `.datarobot/wapi/` state directory at the project root, much like `.git/`: local work happens in the project root while `.datarobot/wapi/` records the remote binding and last-synced state. Once a directory is linked with `dr artifact code init`, the `build` and `code` subcommands read the artifact id from `.datarobot/wapi/config.json`, so you can leave it off. A project linked by an older CLI keeps its state in a root `.wapi/`; the next command that touches state relocates it.
+The `code` subcommands keep a local directory in sync with an artifact's source. They store a `.datarobot/workload/` state directory at the project root, much like `.git/`: local work happens in the project root while `.datarobot/workload/` records the remote binding and last-synced state. Once a directory is linked with `dr artifact code init`, the `build` and `code` subcommands read the artifact id from `.datarobot/workload/config.json`, so you can leave it off. A project linked by an older CLI keeps its state in a root `.wapi/`; the next command that touches state relocates it and prints one line saying so.
 
 A locked, fully built artifact is what you hand to `dr workload create` to deploy. See [`dr workload`](workload.md).
 
@@ -149,7 +149,7 @@ dr artifact delete <artifact-id> [--yes]
 
 ### `build`
 
-Trigger and inspect container image builds for an artifact. Inside a linked directory the `<artifact-id>` argument can be omitted; it is read from `.datarobot/wapi/config.json`.
+Trigger and inspect container image builds for an artifact. Inside a linked directory the `<artifact-id>` argument can be omitted; it is read from `.datarobot/workload/config.json`.
 
 ```bash
 dr artifact build create [<artifact-id>] [--wait]             # trigger a build
@@ -171,11 +171,11 @@ dr artifact code versions [--dir <path>] [--limit N]
 dr artifact code checkout [<ver>] [--dir <path>] [--clean]
 ```
 
-- `init` creates the `.datarobot/wapi/` state directory and binds it to an existing draft artifact. The artifact must already exist (`dr artifact create` or the DataRobot UI); these commands manage an artifact's code, not its lifecycle.
+- `init` creates the `.datarobot/workload/` state directory and binds it to an existing draft artifact. The artifact must already exist (`dr artifact create` or the DataRobot UI); these commands manage an artifact's code, not its lifecycle.
 - `sync` computes a three-way diff against the last synced state and applies it in one versioned step. Conflicts resolve to the remote copy, and your version is kept as a `*.LOCAL.<timestamp>` file. Preview with `--dry-run`, or use `--diff` to also see per-file diffs. Both exit before any remote write.
 - For Python projects, the image build requires a `uv.lock` next to `pyproject.toml`. When your project has `pyproject.toml` but no `uv.lock`, `sync` generates one automatically by running your local `uv lock` (your uv configuration, private indexes, and credentials apply) and uploads it with the rest of your code — commit the generated file to your repo. If `uv` is not installed or lock generation fails, sync still completes and prints what to do (`uv lock`, then re-sync); the image build will fail until a lock file is added. This also happens on `--dry-run`/`--diff`, so the preview matches what a real sync would upload. An existing `uv.lock` is never modified, and sync warns if your `.wapiignore` excludes it.
 - `versions` lists the artifact's catalog versions, marking the one the artifact currently points at (`*`) and noting the one you last synced.
-- `checkout` downloads a version into `.datarobot/wapi/.checkouts/<version-id>/` for read-only inspection; your working directory is left untouched. `--clean` removes checkout directories instead of downloading.
+- `checkout` downloads a version into `.datarobot/workload/.checkouts/<version-id>/` for read-only inspection; your working directory is left untouched. `--clean` removes checkout directories instead of downloading.
 
 ## Shared flags
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -24,7 +24,7 @@ If you're new to developing the CLI, start here:
 - **[Tool registry](tool-registry.md)**&mdash;how install-hint strategies and manager detection work; how to add a new tool or package manager.
 - **[Plugins](plugins.md)**&mdash;develop and test CLI plugins, understand the plugin system architecture.
 - **[Remote plugins](remote-plugins.md)**&mdash;create and distribute remote plugins, plugin registry management.
-- **[Workload `.wapi/` validation](workload-wapi-validation.md)**&mdash;reference for `validator/v10` tags and cross-field rules for workload local state.
+- **[Workload state directory validation](workload-wapi-validation.md)**&mdash;reference for `validator/v10` tags and cross-field rules for workload local state.
 - **[Releasing](releasing.md)**&mdash;release process, versioning strategy, and GoReleaser configuration.
 - **[Telemetry](telemetry.md)**&mdash;how anonymous usage analytics are collected, how to add events, and how to opt out.
 

--- a/docs/development/workload-wapi-validation.md
+++ b/docs/development/workload-wapi-validation.md
@@ -1,12 +1,12 @@
-# Workload `.wapi/` validation reference
+# Workload state directory validation reference
 
-This page documents the struct-tag validation used for workload local state stored in `.wapi/` (for example `config.json` and `manifest.json`).
+This page documents the struct-tag validation used for workload local state stored in `.datarobot/wapi/` (for example `config.json` and `manifest.json`).
 
 Validation is implemented with `github.com/go-playground/validator/v10` and centralized in `internal/workload/wapi/validate.go`.
 
 ## Custom validator tags
 
-The workload `.wapi/` validation uses these custom tags (registered in `internal/workload/wapi/validate.go`):
+The state directory validation uses these custom tags (registered in `internal/workload/wapi/validate.go`):
 
 - **`dr_id`**: Non-empty identifier (max 256 chars) with no `/`, `\`, or `..` (safe for filesystem paths).
 - **`dr_nonempty_ptr`**: If a `*string` is non-nil, the pointed-to string must not be `""` (rejects JSON `""` where `null` was intended).
@@ -56,7 +56,7 @@ Some rules are enforced in code in addition to struct tags:
 
 - **`LoadConfig`**: calls `validateConfig` and returns a `*CorruptedError` on failure.
 - **`LoadManifest`**: calls `validateManifest` and returns a `*CorruptedError` on failure.
-- **`Initialize`**: calls `validateInitOptions` at the start and returns a plain `error` on failure (before `.wapi/` is created).
+- **`Initialize`**: calls `validateInitOptions` at the start and returns a plain `error` on failure (before the state directory is created).
 
 Validation is intentionally **not** run on `SaveConfig` / `SaveManifest` (trusted writers).
 

--- a/docs/development/workload-wapi-validation.md
+++ b/docs/development/workload-wapi-validation.md
@@ -1,6 +1,6 @@
 # Workload state directory validation reference
 
-This page documents the struct-tag validation used for workload local state stored in `.datarobot/wapi/` (for example `config.json` and `manifest.json`).
+This page documents the struct-tag validation used for workload local state stored in `.datarobot/workload/` (for example `config.json` and `manifest.json`).
 
 Validation is implemented with `github.com/go-playground/validator/v10` and centralized in `internal/workload/wapi/validate.go`.
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/testutil"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -42,6 +43,11 @@ func (suite *ConfigTestSuite) SetupTest() {
 	// Sets HOME + USERPROFILE (Windows) and clears XDG_CONFIG_HOME so the
 	// config dir resolves under the temp dir on every platform.
 	testutil.SetTestHomeDir(suite.T(), suite.tempDir)
+
+	// viper is process-global, so without this the suite's results depend on
+	// what an earlier test in the -shuffle order happened to leave set.
+	viperx.Reset()
+	suite.T().Cleanup(viperx.Reset)
 }
 
 func (suite *ConfigTestSuite) TestCreateConfigFileDirIfNotExists() {
@@ -67,24 +73,23 @@ func (suite *ConfigTestSuite) TestReadConfigFileNoPreviousFile() {
 }
 
 func (suite *ConfigTestSuite) TestReadConfigFileWithPreviousFile() {
-	expectedFilePath := filepath.Join(suite.tempDir, ".config/datarobot/drconfig.yaml")
+	suite.Require().NoError(CreateConfigFileDirIfNotExists())
+
 	yamlData := map[string]string{
 		"host":  "https://parakeet.jones.datarobot.com/api/v2",
 		"token": "squak-squak",
 	}
-	rawYamlData, _ := yaml.Marshal(&yamlData)
-	_ = os.WriteFile(expectedFilePath, rawYamlData, 0o644)
 
-	readYamlData := make(map[string]string)
+	rawYamlData, err := yaml.Marshal(&yamlData)
+	suite.Require().NoError(err)
 
-	err := ReadConfigFile("")
-	suite.Require().NoError(err, "Expected no error when reading config file without a previous file")
+	expectedFilePath := filepath.Join(suite.tempDir, ".config/datarobot/drconfig.yaml")
+	suite.Require().NoError(os.WriteFile(expectedFilePath, rawYamlData, 0o600))
 
-	host := viper.GetString("host")
-	suite.Equal(host, readYamlData["host"], "Expected config file to have the same host")
+	suite.Require().NoError(ReadConfigFile(""), "Expected no error when reading an existing config file")
 
-	token := viper.GetString("token")
-	suite.Equal(token, readYamlData["token"], "Expected config file to have the same token")
+	suite.Equal(yamlData["host"], viper.GetString("host"), "Expected config file to have the same host")
+	suite.Equal(yamlData["token"], viper.GetString("token"), "Expected config file to have the same token")
 }
 
 func (suite *ConfigTestSuite) TestCreateConfigFileDirWithXDGConfigHome() {

--- a/internal/config/perms_test.go
+++ b/internal/config/perms_test.go
@@ -34,6 +34,7 @@ import (
 func TestCreateConfigFile_IsOwnerOnly(t *testing.T) {
 	testutil.SetTestHomeDir(t, t.TempDir())
 	viperx.Reset()
+	t.Cleanup(viperx.Reset)
 
 	require.NoError(t, CreateConfigFileDirIfNotExists())
 
@@ -53,6 +54,7 @@ func TestUpdateConfigFile_TightensPreExistingLoosePermissions(t *testing.T) {
 	// path has to chmod explicitly or the token stays world-readable forever.
 	testutil.SetTestHomeDir(t, t.TempDir())
 	viperx.Reset()
+	t.Cleanup(viperx.Reset)
 
 	dir, err := GetConfigDir()
 	require.NoError(t, err)

--- a/internal/envbuilder/discover_test.go
+++ b/internal/envbuilder/discover_test.go
@@ -19,7 +19,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -225,4 +227,29 @@ func TestDepth(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// Component discovery walks .datarobot for YAML, and the workload state
+// directory now lives there too. Nothing it writes is YAML today, so nothing is
+// picked up; this pins that, because a state file that ever arrives as YAML
+// would silently register the CLI's own bookkeeping as a template component.
+func TestDiscoverIgnoresWorkloadState(t *testing.T) {
+	root := t.TempDir()
+	drDir := filepath.Join(root, wapi.RootDirName)
+
+	require.NoError(t, os.MkdirAll(drDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(drDir, "component.yaml"), []byte(testYamlFile1), 0o600))
+
+	// A linked project's state, including a checkout snapshot of user source
+	// that may well contain YAML of its own.
+	stateDir := wapi.Dir(root)
+	checkout := filepath.Join(wapi.CheckoutDir(root, "66f0000000000000000000aa"), "config")
+
+	require.NoError(t, os.MkdirAll(checkout, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "config.json"), []byte(`{"artifactId":"art-1"}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(checkout, "values.yaml"), []byte(testYamlFile2), 0o600))
+
+	found, err := Discover(root, 5)
+	require.NoError(t, err)
+	assert.Equal(t, []string{filepath.Join(drDir, "component.yaml")}, found)
 }

--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -16,20 +16,22 @@ package fsutil
 
 import "os"
 
-// FileExists checks if a given file exists.
+// FileExists checks if a given file exists. Every stat error is false, not
+// just ErrNotExist: ENOTDIR and EACCES return no FileInfo to inspect.
 func FileExists(path string) bool {
 	info, err := os.Stat(path)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return false
 	}
 
 	return !info.IsDir()
 }
 
-// DirExists checks if a given directory exists.
+// DirExists checks if a given directory exists, with the same error handling
+// as FileExists.
 func DirExists(path string) bool {
 	info, err := os.Stat(path)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return false
 	}
 

--- a/internal/fsutil/fsutil_test.go
+++ b/internal/fsutil/fsutil_test.go
@@ -57,7 +57,14 @@ func TestExists_ParentIsAFile(t *testing.T) {
 
 	_, err := os.Stat(nested)
 	require.Error(t, err)
-	require.False(t, os.IsNotExist(err), "this test is meaningless if ENOTDIR reports as not-exist")
+
+	if runtime.GOOS != "windows" {
+		// Unix reports ENOTDIR, which is not ErrNotExist and carries no
+		// FileInfo, so this is the case that used to panic. Windows maps it to
+		// ERROR_PATH_NOT_FOUND, which is ErrNotExist and was always handled.
+		// The behaviour asserted below has to hold either way.
+		require.False(t, os.IsNotExist(err))
+	}
 
 	assert.NotPanics(t, func() {
 		assert.False(t, DirExists(nested))

--- a/internal/fsutil/fsutil_test.go
+++ b/internal/fsutil/fsutil_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExists_HappyPath(t *testing.T) {
+	tmp := t.TempDir()
+
+	file := filepath.Join(tmp, "f")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o600))
+
+	dir := filepath.Join(tmp, "d")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+
+	assert.True(t, FileExists(file))
+	assert.False(t, DirExists(file))
+
+	assert.True(t, DirExists(dir))
+	assert.False(t, FileExists(dir))
+
+	missing := filepath.Join(tmp, "nope")
+	assert.False(t, FileExists(missing))
+	assert.False(t, DirExists(missing))
+}
+
+// A path whose parent is a regular file stats as ENOTDIR, which is not
+// ErrNotExist and yields no FileInfo. Both helpers must report false rather
+// than dereference the nil.
+func TestExists_ParentIsAFile(t *testing.T) {
+	tmp := t.TempDir()
+
+	parent := filepath.Join(tmp, "parent")
+	require.NoError(t, os.WriteFile(parent, []byte("not a directory"), 0o600))
+
+	nested := filepath.Join(parent, "child")
+
+	_, err := os.Stat(nested)
+	require.Error(t, err)
+	require.False(t, os.IsNotExist(err), "this test is meaningless if ENOTDIR reports as not-exist")
+
+	assert.NotPanics(t, func() {
+		assert.False(t, DirExists(nested))
+		assert.False(t, FileExists(nested))
+	})
+}
+
+// An unreadable parent directory stats as EACCES, the other error class that
+// returns no FileInfo.
+func TestExists_UnreadableParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permission bits do not gate stat the same way on Windows")
+	}
+
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permission bits")
+	}
+
+	tmp := t.TempDir()
+
+	parent := filepath.Join(tmp, "parent")
+	require.NoError(t, os.Mkdir(parent, 0o755))
+	require.NoError(t, os.Chmod(parent, 0o000))
+
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+
+	nested := filepath.Join(parent, "child")
+
+	assert.NotPanics(t, func() {
+		assert.False(t, DirExists(nested))
+		assert.False(t, FileExists(nested))
+	})
+}

--- a/internal/validate/validator.go
+++ b/internal/validate/validator.go
@@ -115,7 +115,7 @@ func validateDRSHA256Hex(fl validator.FieldLevel) bool {
 // in a filesystem path segment.
 //
 // This is intended for IDs that may be used under a project directory (e.g.
-// `.wapi/.checkouts/<id>/...`) and therefore must not contain separators or
+// `.datarobot/wapi/.checkouts/<id>/...`) and therefore must not contain separators or
 // traversal sequences.
 func IsValidDRID(s string) bool {
 	if s == "" || len(s) > maxDRIDLen {

--- a/internal/validate/validator.go
+++ b/internal/validate/validator.go
@@ -115,7 +115,7 @@ func validateDRSHA256Hex(fl validator.FieldLevel) bool {
 // in a filesystem path segment.
 //
 // This is intended for IDs that may be used under a project directory (e.g.
-// `.datarobot/wapi/.checkouts/<id>/...`) and therefore must not contain separators or
+// `.datarobot/workload/.checkouts/<id>/...`) and therefore must not contain separators or
 // traversal sequences.
 func IsValidDRID(s string) bool {
 	if s == "" || len(s) > maxDRIDLen {

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -64,6 +64,10 @@ type ContainerGroup struct {
 }
 
 type Container struct {
+	// Name is the container's identifier within its group. Workload runtime
+	// overrides (e.g. resourceAllocation) must reference the container by this
+	// name, so it is parsed for callers that build a runtime spec.
+	Name             string            `json:"name,omitempty"`
 	ImageBuildConfig *ImageBuildConfig `json:"imageBuildConfig,omitempty"`
 	// ImageURI is the resolved container image reference. Server-managed:
 	// before a successful build this is the placeholder from create; after
@@ -71,8 +75,34 @@ type Container struct {
 	ImageURI string `json:"imageUri,omitempty"`
 	// *bool so an absent value round-trips as nil and omitempty drops it
 	// on marshal, instead of re-asserting `false` back to the server.
-	Primary *bool `json:"primary,omitempty"`
+	Primary         *bool            `json:"primary,omitempty"`
+	EnvironmentVars []EnvironmentVar `json:"environmentVars,omitempty"`
 }
+
+// EnvironmentVar is one entry in a container's environmentVars array. A plain
+// var carries Value directly; a credential-backed var has Source ==
+// "dr-credential" and carries DRCredentialID/Key instead, so the secret never
+// appears in the spec. Source is omitempty because the server defaults plain
+// vars to "string".
+//
+// Key selects which field of the credential to use, not to be confused with
+// Name (the env var's own name): one stored credential can bundle several
+// fields, as an S3 credential bundles awsAccessKeyId and awsSecretAccessKey.
+type EnvironmentVar struct {
+	Source         string `json:"source,omitempty"`
+	Name           string `json:"name"`
+	Value          string `json:"value,omitempty"`
+	DRCredentialID string `json:"drCredentialId,omitempty"`
+	Key            string `json:"key,omitempty"`
+}
+
+// EnvironmentVarSourceDRCredential marks a variable the platform resolves from
+// the credential store at container start.
+const EnvironmentVarSourceDRCredential = "dr-credential"
+
+// defaultPrimaryContainerName is the name the CLI writes into the specs it
+// generates, and the fallback for an unnamed primary container.
+const defaultPrimaryContainerName = "primary"
 
 type ImageBuildConfig struct {
 	CodeRef    *CodeRef    `json:"codeRef,omitempty"`
@@ -129,31 +159,38 @@ func (a *Artifact) IsLocked() bool {
 	return strings.EqualFold(a.Status, ArtifactStatusLocked)
 }
 
-// ExtractCodeRef mirrors the write-side selection in setPrimaryCodeRefInRawArtifact:
-// once a primary container is found it commits, returning nil if the primary
-// has no codeRef rather than falling through to a sidecar (which would surface
-// stale catalog info in display). Falls back to containerGroups[0].containers[0]
-// when no container is flagged primary.
-func ExtractCodeRef(artifact Artifact) *DatarobotCodeRef {
-	for _, group := range artifact.Spec.ContainerGroups {
-		for _, container := range group.Containers {
-			if container.Primary == nil || !*container.Primary {
-				continue
+// primaryContainer is the single definition of which container the CLI reads
+// per-container fields from: the one flagged "primary": true, falling back to
+// containerGroups[0].containers[0], nil when the artifact has neither. Every
+// exported Primary* helper goes through it so they cannot disagree. Mirrors
+// setPrimaryCodeRefInRawArtifact: once a primary is found it commits rather
+// than falling through to a sidecar.
+func primaryContainer(artifact Artifact) *Container {
+	for i, group := range artifact.Spec.ContainerGroups {
+		for j, container := range group.Containers {
+			if container.Primary != nil && *container.Primary {
+				return &artifact.Spec.ContainerGroups[i].Containers[j]
 			}
-
-			return codeRefFromContainer(container)
 		}
 	}
 
-	if len(artifact.Spec.ContainerGroups) == 0 {
+	if len(artifact.Spec.ContainerGroups) == 0 || len(artifact.Spec.ContainerGroups[0].Containers) == 0 {
 		return nil
 	}
 
-	if len(artifact.Spec.ContainerGroups[0].Containers) == 0 {
+	return &artifact.Spec.ContainerGroups[0].Containers[0]
+}
+
+// ExtractCodeRef returns the primary container's codeRef, or nil when the
+// primary has no codeRef (rather than falling through to a sidecar, which
+// would surface stale catalog info in display).
+func ExtractCodeRef(artifact Artifact) *DatarobotCodeRef {
+	container := primaryContainer(artifact)
+	if container == nil {
 		return nil
 	}
 
-	return codeRefFromContainer(artifact.Spec.ContainerGroups[0].Containers[0])
+	return codeRefFromContainer(*container)
 }
 
 func codeRefFromContainer(container Container) *DatarobotCodeRef {
@@ -164,31 +201,42 @@ func codeRefFromContainer(container Container) *DatarobotCodeRef {
 	return container.ImageBuildConfig.CodeRef.Datarobot
 }
 
-// GetPrimaryContainerImageURI returns the imageUri of the primary container
-// (the one flagged "primary": true), falling back to
-// containerGroups[0].containers[0] when no primary is marked. Mirrors
-// ExtractCodeRef's selection semantics so reads and writes target the same
-// container after a build updates the spec server-side.
+// GetPrimaryContainerImageURI returns the imageUri of the primary container.
+// Server-managed: the placeholder from create before a build, the produced
+// image after one completes.
 func GetPrimaryContainerImageURI(artifact Artifact) string {
-	for _, group := range artifact.Spec.ContainerGroups {
-		for _, container := range group.Containers {
-			if container.Primary == nil || !*container.Primary {
-				continue
-			}
-
-			return container.ImageURI
-		}
-	}
-
-	if len(artifact.Spec.ContainerGroups) == 0 {
+	container := primaryContainer(artifact)
+	if container == nil {
 		return ""
 	}
 
-	if len(artifact.Spec.ContainerGroups[0].Containers) == 0 {
-		return ""
+	return container.ImageURI
+}
+
+// PrimaryEnvironmentVars returns the environmentVars of the primary container,
+// nil when the artifact has no containers.
+func PrimaryEnvironmentVars(artifact Artifact) []EnvironmentVar {
+	container := primaryContainer(artifact)
+	if container == nil {
+		return nil
 	}
 
-	return artifact.Spec.ContainerGroups[0].Containers[0].ImageURI
+	return container.EnvironmentVars
+}
+
+// PrimaryContainerName returns the name of the artifact's primary container.
+// Callers building a workload runtime spec need it because resourceAllocation
+// overrides are keyed by container name and must match a container in the
+// artifact. An unnamed primary falls back to "primary", which is the CLI's own
+// convention rather than a guarantee: a hand-written artifact that leaves its
+// primary blank will not match, and the server decides what to do with that.
+func PrimaryContainerName(artifact Artifact) string {
+	container := primaryContainer(artifact)
+	if container == nil || container.Name == "" {
+		return defaultPrimaryContainerName
+	}
+
+	return container.Name
 }
 
 func GetArtifact(artifactID string) (*Artifact, error) {

--- a/internal/workload/artifact_test.go
+++ b/internal/workload/artifact_test.go
@@ -790,3 +790,162 @@ func TestLockArtifact_403AlreadyLockedPropagatesAsHTTPError(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, httpErr.StatusCode)
 	assert.Contains(t, err.Error(), "artifact is locked")
 }
+
+func TestPrimaryContainerName(t *testing.T) {
+	primary := true
+
+	t.Run("returns the name of the primary-flagged container", func(t *testing.T) {
+		art := Artifact{Spec: Spec{ContainerGroups: []ContainerGroup{
+			{Containers: []Container{{Name: "sidecar"}, {Name: "main", Primary: &primary}}},
+		}}}
+		assert.Equal(t, "main", PrimaryContainerName(art))
+	})
+
+	t.Run("falls back to the first container when none is flagged primary", func(t *testing.T) {
+		art := Artifact{Spec: Spec{ContainerGroups: []ContainerGroup{
+			{Containers: []Container{{Name: "only"}}},
+		}}}
+		assert.Equal(t, "only", PrimaryContainerName(art))
+	})
+
+	t.Run("falls back to \"primary\" when the artifact has no named container", func(t *testing.T) {
+		assert.Equal(t, "primary", PrimaryContainerName(Artifact{}))
+	})
+
+	t.Run("skips a primary container that has no name", func(t *testing.T) {
+		art := Artifact{Spec: Spec{ContainerGroups: []ContainerGroup{
+			{Containers: []Container{{Primary: &primary}}},
+		}}}
+		assert.Equal(t, "primary", PrimaryContainerName(art))
+	})
+}
+
+func TestPrimaryEnvironmentVars(t *testing.T) {
+	primary := true
+
+	plain := EnvironmentVar{Name: "LOG_LEVEL", Value: "debug"}
+	secret := EnvironmentVar{
+		Source:         EnvironmentVarSourceDRCredential,
+		Name:           "OPENAI_API_KEY",
+		DRCredentialID: "66f0000000000000000000aa",
+		Key:            "apiToken",
+	}
+
+	t.Run("reads the primary-flagged container", func(t *testing.T) {
+		art := Artifact{Spec: Spec{ContainerGroups: []ContainerGroup{{Containers: []Container{
+			{Name: "sidecar", EnvironmentVars: []EnvironmentVar{{Name: "WRONG"}}},
+			{Name: "main", Primary: &primary, EnvironmentVars: []EnvironmentVar{plain, secret}},
+		}}}}}
+		assert.Equal(t, []EnvironmentVar{plain, secret}, PrimaryEnvironmentVars(art))
+	})
+
+	t.Run("falls back to the first container when none is flagged primary", func(t *testing.T) {
+		art := Artifact{Spec: Spec{ContainerGroups: []ContainerGroup{
+			{Containers: []Container{{Name: "only", EnvironmentVars: []EnvironmentVar{plain}}}},
+		}}}
+		assert.Equal(t, []EnvironmentVar{plain}, PrimaryEnvironmentVars(art))
+	})
+
+	t.Run("returns nil for an artifact with no groups or no containers", func(t *testing.T) {
+		assert.Nil(t, PrimaryEnvironmentVars(Artifact{}))
+		assert.Nil(t, PrimaryEnvironmentVars(Artifact{Spec: Spec{
+			ContainerGroups: []ContainerGroup{{Containers: []Container{}}},
+		}}))
+	})
+}
+
+// A credential-backed var must serialize to the reference shape and never
+// carry a value; a plain var must omit the credential fields and the source
+// discriminator, which the server defaults.
+func TestEnvironmentVar_MarshalShapes(t *testing.T) {
+	secret, err := json.Marshal(EnvironmentVar{
+		Source:         EnvironmentVarSourceDRCredential,
+		Name:           "OPENAI_API_KEY",
+		DRCredentialID: "66f0000000000000000000aa",
+		Key:            "apiToken",
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"source": "dr-credential",
+		"name": "OPENAI_API_KEY",
+		"drCredentialId": "66f0000000000000000000aa",
+		"key": "apiToken"
+	}`, string(secret))
+
+	plain, err := json.Marshal(EnvironmentVar{Name: "LOG_LEVEL", Value: "debug"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"name": "LOG_LEVEL", "value": "debug"}`, string(plain))
+}
+
+// Container.Name and EnvironmentVars must survive a round trip through the
+// server document shape, since the plan renderer and runtime-spec builder
+// both read them off a fetched artifact.
+func TestContainer_ParsesNameAndEnvironmentVars(t *testing.T) {
+	var art Artifact
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"id": "art-1",
+		"spec": {"containerGroups": [{"containers": [{
+			"name": "primary",
+			"primary": true,
+			"imageUri": "example/app:1",
+			"environmentVars": [
+				{"name": "LOG_LEVEL", "value": "debug"},
+				{"source": "dr-credential", "name": "TOKEN", "drCredentialId": "66f", "key": "apiToken"}
+			]
+		}]}]}
+	}`), &art))
+
+	assert.Equal(t, "primary", PrimaryContainerName(art))
+
+	vars := PrimaryEnvironmentVars(art)
+	require.Len(t, vars, 2)
+	assert.Equal(t, "debug", vars[0].Value)
+	assert.Empty(t, vars[0].Source, "a plain var carries no source discriminator")
+	assert.Equal(t, EnvironmentVarSourceDRCredential, vars[1].Source)
+	assert.Equal(t, "apiToken", vars[1].Key)
+	assert.Empty(t, vars[1].Value, "a credential-backed var never carries a literal value")
+}
+
+// The four Primary* helpers must always describe the same container. Before
+// they shared a traversal, PrimaryContainerName additionally required a
+// non-empty name, so an unnamed primary made it fall through and report a
+// sidecar's name while the others read the primary.
+func TestPrimaryHelpers_AgreeOnUnnamedPrimary(t *testing.T) {
+	primary := true
+
+	art := Artifact{Spec: Spec{ContainerGroups: []ContainerGroup{{Containers: []Container{
+		{
+			Name:            "sidecar",
+			ImageURI:        "sidecar:1",
+			EnvironmentVars: []EnvironmentVar{{Name: "WRONG"}},
+		},
+		{
+			Name:            "",
+			Primary:         &primary,
+			ImageURI:        "app:1",
+			EnvironmentVars: []EnvironmentVar{{Name: "RIGHT"}},
+		},
+	}}}}}
+
+	assert.Equal(t, "app:1", GetPrimaryContainerImageURI(art))
+	require.Len(t, PrimaryEnvironmentVars(art), 1)
+	assert.Equal(t, "RIGHT", PrimaryEnvironmentVars(art)[0].Name)
+	assert.Equal(t, "primary", PrimaryContainerName(art),
+		"an unnamed primary falls back to the CLI's own convention, never to a sidecar's name")
+	assert.NotEqual(t, "sidecar", PrimaryContainerName(art))
+}
+
+// A primary container in a later group must win over an earlier group's
+// unflagged container, for every helper.
+func TestPrimaryHelpers_AgreeAcrossGroups(t *testing.T) {
+	primary := true
+
+	art := Artifact{Spec: Spec{ContainerGroups: []ContainerGroup{
+		{Containers: []Container{{Name: "first", ImageURI: "first:1"}}},
+		{Containers: []Container{{Name: "real", Primary: &primary, ImageURI: "real:1"}}},
+	}}}
+
+	assert.Equal(t, "real", PrimaryContainerName(art))
+	assert.Equal(t, "real:1", GetPrimaryContainerImageURI(art))
+}

--- a/internal/workload/execenv.go
+++ b/internal/workload/execenv.go
@@ -1,0 +1,83 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"fmt"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// ExecutionEnvironment is the projection of the server's EE document the CLI
+// needs to build a generated-Dockerfile artifact spec.
+type ExecutionEnvironment struct {
+	ID                      string     `json:"id"`
+	Name                    string     `json:"name"`
+	LatestSuccessfulVersion *EEVersion `json:"latestSuccessfulVersion"`
+}
+
+// EEVersion is an execution environment version reference.
+type EEVersion struct {
+	ID string `json:"id"`
+}
+
+type executionEnvironmentList struct {
+	Data []ExecutionEnvironment `json:"data"`
+	Next string                 `json:"next"`
+}
+
+// ResolveExecutionEnvironment finds an execution environment by exact id or
+// name and returns its id and latest successful version id. `dr workload up`
+// uses it to fill the executionEnvironmentId/versionId of a generated-Dockerfile
+// artifact so the user names an EE without pasting ids.
+func ResolveExecutionEnvironment(nameOrID string) (id, versionID string, err error) {
+	pageURL, err := config.GetEndpointURL("/api/v2/executionEnvironments/?limit=100")
+	if err != nil {
+		return "", "", err
+	}
+
+	for pageURL != "" {
+		var list executionEnvironmentList
+
+		if err := drapi.GetJSON(pageURL, "execution environments", &list); err != nil {
+			return "", "", err
+		}
+
+		for _, ee := range list.Data {
+			if ee.ID != nameOrID && ee.Name != nameOrID {
+				continue
+			}
+
+			if ee.LatestSuccessfulVersion == nil {
+				return "", "", fmt.Errorf("execution environment %q has no successful version to build from", nameOrID)
+			}
+
+			return ee.ID, ee.LatestSuccessfulVersion.ID, nil
+		}
+
+		if list.Next == "" {
+			break
+		}
+
+		if err := drapi.AssertNextOnSameHost(list.Next); err != nil {
+			return "", "", err
+		}
+
+		pageURL = list.Next
+	}
+
+	return "", "", fmt.Errorf("execution environment %q not found; check the name in the DataRobot UI under Registry > Environments", nameOrID)
+}

--- a/internal/workload/execenv.go
+++ b/internal/workload/execenv.go
@@ -16,6 +16,7 @@ package workload
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/drapi"
@@ -39,45 +40,109 @@ type executionEnvironmentList struct {
 	Next string                 `json:"next"`
 }
 
+// maxExecEnvPages bounds the paging walk. The list has no natural stopping
+// point the way the limit-bounded listings do, because it scans for a match
+// rather than collecting a page's worth, so a server that keeps handing back a
+// "next" cursor would page forever. Hitting the cap is a broken server, not a
+// large tenant: 100 pages of 100 is well past any real environment count.
+const maxExecEnvPages = 100
+
 // ResolveExecutionEnvironment finds an execution environment by exact id or
 // name and returns its id and latest successful version id. `dr workload up`
 // uses it to fill the executionEnvironmentId/versionId of a generated-Dockerfile
 // artifact so the user names an EE without pasting ids.
+//
+// An id match wins immediately, since ids are unique. Names are not: the
+// platform catalog and a tenant's own environments can carry the same one, so
+// name matches are collected across every page and an ambiguous name is an
+// error rather than whichever copy the server happened to list first. Picking
+// silently would build against the wrong base image and only show up as a
+// puzzling runtime failure.
 func ResolveExecutionEnvironment(nameOrID string) (id, versionID string, err error) {
-	pageURL, err := config.GetEndpointURL("/api/v2/executionEnvironments/?limit=100")
+	byID, byName, err := scanExecutionEnvironments(nameOrID)
 	if err != nil {
 		return "", "", err
 	}
 
-	for pageURL != "" {
+	if byID != nil {
+		return resolveVersion(*byID, nameOrID)
+	}
+
+	if len(byName) > 1 {
+		return "", "", fmt.Errorf(
+			"execution environment %q is ambiguous: %d environments share that name (%s). Pass the id instead",
+			nameOrID, len(byName), strings.Join(execEnvIDs(byName), ", "),
+		)
+	}
+
+	if len(byName) == 1 {
+		return resolveVersion(byName[0], nameOrID)
+	}
+
+	return "", "", fmt.Errorf("execution environment %q not found; check the name in the DataRobot UI under Registry > Environments", nameOrID)
+}
+
+// scanExecutionEnvironments walks the paged listing once, returning the unique
+// id match if one turned up and every environment carrying the name. It stops
+// early on an id hit; a name has to be checked against the whole list before it
+// can be called unambiguous.
+func scanExecutionEnvironments(nameOrID string) (byID *ExecutionEnvironment, byName []ExecutionEnvironment, err error) {
+	pageURL, err := config.GetEndpointURL("/api/v2/executionEnvironments/?limit=100")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for pages := 0; pageURL != ""; pages++ {
+		if pages >= maxExecEnvPages {
+			return nil, nil, fmt.Errorf("execution environment %q not found after %d pages of results", nameOrID, maxExecEnvPages)
+		}
+
 		var list executionEnvironmentList
 
 		if err := drapi.GetJSON(pageURL, "execution environments", &list); err != nil {
-			return "", "", err
+			return nil, nil, err
 		}
 
 		for _, ee := range list.Data {
-			if ee.ID != nameOrID && ee.Name != nameOrID {
-				continue
+			if ee.ID == nameOrID {
+				return &ee, nil, nil
 			}
 
-			if ee.LatestSuccessfulVersion == nil {
-				return "", "", fmt.Errorf("execution environment %q has no successful version to build from", nameOrID)
+			if ee.Name == nameOrID {
+				byName = append(byName, ee)
 			}
-
-			return ee.ID, ee.LatestSuccessfulVersion.ID, nil
 		}
 
 		if list.Next == "" {
-			break
+			return nil, byName, nil
 		}
 
 		if err := drapi.AssertNextOnSameHost(list.Next); err != nil {
-			return "", "", err
+			return nil, nil, err
 		}
 
 		pageURL = list.Next
 	}
 
-	return "", "", fmt.Errorf("execution environment %q not found; check the name in the DataRobot UI under Registry > Environments", nameOrID)
+	return nil, byName, nil
+}
+
+// resolveVersion unwraps the version a build can actually target. nameOrID is
+// carried through so the error names what the user typed rather than whichever
+// of the id or name matched.
+func resolveVersion(ee ExecutionEnvironment, nameOrID string) (id, versionID string, err error) {
+	if ee.LatestSuccessfulVersion == nil {
+		return "", "", fmt.Errorf("execution environment %q has no successful version to build from", nameOrID)
+	}
+
+	return ee.ID, ee.LatestSuccessfulVersion.ID, nil
+}
+
+func execEnvIDs(envs []ExecutionEnvironment) []string {
+	ids := make([]string, 0, len(envs))
+	for _, ee := range envs {
+		ids = append(ids, ee.ID)
+	}
+
+	return ids
 }

--- a/internal/workload/execenv_test.go
+++ b/internal/workload/execenv_test.go
@@ -138,6 +138,91 @@ func TestResolveExecutionEnvironment_NotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), `"nope" not found`)
 }
 
+// Environment names are not unique: the platform catalog and a tenant's own
+// copies can share one. Picking the server's first hit would build against the
+// wrong base image and surface as a puzzling runtime failure, so an ambiguous
+// name is an error naming the candidates.
+func TestResolveExecutionEnvironment_AmbiguousName(t *testing.T) {
+	installSkipAuth(t)
+
+	var srv *httptest.Server
+
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") == "2" {
+			fmt.Fprintf(w, `{"data": [%s], "next": ""}`, eeDoc("ee-2", "Python 3.11", "ver-2"))
+
+			return
+		}
+
+		fmt.Fprintf(w, `{"data": [%s], "next": %q}`,
+			eeDoc("ee-1", "Python 3.11", "ver-1"),
+			srv.URL+"/api/v2/executionEnvironments/?page=2",
+		)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, _, err := ResolveExecutionEnvironment("Python 3.11")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+	assert.Contains(t, err.Error(), "ee-1")
+	assert.Contains(t, err.Error(), "ee-2", "the duplicate on a later page counts too")
+}
+
+// Ids are unique, so an id match is answered from the page it appears on
+// without scanning the rest for name collisions.
+func TestResolveExecutionEnvironment_IDWinsOverDuplicateNames(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data": [%s, %s], "next": ""}`,
+			eeDoc("ee-1", "Shared", "ver-1"),
+			eeDoc("ee-2", "Shared", "ver-2"),
+		)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	id, versionID, err := ResolveExecutionEnvironment("ee-2")
+	require.NoError(t, err)
+	assert.Equal(t, "ee-2", id)
+	assert.Equal(t, "ver-2", versionID)
+}
+
+// Unlike the limit-bounded listings this one scans for a match, so a server
+// that keeps handing back a next cursor has no natural stopping point. The cap
+// turns a hung command into an error.
+func TestResolveExecutionEnvironment_StopsAtPageCap(t *testing.T) {
+	installSkipAuth(t)
+
+	var (
+		srv   *httptest.Server
+		pages int
+	)
+
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		pages++
+
+		fmt.Fprintf(w, `{"data": [%s], "next": %q}`,
+			eeDoc("ee-1", "Other", "ver-1"),
+			srv.URL+"/api/v2/executionEnvironments/?limit=100",
+		)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, _, err := ResolveExecutionEnvironment("Wanted")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pages")
+	assert.Equal(t, maxExecEnvPages, pages, "the walk stops at the cap rather than running forever")
+}
+
 // A next link pointing at another host is an SSRF vector, so pagination must
 // refuse to follow it.
 func TestResolveExecutionEnvironment_RejectsCrossHostNext(t *testing.T) {

--- a/internal/workload/execenv_test.go
+++ b/internal/workload/execenv_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// eeDoc is one execution environment as the server serializes it.
+func eeDoc(id, name, versionID string) string {
+	if versionID == "" {
+		return fmt.Sprintf(`{"id": %q, "name": %q, "latestSuccessfulVersion": null}`, id, name)
+	}
+
+	return fmt.Sprintf(
+		`{"id": %q, "name": %q, "latestSuccessfulVersion": {"id": %q}}`,
+		id, name, versionID,
+	)
+}
+
+func TestResolveExecutionEnvironment_MatchesByName(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data": [%s, %s], "next": ""}`,
+			eeDoc("ee-1", "Python 3.11", "ver-1"),
+			eeDoc("ee-2", "Python 3.12", "ver-2"),
+		)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	id, versionID, err := ResolveExecutionEnvironment("Python 3.12")
+	require.NoError(t, err)
+	assert.Equal(t, "ee-2", id)
+	assert.Equal(t, "ver-2", versionID)
+}
+
+func TestResolveExecutionEnvironment_MatchesByID(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data": [%s], "next": ""}`, eeDoc("ee-1", "Python 3.11", "ver-1"))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	id, versionID, err := ResolveExecutionEnvironment("ee-1")
+	require.NoError(t, err)
+	assert.Equal(t, "ee-1", id)
+	assert.Equal(t, "ver-1", versionID)
+}
+
+// The match may live past the first page, so a miss on page one must follow
+// next rather than reporting not-found.
+func TestResolveExecutionEnvironment_FollowsNextPage(t *testing.T) {
+	installSkipAuth(t)
+
+	var srv *httptest.Server
+
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") == "2" {
+			fmt.Fprintf(w, `{"data": [%s], "next": ""}`, eeDoc("ee-9", "Wanted", "ver-9"))
+
+			return
+		}
+
+		fmt.Fprintf(w, `{"data": [%s], "next": %q}`,
+			eeDoc("ee-1", "Other", "ver-1"),
+			srv.URL+"/api/v2/executionEnvironments/?page=2",
+		)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	id, versionID, err := ResolveExecutionEnvironment("Wanted")
+	require.NoError(t, err)
+	assert.Equal(t, "ee-9", id)
+	assert.Equal(t, "ver-9", versionID)
+}
+
+// An environment whose builds have all failed cannot be built from, and the
+// error must say that rather than "not found", which would send the user
+// looking for a typo.
+func TestResolveExecutionEnvironment_NoSuccessfulVersion(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data": [%s], "next": ""}`, eeDoc("ee-1", "Broken", ""))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, _, err := ResolveExecutionEnvironment("Broken")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no successful version")
+}
+
+func TestResolveExecutionEnvironment_NotFound(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data": [%s], "next": ""}`, eeDoc("ee-1", "Python 3.11", "ver-1"))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, _, err := ResolveExecutionEnvironment("nope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"nope" not found`)
+}
+
+// A next link pointing at another host is an SSRF vector, so pagination must
+// refuse to follow it.
+func TestResolveExecutionEnvironment_RejectsCrossHostNext(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data": [%s], "next": "https://evil.example.com/api/v2/executionEnvironments/"}`,
+			eeDoc("ee-1", "Other", "ver-1"),
+		)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, _, err := ResolveExecutionEnvironment("Wanted")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "not found", "a cross-host next must fail loudly, not fall through to not-found")
+}

--- a/internal/workload/ignore/doc.go
+++ b/internal/workload/ignore/doc.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // Package ignore decides which files the sync engine excludes. The
-// effective set is the union of hardcoded system excludes (.wapi, .git)
+// effective set is the union of hardcoded system excludes (the state
+// directory, .git)
 // and patterns from <project-root>/.wapiignore in gitignore syntax.
 package ignore

--- a/internal/workload/ignore/matcher.go
+++ b/internal/workload/ignore/matcher.go
@@ -32,7 +32,9 @@ const wapiignoreFile = ".wapiignore"
 // entries match as prefixes, so a bare one would also exclude the CLI's own
 // tool state under .datarobot/cli/, which syncs today. The legacy ".wapi"
 // stays listed so an un-migrated project does not upload its state.
-var systemExcludes = []string{".datarobot/wapi", ".wapi", ".git", ".gitignore"}
+//
+// Entries must be lowercase: matchesSystemExclude folds the path it is given.
+var systemExcludes = []string{".datarobot/workload", ".wapi", ".git", ".gitignore"}
 
 // Matcher decides whether a path is excluded from sync. Match is safe for
 // concurrent use after New.
@@ -96,9 +98,18 @@ func (m *Matcher) Match(relPath string, isDir bool) bool {
 
 // matchesSystemExclude reports whether relPath is or lives inside a
 // system-excluded directory.
+//
+// The comparison folds case because macOS and Windows preserve case without
+// distinguishing it: a project that already holds a differently-cased
+// .Datarobot/ gets the state directory created inside it, and an exact-match
+// exclude would then let config.json and manifest.json sync to the remote. The
+// cost is that a case-sensitive filesystem also excludes a genuine .Git or
+// .DataRobot, which is not a directory anyone keeps alongside the real ones.
 func matchesSystemExclude(relPath string) bool {
+	lowered := strings.ToLower(relPath)
+
 	for _, name := range systemExcludes {
-		if relPath == name || strings.HasPrefix(relPath, name+"/") {
+		if lowered == name || strings.HasPrefix(lowered, name+"/") {
 			return true
 		}
 	}

--- a/internal/workload/ignore/matcher.go
+++ b/internal/workload/ignore/matcher.go
@@ -27,7 +27,12 @@ import (
 const wapiignoreFile = ".wapiignore"
 
 // systemExcludes are always-ignored paths, not overridable by .wapiignore.
-var systemExcludes = []string{".wapi", ".git", ".gitignore"}
+//
+// The state directory is listed at its full path, not as a bare ".datarobot":
+// entries match as prefixes, so a bare one would also exclude the CLI's own
+// tool state under .datarobot/cli/, which syncs today. The legacy ".wapi"
+// stays listed so an un-migrated project does not upload its state.
+var systemExcludes = []string{".datarobot/wapi", ".wapi", ".git", ".gitignore"}
 
 // Matcher decides whether a path is excluded from sync. Match is safe for
 // concurrent use after New.

--- a/internal/workload/ignore/matcher_test.go
+++ b/internal/workload/ignore/matcher_test.go
@@ -30,8 +30,8 @@ func TestSystemExcludes_AlwaysApply(t *testing.T) {
 		path string
 		want bool
 	}{
-		{".datarobot/wapi", true},
-		{".datarobot/wapi/config.json", true},
+		{".datarobot/workload", true},
+		{".datarobot/workload/config.json", true},
 		{".wapi", true},             // legacy, still excluded pre-migration
 		{".wapi/config.json", true}, // legacy, still excluded pre-migration
 		{".git", true},
@@ -51,13 +51,37 @@ func TestSystemExcludes_AlwaysApply(t *testing.T) {
 	}
 }
 
+// On macOS and Windows the state directory can end up inside a pre-existing
+// .Datarobot/ that the project already had: the filesystem preserves that
+// casing while treating it as the same directory, so the walk reports a path no
+// exact-match exclude would catch and the state files would sync.
+func TestSystemExcludes_FoldCase(t *testing.T) {
+	m := FromLines(nil)
+
+	for _, p := range []string{
+		".Datarobot/workload/config.json",
+		".DATAROBOT/WORKLOAD",
+		".datarobot/Workload/manifest.json",
+		".WAPI/config.json",
+		".Git/HEAD",
+	} {
+		t.Run(p, func(t *testing.T) {
+			assert.True(t, m.Match(p, false))
+		})
+	}
+
+	// Folding must not swallow neighbours that merely share a prefix.
+	assert.False(t, m.Match(".Datarobot/cli/state.yaml", false))
+	assert.False(t, m.Match(".Datarobot.yaml", false))
+}
+
 func TestSystemExcludes_NotOverridable(t *testing.T) {
 	// User explicitly tries to un-ignore the state dir via negation. Must
 	// still be excluded — the system excludes win.
-	m := FromLines([]string{"!.datarobot/wapi", "!.wapi", "!.git"})
+	m := FromLines([]string{"!.datarobot/workload", "!.wapi", "!.git"})
 
-	assert.True(t, m.Match(".datarobot/wapi", true))
-	assert.True(t, m.Match(".datarobot/wapi/manifest.json", false))
+	assert.True(t, m.Match(".datarobot/workload", true))
+	assert.True(t, m.Match(".datarobot/workload/manifest.json", false))
 	assert.True(t, m.Match(".wapi", true))
 	assert.True(t, m.Match(".git", true))
 }
@@ -103,7 +127,7 @@ func TestNew_NoWapiignore(t *testing.T) {
 	require.NoError(t, err)
 
 	// System excludes still apply.
-	assert.True(t, m.Match(".datarobot/wapi/foo", false))
+	assert.True(t, m.Match(".datarobot/workload/foo", false))
 	// Without a user file, regular paths pass through.
 	assert.False(t, m.Match("agent.py", false))
 }

--- a/internal/workload/ignore/matcher_test.go
+++ b/internal/workload/ignore/matcher_test.go
@@ -30,13 +30,18 @@ func TestSystemExcludes_AlwaysApply(t *testing.T) {
 		path string
 		want bool
 	}{
-		{".wapi", true},
-		{".wapi/config.json", true},
+		{".datarobot/wapi", true},
+		{".datarobot/wapi/config.json", true},
+		{".wapi", true},             // legacy, still excluded pre-migration
+		{".wapi/config.json", true}, // legacy, still excluded pre-migration
 		{".git", true},
 		{".git/HEAD", true},
 		{".gitignore", true},
 		{"agent.py", false},
-		{".wapiignore", false}, // user-editable, lives at root
+		{".wapiignore", false},     // user-editable, lives at root
+		{".datarobot.yaml", false}, // the committed manifest is a file, not the state dir
+		{".datarobot/cli", false},  // the CLI's own tool state is not sync state
+		{".datarobot/cli/state.yaml", false},
 	}
 
 	for _, tc := range cases {
@@ -47,12 +52,13 @@ func TestSystemExcludes_AlwaysApply(t *testing.T) {
 }
 
 func TestSystemExcludes_NotOverridable(t *testing.T) {
-	// User explicitly tries to un-ignore .wapi via negation. Must still be
-	// excluded — the system excludes win.
-	m := FromLines([]string{"!.wapi", "!.git"})
+	// User explicitly tries to un-ignore the state dir via negation. Must
+	// still be excluded — the system excludes win.
+	m := FromLines([]string{"!.datarobot/wapi", "!.wapi", "!.git"})
 
+	assert.True(t, m.Match(".datarobot/wapi", true))
+	assert.True(t, m.Match(".datarobot/wapi/manifest.json", false))
 	assert.True(t, m.Match(".wapi", true))
-	assert.True(t, m.Match(".wapi/manifest.json", false))
 	assert.True(t, m.Match(".git", true))
 }
 
@@ -97,7 +103,7 @@ func TestNew_NoWapiignore(t *testing.T) {
 	require.NoError(t, err)
 
 	// System excludes still apply.
-	assert.True(t, m.Match(".wapi/foo", false))
+	assert.True(t, m.Match(".datarobot/wapi/foo", false))
 	// Without a user file, regular paths pass through.
 	assert.False(t, m.Match("agent.py", false))
 }

--- a/internal/workload/resolveart.go
+++ b/internal/workload/resolveart.go
@@ -30,12 +30,12 @@ const (
 
 // ResolveArtifactID returns the artifact id to operate on. When explicit is
 // non-empty it is returned verbatim with source "explicit". Otherwise the
-// current working directory is searched for a .wapi/config.json (the same
-// project-linked sync state managed by 'dr artifact code init/sync') and the
-// id is read from there with source "wapi".
+// current working directory is searched for the project's config.json (the
+// same project-linked sync state managed by 'dr artifact code init/sync') and
+// the id is read from there with source "wapi".
 //
 // Returns a user-facing error when neither source provides one so callers can
-// surface the .wapi-init hint without further wrapping.
+// surface the init hint without further wrapping.
 func ResolveArtifactID(explicit string) (string, string, error) {
 	if explicit != "" {
 		return explicit, ArtifactIDSourceExplicit, nil
@@ -54,10 +54,10 @@ func ResolveArtifactID(explicit string) (string, string, error) {
 	cfg, err := wapi.LoadConfig(absDir)
 	if err != nil {
 		if errors.Is(err, wapi.ErrNotInitialized) {
-			return "", "", fmt.Errorf("artifact id not provided and no .wapi project in %s. Run 'dr artifact code init <artifact-id>' or pass the id explicitly", absDir)
+			return "", "", fmt.Errorf("artifact id not provided and no linked project in %s. Run 'dr artifact code init <artifact-id>' or pass the id explicitly", absDir)
 		}
 
-		return "", "", fmt.Errorf("read .wapi/config.json: %w", err)
+		return "", "", fmt.Errorf("read %s: %w", wapi.ConfigPath(absDir), err)
 	}
 
 	return cfg.ArtifactID, ArtifactIDSourceWAPI, nil

--- a/internal/workload/resolveart_test.go
+++ b/internal/workload/resolveart_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,9 +35,19 @@ const validResolveConfig = `{
 func writeWAPIConfig(t *testing.T, dir, body string) {
 	t.Helper()
 
-	wapiDir := filepath.Join(dir, ".wapi")
-	require.NoError(t, os.MkdirAll(wapiDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(wapiDir, "config.json"), []byte(body), 0o600))
+	stateDir := wapi.Dir(dir)
+	require.NoError(t, os.MkdirAll(stateDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, "config.json"), []byte(body), 0o600))
+}
+
+// writeLegacyWAPIConfig seeds the pre-migration project-root location, which
+// stays readable until a command migrates it.
+func writeLegacyWAPIConfig(t *testing.T, dir, body string) {
+	t.Helper()
+
+	legacy := filepath.Join(dir, wapi.LegacyDirName)
+	require.NoError(t, os.MkdirAll(legacy, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(legacy, "config.json"), []byte(body), 0o600))
 }
 
 func TestResolveArtifactID_ExplicitWinsOverWAPI(t *testing.T) {
@@ -70,7 +81,7 @@ func TestResolveArtifactID_NotInitializedHasUserHint(t *testing.T) {
 
 	_, _, err := ResolveArtifactID("")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no .wapi project")
+	assert.Contains(t, err.Error(), "no linked project")
 	assert.Contains(t, err.Error(), "dr artifact code init")
 }
 
@@ -82,5 +93,17 @@ func TestResolveArtifactID_CorruptConfigPropagates(t *testing.T) {
 
 	_, _, err := ResolveArtifactID("")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), ".wapi/config.json")
+	assert.Contains(t, err.Error(), filepath.Join(wapi.RootDirName, wapi.StateDirName, "config.json"))
+}
+
+func TestResolveArtifactID_ReadsLegacyStateDir(t *testing.T) {
+	dir := t.TempDir()
+
+	writeLegacyWAPIConfig(t, dir, validResolveConfig)
+	t.Chdir(dir)
+
+	id, source, err := ResolveArtifactID("")
+	require.NoError(t, err)
+	assert.Equal(t, "art-from-wapi-000000000", id)
+	assert.Equal(t, ArtifactIDSourceWAPI, source)
 }

--- a/internal/workload/sync/doc.go
+++ b/internal/workload/sync/doc.go
@@ -14,6 +14,6 @@
 
 // Package sync is the engine behind `dr artifact code sync`. It walks the
 // project, builds a three-way diff against base and remote manifests,
-// executes the plan with rollback safety, and updates .wapi/ state on
+// executes the plan with rollback safety, and updates the local state on
 // success. The `dr artifact code sync` CLI command wires it in.
 package sync

--- a/internal/workload/sync/engine.go
+++ b/internal/workload/sync/engine.go
@@ -109,6 +109,7 @@ type Engine struct {
 	result         *Result
 	startedAt      time.Time
 	staleNote      bool
+	migrationNote  string
 
 	lockfileFn        LockfileRunner
 	lockfileGenerated bool
@@ -222,6 +223,11 @@ func (e *Engine) Close() error {
 // StaleRollbackRestored reports whether Phase 0 restored a stale rollback
 // from a previously crashed sync.
 func (e *Engine) StaleRollbackRestored() bool { return e.staleNote }
+
+// StateMigrationNotice is Phase 0's one-line account of where local state now
+// lives, empty when the location did not change. The preview modes never
+// migrate, so it is always empty for --dry-run and --diff.
+func (e *Engine) StateMigrationNotice() string { return e.migrationNote }
 
 func (e *Engine) releaseLock() error {
 	if e.lock == nil {

--- a/internal/workload/sync/limits.go
+++ b/internal/workload/sync/limits.go
@@ -25,7 +25,7 @@ const (
 	DiskSpaceMarginMB = 100
 
 	// RollbackMaxFiles caps the rollback set so a single sync cannot
-	// produce a multi-gigabyte .wapi/.rollback/ tree.
+	// produce a multi-gigabyte rollback tree.
 	RollbackMaxFiles = 1000
 
 	// Stage path is used when files <= threshold AND bytes <= threshold;

--- a/internal/workload/sync/path_safety_test.go
+++ b/internal/workload/sync/path_safety_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -174,7 +175,7 @@ func TestValidateServerPaths_SkipsLocalDrivenEntries(t *testing.T) {
 // Phase-level regression: an unsafe path in plan.Downloads would
 // otherwise reach rb.Backup via backupDownloadTargets before any
 // per-call-site guard fired. The up-front check must short-circuit
-// before NewRollback runs, so no .wapi/.rollback dir is created and
+// before NewRollback runs, so no rollback dir is created and
 // no bytes outside e.projectDir are read.
 func TestPhase5Execute_RejectsUnsafePathBeforeAnyFilesystemOp(t *testing.T) {
 	dir := t.TempDir()
@@ -197,7 +198,7 @@ func TestPhase5Execute_RejectsUnsafePathBeforeAnyFilesystemOp(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "server returned unsafe download path")
 
-	_, statErr := os.Stat(filepath.Join(dir, ".wapi", rollbackDirName))
+	_, statErr := os.Stat(wapi.RollbackDir(dir))
 	assert.True(t, os.IsNotExist(statErr), "rollback dir must not be created when validation fails")
 
 	_, statErr = os.Stat(sentinel)

--- a/internal/workload/sync/phase0_preflight.go
+++ b/internal/workload/sync/phase0_preflight.go
@@ -31,7 +31,7 @@ import (
 // fall back to the legacy location on their own.
 func phase0Preflight(e *Engine) error {
 	if !e.opts.DryRun && !e.opts.ShowDiffs {
-		wapi.EnsureMigrated(e.projectDir)
+		e.migrationNote = wapi.EnsureMigrated(e.projectDir)
 	}
 
 	restored, err := RestoreStaleIfPresent(e.projectDir)

--- a/internal/workload/sync/phase0_preflight.go
+++ b/internal/workload/sync/phase0_preflight.go
@@ -21,10 +21,19 @@ import (
 	"github.com/datarobot/cli/internal/workload/wapi"
 )
 
-// phase0Preflight does stale-rollback recovery, .wapi/ presence check,
-// and acquires the project lock. Recovery runs before the lock so a
-// crashed-mid-sync process gets cleaned up by whoever runs next.
+// phase0Preflight migrates legacy state, does stale-rollback recovery, checks
+// the project is linked, and acquires the project lock. Migration runs first
+// so everything after it resolves one state directory; recovery runs before
+// the lock so a crashed-mid-sync process gets cleaned up by whoever runs next.
+//
+// The preview modes skip the migration: --dry-run and --diff should not move
+// anything on disk, and they read fine either way because the path helpers
+// fall back to the legacy location on their own.
 func phase0Preflight(e *Engine) error {
+	if !e.opts.DryRun && !e.opts.ShowDiffs {
+		wapi.EnsureMigrated(e.projectDir)
+	}
+
 	restored, err := RestoreStaleIfPresent(e.projectDir)
 	if err != nil {
 		return fmt.Errorf("recover stale rollback: %w", err)

--- a/internal/workload/sync/phase1_gather.go
+++ b/internal/workload/sync/phase1_gather.go
@@ -27,7 +27,7 @@ import (
 func phase1Gather(e *Engine) error {
 	cfg, err := wapi.LoadConfig(e.projectDir)
 	if err != nil {
-		return fmt.Errorf("read .wapi/config.json: %w", err)
+		return fmt.Errorf("read %s: %w", wapi.ConfigPath(e.projectDir), err)
 	}
 
 	e.config = cfg
@@ -38,7 +38,7 @@ func phase1Gather(e *Engine) error {
 			return fmt.Errorf("manifest missing: %w", err)
 		}
 
-		return fmt.Errorf("read .wapi/manifest.json: %w", err)
+		return fmt.Errorf("read manifest.json in %s: %w", wapi.Dir(e.projectDir), err)
 	}
 
 	e.base = baseFromManifest(manifest)

--- a/internal/workload/sync/phase6_state.go
+++ b/internal/workload/sync/phase6_state.go
@@ -108,7 +108,7 @@ func buildNewBaseManifest(e *Engine, syncedVersionID string, syncedAt time.Time)
 	}
 }
 
-// syncHistoryEntry assembles the JSONL line written to .wapi/history.log.
+// syncHistoryEntry assembles the JSONL line written to history.log.
 func syncHistoryEntry(e *Engine, now time.Time) wapi.HistoryEntry {
 	entry := wapi.HistoryEntry{
 		"ts":         now.Format(time.RFC3339),

--- a/internal/workload/sync/rollback.go
+++ b/internal/workload/sync/rollback.go
@@ -21,14 +21,13 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"github.com/datarobot/cli/internal/workload/wapi"
 )
 
-const rollbackDirName = ".rollback"
-
-// Rollback owns the .wapi/.rollback/ tree for a single sync run. Call
-// Backup before each destructive operation, then Discard on success or
-// Restore on failure. Newly created files go through TrackCreated so
-// Restore can remove them.
+// Rollback owns the rollback tree for a single sync run. Call Backup before
+// each destructive operation, then Discard on success or Restore on failure.
+// Newly created files go through TrackCreated so Restore can remove them.
 type Rollback struct {
 	projectDir string
 	rollDir    string
@@ -38,7 +37,7 @@ type Rollback struct {
 // NewRollback creates the rollback directory. Returns an error if a stale
 // rollback already exists; callers must run RestoreStaleIfPresent first.
 func NewRollback(projectDir string) (*Rollback, error) {
-	rollDir := filepath.Join(projectDir, ".wapi", rollbackDirName)
+	rollDir := wapi.RollbackDir(projectDir)
 
 	if err := os.Mkdir(rollDir, 0o755); err != nil {
 		if errors.Is(err, os.ErrExist) {
@@ -122,12 +121,28 @@ func (r *Rollback) Restore() error {
 	return restoreFromDir(r.rollDir, r.projectDir)
 }
 
-// RestoreStaleIfPresent restores any existing .wapi/.rollback/ tree and
-// removes it. The bool indicates whether a restore happened so callers
-// can warn the user.
+// RestoreStaleIfPresent restores any existing rollback tree and removes it.
+// The bool indicates whether a restore happened so callers can warn the user.
+// It sweeps every candidate location (see wapi.StaleRollbackDirs) so backups
+// left by a sync that crashed before the state directory moved still apply.
 func RestoreStaleIfPresent(projectDir string) (bool, error) {
-	rollDir := filepath.Join(projectDir, ".wapi", rollbackDirName)
+	restored := false
 
+	for _, rollDir := range wapi.StaleRollbackDirs(projectDir) {
+		did, err := restoreStaleDir(rollDir, projectDir)
+		restored = restored || did
+
+		if err != nil {
+			return restored, err
+		}
+	}
+
+	return restored, nil
+}
+
+// restoreStaleDir applies one rollback tree and removes it. A missing tree is
+// not an error.
+func restoreStaleDir(rollDir, projectDir string) (bool, error) {
 	info, err := os.Stat(rollDir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/workload/sync/rollback_test.go
+++ b/internal/workload/sync/rollback_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +28,7 @@ func setupProject(t *testing.T) string {
 	t.Helper()
 
 	dir := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".wapi"), 0o755))
+	require.NoError(t, os.MkdirAll(wapi.Dir(dir), 0o755))
 
 	return dir
 }
@@ -84,7 +85,7 @@ func TestRollback_MissingFileNoop(t *testing.T) {
 
 func TestRollback_AlreadyExists(t *testing.T) {
 	dir := setupProject(t)
-	require.NoError(t, os.Mkdir(filepath.Join(dir, ".wapi", ".rollback"), 0o755))
+	require.NoError(t, os.Mkdir(wapi.RollbackDir(dir), 0o755))
 
 	_, err := NewRollback(dir)
 	require.Error(t, err)
@@ -95,7 +96,7 @@ func TestRestoreStaleIfPresent(t *testing.T) {
 	dir := setupProject(t)
 	writeProjectFile(t, dir, "agent.py", "WAS-BROKEN")
 
-	rollDir := filepath.Join(dir, ".wapi", ".rollback")
+	rollDir := wapi.RollbackDir(dir)
 	require.NoError(t, os.MkdirAll(rollDir, 0o755))
 
 	require.NoError(t, os.WriteFile(filepath.Join(rollDir, "agent.py"), []byte("intact"), 0o644))
@@ -114,6 +115,45 @@ func TestRestoreStaleIfPresent(t *testing.T) {
 
 func TestRestoreStaleIfPresent_None(t *testing.T) {
 	dir := setupProject(t)
+
+	restored, err := RestoreStaleIfPresent(dir)
+	require.NoError(t, err)
+	assert.False(t, restored)
+}
+
+// A sync that crashed before the state directory moved leaves its backups
+// under the legacy path. If the project also has a current state directory,
+// EnsureMigrated refuses to merge the two, so nothing relocates those
+// backups; recovery has to find them there or the user's overwritten files
+// are lost.
+func TestRestoreStaleIfPresent_RecoversFromLegacyLocation(t *testing.T) {
+	dir := t.TempDir()
+
+	// Current state dir exists, so EnsureMigrated would leave the legacy one
+	// in place rather than merging.
+	require.NoError(t, os.MkdirAll(wapi.Dir(dir), 0o755))
+
+	legacyRollback := filepath.Join(dir, wapi.LegacyDirName, wapi.RollbackDirName)
+	require.NoError(t, os.MkdirAll(legacyRollback, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(legacyRollback, "agent.py"), []byte("original\n"), 0o600))
+
+	// The working tree currently holds the half-applied server copy.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "agent.py"), []byte("clobbered\n"), 0o600))
+
+	restored, err := RestoreStaleIfPresent(dir)
+	require.NoError(t, err)
+	assert.True(t, restored, "a stranded legacy rollback must be reported as restored")
+
+	body, err := os.ReadFile(filepath.Join(dir, "agent.py"))
+	require.NoError(t, err)
+	assert.Equal(t, "original\n", string(body), "the user's file must come back")
+
+	assert.NoDirExists(t, legacyRollback, "the tree is consumed once applied")
+}
+
+func TestRestoreStaleIfPresent_NoTreeAnywhere(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(wapi.Dir(dir), 0o755))
 
 	restored, err := RestoreStaleIfPresent(dir)
 	require.NoError(t, err)

--- a/internal/workload/sync/synclock.go
+++ b/internal/workload/sync/synclock.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/datarobot/cli/internal/workload/wapi"
 )
 
 const syncLockFile = "sync.lock"
@@ -28,15 +30,17 @@ type SyncLock struct {
 	f    *os.File
 }
 
-// AcquireSyncLock opens .wapi/sync.lock and acquires an exclusive lock
-// without waiting. Cross-platform polish is tracked in RAPTOR-16928.
+// AcquireSyncLock opens sync.lock inside the project's state directory and
+// acquires an exclusive lock without waiting. The lock is advisory and
+// per-platform (flock on unix, LockFileEx on Windows), so it guards against a
+// second CLI process on the same machine, not against a shared filesystem.
 func AcquireSyncLock(projectDir string) (*SyncLock, error) {
-	wapiDir := filepath.Join(projectDir, ".wapi")
-	if _, err := os.Stat(wapiDir); err != nil {
+	stateDir := wapi.Dir(projectDir)
+	if _, err := os.Stat(stateDir); err != nil {
 		return nil, fmt.Errorf("acquire sync lock: %w", err)
 	}
 
-	path := filepath.Join(wapiDir, syncLockFile)
+	path := filepath.Join(stateDir, syncLockFile)
 
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {

--- a/internal/workload/wapi/config.go
+++ b/internal/workload/wapi/config.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-// Config is the parsed representation of .wapi/config.json — the identity and
+// Config is the parsed representation of the project's config.json — the identity and
 // sync-state pointer for the project directory.
 //
 // CatalogID and LastSyncedVersionID use pointer semantics so that an empty
@@ -35,8 +35,8 @@ type Config struct {
 	CLIVersion          string    `json:"cliVersion" validate:"required"`
 }
 
-// LoadConfig reads and parses .wapi/config.json. Returns ErrNotInitialized if
-// .wapi/ (or config.json inside it) is missing, and a *CorruptedError
+// LoadConfig reads and parses the project's config.json. Returns ErrNotInitialized if
+// the state directory (or config.json inside it) is missing, and a *CorruptedError
 // wrapping parse or semantic validation failures if the file is unreadable,
 // malformed, or invalid.
 func LoadConfig(projectDir string) (Config, error) {
@@ -64,8 +64,8 @@ func LoadConfig(projectDir string) (Config, error) {
 	return cfg, nil
 }
 
-// SaveConfig atomically writes the config to .wapi/config.json. Returns
-// ErrNotInitialized if .wapi/ does not exist.
+// SaveConfig atomically writes the config to the project's config.json. Returns
+// ErrNotInitialized if the state directory does not exist.
 func SaveConfig(projectDir string, c Config) error {
 	if err := writeConfig(projectDir, c); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -78,9 +78,9 @@ func SaveConfig(projectDir string, c Config) error {
 	return nil
 }
 
-// writeConfig writes the config to .wapi/config.json. Shared by SaveConfig (which
+// writeConfig writes the config to config.json. Shared by SaveConfig (which
 // maps os.ErrNotExist → ErrNotInitialized) and by Initialize (which has
-// just mkdir'd .wapi/, so that error can't occur).
+// just mkdir'd the state directory, so that error can't occur).
 func writeConfig(projectDir string, c Config) error {
 	data, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {

--- a/internal/workload/wapi/config_test.go
+++ b/internal/workload/wapi/config_test.go
@@ -68,7 +68,7 @@ func TestConfig_SaveLoadRoundTrip_NullsForEmptyOptionals(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	raw, err := os.ReadFile(filepath.Join(tmp, DirName, configFile))
+	raw, err := os.ReadFile(filepath.Join(Dir(tmp), configFile))
 	require.NoError(t, err)
 
 	var parsed map[string]any
@@ -104,7 +104,7 @@ func TestConfig_LoadCorrupted_InvalidJSON(t *testing.T) {
 	tmp := t.TempDir()
 	initWapiDir(t, tmp)
 
-	path := filepath.Join(tmp, DirName, configFile)
+	path := filepath.Join(Dir(tmp), configFile)
 	err := os.WriteFile(path, []byte("not json {"), 0o644)
 	require.NoError(t, err)
 
@@ -122,7 +122,7 @@ func TestConfig_LoadCorrupted_WrongType(t *testing.T) {
 	tmp := t.TempDir()
 	initWapiDir(t, tmp)
 
-	path := filepath.Join(tmp, DirName, configFile)
+	path := filepath.Join(Dir(tmp), configFile)
 	err := os.WriteFile(path, []byte(`{"createdAt": 42}`), 0o644)
 	require.NoError(t, err)
 
@@ -173,7 +173,7 @@ func TestConfig_LoadInvalid(t *testing.T) {
 			tmp := t.TempDir()
 			initWapiDir(t, tmp)
 
-			path := filepath.Join(tmp, DirName, configFile)
+			path := filepath.Join(Dir(tmp), configFile)
 			err := os.WriteFile(path, []byte(tc.json), 0o644)
 			require.NoError(t, err)
 

--- a/internal/workload/wapi/doc.go
+++ b/internal/workload/wapi/doc.go
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package wapi manages the .datarobot/wapi/ directory — the local, machine-managed sync
-// state for a DataRobot workload project (conceptually .git/ for a workload).
+// Package wapi manages the .datarobot/workload/ directory: the local,
+// machine-managed sync state for a DataRobot workload project (conceptually
+// .git/ for a workload). The package keeps the internal name; only the
+// directory it manages is named for the product surface.
 //
 // It exposes plain functions that read and write the files inside it:
 // config.json (identity + sync state), manifest.json (the BASE manifest from

--- a/internal/workload/wapi/doc.go
+++ b/internal/workload/wapi/doc.go
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package wapi manages the .wapi/ directory — the local, machine-managed sync
+// Package wapi manages the .datarobot/wapi/ directory — the local, machine-managed sync
 // state for a DataRobot workload project (conceptually .git/ for a workload).
 //
-// It exposes plain functions that read and write the files inside .wapi/:
+// It exposes plain functions that read and write the files inside it:
 // config.json (identity + sync state), manifest.json (the BASE manifest from
 // the last successful sync), .gitignore, and history.log (append-only JSONL
 // with 1 MB rotation). It also drops a .wapiignore template at the project

--- a/internal/workload/wapi/errors.go
+++ b/internal/workload/wapi/errors.go
@@ -30,9 +30,8 @@ var ErrAlreadyLinked = errors.New("Project already linked: state directory exist
 var ErrNotInitialized = errors.New("State directory not found.")
 
 // CorruptedError wraps a read, parse, or semantic validation failure for a
-// specific file under the state directory. It carries the absolute path of
-// the corrupted
-// file so callers can include it in user-facing diagnostics.
+// specific file under the state directory. It carries the absolute path of the
+// corrupted file so callers can include it in user-facing diagnostics.
 type CorruptedError struct {
 	Path string
 	Err  error

--- a/internal/workload/wapi/errors.go
+++ b/internal/workload/wapi/errors.go
@@ -20,16 +20,18 @@ import (
 )
 
 // ErrAlreadyLinked is returned by Initialize when the project directory
-// already contains a .wapi/ directory.
-var ErrAlreadyLinked = errors.New("Project already linked: .wapi/ exists.")
+// already has a state directory, at either the current or the legacy
+// location.
+var ErrAlreadyLinked = errors.New("Project already linked: state directory exists.")
 
 // ErrNotInitialized is returned by Load/Save/Append operations when the
-// project directory has no .wapi/ directory. CLI consumers are responsible
+// project directory has no state directory. CLI consumers are responsible
 // for translating this into a user-facing hint about how to initialize.
-var ErrNotInitialized = errors.New(".wapi/ not found.")
+var ErrNotInitialized = errors.New("State directory not found.")
 
 // CorruptedError wraps a read, parse, or semantic validation failure for a
-// specific file under .wapi/. It carries the absolute path of the corrupted
+// specific file under the state directory. It carries the absolute path of
+// the corrupted
 // file so callers can include it in user-facing diagnostics.
 type CorruptedError struct {
 	Path string
@@ -37,7 +39,7 @@ type CorruptedError struct {
 }
 
 func (e *CorruptedError) Error() string {
-	return fmt.Sprintf(".wapi/ file is corrupted at %s: %v", e.Path, e.Err)
+	return fmt.Sprintf("State file is corrupted at %s: %v", e.Path, e.Err)
 }
 
 func (e *CorruptedError) Unwrap() error {

--- a/internal/workload/wapi/helpers_test.go
+++ b/internal/workload/wapi/helpers_test.go
@@ -16,7 +16,6 @@ package wapi
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -28,13 +27,13 @@ func testHash(c byte) string {
 	return strings.Repeat(string(c), 64)
 }
 
-// initWapiDir creates an empty .wapi/ directory inside projectDir so that
+// initWapiDir creates an empty state directory inside projectDir so that
 // Load* / Save* / AppendHistory operations bypass their ErrNotInitialized
 // short-circuit. Used by config, manifest, and history tests that only care
 // about the read/write behaviour, not the Exists precondition.
 func initWapiDir(t *testing.T, projectDir string) {
 	t.Helper()
 
-	err := os.MkdirAll(filepath.Join(projectDir, DirName), 0o755)
+	err := os.MkdirAll(Dir(projectDir), 0o755)
 	require.NoError(t, err)
 }

--- a/internal/workload/wapi/history.go
+++ b/internal/workload/wapi/history.go
@@ -21,17 +21,17 @@ import (
 	"os"
 )
 
-// HistoryEntry is one JSONL record in .wapi/history.log. It is deliberately
+// HistoryEntry is one JSONL record in the project's history.log. It is deliberately
 // open-schema: each operation type owns its own field shape. Callers SHOULD
 // populate at least "ts" (RFC3339 UTC timestamp) and "op".
 type HistoryEntry map[string]any
 
 // AppendHistory writes entry as a single JSON object followed by "\n" to
-// .wapi/history.log. If the existing log has grown to historyRotateBytes or
+// history.log. If the existing log has grown to historyRotateBytes or
 // more, it is renamed to history.log.1 first (overwriting any prior .1 —
 // only one backup is retained).
 //
-// Returns ErrNotInitialized if .wapi/ does not exist. Unlike SaveConfig /
+// Returns ErrNotInitialized if the state directory does not exist. Unlike SaveConfig /
 // SaveManifest, appends use O_APPEND rather than an atomic rename (which
 // would lose prior entries). The caller is responsible for serializing
 // concurrent writers via an external lock.

--- a/internal/workload/wapi/history_test.go
+++ b/internal/workload/wapi/history_test.go
@@ -76,7 +76,7 @@ func TestAppendHistory_WritesOneJSONLine(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	entries := readHistoryLines(t, filepath.Join(tmp, DirName, HistoryFile))
+	entries := readHistoryLines(t, filepath.Join(Dir(tmp), HistoryFile))
 	require.Len(t, entries, 1)
 	assert.Equal(t, "init", entries[0]["op"])
 	assert.Equal(t, "bar", entries[0]["foo"])
@@ -92,7 +92,7 @@ func TestAppendHistory_MultipleAppendsPreserveOrder(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	entries := readHistoryLines(t, filepath.Join(tmp, DirName, HistoryFile))
+	entries := readHistoryLines(t, filepath.Join(Dir(tmp), HistoryFile))
 	require.Len(t, entries, len(ops))
 
 	for i, op := range ops {
@@ -104,8 +104,8 @@ func TestAppendHistory_RotatesAtThreshold(t *testing.T) {
 	tmp := t.TempDir()
 	initWapiDir(t, tmp)
 
-	path := filepath.Join(tmp, DirName, HistoryFile)
-	backup := filepath.Join(tmp, DirName, historyBackupFile)
+	path := filepath.Join(Dir(tmp), HistoryFile)
+	backup := filepath.Join(Dir(tmp), historyBackupFile)
 
 	// Seed the log at exactly the rotation threshold. Truncate creates a
 	// sparse file on APFS/ext4, so no 1 MB of zeros is actually written.
@@ -129,9 +129,9 @@ func TestAppendHistory_RotationKeepsOneBackup(t *testing.T) {
 	tmp := t.TempDir()
 	initWapiDir(t, tmp)
 
-	path := filepath.Join(tmp, DirName, HistoryFile)
-	backup := filepath.Join(tmp, DirName, historyBackupFile)
-	secondBackup := filepath.Join(tmp, DirName, "history.log.2")
+	path := filepath.Join(Dir(tmp), HistoryFile)
+	backup := filepath.Join(Dir(tmp), historyBackupFile)
+	secondBackup := filepath.Join(Dir(tmp), "history.log.2")
 
 	// First rotation (sparse via Truncate, see TestAppendHistory_RotatesAtThreshold).
 	err := os.WriteFile(path, nil, 0o644)
@@ -166,8 +166,8 @@ func TestAppendHistory_RotationRenameFailureSurfaces(t *testing.T) {
 	tmp := t.TempDir()
 	initWapiDir(t, tmp)
 
-	path := filepath.Join(tmp, DirName, HistoryFile)
-	backup := filepath.Join(tmp, DirName, historyBackupFile)
+	path := filepath.Join(Dir(tmp), HistoryFile)
+	backup := filepath.Join(Dir(tmp), historyBackupFile)
 
 	err := os.WriteFile(path, nil, 0o644)
 	require.NoError(t, err)

--- a/internal/workload/wapi/init.go
+++ b/internal/workload/wapi/init.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/datarobot/cli/internal/fsutil"
@@ -34,20 +35,21 @@ type InitOptions struct {
 	LastSyncedVersionID string `validate:"omitempty,dr_id"`
 }
 
-// Initialize creates the .wapi/ directory at projectDir and writes all the
+// Initialize creates the state directory at projectDir and writes all the
 // bootstrap files: config.json, manifest.json (empty BASE), .gitignore ("*"),
 // and an "init" entry in history.log. It also drops the .wapiignore template
 // at projectDir if the user has no .wapiignore yet.
 //
 // Basic input validation happens before any filesystem changes (including
-// creating projectDir or running mkdir for .wapi/).
+// creating projectDir or running mkdir for the state directory).
 //
 // projectDir is created (with any missing parents) if it does not already
 // exist, matching the convenience of `git init <newdir>`.
 //
-// Returns ErrAlreadyLinked if .wapi/ already exists. On partial failure after
-// mkdir, the incomplete .wapi/ tree is left in place for the user to inspect
-// or remove manually rather than attempting rollback.
+// Returns ErrAlreadyLinked if the project is already linked, at either the
+// current or the legacy location. On partial failure after mkdir, the
+// incomplete tree is left in place for the user to inspect or remove manually
+// rather than attempting rollback.
 func Initialize(projectDir string, opts InitOptions) error {
 	if err := validateInitOptions(opts); err != nil {
 		return err
@@ -57,12 +59,8 @@ func Initialize(projectDir string, opts InitOptions) error {
 		return fmt.Errorf("create project directory %s: %w", projectDir, err)
 	}
 
-	if err := os.Mkdir(wapiDir(projectDir), 0o755); err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return ErrAlreadyLinked
-		}
-
-		return fmt.Errorf("create .wapi/ directory: %w", err)
+	if err := createStateDir(projectDir); err != nil {
+		return err
 	}
 
 	now := time.Now().UTC()
@@ -101,4 +99,25 @@ func Initialize(projectDir string, opts InitOptions) error {
 		"baseFiles": 0,
 		"duration":  "0.0s",
 	})
+}
+
+// createStateDir makes the state directory for a fresh link. Dir resolves to
+// the legacy location when one is present, so an un-migrated project reports
+// ErrAlreadyLinked rather than acquiring a second state directory.
+func createStateDir(projectDir string) error {
+	stateDir := Dir(projectDir)
+
+	if err := os.MkdirAll(filepath.Dir(stateDir), 0o755); err != nil {
+		return fmt.Errorf("create %s directory: %w", RootDirName, err)
+	}
+
+	if err := os.Mkdir(stateDir, 0o755); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return ErrAlreadyLinked
+		}
+
+		return fmt.Errorf("create %s directory: %w", stateDir, err)
+	}
+
+	return nil
 }

--- a/internal/workload/wapi/init_test.go
+++ b/internal/workload/wapi/init_test.go
@@ -39,8 +39,8 @@ func TestInitialize_CreatesFullLayout(t *testing.T) {
 
 	require.NoError(t, err)
 
-	// .wapi/ listing — exactly the four machine-managed files.
-	entries, err := os.ReadDir(filepath.Join(tmp, DirName))
+	// State dir listing — exactly the four machine-managed files.
+	entries, err := os.ReadDir(Dir(tmp))
 	require.NoError(t, err)
 
 	names := make([]string, 0, len(entries))
@@ -50,8 +50,8 @@ func TestInitialize_CreatesFullLayout(t *testing.T) {
 
 	assert.ElementsMatch(t, []string{gitignoreFile, configFile, HistoryFile, manifestFile}, names)
 
-	// .wapi/.gitignore is "*\n".
-	gi, err := os.ReadFile(filepath.Join(tmp, DirName, gitignoreFile))
+	// The self-ignoring .gitignore is "*\n".
+	gi, err := os.ReadFile(filepath.Join(Dir(tmp), gitignoreFile))
 	require.NoError(t, err)
 	assert.Equal(t, "*\n", string(gi))
 
@@ -73,7 +73,7 @@ func TestInitialize_CreatesFullLayout(t *testing.T) {
 	assert.False(t, cfg.CreatedAt.After(after), "CreatedAt should be <= after")
 
 	// manifest.json is empty BASE with explicit null sync pointers.
-	raw, err := os.ReadFile(filepath.Join(tmp, DirName, manifestFile))
+	raw, err := os.ReadFile(filepath.Join(Dir(tmp), manifestFile))
 	require.NoError(t, err)
 
 	var parsed map[string]any
@@ -95,7 +95,7 @@ func TestInitialize_WritesInitHistoryEntry(t *testing.T) {
 	err := Initialize(tmp, InitOptions{ArtifactID: "art-abc-123"})
 	require.NoError(t, err)
 
-	entries := readHistoryLines(t, filepath.Join(tmp, DirName, HistoryFile))
+	entries := readHistoryLines(t, filepath.Join(Dir(tmp), HistoryFile))
 	require.Len(t, entries, 1)
 
 	e := entries[0]
@@ -118,7 +118,7 @@ func TestInitialize_HistoryCatalogPresentForExistingCode(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	entries := readHistoryLines(t, filepath.Join(tmp, DirName, HistoryFile))
+	entries := readHistoryLines(t, filepath.Join(Dir(tmp), HistoryFile))
 	require.Len(t, entries, 1)
 	assert.Equal(t, "cat-xyz-789", entries[0]["catalog"])
 }
@@ -130,7 +130,7 @@ func TestInitialize_CreatesMissingProjectDir(t *testing.T) {
 	err := Initialize(nested, InitOptions{ArtifactID: "art-abc"})
 	require.NoError(t, err)
 
-	assert.True(t, Exists(nested), "project dir + .wapi/ must be created end-to-end")
+	assert.True(t, Exists(nested), "project dir + state dir must be created end-to-end")
 }
 
 func TestInitialize_AlreadyLinked(t *testing.T) {
@@ -164,7 +164,7 @@ func TestInitialize_NullsForEmptyOptionals(t *testing.T) {
 	err := Initialize(tmp, InitOptions{ArtifactID: "art-abc"})
 	require.NoError(t, err)
 
-	raw, err := os.ReadFile(filepath.Join(tmp, DirName, configFile))
+	raw, err := os.ReadFile(filepath.Join(Dir(tmp), configFile))
 	require.NoError(t, err)
 
 	var parsed map[string]any

--- a/internal/workload/wapi/manifest.go
+++ b/internal/workload/wapi/manifest.go
@@ -29,7 +29,7 @@ type FileMeta struct {
 	Size int64  `json:"size" validate:"gte=0"`
 }
 
-// Manifest is the parsed representation of .wapi/manifest.json — the BASE
+// Manifest is the parsed representation of the project's manifest.json — the BASE
 // snapshot of "what both sides looked like the last time we successfully
 // synced." Written by Initialize (empty) and by the sync engine.
 //
@@ -44,8 +44,8 @@ type Manifest struct {
 	Files           map[string]FileMeta `json:"files" validate:"dive"`
 }
 
-// LoadManifest reads and parses .wapi/manifest.json. Returns
-// ErrNotInitialized if .wapi/ (or manifest.json inside it) is missing, and
+// LoadManifest reads and parses the project's manifest.json. Returns
+// ErrNotInitialized if the state directory (or manifest.json inside it) is missing, and
 // a *CorruptedError wrapping parse or semantic validation failures if the
 // file is unreadable, malformed, or invalid.
 func LoadManifest(projectDir string) (Manifest, error) {
@@ -77,8 +77,8 @@ func LoadManifest(projectDir string) (Manifest, error) {
 	return m, nil
 }
 
-// SaveManifest atomically writes the manifest to .wapi/manifest.json. Returns
-// ErrNotInitialized if .wapi/ does not exist.
+// SaveManifest atomically writes the manifest to manifest.json. Returns
+// ErrNotInitialized if the state directory does not exist.
 func SaveManifest(projectDir string, m Manifest) error {
 	if err := writeManifest(projectDir, m); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -91,7 +91,7 @@ func SaveManifest(projectDir string, m Manifest) error {
 	return nil
 }
 
-// writeManifest writes the manifest to .wapi/manifest.json. Shared by SaveManifest
+// writeManifest writes the manifest to manifest.json. Shared by SaveManifest
 // (which maps os.ErrNotExist → ErrNotInitialized) and by Initialize.
 func writeManifest(projectDir string, m Manifest) error {
 	// Ensure JSON emits "files": {} rather than "files": null.

--- a/internal/workload/wapi/manifest_test.go
+++ b/internal/workload/wapi/manifest_test.go
@@ -65,7 +65,7 @@ func TestManifest_EmptyFilesMap(t *testing.T) {
 	err := SaveManifest(tmp, Manifest{Version: ManifestVersion})
 	require.NoError(t, err)
 
-	raw, err := os.ReadFile(filepath.Join(tmp, DirName, manifestFile))
+	raw, err := os.ReadFile(filepath.Join(Dir(tmp), manifestFile))
 	require.NoError(t, err)
 
 	var parsed map[string]any
@@ -124,7 +124,7 @@ func TestManifest_LoadCorrupted(t *testing.T) {
 	tmp := t.TempDir()
 	initWapiDir(t, tmp)
 
-	path := filepath.Join(tmp, DirName, manifestFile)
+	path := filepath.Join(Dir(tmp), manifestFile)
 	err := os.WriteFile(path, []byte("not json"), 0o644)
 	require.NoError(t, err)
 
@@ -181,7 +181,7 @@ func TestManifest_LoadInvalid(t *testing.T) {
 			tmp := t.TempDir()
 			initWapiDir(t, tmp)
 
-			path := filepath.Join(tmp, DirName, manifestFile)
+			path := filepath.Join(Dir(tmp), manifestFile)
 			err := os.WriteFile(path, []byte(tc.json), 0o644)
 			require.NoError(t, err)
 

--- a/internal/workload/wapi/migrate.go
+++ b/internal/workload/wapi/migrate.go
@@ -15,7 +15,9 @@
 package wapi
 
 import (
+	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/datarobot/cli/internal/fsutil"
@@ -23,39 +25,53 @@ import (
 )
 
 // EnsureMigrated moves a project's state out of the legacy root .wapi/ and
-// into .datarobot/wapi/. Call it before any command that touches state.
+// into .datarobot/workload/. Call it before any command that touches state.
 //
-// It is silent and cannot fail. The state directory is machine-managed and
-// undocumented, so relocating it is housekeeping the user cannot act on. A
-// move that cannot be completed leaves the legacy directory alone and Dir
-// keeps resolving there, so the command carries on either way.
-func EnsureMigrated(projectDir string) {
+// It cannot fail. A move that cannot be completed leaves the legacy directory
+// alone and Dir keeps resolving there, so the command carries on either way.
+//
+// The return value is a one-line notice, empty when there is nothing to say.
+// The directory is machine-managed but it is not invisible: a user who watches
+// one at their project root vanish, or a stale one linger, is owed a sentence
+// saying which location is now in use. Printing it is the caller's job, so
+// this package keeps doing no I/O beyond the state files themselves.
+func EnsureMigrated(projectDir string) string {
 	legacy := legacyDir(projectDir)
 	if !fsutil.DirExists(legacy) {
-		return
+		return ""
 	}
 
 	current := filepath.Join(projectDir, RootDirName, StateDirName)
+	currentName := path.Join(RootDirName, StateDirName)
 
 	// Both present means someone re-linked by hand. The current location wins;
 	// never merge two trees.
 	if fsutil.DirExists(current) {
 		log.Debug("state dir migration: skipped, both locations present", "legacy", legacy, "current", current)
 
-		return
+		return fmt.Sprintf("Using %s/ for local state; the legacy %s/ is no longer read and can be deleted.", currentName, LegacyDirName)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(current), 0o755); err != nil {
 		log.Debug("state dir migration: create parent failed, using legacy location", "dir", filepath.Dir(current), "err", err)
 
-		return
+		return unmovedNotice(currentName)
 	}
 
 	if err := os.Rename(legacy, current); err != nil {
 		log.Debug("state dir migration: rename failed, using legacy location", "from", legacy, "to", current, "err", err)
 
-		return
+		return unmovedNotice(currentName)
 	}
 
 	log.Debug("state dir migration: moved", "from", legacy, "to", current)
+
+	return fmt.Sprintf("Moved local state from %s/ to %s/.", LegacyDirName, currentName)
+}
+
+// unmovedNotice names the location still in use when the move could not be
+// made, so a read-only or otherwise stuck project explains itself rather than
+// looking like the state directory was ignored.
+func unmovedNotice(currentName string) string {
+	return fmt.Sprintf("Could not move local state from %s/ to %s/; using %s/ for now.", LegacyDirName, currentName, LegacyDirName)
 }

--- a/internal/workload/wapi/migrate.go
+++ b/internal/workload/wapi/migrate.go
@@ -1,0 +1,61 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wapi
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/datarobot/cli/internal/fsutil"
+	"github.com/datarobot/cli/internal/log"
+)
+
+// EnsureMigrated moves a project's state out of the legacy root .wapi/ and
+// into .datarobot/wapi/. Call it before any command that touches state.
+//
+// It is silent and cannot fail. The state directory is machine-managed and
+// undocumented, so relocating it is housekeeping the user cannot act on. A
+// move that cannot be completed leaves the legacy directory alone and Dir
+// keeps resolving there, so the command carries on either way.
+func EnsureMigrated(projectDir string) {
+	legacy := legacyDir(projectDir)
+	if !fsutil.DirExists(legacy) {
+		return
+	}
+
+	current := filepath.Join(projectDir, RootDirName, StateDirName)
+
+	// Both present means someone re-linked by hand. The current location wins;
+	// never merge two trees.
+	if fsutil.DirExists(current) {
+		log.Debug("state dir migration: skipped, both locations present", "legacy", legacy, "current", current)
+
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(current), 0o755); err != nil {
+		log.Debug("state dir migration: create parent failed, using legacy location", "dir", filepath.Dir(current), "err", err)
+
+		return
+	}
+
+	if err := os.Rename(legacy, current); err != nil {
+		log.Debug("state dir migration: rename failed, using legacy location", "from", legacy, "to", current, "err", err)
+
+		return
+	}
+
+	log.Debug("state dir migration: moved", "from", legacy, "to", current)
+}

--- a/internal/workload/wapi/migrate_test.go
+++ b/internal/workload/wapi/migrate_test.go
@@ -16,6 +16,7 @@ package wapi
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -40,8 +41,7 @@ func seedLegacyDir(t *testing.T, projectDir string) string {
 func TestEnsureMigrated_NothingToDo(t *testing.T) {
 	tmp := t.TempDir()
 
-	EnsureMigrated(tmp)
-
+	assert.Empty(t, EnsureMigrated(tmp), "a project with nothing to migrate says nothing")
 	assert.NoDirExists(t, filepath.Join(tmp, RootDirName), "an unlinked project is not given directories it never had")
 }
 
@@ -49,22 +49,28 @@ func TestEnsureMigrated_MovesLegacyDir(t *testing.T) {
 	tmp := t.TempDir()
 	legacy := seedLegacyDir(t, tmp)
 
-	EnsureMigrated(tmp)
+	notice := EnsureMigrated(tmp)
 
 	assert.NoDirExists(t, legacy)
 
 	current := filepath.Join(tmp, RootDirName, StateDirName)
 	assert.DirExists(t, current)
 
+	// The directory moved out from under the user, so the run says so and names
+	// both ends of the move.
+	assert.Contains(t, notice, LegacyDirName)
+	assert.Contains(t, notice, path.Join(RootDirName, StateDirName))
+
 	// The files travelled, not just the directory.
 	raw, err := os.ReadFile(filepath.Join(current, configFile))
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"artifactId":"art-1"}`, string(raw))
 
-	// Dir now resolves to the new location, and a second call changes nothing.
+	// Dir now resolves to the new location, and a second call changes nothing
+	// and has nothing left to report.
 	assert.Equal(t, current, Dir(tmp))
 
-	EnsureMigrated(tmp)
+	assert.Empty(t, EnsureMigrated(tmp), "the notice is not repeated on every later command")
 	assert.Equal(t, current, Dir(tmp))
 	assert.NoDirExists(t, legacy)
 }
@@ -80,9 +86,11 @@ func TestEnsureMigrated_BothPresentKeepsCurrent(t *testing.T) {
 	require.NoError(t, os.MkdirAll(current, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(current, configFile), []byte(`{"artifactId":"art-2"}`), 0o600))
 
-	EnsureMigrated(tmp)
+	notice := EnsureMigrated(tmp)
 
 	assert.DirExists(t, legacy, "the leftover is left for the user to inspect, not deleted")
+	assert.Contains(t, notice, LegacyDirName, "a leftover the CLI no longer reads is worth one line")
+	assert.Contains(t, notice, "deleted", "and the line says what to do about it")
 
 	raw, err := os.ReadFile(filepath.Join(current, configFile))
 	require.NoError(t, err)
@@ -108,9 +116,10 @@ func TestEnsureMigrated_UnmovableFallsBackToLegacy(t *testing.T) {
 	require.NoError(t, os.Chmod(tmp, 0o500))
 	t.Cleanup(func() { _ = os.Chmod(tmp, 0o700) })
 
-	EnsureMigrated(tmp)
+	notice := EnsureMigrated(tmp)
 
 	assert.DirExists(t, legacy)
 	assert.Equal(t, legacy, Dir(tmp), "commands keep reading the legacy location for this run")
 	assert.True(t, Exists(tmp), "the project is still linked")
+	assert.Contains(t, notice, LegacyDirName, "a stuck move explains which location is in use rather than going quiet")
 }

--- a/internal/workload/wapi/migrate_test.go
+++ b/internal/workload/wapi/migrate_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wapi
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedLegacyDir lays down a legacy root state directory with one recognisable
+// file in it, so tests can prove the contents travelled rather than just the
+// directory name.
+func seedLegacyDir(t *testing.T, projectDir string) string {
+	t.Helper()
+
+	legacy := filepath.Join(projectDir, LegacyDirName)
+	require.NoError(t, os.Mkdir(legacy, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(legacy, configFile), []byte(`{"artifactId":"art-1"}`), 0o600))
+
+	return legacy
+}
+
+func TestEnsureMigrated_NothingToDo(t *testing.T) {
+	tmp := t.TempDir()
+
+	EnsureMigrated(tmp)
+
+	assert.NoDirExists(t, filepath.Join(tmp, RootDirName), "an unlinked project is not given directories it never had")
+}
+
+func TestEnsureMigrated_MovesLegacyDir(t *testing.T) {
+	tmp := t.TempDir()
+	legacy := seedLegacyDir(t, tmp)
+
+	EnsureMigrated(tmp)
+
+	assert.NoDirExists(t, legacy)
+
+	current := filepath.Join(tmp, RootDirName, StateDirName)
+	assert.DirExists(t, current)
+
+	// The files travelled, not just the directory.
+	raw, err := os.ReadFile(filepath.Join(current, configFile))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"artifactId":"art-1"}`, string(raw))
+
+	// Dir now resolves to the new location, and a second call changes nothing.
+	assert.Equal(t, current, Dir(tmp))
+
+	EnsureMigrated(tmp)
+	assert.Equal(t, current, Dir(tmp))
+	assert.NoDirExists(t, legacy)
+}
+
+// A project that already keeps state in .datarobot but still has a leftover
+// root directory is not merged: the current location wins and the leftover is
+// left alone, because guessing which tree is authoritative could destroy state.
+func TestEnsureMigrated_BothPresentKeepsCurrent(t *testing.T) {
+	tmp := t.TempDir()
+	legacy := seedLegacyDir(t, tmp)
+
+	current := filepath.Join(tmp, RootDirName, StateDirName)
+	require.NoError(t, os.MkdirAll(current, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(current, configFile), []byte(`{"artifactId":"art-2"}`), 0o600))
+
+	EnsureMigrated(tmp)
+
+	assert.DirExists(t, legacy, "the leftover is left for the user to inspect, not deleted")
+
+	raw, err := os.ReadFile(filepath.Join(current, configFile))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"artifactId":"art-2"}`, string(raw), "current state must not be overwritten by the leftover")
+}
+
+// A move that cannot happen must not fail the command: the legacy directory
+// stays readable and every path helper keeps resolving to it.
+func TestEnsureMigrated_UnmovableFallsBackToLegacy(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permission bits do not block rename the same way on Windows")
+	}
+
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permission bits")
+	}
+
+	tmp := t.TempDir()
+	legacy := seedLegacyDir(t, tmp)
+
+	// A read-only project dir blocks both the mkdir of .datarobot and the
+	// rename out of the legacy location.
+	require.NoError(t, os.Chmod(tmp, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(tmp, 0o700) })
+
+	EnsureMigrated(tmp)
+
+	assert.DirExists(t, legacy)
+	assert.Equal(t, legacy, Dir(tmp), "commands keep reading the legacy location for this run")
+	assert.True(t, Exists(tmp), "the project is still linked")
+}

--- a/internal/workload/wapi/paths.go
+++ b/internal/workload/wapi/paths.go
@@ -22,7 +22,21 @@ import (
 
 // Exported names used by external callers (tests, sync commands).
 const (
-	DirName          = ".wapi"
+	// RootDirName is the single directory a project gives DataRobot. The CLI
+	// already keeps its tool state under it, so sync state joins it rather
+	// than claiming a second dot-entry at the project root.
+	RootDirName = ".datarobot"
+
+	// StateDirName is the sync state directory, nested inside RootDirName.
+	StateDirName = "wapi"
+
+	// LegacyDirName is where sync state lived before it moved under
+	// RootDirName. EnsureMigrated relocates it.
+	LegacyDirName = ".wapi"
+
+	// RollbackDirName is the sync engine's per-run backup tree.
+	RollbackDirName = ".rollback"
+
 	HistoryFile      = "history.log"
 	ManifestVersion  = 1
 	CheckoutsDirName = ".checkouts"
@@ -44,47 +58,91 @@ const (
 	historyRotateBytes int64 = 1 << 20
 )
 
-func wapiDir(projectDir string) string {
-	return filepath.Join(projectDir, DirName)
+// Dir is the directory holding this project's machine-managed sync state:
+// <projectDir>/.datarobot/wapi, falling back to a legacy <projectDir>/.wapi
+// that EnsureMigrated has not moved yet. The fallback is a stat rather than
+// cached state, so a migration that cannot complete degrades to reading the
+// old location instead of failing the command. It can go once the workload
+// feature gate is removed.
+func Dir(projectDir string) string {
+	current := filepath.Join(projectDir, RootDirName, StateDirName)
+	if fsutil.DirExists(current) {
+		return current
+	}
+
+	if legacy := legacyDir(projectDir); fsutil.DirExists(legacy) {
+		return legacy
+	}
+
+	return current
+}
+
+func legacyDir(projectDir string) string {
+	return filepath.Join(projectDir, LegacyDirName)
+}
+
+// RollbackDir is the sync engine's backup tree for a single run. Callers go
+// through this rather than joining the name themselves.
+func RollbackDir(projectDir string) string {
+	return filepath.Join(Dir(projectDir), RollbackDirName)
+}
+
+// StaleRollbackDirs lists every place a rollback tree from a crashed sync
+// could be sitting, current location first. Recovery looks wider than
+// RollbackDir alone because a sync that crashed before the state directory
+// moved leaves its backups under the legacy path, where nothing will relocate
+// them if a current directory also exists. They are the only copy of the
+// user's overwritten files.
+func StaleRollbackDirs(projectDir string) []string {
+	current := filepath.Join(projectDir, RootDirName, StateDirName, RollbackDirName)
+	legacy := filepath.Join(legacyDir(projectDir), RollbackDirName)
+
+	return []string{current, legacy}
+}
+
+// ConfigPath is the project's config.json, exported so commands can name the
+// real file when wrapping a read error rather than hard-coding a path.
+func ConfigPath(projectDir string) string {
+	return configPath(projectDir)
 }
 
 func configPath(projectDir string) string {
-	return filepath.Join(wapiDir(projectDir), configFile)
+	return filepath.Join(Dir(projectDir), configFile)
 }
 
 func manifestPath(projectDir string) string {
-	return filepath.Join(wapiDir(projectDir), manifestFile)
+	return filepath.Join(Dir(projectDir), manifestFile)
 }
 
 func historyPath(projectDir string) string {
-	return filepath.Join(wapiDir(projectDir), HistoryFile)
+	return filepath.Join(Dir(projectDir), HistoryFile)
 }
 
 func historyBackupPath(projectDir string) string {
-	return filepath.Join(wapiDir(projectDir), historyBackupFile)
+	return filepath.Join(Dir(projectDir), historyBackupFile)
 }
 
 func gitignorePath(projectDir string) string {
-	return filepath.Join(wapiDir(projectDir), gitignoreFile)
+	return filepath.Join(Dir(projectDir), gitignoreFile)
 }
 
-// .wapiignore lives at the project root (not inside .wapi/) so it is visible
-// in the IDE and version-controllable, the same convention as .gitignore.
+// .wapiignore lives at the project root, not inside the state directory: it is
+// authored and committed by the user, the same convention as .gitignore.
 func wapiignorePath(projectDir string) string {
 	return filepath.Join(projectDir, wapiignoreFile)
 }
 
-// Exists reports whether the project directory contains a .wapi/ directory.
-// Returns false if .wapi exists as a file rather than a directory.
+// Exists reports whether the project is linked, at either the current or the
+// legacy location. False if the path is a file rather than a directory.
 func Exists(projectDir string) bool {
-	return fsutil.DirExists(wapiDir(projectDir))
+	return fsutil.DirExists(Dir(projectDir))
 }
 
 // CheckoutsDir is the parent directory holding read-only version snapshots
 // produced by `dr artifact code checkout`. Each snapshot is a sub-directory
 // named after the full catalog version ID.
 func CheckoutsDir(projectDir string) string {
-	return filepath.Join(wapiDir(projectDir), CheckoutsDirName)
+	return filepath.Join(Dir(projectDir), CheckoutsDirName)
 }
 
 // CheckoutDir is the snapshot directory for a single version, identified by

--- a/internal/workload/wapi/paths.go
+++ b/internal/workload/wapi/paths.go
@@ -28,7 +28,9 @@ const (
 	RootDirName = ".datarobot"
 
 	// StateDirName is the sync state directory, nested inside RootDirName.
-	StateDirName = "wapi"
+	// It is named after the product surface rather than the package, so the
+	// path a user sees does not carry an internal codename.
+	StateDirName = "workload"
 
 	// LegacyDirName is where sync state lived before it moved under
 	// RootDirName. EnsureMigrated relocates it.
@@ -59,7 +61,7 @@ const (
 )
 
 // Dir is the directory holding this project's machine-managed sync state:
-// <projectDir>/.datarobot/wapi, falling back to a legacy <projectDir>/.wapi
+// <projectDir>/.datarobot/workload, falling back to a legacy <projectDir>/.wapi
 // that EnsureMigrated has not moved yet. The fallback is a stat rather than
 // cached state, so a migration that cannot complete degrades to reading the
 // old location instead of failing the command. It can go once the workload

--- a/internal/workload/wapi/paths_test.go
+++ b/internal/workload/wapi/paths_test.go
@@ -32,16 +32,49 @@ func TestExists_Missing(t *testing.T) {
 func TestExists_PresentDir(t *testing.T) {
 	tmp := t.TempDir()
 
-	err := os.Mkdir(filepath.Join(tmp, DirName), 0o755)
+	err := os.MkdirAll(filepath.Join(tmp, RootDirName, StateDirName), 0o755)
 	require.NoError(t, err)
 
 	assert.True(t, Exists(tmp))
 }
 
+// A project linked by an older CLI is still linked: Dir falls back to the
+// legacy location until EnsureMigrated moves it.
+func TestExists_PresentAtLegacyDir(t *testing.T) {
+	tmp := t.TempDir()
+
+	err := os.Mkdir(filepath.Join(tmp, LegacyDirName), 0o755)
+	require.NoError(t, err)
+
+	assert.True(t, Exists(tmp))
+	assert.Equal(t, filepath.Join(tmp, LegacyDirName), Dir(tmp))
+}
+
+// The current location wins when both exist, so a half-finished migration
+// cannot make commands read stale state.
+func TestDir_PrefersCurrentOverLegacy(t *testing.T) {
+	tmp := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tmp, RootDirName, StateDirName), 0o755))
+	require.NoError(t, os.Mkdir(filepath.Join(tmp, LegacyDirName), 0o755))
+
+	assert.Equal(t, filepath.Join(tmp, RootDirName, StateDirName), Dir(tmp))
+}
+
+// With nothing on disk yet, Dir names where state will be created rather
+// than the legacy location.
+func TestDir_UnlinkedProjectNamesCurrentLocation(t *testing.T) {
+	tmp := t.TempDir()
+
+	assert.Equal(t, filepath.Join(tmp, RootDirName, StateDirName), Dir(tmp))
+}
+
 func TestExists_IsFileNotDir(t *testing.T) {
 	tmp := t.TempDir()
 
-	err := os.WriteFile(filepath.Join(tmp, DirName), []byte("oops"), 0o644)
+	require.NoError(t, os.Mkdir(filepath.Join(tmp, RootDirName), 0o755))
+
+	err := os.WriteFile(filepath.Join(tmp, RootDirName, StateDirName), []byte("oops"), 0o644)
 	require.NoError(t, err)
 
 	assert.False(t, Exists(tmp))

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -95,6 +95,36 @@ func knownWorkloadStatuses() []string {
 	}
 }
 
+// IsTerminalWorkloadStatus reports whether a "wait until running" poll loop
+// should stop: running is terminal success; errored and terminated are terminal
+// failures. Every other status is non-terminal so the loop keeps polling. That
+// deliberately includes the steady non-running states (stopped, suspended,
+// interrupted): WaitForWorkload only runs after the caller has created or
+// started the workload, so those states are transient on the way up, not a
+// reason to bail. A workload that never leaves them surfaces via the timeout
+// rather than a spurious "settled" error on the first, still-stale poll.
+func IsTerminalWorkloadStatus(s string) bool {
+	switch s {
+	case WorkloadStatusRunning,
+		WorkloadStatusErrored,
+		WorkloadStatusTerminated:
+		return true
+	}
+
+	return false
+}
+
+// IsWorkloadErrorStatus reports whether s is a terminal failure a caller should
+// surface as an error rather than a settled state.
+func IsWorkloadErrorStatus(s string) bool {
+	switch s {
+	case WorkloadStatusErrored, WorkloadStatusTerminated:
+		return true
+	}
+
+	return false
+}
+
 // Workload is the projection of the server's workload document the CLI
 // renders. Server-side extras (owners, permissions, creator, stats) are
 // deliberately not parsed so they cannot leak into scripted output.
@@ -317,6 +347,50 @@ func GetWorkload(workloadID string) (*Workload, error) {
 	}
 
 	return &workload, nil
+}
+
+// WaitForWorkload polls GetWorkload on interval until the workload reaches a
+// terminal status (see IsTerminalWorkloadStatus) or deadline expires. It
+// returns the final Workload in every non-poll-error case so callers can render
+// it:
+//   - running: success, nil error.
+//   - errored/terminated: the final workload alongside a failure error.
+//   - timeout: the last-seen workload alongside a timeout error (this covers a
+//     workload stuck in a non-running steady state such as stopped).
+//
+// onTick may be nil and is invoked after each poll for debug-only observation,
+// mirroring WaitForBuild.
+func WaitForWorkload(
+	workloadID string,
+	interval, timeout time.Duration,
+	onTick func(*Workload),
+) (*Workload, error) {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		wl, err := GetWorkload(workloadID)
+		if err != nil {
+			return nil, fmt.Errorf("poll workload %s: %w", workloadID, err)
+		}
+
+		if onTick != nil {
+			onTick(wl)
+		}
+
+		if IsTerminalWorkloadStatus(wl.Status) {
+			if IsWorkloadErrorStatus(wl.Status) {
+				return wl, fmt.Errorf("workload %s ended with status %s; run 'dr workload logs %s' to inspect", workloadID, wl.Status, workloadID)
+			}
+
+			return wl, nil
+		}
+
+		if time.Now().After(deadline) {
+			return wl, fmt.Errorf("timeout waiting for workload %s after %s", workloadID, timeout)
+		}
+
+		time.Sleep(interval)
+	}
 }
 
 type WorkloadList struct {

--- a/internal/workload/workload_test.go
+++ b/internal/workload/workload_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -484,4 +485,140 @@ func TestNewWorkloadOutput_FormatsTimestampsRFC3339(t *testing.T) {
 	assert.Equal(t, "2026-06-10T08:00:00Z", out.CreatedAt)
 	assert.Equal(t, "2026-06-10T08:05:00Z", out.UpdatedAt)
 	assert.Equal(t, "https://e/", out.Endpoint)
+}
+
+func TestIsTerminalWorkloadStatus(t *testing.T) {
+	terminal := []string{
+		WorkloadStatusRunning,
+		WorkloadStatusErrored,
+		WorkloadStatusTerminated,
+	}
+
+	nonTerminal := []string{
+		WorkloadStatusSubmitted,
+		WorkloadStatusProvisioning,
+		WorkloadStatusLaunching,
+		WorkloadStatusStopping,
+		WorkloadStatusStopped,
+		WorkloadStatusSuspended,
+		WorkloadStatusInterrupted,
+		WorkloadStatusUnknown,
+	}
+
+	for _, s := range terminal {
+		assert.True(t, IsTerminalWorkloadStatus(s), "%s should be terminal", s)
+	}
+
+	for _, s := range nonTerminal {
+		assert.False(t, IsTerminalWorkloadStatus(s), "%s should not be terminal", s)
+	}
+}
+
+func TestIsWorkloadErrorStatus(t *testing.T) {
+	for _, s := range []string{WorkloadStatusErrored, WorkloadStatusTerminated} {
+		assert.True(t, IsWorkloadErrorStatus(s), "%s should be an error status", s)
+	}
+
+	steady := []string{
+		WorkloadStatusRunning,
+		WorkloadStatusStopped,
+		WorkloadStatusSuspended,
+		WorkloadStatusInterrupted,
+		WorkloadStatusUnknown,
+	}
+
+	for _, s := range steady {
+		assert.False(t, IsWorkloadErrorStatus(s), "%s should not be an error status", s)
+	}
+}
+
+func TestWaitForWorkload_RunningReturnsNil(t *testing.T) {
+	installSkipAuth(t)
+
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		page := atomic.AddInt32(&hits, 1)
+
+		status := WorkloadStatusLaunching
+		if page >= 2 {
+			status = WorkloadStatusRunning
+		}
+
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", status))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	var ticks int
+
+	wl, err := WaitForWorkload("wl-1", time.Millisecond, time.Second, func(*Workload) {
+		ticks++
+	})
+	require.NoError(t, err)
+	assert.Equal(t, WorkloadStatusRunning, wl.Status)
+	assert.GreaterOrEqual(t, ticks, 2)
+}
+
+func TestWaitForWorkload_ErroredReturnsError(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", WorkloadStatusErrored))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkload("wl-1", time.Millisecond, time.Second, nil)
+	require.Error(t, err)
+	require.NotNil(t, wl, "errored returns final Workload alongside error")
+	assert.Equal(t, WorkloadStatusErrored, wl.Status)
+	assert.Contains(t, err.Error(), WorkloadStatusErrored)
+}
+
+func TestWaitForWorkload_PollsThroughStoppedUntilRunning(t *testing.T) {
+	installSkipAuth(t)
+
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		page := atomic.AddInt32(&hits, 1)
+
+		// A just-started workload can still report 'stopped' on the first poll;
+		// WaitForWorkload must keep polling rather than treat it as terminal.
+		status := WorkloadStatusStopped
+		if page >= 2 {
+			status = WorkloadStatusRunning
+		}
+
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", status))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkload("wl-1", time.Millisecond, time.Second, nil)
+	require.NoError(t, err)
+	assert.Equal(t, WorkloadStatusRunning, wl.Status)
+}
+
+func TestWaitForWorkload_Timeout(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", WorkloadStatusProvisioning))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := WaitForWorkload("wl-1", 5*time.Millisecond, 25*time.Millisecond, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
 }


### PR DESCRIPTION
# RATIONALE

A project that uses the workload commands ends up with two DataRobot entries at its root: the `.datarobot.yaml` manifest and a separate `.wapi/` state directory. Two sibling dot-entries for one product reads like two tools, and it is the first thing a user sees when they open the project. All CLI-owned state moves under `.datarobot/`, which this CLI already uses for `.datarobot/cli/state.yaml`.

The same change also ports the `internal/workload` primitives that `dr workload up` will build on. No command surface changes there, so nothing user-visible ships from that half.

Closes RAPTOR-18983 and RAPTOR-18974.

## CHANGES

### State directory

- `.wapi/` becomes `.datarobot/wapi/`, holding the same `config.json`, `manifest.json`, `history.log`, `.checkouts/` and self-ignoring `.gitignore`.
- `wapi.Dir()` is the single resolver. It falls back to a legacy root `.wapi/` when one is present, so a project linked by an older CLI stays readable. The fallback is a stat rather than cached state, so a migration that cannot complete degrades to reading the old location instead of failing the command.
- `wapi.EnsureMigrated()` relocates a legacy directory on the next state-touching command. It is silent and cannot fail; both outcomes are logged at debug level. `--dry-run` and `--diff` skip it, so a preview never moves anything on disk.
- `systemExcludes` gains `.datarobot/wapi`, not a bare `.datarobot`. Entries match as prefixes, so a bare one would also stop syncing `.datarobot/cli/state.yaml`. The legacy `.wapi` stays listed so an un-migrated project does not upload its own state.
- Hand-built paths in `sync/rollback.go` and `sync/synclock.go` now go through the package, so there is one definition of where state lives.
- Stale rollback recovery sweeps both locations, so backups from a sync that crashed before the directory moved are still applied.
- Help text and error strings across `cmd/artifact/code` and `cmd/artifact/build` follow. Read errors name the real file via `wapi.ConfigPath()` instead of a hard-coded path.
- `.wapiignore` stays at the project root: it is authored and committed by the user, the same convention as `.gitignore`.

### Workload internals

- `WaitForWorkload` with `IsTerminalWorkloadStatus` and `IsWorkloadErrorStatus`.
- New `internal/workload/execenv.go`: `ResolveExecutionEnvironment` maps a name or id to both execution-environment ids for generated-mode builds.
- Artifact spec primitives: `Container.Name`, `Container.EnvironmentVars`, the `EnvironmentVar` type including its credential-backed source shape, and the `PrimaryContainerName` and `PrimaryEnvironmentVars` helpers.
- `PatchPrimaryContainer` is deliberately not ported: artifacts are immutable now, every change mints a new version, and that removed every caller.

### Along the way

- `fsutil.DirExists` and `FileExists` handled only `ErrNotExist`, leaving `info` nil on any other stat error and dereferencing it. A project root containing a file named `.datarobot` produced a stack trace; both now return false for every stat error.
- The primary-container traversal existed in four copies in `artifact.go` and had drifted: `PrimaryContainerName` required a non-empty name, so an unnamed primary made it report a sidecar's name while the other three read the primary. All four now share one `primaryContainer()` helper.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.
