### PR TITLE
[CFX-7264] Add a --source filter to dr llm-gateway list and fetch both sources in parallel

### DIFF
--- a/cmd/llm-gateway/list/cmd.go
+++ b/cmd/llm-gateway/list/cmd.go
@@ -51,6 +51,8 @@ type LLMOutput struct {
 func Cmd() *cobra.Command {
 	var outputFormat outputformat.OutputFormat
 
+	source := SourceAll
+
 	cmd := &cobra.Command{
 		Use:          "list",
 		Aliases:      []string{"ls"},
@@ -59,7 +61,7 @@ func Cmd() *cobra.Command {
 		SilenceUsage: true,
 		PreRunE:      auth.EnsureAuthenticatedE,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			llmList, err := drapi.GetLLMsAndDeployed()
+			llmList, err := fetchLLMs(source)
 			if err != nil {
 				return err
 			}
@@ -81,9 +83,17 @@ func Cmd() *cobra.Command {
 
 	outputformat.AddFlag(cmd, &outputFormat)
 
+	cmd.Flags().Var(&source, "source",
+		fmt.Sprintf("LLM sources to list (%s, %s, %s)", SourceAll, SourceGateway, SourceDeployed))
+
+	_ = cmd.RegisterFlagCompletionFunc("source", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{string(SourceAll), string(SourceGateway), string(SourceDeployed)}, cobra.ShellCompDirectiveNoFileComp
+	})
+
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
 			"output_format": string(outputFormat),
+			"source":        string(source),
 		}
 	})
 

--- a/cmd/llm-gateway/list/cmd_test.go
+++ b/cmd/llm-gateway/list/cmd_test.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/datarobot/cli/internal/config"
@@ -63,6 +65,67 @@ func setupLLMServer(t *testing.T, llms []drapi.LLM) {
 		srv.Close()
 		viperx.Reset()
 	})
