### PR TITLE
[RAPTOR-18975] feat(workload): read a running workload's spec into a manifest

### DIFF
--- a/internal/workload/document.go
+++ b/internal/workload/document.go
@@ -1,0 +1,80 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// Document is a server response kept as it arrived. The typed Workload and
+// Artifact structs are deliberate projections: they parse the handful of
+// fields the CLI renders and drop the rest. That is right for printing and
+// wrong for copying, because a field this CLI does not know about is still a
+// field the workload is running with.
+//
+// Setup uses these when it binds to a live workload: the manifest it writes
+// has to be able to say everything the workload already says, including
+// blocks no release of this CLI has heard of, or the first deploy from that
+// file would quietly strip them.
+type Document map[string]any
+
+// GetWorkloadDocument fetches a workload as the server has it.
+func GetWorkloadDocument(workloadID string) (Document, error) {
+	url, err := config.GetEndpointURL("/api/v2/workloads/" + escapeID(workloadID) + "/")
+	if err != nil {
+		return nil, err
+	}
+
+	var doc Document
+
+	if err := drapi.GetJSON(url, "workload", &doc); err != nil {
+		return nil, err
+	}
+
+	return doc, nil
+}
+
+// GetArtifactDocument fetches an artifact as the server has it.
+func GetArtifactDocument(artifactID string) (Document, error) {
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/")
+	if err != nil {
+		return nil, err
+	}
+
+	var doc Document
+
+	if err := drapi.GetJSON(url, "artifact", &doc); err != nil {
+		return nil, err
+	}
+
+	return doc, nil
+}
+
+// String returns the document's value for key, "" when absent or not a
+// string.
+func (d Document) String(key string) string {
+	value, _ := d[key].(string)
+
+	return value
+}
+
+// Map returns the document's nested object for key, nil when absent or not an
+// object.
+func (d Document) Map(key string) map[string]any {
+	value, _ := d[key].(map[string]any)
+
+	return value
+}

--- a/internal/workload/execenv.go
+++ b/internal/workload/execenv.go
@@ -82,6 +82,80 @@ func ResolveExecutionEnvironment(nameOrID string) (id, versionID string, err err
 	return "", "", fmt.Errorf("execution environment %q not found; check the name in the DataRobot UI under Registry > Environments", nameOrID)
 }
 
+// ListExecutionEnvironments returns up to limit environments that have a
+// version to build from, for the setup wizard's base-image picker. Ones with
+// no successful version are dropped rather than offered: picking one would
+// fail at build time with nothing the user could do about it.
+func ListExecutionEnvironments(limit int) ([]ExecutionEnvironment, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("limit must be positive, got %d", limit)
+	}
+
+	pageURL, err := config.GetEndpointURL("/api/v2/executionEnvironments/?limit=100")
+	if err != nil {
+		return nil, err
+	}
+
+	environments := make([]ExecutionEnvironment, 0, limit)
+
+	for pages := 0; pageURL != ""; pages++ {
+		if pages >= maxExecEnvPages {
+			// Silently returning a partial list would read as "these are all
+			// the base images", which is the wrong thing to choose from.
+			return nil, fmt.Errorf("execution environments did not finish listing after %d pages", maxExecEnvPages)
+		}
+
+		var list executionEnvironmentList
+
+		if err := drapi.GetJSON(pageURL, "execution environments", &list); err != nil {
+			return nil, err
+		}
+
+		if environments = appendBuildable(environments, list.Data, limit); len(environments) == limit {
+			return environments, nil
+		}
+
+		next, err := nextPage(list.Next)
+		if err != nil {
+			return nil, err
+		}
+
+		pageURL = next
+	}
+
+	return environments, nil
+}
+
+// appendBuildable adds the environments a build can target, stopping at limit.
+func appendBuildable(into, page []ExecutionEnvironment, limit int) []ExecutionEnvironment {
+	for _, ee := range page {
+		if ee.LatestSuccessfulVersion == nil {
+			continue
+		}
+
+		into = append(into, ee)
+
+		if len(into) == limit {
+			return into
+		}
+	}
+
+	return into
+}
+
+// nextPage validates a paging cursor, returning "" at the end of the listing.
+func nextPage(next string) (string, error) {
+	if next == "" {
+		return "", nil
+	}
+
+	if err := drapi.AssertNextOnSameHost(next); err != nil {
+		return "", err
+	}
+
+	return next, nil
+}
+
 // scanExecutionEnvironments walks the paged listing once, returning the unique
 // id match if one turned up and every environment carrying the name. It stops
 // early on an id hit; a name has to be checked against the whole list before it

--- a/internal/workload/execenv_test.go
+++ b/internal/workload/execenv_test.go
@@ -242,3 +242,75 @@ func TestResolveExecutionEnvironment_RejectsCrossHostNext(t *testing.T) {
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "not found", "a cross-host next must fail loudly, not fall through to not-found")
 }
