### PR TITLE
[RAPTOR-18973] feat(workload): manifest package core: parse, locate, compile

### DIFF
--- a/internal/workload/manifest/compile.go
+++ b/internal/workload/manifest/compile.go
@@ -1,0 +1,255 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// credentialShorthandPrefix starts the manifest's compact credential
+	// value form, dr-credential:<credential-id>/<key>. The compiler rewrites
+	// it into the API's object form; the object form is accepted in the file
+	// as well.
+	credentialShorthandPrefix = "dr-credential:"
+
+	// credentialSource is the API's source discriminator for
+	// credential-backed environment variables. It mirrors the workload
+	// package's EnvironmentVarSourceDRCredential without importing it, so
+	// this package stays standalone; a test locks the two together.
+	credentialSource = "dr-credential"
+)
+
+// CredentialRef names one stored credential the manifest references, in
+// either value form. The manifest package performs no API calls; callers
+// verify each referenced credential exists (a GET per CredentialID) before
+// anything mutates, so a stale id fails in milliseconds instead of after a
+// build.
+type CredentialRef struct {
+	CredentialID string
+	// Key selects which field of the credential feeds the variable.
+	Key string
+	// EnvName is the environment variable the reference feeds, so errors can
+	// name the variable rather than only the credential id.
+	EnvName string
+	// Line is where the reference appears in the manifest.
+	Line int
+}
+
+// Compiled is a manifest lowered to what the API accepts.
+type Compiled struct {
+	// Payload is valid workload-create input: the manifest with the
+	// CLI-managed workloadId stripped and credential shorthand expanded,
+	// unknown blocks passed through untouched.
+	Payload json.RawMessage
+	// WorkloadID is the stripped binding, "" when the manifest is unbound.
+	WorkloadID string
+	// CredentialRefs lists every credential the payload references.
+	CredentialRefs []CredentialRef
+}
+
+// Compile lowers the manifest to a workload-create payload. It does not run
+// the validation ledger; call Validate first for line-anchored errors.
+// Compile still refuses a malformed credential shorthand rather than sending
+// it to the API as a literal value.
+func (m *Manifest) Compile() (*Compiled, error) {
+	refs, fieldErrs := collectCredentialRefs(m.root)
+	if len(fieldErrs) > 0 {
+		return nil, &ValidationError{File: m.fileLabel(), Errors: fieldErrs}
+	}
+
+	var doc map[string]any
+
+	if err := m.root.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("cannot decode manifest: %w", err)
+	}
+
+	workloadID := m.WorkloadID()
+
+	delete(doc, keyWorkloadID)
+	expandCredentialShorthand(doc)
+
+	payload, err := json.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert manifest to JSON: %w", err)
+	}
+
+	return &Compiled{Payload: payload, WorkloadID: workloadID, CredentialRefs: refs}, nil
+}
+
+// expandCredentialShorthand rewrites every environmentVars entry carrying
+// the shorthand into the API object form. The walk is shape-agnostic so
+// environmentVars is found wherever the spec puts it: containerGroups,
+// components, or locations the platform adds later.
+func expandCredentialShorthand(value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			if key == keyEnvironmentVars {
+				expandVarsList(child)
+			}
+
+			expandCredentialShorthand(child)
+		}
+	case []any:
+		for _, item := range typed {
+			expandCredentialShorthand(item)
+		}
+	}
+}
+
+func expandVarsList(value any) {
+	list, ok := value.([]any)
+	if !ok {
+		return
+	}
+
+	for _, item := range list {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		raw, ok := entry[keyValue].(string)
+		if !ok || !strings.HasPrefix(raw, credentialShorthandPrefix) {
+			continue
+		}
+
+		id, key, ok := parseCredentialShorthand(raw)
+		if !ok {
+			// Unreachable after Compile's syntax gate; leaving the raw value
+			// in place is still safer than inventing a partial object.
+			continue
+		}
+
+		delete(entry, keyValue)
+		entry[keySource] = credentialSource
+		entry[keyDRCredentialID] = id
+		entry[keyKey] = key
+	}
+}
+
+// parseCredentialShorthand splits dr-credential:<credential-id>/<key> into
+// its parts; ok is false when either part is empty. The key may itself
+// contain slashes: only the first one separates.
+func parseCredentialShorthand(value string) (id, key string, ok bool) {
+	rest := strings.TrimPrefix(value, credentialShorthandPrefix)
+
+	id, key, found := strings.Cut(rest, "/")
+	if !found || id == "" || key == "" {
+		return "", "", false
+	}
+
+	return id, key, true
+}
+
+// collectCredentialRefs walks every environmentVars sequence in the tree and
+// returns each dr-credential reference, shorthand and object form alike,
+// with syntax problems collected alongside. Validate reports the problems;
+// Compile returns the refs so callers can GET-verify each credential before
+// anything mutates.
+func collectCredentialRefs(root *yaml.Node) ([]CredentialRef, []FieldError) {
+	c := &refCollector{}
+	c.walk(root, "")
+
+	return c.refs, c.errs
+}
+
+type refCollector struct {
+	refs []CredentialRef
+	errs []FieldError
+}
+
+func (c *refCollector) walk(node *yaml.Node, path string) {
+	switch node.Kind {
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i].Value
+			value := node.Content[i+1]
+
+			if key == keyEnvironmentVars {
+				c.collectFromVars(value, joinPath(path, key))
+			}
+
+			c.walk(value, joinPath(path, key))
+		}
+	case yaml.SequenceNode:
+		for i, item := range node.Content {
+			c.walk(item, fmt.Sprintf("%s[%d]", path, i))
+		}
+	case yaml.DocumentNode, yaml.ScalarNode, yaml.AliasNode:
+		// Leaves, and containers the walk does not descend into.
+	}
+}
+
+func (c *refCollector) collectFromVars(vars *yaml.Node, path string) {
+	for i, entry := range seqItems(vars) {
+		entryPath := fmt.Sprintf("%s[%d]", path, i)
+		name, _ := scalarString(mapValue(entry, keyName))
+
+		if value, ok := scalarString(mapValue(entry, keyValue)); ok && strings.HasPrefix(value, credentialShorthandPrefix) {
+			c.addShorthand(mapValue(entry, keyValue), entryPath, name, value)
+			continue
+		}
+
+		if source, _ := scalarString(mapValue(entry, keySource)); source == credentialSource {
+			c.addObjectForm(entry, entryPath, name)
+		}
+	}
+}
+
+func (c *refCollector) addShorthand(node *yaml.Node, path, name, value string) {
+	id, key, ok := parseCredentialShorthand(value)
+	if !ok {
+		c.errs = append(c.errs, FieldError{
+			Path: path + "." + keyValue,
+			Line: node.Line,
+			Msg:  fmt.Sprintf("credential reference %q must be %s<credential-id>/<key>", value, credentialShorthandPrefix),
+		})
+
+		return
+	}
+
+	c.refs = append(c.refs, CredentialRef{CredentialID: id, Key: key, EnvName: name, Line: node.Line})
+}
+
+func (c *refCollector) addObjectForm(entry *yaml.Node, path, name string) {
+	id, _ := scalarString(mapValue(entry, keyDRCredentialID))
+	key, _ := scalarString(mapValue(entry, keyKey))
+
+	if id == "" {
+		c.errs = append(c.errs, FieldError{
+			Path: path + "." + keyDRCredentialID,
+			Line: entry.Line,
+			Msg:  fmt.Sprintf("%s is required when source is %s", keyDRCredentialID, credentialSource),
+		})
+	}
+
+	if key == "" {
+		c.errs = append(c.errs, FieldError{
+			Path: path + "." + keyKey,
+			Line: entry.Line,
+			Msg:  fmt.Sprintf("%s is required when source is %s", keyKey, credentialSource),
+		})
+	}
+
+	if id != "" {
+		c.refs = append(c.refs, CredentialRef{CredentialID: id, Key: key, EnvName: name, Line: entry.Line})
+	}
+}