+}
+
+const (
+	sourceGatewayBody  = `{"data":[{"llmId":"llm-001","name":"GPT-4o","provider":"azure","model":"gpt-4o","isActive":true}],"count":1,"totalCount":1}`
+	sourceDeployedBody = `{"data":[{"id":"dep-001","label":"RAG LLM","status":"active","model":{"targetType":"TextGeneration"}}],"count":1,"totalCount":1}`
+)
+
+// hitRecorder counts requests per source route so a test can assert that a
+// --source filter skipped a request rather than merely discarding its rows.
+type hitRecorder struct {
+	catalog     atomic.Int32
+	deployments atomic.Int32
+}
+
+// setupSourceServer serves the catalog and deployments routes separately and
+// records which were reached. A non-zero catalogFail or deployedFail makes that
+// route respond with the given status instead of a body.
+func setupSourceServer(t *testing.T, catalogFail, deployedFail int) *hitRecorder {
+	t.Helper()
+
+	hits := &hitRecorder{}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, fail := sourceGatewayBody, catalogFail
+
+		switch {
+		case strings.Contains(r.URL.Path, "/deployments"):
+			hits.deployments.Add(1)
+
+			body, fail = sourceDeployedBody, deployedFail
+		case strings.Contains(r.URL.Path, "/catalog"):
+			hits.catalog.Add(1)
+		default:
+			http.NotFound(w, r)
+
+			return
+		}
+
+		if fail != 0 {
+			http.Error(w, "boom", fail)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+
+	viperx.Reset()
+	viperx.Set(config.DataRobotURL, srv.URL)
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+	// skip_auth trusts the viper token directly; without it resolveToken makes a
+	// verification request this routed handler would 404.
+	viperx.Set(config.SkipAuthKey, true)
+
+	t.Cleanup(func() {
+		srv.Close()
+		viperx.Reset()
+	})
+
+	return hits
 }
 
 // captureStdout redirects os.Stdout for the duration of fn and returns what was written.
@@ -311,4 +374,149 @@ func TestPrintLLMTable_DeployedRow(t *testing.T) {
 
 	// The sentinel model is blanked to "-" in the table (JSON-only contract).
 	assert.NotContains(t, out, "datarobot/datarobot-deployed-llm")
+}
+
+// --- --source ---
+
+func TestSource_SetValid(t *testing.T) {
+	for _, want := range []Source{SourceAll, SourceGateway, SourceDeployed} {
+		var got Source
+
+		require.NoError(t, got.Set(string(want)))
+		assert.Equal(t, want, got)
+	}
+}
+
+func TestSource_SetInvalid(t *testing.T) {
+	var s Source
+
+	err := s.Set("deployments")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid source")
+	assert.Contains(t, err.Error(), "gateway")
+}
+
+// The flag values must stay equal to the strings the SOURCE column and the
+// JSON "source" field emit, so a filter can be copied out of a listing.
+func TestSource_MatchesOutputValues(t *testing.T) {
+	assert.Equal(t, drapi.LLMKindGateway, string(SourceGateway))
+	assert.Equal(t, drapi.LLMKindDeployed, string(SourceDeployed))
+}
+
+// TestListCmd_SourceGatewaySkipsDeployments is the point of the flag: the
+// deployments request is not made at all, not merely filtered out afterwards.
+func TestListCmd_SourceGatewaySkipsDeployments(t *testing.T) {
+	hits := setupSourceServer(t, 0, 0)
+
+	root := newTestCmd(t)
+	root.SetArgs([]string{"list", "--source", "gateway", "--output-format", "json"})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, root.Execute())
+	})
+
+	assert.Positive(t, hits.catalog.Load())
+	assert.Zero(t, hits.deployments.Load())
+
+	var envelope struct {
+		LLMs []LLMOutput `json:"llms"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(out), &envelope))
+	require.Len(t, envelope.LLMs, 1)
+	assert.Equal(t, "llm-001", envelope.LLMs[0].ID)
+	assert.Equal(t, drapi.LLMKindGateway, envelope.LLMs[0].Source)
+}
+
+func TestListCmd_SourceDeployedSkipsCatalog(t *testing.T) {
+	hits := setupSourceServer(t, 0, 0)
+
+	root := newTestCmd(t)
+	root.SetArgs([]string{"list", "--source", "deployed", "--output-format", "json"})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, root.Execute())
+	})
+
+	assert.Positive(t, hits.deployments.Load())
+	assert.Zero(t, hits.catalog.Load())
+
+	var envelope struct {
+		LLMs []LLMOutput `json:"llms"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(out), &envelope))
+	require.Len(t, envelope.LLMs, 1)
+	assert.Equal(t, "dep-001", envelope.LLMs[0].ID)
+	assert.Equal(t, "dep-001", envelope.LLMs[0].DeploymentID)
+	assert.Equal(t, drapi.LLMKindDeployed, envelope.LLMs[0].Source)
+}
+
+// Omitting --source must keep the pre-flag behavior: both sources queried.
+func TestListCmd_SourceDefaultsToAll(t *testing.T) {
+	hits := setupSourceServer(t, 0, 0)
+
+	root := newTestCmd(t)
+	root.SetArgs([]string{"list", "--output-format", "json"})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, root.Execute())
+	})
+
+	assert.Positive(t, hits.catalog.Load())
+	assert.Positive(t, hits.deployments.Load())
+
+	var envelope struct {
+		LLMs []LLMOutput `json:"llms"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(out), &envelope))
+	assert.Len(t, envelope.LLMs, 2)
+}
+
+func TestListCmd_SourceInvalidValue(t *testing.T) {
+	setupSourceServer(t, 0, 0)
+
+	root := newTestCmd(t)
+	root.SetArgs([]string{"list", "--source", "bogus"})
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid source")
+}
+
+// A single-source request has no remainder to fall back on, so its failure is
+// an error rather than the union path's soft-degrade to the other source.
+func TestListCmd_SingleSourceFailureIsAnError(t *testing.T) {
+	setupSourceServer(t, 0, http.StatusInternalServerError)
+
+	root := newTestCmd(t)
+	root.SetArgs([]string{"list", "--source", "deployed"})
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+
+	require.Error(t, root.Execute())
+}
+
+// The same failure under the default --source all still degrades to the
+// reachable source, unchanged by the flag.
+func TestListCmd_AllStillSoftDegrades(t *testing.T) {
+	setupSourceServer(t, 0, http.StatusInternalServerError)
+
+	root := newTestCmd(t)
+	root.SetArgs([]string{"list", "--output-format", "json"})
+
+	out := captureStdout(t, func() {
+		require.NoError(t, root.Execute())
+	})
+
+	var envelope struct {
+		LLMs []LLMOutput `json:"llms"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(out), &envelope))
+	require.Len(t, envelope.LLMs, 1)
+	assert.Equal(t, drapi.LLMKindGateway, envelope.LLMs[0].Source)
 }

--- a/cmd/llm-gateway/list/cmd_test.go
+++ b/cmd/llm-gateway/list/cmd_test.go
@@ -520,3 +520,55 @@ func TestListCmd_AllStillSoftDegrades(t *testing.T) {
 	require.Len(t, envelope.LLMs, 1)
 	assert.Equal(t, drapi.LLMKindGateway, envelope.LLMs[0].Source)
 }