+
+// The base-image picker offers only what a build can actually target: an
+// environment with no successful version would fail at build time with
+// nothing the user could do about it.
+func TestListExecutionEnvironments_SkipsVersionlessEnvironments(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data": [%s, %s, %s], "next": ""}`,
+			eeDoc("ee-1", "Python 3.11", "ver-1"),
+			eeDoc("ee-2", "Never built", ""),
+			eeDoc("ee-3", "Python 3.12", "ver-3"),
+		)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	environments, err := ListExecutionEnvironments(50)
+	require.NoError(t, err)
+
+	require.Len(t, environments, 2)
+	assert.Equal(t, "ee-1", environments[0].ID)
+	assert.Equal(t, "ee-3", environments[1].ID)
+}
+
+func TestListExecutionEnvironments_StopsAtTheLimit(t *testing.T) {
+	installSkipAuth(t)
+
+	// next is filled in once the server has an address; the handler only ever
+	// echoes this test's own value, never anything from the request.
+	var next string
+
+	pages := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		pages++
+
+		fmt.Fprintf(w, `{"data": [%s, %s], "next": %q}`,
+			eeDoc(fmt.Sprintf("ee-%da", pages), "A", "ver-a"),
+			eeDoc(fmt.Sprintf("ee-%db", pages), "B", "ver-b"),
+			next,
+		)
+	}))
+
+	defer srv.Close()
+
+	next = srv.URL + "/api/v2/executionEnvironments/?limit=100&page=2"
+
+	installEndpoint(t, srv.URL)
+
+	environments, err := ListExecutionEnvironments(3)
+	require.NoError(t, err)
+
+	assert.Len(t, environments, 3)
+	assert.Equal(t, 2, pages, "paging stops as soon as the limit is reached")
+}
+
+func TestListExecutionEnvironments_ServerError(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := ListExecutionEnvironments(50)
+	require.Error(t, err)
+}

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -1,0 +1,733 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// serverManagedKeys never belong in a manifest, at any depth. They are the
+// server's own bookkeeping: it assigns them, and a file that repeats them
+// back is either ignored or rejected. Stripping them recursively is safe
+// because the create spec has no legitimate key by these names anywhere.
+var serverManagedKeys = []string{"id", "createdAt", "updatedAt", "status", "endpoint", "artifactId", "workloadId"}
+
+// Live is a running workload, downloaded so a manifest can be written that
+// says everything the workload already says. Setup uses it when the user
+// binds to an existing workload: the alternative, generating a file from the
+// wizard's own small vocabulary, would silently drop the autoscaling, the
+// extra containers and the GPU bundle that workload is running with, and the
+// next deploy would apply that loss.
+//
+// Spec and Runtime are held as the server's own documents rather than parsed
+// into structs, for the same reason the reader is node-based: a block this
+// release has never heard of still has to survive the round trip.
+type Live struct {
+	WorkloadID   string
+	Name         string
+	Importance   string
+	ArtifactName string
+	Spec         map[string]any
+	Runtime      map[string]any
+}
+
+// NewLive assembles the live view from the two documents the server returns,
+// stripping what only the server may set. workloadDoc is the workload,
+// artifactDoc the artifact it currently runs.
+func NewLive(workloadID string, workloadDoc, artifactDoc map[string]any) Live {
+	live := Live{
+		WorkloadID:   workloadID,
+		Name:         stringAt(workloadDoc, keyName),
+		Importance:   stringAt(workloadDoc, keyImportance),
+		ArtifactName: stringAt(artifactDoc, keyName),
+		Spec:         stripServerManaged(mapAt(artifactDoc, keySpec)),
+		Runtime:      stripServerManaged(mapAt(workloadDoc, keyRuntime)),
+	}
+
+	stripBuildOutputs(live.Spec)
+
+	return live
+}
+
+// Type reports the artifact's kind, so the wizard's Q3 opens on what the
+// workload already is.
+func (l Live) Type() string {
+	return stringAt(l.Spec, "type")
+}
+
+// Defaults reads the live spec into the answers the wizard's screens open on.
+// Everything it cannot find keeps the documented default, so a spec shaped in
+// a way this release does not recognize still produces usable screens; the
+// parts it did not understand are preserved in Spec regardless.
+func (l Live) Defaults() Draft {
+	draft := Draft{
+		WorkloadID: l.WorkloadID,
+		Name:       l.Name,
+		Importance: orDefaultString(l.Importance, DefaultImportance),
+		Type:       orDefaultString(l.Type(), TypeService),
+		A2AEnabled: boolAt(l.Spec, "a2aEnabled"),
+		Port:       DefaultPort,
+		HealthPath: DefaultHealthPath,
+		Build:      Build{Mode: BuildModeDockerfile},
+		Runtime:    l.runtimeDefaults(),
+	}
+
+	container := l.primaryContainer()
+	if container == nil {
+		return draft
+	}
+
+	if port, ok := intAt(container, keyPort); ok {
+		draft.Port = port
+	}
+
+	if path := stringAt(mapAt(container, "readinessProbe"), "path"); path != "" {
+		draft.HealthPath = path
+	}
+
+	draft.Build = liveBuild(container)
+
+	return draft
+}
+
+// BuildMode reports how the primary container's image comes to be, in the
+// wizard's vocabulary: BuildModeDockerfile, BuildModeGenerated or
+// BuildModeImage. It is "" for a manifest with no inline artifact, which is
+// what a manifest bound to an existing artifact by id looks like.
+func (m *Manifest) BuildMode() string {
+	container := primaryContainerNode(mapValue(mapValue(m.root, keyArtifact), keySpec))
+	if container == nil {
+		return ""
+	}
+
+	dockerfile := mapValue(mapValue(container, keyImageBuildConfig), keyDockerfile)
+	source, _ := scalarString(mapValue(dockerfile, keySource))
+
+	switch source {
+	case sourceProvided:
+		return BuildModeDockerfile
+	case sourceGenerated:
+		return BuildModeGenerated
+	}
+
+	if uri, _ := scalarString(mapValue(container, keyImageURI)); uri != "" {
+		return BuildModeImage
+	}
+
+	return ""
+}
+
+// primaryContainerNode finds the container traffic reaches in a parsed spec,
+// falling back to the first container the way the live-document walk does.
+func primaryContainerNode(spec *yaml.Node) *yaml.Node {
+	var first *yaml.Node
+
+	for _, group := range seqItems(mapValue(spec, keyContainerGroups)) {
+		for _, container := range seqItems(mapValue(group, keyContainers)) {
+			if first == nil {
+				first = container
+			}
+
+			if isTrue(mapValue(container, keyPrimary)) {
+				return container
+			}
+		}
+	}
+
+	return first
+}
+
+// runtimeDefaults reads the sizing the workload is actually running with, so
+// the confirm screen reports that rather than the documented defaults. A
+// group using autoscaling has no replica count to report, and the zero it
+// leaves behind is what tells Apply not to write one.
+func (l Live) runtimeDefaults() Runtime {
+	runtime := Runtime{Replicas: DefaultReplicas, CPU: DefaultCPU, Memory: DefaultMemory}
+
+	groups := slicesAt(l.Runtime, keyContainerGroups)
+	if len(groups) == 0 {
+		return runtime
+	}
+
+	group := groups[0]
+
+	if replicas, ok := intAt(group, keyReplicaCount); ok {
+		runtime.Replicas = replicas
+	}
+
+	if mapAt(group, keyAutoscaling) != nil {
+		runtime.Replicas = 0
+	}
+
+	containers := slicesAt(group, keyContainers)
+	if len(containers) == 0 {
+		return runtime
+	}
+
+	allocation := mapAt(containers[0], keyResourceAllocation)
+
+	if cpu, ok := floatAt(allocation, "cpu"); ok {
+		runtime.CPU = cpu
+	}
+
+	if memory := stringAt(allocation, keyMemory); memory != "" {
+		runtime.Memory = memory
+	}
+
+	return runtime
+}
+
+// liveBuild reads which image source the container uses. A build block whose
+// source this release does not recognize reports BuildModeUnchanged rather
+// than being forced into the nearest known mode: the block is preserved as it
+// stands, and the wizard offers to keep it.
+func liveBuild(container map[string]any) Build {
+	buildConfig := mapAt(container, keyImageBuildConfig)
+	dockerfile := mapAt(buildConfig, keyDockerfile)
+
+	switch stringAt(dockerfile, keySource) {
+	case sourceProvided:
+		return Build{Mode: BuildModeDockerfile}
+	case sourceGenerated:
+		return Build{
+			Mode:                          BuildModeGenerated,
+			ExecutionEnvironmentID:        stringAt(dockerfile, keyExecEnvID),
+			ExecutionEnvironmentVersionID: stringAt(dockerfile, keyExecEnvVersionID),
+			Entrypoint:                    stringsAt(dockerfile, keyEntrypoint),
+		}
+	}
+
+	if buildConfig != nil {
+		return Build{Mode: BuildModeUnchanged}
+	}
+
+	return Build{Mode: BuildModeImage, ImageURI: stringAt(container, keyImageURI)}
+}
+
+// Apply writes the wizard's answers onto the live spec and returns the
+// result, leaving the original untouched so the confirm screen can diff one
+// against the other. Only the fields the wizard actually asks about are
+// touched; everything else the workload runs with is carried over as it is.
+func (l Live) Apply(draft Draft) (Live, error) {
+	applied := l
+	applied.Name = draft.Name
+	applied.Importance = draft.Importance
+	applied.Spec = deepCopyMap(l.Spec)
+	applied.Runtime = deepCopyMap(l.Runtime)
+
+	if applied.Spec == nil {
+		applied.Spec = map[string]any{}
+	}
+
+	applied.Spec["type"] = draft.Type
+
+	if draft.Type == TypeAgent && draft.A2AEnabled {
+		applied.Spec["a2aEnabled"] = true
+	} else {
+		delete(applied.Spec, "a2aEnabled")
+	}
+
+	container := primaryContainerOf(applied.Spec)
+	if container == nil {
+		return Live{}, fmt.Errorf("workload %s has no primary container to update; edit %s by hand instead",
+			l.WorkloadID, FileName)
+	}
+
+	applyReadiness(container, draft)
+	applyEnvVars(container, draft.EnvVars)
+	applied.applyRuntime(draft.Runtime)
+
+	if err := applyBuild(container, draft.Build); err != nil {
+		return Live{}, err
+	}
+
+	return applied, nil
+}
+
+// applyEnvVars merges the .env variables into the container's existing list.
+// A name the workload already declares is left alone: the running value is
+// the one in use, and .env is the developer's copy, which may well be stale.
+func applyEnvVars(container map[string]any, vars []EnvVar) {
+	if len(vars) == 0 {
+		return
+	}
+
+	existing, _ := container[keyEnvironmentVars].([]any)
+
+	declared := make(map[string]bool, len(existing))
+
+	for _, entry := range existing {
+		if typed, ok := entry.(map[string]any); ok {
+			declared[stringAt(typed, keyName)] = true
+		}
+	}
+
+	for _, v := range vars {
+		if declared[v.Name] {
+			continue
+		}
+
+		value := v.Value
+		if v.Secret {
+			value = credentialShorthandPrefix + CredentialPlaceholder + "/" + credentialKey
+		}
+
+		existing = append(existing, map[string]any{keyName: v.Name, keyValue: value})
+	}
+
+	container[keyEnvironmentVars] = existing
+}
+
+// applyRuntime writes the sizing answers onto the live runtime block, leaving
+// alone what the wizard has no question for: the GPU bundles, the autoscaling
+// policies and every container past the first. A zero field means "not
+// answered", so it keeps whatever the workload is running with.
+func (l *Live) applyRuntime(runtime Runtime) {
+	group := l.runtimeGroup()
+	if group == nil {
+		return
+	}
+
+	// Writing a replica count onto an autoscaled group would produce a file
+	// the ledger rejects, so an autoscaled workload keeps its autoscaling and
+	// the answer is dropped.
+	if runtime.Replicas > 0 && mapAt(group, keyAutoscaling) == nil {
+		group[keyReplicaCount] = runtime.Replicas
+	}
+
+	container := runtimeContainer(group, l.primaryContainerName())
+	if container == nil {
+		return
+	}
+
+	allocation := mapAt(container, keyResourceAllocation)
+	if allocation == nil {
+		allocation = map[string]any{}
+		container[keyResourceAllocation] = allocation
+	}
+
+	if runtime.CPU > 0 {
+		allocation["cpu"] = runtime.CPU
+	}
+
+	if runtime.Memory != "" {
+		allocation[keyMemory] = runtime.Memory
+	}
+}
+
+// runtimeGroup is the sizing block the answers apply to, created to match the
+// artifact when the workload has none. A workload can legitimately run
+// without a runtime block, and returning early there would drop every sizing
+// answer the user just gave without saying so.
+func (l *Live) runtimeGroup() map[string]any {
+	if groups := slicesAt(l.Runtime, keyContainerGroups); len(groups) > 0 {
+		return groups[0]
+	}
+
+	name := l.artifactGroupName()
+	if name == "" {
+		return nil
+	}
+
+	group := map[string]any{keyName: name, keyContainers: []any{}}
+
+	if l.Runtime == nil {
+		l.Runtime = map[string]any{}
+	}
+
+	l.Runtime[keyContainerGroups] = []any{group}
+
+	return group
+}
+
+// runtimeContainer is the sizing entry for name, created when the group does
+// not list it yet. The runtime and artifact lists are joined by name, so a
+// container invented here has to carry the artifact's.
+func runtimeContainer(group map[string]any, name string) map[string]any {
+	if name == "" {
+		return nil
+	}
+
+	for _, container := range slicesAt(group, keyContainers) {
+		if stringAt(container, keyName) == name {
+			return container
+		}
+	}
+
+	container := map[string]any{keyName: name}
+	existing, _ := group[keyContainers].([]any)
+	group[keyContainers] = append(existing, container)
+
+	return container
+}
+
+// artifactGroupName and primaryContainerName name the artifact's own group
+// and primary container, which the runtime block has to match.
+func (l Live) artifactGroupName() string {
+	groups := slicesAt(l.Spec, keyContainerGroups)
+	if len(groups) == 0 {
+		return ""
+	}
+
+	return stringAt(groups[0], keyName)
+}
+
+func (l Live) primaryContainerName() string {
+	container := l.primaryContainer()
+	if container == nil {
+		return ""
+	}
+
+	return stringAt(container, keyName)
+}
+
+// applyReadiness writes the port and, where the workload already has a
+// readiness probe, keeps it pointing at the same place. It does not add one:
+// a workload deliberately running without a probe should not acquire the
+// wizard's default /health, which a container that does not serve it would
+// never pass.
+func applyReadiness(container map[string]any, draft Draft) {
+	container[keyPort] = draft.Port
+
+	// The container being edited is the one traffic reaches, and the ledger
+	// only allows a port on a container that says so. A spec that flagged
+	// nothing would otherwise produce a file rejecting its own port.
+	container[keyPrimary] = true
+
+	probe := mapAt(container, "readinessProbe")
+	if probe == nil {
+		return
+	}
+
+	probe["path"] = draft.HealthPath
+	probe[keyPort] = draft.Port
+}
+
+// applyBuild sets the image source, editing the live build block in place
+// rather than replacing it. The Build struct models only the fields the
+// wizard asks about; a build block can carry more (build arguments, a
+// timeout, whatever the platform adds next), and rebuilding it from the
+// struct would silently drop all of it. Only the other two forms are removed,
+// so the container never names an image and a way to build one at once.
+func applyBuild(container map[string]any, build Build) error {
+	switch build.Mode {
+	case BuildModeUnchanged:
+		// The live block says something this release does not model. Leaving
+		// it exactly as it is beats rewriting it into the nearest thing the
+		// Build struct can express.
+
+	case BuildModeImage:
+		delete(container, keyImageBuildConfig)
+
+		container[keyImageURI] = build.ImageURI
+
+	case BuildModeDockerfile:
+		delete(container, keyImageURI)
+
+		dockerfile := buildDockerfileBlock(container)
+		dockerfile[keySource] = sourceProvided
+
+		// The generated-only fields are meaningless under a provided
+		// Dockerfile, so switching away from generated takes them with it.
+		delete(dockerfile, keyExecEnvID)
+		delete(dockerfile, keyExecEnvVersionID)
+		delete(dockerfile, keyEntrypoint)
+
+	case BuildModeGenerated:
+		delete(container, keyImageURI)
+
+		dockerfile := buildDockerfileBlock(container)
+		dockerfile[keySource] = sourceGenerated
+		dockerfile[keyExecEnvID] = build.ExecutionEnvironmentID
+		dockerfile[keyExecEnvVersionID] = build.ExecutionEnvironmentVersionID
+		dockerfile[keyEntrypoint] = toAnySlice(build.Entrypoint)
+
+	default:
+		return fmt.Errorf("unknown build mode %q", build.Mode)
+	}
+
+	return nil
+}
+
+// buildDockerfileBlock returns the container's build block to edit, creating
+// the nesting only where the container had none.
+func buildDockerfileBlock(container map[string]any) map[string]any {
+	buildConfig := mapAt(container, keyImageBuildConfig)
+	if buildConfig == nil {
+		buildConfig = map[string]any{}
+		container[keyImageBuildConfig] = buildConfig
+	}
+
+	dockerfile := mapAt(buildConfig, keyDockerfile)
+	if dockerfile == nil {
+		dockerfile = map[string]any{}
+		buildConfig[keyDockerfile] = dockerfile
+	}
+
+	return dockerfile
+}
+
+// Render writes the live view as a manifest: the same file shape Draft
+// produces, with the artifact spec and runtime blocks passed through as the
+// platform gave them.
+func (l Live) Render() ([]byte, error) {
+	spec, err := documentNode(l.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	artifact := []field{{key: keyName, value: scalar(l.ArtifactName)}}
+	if spec != nil {
+		artifact = append(artifact, field{key: keySpec, value: spec})
+	}
+
+	fields := []field{
+		{key: keyWorkloadID, value: scalar(l.WorkloadID), comment: workloadIDComment},
+		{key: keyName, value: scalar(l.Name)},
+		{
+			key: keyImportance, value: scalar(orDefaultString(l.Importance, DefaultImportance)),
+			comment: "low | moderate | high | critical",
+		},
+		{key: keyArtifact, value: mapping(artifact...)},
+	}
+
+	runtime, err := documentNode(l.Runtime)
+	if err != nil {
+		return nil, err
+	}
+
+	if runtime != nil {
+		fields = append(fields, field{key: keyRuntime, value: runtime})
+	}
+
+	var buf bytes.Buffer
+
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+
+	if err := enc.Encode(mapping(fields...)); err != nil {
+		return nil, fmt.Errorf("cannot render manifest: %w", err)
+	}
+
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("cannot render manifest: %w", err)
+	}
+
+	return spaceTopLevelBlocks(buf.Bytes()), nil
+}
+
+// primaryContainer finds the container traffic reaches: the one flagged
+// primary, falling back to the first container of the first group for a spec
+// that flags nothing.
+func (l Live) primaryContainer() map[string]any {
+	return primaryContainerOf(l.Spec)
+}
+
+func primaryContainerOf(spec map[string]any) map[string]any {
+	var first map[string]any
+
+	for _, group := range slicesAt(spec, keyContainerGroups) {
+		for _, container := range slicesAt(group, keyContainers) {
+			if first == nil {
+				first = container
+			}
+
+			if boolAt(container, keyPrimary) {
+				return container
+			}
+		}
+	}
+
+	return first
+}
+
+// documentNode encodes a server document as a YAML node, nil for an empty
+// one so the key is left out rather than written as an empty mapping.
+func documentNode(document map[string]any) (*yaml.Node, error) {
+	if len(document) == 0 {
+		return nil, nil
+	}
+
+	node := &yaml.Node{}
+	if err := node.Encode(document); err != nil {
+		return nil, fmt.Errorf("cannot render the live spec: %w", err)
+	}
+
+	return node, nil
+}
+
+// stripServerManaged removes the server's bookkeeping from a copy of the
+// document, at every level.
+func stripServerManaged(document map[string]any) map[string]any {
+	copied := deepCopyMap(document)
+	stripKeys(copied)
+
+	return copied
+}
+
+func stripKeys(value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for _, key := range serverManagedKeys {
+			delete(typed, key)
+		}
+
+		for _, child := range typed {
+			stripKeys(child)
+		}
+	case []any:
+		for _, item := range typed {
+			stripKeys(item)
+		}
+	}
+}
+
+// stripBuildOutputs removes what a build produced rather than what a build
+// was asked to do. A container that says how to build itself also carries the
+// image that came out and the code the last sync uploaded; both are re-earned
+// by the next deploy, and writing them into the file would pin a workload to
+// yesterday's image.
+func stripBuildOutputs(spec map[string]any) {
+	for _, group := range slicesAt(spec, keyContainerGroups) {
+		for _, container := range slicesAt(group, keyContainers) {
+			buildConfig := mapAt(container, keyImageBuildConfig)
+			if buildConfig == nil {
+				continue
+			}
+
+			delete(container, keyImageURI)
+			delete(buildConfig, "codeRef")
+		}
+	}
+}
+
+func deepCopyMap(document map[string]any) map[string]any {
+	if document == nil {
+		return nil
+	}
+
+	copied := make(map[string]any, len(document))
+	for key, value := range document {
+		copied[key] = deepCopyValue(value)
+	}
+
+	return copied
+}
+
+func deepCopyValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return deepCopyMap(typed)
+	case []any:
+		copied := make([]any, len(typed))
+		for i, item := range typed {
+			copied[i] = deepCopyValue(item)
+		}
+
+		return copied
+	default:
+		return typed
+	}
+}
+
+func stringAt(document map[string]any, key string) string {
+	value, _ := document[key].(string)
+
+	return value
+}
+
+// floatAt reads a number that arrived as JSON (always float64), as YAML (int
+// for a whole number) or from a previous Apply (a Go int).
+func floatAt(document map[string]any, key string) (float64, bool) {
+	switch value := document[key].(type) {
+	case float64:
+		return value, true
+	case int:
+		return float64(value), true
+	default:
+		return 0, false
+	}
+}
+
+func boolAt(document map[string]any, key string) bool {
+	value, _ := document[key].(bool)
+
+	return value
+}
+
+// intAt reads a number that arrived through JSON, where every number is a
+// float64, or through YAML, where a whole number is an int.
+func intAt(document map[string]any, key string) (int, bool) {
+	switch value := document[key].(type) {
+	case int:
+		return value, true
+	case float64:
+		return int(value), true
+	default:
+		return 0, false
+	}
+}
+
+func mapAt(document map[string]any, key string) map[string]any {
+	value, _ := document[key].(map[string]any)
+
+	return value
+}
+
+func slicesAt(document map[string]any, key string) []map[string]any {
+	items, _ := document[key].([]any)
+	out := make([]map[string]any, 0, len(items))
+
+	for _, item := range items {
+		if typed, ok := item.(map[string]any); ok {
+			out = append(out, typed)
+		}
+	}
+
+	return out
+}
+
+func stringsAt(document map[string]any, key string) []string {
+	items, _ := document[key].([]any)
+	out := make([]string, 0, len(items))
+
+	for _, item := range items {
+		if typed, ok := item.(string); ok {
+			out = append(out, typed)
+		}
+	}
+
+	return out
+}
+
+func toAnySlice(values []string) []any {
+	out := make([]any, len(values))
+	for i, value := range values {
+		out[i] = value
+	}
+
+	return out
+}
+
+func orDefaultString(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+
+	return value
+}

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -27,6 +27,16 @@ import (
 // because the create spec has no legitimate key by these names anywhere.
 var serverManagedKeys = []string{"id", "createdAt", "updatedAt", "status", "endpoint", "artifactId", "workloadId"}
 
+// Probe field names. They live here rather than with the ledger's spec keys
+// because no validation rule reads them: binding is the only thing in this
+// package that has to tell a probe from any other block it preserves.
+const (
+	keyReadinessProbe = "readinessProbe"
+	keyStartupProbe   = "startupProbe"
+	keyLivenessProbe  = "livenessProbe"
+	keyPath           = "path"
+)
+
 // Live is a running workload, downloaded so a manifest can be written that
 // says everything the workload already says. Setup uses it when the user
 // binds to an existing workload: the alternative, generating a file from the
@@ -96,7 +106,7 @@ func (l Live) Defaults() Draft {
 		draft.Port = port
 	}
 
-	if path := stringAt(mapAt(container, "readinessProbe"), "path"); path != "" {
+	if path := stringAt(mapAt(container, keyReadinessProbe), keyPath); path != "" {
 		draft.HealthPath = path
 	}
 
@@ -170,16 +180,21 @@ func (l Live) runtimeDefaults() Runtime {
 		runtime.Replicas = replicas
 	}
 
-	if mapAt(group, keyAutoscaling) != nil {
+	if autoscalingActive(group) {
 		runtime.Replicas = 0
 	}
 
-	containers := slicesAt(group, keyContainers)
-	if len(containers) == 0 {
+	// The container Apply writes to, not whichever the server listed first. A
+	// group can list a sidecar ahead of the primary, and seeding the wizard
+	// from that would have the user accept the sidecar's sizing onto the
+	// primary and silently shrink what is running. A group that does not list
+	// the primary at all has no sizing to report, and Apply creates the entry.
+	container := findRuntimeContainer(group, l.primaryContainerName())
+	if container == nil {
 		return runtime
 	}
 
-	allocation := mapAt(containers[0], keyResourceAllocation)
+	allocation := mapAt(container, keyResourceAllocation)
 
 	if cpu, ok := floatAt(allocation, "cpu"); ok {
 		runtime.CPU = cpu
@@ -306,7 +321,7 @@ func (l *Live) applyRuntime(runtime Runtime) {
 	// Writing a replica count onto an autoscaled group would produce a file
 	// the ledger rejects, so an autoscaled workload keeps its autoscaling and
 	// the answer is dropped.
-	if runtime.Replicas > 0 && mapAt(group, keyAutoscaling) == nil {
+	if runtime.Replicas > 0 && !autoscalingActive(group) {
 		group[keyReplicaCount] = runtime.Replicas
 	}
 
@@ -355,10 +370,51 @@ func (l *Live) runtimeGroup() map[string]any {
 	return group
 }
 
+// autoscalingActive reports whether the group is actually autoscaling. A block
+// that is present but switched off is not, which is the rule the create-payload
+// check and the manifest ledger already apply. Live agreeing with them is what
+// keeps a replica answer from being dropped for a workload that is not
+// autoscaling: the file it would produce is one the ledger accepts.
+func autoscalingActive(group map[string]any) bool {
+	autoscaling := mapAt(group, keyAutoscaling)
+	if autoscaling == nil {
+		return false
+	}
+
+	// Absent means on, matching the platform's own default.
+	enabled, present := autoscaling[keyEnabled]
+	if !present || enabled == nil {
+		return true
+	}
+
+	on, ok := enabled.(bool)
+
+	return ok && on
+}
+
 // runtimeContainer is the sizing entry for name, created when the group does
 // not list it yet. The runtime and artifact lists are joined by name, so a
 // container invented here has to carry the artifact's.
 func runtimeContainer(group map[string]any, name string) map[string]any {
+	if name == "" {
+		return nil
+	}
+
+	if container := findRuntimeContainer(group, name); container != nil {
+		return container
+	}
+
+	container := map[string]any{keyName: name}
+	existing, _ := group[keyContainers].([]any)
+	group[keyContainers] = append(existing, container)
+
+	return container
+}
+
+// findRuntimeContainer is the sizing entry for name, nil when the group does
+// not list one. Kept separate from runtimeContainer so the read path can ask
+// the question without the write path's side effect of inventing an entry.
+func findRuntimeContainer(group map[string]any, name string) map[string]any {
 	if name == "" {
 		return nil
 	}
@@ -369,11 +425,7 @@ func runtimeContainer(group map[string]any, name string) map[string]any {
 		}
 	}
 
-	container := map[string]any{keyName: name}
-	existing, _ := group[keyContainers].([]any)
-	group[keyContainers] = append(existing, container)
-
-	return container
+	return nil
 }
 
 // artifactGroupName and primaryContainerName name the artifact's own group
@@ -402,6 +454,8 @@ func (l Live) primaryContainerName() string {
 // wizard's default /health, which a container that does not serve it would
 // never pass.
 func applyReadiness(container map[string]any, draft Draft) {
+	previous, hadPort := intAt(container, keyPort)
+
 	container[keyPort] = draft.Port
 
 	// The container being edited is the one traffic reaches, and the ledger
@@ -409,13 +463,27 @@ func applyReadiness(container map[string]any, draft Draft) {
 	// nothing would otherwise produce a file rejecting its own port.
 	container[keyPrimary] = true
 
-	probe := mapAt(container, "readinessProbe")
-	if probe == nil {
+	if probe := mapAt(container, keyReadinessProbe); probe != nil {
+		probe[keyPath] = draft.HealthPath
+		probe[keyPort] = draft.Port
+	}
+
+	if !hadPort || previous == draft.Port {
 		return
 	}
 
-	probe["path"] = draft.HealthPath
-	probe[keyPort] = draft.Port
+	// The other probes are blocks the wizard has no question for, and they are
+	// preserved as they stand. One that was watching the container's port still
+	// has to follow it: a startup probe left behind on the old port is how a
+	// changed port becomes a deploy that never reports ready. A probe aimed
+	// somewhere else was aimed there deliberately and keeps its own port.
+	for _, key := range []string{keyStartupProbe, keyLivenessProbe} {
+		probe := mapAt(container, key)
+
+		if port, ok := intAt(probe, keyPort); ok && port == previous {
+			probe[keyPort] = draft.Port
+		}
+	}
 }
 
 // applyBuild sets the image source, editing the live build block in place

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -1,0 +1,434 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// liveWorkloadJSON and liveArtifactJSON are shaped like the server's own
+// responses, including the things the wizard has no vocabulary for:
+// autoscaling, a GPU bundle, a second container, a credential-backed
+// variable. Those are exactly what binding must not lose.
+const liveWorkloadJSON = `{
+  "id": "68b0c1d2e3f4a5b6c7d8e9f0",
+  "name": "gpt-oss-20b-vllm",
+  "status": "running",
+  "importance": "moderate",
+  "artifactId": "68a0000000000000000000a1",
+  "endpoint": "https://app.datarobot.com/workloads/68b0/",
+  "createdAt": "2026-07-02T10:00:00Z",
+  "runtime": {
+    "containerGroups": [
+      {
+        "name": "default",
+        "resourceBundles": ["gpu.medium"],
+        "autoscaling": {
+          "enabled": true,
+          "minReplicaCount": 1,
+          "maxReplicaCount": 4,
+          "policies": [{"scalingMetric": "gpuCacheUtilization", "target": 70}]
+        },
+        "containers": [
+          {"name": "vllm-server", "resourceAllocation": {"cpu": 3, "memory": "22GB", "gpu": 1}},
+          {"name": "metrics-bridge", "resourceAllocation": {"cpu": 0.5, "memory": "2GB"}}
+        ]
+      }
+    ]
+  }
+}`
+
+const liveArtifactJSON = `{
+  "id": "68a0000000000000000000a1",
+  "name": "gpt-oss-20b-vllm-artifact",
+  "status": "locked",
+  "createdAt": "2026-07-02T09:00:00Z",
+  "spec": {
+    "type": "service",
+    "containerGroups": [
+      {
+        "name": "default",
+        "containers": [
+          {
+            "name": "vllm-server",
+            "primary": true,
+            "port": 8000,
+            "imageUri": "registry.internal/built-by-the-server:sha-abc123",
+            "imageBuildConfig": {
+              "dockerfile": {"source": "provided"},
+              "codeRef": {"datarobot": {"catalogId": "cat1", "catalogVersionId": "ver1"}}
+            },
+            "environmentVars": [
+              {"name": "HF_HOME", "value": "/tmp/hf"},
+              {"name": "HUGGING_FACE_HUB_TOKEN", "source": "dr-credential",
+               "drCredentialId": "66f1a2b3c4d5e6f7a8b9c0d1", "key": "apiToken"}
+            ],
+            "readinessProbe": {"path": "/health", "port": 8000, "periodSeconds": 10},
+            "startupProbe": {"path": "/health", "port": 8000, "periodSeconds": 15, "failureThreshold": 60}
+          },
+          {"name": "metrics-bridge", "imageUri": "registry/vllm-metrics-bridge:v1"}
+        ]
+      }
+    ]
+  }
+}`
+
+func liveFixture(t *testing.T) Live {
+	t.Helper()
+
+	var workloadDoc, artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(liveWorkloadJSON), &workloadDoc))
+	require.NoError(t, json.Unmarshal([]byte(liveArtifactJSON), &artifactDoc))
+
+	return NewLive("68b0c1d2e3f4a5b6c7d8e9f0", workloadDoc, artifactDoc)
+}
+
+func TestNewLive_StripsWhatOnlyTheServerSets(t *testing.T) {
+	live := liveFixture(t)
+	rendered, err := live.Render()
+	require.NoError(t, err)
+
+	for _, unwanted := range []string{"createdAt", "68a0000000000000000000a1", "app.datarobot.com", "status: locked"} {
+		assert.NotContains(t, string(rendered), unwanted)
+	}
+
+	// The binding itself is the one id the file carries.
+	assert.Contains(t, string(rendered), "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0")
+}
+
+// The image a build produced and the code the last sync uploaded are earned
+// again by the next deploy. Writing them down would pin the workload to
+// yesterday's image.
+func TestNewLive_StripsBuildOutputs(t *testing.T) {
+	rendered, err := liveFixture(t).Render()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(rendered), "built-by-the-server")
+	assert.NotContains(t, string(rendered), "codeRef")
+	assert.Contains(t, string(rendered), "source: provided")
+
+	// A container that genuinely runs a published image keeps it.
+	assert.Contains(t, string(rendered), "registry/vllm-metrics-bridge:v1")
+}
+
+// Everything the wizard has no question for still has to survive, because
+// the file it writes is what the next deploy applies.
+func TestLive_RenderKeepsWhatTheWizardCannotSay(t *testing.T) {
+	rendered, err := liveFixture(t).Render()
+	require.NoError(t, err)
+
+	for _, kept := range []string{
+		"autoscaling", "gpuCacheUtilization", "resourceBundles", "gpu.medium",
+		"metrics-bridge", "startupProbe", "dr-credential", "HUGGING_FACE_HUB_TOKEN",
+	} {
+		assert.Contains(t, string(rendered), kept, "binding must not drop %s", kept)
+	}
+}
+
+func TestLive_DefaultsComeFromTheLiveSpec(t *testing.T) {
+	defaults := liveFixture(t).Defaults()
+
+	assert.Equal(t, "gpt-oss-20b-vllm", defaults.Name)
+	assert.Equal(t, "moderate", defaults.Importance)
+	assert.Equal(t, TypeService, defaults.Type)
+	assert.Equal(t, 8000, defaults.Port)
+	assert.Equal(t, "/health", defaults.HealthPath)
+	assert.Equal(t, BuildModeDockerfile, defaults.Build.Mode)
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", defaults.WorkloadID)
+}
+
+func TestLive_ApplyChangesOnlyWhatWasAsked(t *testing.T) {
+	live := liveFixture(t)
+
+	draft := live.Defaults()
+	draft.Port = 9000
+	draft.HealthPath = "/ready"
+	draft.Build = Build{Mode: BuildModeImage, ImageURI: "registry/team/app:v2"}
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "port: 9000")
+	assert.Contains(t, string(rendered), "path: /ready")
+	assert.Contains(t, string(rendered), "imageUri: registry/team/app:v2")
+	// The build config it replaced is gone, so the container names one source.
+	assert.NotContains(t, string(rendered), "imageBuildConfig")
+	// And the parts nobody asked about are still there.
+	assert.Contains(t, string(rendered), "autoscaling")
+	assert.Contains(t, string(rendered), "metrics-bridge")
+
+	// Apply leaves the original alone so the confirm screen can diff them.
+	before, err := live.Render()
+	require.NoError(t, err)
+	assert.Contains(t, string(before), "port: 8000")
+}
+
+func TestLive_ApplySwitchesToAGeneratedBuild(t *testing.T) {
+	live := liveFixture(t)
+
+	draft := live.Defaults()
+	draft.Build = Build{
+		Mode:                          BuildModeGenerated,
+		ExecutionEnvironmentID:        "68a1",
+		ExecutionEnvironmentVersionID: "68a2",
+		Entrypoint:                    []string{"python", "main.py"},
+	}
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "source: generated")
+	assert.Contains(t, string(rendered), "executionEnvironmentId: 68a1")
+	assert.Contains(t, string(rendered), "- python")
+}
+
+func TestLive_ApplyTogglesA2A(t *testing.T) {
+	live := liveFixture(t)
+
+	draft := live.Defaults()
+	draft.Type = TypeAgent
+	draft.A2AEnabled = true
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "type: agent")
+	assert.Contains(t, string(rendered), "a2aEnabled: true")
+
+	draft.A2AEnabled = false
+
+	applied, err = live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err = applied.Render()
+	require.NoError(t, err)
+	assert.NotContains(t, string(rendered), "a2aEnabled")
+}
+
+// A downloaded workload has to produce a file this CLI can read back and
+// deploy, or binding has just written a dead end.
+func TestLive_RenderRoundTripsThroughValidate(t *testing.T) {
+	live := liveFixture(t)
+
+	draft := live.Defaults()
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	// The live spec builds a provided Dockerfile, so the ledger's file check
+	// needs one; "" skips the file-existence rules the same way a preview does.
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+
+	compiled, err := parsed.Compile()
+	require.NoError(t, err)
+
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", compiled.WorkloadID)
+	require.Len(t, compiled.CredentialRefs, 1)
+	assert.Equal(t, "66f1a2b3c4d5e6f7a8b9c0d1", compiled.CredentialRefs[0].CredentialID)
+}
+
+// A spec with no container to update is a workload the wizard cannot honestly
+// edit, so it says so instead of writing something plausible.
+func TestLive_ApplyWithoutAPrimaryContainer(t *testing.T) {
+	live := NewLive("68b0", map[string]any{"name": "empty"}, map[string]any{"name": "empty-artifact"})
+
+	_, err := live.Apply(live.Defaults())
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "no primary container")
+}
+
+// An unflagged spec still has a container traffic reaches: the first one.
+func TestLive_PrimaryFallsBackToTheFirstContainer(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "spec": {"containerGroups": [{"name": "default", "containers": [
+        {"name": "only", "port": 8080, "imageUri": "nginx:latest"}
+      ]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	assert.Equal(t, 8080, live.Defaults().Port)
+}
+
+// A build block can carry more than the wizard models (build arguments, a
+// timeout, whatever the platform adds next). Rebuilding it from the Build
+// struct would drop all of it on a run that changed nothing.
+func TestLive_ApplyKeepsUnknownBuildKeys(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+        {"name": "primary", "primary": true, "port": 8080, "imageBuildConfig": {
+          "dockerfile": {"source": "provided", "buildArgs": {"NODE_ENV": "production"}, "target": "runtime"},
+          "buildTimeoutSeconds": 3600,
+          "someFuturePlatformKey": {"nested": true}
+        }}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	applied, err := live.Apply(live.Defaults())
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	for _, kept := range []string{"buildArgs", "NODE_ENV", "target", "buildTimeoutSeconds", "someFuturePlatformKey"} {
+		assert.Contains(t, string(rendered), kept, "changing nothing must not drop %s", kept)
+	}
+}
+
+// A build source this release does not know is kept as it stands rather than
+// forced into the nearest mode the Build struct can express.
+func TestLive_UnknownBuildSourceIsPreserved(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+        {"name": "primary", "primary": true, "port": 8080,
+         "imageBuildConfig": {"buildpack": {"builder": "paketo/builder:base"}}}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	assert.Equal(t, BuildModeUnchanged, live.Defaults().Build.Mode)
+
+	applied, err := live.Apply(live.Defaults())
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "buildpack")
+	assert.Contains(t, string(rendered), "paketo/builder:base")
+	assert.NotContains(t, string(rendered), `imageUri: ""`, "an empty image must never be invented")
+}
+
+// A workload deliberately running without a readiness probe must not acquire
+// the wizard's default one, which its container would never pass.
+func TestLive_ApplyDoesNotInventAReadinessProbe(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+        {"name": "primary", "primary": true, "port": 9000, "imageUri": "registry/a:v1"}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	applied, err := live.Apply(live.Defaults())
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(rendered), "readinessProbe")
+
+	// One that does have a probe keeps it pointing where the answers say.
+	draft := live.Defaults()
+	draft.HealthPath = "/ready"
+
+	applied, err = live.Apply(draft)
+	require.NoError(t, err)
+	rendered, err = applied.Render()
+	require.NoError(t, err)
+	assert.NotContains(t, string(rendered), "/ready", "no probe means nothing to point")
+}
+
+// A spec that flags no primary container still has one traffic reaches, and
+// the file must say so or the ledger rejects the port it just wrote.
+func TestLive_ApplyFlagsTheContainerItEdits(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+        {"name": "only", "port": 8080, "imageUri": "registry/a:v1"}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	applied, err := live.Apply(live.Defaults())
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate(), "the written file must satisfy the reader that wrote it")
+}
+
+// The confirm screen reads its runtime line from here, so it has to describe
+// the workload rather than the documented defaults.
+func TestLive_DefaultsReadTheLiveSizing(t *testing.T) {
+	runtime := liveFixture(t).Defaults().Runtime
+
+	assert.Equal(t, 0, runtime.Replicas, "an autoscaled group has no replica count to report")
+	assert.InEpsilon(t, 3.0, runtime.CPU, 0.0001)
+	assert.Equal(t, "22GB", runtime.Memory)
+}
+
+// Sizing answers reach the runtime block, and an autoscaled group keeps its
+// autoscaling rather than gaining a replica count the ledger would reject.
+func TestLive_ApplyRuntime(t *testing.T) {
+	live := liveFixture(t)
+
+	draft := live.Defaults()
+	draft.Runtime = Runtime{Replicas: 9, CPU: 16, Memory: "32GB"}
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "cpu: 16")
+	assert.Contains(t, string(rendered), "memory: 32GB")
+	assert.NotContains(t, string(rendered), "replicaCount", "an autoscaled group must not gain one")
+	assert.Contains(t, string(rendered), "maxReplicaCount: 4", "the autoscaling policy is untouched")
+	assert.Contains(t, string(rendered), "metrics-bridge")
+	assert.Contains(t, string(rendered), "2GB", "the second container's allocation is untouched")
+
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+}

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -373,6 +373,52 @@ func TestLive_ApplyDoesNotInventAReadinessProbe(t *testing.T) {
 	assert.NotContains(t, string(rendered), "/ready", "no probe means nothing to point")
 }
 
+// A workload can carry probes the wizard has no question for. Changing the
+// port has to take them along: a startup probe left behind on the old port is
+// a workload that builds, starts, and then never reports ready.
+func TestLive_ApplyMovesPreservedProbesWithThePort(t *testing.T) {
+	live := liveFixture(t)
+
+	draft := live.Defaults()
+	draft.Port = 9000
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), keyStartupProbe)
+	assert.NotContains(t, string(rendered), "8000", "every probe watching the container's port follows it")
+	assert.Contains(t, string(rendered), "failureThreshold: 60", "the rest of the probe is untouched")
+}
+
+// A probe on a port of its own was pointed there deliberately, so it stays
+// where it is rather than being dragged along with the container's port.
+func TestLive_ApplyLeavesAProbeOnItsOwnPort(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+        {"name": "primary", "primary": true, "port": 8080, "imageUri": "registry/a:v1",
+         "livenessProbe": {"path": "/admin/live", "port": 9900}}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	draft := live.Defaults()
+	draft.Port = 9000
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "port: 9900")
+}
+
 // A spec that flags no primary container still has one traffic reaches, and
 // the file must say so or the ledger rejects the port it just wrote.
 func TestLive_ApplyFlagsTheContainerItEdits(t *testing.T) {
@@ -405,6 +451,167 @@ func TestLive_DefaultsReadTheLiveSizing(t *testing.T) {
 	assert.Equal(t, 0, runtime.Replicas, "an autoscaled group has no replica count to report")
 	assert.InEpsilon(t, 3.0, runtime.CPU, 0.0001)
 	assert.Equal(t, "22GB", runtime.Memory)
+}
+
+// The runtime list is joined to the artifact by name, not by position. Reading
+// the sizing from whichever container the server happened to list first would
+// show the user a sidecar's allocation, and accepting it would then write that
+// onto the primary and shrink what is running.
+func TestLive_DefaultsReadThePrimaryNotTheFirstListed(t *testing.T) {
+	var workloadDoc, artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "sidecar-first",
+      "runtime": {"containerGroups": [{"name": "default", "replicaCount": 2, "containers": [
+        {"name": "metrics-bridge", "resourceAllocation": {"cpu": 0.25, "memory": "256MB"}},
+        {"name": "app", "resourceAllocation": {"cpu": 4, "memory": "8GB"}}]}]}
+    }`), &workloadDoc))
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "sidecar-first-artifact",
+      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+        {"name": "app", "primary": true, "port": 8080, "imageUri": "example/app:v1"},
+        {"name": "metrics-bridge", "imageUri": "example/bridge:v1"}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", workloadDoc, artifactDoc)
+
+	draft := live.Defaults()
+	assert.InEpsilon(t, 4.0, draft.Runtime.CPU, 0.0001)
+	assert.Equal(t, "8GB", draft.Runtime.Memory)
+
+	// Accepting what was shown leaves both containers exactly as they were.
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "cpu: 4")
+	assert.Contains(t, string(rendered), "memory: 8GB")
+	assert.Contains(t, string(rendered), "cpu: 0.25", "the sidecar keeps its own sizing")
+	assert.Contains(t, string(rendered), "memory: 256MB")
+}
+
+// An autoscaling block that is switched off is not autoscaling, which is the
+// rule both the create-payload check and the manifest ledger already apply.
+// Live dissenting from it dropped the user's replica answer for a workload
+// that was not autoscaling at all, and said nothing about it.
+func TestLive_DisabledAutoscalingKeepsTheReplicaAnswer(t *testing.T) {
+	var workloadDoc, artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "paused-autoscaling",
+      "runtime": {"containerGroups": [{"name": "default", "replicaCount": 3,
+        "autoscaling": {"enabled": false, "minReplicaCount": 1, "maxReplicaCount": 4},
+        "containers": [{"name": "app", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}]}]}
+    }`), &workloadDoc))
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+        {"name": "app", "primary": true, "port": 8080, "imageUri": "example/app:v1"}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", workloadDoc, artifactDoc)
+
+	draft := live.Defaults()
+	assert.Equal(t, 3, draft.Runtime.Replicas, "the group's own count, not the autoscaled zero")
+
+	draft.Runtime.Replicas = 9
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "replicaCount: 9")
+	assert.Contains(t, string(rendered), "enabled: false", "the policy is preserved as it stands")
+
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate(), "the ledger allows a count alongside disabled autoscaling")
+}
+
+// Environment variables merge rather than replace. A name the workload already
+// declares keeps its running value, because .env is the developer's copy and
+// may well be stale, while a name only .env knows about is appended.
+func TestLive_ApplyMergesEnvVars(t *testing.T) {
+	live := liveFixture(t)
+
+	draft := live.Defaults()
+	draft.EnvVars = []EnvVar{
+		{Name: "HF_HOME", Value: "/home/dev/.cache/hf"},
+		{Name: "LOG_LEVEL", Value: "debug"},
+		{Name: "OPENAI_API_KEY", Secret: true},
+	}
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "value: /tmp/hf", "the running value wins over the local copy")
+	assert.NotContains(t, string(rendered), "/home/dev/.cache/hf")
+	assert.Contains(t, string(rendered), "LOG_LEVEL")
+	assert.Contains(t, string(rendered), "value: debug")
+	assert.Contains(t, string(rendered), "dr-credential:"+CredentialPlaceholder+"/apiToken")
+
+	// Both reference forms have to survive to the payload: the object form the
+	// server sent, and the shorthand this merge just wrote.
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+
+	compiled, err := parsed.Compile()
+	require.NoError(t, err)
+
+	referenced := make([]string, 0, len(compiled.CredentialRefs))
+	for _, ref := range compiled.CredentialRefs {
+		referenced = append(referenced, ref.EnvName)
+	}
+
+	assert.ElementsMatch(t, []string{"HUGGING_FACE_HUB_TOKEN", "OPENAI_API_KEY"}, referenced)
+}
+
+// BuildMode reads a parsed manifest rather than a live document: setup asks it
+// what the file already says before offering to change it. Driven through
+// Render so the reader and the writer are held to the same vocabulary.
+func TestManifest_BuildMode(t *testing.T) {
+	generated := Build{
+		Mode:                          BuildModeGenerated,
+		ExecutionEnvironmentID:        "68a1b2c3d4e5f6a7b8c9d0e1",
+		ExecutionEnvironmentVersionID: "68a1b2c3d4e5f6a7b8c9d0e2",
+		Entrypoint:                    []string{"python", "main.py"},
+	}
+
+	for want, build := range map[string]Build{
+		BuildModeDockerfile: {Mode: BuildModeDockerfile},
+		BuildModeGenerated:  generated,
+		BuildModeImage:      {Mode: BuildModeImage, ImageURI: "nginx:latest"},
+	} {
+		t.Run(want, func(t *testing.T) {
+			draft := serviceDraft()
+			draft.Build = build
+
+			out, err := draft.Render()
+			require.NoError(t, err)
+
+			m, err := Parse(out, "")
+			require.NoError(t, err)
+
+			assert.Equal(t, want, m.BuildMode())
+		})
+	}
+}
+
+// A manifest bound to an artifact by id carries no inline spec to read.
+func TestManifest_BuildModeWithoutAnInlineArtifact(t *testing.T) {
+	m, err := Parse([]byte("name: my-app\nartifactId: 68a0000000000000000000a1\n"), "")
+	require.NoError(t, err)
+
+	assert.Empty(t, m.BuildMode())
 }
 
 // Sizing answers reach the runtime block, and an autoscaled group keeps its