--- a/internal/workload/manifest/compile.go
+++ b/internal/workload/manifest/compile.go
@@ -177,6 +177,11 @@ type refCollector struct {
 }
 
 func (c *refCollector) walk(node *yaml.Node, path string) {
+	node = resolveAlias(node)
+	if node == nil {
+		return
+	}
+
 	switch node.Kind {
 	case yaml.MappingNode:
 		for i := 0; i+1 < len(node.Content); i += 2 {
@@ -194,7 +199,9 @@ func (c *refCollector) walk(node *yaml.Node, path string) {
 			c.walk(item, fmt.Sprintf("%s[%d]", path, i))
 		}
 	case yaml.DocumentNode, yaml.ScalarNode, yaml.AliasNode:
-		// Leaves, and containers the walk does not descend into.
+		// Leaves. AliasNode is unreachable here: resolveAlias above already
+		// replaced it with the node it anchors, but the exhaustive linter
+		// wants every yaml.Kind accounted for.
 	}
 }
 

--- a/internal/workload/manifest/compile_test.go
+++ b/internal/workload/manifest/compile_test.go
@@ -143,6 +143,77 @@ artifact: null
 	}`, string(compiled.Payload))
 }
 
+// A manifest may define a shared environmentVars block anywhere and alias it
+// into containerGroups, e.g. to keep several containers' variables in sync.
+// The anchor itself sits under a key other than environmentVars, so the only
+// place the credential walk can find this reference at all is by resolving
+// the alias at its environmentVars usage.
+func TestCompile_ExpandsCredentialShorthandThroughAlias(t *testing.T) {
+	m, err := Parse([]byte(`name: my-app
+definitions:
+  sharedEnv: &sharedEnv
+    - name: OPENAI_API_KEY
+      value: dr-credential:68f0cccc0000000000000003/apiToken
+artifact:
+  spec:
+    containerGroups:
+      - containers:
+          - name: primary
+            imageUri: a:1
+            environmentVars: *sharedEnv
+`), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	require.Len(t, compiled.CredentialRefs, 1)
+	assert.Equal(t, "68f0cccc0000000000000003", compiled.CredentialRefs[0].CredentialID)
+
+	var payload struct {
+		Artifact struct {
+			Spec struct {
+				ContainerGroups []struct {
+					Containers []struct {
+						EnvironmentVars []workload.EnvironmentVar `json:"environmentVars"`
+					} `json:"containers"`
+				} `json:"containerGroups"`
+			} `json:"spec"`
+		} `json:"artifact"`
+	}
+	require.NoError(t, json.Unmarshal(compiled.Payload, &payload))
+
+	envVars := payload.Artifact.Spec.ContainerGroups[0].Containers[0].EnvironmentVars
+	require.Len(t, envVars, 1)
+	assert.Equal(t, workload.EnvironmentVar{
+		Source:         workload.EnvironmentVarSourceDRCredential,
+		Name:           "OPENAI_API_KEY",
+		DRCredentialID: "68f0cccc0000000000000003",
+		Key:            "apiToken",
+	}, envVars[0])
+}
+
+func TestCompile_MalformedShorthandThroughAliasFails(t *testing.T) {
+	m, err := Parse([]byte(`name: my-app
+definitions:
+  sharedEnv: &sharedEnv
+    - name: KEY
+      value: dr-credential:no-key-part
+artifact:
+  spec:
+    containerGroups:
+      - containers:
+          - imageUri: a:1
+            environmentVars: *sharedEnv
+`), "")
+	require.NoError(t, err)
+
+	_, err = m.Compile()
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "must be dr-credential:<credential-id>/<key>")
+}
+
 func TestCompile_MalformedShorthandFails(t *testing.T) {
 	m, err := Parse([]byte(`name: my-app
 artifact:

