### PR TITLE
[CFX-7450] revert: re-enable telemetry

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -17,14 +17,12 @@ builds:
       binary: "dr"
       mod_timestamp: "{{ .CommitTimestamp }}"
 
-      # Telemetry disabled pending legal approval. To re-enable, add this back
-      # to the ldflags block below:
-      #   -X "github.com/datarobot/cli/internal/telemetry.AmplitudeAPIKey={{ if index .Env "AMPLITUDE_API_KEY" }}{{ .Env.AMPLITUDE_API_KEY }}{{ end }}"
       ldflags:
         - >
           -X "github.com/datarobot/cli/internal/version.Version={{ .Tag }}"
           -X "github.com/datarobot/cli/internal/version.GitCommit={{ .ShortCommit }}"
           -X "github.com/datarobot/cli/internal/version.BuildDate={{ .CommitDate }}"
+          -X "github.com/datarobot/cli/internal/telemetry.AmplitudeAPIKey={{ if index .Env "AMPLITUDE_API_KEY" }}{{ .Env.AMPLITUDE_API_KEY }}{{ end }}"
           -X "github.com/datarobot/cli/internal/telemetry.InstallMethod=release"
 
       goarch:


### PR DESCRIPTION
Reverts CFX-6347 (PR #544) which disabled the AmplitudeAPIKey ldflag in goreleaser.yaml pending external stakeholder approval; this has happened so...

Restores the ldflag line so release builds inject the Amplitude API key at build time, re-enabling telemetry collection.

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1785984779.017489 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turns telemetry back on for release artifacts (privacy/compliance surface); behavior matches pre-disable releases and still respects user opt-out.
> 
> **Overview**
> **Re-enables telemetry for official release builds** by restoring the `AmplitudeAPIKey` `-X` ldflag in `goreleaser.yaml` (reverting the temporary disable from CFX-6347 / PR #544).
> 
> Release pipelines that set `AMPLITUDE_API_KEY` will again bake the key into `internal/telemetry.AmplitudeAPIKey` at link time, so `IsEnabled()` can turn on Amplitude for release binaries. Dev/source builds without the env var still get an empty key and remain no-op. User opt-out via `disable-telemetry` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a67dc3c19622715556467fa2281b0da0a129375b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->