### PR DESCRIPTION
# RATIONALE

`dr workload config` opens by asking whether to create a new workload or bind the project to one that already exists. Binding is only safe if the manifest written out is the workload's **own** spec: a manifest assembled from the wizard's defaults would look plausible and silently downgrade something running the first time `dr workload up` was called against it.

This PR is the read side of that, split out from the wizard so the "do not lose fields the server sent" argument gets reviewed on its own.

## CHANGES

**`internal/workload/document.go`**

`Document` is `map[string]any`, with `GetWorkloadDocument` and `GetArtifactDocument` fetching one. Untyped on purpose: the typed clients in this package model the fields the CLI needs, and anything else the API returns is dropped on decode. For a spec we are about to write into a file the user keeps, dropping unknown fields is the failure mode, not an optimisation.

**`internal/workload/execenv.go`**

`ListExecutionEnvironments(limit)` paginates and keeps only environments that can actually be built from, so the picker cannot offer a choice that fails later at build time.

**`internal/workload/manifest/live.go`**

`Live` holds the two server documents raw and edits them in place:

- `Defaults()` reads a `Draft` out of the live spec, so the screens after the binding question open on what the workload actually does rather than on the wizard's defaults.
- `Apply(draft)` writes answers back into the live documents, field by field. It never rebuilds a block from the `Draft` struct, because `Draft` models only the subset the wizard asks about and a rebuild drops the rest. Environment variables merge rather than replace: a name the workload already declares keeps its running value, since a stale local `.env` copy should not overwrite what is live.
- `Render()` emits the manifest, stripping the keys the server owns (`id`, `createdAt`, `updatedAt`, `status`, `endpoint`, `artifactId`, `workloadId`) so the result is valid `dr workload create --spec-file` input rather than a snapshot that cannot be replayed.