--- a/internal/workload/manifest/compile_test.go
+++ b/internal/workload/manifest/compile_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompile_StripsWorkloadID(t *testing.T) {
+	m, err := Parse([]byte(`workloadId: 68b0aaaa0000000000000001
+name: my-app
+artifactId: 68b0bbbb0000000000000002
+`), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	assert.Equal(t, "68b0aaaa0000000000000001", compiled.WorkloadID)
+	assert.JSONEq(t, `{"name": "my-app", "artifactId": "68b0bbbb0000000000000002"}`, string(compiled.Payload))
+}
+
+// The shorthand must compile to exactly the object the workload package's
+// EnvironmentVar marshals to: the expected JSON is built from that struct, so
+// a drifted field tag fails here instead of at the API.
+func TestCompile_ExpandsCredentialShorthand(t *testing.T) {
+	m, err := Parse([]byte(`name: my-app
+artifact:
+  spec:
+    containerGroups:
+      - containers:
+          - name: primary
+            imageUri: a:1
+            environmentVars:
+              - name: OPENAI_API_KEY
+                value: dr-credential:68f0cccc0000000000000003/apiToken
+`), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	expandedVar, err := json.Marshal(workload.EnvironmentVar{
+		Source:         workload.EnvironmentVarSourceDRCredential,
+		Name:           "OPENAI_API_KEY",
+		DRCredentialID: "68f0cccc0000000000000003",
+		Key:            "apiToken",
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t, fmt.Sprintf(`{
+		"name": "my-app",
+		"artifact": {
+			"spec": {
+				"containerGroups": [{
+					"containers": [{
+						"name": "primary",
+						"imageUri": "a:1",
+						"environmentVars": [%s]
+					}]
+				}]
+			}
+		}
+	}`, expandedVar), string(compiled.Payload))
+
+	require.Len(t, compiled.CredentialRefs, 1)
+
+	ref := compiled.CredentialRefs[0]
+	assert.Equal(t, "68f0cccc0000000000000003", ref.CredentialID)
+	assert.Equal(t, "apiToken", ref.Key)
+	assert.Equal(t, "OPENAI_API_KEY", ref.EnvName)
+	assert.Positive(t, ref.Line)
+}
+
+func TestCompile_ObjectFormPassthroughAndCollected(t *testing.T) {
+	m, err := Parse([]byte(`name: my-app
+artifact:
+  spec:
+    containerGroups:
+      - containers:
+          - name: primary
+            imageUri: a:1
+            environmentVars:
+              - name: OPENAI_API_KEY
+                source: dr-credential
+                drCredentialId: 68f0cccc0000000000000003
+                key: apiToken
+`), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	var payload map[string]any
+
+	require.NoError(t, json.Unmarshal(compiled.Payload, &payload))
+	assert.NotContains(t, string(compiled.Payload), credentialShorthandPrefix+"68f0")
+
+	require.Len(t, compiled.CredentialRefs, 1)
+	assert.Equal(t, "68f0cccc0000000000000003", compiled.CredentialRefs[0].CredentialID)
+	assert.Equal(t, "apiToken", compiled.CredentialRefs[0].Key)
+}
+
+// Unknown blocks pass through untouched so platform additions need no CLI
+// release.
+func TestCompile_UnknownKeysSurvive(t *testing.T) {
+	m, err := Parse([]byte(`name: my-app
+artifactId: abc
+futureTopLevel:
+  anything:
+    - 1
+    - two
+artifact: null
+`), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"name": "my-app",
+		"artifactId": "abc",
+		"futureTopLevel": {"anything": [1, "two"]},
+		"artifact": null
+	}`, string(compiled.Payload))
+}
+
+func TestCompile_MalformedShorthandFails(t *testing.T) {
+	m, err := Parse([]byte(`name: my-app
+artifact:
+  spec:
+    containerGroups:
+      - containers:
+          - imageUri: a:1
+            environmentVars:
+              - name: KEY
+                value: dr-credential:no-key-part
+`), "")
+	require.NoError(t, err)
+
+	_, err = m.Compile()
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "must be dr-credential:<credential-id>/<key>")
+}
+
+// The compiled payload minus the CLI keys must be valid workload-create
+// input; holding that property here is the down-payment on the end-to-end
+// smoke test that deploys a wizard-written manifest.
+func TestCompile_PayloadIsValidCreateSpec(t *testing.T) {
+	m, err := Parse([]byte(validManifest), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	assert.NoError(t, workload.ValidateWorkloadCreateRequest(compiled.Payload))
+}

--- a/internal/workload/manifest/doc.go
+++ b/internal/workload/manifest/doc.go
@@ -1,0 +1,39 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package manifest owns the committed .datarobot.yaml workload manifest: the
+// repository-root file that is the platform's workload-create spec verbatim,
+// plus the two CLI-managed conveniences layered on top. workloadId binds the
+// file to a workload and is stripped before every API call; the
+// dr-credential:<credential-id>/<key> value shorthand compiles to the API's
+// credential-backed environment variable object (the object form is accepted
+// in the file as well).
+//
+// There are no typed spec structs here on purpose: the workload-api schema
+// moves faster than any struct would, so unknown blocks pass through to the
+// API untouched and platform additions need no CLI release. The package
+// parses the file once into a yaml.Node tree and derives everything from it:
+// Validate walks the nodes so every finding carries its manifest line,
+// Compile lowers the tree to the JSON create payload, and WriteWorkloadID
+// performs the package's only write, a single-key edit that keeps the user's
+// comments, unknown keys and their order intact. config never rewrites an
+// existing manifest; after the first write the file is the interface.
+//
+// Non-scope: no HTTP. Compile returns CredentialRefs so callers can verify
+// each referenced credential against the store (one GET per credential)
+// before anything mutates; the lookup itself lives with the workload API
+// clients. No wizard UI and no sync state either: the similarly named
+// wapi.Manifest is the .datarobot/workload/manifest.json sync index, a
+// different file entirely.
+package manifest

--- a/internal/workload/manifest/doc.go
+++ b/internal/workload/manifest/doc.go
@@ -24,11 +24,12 @@
 // moves faster than any struct would, so unknown blocks pass through to the
 // API untouched and platform additions need no CLI release. The package
 // parses the file once into a yaml.Node tree and derives everything from it:
-// Validate walks the nodes so every finding carries its manifest line,
-// Compile lowers the tree to the JSON create payload, and WriteWorkloadID
-// performs the package's only write, a single-key edit that keeps the user's
-// comments, unknown keys and their order intact. config never rewrites an
-// existing manifest; after the first write the file is the interface.
+// Compile lowers the tree to the JSON create payload. A stacked follow-up
+// adds Validate, walking the same tree so every finding carries its manifest
+// line, and WriteWorkloadID, the package's only write: a single-key edit
+// that keeps the user's comments, unknown keys and their order intact.
+// config never rewrites an existing manifest; after the first write the
+// file is the interface.
 //
 // Non-scope: no HTTP. Compile returns CredentialRefs so callers can verify
 // each referenced credential against the store (one GET per credential)

--- a/internal/workload/manifest/errors.go
+++ b/internal/workload/manifest/errors.go
@@ -1,0 +1,51 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FieldError is one finding against the manifest, anchored to the line it
+// came from. Path names YAML keys the way the file spells them, e.g.
+// artifact.spec.containerGroups[0].containers[1].port.
+type FieldError struct {
+	Path string
+	Line int
+	Msg  string
+}
+
+func (e FieldError) Error() string {
+	return fmt.Sprintf("line %d: %s: %s", e.Line, e.Path, e.Msg)
+}
+
+// ValidationError collects every finding for one manifest: problems are
+// reported in a single pass rather than stopping at the first.
+type ValidationError struct {
+	File   string
+	Errors []FieldError
+}
+
+func (e *ValidationError) Error() string {
+	lines := make([]string, 0, len(e.Errors)+1)
+	lines = append(lines, fmt.Sprintf("invalid manifest %s:", e.File))
+
+	for _, fieldErr := range e.Errors {
+		lines = append(lines, "  "+fieldErr.Error())
+	}
+
+	return strings.Join(lines, "\n")
+}

--- a/internal/workload/manifest/helpers_test.go
+++ b/internal/workload/manifest/helpers_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// validManifest exercises every ledger rule on its passing side: inline
+// artifact with a flagged primary, both credential value forms, and a
+// runtime block whose names match the artifact's.
+const validManifest = `workloadId: 68b0aaaa0000000000000001
+name: my-app
+importance: HIGH
+artifact:
+  name: my-app-artifact
+  status: draft
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageUri: nginx:latest
+            environmentVars:
+              - name: LOG_LEVEL
+                value: debug
+              - name: OPENAI_API_KEY
+                value: dr-credential:68f0cccc0000000000000003/apiToken
+runtime:
+  containerGroups:
+    - name: default
+      replicaCount: 2
+      containers:
+        - name: primary
+          resourceAllocation:
+            cpu: 0.5
+            memory: 512MB
+`
+
+func writeManifest(t *testing.T, dir, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, FileName)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}

--- a/internal/workload/manifest/keys.go
+++ b/internal/workload/manifest/keys.go
@@ -1,0 +1,32 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+// Manifest-level and credential field names, defined once so a schema rename
+// is a one-line change. The validation ledger declares the deeper spec field
+// names it walks in its own file.
+const (
+	keyArtifact        = "artifact"
+	keyArtifactID      = "artifactId"
+	keyDRCredentialID  = "drCredentialId"
+	keyEnvironmentVars = "environmentVars"
+	keyImportance      = "importance"
+	keyKey             = "key"
+	keyName            = "name"
+	keyRuntime         = "runtime"
+	keySource          = "source"
+	keyValue           = "value"
+	keyWorkloadID      = "workloadId"
+)

--- a/internal/workload/manifest/manifest.go
+++ b/internal/workload/manifest/manifest.go
@@ -1,0 +1,176 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/datarobot/cli/internal/fsutil"
+	"gopkg.in/yaml.v3"
+)
+
+// FileName is the manifest's file name, conventionally at the repository root.
+const FileName = ".datarobot.yaml"
+
+// ErrNotFound reports that Locate found no manifest. Callers branch on it
+// with errors.Is, e.g. to fall into the setup wizard instead of failing.
+var ErrNotFound = errors.New("no " + FileName + " manifest found")
+
+// recognizedKeys are the top-level keys that identify a workload manifest. A
+// file with none of them is rejected as foreign rather than deployed as an
+// all-defaults workload.
+var recognizedKeys = []string{keyWorkloadID, keyName, keyImportance, keyArtifact, keyArtifactID, keyRuntime}
+
+// Manifest is a parsed .datarobot.yaml. Validation and compilation both
+// derive from the one retained parse tree, so they cannot disagree about
+// what the file says.
+type Manifest struct {
+	// Path is the absolute path the manifest was loaded from, "" when it was
+	// parsed from bytes.
+	Path string
+	// Dir anchors file-existence rules such as the provided-mode Dockerfile
+	// check; "" skips them.
+	Dir string
+
+	root *yaml.Node
+}
+
+// Load reads and parses the manifest at path. The file's directory becomes
+// Dir, anchoring file-existence validation rules.
+func Load(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("manifest not found: %s", path)
+		}
+
+		return nil, fmt.Errorf("cannot read manifest %s: %w", path, err)
+	}
+
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve manifest path %s: %w", path, err)
+	}
+
+	m, err := Parse(data, filepath.Dir(abs))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+
+	m.Path = abs
+
+	return m, nil
+}
+
+// Parse parses manifest bytes. dir anchors file-existence validation rules;
+// pass "" to skip them, e.g. when previewing content that is not on disk
+// yet. JSON content parses too: the manifest format is whatever the create
+// endpoint accepts, and YAML is a superset of JSON.
+func Parse(data []byte, dir string) (*Manifest, error) {
+	var doc yaml.Node
+
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("invalid YAML: %w", err)
+	}
+
+	root := &doc
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		root = root.Content[0]
+	}
+
+	if root.Kind == 0 {
+		return nil, errors.New("file is empty")
+	}
+
+	if root.Kind != yaml.MappingNode {
+		return nil, errors.New("root must be a YAML mapping")
+	}
+
+	if !hasRecognizedKey(root) {
+		return nil, fmt.Errorf("does not look like a DataRobot workload manifest (none of %s present)",
+			strings.Join(recognizedKeys, ", "))
+	}
+
+	return &Manifest{Dir: dir, root: root}, nil
+}
+
+// Locate searches for the manifest in startDir and each ancestor, the way
+// git finds its repository root. The walk is lexical: symlinks are not
+// resolved, and it stops after checking the user's home directory or the
+// filesystem root, whichever comes first. Returns ErrNotFound when no
+// manifest exists on the walk.
+func Locate(startDir string) (string, error) {
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve %s: %w", startDir, err)
+	}
+
+	home, _ := os.UserHomeDir()
+
+	for {
+		candidate := filepath.Join(dir, FileName)
+		if fsutil.FileExists(candidate) {
+			return candidate, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if dir == home || parent == dir {
+			return "", fmt.Errorf("%w in %s or any parent directory", ErrNotFound, startDir)
+		}
+
+		dir = parent
+	}
+}
+
+// WorkloadID returns the CLI-managed workload binding, "" when the manifest
+// is not yet bound to a workload.
+func (m *Manifest) WorkloadID() string {
+	return topLevelString(m.root, keyWorkloadID)
+}
+
+// Name returns the workload name, "" when absent.
+func (m *Manifest) Name() string {
+	return topLevelString(m.root, keyName)
+}
+
+// fileLabel names the manifest in error messages: the real path when the
+// manifest came from disk, the conventional file name otherwise.
+func (m *Manifest) fileLabel() string {
+	if m.Path != "" {
+		return m.Path
+	}
+
+	return FileName
+}
+
+func hasRecognizedKey(root *yaml.Node) bool {
+	for _, key := range recognizedKeys {
+		if mapValue(root, key) != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func topLevelString(root *yaml.Node, key string) string {
+	value, _ := scalarString(mapValue(root, key))
+
+	return value
+}

--- a/internal/workload/manifest/manifest_test.go
+++ b/internal/workload/manifest/manifest_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad_ValidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := writeManifest(t, dir, validManifest)
+
+	m, err := Load(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-app", m.Name())
+	assert.Equal(t, "68b0aaaa0000000000000001", m.WorkloadID())
+	assert.Equal(t, path, m.Path)
+	assert.Equal(t, dir, m.Dir)
+}
+
+// JSON content parses too: the manifest is whatever the create endpoint
+// accepts, and YAML is a superset of JSON.
+func TestLoad_JSONContent(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), `{"name": "my-app", "artifactId": "68b0bbbb0000000000000002"}`)
+
+	m, err := Load(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-app", m.Name())
+	assert.Empty(t, m.WorkloadID())
+}
+
+func TestLoad_EmptyFileRejected(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), "")
+
+	_, err := Load(path)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "file is empty")
+}
+
+func TestLoad_CommentOnlyFileRejected(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), "# nothing here yet\n")
+
+	_, err := Load(path)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "file is empty")
+}
+
+func TestLoad_ForeignFileRejected(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), `apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: my-app
+`)
+
+	_, err := Load(path)
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "does not look like a DataRobot workload manifest")
+}
+
+func TestLoad_FileNotFound(t *testing.T) {
+	_, err := Load(filepath.Join(t.TempDir(), FileName))
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "manifest not found")
+}
+
+func TestParse_RootNotMapping(t *testing.T) {
+	_, err := Parse([]byte("- one\n- two\n"), "")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "root must be a YAML mapping")
+}
+
+func TestParse_InvalidYAML(t *testing.T) {
+	_, err := Parse([]byte("name: [unclosed"), "")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "invalid YAML")
+}
+
+func TestManifest_WorkloadIDAbsent(t *testing.T) {
+	m, err := Parse([]byte("name: my-app\n"), "")
+	require.NoError(t, err)
+
+	assert.Empty(t, m.WorkloadID())
+}
+
+func TestLocate_StartDir(t *testing.T) {
+	dir := t.TempDir()
+	path := writeManifest(t, dir, validManifest)
+
+	found, err := Locate(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, path, found)
+}
+
+func TestLocate_AncestorDir(t *testing.T) {
+	root := t.TempDir()
+	path := writeManifest(t, root, validManifest)
+
+	nested := filepath.Join(root, "services", "api", "handlers")
+	require.NoError(t, os.MkdirAll(nested, 0o750))
+
+	found, err := Locate(nested)
+	require.NoError(t, err)
+
+	assert.Equal(t, path, found)
+}
+
+func TestLocate_NotFound(t *testing.T) {
+	_, err := Locate(t.TempDir())
+	require.Error(t, err)
+
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// A directory named .datarobot.yaml is not a manifest; the walk keeps
+// climbing past it.
+func TestLocate_IgnoresDirectory(t *testing.T) {
+	root := t.TempDir()
+	path := writeManifest(t, root, validManifest)
+
+	child := filepath.Join(root, "sub")
+	require.NoError(t, os.MkdirAll(filepath.Join(child, FileName), 0o750))
+
+	found, err := Locate(child)
+	require.NoError(t, err)
+
+	assert.Equal(t, path, found)
+}

--- a/internal/workload/manifest/node.go
+++ b/internal/workload/manifest/node.go
@@ -1,0 +1,69 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import "gopkg.in/yaml.v3"
+
+// yaml.v3 tag names for the scalar kinds the helpers below distinguish.
+const (
+	strTag  = "!!str"
+	nullTag = "!!null"
+)
+
+// mapValue returns the value node for key in a mapping node, nil when the
+// key is absent or node is not a mapping. Nil-safe so lookups chain:
+// mapValue(mapValue(root, "artifact"), "spec").
+func mapValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+
+	return nil
+}
+
+// seqItems returns a sequence node's items, nil for anything else.
+func seqItems(node *yaml.Node) []*yaml.Node {
+	if node == nil || node.Kind != yaml.SequenceNode {
+		return nil
+	}
+
+	return node.Content
+}
+
+// scalarString returns a scalar node's string value; ok is false for nil,
+// non-scalar and null nodes.
+func scalarString(node *yaml.Node) (string, bool) {
+	if node == nil || node.Kind != yaml.ScalarNode || node.Tag == nullTag {
+		return "", false
+	}
+
+	return node.Value, true
+}
+
+// joinPath extends a YAML path with a key, leaving no leading dot on the
+// root.
+func joinPath(base, key string) string {
+	if base == "" {
+		return key
+	}
+
+	return base + "." + key
+}

--- a/internal/workload/manifest/node.go
+++ b/internal/workload/manifest/node.go
@@ -16,23 +16,34 @@ package manifest
 
 import "gopkg.in/yaml.v3"
 
-// yaml.v3 tag names for the scalar kinds the helpers below distinguish.
-const (
-	strTag  = "!!str"
-	nullTag = "!!null"
-)
+// nullTag is the yaml.v3 tag for an explicit YAML null, the one scalar kind
+// the helpers below reject.
+const nullTag = "!!null"
+
+// resolveAlias follows an alias to the node it anchors, so the helpers below
+// see through YAML anchors/aliases the same way they see a literal value.
+// yaml.v3 aliases point directly at the anchored node, never at another
+// alias, so one hop is enough.
+func resolveAlias(node *yaml.Node) *yaml.Node {
+	if node != nil && node.Kind == yaml.AliasNode {
+		return node.Alias
+	}
+
+	return node
+}
 
 // mapValue returns the value node for key in a mapping node, nil when the
 // key is absent or node is not a mapping. Nil-safe so lookups chain:
 // mapValue(mapValue(root, "artifact"), "spec").
 func mapValue(node *yaml.Node, key string) *yaml.Node {
+	node = resolveAlias(node)
 	if node == nil || node.Kind != yaml.MappingNode {
 		return nil
 	}
 
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		if node.Content[i].Value == key {
-			return node.Content[i+1]
+			return resolveAlias(node.Content[i+1])
 		}
 	}
 
@@ -41,6 +52,7 @@ func mapValue(node *yaml.Node, key string) *yaml.Node {
 
 // seqItems returns a sequence node's items, nil for anything else.
 func seqItems(node *yaml.Node) []*yaml.Node {
+	node = resolveAlias(node)
 	if node == nil || node.Kind != yaml.SequenceNode {
 		return nil
 	}


### PR DESCRIPTION
# RATIONALE

`dr workload up` deploys from one committed file: `.datarobot.yaml` at the repository root, the exact spec `dr workload create --spec-file` accepts today plus two CLI-managed conveniences. This PR adds the package that owns that file. It is the remaining blocker for the `config` wizard (RAPTOR-18975) and the `up` core (RAPTOR-18976). No command surface changes; nothing user-visible ships.

There are deliberately no typed spec structs: the workload-api schema moves faster than any struct would, so unknown blocks pass through untouched and platform additions need no CLI release. The file parses once into a yaml.Node tree and everything derives from it, which is what makes line-anchored errors and comment-preserving writes possible.

This is the first of two stacked PRs for the ticket, split to keep each at about 1k lines: this one carries the read path (parse, locate, compile); the stacked follow-up carries the validation ledger and the workloadId write-back. Part of RAPTOR-18973.

## CHANGES

New package `internal/workload/manifest`; no existing files are touched.

### Parse and locate (`manifest.go`, `node.go`, `keys.go`)

- `Load` / `Parse`: one YAML parse; JSON content parses too, since the manifest is whatever the create endpoint accepts and YAML is a superset of JSON. Empty, comment-only, non-mapping and foreign files (none of the recognized top-level keys present) are rejected rather than deployed as an all-defaults workload.
- `Locate` searches upward from the working directory the way git finds its repository root, stopping after the home directory or the filesystem root. `ErrNotFound` is `errors.Is`-able so `up` can fall into the wizard instead of failing.
- `WorkloadID()` and `Name()` accessors for the two fields the CLI itself reads.
- `node.go` holds the nil-safe yaml.Node accessors the whole package chains lookups with; `keys.go` names the manifest-level fields once.

### Error types (`errors.go`)

- `FieldError` carries the YAML path and manifest line of one finding; `ValidationError` collects every finding for a file in one pass. Compile uses them for credential syntax errors now; the stacked ledger PR reports through the same types.

### Compile (`compile.go`)

- `Compile` lowers the tree to the JSON create payload: strips `workloadId`, expands the `dr-credential:<credential-id>/<key>` value shorthand into the API's credential-backed object form (the object form is accepted in the file as well), and passes unknown blocks through untouched. The environmentVars walk is shape-agnostic, so the shorthand works wherever the spec puts variables. A malformed shorthand is refused rather than sent to the API as a literal value.
- Returns `CredentialRefs` so callers can verify each referenced credential with a GET before anything mutates; the credential lookup client lands with RAPTOR-18977.

### Tests

- Load/Parse rejection cases, `Locate` walk semantics (ancestor hit, not-found, a directory named `.datarobot.yaml` skipped), shorthand expansion locked against `workload.EnvironmentVar`'s JSON tags so a drifted field name fails in CI instead of at the API, unknown-key passthrough, and the compiled payload asserted to be valid `workload.ValidateWorkloadCreateRequest` input (the down-payment on the end-to-end smoke property in RAPTOR-18971).

## NOTES

Stacked follow-up (same ticket): the validation ledger (`Validate` with the full line-anchored rule set) and `WriteWorkloadID` (the comment-preserving write-back). Deferred beyond that, as the ticket allows: the ancestor-manifest warning (RAPTOR-18975 builds it on `Locate`), the full-file write for the wizard (RAPTOR-18975), and the credential lookup client (RAPTOR-18977).

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained new package with no command wiring; credential handling is compile-time validation and expansion covered by tests, with no HTTP or deploy path changes yet.
> 
> **Overview**
> Introduces **`internal/workload/manifest`**, a new library for the repo-root **`.datarobot.yaml`** file that will back `dr workload up`. There are **no CLI or existing-package changes** in this PR.
> 
> **Parse and discover:** `Load`/`Parse` keep a single `yaml.Node` tree (YAML or JSON), reject empty, foreign, or non-mapping files unless recognized workload keys are present, and **`Locate`** walks ancestors (git-style) with **`ErrNotFound`** for wizard fallback. **`WorkloadID()`** / **`Name()`** expose CLI-relevant top-level fields.
> 
> **Compile:** **`Compile`** strips **`workloadId`** from the API payload, expands **`dr-credential:<id>/<key>`** env var shorthand anywhere **`environmentVars`** appears, accepts the object form as-is, passes unknown schema through, and returns **`CredentialRefs`** plus line-anchored **`FieldError`** / **`ValidationError`** on bad credential syntax. Tests lock expansion to **`workload.EnvironmentVar`** JSON and assert the payload passes **`ValidateWorkloadCreateRequest`**.
> 
> Validation ledger and **`WriteWorkloadID`** are explicitly deferred to a stacked follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15757eebe7593ae506541a4966ff2cd6b176f6cd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->