+
+// TestFetchLLMs_CountMatchesRowsAcrossSources pins the one contract fetchLLMs
+// owns: Count and TotalCount describe the rows returned, whatever --source was
+// asked for. The gateway branch needs a paginated catalog to be meaningful,
+// since GetLLMs otherwise leaves the last page's own counts in place and they
+// happen to agree.
+func TestFetchLLMs_CountMatchesRowsAcrossSources(t *testing.T) {
+	var srv *httptest.Server
+
+	catalogPage := 0
+
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(r.URL.Path, "/deployments") {
+			_, _ = io.WriteString(w, sourceDeployedBody)
+
+			return
+		}
+
+		// Two catalog pages, one active model each, with per-page counts that
+		// do not describe the merged result.
+		catalogPage++
+		if catalogPage == 1 {
+			_, _ = io.WriteString(w, `{"data":[{"llmId":"llm-001","name":"One","isActive":true}],"count":1,"totalCount":2,"next":"`+srv.URL+`/api/v2/genai/llmgw/catalog/?offset=100"}`)
+
+			return
+		}
+
+		_, _ = io.WriteString(w, `{"data":[{"llmId":"llm-002","name":"Two","isActive":true}],"count":1,"totalCount":2,"next":""}`)
+	}))
+
+	viperx.Reset()
+	viperx.Set(config.DataRobotURL, srv.URL)
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+	viperx.Set(config.SkipAuthKey, true)
+
+	t.Cleanup(func() {
+		srv.Close()
+		viperx.Reset()
+	})
+
+	for _, source := range []Source{SourceGateway, SourceDeployed, SourceAll} {
+		catalogPage = 0
+
+		got, err := fetchLLMs(source)
+		require.NoError(t, err, source)
+
+		assert.Equal(t, len(got.LLMs), got.Count, "Count for --source %s", source)
+		assert.Equal(t, len(got.LLMs), got.TotalCount, "TotalCount for --source %s", source)
+	}
+}