No command uses this yet. It is wired up by the `dr workload config` PR stacked on top.

## TESTING

- `Defaults` then `Apply` then `Render` against recorded workload and artifact documents, asserting unknown blocks survive the round trip.
- Coverage for the three shapes that previously lost data: a bound workload with no `runtime` block, a bound workload with its own environment variables, and a bound workload whose kind the wizard cannot author.
- `task lint` clean on linux, darwin and windows; `task test` green.

## RELATED

Stacked on the manifest render/validate PR. The `dr workload config` command stacks on this one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deploy-facing manifest generation and in-place spec mutation; mistakes could strip GPU/autoscaling/extra containers on the next `up`, but behavior is heavily tested and not yet exposed via a command.
> 
> **Overview**
> Adds the **read path for binding** an existing workload: fetch full workload/artifact API payloads and turn them into a manifest without dropping fields the wizard does not model.
> 
> **Untyped API documents** (`Document`, `GetWorkloadDocument`, `GetArtifactDocument`) replace typed decode when the goal is to copy the server’s spec into a file.
> 
> **`manifest.Live`** holds artifact `spec` and workload `runtime` as `map[string]any`. `Defaults()` seeds wizard answers from the live primary container; **`Apply`** patches only wizard-owned fields in place (env vars merge and do not overwrite live names; autoscaled groups keep autoscaling; unknown build blocks use `BuildModeUnchanged`). **`Render`** writes `dr-workload.yaml`, strips server-managed keys recursively, and removes build outputs (`imageUri`, `codeRef`) so the next deploy does not pin stale images.
> 
> Also adds **`ListExecutionEnvironments`** (buildable EEs only, paginated) for a future base-image picker, plus **`Manifest.BuildMode()`** for parsed manifests.
> 
> No CLI command calls this yet; stacked `dr workload config` will wire it up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb09d8be5ef18ee1e81f515bda3990824e5ced24. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->