### PR TITLE
[CFX-7448] docs(telemetry): remove anonymous analytics language

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -239,7 +239,7 @@ func init() {
 	RootCmd.PersistentFlags().Duration("plugin-discovery-timeout", 2*time.Second, "timeout for plugin discovery (0s disables)")
 	RootCmd.PersistentFlags().Duration("plugin-update-check-interval", internalPlugin.DefaultUpdateCheckInterval, "cooldown between plugin update checks (0s disables)")
 	RootCmd.PersistentFlags().Bool("skip-plugin-update-check", false, "skip plugin update checks before running plugins")
-	RootCmd.PersistentFlags().Bool("disable-telemetry", false, "disable anonymous usage telemetry")
+	RootCmd.PersistentFlags().Bool("disable-telemetry", false, "disable usage telemetry")
 
 	// Private CA / TLS flags
 	RootCmd.PersistentFlags().BoolP("skip-certificate-check", "k", false, "skip TLS certificate verification (insecure)")

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -26,7 +26,7 @@ If you're new to developing the CLI, start here:
 - **[Remote plugins](remote-plugins.md)**&mdash;create and distribute remote plugins, plugin registry management.
 - **[Workload `.wapi/` validation](workload-wapi-validation.md)**&mdash;reference for `validator/v10` tags and cross-field rules for workload local state.
 - **[Releasing](releasing.md)**&mdash;release process, versioning strategy, and GoReleaser configuration.
-- **[Telemetry](telemetry.md)**&mdash;how anonymous usage analytics are collected, how to add events, and how to opt out.
+- **[Telemetry](telemetry.md)**&mdash;how usage analytics linked to your DataRobot user ID are collected, how to add events, and how to opt out.
 
 ## Quick reference
 

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry
 
-The CLI collects anonymous usage analytics via [Amplitude](https://amplitude.com/) to help the DataRobot team understand how the tool is used. Telemetry is implemented in `internal/telemetry/`. On each CLI invocation a `Client` is created with a set of `CommonProperties`, events are queued via `Client.Track()`, and the queue is flushed at process exit via `Client.Flush()`.
+The CLI collects usage analytics linked to your DataRobot user ID via [Amplitude](https://amplitude.com/) to help the DataRobot team understand how the tool is used. Telemetry is an optional feature that can be turned off at any time (see [Configuring and disabling telemetry](#configuring-and-disabling-telemetry)). All telemetry data is stored in the USA. Telemetry is implemented in `internal/telemetry/`. On each CLI invocation a `Client` is created with a set of `CommonProperties`, events are queued via `Client.Track()`, and the queue is flushed at process exit via `Client.Flush()`.
 
 When telemetry is disabled, every operation is a safe no-op — events are logged to the debug logger instead of being sent over the network.
 
@@ -38,7 +38,7 @@ Telemetry makes outbound HTTPS requests to two services. In network-restricted e
 | `api.eu.amplitude.com`                                     | Amplitude HTTP API (EU zone) — only if `ServerZone` is set to EU                                              | 443  |
 | *configured DataRobot endpoint* (e.g. `app.datarobot.com`) | `GET /api/v2/account/info/` — fetches the `user_id`, `organization_id`, and `tenant_id` for event attribution | 443  |
 
-The DataRobot endpoint call is only made when the user is authenticated and the cached account info is stale or absent (see [User ID](#user-id)). If that call fails due to network restrictions, telemetry falls back to anonymous (`device_id`-only) tracking — the CLI does not error.
+The DataRobot endpoint call is only made when the user is authenticated and the cached account info is stale or absent (see [User ID](#user-id)). If that call fails due to network restrictions, telemetry falls back to `device_id`-only tracking — the CLI does not error.
 
 No other hosts are contacted by the telemetry subsystem.
 
@@ -59,9 +59,9 @@ Amplitude requires a `device_id` or `user_id` on every event. The CLI uses a sta
 
 ## User ID
 
-When the user is authenticated, the CLI sends a real DataRobot `uid` as the top-level Amplitude `user_id` field. If the user is unauthenticated (no API token, invalid token, or network failure with no valid cache), the field is left empty and Amplitude falls back to `device_id`-only anonymous tracking.
+When the user is authenticated, the CLI sends a real DataRobot `uid` as the top-level Amplitude `user_id` field. If the user is unauthenticated (no API token, invalid token, or network failure with no valid cache), the field is left empty and Amplitude falls back to `device_id`-only tracking.
 
-The `uid` is fetched from `GET /api/v2/account/info/`, which returns an `AccountInfo` response containing the user's unique identifier, organization ID, and tenant ID. The `uid` is stable per DataRobot instance and is not PII (email is deliberately excluded from telemetry to avoid transmitting personally identifiable information). The organization ID and tenant ID are also cached and sent as event properties (see [Common Properties](#common-properties)).
+The `uid` is fetched from `GET /api/v2/account/info/`, which returns an `AccountInfo` response containing the user's unique identifier, organization ID, and tenant ID. The `uid` is stable per DataRobot instance and uniquely identifies your DataRobot user account. Email is deliberately excluded from telemetry payloads. The organization ID and tenant ID are also cached and sent as event properties (see [Common Properties](#common-properties)).
 
 ### Caching
 
@@ -95,7 +95,7 @@ On subsequent invocations, when no fresh API response is available, the cache is
 - **Token fingerprint match**: the cached `token_fingerprint` must equal the SHA-256 hex of the current API token
 - **Completeness check**: the cache must contain both a non-empty `uid` and `organization_id`. Cache files written by older CLI versions (before `organization_id`/`tenant_id` were added) are treated as partial and trigger a re-fetch. (`tenant_id` may legitimately be empty for legacy or system accounts, so it is not included in this check.)
 
-If any check fails, the cache is treated as stale and a fresh API call is made. If the API call also fails (network error), the cached `uid` is still used as long as the endpoint and token fingerprint match — this preserves tracking in offline scenarios. If the endpoint or token changed and the API is unreachable, `user_id` is left empty (anonymous tracking).
+If any check fails, the cache is treated as stale and a fresh API call is made. If the API call also fails (network error), the cached `uid` is still used as long as the endpoint and token fingerprint match — this preserves tracking in offline scenarios. If the endpoint or token changed and the API is unreachable, `user_id` is left empty (`device_id`-only tracking).
 
 This ensures correct behavior in shared environments (e.g., Codespaces) where two users may authenticate sequentially with different tokens — the token fingerprint prevents incorrectly attributing User B's activity to User A's cached `uid`.
 
@@ -108,9 +108,9 @@ This ensures correct behavior in shared environments (e.g., Codespaces) where tw
 | Endpoint changed                                                 | Re-fetch from API, update cache                       |
 | Token changed (rotation / new user)                              | Re-fetch from API, update cache                       |
 | Partial cache (old CLI version, missing `org_id`)                | Re-fetch from API, update cache                       |
-| No API token / invalid token                                     | Empty `user_id`, anonymous tracking                   |
+| No API token / invalid token                                     | Empty `user_id`, `device_id`-only tracking            |
 | Network error, same endpoint + token, valid cache                | Return cached `uid`, `org_id`, `tenant_id`            |
-| Network error, endpoint/token changed                            | Empty `user_id`, anonymous tracking                   |
+| Network error, endpoint/token changed                            | Empty `user_id`, `device_id`-only tracking            |
 
 ## Common Properties
 
@@ -122,7 +122,7 @@ These map to Amplitude's built-in fields and power native segmentation (version 
 
 | Field         | Source                                                                                                                                                                                      |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `user_id`     | DataRobot `uid` from `GET /api/v2/account/info/`, cached to disk with endpoint + token fingerprint validation; empty (anonymous) if unauthenticated or cache miss — see [User ID](#user-id) |
+| `user_id`     | DataRobot `uid` from `GET /api/v2/account/info/`, cached to disk with endpoint + token fingerprint validation; empty if unauthenticated or cache miss — see [User ID](#user-id) |
 | `device_id`   | OS machine ID (hashed) or persisted UUID — see [Device ID](#device-id) above                                                                                                                |
 | `session_id`  | Unix millisecond timestamp generated once per process invocation — Amplitude uses this as the built-in Session ID for session-based analysis                                                |
 | `app_version` | CLI version set at build time via ldflags                                                                                                                                                   |

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -146,7 +146,7 @@ export DATAROBOT_API_CONSUMER_TRACKING_ENABLED=false
 
 ### Telemetry
 
-The CLI collects anonymous usage analytics to help improve the tool. To disable telemetry:
+The CLI collects usage analytics linked to your DataRobot user ID to help improve the tool. Telemetry is an optional feature that can be turned off at any time, and all telemetry data is stored in the USA. To disable telemetry:
 
 ```bash
 # Per-invocation

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package telemetry provides anonymous usage analytics for the DataRobot CLI.
+// Package telemetry provides usage analytics for the DataRobot CLI.
 //
 // Telemetry is collected via the Amplitude analytics-go SDK. When telemetry is
 // disabled (via --disable-telemetry flag, DATAROBOT_CLI_DISABLE_TELEMETRY env var,


### PR DESCRIPTION
Update all telemetry documentation to accurately describe the data collection:

- Replace "anonymous usage analytics" with "usage analytics linked to your DataRobot user ID" across docs and source comments
- Add statement that all telemetry data is stored in the USA
- Emphasize that telemetry is optional and can be turned off
- Remove the inaccurate "is not PII" claim from the User ID section

Files changed:
- docs/development/telemetry.md: intro paragraph, User ID section
- docs/user-guide/configuration.md: telemetry section intro
- docs/development/README.md: telemetry link description
- internal/telemetry/telemetry.go: package doc comment
- cmd/root.go: --disable-telemetry flag help text

# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1785966719.328939 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and help-string only; no changes to telemetry collection, networking, or opt-out behavior.
> 
> **Overview**
> This PR **updates telemetry wording** so docs and in-app help match what the CLI actually sends: analytics tied to your **DataRobot user ID** when authenticated, not described as anonymous.
> 
> **Docs** (`telemetry.md`, user `configuration.md`, dev `README`) now state that telemetry is **optional**, can be disabled anytime, and that **data is stored in the USA**. The User ID section drops the claim that `uid` “is not PII” and instead says it uniquely identifies the DataRobot account (email still excluded from payloads). Tables and fallback behavior are relabeled from “anonymous tracking” to **`device_id`-only tracking** when `user_id` is empty.
> 
> **Minor surface text**: `--disable-telemetry` help drops “anonymous”; `internal/telemetry` package comment matches the new framing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4239c903e9608f8a106bf35ebb473a88ad59649. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->