--- a/cmd/llm-gateway/list/source.go
+++ b/cmd/llm-gateway/list/source.go
@@ -21,9 +21,9 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// Source selects which LLM sources the list command queries. The gateway and
-// deployed values are the same strings the SOURCE column and the JSON "source"
-// field carry, so a filter can be copied straight out of a listing.
+// Source selects which LLM sources the list command queries. Its gateway and
+// deployed values are the strings the SOURCE column and the JSON "source" field
+// already carry, so a filter can be copied straight out of a listing.
 type Source string
 
 const (
@@ -57,13 +57,12 @@ func (s *Source) Type() string {
 	return "source"
 }
 
-// fetchLLMs queries only the sources the filter needs, skipping the request the
-// other source would have made.
+// fetchLLMs skips the request the unselected source would have made.
 //
 // A single-source request returns its error rather than degrading to an empty
-// list: the union path can fall back on the other source, but here there is no
-// remainder to show, and reporting "no models" for an unreachable catalog reads
-// as an empty instance.
+// list. The union path can fall back on the other source; here there is no
+// remainder to show, and "no models" for an unreachable catalog reads as an
+// empty instance.
 func fetchLLMs(source Source) (*drapi.LLMList, error) {
 	if source == SourceGateway {
 		gateway, err := drapi.GetLLMs()

--- a/cmd/llm-gateway/list/source.go
+++ b/cmd/llm-gateway/list/source.go
@@ -66,7 +66,17 @@ func (s *Source) Type() string {
 // as an empty instance.
 func fetchLLMs(source Source) (*drapi.LLMList, error) {
 	if source == SourceGateway {
-		return drapi.GetLLMs()
+		gateway, err := drapi.GetLLMs()
+		if err != nil {
+			return nil, err
+		}
+
+		// GetLLMs leaves Count and TotalCount as the last decoded page reported
+		// them, which is not the filtered row count. Restate them over the rows
+		// actually returned so all three branches agree on what the fields mean.
+		gateway.Count, gateway.TotalCount = len(gateway.LLMs), len(gateway.LLMs)
+
+		return gateway, nil
 	}
 
 	if source == SourceDeployed {

--- a/cmd/llm-gateway/list/source.go
+++ b/cmd/llm-gateway/list/source.go
@@ -1,0 +1,83 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"fmt"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/spf13/pflag"
+)
+
+// Source selects which LLM sources the list command queries. The gateway and
+// deployed values are the same strings the SOURCE column and the JSON "source"
+// field carry, so a filter can be copied straight out of a listing.
+type Source string
+
+const (
+	SourceAll      Source = "all"
+	SourceGateway  Source = drapi.LLMKindGateway
+	SourceDeployed Source = drapi.LLMKindDeployed
+)
+
+var _ pflag.Value = (*Source)(nil)
+
+func (s *Source) String() string {
+	if s == nil {
+		return ""
+	}
+
+	return string(*s)
+}
+
+func (s *Source) Set(v string) error {
+	switch Source(v) {
+	case SourceAll, SourceGateway, SourceDeployed:
+		*s = Source(v)
+
+		return nil
+	}
+
+	return fmt.Errorf("invalid source %q: use %s, %s, or %s", v, SourceAll, SourceGateway, SourceDeployed)
+}
+
+func (s *Source) Type() string {
+	return "source"
+}
+
+// fetchLLMs queries only the sources the filter needs, skipping the request the
+// other source would have made.
+//
+// A single-source request returns its error rather than degrading to an empty
+// list: the union path can fall back on the other source, but here there is no
+// remainder to show, and reporting "no models" for an unreachable catalog reads
+// as an empty instance.
+func fetchLLMs(source Source) (*drapi.LLMList, error) {
+	if source == SourceGateway {
+		return drapi.GetLLMs()
+	}
+
+	if source == SourceDeployed {
+		deployed, err := drapi.GetDeployedLLMs()
+		if err != nil {
+			return nil, err
+		}
+
+		return &drapi.LLMList{LLMs: deployed, Count: len(deployed), TotalCount: len(deployed)}, nil
+	}
+
+	// SourceAll, and a zero value that never went through Set.
+	return drapi.GetLLMsAndDeployed()
+}

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -248,6 +248,10 @@ dr llm-gateway list
 # List as JSON
 dr llm-gateway list --output-format json
 
+# Restrict to one source (skips the other source's request)
+dr llm-gateway list --source gateway
+dr llm-gateway list --source deployed
+
 # Select a default LLM interactively (TUI picker)
 dr llm-gateway select
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -353,7 +353,7 @@ For detailed documentation on each command, see:
 - **[plugin](plugins.md)**&mdash;inspect and manage installed CLI plugins (alias: `plugins`).
 
 - **[llm-gateway](llm-gateway.md)**&mdash;list and configure the default LLM, across LLM Gateway catalog models and DataRobot-deployed LLMs (aliases: `llm`, `llm-gateways`).
-  - `list` (`ls`)&mdash;fetch available LLMs from both sources and display them in a table (`ID · NAME · SOURCE · PROVIDER · MODEL · CONTEXT`). The currently-selected model is marked with `*`. Supports `--output-format json` (each entry includes `source`, `deployment_id`, and a `selected` boolean).
+  - `list` (`ls`)&mdash;fetch available LLMs and display them in a table (`ID · NAME · SOURCE · PROVIDER · MODEL · CONTEXT`). The currently-selected model is marked with `*`. Both sources are queried in parallel by default; `--source gateway` or `--source deployed` narrows it to one and skips the other request. Supports `--output-format json` (each entry includes `source`, `deployment_id`, and a `selected` boolean).
   - `select [llm-id]`&mdash;set the default LLM. Without an argument, launches an interactive TUI picker. With an argument (a gateway model id or a deployment id), validates it against the available LLMs and persists it immediately. The selection is saved to `drconfig.yaml` under the key `default-llm-id`.
 
 - **[pipeline](pipeline.md)**&mdash;manage AI/ML pipelines orchestrated by Covalent (feature-gated behind `DATAROBOT_CLI_FEATURE_PIPELINE=true`).

--- a/docs/commands/llm-gateway.md
+++ b/docs/commands/llm-gateway.md
@@ -13,10 +13,10 @@ dr llm [flags]           # alias
 
 The `dr llm-gateway` group exposes two subcommands:
 
-- **`list`** — fetch available LLMs from two sources and display them as a table or JSON: active LLM Gateway catalog models (`/api/v2/genai/llmgw/catalog/`) and DataRobot-deployed LLMs (`/api/v2/deployments/`, deployments whose champion model is a `TextGeneration` model). A `SOURCE` column / `source` field distinguishes the two.
+- **`list`** — fetch available LLMs from two sources and display them as a table or JSON: active LLM Gateway catalog models (`/api/v2/genai/llmgw/catalog/`) and DataRobot-deployed LLMs (`/api/v2/deployments/`, deployments whose champion model is a `TextGeneration` model). A `SOURCE` column / `source` field distinguishes the two. `--source` narrows it to one.
 - **`select`** — choose a default LLM, either by ID or through an interactive TUI picker. The selection is persisted to `drconfig.yaml` and read by other CLI commands.
 
-Each source is best-effort: if one source cannot be reached (e.g. an empty LLM Gateway on-prem, or no deployment access), the command logs a warning and lists the other. It errors only when both sources fail.
+When both sources are queried (`select`, and `list` without `--source`), each is best-effort: if one cannot be reached (e.g. an empty LLM Gateway on-prem, or no deployment access), the command logs a warning and lists the other, and errors only when both fail. The two are fetched in parallel, so the command waits on the slower source rather than on both in turn. Asking `list` for a single source instead makes a failure to reach it an error, since there is no other source left to show.
 
 **Aliases:** `llm`, `llm-gateways`
 
@@ -34,9 +34,7 @@ dr llm ls               # shortest alias
 **Flags:**
 
 - `--output-format <json>` — emit machine-parseable JSON instead of a table.
-- `--source <all|gateway|deployed>` — which sources to query. Defaults to `all`. `gateway` and `deployed` skip the request the other source would have made, so a script that needs one source does not wait on both. The values are the same strings the `SOURCE` column and the JSON `source` field carry.
-
-When `--source` names a single source, a failure to reach it is an error. Only the default `all` degrades to the source that is still reachable — with one source requested there is no remainder to show, and reporting an empty list would read as an instance with no models.
+- `--source <all|gateway|deployed>` — which sources to query. Defaults to `all`. `gateway` and `deployed` skip the request the other source would have made, so a script that needs one source does not wait on both. The values are the same strings the `SOURCE` column and the JSON `source` field carry. A single source that cannot be reached is an error rather than an empty list.
 
 **Output columns (table):**
 
@@ -78,7 +76,7 @@ dr llm-gateway list
 # JSON output
 dr llm-gateway list --output-format json
 
-# One source only — skips the request the other source would have made
+# One source only. Skips the request the other source would have made.
 dr llm-gateway list --source gateway
 dr llm-gateway list --source deployed --output-format json
 

--- a/docs/commands/llm-gateway.md
+++ b/docs/commands/llm-gateway.md
@@ -34,6 +34,9 @@ dr llm ls               # shortest alias
 **Flags:**
 
 - `--output-format <json>` — emit machine-parseable JSON instead of a table.
+- `--source <all|gateway|deployed>` — which sources to query. Defaults to `all`. `gateway` and `deployed` skip the request the other source would have made, so a script that needs one source does not wait on both. The values are the same strings the `SOURCE` column and the JSON `source` field carry.
+
+When `--source` names a single source, a failure to reach it is an error. Only the default `all` degrades to the source that is still reachable — with one source requested there is no remainder to show, and reporting an empty list would read as an instance with no models.
 
 **Output columns (table):**
 
@@ -74,6 +77,10 @@ dr llm-gateway list
 
 # JSON output
 dr llm-gateway list --output-format json
+
+# One source only — skips the request the other source would have made
+dr llm-gateway list --source gateway
+dr llm-gateway list --source deployed --output-format json
 
 # Aliases
 dr llm list

--- a/internal/drapi/client.go
+++ b/internal/drapi/client.go
@@ -31,17 +31,14 @@ import (
 // callers don't specify their own.
 const DefaultClientTimeout = 30 * time.Second
 
-// tokenMu guards every access to the `token` global (declared in get.go),
-// including GetToken and SetToken. Callers that fetch from more than one
-// endpoint concurrently (GetLLMsAndDeployed) would otherwise race on it.
-// getToken holds the lock across resolveToken as well, so the first concurrent
-// caller's verification round-trip is not duplicated by the rest.
+// tokenMu guards the `token` global. See its declaration in get.go.
 var tokenMu sync.Mutex
 
 // getToken returns the memoized API token, resolving and caching it on first
-// use to avoid repeated VerifyToken() round-trips. A failed resolve is not
-// cached, so a later call retries. The underlying `token` variable and
-// resolveToken() function are defined in get.go.
+// use to avoid repeated VerifyToken() round-trips. The lock is held across
+// resolveToken so concurrent callers share one round-trip instead of each
+// making their own. A failed resolve is not cached, so a later call retries.
+// The `token` variable and resolveToken() are defined in get.go.
 func getToken() (string, error) {
 	tokenMu.Lock()
 	defer tokenMu.Unlock()

--- a/internal/drapi/client.go
+++ b/internal/drapi/client.go
@@ -31,10 +31,11 @@ import (
 // callers don't specify their own.
 const DefaultClientTimeout = 30 * time.Second
 
-// tokenMu guards the lazy resolve-and-cache in getToken. Callers that fetch
-// from more than one endpoint concurrently (GetLLMsAndDeployed) would otherwise
-// race on the `token` global, and holding the lock across resolveToken keeps
-// the first concurrent caller's round-trip from being duplicated by the rest.
+// tokenMu guards every access to the `token` global (declared in get.go),
+// including GetToken and SetToken. Callers that fetch from more than one
+// endpoint concurrently (GetLLMsAndDeployed) would otherwise race on it.
+// getToken holds the lock across resolveToken as well, so the first concurrent
+// caller's verification round-trip is not duplicated by the rest.
 var tokenMu sync.Mutex
 
 // getToken returns the memoized API token, resolving and caching it on first

--- a/internal/drapi/client.go
+++ b/internal/drapi/client.go
@@ -23,6 +23,7 @@ package drapi
 
 import (
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -30,10 +31,20 @@ import (
 // callers don't specify their own.
 const DefaultClientTimeout = 30 * time.Second
 
+// tokenMu guards the lazy resolve-and-cache in getToken. Callers that fetch
+// from more than one endpoint concurrently (GetLLMsAndDeployed) would otherwise
+// race on the `token` global, and holding the lock across resolveToken keeps
+// the first concurrent caller's round-trip from being duplicated by the rest.
+var tokenMu sync.Mutex
+
 // getToken returns the memoized API token, resolving and caching it on first
-// use to avoid repeated VerifyToken() round-trips. The underlying `token`
-// variable and resolveToken() function are defined in get.go.
+// use to avoid repeated VerifyToken() round-trips. A failed resolve is not
+// cached, so a later call retries. The underlying `token` variable and
+// resolveToken() function are defined in get.go.
 func getToken() (string, error) {
+	tokenMu.Lock()
+	defer tokenMu.Unlock()
+
 	if token != "" {
 		return token, nil
 	}

--- a/internal/drapi/client_test.go
+++ b/internal/drapi/client_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -119,4 +120,35 @@ func TestAuthorizeRequest_DoesNotConsumeBody(t *testing.T) {
 	body, err := io.ReadAll(req.Body)
 	require.NoError(t, err)
 	assert.Equal(t, "payload", string(body))
+}
+
+// TestTokenAccessorsAreGuarded drives SetToken and GetToken against getToken
+// concurrently. All three touch the same package global, and getToken is
+// reached from two goroutines whenever GetLLMsAndDeployed runs, so a re-auth
+// path calling SetToken mid-fetch must not race the readers. Only fails under
+// -race, which is how the suite runs.
+func TestTokenAccessorsAreGuarded(t *testing.T) {
+	resetTokenCache(t)
+	want := withSkipAuth(t, "concurrent-token")
+
+	var wg sync.WaitGroup
+
+	for range 8 {
+		wg.Add(3)
+
+		go func() { defer wg.Done(); SetToken(want) }()
+		go func() { defer wg.Done(); _ = GetToken() }()
+
+		go func() {
+			defer wg.Done()
+
+			got, err := getToken()
+			assert.NoError(t, err)
+			assert.Equal(t, want, got)
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, want, GetToken())
 }

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -43,15 +43,25 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("HTTP error: %d %s (url: %s)", e.StatusCode, http.StatusText(e.StatusCode), e.URL)
 }
 
+// token is the cached API token. Every access goes through tokenMu (declared in
+// client.go): GetLLMsAndDeployed fetches from two endpoints at once, so a
+// re-auth or refresh path calling SetToken mid-fetch would otherwise race the
+// readers.
 var token string
 
 // GetToken returns the current cached API token.
 func GetToken() string {
+	tokenMu.Lock()
+	defer tokenMu.Unlock()
+
 	return token
 }
 
 // SetToken sets the cached API token.
 func SetToken(value string) {
+	tokenMu.Lock()
+	defer tokenMu.Unlock()
+
 	token = value
 }
 

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -43,10 +43,10 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("HTTP error: %d %s (url: %s)", e.StatusCode, http.StatusText(e.StatusCode), e.URL)
 }
 
-// token is the cached API token. Every access goes through tokenMu (declared in
-// client.go): GetLLMsAndDeployed fetches from two endpoints at once, so a
-// re-auth or refresh path calling SetToken mid-fetch would otherwise race the
-// readers.
+// token is the cached API token. Every read and write takes tokenMu (declared
+// in client.go), including the accessors below: GetLLMsAndDeployed fetches two
+// endpoints at once, so a refresh path calling SetToken mid-fetch would race
+// the readers.
 var token string
 
 // GetToken returns the current cached API token.

--- a/internal/drapi/llms.go
+++ b/internal/drapi/llms.go
@@ -17,6 +17,7 @@ package drapi
 import (
 	"errors"
 	"strings"
+	"sync"
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/log"
@@ -219,9 +220,34 @@ func GetDeployedLLMs() ([]LLM, error) {
 // is logged and the other source is still returned, so an empty or disabled
 // gateway (common on-prem) or missing deployment access does not blank the
 // list. An error is returned only when both sources fail.
+//
+// The two sources are fetched concurrently: each is a paginated round-trip set,
+// so serial fetching made the caller pay their sum rather than the slower of
+// the two.
 func GetLLMsAndDeployed() (*LLMList, error) {
-	gateway, gwErr := GetLLMs()
-	deployed, depErr := GetDeployedLLMs()
+	var (
+		gateway  *LLMList
+		deployed []LLM
+		gwErr    error
+		depErr   error
+		wg       sync.WaitGroup
+	)
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		gateway, gwErr = GetLLMs()
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		deployed, depErr = GetDeployedLLMs()
+	}()
+
+	wg.Wait()
 
 	var warnings []string
 

--- a/internal/drapi/llms.go
+++ b/internal/drapi/llms.go
@@ -221,15 +221,13 @@ func GetDeployedLLMs() ([]LLM, error) {
 // gateway (common on-prem) or missing deployment access does not blank the
 // list. An error is returned only when both sources fail.
 //
-// The two sources are fetched concurrently: each is a paginated round-trip set,
-// so serial fetching made the caller pay their sum rather than the slower of
-// the two.
+// The sources are fetched concurrently. Each is a paginated round-trip set, so
+// the caller waits on the slower one instead of both.
 //
-// Both goroutines log through internal/log, whose stderrLogger global is
-// rewritten by tui.Run via StopStderr/StartStderr. Nothing overlaps today
-// because select starts its picker only after this returns. Driving this call
-// from inside a running TUI (a spinner around the fetch, say) would make that a
-// live race, so keep the fetch outside the TUI.
+// Keep this call outside a running TUI. Both goroutines log through
+// internal/log, whose stderrLogger global tui.Run rewrites. Nothing overlaps
+// today because select starts its picker after this returns, but wrapping the
+// fetch in a spinner would make that a live race.
 func GetLLMsAndDeployed() (*LLMList, error) {
 	var (
 		gateway  *LLMList

--- a/internal/drapi/llms.go
+++ b/internal/drapi/llms.go
@@ -224,6 +224,12 @@ func GetDeployedLLMs() ([]LLM, error) {
 // The two sources are fetched concurrently: each is a paginated round-trip set,
 // so serial fetching made the caller pay their sum rather than the slower of
 // the two.
+//
+// Both goroutines log through internal/log, whose stderrLogger global is
+// rewritten by tui.Run via StopStderr/StartStderr. Nothing overlaps today
+// because select starts its picker only after this returns. Driving this call
+// from inside a running TUI (a spinner around the fetch, say) would make that a
+// live race, so keep the fetch outside the TUI.
 func GetLLMsAndDeployed() (*LLMList, error) {
 	var (
 		gateway  *LLMList

--- a/internal/drapi/llms_test.go
+++ b/internal/drapi/llms_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
-	"sync/atomic"
+	"sync"
 	"testing"
 	"time"
 
@@ -246,25 +246,45 @@ func TestGetLLMsAndDeployed_BothFail(t *testing.T) {
 // has been entered. A serial fetch can never satisfy both, so this is what
 // stops the two sources from silently reverting to sum-of-both latency; the
 // union and soft-degrade tests pass either way.
+//
+// The barrier keys on the route, not on a request count: if either fixture ever
+// grows a Next page, two pages from one source would satisfy a counter and the
+// test would go green against a serial implementation.
 func TestGetLLMsAndDeployed_FetchesConcurrently(t *testing.T) {
 	var (
-		arrived atomic.Int32
-		both    = make(chan struct{})
+		mu    sync.Mutex
+		seen  = map[string]bool{}
+		both  = make(chan struct{})
+		route = func(path string) string {
+			if strings.Contains(path, "/deployments") {
+				return "deployments"
+			}
+
+			return "catalog"
+		}
 	)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if arrived.Add(1) == 2 {
-			close(both)
+		name := route(r.URL.Path)
+
+		mu.Lock()
+		if !seen[name] {
+			seen[name] = true
+
+			if len(seen) == 2 {
+				close(both)
+			}
 		}
+		mu.Unlock()
 
 		select {
 		case <-both:
 		case <-time.After(3 * time.Second):
-			t.Error("requests did not overlap: the two sources are being fetched serially")
+			t.Errorf("%s did not overlap the other source: the two are being fetched serially", name)
 		}
 
 		body := gatewayBody
-		if strings.Contains(r.URL.Path, "/deployments") {
+		if name == "deployments" {
 			body = deployedBody
 		}
 

--- a/internal/drapi/llms_test.go
+++ b/internal/drapi/llms_test.go
@@ -20,7 +20,9 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
@@ -238,4 +240,65 @@ func TestGetLLMsAndDeployed_BothFail(t *testing.T) {
 
 	_, err := GetLLMsAndDeployed()
 	assert.Error(t, err)
+}
+
+// TestGetLLMsAndDeployed_FetchesConcurrently holds each route until the other
+// has been entered. A serial fetch can never satisfy both, so this is what
+// stops the two sources from silently reverting to sum-of-both latency; the
+// union and soft-degrade tests pass either way.
+func TestGetLLMsAndDeployed_FetchesConcurrently(t *testing.T) {
+	var (
+		arrived atomic.Int32
+		both    = make(chan struct{})
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if arrived.Add(1) == 2 {
+			close(both)
+		}
+
+		select {
+		case <-both:
+		case <-time.After(3 * time.Second):
+			t.Error("requests did not overlap: the two sources are being fetched serially")
+		}
+
+		body := gatewayBody
+		if strings.Contains(r.URL.Path, "/deployments") {
+			body = deployedBody
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+
+	viperx.Reset()
+	viperx.Set(config.DataRobotURL, srv.URL)
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+	viperx.Set(config.SkipAuthKey, true)
+
+	t.Cleanup(func() {
+		srv.Close()
+		viperx.Reset()
+	})
+
+	list, err := GetLLMsAndDeployed()
+	require.NoError(t, err)
+	assert.Len(t, list.LLMs, 2)
+}
+
+// TestGetLLMsAndDeployed_ColdTokenIsRaceFree drives the concurrent fetch with an
+// unresolved token so both goroutines race to populate the `token` global. It
+// only fails under -race, which is how the suite runs.
+func TestGetLLMsAndDeployed_ColdTokenIsRaceFree(t *testing.T) {
+	setupRoutedServer(t, routeResponse{body: gatewayBody}, routeResponse{body: deployedBody})
+
+	previous := token
+	token = ""
+
+	t.Cleanup(func() { token = previous })
+
+	list, err := GetLLMsAndDeployed()
+	require.NoError(t, err)
+	assert.Len(t, list.LLMs, 2)
 }

--- a/internal/drapi/llms_test.go
+++ b/internal/drapi/llms_test.go
@@ -242,14 +242,17 @@ func TestGetLLMsAndDeployed_BothFail(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestGetLLMsAndDeployed_FetchesConcurrently holds each route until the other
-// has been entered. A serial fetch can never satisfy both, so this is what
-// stops the two sources from silently reverting to sum-of-both latency; the
-// union and soft-degrade tests pass either way.
+// TestGetLLMsAndDeployed_FetchesConcurrently makes each route block until the
+// other one has arrived. A serial fetch deadlocks on that: the second request
+// cannot start until the first returns, and the first is waiting on the second.
+// It stalls until the timeout and fails. Only overlapping requests get through.
 //
-// The barrier keys on the route, not on a request count: if either fixture ever
-// grows a Next page, two pages from one source would satisfy a counter and the
-// test would go green against a serial implementation.
+// Every other test in this file passes either way, so this is the only thing
+// standing between a later refactor and a silent return to sum-of-both latency.
+//
+// The barrier keys on the route rather than counting requests: if either
+// fixture grows a Next page, two pages from one source would satisfy a counter
+// and the test would pass against a serial fetch.
 func TestGetLLMsAndDeployed_FetchesConcurrently(t *testing.T) {
 	var (
 		mu    sync.Mutex


### PR DESCRIPTION
## Summary

`dr llm-gateway list` fetched the LLM Gateway catalog and DataRobot deployments one after the other, so it waited on the sum of both. They now run in parallel. New `--source gateway|deployed` skips the other request entirely. Default `all` keeps today's behavior.

Against a server with a fixed 2s delay per route: 6.34s before, 4.21s after. One round-trip removed.

## Notes for review

The cached API token was resolved lazily and written without a lock, so two concurrent fetches raced on it. Every access now takes a mutex. `getToken` holds it across the resolve so concurrent callers share one verification round-trip.

A single source that cannot be reached is an error. Only `all` degrades to whichever source is still up, since with one source requested there is no remainder to show.

## Output

Default, both sources:

```
$ dr llm-gateway list
Available LLMs
──────────────
╭───────────────────────────────┬────────────────────────────┬──────────┬──────────────┬─────────────────────┬─────────╮
│ ID                            │ NAME                       │ SOURCE   │ PROVIDER     │ MODEL               │ CONTEXT │
├───────────────────────────────┼────────────────────────────┼──────────┼──────────────┼─────────────────────┼─────────┤
│   azure-openai-gpt-5-5        │ Azure OpenAI GPT-5.5       │ gateway  │ Azure OpenAI │ azure/gpt-5-5-2026- │ 1050000 │
│                               │                            │          │              │ 04-23               │         │
│   anthropic-claude-sonnet-4-6 │ Anthropic Claude Sonnet    │ gateway  │ Anthropic    │ bedrock/anthropic.c │ 200000  │
│                               │ 4.6                        │          │              │ laude-sonnet-4-6    │         │
│   6512a0b3f4d5e6a7b8c9d0e1    │ Support RAG Assistant      │ deployed │ -            │ -                   │ -       │
│   6512a0b3f4d5e6a7b8c9d0e2    │ Claims Summarizer          │ deployed │ -            │ -                   │ -       │
╰───────────────────────────────┴────────────────────────────┴──────────┴──────────────┴─────────────────────┴─────────╯
```

One source, no request to the other:

```
$ dr llm-gateway list --source deployed
Available LLMs
──────────────
╭────────────────────────────┬───────────────────────┬──────────┬──────────┬───────┬─────────╮
│ ID                         │ NAME                  │ SOURCE   │ PROVIDER │ MODEL │ CONTEXT │
├────────────────────────────┼───────────────────────┼──────────┼──────────┼───────┼─────────┤
│   6512a0b3f4d5e6a7b8c9d0e1 │ Support RAG Assistant │ deployed │ -        │ -     │ -       │
│   6512a0b3f4d5e6a7b8c9d0e2 │ Claims Summarizer     │ deployed │ -        │ -     │ -       │
╰────────────────────────────┴───────────────────────┴──────────┴──────────┴───────┴─────────╯
```

JSON shape is unchanged. `source` carries the values `--source` takes:

```
$ dr llm-gateway list --source gateway --output-format json
{
  "llms": [
    {
      "id": "azure-openai-gpt-5-5",
      "name": "Azure OpenAI GPT-5.5",
      "source": "gateway",
      "provider": "Azure OpenAI",
      "model": "azure/gpt-5-5-2026-04-23",
      "description": "Frontier model for complex professional work.",
      "context_size": 1050000,
      "deployment_id": "",
      "selected": false
    },
```

```
$ dr llm-gateway list --source bogus
Error: invalid argument "bogus" for "--source" flag: invalid source "bogus": use all, gateway, or deployed
```

## Technical Changes

- `internal/drapi/llms.go`: both fetches in goroutines. Ordering, per-source warnings, and the both-failed error unchanged.
- `internal/drapi/client.go`, `internal/drapi/get.go`: mutex over every access to the cached token.
- `cmd/llm-gateway/list/source.go`: new. `Source` flag type and `fetchLLMs`, plus a `Count` fix.
- `cmd/llm-gateway/list/cmd.go`: flag, shell completion, telemetry field.
- `docs/commands/`: the flag, and the best-effort claim scoped to where it holds.
- 10 tests. The load-bearing ones pin the route overlap, the skipped request, and the token accessors under `-race`.

`select` picks up the parallel fetch. It does not get `--source`.
<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1786466282.191399 -->
<!-- rr:slack:end -->