### PR TITLE
[CFX-6414] fix(dotenv): make --if-needed skip only when .env is complete

### DIFF
--- a/internal/fsutil/atomicwrite.go
+++ b/internal/fsutil/atomicwrite.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package wapi
+package fsutil
 
 import (
 	"fmt"
@@ -20,14 +20,50 @@ import (
 	"path/filepath"
 )
 
-const atomicFileMode os.FileMode = 0o644
+// DefaultFileMode is the permission CLI-written data files get: readable by
+// anyone who can read the project, writable by the owner. Exported so callers
+// that open a file themselves (an append-only log, say) stay consistent with
+// what AtomicWriteFile leaves behind.
+const DefaultFileMode os.FileMode = 0o644
 
-// atomicWriteFile writes data to a sibling temp file in the same directory as
+// targetMode is the permission the written file should end up with.
+//
+// Replacing a file keeps the mode it already had: a user who tightened
+// something to 0600 should not find it widened by an unrelated edit. A new
+// file gets what a plain create would give it, umask included, because
+// os.CreateTemp makes the temp file 0600 and chmodding to a fixed mode would
+// hand a developer with a restrictive umask a wider file than everything else
+// they write.
+func targetMode(path string) (os.FileMode, error) {
+	if info, err := os.Stat(path); err == nil {
+		return info.Mode().Perm(), nil
+	}
+
+	// The cheapest way to learn what the umask allows is to let the kernel
+	// apply it, in the directory the file is going to live in.
+	probe, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, DefaultFileMode)
+	if err != nil {
+		// Something else created it in between, or the directory refuses; the
+		// rename below reports whichever it is.
+		return DefaultFileMode, nil
+	}
+
+	_ = probe.Close()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	return info.Mode().Perm(), nil
+}
+
+// AtomicWriteFile writes data to a sibling temp file in the same directory as
 // path, fsyncs it, then renames it over path. os.Rename is atomic on POSIX
 // and handled as replace-on-existing by Go on Windows. The parent directory
 // is fsynced after rename so the new dentry survives a crash. The temp file
 // is removed on any failure before rename so no .tmp.* leftovers remain.
-func atomicWriteFile(path string, data []byte) (err error) {
+func AtomicWriteFile(path string, data []byte) (err error) {
 	dir := filepath.Dir(path)
 
 	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
@@ -57,7 +93,12 @@ func atomicWriteFile(path string, data []byte) (err error) {
 		return fmt.Errorf("close temp file %s: %w", tmp.Name(), err)
 	}
 
-	if err = os.Chmod(tmp.Name(), atomicFileMode); err != nil {
+	mode, err := targetMode(path)
+	if err != nil {
+		return err
+	}
+
+	if err = os.Chmod(tmp.Name(), mode); err != nil {
 		return fmt.Errorf("chmod temp file %s: %w", tmp.Name(), err)
 	}
 

--- a/internal/fsutil/atomicwrite_test.go
+++ b/internal/fsutil/atomicwrite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package wapi
+package fsutil
 
 import (
 	"os"
@@ -28,20 +28,55 @@ func TestAtomicWriteFile_CreatesNew(t *testing.T) {
 	tmp := t.TempDir()
 	target := filepath.Join(tmp, "new.json")
 
-	err := atomicWriteFile(target, []byte(`{"hello":"world"}`))
+	err := AtomicWriteFile(target, []byte(`{"hello":"world"}`))
 	require.NoError(t, err)
 
 	got, err := os.ReadFile(target)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"hello":"world"}`, string(got))
 
-	info, err := os.Stat(target)
+	assertSameModeAsPlainWrite(t, target)
+}
+
+// assertSameModeAsPlainWrite compares against a file the standard library
+// just created with the same requested mode, so the assertion holds under any
+// umask rather than only the developer's. It is also the contract: a file the
+// CLI writes should be no wider than one the user's own tools would write.
+func assertSameModeAsPlainWrite(t *testing.T, path string) {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		// Windows does not enforce Unix permission bits.
+		return
+	}
+
+	reference := filepath.Join(t.TempDir(), "reference")
+	require.NoError(t, os.WriteFile(reference, nil, DefaultFileMode))
+
+	want, err := os.Stat(reference)
 	require.NoError(t, err)
 
-	if runtime.GOOS != "windows" {
-		// Windows does not enforce Unix permission bits.
-		assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
+	got, err := os.Stat(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, want.Mode().Perm(), got.Mode().Perm())
+}
+
+// A file that already exists keeps the mode it had: tightening a manifest to
+// 0600 should survive an unrelated edit such as the workload-id write-back.
+func TestAtomicWriteFile_PreservesAnExistingMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not enforce Unix permission bits")
 	}
+
+	target := filepath.Join(t.TempDir(), "tightened")
+	require.NoError(t, os.WriteFile(target, []byte("old"), 0o600))
+
+	require.NoError(t, AtomicWriteFile(target, []byte("new")))
+
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 }
 
 func TestAtomicWriteFile_OverwritesExisting(t *testing.T) {
@@ -51,7 +86,7 @@ func TestAtomicWriteFile_OverwritesExisting(t *testing.T) {
 	err := os.WriteFile(target, []byte("old"), 0o644)
 	require.NoError(t, err)
 
-	err = atomicWriteFile(target, []byte("new"))
+	err = AtomicWriteFile(target, []byte("new"))
 	require.NoError(t, err)
 
 	got, err := os.ReadFile(target)
@@ -69,7 +104,7 @@ func TestAtomicWriteFile_CleansTmpWhenRenameFails(t *testing.T) {
 	err := os.Mkdir(target, 0o755)
 	require.NoError(t, err)
 
-	err = atomicWriteFile(target, []byte("payload"))
+	err = AtomicWriteFile(target, []byte("payload"))
 	require.Error(t, err)
 
 	entries, err := os.ReadDir(tmp)

--- a/internal/workload/document.go
+++ b/internal/workload/document.go
@@ -1,0 +1,80 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// Document is a server response kept as it arrived. The typed Workload and
+// Artifact structs are deliberate projections: they parse the handful of
+// fields the CLI renders and drop the rest. That is right for printing and
+// wrong for copying, because a field this CLI does not know about is still a
+// field the workload is running with.
+//
+// Setup uses these when it binds to a live workload: the manifest it writes
+// has to be able to say everything the workload already says, including
+// blocks no release of this CLI has heard of, or the first deploy from that
+// file would quietly strip them.
+type Document map[string]any
+
+// GetWorkloadDocument fetches a workload as the server has it.
+func GetWorkloadDocument(workloadID string) (Document, error) {
+	url, err := config.GetEndpointURL("/api/v2/workloads/" + escapeID(workloadID) + "/")
+	if err != nil {
+		return nil, err
+	}
+
+	var doc Document
+
+	if err := drapi.GetJSON(url, "workload", &doc); err != nil {
+		return nil, err
+	}
+
+	return doc, nil
+}
+
+// GetArtifactDocument fetches an artifact as the server has it.
+func GetArtifactDocument(artifactID string) (Document, error) {
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/")
+	if err != nil {
+		return nil, err
+	}
+
+	var doc Document
+
+	if err := drapi.GetJSON(url, "artifact", &doc); err != nil {
+		return nil, err
+	}
+
+	return doc, nil
+}
+
+// String returns the document's value for key, "" when absent or not a
+// string.
+func (d Document) String(key string) string {
+	value, _ := d[key].(string)
+
+	return value
+}
+
+// Map returns the document's nested object for key, nil when absent or not an
+// object.
+func (d Document) Map(key string) map[string]any {
+	value, _ := d[key].(map[string]any)
+
+	return value
+}

--- a/internal/workload/execenv.go
+++ b/internal/workload/execenv.go
@@ -82,6 +82,80 @@ func ResolveExecutionEnvironment(nameOrID string) (id, versionID string, err err
 	return "", "", fmt.Errorf("execution environment %q not found; check the name in the DataRobot UI under Registry > Environments", nameOrID)
 }
 
+// ListExecutionEnvironments returns up to limit environments that have a
+// version to build from, for the setup wizard's base-image picker. Ones with
+// no successful version are dropped rather than offered: picking one would
+// fail at build time with nothing the user could do about it.
+func ListExecutionEnvironments(limit int) ([]ExecutionEnvironment, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("limit must be positive, got %d", limit)
+	}
+
+	pageURL, err := config.GetEndpointURL("/api/v2/executionEnvironments/?limit=100")
+	if err != nil {
+		return nil, err
+	}
+
+	environments := make([]ExecutionEnvironment, 0, limit)
+
+	for pages := 0; pageURL != ""; pages++ {
+		if pages >= maxExecEnvPages {
+			// Silently returning a partial list would read as "these are all
+			// the base images", which is the wrong thing to choose from.
+			return nil, fmt.Errorf("execution environments did not finish listing after %d pages", maxExecEnvPages)
+		}
+
+		var list executionEnvironmentList
+
+		if err := drapi.GetJSON(pageURL, "execution environments", &list); err != nil {
+			return nil, err
+		}
+
+		if environments = appendBuildable(environments, list.Data, limit); len(environments) == limit {
+			return environments, nil
+		}
+
+		next, err := nextPage(list.Next)
+		if err != nil {
+			return nil, err
+		}
+
+		pageURL = next
+	}
+
+	return environments, nil
+}
+
+// appendBuildable adds the environments a build can target, stopping at limit.
+func appendBuildable(into, page []ExecutionEnvironment, limit int) []ExecutionEnvironment {
+	for _, ee := range page {
+		if ee.LatestSuccessfulVersion == nil {
+			continue
+		}
+
+		into = append(into, ee)
+
+		if len(into) == limit {
+			return into
+		}
+	}
+
+	return into
+}
+
+// nextPage validates a paging cursor, returning "" at the end of the listing.
+func nextPage(next string) (string, error) {
+	if next == "" {
+		return "", nil
+	}
+
+	if err := drapi.AssertNextOnSameHost(next); err != nil {
+		return "", err
+	}
+
+	return next, nil
+}
+
 // scanExecutionEnvironments walks the paged listing once, returning the unique
 // id match if one turned up and every environment carrying the name. It stops
 // early on an id hit; a name has to be checked against the whole list before it

--- a/internal/workload/execenv_test.go
+++ b/internal/workload/execenv_test.go
@@ -242,3 +242,75 @@ func TestResolveExecutionEnvironment_RejectsCrossHostNext(t *testing.T) {
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "not found", "a cross-host next must fail loudly, not fall through to not-found")
 }
+
+// The base-image picker offers only what a build can actually target: an
+// environment with no successful version would fail at build time with
+// nothing the user could do about it.
+func TestListExecutionEnvironments_SkipsVersionlessEnvironments(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data": [%s, %s, %s], "next": ""}`,
+			eeDoc("ee-1", "Python 3.11", "ver-1"),
+			eeDoc("ee-2", "Never built", ""),
+			eeDoc("ee-3", "Python 3.12", "ver-3"),
+		)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	environments, err := ListExecutionEnvironments(50)
+	require.NoError(t, err)
+
+	require.Len(t, environments, 2)
+	assert.Equal(t, "ee-1", environments[0].ID)
+	assert.Equal(t, "ee-3", environments[1].ID)
+}
+
+func TestListExecutionEnvironments_StopsAtTheLimit(t *testing.T) {
+	installSkipAuth(t)
+
+	// next is filled in once the server has an address; the handler only ever
+	// echoes this test's own value, never anything from the request.
+	var next string
+
+	pages := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		pages++
+
+		fmt.Fprintf(w, `{"data": [%s, %s], "next": %q}`,
+			eeDoc(fmt.Sprintf("ee-%da", pages), "A", "ver-a"),
+			eeDoc(fmt.Sprintf("ee-%db", pages), "B", "ver-b"),
+			next,
+		)
+	}))
+
+	defer srv.Close()
+
+	next = srv.URL + "/api/v2/executionEnvironments/?limit=100&page=2"
+
+	installEndpoint(t, srv.URL)
+
+	environments, err := ListExecutionEnvironments(3)
+	require.NoError(t, err)
+
+	assert.Len(t, environments, 3)
+	assert.Equal(t, 2, pages, "paging stops as soon as the limit is reached")
+}
+
+func TestListExecutionEnvironments_ServerError(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := ListExecutionEnvironments(50)
+	require.Error(t, err)
+}

--- a/internal/workload/manifest/doc.go
+++ b/internal/workload/manifest/doc.go
@@ -20,16 +20,19 @@
 // credential-backed environment variable object (the object form is accepted
 // in the file as well).
 //
-// There are no typed spec structs here on purpose: the workload-api schema
-// moves faster than any struct would, so unknown blocks pass through to the
-// API untouched and platform additions need no CLI release. The package
-// parses the file once into a yaml.Node tree and derives everything from it:
-// Compile lowers the tree to the JSON create payload. A stacked follow-up
-// adds Validate, walking the same tree so every finding carries its manifest
-// line, and WriteWorkloadID, the package's only write: a single-key edit
-// that keeps the user's comments, unknown keys and their order intact.
-// config never rewrites an existing manifest; after the first write the
-// file is the interface.
+// There are no typed spec structs for reading on purpose: the workload-api
+// schema moves faster than any struct would, so unknown blocks pass through
+// to the API untouched and platform additions need no CLI release. The
+// package parses the file once into a yaml.Node tree and derives everything
+// from it: Compile lowers the tree to the JSON create payload, and Validate
+// walks the same tree so every finding carries its manifest line.
+//
+// Writing is the narrow half. Draft is the fixed subset the setup wizard
+// settles, and Render turns it into the commented file the confirm screen
+// shows; Write creates that file and refuses to overwrite one. After the
+// first write the file is the interface, and WriteWorkloadID is the only
+// edit the CLI makes to it: a single-key write-back that keeps the user's
+// comments, unknown keys and their order intact.
 //
 // Non-scope: no HTTP. Compile returns CredentialRefs so callers can verify
 // each referenced credential against the store (one GET per credential)

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -1,0 +1,733 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// serverManagedKeys never belong in a manifest, at any depth. They are the
+// server's own bookkeeping: it assigns them, and a file that repeats them
+// back is either ignored or rejected. Stripping them recursively is safe
+// because the create spec has no legitimate key by these names anywhere.
+var serverManagedKeys = []string{"id", "createdAt", "updatedAt", "status", "endpoint", "artifactId", "workloadId"}
+
+// Live is a running workload, downloaded so a manifest can be written that
+// says everything the workload already says. Setup uses it when the user
+// binds to an existing workload: the alternative, generating a file from the
+// wizard's own small vocabulary, would silently drop the autoscaling, the
+// extra containers and the GPU bundle that workload is running with, and the
+// next deploy would apply that loss.
+//
+// Spec and Runtime are held as the server's own documents rather than parsed
+// into structs, for the same reason the reader is node-based: a block this
+// release has never heard of still has to survive the round trip.
+type Live struct {
+	WorkloadID   string
+	Name         string
+	Importance   string
+	ArtifactName string
+	Spec         map[string]any
+	Runtime      map[string]any
+}
+
+// NewLive assembles the live view from the two documents the server returns,
+// stripping what only the server may set. workloadDoc is the workload,
+// artifactDoc the artifact it currently runs.
+func NewLive(workloadID string, workloadDoc, artifactDoc map[string]any) Live {
+	live := Live{
+		WorkloadID:   workloadID,
+		Name:         stringAt(workloadDoc, keyName),
+		Importance:   stringAt(workloadDoc, keyImportance),
+		ArtifactName: stringAt(artifactDoc, keyName),
+		Spec:         stripServerManaged(mapAt(artifactDoc, keySpec)),
+		Runtime:      stripServerManaged(mapAt(workloadDoc, keyRuntime)),
+	}
+
+	stripBuildOutputs(live.Spec)
+
+	return live
+}
+
+// Type reports the artifact's kind, so the wizard's Q3 opens on what the
+// workload already is.
+func (l Live) Type() string {
+	return stringAt(l.Spec, "type")
+}
+
+// Defaults reads the live spec into the answers the wizard's screens open on.
+// Everything it cannot find keeps the documented default, so a spec shaped in
+// a way this release does not recognize still produces usable screens; the
+// parts it did not understand are preserved in Spec regardless.
+func (l Live) Defaults() Draft {
+	draft := Draft{
+		WorkloadID: l.WorkloadID,
+		Name:       l.Name,
+		Importance: orDefaultString(l.Importance, DefaultImportance),
+		Type:       orDefaultString(l.Type(), TypeService),
+		A2AEnabled: boolAt(l.Spec, "a2aEnabled"),
+		Port:       DefaultPort,
+		HealthPath: DefaultHealthPath,
+		Build:      Build{Mode: BuildModeDockerfile},
+		Runtime:    l.runtimeDefaults(),
+	}
+
+	container := l.primaryContainer()
+	if container == nil {
+		return draft
+	}
+
+	if port, ok := intAt(container, keyPort); ok {
+		draft.Port = port
+	}
+
+	if path := stringAt(mapAt(container, "readinessProbe"), "path"); path != "" {
+		draft.HealthPath = path
+	}
+
+	draft.Build = liveBuild(container)
+
+	return draft
+}
+
+// BuildMode reports how the primary container's image comes to be, in the
+// wizard's vocabulary: BuildModeDockerfile, BuildModeGenerated or
+// BuildModeImage. It is "" for a manifest with no inline artifact, which is
+// what a manifest bound to an existing artifact by id looks like.
+func (m *Manifest) BuildMode() string {
+	container := primaryContainerNode(mapValue(mapValue(m.root, keyArtifact), keySpec))
+	if container == nil {
+		return ""
+	}
+
+	dockerfile := mapValue(mapValue(container, keyImageBuildConfig), keyDockerfile)
+	source, _ := scalarString(mapValue(dockerfile, keySource))
+
+	switch source {
+	case sourceProvided:
+		return BuildModeDockerfile
+	case sourceGenerated:
+		return BuildModeGenerated
+	}
+
+	if uri, _ := scalarString(mapValue(container, keyImageURI)); uri != "" {
+		return BuildModeImage
+	}
+
+	return ""
+}
+
+// primaryContainerNode finds the container traffic reaches in a parsed spec,
+// falling back to the first container the way the live-document walk does.
+func primaryContainerNode(spec *yaml.Node) *yaml.Node {
+	var first *yaml.Node
+
+	for _, group := range seqItems(mapValue(spec, keyContainerGroups)) {
+		for _, container := range seqItems(mapValue(group, keyContainers)) {
+			if first == nil {
+				first = container
+			}
+
+			if isTrue(mapValue(container, keyPrimary)) {
+				return container
+			}
+		}
+	}
+
+	return first
+}
+
+// runtimeDefaults reads the sizing the workload is actually running with, so
+// the confirm screen reports that rather than the documented defaults. A
+// group using autoscaling has no replica count to report, and the zero it
+// leaves behind is what tells Apply not to write one.
+func (l Live) runtimeDefaults() Runtime {
+	runtime := Runtime{Replicas: DefaultReplicas, CPU: DefaultCPU, Memory: DefaultMemory}
+
+	groups := slicesAt(l.Runtime, keyContainerGroups)
+	if len(groups) == 0 {
+		return runtime
+	}
+
+	group := groups[0]
+
+	if replicas, ok := intAt(group, keyReplicaCount); ok {
+		runtime.Replicas = replicas
+	}
+
+	if mapAt(group, keyAutoscaling) != nil {
+		runtime.Replicas = 0
+	}
+
+	containers := slicesAt(group, keyContainers)
+	if len(containers) == 0 {
+		return runtime
+	}
+
+	allocation := mapAt(containers[0], keyResourceAllocation)
+
+	if cpu, ok := floatAt(allocation, "cpu"); ok {
+		runtime.CPU = cpu
+	}
+
+	if memory := stringAt(allocation, keyMemory); memory != "" {
+		runtime.Memory = memory
+	}
+
+	return runtime
+}
+
+// liveBuild reads which image source the container uses. A build block whose
+// source this release does not recognize reports BuildModeUnchanged rather
+// than being forced into the nearest known mode: the block is preserved as it
+// stands, and the wizard offers to keep it.
+func liveBuild(container map[string]any) Build {
+	buildConfig := mapAt(container, keyImageBuildConfig)
+	dockerfile := mapAt(buildConfig, keyDockerfile)
+
+	switch stringAt(dockerfile, keySource) {
+	case sourceProvided:
+		return Build{Mode: BuildModeDockerfile}
+	case sourceGenerated:
+		return Build{
+			Mode:                          BuildModeGenerated,
+			ExecutionEnvironmentID:        stringAt(dockerfile, keyExecEnvID),
+			ExecutionEnvironmentVersionID: stringAt(dockerfile, keyExecEnvVersionID),
+			Entrypoint:                    stringsAt(dockerfile, keyEntrypoint),
+		}
+	}
+
+	if buildConfig != nil {
+		return Build{Mode: BuildModeUnchanged}
+	}
+
+	return Build{Mode: BuildModeImage, ImageURI: stringAt(container, keyImageURI)}
+}
+
+// Apply writes the wizard's answers onto the live spec and returns the
+// result, leaving the original untouched so the confirm screen can diff one
+// against the other. Only the fields the wizard actually asks about are
+// touched; everything else the workload runs with is carried over as it is.
+func (l Live) Apply(draft Draft) (Live, error) {
+	applied := l
+	applied.Name = draft.Name
+	applied.Importance = draft.Importance
+	applied.Spec = deepCopyMap(l.Spec)
+	applied.Runtime = deepCopyMap(l.Runtime)
+
+	if applied.Spec == nil {
+		applied.Spec = map[string]any{}
+	}
+
+	applied.Spec["type"] = draft.Type
+
+	if draft.Type == TypeAgent && draft.A2AEnabled {
+		applied.Spec["a2aEnabled"] = true
+	} else {
+		delete(applied.Spec, "a2aEnabled")
+	}
+
+	container := primaryContainerOf(applied.Spec)
+	if container == nil {
+		return Live{}, fmt.Errorf("workload %s has no primary container to update; edit %s by hand instead",
+			l.WorkloadID, FileName)
+	}
+
+	applyReadiness(container, draft)
+	applyEnvVars(container, draft.EnvVars)
+	applied.applyRuntime(draft.Runtime)
+
+	if err := applyBuild(container, draft.Build); err != nil {
+		return Live{}, err
+	}
+
+	return applied, nil
+}
+
+// applyEnvVars merges the .env variables into the container's existing list.
+// A name the workload already declares is left alone: the running value is
+// the one in use, and .env is the developer's copy, which may well be stale.
+func applyEnvVars(container map[string]any, vars []EnvVar) {
+	if len(vars) == 0 {
+		return
+	}
+
+	existing, _ := container[keyEnvironmentVars].([]any)
+
+	declared := make(map[string]bool, len(existing))
+
+	for _, entry := range existing {
+		if typed, ok := entry.(map[string]any); ok {
+			declared[stringAt(typed, keyName)] = true
+		}
+	}
+
+	for _, v := range vars {
+		if declared[v.Name] {
+			continue
+		}
+
+		value := v.Value
+		if v.Secret {
+			value = credentialShorthandPrefix + CredentialPlaceholder + "/" + credentialKey
+		}
+
+		existing = append(existing, map[string]any{keyName: v.Name, keyValue: value})
+	}
+
+	container[keyEnvironmentVars] = existing
+}
+
+// applyRuntime writes the sizing answers onto the live runtime block, leaving
+// alone what the wizard has no question for: the GPU bundles, the autoscaling
+// policies and every container past the first. A zero field means "not
+// answered", so it keeps whatever the workload is running with.
+func (l *Live) applyRuntime(runtime Runtime) {
+	group := l.runtimeGroup()
+	if group == nil {
+		return
+	}
+
+	// Writing a replica count onto an autoscaled group would produce a file
+	// the ledger rejects, so an autoscaled workload keeps its autoscaling and
+	// the answer is dropped.
+	if runtime.Replicas > 0 && mapAt(group, keyAutoscaling) == nil {
+		group[keyReplicaCount] = runtime.Replicas
+	}
+
+	container := runtimeContainer(group, l.primaryContainerName())
+	if container == nil {
+		return
+	}
+
+	allocation := mapAt(container, keyResourceAllocation)
+	if allocation == nil {
+		allocation = map[string]any{}
+		container[keyResourceAllocation] = allocation
+	}
+
+	if runtime.CPU > 0 {
+		allocation["cpu"] = runtime.CPU
+	}
+
+	if runtime.Memory != "" {
+		allocation[keyMemory] = runtime.Memory
+	}
+}
+
+// runtimeGroup is the sizing block the answers apply to, created to match the
+// artifact when the workload has none. A workload can legitimately run
+// without a runtime block, and returning early there would drop every sizing
+// answer the user just gave without saying so.
+func (l *Live) runtimeGroup() map[string]any {
+	if groups := slicesAt(l.Runtime, keyContainerGroups); len(groups) > 0 {
+		return groups[0]
+	}
+
+	name := l.artifactGroupName()
+	if name == "" {
+		return nil
+	}
+
+	group := map[string]any{keyName: name, keyContainers: []any{}}
+
+	if l.Runtime == nil {
+		l.Runtime = map[string]any{}
+	}
+
+	l.Runtime[keyContainerGroups] = []any{group}
+
+	return group
+}
+
+// runtimeContainer is the sizing entry for name, created when the group does
+// not list it yet. The runtime and artifact lists are joined by name, so a
+// container invented here has to carry the artifact's.
+func runtimeContainer(group map[string]any, name string) map[string]any {
+	if name == "" {
+		return nil
+	}
+
+	for _, container := range slicesAt(group, keyContainers) {
+		if stringAt(container, keyName) == name {
+			return container
+		}
+	}
+
+	container := map[string]any{keyName: name}
+	existing, _ := group[keyContainers].([]any)
+	group[keyContainers] = append(existing, container)
+
+	return container
+}
+
+// artifactGroupName and primaryContainerName name the artifact's own group
+// and primary container, which the runtime block has to match.
+func (l Live) artifactGroupName() string {
+	groups := slicesAt(l.Spec, keyContainerGroups)
+	if len(groups) == 0 {
+		return ""
+	}
+
+	return stringAt(groups[0], keyName)
+}
+
+func (l Live) primaryContainerName() string {
+	container := l.primaryContainer()
+	if container == nil {
+		return ""
+	}
+
+	return stringAt(container, keyName)
+}
+
+// applyReadiness writes the port and, where the workload already has a
+// readiness probe, keeps it pointing at the same place. It does not add one:
+// a workload deliberately running without a probe should not acquire the
+// wizard's default /health, which a container that does not serve it would
+// never pass.
+func applyReadiness(container map[string]any, draft Draft) {
+	container[keyPort] = draft.Port
+
+	// The container being edited is the one traffic reaches, and the ledger
+	// only allows a port on a container that says so. A spec that flagged
+	// nothing would otherwise produce a file rejecting its own port.
+	container[keyPrimary] = true
+
+	probe := mapAt(container, "readinessProbe")
+	if probe == nil {
+		return
+	}
+
+	probe["path"] = draft.HealthPath
+	probe[keyPort] = draft.Port
+}
+
+// applyBuild sets the image source, editing the live build block in place
+// rather than replacing it. The Build struct models only the fields the
+// wizard asks about; a build block can carry more (build arguments, a
+// timeout, whatever the platform adds next), and rebuilding it from the
+// struct would silently drop all of it. Only the other two forms are removed,
+// so the container never names an image and a way to build one at once.
+func applyBuild(container map[string]any, build Build) error {
+	switch build.Mode {
+	case BuildModeUnchanged:
+		// The live block says something this release does not model. Leaving
+		// it exactly as it is beats rewriting it into the nearest thing the
+		// Build struct can express.
+
+	case BuildModeImage:
+		delete(container, keyImageBuildConfig)
+
+		container[keyImageURI] = build.ImageURI
+
+	case BuildModeDockerfile:
+		delete(container, keyImageURI)
+
+		dockerfile := buildDockerfileBlock(container)
+		dockerfile[keySource] = sourceProvided
+
+		// The generated-only fields are meaningless under a provided
+		// Dockerfile, so switching away from generated takes them with it.
+		delete(dockerfile, keyExecEnvID)
+		delete(dockerfile, keyExecEnvVersionID)
+		delete(dockerfile, keyEntrypoint)
+
+	case BuildModeGenerated:
+		delete(container, keyImageURI)
+
+		dockerfile := buildDockerfileBlock(container)
+		dockerfile[keySource] = sourceGenerated
+		dockerfile[keyExecEnvID] = build.ExecutionEnvironmentID
+		dockerfile[keyExecEnvVersionID] = build.ExecutionEnvironmentVersionID
+		dockerfile[keyEntrypoint] = toAnySlice(build.Entrypoint)
+
+	default:
+		return fmt.Errorf("unknown build mode %q", build.Mode)
+	}
+
+	return nil
+}
+
+// buildDockerfileBlock returns the container's build block to edit, creating
+// the nesting only where the container had none.
+func buildDockerfileBlock(container map[string]any) map[string]any {
+	buildConfig := mapAt(container, keyImageBuildConfig)
+	if buildConfig == nil {
+		buildConfig = map[string]any{}
+		container[keyImageBuildConfig] = buildConfig
+	}
+
+	dockerfile := mapAt(buildConfig, keyDockerfile)
+	if dockerfile == nil {
+		dockerfile = map[string]any{}
+		buildConfig[keyDockerfile] = dockerfile
+	}
+
+	return dockerfile
+}
+
+// Render writes the live view as a manifest: the same file shape Draft
+// produces, with the artifact spec and runtime blocks passed through as the
+// platform gave them.
+func (l Live) Render() ([]byte, error) {
+	spec, err := documentNode(l.Spec)
+	if err != nil {
+		return nil, err
+	}
+
+	artifact := []field{{key: keyName, value: scalar(l.ArtifactName)}}
+	if spec != nil {
+		artifact = append(artifact, field{key: keySpec, value: spec})
+	}
+
+	fields := []field{
+		{key: keyWorkloadID, value: scalar(l.WorkloadID), comment: workloadIDComment},
+		{key: keyName, value: scalar(l.Name)},
+		{
+			key: keyImportance, value: scalar(orDefaultString(l.Importance, DefaultImportance)),
+			comment: "low | moderate | high | critical",
+		},
+		{key: keyArtifact, value: mapping(artifact...)},
+	}
+
+	runtime, err := documentNode(l.Runtime)
+	if err != nil {
+		return nil, err
+	}
+
+	if runtime != nil {
+		fields = append(fields, field{key: keyRuntime, value: runtime})
+	}
+
+	var buf bytes.Buffer
+
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+
+	if err := enc.Encode(mapping(fields...)); err != nil {
+		return nil, fmt.Errorf("cannot render manifest: %w", err)
+	}
+
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("cannot render manifest: %w", err)
+	}
+
+	return spaceTopLevelBlocks(buf.Bytes()), nil
+}
+
+// primaryContainer finds the container traffic reaches: the one flagged
+// primary, falling back to the first container of the first group for a spec
+// that flags nothing.
+func (l Live) primaryContainer() map[string]any {
+	return primaryContainerOf(l.Spec)
+}
+
+func primaryContainerOf(spec map[string]any) map[string]any {
+	var first map[string]any
+
+	for _, group := range slicesAt(spec, keyContainerGroups) {
+		for _, container := range slicesAt(group, keyContainers) {
+			if first == nil {
+				first = container
+			}
+
+			if boolAt(container, keyPrimary) {
+				return container
+			}
+		}
+	}
+
+	return first
+}
+
+// documentNode encodes a server document as a YAML node, nil for an empty
+// one so the key is left out rather than written as an empty mapping.
+func documentNode(document map[string]any) (*yaml.Node, error) {
+	if len(document) == 0 {
+		return nil, nil
+	}
+
+	node := &yaml.Node{}
+	if err := node.Encode(document); err != nil {
+		return nil, fmt.Errorf("cannot render the live spec: %w", err)
+	}
+
+	return node, nil
+}
+
+// stripServerManaged removes the server's bookkeeping from a copy of the
+// document, at every level.
+func stripServerManaged(document map[string]any) map[string]any {
+	copied := deepCopyMap(document)
+	stripKeys(copied)
+
+	return copied
+}
+
+func stripKeys(value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for _, key := range serverManagedKeys {
+			delete(typed, key)
+		}
+
+		for _, child := range typed {
+			stripKeys(child)
+		}
+	case []any:
+		for _, item := range typed {
+			stripKeys(item)
+		}
+	}
+}
+
+// stripBuildOutputs removes what a build produced rather than what a build
+// was asked to do. A container that says how to build itself also carries the
+// image that came out and the code the last sync uploaded; both are re-earned
+// by the next deploy, and writing them into the file would pin a workload to
+// yesterday's image.
+func stripBuildOutputs(spec map[string]any) {
+	for _, group := range slicesAt(spec, keyContainerGroups) {
+		for _, container := range slicesAt(group, keyContainers) {
+			buildConfig := mapAt(container, keyImageBuildConfig)
+			if buildConfig == nil {
+				continue
+			}
+
+			delete(container, keyImageURI)
+			delete(buildConfig, "codeRef")
+		}
+	}
+}
+
+func deepCopyMap(document map[string]any) map[string]any {
+	if document == nil {
+		return nil
+	}
+
+	copied := make(map[string]any, len(document))
+	for key, value := range document {
+		copied[key] = deepCopyValue(value)
+	}
+
+	return copied
+}
+
+func deepCopyValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return deepCopyMap(typed)
+	case []any:
+		copied := make([]any, len(typed))
+		for i, item := range typed {
+			copied[i] = deepCopyValue(item)
+		}
+
+		return copied
+	default:
+		return typed
+	}
+}
+
+func stringAt(document map[string]any, key string) string {
+	value, _ := document[key].(string)
+
+	return value
+}
+
+// floatAt reads a number that arrived as JSON (always float64), as YAML (int
+// for a whole number) or from a previous Apply (a Go int).
+func floatAt(document map[string]any, key string) (float64, bool) {
+	switch value := document[key].(type) {
+	case float64:
+		return value, true
+	case int:
+		return float64(value), true
+	default:
+		return 0, false
+	}
+}
+
+func boolAt(document map[string]any, key string) bool {
+	value, _ := document[key].(bool)
+
+	return value
+}
+
+// intAt reads a number that arrived through JSON, where every number is a
+// float64, or through YAML, where a whole number is an int.
+func intAt(document map[string]any, key string) (int, bool) {
+	switch value := document[key].(type) {
+	case int:
+		return value, true
+	case float64:
+		return int(value), true
+	default:
+		return 0, false
+	}
+}
+
+func mapAt(document map[string]any, key string) map[string]any {
+	value, _ := document[key].(map[string]any)
+
+	return value
+}
+
+func slicesAt(document map[string]any, key string) []map[string]any {
+	items, _ := document[key].([]any)
+	out := make([]map[string]any, 0, len(items))
+
+	for _, item := range items {
+		if typed, ok := item.(map[string]any); ok {
+			out = append(out, typed)
+		}
+	}
+
+	return out
+}
+
+func stringsAt(document map[string]any, key string) []string {
+	items, _ := document[key].([]any)
+	out := make([]string, 0, len(items))
+
+	for _, item := range items {
+		if typed, ok := item.(string); ok {
+			out = append(out, typed)
+		}
+	}
+
+	return out
+}
+
+func toAnySlice(values []string) []any {
+	out := make([]any, len(values))
+	for i, value := range values {
+		out[i] = value
+	}
+
+	return out
+}
+
+func orDefaultString(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+
+	return value
+}

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -1,0 +1,434 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// liveWorkloadJSON and liveArtifactJSON are shaped like the server's own
+// responses, including the things the wizard has no vocabulary for:
+// autoscaling, a GPU bundle, a second container, a credential-backed
+// variable. Those are exactly what binding must not lose.
+const liveWorkloadJSON = `{
+  "id": "68b0c1d2e3f4a5b6c7d8e9f0",
+  "name": "gpt-oss-20b-vllm",
+  "status": "running",
+  "importance": "moderate",
+  "artifactId": "68a0000000000000000000a1",
+  "endpoint": "https://app.datarobot.com/workloads/68b0/",
+  "createdAt": "2026-07-02T10:00:00Z",
+  "runtime": {
+    "containerGroups": [
+      {
+        "name": "default",
+        "resourceBundles": ["gpu.medium"],
+        "autoscaling": {
+          "enabled": true,
+          "minReplicaCount": 1,
+          "maxReplicaCount": 4,
+          "policies": [{"scalingMetric": "gpuCacheUtilization", "target": 70}]
+        },
+        "containers": [
+          {"name": "vllm-server", "resourceAllocation": {"cpu": 3, "memory": "22GB", "gpu": 1}},
+          {"name": "metrics-bridge", "resourceAllocation": {"cpu": 0.5, "memory": "2GB"}}
+        ]
+      }
+    ]
+  }
+}`
+
+const liveArtifactJSON = `{
+  "id": "68a0000000000000000000a1",
+  "name": "gpt-oss-20b-vllm-artifact",
+  "status": "locked",
+  "createdAt": "2026-07-02T09:00:00Z",
+  "spec": {
+    "type": "service",
+    "containerGroups": [
+      {
+        "name": "default",
+        "containers": [
+          {
+            "name": "vllm-server",
+            "primary": true,
+            "port": 8000,
+            "imageUri": "registry.internal/built-by-the-server:sha-abc123",
+            "imageBuildConfig": {
+              "dockerfile": {"source": "provided"},
+              "codeRef": {"datarobot": {"catalogId": "cat1", "catalogVersionId": "ver1"}}
+            },
+            "environmentVars": [
+              {"name": "HF_HOME", "value": "/tmp/hf"},
+              {"name": "HUGGING_FACE_HUB_TOKEN", "source": "dr-credential",
+               "drCredentialId": "66f1a2b3c4d5e6f7a8b9c0d1", "key": "apiToken"}
+            ],
+            "readinessProbe": {"path": "/health", "port": 8000, "periodSeconds": 10},
+            "startupProbe": {"path": "/health", "port": 8000, "periodSeconds": 15, "failureThreshold": 60}
+          },
+          {"name": "metrics-bridge", "imageUri": "registry/vllm-metrics-bridge:v1"}
+        ]
+      }
+    ]
+  }
+}`
+
+func liveFixture(t *testing.T) Live {
+	t.Helper()
+
+	var workloadDoc, artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(liveWorkloadJSON), &workloadDoc))
+	require.NoError(t, json.Unmarshal([]byte(liveArtifactJSON), &artifactDoc))
+
+	return NewLive("68b0c1d2e3f4a5b6c7d8e9f0", workloadDoc, artifactDoc)
+}
+
+func TestNewLive_StripsWhatOnlyTheServerSets(t *testing.T) {
+	live := liveFixture(t)
+	rendered, err := live.Render()
+	require.NoError(t, err)
+
+	for _, unwanted := range []string{"createdAt", "68a0000000000000000000a1", "app.datarobot.com", "status: locked"} {
+		assert.NotContains(t, string(rendered), unwanted)
+	}
+
+	// The binding itself is the one id the file carries.
+	assert.Contains(t, string(rendered), "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0")
+}
+
+// The image a build produced and the code the last sync uploaded are earned
+// again by the next deploy. Writing them down would pin the workload to
+// yesterday's image.
+func TestNewLive_StripsBuildOutputs(t *testing.T) {
+	rendered, err := liveFixture(t).Render()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(rendered), "built-by-the-server")
+	assert.NotContains(t, string(rendered), "codeRef")
+	assert.Contains(t, string(rendered), "source: provided")
+
+	// A container that genuinely runs a published image keeps it.
+	assert.Contains(t, string(rendered), "registry/vllm-metrics-bridge:v1")
+}
+
+// Everything the wizard has no question for still has to survive, because
+// the file it writes is what the next deploy applies.
+func TestLive_RenderKeepsWhatTheWizardCannotSay(t *testing.T) {
+	rendered, err := liveFixture(t).Render()
+	require.NoError(t, err)
+
+	for _, kept := range []string{
+		"autoscaling", "gpuCacheUtilization", "resourceBundles", "gpu.medium",
+		"metrics-bridge", "startupProbe", "dr-credential", "HUGGING_FACE_HUB_TOKEN",
+	} {
+		assert.Contains(t, string(rendered), kept, "binding must not drop %s", kept)
+	}
+}
+
+func TestLive_DefaultsComeFromTheLiveSpec(t *testing.T) {
+	defaults := liveFixture(t).Defaults()
+
+	assert.Equal(t, "gpt-oss-20b-vllm", defaults.Name)
+	assert.Equal(t, "moderate", defaults.Importance)
+	assert.Equal(t, TypeService, defaults.Type)
+	assert.Equal(t, 8000, defaults.Port)
+	assert.Equal(t, "/health", defaults.HealthPath)
+	assert.Equal(t, BuildModeDockerfile, defaults.Build.Mode)
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", defaults.WorkloadID)
+}
+
+func TestLive_ApplyChangesOnlyWhatWasAsked(t *testing.T) {
+	live := liveFixture(t)
+
+	draft := live.Defaults()
+	draft.Port = 9000
+	draft.HealthPath = "/ready"
+	draft.Build = Build{Mode: BuildModeImage, ImageURI: "registry/team/app:v2"}
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "port: 9000")
+	assert.Contains(t, string(rendered), "path: /ready")
+	assert.Contains(t, string(rendered), "imageUri: registry/team/app:v2")
+	// The build config it replaced is gone, so the container names one source.
+	assert.NotContains(t, string(rendered), "imageBuildConfig")
+	// And the parts nobody asked about are still there.
+	assert.Contains(t, string(rendered), "autoscaling")
+	assert.Contains(t, string(rendered), "metrics-bridge")
+
+	// Apply leaves the original alone so the confirm screen can diff them.
+	before, err := live.Render()
+	require.NoError(t, err)
+	assert.Contains(t, string(before), "port: 8000")
+}
+
+func TestLive_ApplySwitchesToAGeneratedBuild(t *testing.T) {
+	live := liveFixture(t)
+
+	draft := live.Defaults()
+	draft.Build = Build{
+		Mode:                          BuildModeGenerated,
+		ExecutionEnvironmentID:        "68a1",
+		ExecutionEnvironmentVersionID: "68a2",
+		Entrypoint:                    []string{"python", "main.py"},
+	}
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "source: generated")
+	assert.Contains(t, string(rendered), "executionEnvironmentId: 68a1")
+	assert.Contains(t, string(rendered), "- python")
+}
+
+func TestLive_ApplyTogglesA2A(t *testing.T) {
+	live := liveFixture(t)
+
+	draft := live.Defaults()
+	draft.Type = TypeAgent
+	draft.A2AEnabled = true
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "type: agent")
+	assert.Contains(t, string(rendered), "a2aEnabled: true")
+
+	draft.A2AEnabled = false
+
+	applied, err = live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err = applied.Render()
+	require.NoError(t, err)
+	assert.NotContains(t, string(rendered), "a2aEnabled")
+}
+
+// A downloaded workload has to produce a file this CLI can read back and
+// deploy, or binding has just written a dead end.
+func TestLive_RenderRoundTripsThroughValidate(t *testing.T) {
+	live := liveFixture(t)
+
+	draft := live.Defaults()
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	// The live spec builds a provided Dockerfile, so the ledger's file check
+	// needs one; "" skips the file-existence rules the same way a preview does.
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+
+	compiled, err := parsed.Compile()
+	require.NoError(t, err)
+
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", compiled.WorkloadID)
+	require.Len(t, compiled.CredentialRefs, 1)
+	assert.Equal(t, "66f1a2b3c4d5e6f7a8b9c0d1", compiled.CredentialRefs[0].CredentialID)
+}
+
+// A spec with no container to update is a workload the wizard cannot honestly
+// edit, so it says so instead of writing something plausible.
+func TestLive_ApplyWithoutAPrimaryContainer(t *testing.T) {
+	live := NewLive("68b0", map[string]any{"name": "empty"}, map[string]any{"name": "empty-artifact"})
+
+	_, err := live.Apply(live.Defaults())
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "no primary container")
+}
+
+// An unflagged spec still has a container traffic reaches: the first one.
+func TestLive_PrimaryFallsBackToTheFirstContainer(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "spec": {"containerGroups": [{"name": "default", "containers": [
+        {"name": "only", "port": 8080, "imageUri": "nginx:latest"}
+      ]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	assert.Equal(t, 8080, live.Defaults().Port)
+}
+
+// A build block can carry more than the wizard models (build arguments, a
+// timeout, whatever the platform adds next). Rebuilding it from the Build
+// struct would drop all of it on a run that changed nothing.
+func TestLive_ApplyKeepsUnknownBuildKeys(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+        {"name": "primary", "primary": true, "port": 8080, "imageBuildConfig": {
+          "dockerfile": {"source": "provided", "buildArgs": {"NODE_ENV": "production"}, "target": "runtime"},
+          "buildTimeoutSeconds": 3600,
+          "someFuturePlatformKey": {"nested": true}
+        }}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	applied, err := live.Apply(live.Defaults())
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	for _, kept := range []string{"buildArgs", "NODE_ENV", "target", "buildTimeoutSeconds", "someFuturePlatformKey"} {
+		assert.Contains(t, string(rendered), kept, "changing nothing must not drop %s", kept)
+	}
+}
+
+// A build source this release does not know is kept as it stands rather than
+// forced into the nearest mode the Build struct can express.
+func TestLive_UnknownBuildSourceIsPreserved(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+        {"name": "primary", "primary": true, "port": 8080,
+         "imageBuildConfig": {"buildpack": {"builder": "paketo/builder:base"}}}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	assert.Equal(t, BuildModeUnchanged, live.Defaults().Build.Mode)
+
+	applied, err := live.Apply(live.Defaults())
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "buildpack")
+	assert.Contains(t, string(rendered), "paketo/builder:base")
+	assert.NotContains(t, string(rendered), `imageUri: ""`, "an empty image must never be invented")
+}
+
+// A workload deliberately running without a readiness probe must not acquire
+// the wizard's default one, which its container would never pass.
+func TestLive_ApplyDoesNotInventAReadinessProbe(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+        {"name": "primary", "primary": true, "port": 9000, "imageUri": "registry/a:v1"}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	applied, err := live.Apply(live.Defaults())
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(rendered), "readinessProbe")
+
+	// One that does have a probe keeps it pointing where the answers say.
+	draft := live.Defaults()
+	draft.HealthPath = "/ready"
+
+	applied, err = live.Apply(draft)
+	require.NoError(t, err)
+	rendered, err = applied.Render()
+	require.NoError(t, err)
+	assert.NotContains(t, string(rendered), "/ready", "no probe means nothing to point")
+}
+
+// A spec that flags no primary container still has one traffic reaches, and
+// the file must say so or the ledger rejects the port it just wrote.
+func TestLive_ApplyFlagsTheContainerItEdits(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+        {"name": "only", "port": 8080, "imageUri": "registry/a:v1"}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	applied, err := live.Apply(live.Defaults())
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate(), "the written file must satisfy the reader that wrote it")
+}
+
+// The confirm screen reads its runtime line from here, so it has to describe
+// the workload rather than the documented defaults.
+func TestLive_DefaultsReadTheLiveSizing(t *testing.T) {
+	runtime := liveFixture(t).Defaults().Runtime
+
+	assert.Equal(t, 0, runtime.Replicas, "an autoscaled group has no replica count to report")
+	assert.InEpsilon(t, 3.0, runtime.CPU, 0.0001)
+	assert.Equal(t, "22GB", runtime.Memory)
+}
+
+// Sizing answers reach the runtime block, and an autoscaled group keeps its
+// autoscaling rather than gaining a replica count the ledger would reject.
+func TestLive_ApplyRuntime(t *testing.T) {
+	live := liveFixture(t)
+
+	draft := live.Defaults()
+	draft.Runtime = Runtime{Replicas: 9, CPU: 16, Memory: "32GB"}
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "cpu: 16")
+	assert.Contains(t, string(rendered), "memory: 32GB")
+	assert.NotContains(t, string(rendered), "replicaCount", "an autoscaled group must not gain one")
+	assert.Contains(t, string(rendered), "maxReplicaCount: 4", "the autoscaling policy is untouched")
+	assert.Contains(t, string(rendered), "metrics-bridge")
+	assert.Contains(t, string(rendered), "2GB", "the second container's allocation is untouched")
+
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+}

--- a/internal/workload/manifest/node.go
+++ b/internal/workload/manifest/node.go
@@ -16,9 +16,14 @@ package manifest
 
 import "gopkg.in/yaml.v3"
 
-// nullTag is the yaml.v3 tag for an explicit YAML null, the one scalar kind
-// the helpers below reject.
-const nullTag = "!!null"
+// yaml.v3 scalar tags the helpers below discriminate on. nullTag is the one
+// scalar kind scalarString rejects; the other two keep a typed read from
+// accepting a quoted lookalike.
+const (
+	nullTag = "!!null"
+	intTag  = "!!int"
+	boolTag = "!!bool"
+)
 
 // resolveAlias follows an alias to the node it anchors, so the helpers below
 // see through YAML anchors/aliases the same way they see a literal value.
@@ -68,6 +73,41 @@ func scalarString(node *yaml.Node) (string, bool) {
 	}
 
 	return node.Value, true
+}
+
+// scalarInt returns a scalar node's integer value; ok is false for nil,
+// non-scalar and non-numeric nodes. YAML's own tag resolution decides what
+// counts as a number, so quoted "8080" is a string and does not pass.
+func scalarInt(node *yaml.Node) (int, bool) {
+	if node == nil || node.Kind != yaml.ScalarNode || node.Tag != intTag {
+		return 0, false
+	}
+
+	// Decoded rather than parsed by hand: YAML writes integers in more ways
+	// than Atoi reads (8_080, 0x10, 0o17), and a reader that disagrees with
+	// its own parser rejects files that plainly state a number.
+	var value int
+
+	if err := node.Decode(&value); err != nil {
+		return 0, false
+	}
+
+	return value, true
+}
+
+// isTrue reports whether node is the YAML boolean true. Anything else,
+// including a missing node and the string "true", is false.
+func isTrue(node *yaml.Node) bool {
+	node = resolveAlias(node)
+	if node == nil || node.Kind != yaml.ScalarNode || node.Tag != boolTag {
+		return false
+	}
+
+	// Decoded for the same reason as scalarInt: True and TRUE are the same
+	// boolean to YAML, and comparing the raw text reads them as false.
+	var value bool
+
+	return node.Decode(&value) == nil && value
 }
 
 // joinPath extends a YAML path with a key, leaving no leading dot on the

--- a/internal/workload/manifest/validate.go
+++ b/internal/workload/manifest/validate.go
@@ -1,0 +1,496 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"cmp"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/datarobot/cli/internal/fsutil"
+	"gopkg.in/yaml.v3"
+)
+
+// Spec field names the ledger walks. They live here rather than in keys.go
+// because they are the ledger's business: every one of them exists because a
+// rule below reads it.
+const (
+	keyAutoscaling        = "autoscaling"
+	keyContainerGroups    = "containerGroups"
+	keyContainers         = "containers"
+	keyDockerfile         = "dockerfile"
+	keyEnabled            = "enabled"
+	keyEntrypoint         = "entrypoint"
+	keyExecEnvID          = "executionEnvironmentId"
+	keyExecEnvVersionID   = "executionEnvironmentVersionId"
+	keyImageBuildConfig   = "imageBuildConfig"
+	keyImageURI           = "imageUri"
+	keyMemory             = "memory"
+	keyPort               = "port"
+	keyPrimary            = "primary"
+	keyReplicaCount       = "replicaCount"
+	keyResourceAllocation = "resourceAllocation"
+	keySpec               = "spec"
+)
+
+// Dockerfile sources: whether the user brings the Dockerfile or the platform
+// generates one from an execution environment.
+const (
+	sourceProvided  = "provided"
+	sourceGenerated = "generated"
+)
+
+// dockerfileName is the only Dockerfile a provided build may name. Setup
+// writes no path at all, so this is a fixed expectation of the project root
+// rather than a default that can be pointed elsewhere.
+const dockerfileName = "Dockerfile"
+
+// minPrimaryPort is the lowest port the primary container may listen on.
+// Containers run unprivileged, so a lower port cannot be bound and the
+// workload never becomes ready.
+const minPrimaryPort = 1024
+
+// memoryPattern accepts a raw byte count or a 1000-based suffix, in any case
+// and with optional space, because 512mb and 512 MB are what people type.
+// Binary suffixes (Ki, Mi, Gi) are deliberately absent rather than converted:
+// the platform reads 4Gi as its decimal namesake, so a file that means 4
+// gibibytes would silently get 4 gigabytes.
+var memoryPattern = regexp.MustCompile(`^([0-9]+)\s*(B|KB|MB|GB|TB)?$`)
+
+// memoryUnits are the suffixes as the file should spell them.
+var memoryUnits = []string{"B", "KB", "MB", "GB", "TB"}
+
+// ValidMemory reports whether value is a size the platform reads the way it
+// is written. Exported so a caller can reject a bad --memory at the flag
+// rather than at the file it would have produced.
+func ValidMemory(value string) bool {
+	return memoryPattern.MatchString(strings.ToUpper(strings.TrimSpace(value)))
+}
+
+// NormalizeMemory returns value in the spelling the file should carry:
+// uppercase unit, no space. It returns value unchanged when it is not a size
+// this package recognizes, leaving the verdict to ValidMemory.
+func NormalizeMemory(value string) string {
+	match := memoryPattern.FindStringSubmatch(strings.ToUpper(strings.TrimSpace(value)))
+	if match == nil {
+		return value
+	}
+
+	return match[1] + match[2]
+}
+
+// MemoryUnits lists the suffixes a size may carry, for a prompt that would
+// rather show them than describe them.
+func MemoryUnits() []string {
+	return slices.Clone(memoryUnits)
+}
+
+// MinPrimaryPort is the lowest port a primary container may listen on.
+const MinPrimaryPort = minPrimaryPort
+
+// Validate walks the parse tree and reports every rule the manifest breaks,
+// each finding anchored to the line it came from, so a bad file fails in
+// milliseconds instead of after a build. Findings are collected in one pass
+// and returned as a *ValidationError sorted by line.
+//
+// The ledger checks what the CLI can check locally and nothing more. Rules
+// the platform has not documented are passed through untouched, so platform
+// additions need no CLI release and a mistake inside such a block surfaces as
+// the server's error. Credential references are checked for syntax here;
+// verifying that each one exists is a GET the caller makes with
+// Compiled.CredentialRefs.
+func (m *Manifest) Validate() error {
+	v := &validator{dir: m.Dir}
+
+	v.checkName(m.root)
+	v.checkArtifactBinding(m.root)
+
+	groups := v.checkArtifact(mapValue(m.root, keyArtifact))
+	v.checkRuntime(mapValue(m.root, keyRuntime), groups)
+
+	if _, errs := collectCredentialRefs(m.root); len(errs) > 0 {
+		v.errs = append(v.errs, errs...)
+	}
+
+	if len(v.errs) == 0 {
+		return nil
+	}
+
+	slices.SortStableFunc(v.errs, func(a, b FieldError) int { return cmp.Compare(a.Line, b.Line) })
+
+	return &ValidationError{File: m.fileLabel(), Errors: v.errs}
+}
+
+// validator accumulates findings across one pass over the tree.
+type validator struct {
+	// dir anchors file-existence rules; "" skips them.
+	dir  string
+	errs []FieldError
+}
+
+// add records a finding at node's line. A nil node means the key is missing
+// entirely, in which case anchor names the nearest node that does exist so
+// the message still points somewhere useful.
+func (v *validator) add(node, anchor *yaml.Node, path, format string, args ...any) {
+	line := 0
+
+	switch {
+	case node != nil:
+		line = node.Line
+	case anchor != nil:
+		line = anchor.Line
+	}
+
+	v.errs = append(v.errs, FieldError{Path: path, Line: line, Msg: fmt.Sprintf(format, args...)})
+}
+
+// checkName holds the one field the create endpoint always needs.
+func (v *validator) checkName(root *yaml.Node) {
+	node := mapValue(root, keyName)
+
+	if name, ok := scalarString(node); !ok || name == "" {
+		v.add(node, root, keyName, "is required and must be a non-empty string")
+	}
+}
+
+// checkArtifactBinding holds the create endpoint's either-or: an inline
+// artifact to build, or the id of one that already exists.
+func (v *validator) checkArtifactBinding(root *yaml.Node) {
+	inline := mapValue(root, keyArtifact)
+	byID, _ := scalarString(mapValue(root, keyArtifactID))
+
+	if (inline != nil) == (byID != "") {
+		v.add(nil, root, "",
+			"exactly one of %s (inline definition) or %s (existing artifact) is required",
+			keyArtifact, keyArtifactID)
+	}
+}
+
+// groupShape is what the runtime block has to match: the artifact's group and
+// container names. The two lists are joined by name, so a typo on either side
+// means the runtime sizing silently applies to nothing.
+type groupShape struct {
+	name       string
+	containers []string
+}
+
+// checkArtifact validates the inline artifact and returns the container-group
+// shape the runtime block is checked against. A manifest that binds an
+// existing artifact by id returns no shape, and the runtime name checks are
+// skipped: the names live server-side where the CLI cannot see them.
+func (v *validator) checkArtifact(artifact *yaml.Node) []groupShape {
+	if artifact == nil {
+		return nil
+	}
+
+	spec := mapValue(artifact, keySpec)
+	if spec == nil {
+		v.add(nil, artifact, joinPath(keyArtifact, keySpec), "is required for an inline artifact")
+
+		return nil
+	}
+
+	specPath := joinPath(keyArtifact, keySpec)
+	groupsNode := mapValue(spec, keyContainerGroups)
+	groups := seqItems(groupsNode)
+
+	if len(groups) == 0 {
+		v.add(groupsNode, spec, joinPath(specPath, keyContainerGroups), "must list at least one container group")
+
+		return nil
+	}
+
+	shapes := make([]groupShape, 0, len(groups))
+
+	for i, group := range groups {
+		shapes = append(shapes, v.checkArtifactGroup(group, fmt.Sprintf("%s.%s[%d]", specPath, keyContainerGroups, i)))
+	}
+
+	return shapes
+}
+
+func (v *validator) checkArtifactGroup(group *yaml.Node, path string) groupShape {
+	shape := groupShape{}
+
+	name, ok := scalarString(mapValue(group, keyName))
+	if !ok || name == "" {
+		v.add(mapValue(group, keyName), group, joinPath(path, keyName),
+			"is required: runtime sizing is joined to the artifact by group name")
+	}
+
+	shape.name = name
+
+	containersNode := mapValue(group, keyContainers)
+	containers := seqItems(containersNode)
+
+	if len(containers) == 0 {
+		v.add(containersNode, group, joinPath(path, keyContainers), "must list at least one container")
+
+		return shape
+	}
+
+	primaries := 0
+
+	for i, container := range containers {
+		containerPath := fmt.Sprintf("%s.%s[%d]", path, keyContainers, i)
+
+		containerName, ok := scalarString(mapValue(container, keyName))
+		if !ok || containerName == "" {
+			v.add(mapValue(container, keyName), container, joinPath(containerPath, keyName), "is required")
+		}
+
+		shape.containers = append(shape.containers, containerName)
+
+		primary := isTrue(mapValue(container, keyPrimary))
+		if primary {
+			primaries++
+		}
+
+		v.checkImageSource(container, containerPath)
+		v.checkPort(container, containerPath, primary)
+	}
+
+	// Two primaries in one group is unambiguously wrong: only one container
+	// can be the one traffic reaches. Zero is left to the server, which knows
+	// whether an auxiliary group without an entry point is legal.
+	if primaries > 1 {
+		v.add(group, group, path, "has %d containers marked %s; only one can be", primaries, keyPrimary)
+	}
+
+	return shape
+}
+
+// checkImageSource holds the exactly-one rule: a container names an image or
+// says how to build one, never both and never neither.
+func (v *validator) checkImageSource(container *yaml.Node, path string) {
+	imageURI, hasImage := scalarString(mapValue(container, keyImageURI))
+	hasImage = hasImage && imageURI != ""
+	buildConfig := mapValue(container, keyImageBuildConfig)
+
+	switch {
+	case hasImage && buildConfig != nil:
+		v.add(buildConfig, container, path,
+			"sets both %s and %s; a container names an image or says how to build one, never both",
+			keyImageURI, keyImageBuildConfig)
+	case !hasImage && buildConfig == nil:
+		v.add(nil, container, path, "must set either %s or %s", keyImageURI, keyImageBuildConfig)
+	case buildConfig != nil:
+		v.checkBuildConfig(buildConfig, joinPath(path, keyImageBuildConfig))
+	}
+}
+
+// checkBuildConfig validates a build block. A misspelled key inside it lands
+// here rather than passing through: without a readable dockerfile block there
+// is no build to run, so the file is wrong in a way the platform cannot
+// reinterpret later.
+func (v *validator) checkBuildConfig(buildConfig *yaml.Node, path string) {
+	dockerfile := mapValue(buildConfig, keyDockerfile)
+	if dockerfile == nil {
+		v.add(buildConfig, buildConfig, joinPath(path, keyDockerfile),
+			"is required: %s must say how the image is built", keyImageBuildConfig)
+
+		return
+	}
+
+	dockerfilePath := joinPath(path, keyDockerfile)
+	sourceNode := mapValue(dockerfile, keySource)
+	source, _ := scalarString(sourceNode)
+
+	switch source {
+	case sourceProvided:
+		v.checkProvidedBuild(dockerfile, dockerfilePath)
+	case sourceGenerated:
+		v.checkGeneratedBuild(dockerfile, dockerfilePath)
+	default:
+		v.add(sourceNode, dockerfile, joinPath(dockerfilePath, keySource),
+			"must be %q (build the repository's %s) or %q (build from a DataRobot base image)",
+			sourceProvided, dockerfileName, sourceGenerated)
+	}
+}
+
+// checkProvidedBuild fails a provided build with no Dockerfile to build,
+// which would otherwise be discovered only once the server-side build starts.
+func (v *validator) checkProvidedBuild(dockerfile *yaml.Node, path string) {
+	if v.dir == "" {
+		return
+	}
+
+	if !fsutil.FileExists(filepath.Join(v.dir, dockerfileName)) {
+		v.add(dockerfile, dockerfile, path,
+			"source is %q but no %s exists in %s", sourceProvided, dockerfileName, v.dir)
+	}
+}
+
+// checkGeneratedBuild holds the three fields a generated build cannot be
+// reproduced without. Both environment ids are recorded, not just the name,
+// so the same file builds the same image after the environment moves on.
+func (v *validator) checkGeneratedBuild(dockerfile *yaml.Node, path string) {
+	for _, key := range []string{keyExecEnvID, keyExecEnvVersionID} {
+		node := mapValue(dockerfile, key)
+
+		if value, ok := scalarString(node); !ok || value == "" {
+			v.add(node, dockerfile, joinPath(path, key),
+				"is required when source is %q", sourceGenerated)
+		}
+	}
+
+	entrypoint := mapValue(dockerfile, keyEntrypoint)
+	if len(seqItems(entrypoint)) == 0 {
+		v.add(entrypoint, dockerfile, joinPath(path, keyEntrypoint),
+			"is required when source is %q and must list at least one argument", sourceGenerated)
+	}
+}
+
+// checkPort holds the port rules that decide whether traffic can reach the
+// container at all.
+func (v *validator) checkPort(container *yaml.Node, path string, primary bool) {
+	node := mapValue(container, keyPort)
+	portPath := joinPath(path, keyPort)
+
+	if !primary {
+		if node != nil {
+			v.add(node, container, portPath,
+				"is only allowed on the primary container; traffic reaches the group through that one")
+		}
+
+		return
+	}
+
+	port, ok := scalarInt(node)
+	if !ok {
+		v.add(node, container, portPath, "is required on the primary container and must be a number")
+
+		return
+	}
+
+	if port < minPrimaryPort {
+		v.add(node, container, portPath,
+			"is %d; the primary container runs unprivileged and must listen on %d or above", port, minPrimaryPort)
+	}
+}
+
+// checkRuntime validates the sizing half of the file against the shape of the
+// artifact half.
+func (v *validator) checkRuntime(runtime *yaml.Node, shapes []groupShape) {
+	if runtime == nil {
+		return
+	}
+
+	for i, group := range seqItems(mapValue(runtime, keyContainerGroups)) {
+		path := fmt.Sprintf("%s.%s[%d]", keyRuntime, keyContainerGroups, i)
+
+		v.checkScaling(group, path)
+
+		name, _ := scalarString(mapValue(group, keyName))
+		shape, matched := findShape(shapes, name)
+
+		if shapes != nil && !matched {
+			v.add(mapValue(group, keyName), group, joinPath(path, keyName),
+				"%q matches no artifact container group (have %s)", name, quotedNames(shapeNames(shapes)))
+		}
+
+		v.checkRuntimeContainers(group, path, shape, matched)
+	}
+}
+
+func (v *validator) checkRuntimeContainers(group *yaml.Node, path string, shape groupShape, matched bool) {
+	for i, container := range seqItems(mapValue(group, keyContainers)) {
+		containerPath := fmt.Sprintf("%s.%s[%d]", path, keyContainers, i)
+		name, _ := scalarString(mapValue(container, keyName))
+
+		if matched && !slices.Contains(shape.containers, name) {
+			v.add(mapValue(container, keyName), container, joinPath(containerPath, keyName),
+				"%q matches no container in artifact group %q (have %s)",
+				name, shape.name, quotedNames(shape.containers))
+		}
+
+		v.checkMemory(mapValue(container, keyResourceAllocation), joinPath(containerPath, keyResourceAllocation))
+	}
+}
+
+// checkScaling holds replicaCount against autoscaling. A group may say how
+// many replicas to run or how to scale them, not both. Autoscaling switched
+// off is not scaling, so an explicit enabled:false leaves replicaCount alone,
+// matching what the create endpoint accepts.
+func (v *validator) checkScaling(group *yaml.Node, path string) {
+	replicas := mapValue(group, keyReplicaCount)
+	autoscaling := mapValue(group, keyAutoscaling)
+
+	if replicas == nil || autoscaling == nil {
+		return
+	}
+
+	enabled := mapValue(autoscaling, keyEnabled)
+	if enabled != nil && !isTrue(enabled) {
+		return
+	}
+
+	v.add(replicas, group, joinPath(path, keyReplicaCount),
+		"cannot be set alongside %s; omit one of them", keyAutoscaling)
+}
+
+// checkMemory holds the unit rule for a container's memory allocation.
+func (v *validator) checkMemory(allocation *yaml.Node, path string) {
+	node := mapValue(allocation, keyMemory)
+
+	value, ok := scalarString(node)
+	if !ok {
+		return
+	}
+
+	if !ValidMemory(value) {
+		v.add(node, allocation, joinPath(path, keyMemory),
+			"%q is not a valid size: use a byte count or a 1000-based unit (B, KB, MB, GB). "+
+				"Binary units such as Gi are read as their decimal namesakes, so they are rejected rather than silently converted",
+			value)
+	}
+}
+
+func findShape(shapes []groupShape, name string) (groupShape, bool) {
+	for _, shape := range shapes {
+		if shape.name == name {
+			return shape, true
+		}
+	}
+
+	return groupShape{}, false
+}
+
+func shapeNames(shapes []groupShape) []string {
+	names := make([]string, 0, len(shapes))
+	for _, shape := range shapes {
+		names = append(names, shape.name)
+	}
+
+	return names
+}
+
+// quotedNames renders a name list for an error message, so the fix is visible
+// without opening the other half of the file.
+func quotedNames(names []string) string {
+	if len(names) == 0 {
+		return "none"
+	}
+
+	quoted := make([]string, 0, len(names))
+	for _, name := range names {
+		quoted = append(quoted, fmt.Sprintf("%q", name))
+	}
+
+	return strings.Join(quoted, ", ")
+}

--- a/internal/workload/manifest/validate_test.go
+++ b/internal/workload/manifest/validate_test.go
@@ -1,0 +1,529 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validateString parses content and runs the ledger over it. dir anchors the
+// file-existence rules; pass "" to skip them.
+func validateString(t *testing.T, dir, content string) error {
+	t.Helper()
+
+	m, err := Parse([]byte(content), dir)
+	require.NoError(t, err)
+
+	return m.Validate()
+}
+
+// requireFindings asserts the exact set of findings, each as a line number
+// and a fragment of its message. Line numbers are part of the contract: a
+// finding that cannot point at the offending line is not much of a fix hint.
+func requireFindings(t *testing.T, err error, want []FieldError) {
+	t.Helper()
+
+	require.Error(t, err)
+
+	var validationErr *ValidationError
+
+	require.ErrorAs(t, err, &validationErr)
+	require.Len(t, validationErr.Errors, len(want), "findings: %v", validationErr.Errors)
+
+	for i, expected := range want {
+		got := validationErr.Errors[i]
+
+		assert.Equal(t, expected.Line, got.Line, "finding %d line", i)
+		assert.Equal(t, expected.Path, got.Path, "finding %d path", i)
+		assert.Contains(t, got.Msg, expected.Msg, "finding %d message", i)
+	}
+}
+
+func TestValidate_AcceptsValidManifest(t *testing.T) {
+	require.NoError(t, validateString(t, "", validManifest))
+}
+
+// The everyday file from the design: a service built from the repository's
+// Dockerfile, with the Dockerfile actually there.
+func TestValidate_AcceptsRenderedDefaults(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, dockerfileName), []byte("FROM scratch\n"), 0o600))
+
+	out, err := serviceDraft().Render()
+	require.NoError(t, err)
+
+	require.NoError(t, validateString(t, dir, string(out)))
+}
+
+func TestValidate_NameRequired(t *testing.T) {
+	err := validateString(t, "", `artifactId: 68b0bbbb0000000000000002
+name: ""
+`)
+
+	requireFindings(t, err, []FieldError{{Line: 2, Path: keyName, Msg: "is required"}})
+}
+
+func TestValidate_ArtifactBinding(t *testing.T) {
+	tests := map[string]string{
+		"neither": `name: my-app
+importance: low
+`,
+		"both": `name: my-app
+artifactId: 68b0bbbb0000000000000002
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageUri: nginx:latest
+`,
+	}
+
+	for name, content := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateString(t, "", content)
+
+			requireFindings(t, err, []FieldError{{Line: 1, Path: "", Msg: "exactly one of artifact"}})
+		})
+	}
+}
+
+func TestValidate_InlineArtifactNeedsSpec(t *testing.T) {
+	err := validateString(t, "", `name: my-app
+artifact:
+  name: my-app-artifact
+`)
+
+	requireFindings(t, err, []FieldError{{Line: 3, Path: "artifact.spec", Msg: "is required for an inline artifact"}})
+}
+
+func TestValidate_ContainerGroupsRequired(t *testing.T) {
+	err := validateString(t, "", `name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+`)
+
+	requireFindings(t, err, []FieldError{
+		{Line: 5, Path: "artifact.spec.containerGroups", Msg: "at least one container group"},
+	})
+}
+
+func TestValidate_ImageSource(t *testing.T) {
+	tests := map[string]struct {
+		container string
+		want      FieldError
+	}{
+		"both": {
+			container: `            imageUri: nginx:latest
+            imageBuildConfig:
+              dockerfile:
+                source: provided
+`,
+			want: FieldError{Line: 14, Msg: "never both"},
+		},
+		"neither": {
+			container: "",
+			want:      FieldError{Line: 9, Msg: "must set either imageUri or imageBuildConfig"},
+		},
+		"typo in the build block": {
+			container: `            imageBuildConfig:
+              dockerfle:
+                source: provided
+`,
+			want: FieldError{Line: 13, Msg: "imageBuildConfig must say how the image is built"},
+		},
+		"unknown source": {
+			container: `            imageBuildConfig:
+              dockerfile:
+                source: magic
+`,
+			want: FieldError{Line: 14, Msg: `must be "provided"`},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateString(t, "", serviceWithContainerBody(test.container))
+
+			require.Error(t, err)
+
+			var validationErr *ValidationError
+
+			require.ErrorAs(t, err, &validationErr)
+			require.Len(t, validationErr.Errors, 1, "findings: %v", validationErr.Errors)
+			assert.Equal(t, test.want.Line, validationErr.Errors[0].Line)
+			assert.Contains(t, validationErr.Errors[0].Msg, test.want.Msg)
+		})
+	}
+}
+
+// A provided build with nothing to build fails here rather than after the
+// sync, the build queue and the wait.
+func TestValidate_ProvidedBuildNeedsDockerfile(t *testing.T) {
+	dir := t.TempDir()
+	content := serviceWithContainerBody(`            imageBuildConfig:
+              dockerfile:
+                source: provided
+`)
+
+	err := validateString(t, dir, content)
+	requireFindings(t, err, []FieldError{
+		{Line: 14, Path: "artifact.spec.containerGroups[0].containers[0].imageBuildConfig.dockerfile", Msg: "no Dockerfile exists in"},
+	})
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, dockerfileName), []byte("FROM scratch\n"), 0o600))
+	require.NoError(t, validateString(t, dir, content))
+}
+
+func TestValidate_GeneratedBuildNeedsEnvironmentAndEntrypoint(t *testing.T) {
+	err := validateString(t, "", serviceWithContainerBody(`            imageBuildConfig:
+              dockerfile:
+                source: generated
+`))
+
+	base := "artifact.spec.containerGroups[0].containers[0].imageBuildConfig.dockerfile"
+	requireFindings(t, err, []FieldError{
+		{Line: 14, Path: base + ".executionEnvironmentId", Msg: "is required"},
+		{Line: 14, Path: base + ".executionEnvironmentVersionId", Msg: "is required"},
+		{Line: 14, Path: base + ".entrypoint", Msg: "at least one argument"},
+	})
+}
+
+func TestValidate_PrimaryPortFloor(t *testing.T) {
+	err := validateString(t, "", `name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 80
+            imageUri: nginx:latest
+`)
+
+	requireFindings(t, err, []FieldError{
+		{Line: 11, Path: "artifact.spec.containerGroups[0].containers[0].port", Msg: "must listen on 1024 or above"},
+	})
+}
+
+func TestValidate_PrimaryPortRequired(t *testing.T) {
+	err := validateString(t, "", `name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            imageUri: nginx:latest
+`)
+
+	requireFindings(t, err, []FieldError{
+		{Line: 9, Path: "artifact.spec.containerGroups[0].containers[0].port", Msg: "is required on the primary container"},
+	})
+}
+
+func TestValidate_NonPrimaryContainerIsPortless(t *testing.T) {
+	err := validateString(t, "", `name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageUri: nginx:latest
+          - name: metrics-bridge
+            port: 9000
+            imageUri: registry/metrics:v1
+`)
+
+	requireFindings(t, err, []FieldError{
+		{Line: 14, Path: "artifact.spec.containerGroups[0].containers[1].port", Msg: "only allowed on the primary container"},
+	})
+}
+
+func TestValidate_OnlyOnePrimaryPerGroup(t *testing.T) {
+	err := validateString(t, "", `name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageUri: nginx:latest
+          - name: also-primary
+            primary: true
+            port: 9000
+            imageUri: registry/other:v1
+`)
+
+	requireFindings(t, err, []FieldError{
+		{Line: 7, Path: "artifact.spec.containerGroups[0]", Msg: "only one can be"},
+	})
+}
+
+func TestValidate_ScalingIsEitherOr(t *testing.T) {
+	err := validateString(t, "", runtimeWithGroupBody(`      replicaCount: 3
+      autoscaling:
+        enabled: true
+        minReplicaCount: 1
+        maxReplicaCount: 4
+`))
+
+	requireFindings(t, err, []FieldError{
+		{Line: 16, Path: "runtime.containerGroups[0].replicaCount", Msg: "cannot be set alongside autoscaling"},
+	})
+}
+
+// Autoscaling switched off is not scaling, so replicaCount still decides. The
+// create endpoint accepts this, and the ledger must not be stricter than the
+// thing it is protecting.
+func TestValidate_DisabledAutoscalingAllowsReplicaCount(t *testing.T) {
+	require.NoError(t, validateString(t, "", runtimeWithGroupBody(`      replicaCount: 3
+      autoscaling:
+        enabled: false
+`)))
+}
+
+func TestValidate_RuntimeNamesMustMatchTheArtifact(t *testing.T) {
+	err := validateString(t, "", `name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageUri: nginx:latest
+runtime:
+  containerGroups:
+    - name: dfault
+      replicaCount: 1
+      containers:
+        - name: primry
+          resourceAllocation: {cpu: 0.5, memory: 512MB}
+`)
+
+	requireFindings(t, err, []FieldError{
+		{Line: 15, Path: "runtime.containerGroups[0].name", Msg: `"dfault" matches no artifact container group`},
+	})
+}
+
+// A container name is only checkable once its group matched; reporting both
+// for one typo would send the reader chasing a second problem that is not
+// there.
+func TestValidate_RuntimeContainerNameMustMatch(t *testing.T) {
+	err := validateString(t, "", runtimeWithGroupBody(`      replicaCount: 1
+      containers:
+        - name: primry
+          resourceAllocation: {cpu: 0.5, memory: 512MB}
+`))
+
+	requireFindings(t, err, []FieldError{
+		{Line: 18, Path: "runtime.containerGroups[0].containers[0].name", Msg: `"primry" matches no container in artifact group "default"`},
+	})
+}
+
+// A manifest that binds an existing artifact by id has no local names to
+// match against, so the runtime block is taken at its word.
+func TestValidate_RuntimeNamesUncheckedForArtifactByID(t *testing.T) {
+	require.NoError(t, validateString(t, "", `name: my-app
+artifactId: 68b0bbbb0000000000000002
+runtime:
+  containerGroups:
+    - name: whatever-the-artifact-calls-it
+      replicaCount: 1
+      containers:
+        - name: primary
+          resourceAllocation: {cpu: 0.5, memory: 512MB}
+`))
+}
+
+func TestValidate_MemoryUnits(t *testing.T) {
+	accepted := []string{"512MB", "4GB", "1000B", "1048576"}
+	for _, value := range accepted {
+		t.Run("accepts "+value, func(t *testing.T) {
+			require.NoError(t, validateString(t, "", runtimeWithGroupBody(`      replicaCount: 1
+      containers:
+        - name: primary
+          resourceAllocation: {cpu: 0.5, memory: `+value+`}
+`)))
+		})
+	}
+
+	rejected := []string{"4Gi", "512Mi", "big", "0.5GB"}
+	for _, value := range rejected {
+		t.Run("rejects "+value, func(t *testing.T) {
+			err := validateString(t, "", runtimeWithGroupBody(`      replicaCount: 1
+      containers:
+        - name: primary
+          resourceAllocation: {cpu: 0.5, memory: `+value+`}
+`))
+
+			requireFindings(t, err, []FieldError{
+				{Line: 19, Path: "runtime.containerGroups[0].containers[0].resourceAllocation.memory", Msg: "is not a valid size"},
+			})
+		})
+	}
+}
+
+// A malformed credential reference is a manifest error like any other, and it
+// arrives with its line rather than as a mystery value at deploy time.
+func TestValidate_CredentialShorthandSyntax(t *testing.T) {
+	err := validateString(t, "", `name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageUri: nginx:latest
+            environmentVars:
+              - name: OPENAI_API_KEY
+                value: dr-credential:68f0cccc0000000000000003
+`)
+
+	requireFindings(t, err, []FieldError{
+		{Line: 15, Path: "artifact.spec.containerGroups[0].containers[0].environmentVars[0].value", Msg: "must be dr-credential:"},
+	})
+}
+
+// Every problem in one pass, ordered by line, so one run of the command is
+// enough to fix the file.
+func TestValidate_ReportsEveryFindingInLineOrder(t *testing.T) {
+	err := validateString(t, "", `artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 80
+            imageUri: nginx:latest
+runtime:
+  containerGroups:
+    - name: dfault
+      replicaCount: 1
+`)
+
+	requireFindings(t, err, []FieldError{
+		{Line: 1, Path: keyName, Msg: "is required"},
+		{Line: 10, Path: "artifact.spec.containerGroups[0].containers[0].port", Msg: "must listen on 1024 or above"},
+		{Line: 14, Path: "runtime.containerGroups[0].name", Msg: "matches no artifact container group"},
+	})
+}
+
+// serviceWithContainerBody builds a one-container service whose image source
+// lines are the caller's, so an image-source case reads as just that case.
+// The container body starts at line 12.
+func serviceWithContainerBody(body string) string {
+	return `name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+` + body
+}
+
+// runtimeWithGroupBody builds a valid service plus one runtime group whose
+// body is the caller's. The group body starts at line 16.
+func runtimeWithGroupBody(body string) string {
+	return `name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageUri: nginx:latest
+runtime:
+  containerGroups:
+    - name: default
+` + body
+}
+
+// Memory is what people type, not only what the file should say: case and a
+// stray space are accepted and normalized, while binary units stay rejected
+// because the platform would read them as their decimal namesakes.
+func TestValidMemory_AcceptsWhatPeopleType(t *testing.T) {
+	accepted := map[string]string{
+		"512MB":   "512MB",
+		"512mb":   "512MB",
+		"512Mb":   "512MB",
+		"512 MB":  "512MB",
+		" 4gb ":   "4GB",
+		"1000":    "1000",
+		"2tb":     "2TB",
+		"1048576": "1048576",
+	}
+
+	for input, want := range accepted {
+		t.Run("accepts "+input, func(t *testing.T) {
+			assert.True(t, ValidMemory(input))
+			assert.Equal(t, want, NormalizeMemory(input))
+		})
+	}
+
+	for _, input := range []string{"4Gi", "512Mi", "1KiB", "big", "0.5GB", "MB", "512 M B"} {
+		t.Run("rejects "+input, func(t *testing.T) {
+			assert.False(t, ValidMemory(input))
+			assert.Equal(t, input, NormalizeMemory(input), "an unrecognized size is returned untouched")
+		})
+	}
+}

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -1,0 +1,564 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/datarobot/cli/internal/fsutil"
+	"gopkg.in/yaml.v3"
+)
+
+// Workload kinds the setup wizard can write. The full set the format accepts
+// is larger (stacks, NIMs); those are hand-written or added by later wizard
+// tracks, and pass through the reader either way.
+const (
+	TypeService = "service"
+	TypeAgent   = "agent"
+)
+
+// Build modes, named the way the user chooses them rather than the way the
+// spec spells them: BuildModeDockerfile writes source: provided.
+const (
+	BuildModeDockerfile = "dockerfile"
+	BuildModeGenerated  = "generated"
+	BuildModeImage      = "image"
+
+	// BuildModeUnchanged means the live container's build block says
+	// something this release does not model, so it is carried over verbatim
+	// instead of being rewritten. It only ever comes from a live workload;
+	// Draft.Render rejects it, because there is nothing to render from.
+	BuildModeUnchanged = "unchanged"
+)
+
+// Importance levels, in the order the platform ranks them. The enum itself
+// is not verified against a running platform, so the reader does not enforce
+// it: an unrecognized value passes through and the server decides.
+var ImportanceLevels = []string{"low", "moderate", "high", "critical"}
+
+// ValidImportance reports whether value is one of ImportanceLevels, for a
+// caller that would rather reject a typo at the prompt than at the API.
+func ValidImportance(value string) bool {
+	return slices.Contains(ImportanceLevels, value)
+}
+
+const (
+	DefaultImportance = "low"
+	DefaultPort       = 8080
+	DefaultHealthPath = "/health"
+	DefaultReplicas   = 1
+	DefaultCPU        = 0.5
+	DefaultMemory     = "512MB"
+
+	// GroupName and PrimaryContainerName appear in both halves of the file,
+	// which is how the sizing block is joined to the artifact block.
+	GroupName            = "default"
+	PrimaryContainerName = "primary"
+
+	// ArtifactNameSuffix derives the artifact name from the workload name, so
+	// the two are recognizably one project in listings.
+	ArtifactNameSuffix = "-artifact"
+)
+
+// atomicWrite is the durable write, a variable so a test can make it fail and
+// check that the reservation is taken back.
+var atomicWrite = fsutil.AtomicWriteFile
+
+// ErrExists reports that a manifest is already present at the target path.
+// Setup never rewrites one: the file is the interface after the first write,
+// and every later change is a hand edit.
+var ErrExists = errors.New(FileName + " already exists")
+
+// Draft is what the setup wizard settles: the fixed subset of the spec a
+// generated file spells out. It is not a spec struct. Reading stays
+// node-based so unknown blocks survive a round trip, and a hand-edited file
+// can say things no Draft field can express.
+type Draft struct {
+	// WorkloadID binds the file to a live workload; empty means the workload
+	// is created by the first up.
+	WorkloadID string
+	Name       string
+	Importance string
+	// Type is TypeService or TypeAgent.
+	Type string
+	// A2AEnabled publishes an agent's A2A card to the tenant-wide registry.
+	// Written only when true, because false is the platform's own default.
+	A2AEnabled bool
+	Build      Build
+	// Port is the primary container's port, and the readiness probe's.
+	Port       int
+	HealthPath string
+	Runtime    Runtime
+	// EnvVars are the variables a local .env defines, already classified by
+	// the caller. They are written into environmentVars: an ordinary value as
+	// the literal it is, a secret as a credential reference carrying
+	// CredentialPlaceholder, because no credential exists for it yet. An
+	// empty slice writes nothing.
+	EnvVars []EnvVar
+}
+
+// EnvVar is one .env variable as the manifest will carry it. Deciding which
+// are secret is the caller's job, because that needs the values.
+type EnvVar struct {
+	Name string
+	// Value is written as a literal, and is empty for a secret: a secret's
+	// value belongs in the credential store and never in this file.
+	Value string
+	// Secret means the value belongs in the credential store, so the entry is
+	// written as a reference carrying CredentialPlaceholder in place of an id
+	// that does not exist yet.
+	Secret bool
+}
+
+// CredentialPlaceholder stands in for a credential id until one is created.
+// It is written in full rather than left as a comment: a reference that is
+// visibly unfinished fails at deploy naming the variable, where a commented
+// entry would deploy cleanly and leave the container without its secret.
+const CredentialPlaceholder = "PLACEHOLDER"
+
+// credentialKey is the field of a credential a reference reads. Every
+// placeholder names the same one, because swapping the id for a real one is
+// then the only edit needed.
+const credentialKey = "apiToken"
+
+// Build is how the image comes to be: exactly one of the three modes, with
+// the fields that mode needs.
+type Build struct {
+	Mode string
+	// ImageURI is set for BuildModeImage.
+	ImageURI string
+	// The rest are set for BuildModeGenerated. Both environment ids are
+	// recorded, resolved once at setup, so builds stay reproducible after the
+	// environment moves on.
+	ExecutionEnvironmentID        string
+	ExecutionEnvironmentVersionID string
+	Entrypoint                    []string
+}
+
+// Runtime is the sizing half: tunable at any moment with no new artifact
+// version and no rebuild.
+type Runtime struct {
+	Replicas int
+	CPU      float64
+	Memory   string
+}
+
+// Path returns the manifest path for a project directory.
+func Path(dir string) string {
+	return filepath.Join(dir, FileName)
+}
+
+// ArtifactName returns the artifact name derived from a workload name.
+func ArtifactName(workloadName string) string {
+	return workloadName + ArtifactNameSuffix
+}
+
+// Render turns a draft into the bytes of a manifest: the platform's own spec,
+// commented where a reader would otherwise have to look something up. Every
+// field the wizard settles is written explicitly rather than left to a
+// reader's defaults, so the file means the same thing to this CLI and to
+// push-to-deploy.
+//
+// Render does not validate. Parse the result and call Validate, which is what
+// the wizard does before writing anything.
+func (d Draft) Render() ([]byte, error) {
+	build, err := d.buildFields()
+	if err != nil {
+		return nil, err
+	}
+
+	root := mapping(d.topLevelFields(build)...)
+
+	var buf bytes.Buffer
+
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+
+	if err := enc.Encode(root); err != nil {
+		return nil, fmt.Errorf("cannot render manifest: %w", err)
+	}
+
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("cannot render manifest: %w", err)
+	}
+
+	return spaceTopLevelBlocks(buf.Bytes()), nil
+}
+
+// Write creates the manifest at path. It refuses to overwrite an existing
+// one, and it is all-or-nothing: a failed write leaves no file at all, rather
+// than a truncated manifest that the refuse-to-overwrite rule would then stop
+// anyone from repairing.
+//
+// The exclusive create is what makes the refusal a check rather than a race:
+// two processes configuring the same directory cannot both believe they wrote
+// the file. It is a reservation, immediately released, so the content still
+// arrives through the atomic rename.
+func Write(path string, data []byte) error {
+	reservation, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, fsutil.DefaultFileMode)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("%w: %s", ErrExists, path)
+		}
+
+		return fmt.Errorf("cannot create %s: %w", path, err)
+	}
+
+	_ = reservation.Close()
+
+	if err := atomicWrite(path, data); err != nil {
+		// The reservation is ours and still empty, so taking it back leaves
+		// the directory as it was found.
+		_ = os.Remove(path)
+
+		return err
+	}
+
+	return nil
+}
+
+// WriteWorkloadID records the binding in an existing manifest, the one edit
+// the CLI makes to a file the user owns: up writes the id back the moment the
+// workload exists, so the next run finds it. Comments, unknown keys and their
+// order are preserved, because the file is re-emitted from the tree it was
+// parsed into rather than regenerated.
+func WriteWorkloadID(path, workloadID string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("cannot read %s: %w", path, err)
+	}
+
+	var doc yaml.Node
+
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("cannot parse %s: %w", path, err)
+	}
+
+	if len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
+		return fmt.Errorf("cannot record the workload id in %s: root must be a YAML mapping", path)
+	}
+
+	setWorkloadID(doc.Content[0], workloadID)
+
+	var buf bytes.Buffer
+
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+
+	if err := enc.Encode(&doc); err != nil {
+		return fmt.Errorf("cannot render %s: %w", path, err)
+	}
+
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("cannot render %s: %w", path, err)
+	}
+
+	return fsutil.AtomicWriteFile(path, buf.Bytes())
+}
+
+// setWorkloadID replaces the binding in place when the key is there, and
+// otherwise inserts it as the first key. A head comment on what used to be
+// the first key is a file banner, so it moves up with the insertion instead
+// of ending up stranded in the middle of the file.
+func setWorkloadID(root *yaml.Node, workloadID string) {
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value == keyWorkloadID {
+			root.Content[i+1].SetString(workloadID)
+
+			return
+		}
+	}
+
+	key := scalar(keyWorkloadID)
+	key.LineComment = workloadIDComment
+
+	if len(root.Content) > 0 {
+		key.HeadComment = root.Content[0].HeadComment
+		root.Content[0].HeadComment = ""
+	}
+
+	root.Content = append([]*yaml.Node{key, scalar(workloadID)}, root.Content...)
+}
+
+const workloadIDComment = "managed by the CLI"
+
+func (d Draft) topLevelFields(build field) []field {
+	fields := make([]field, 0, 5)
+
+	if d.WorkloadID != "" {
+		fields = append(fields, field{key: keyWorkloadID, value: scalar(d.WorkloadID), comment: workloadIDComment})
+	}
+
+	importance := d.Importance
+	if importance == "" {
+		importance = DefaultImportance
+	}
+
+	fields = append(fields,
+		field{key: keyName, value: scalar(d.Name)},
+		field{key: keyImportance, value: scalar(importance), comment: strings.Join(ImportanceLevels, " | ")},
+		field{key: keyArtifact, value: d.artifact(build)},
+		field{key: keyRuntime, value: d.runtime()},
+	)
+
+	return fields
+}
+
+// artifact renders the half that says what runs: the versioned, lockable
+// definition.
+func (d Draft) artifact(build field) *yaml.Node {
+	spec := []field{{key: "type", value: scalar(d.Type)}}
+
+	if d.A2AEnabled {
+		spec = append(spec, field{
+			key:     "a2aEnabled",
+			value:   boolean(true),
+			comment: "discoverable tenant-wide",
+		})
+	}
+
+	probe := mapping(
+		field{key: "path", value: scalar(d.HealthPath)},
+		field{key: keyPort, value: number(d.Port)},
+	)
+
+	container := []field{
+		{key: keyName, value: scalar(PrimaryContainerName)},
+		{key: keyPrimary, value: boolean(true)},
+		{key: keyPort, value: number(d.Port), comment: "must be 1024 or above"},
+		build,
+		{key: "readinessProbe", value: probe},
+	}
+
+	if vars := d.environmentVars(); vars != nil {
+		container = append(container, field{key: keyEnvironmentVars, value: vars})
+	}
+
+	spec = append(spec, field{key: keyContainerGroups, value: sequence(mapping(
+		field{key: keyName, value: scalar(GroupName)},
+		field{key: keyContainers, value: sequence(mapping(container...))},
+	))})
+
+	return mapping(
+		field{key: keyName, value: scalar(ArtifactName(d.Name))},
+		field{key: keySpec, value: mapping(spec...)},
+	)
+}
+
+// runtime renders the half that says how much it runs with.
+func (d Draft) runtime() *yaml.Node {
+	allocation := mapping(
+		field{key: "cpu", value: decimal(d.Runtime.CPU)},
+		field{key: keyMemory, value: scalar(d.Runtime.Memory)},
+	)
+	allocation.Style = yaml.FlowStyle
+
+	return mapping(field{key: keyContainerGroups, value: sequence(mapping(
+		field{key: keyName, value: scalar(GroupName), comment: "matches the artifact group"},
+		field{key: keyReplicaCount, value: number(d.Runtime.Replicas)},
+		field{key: keyContainers, value: sequence(mapping(
+			field{key: keyName, value: scalar(PrimaryContainerName)},
+			field{key: keyResourceAllocation, value: allocation},
+		))},
+	))})
+}
+
+// environmentVars renders the .env variables the manifest carries. Ordinary
+// settings become literals. Secrets become credential references carrying
+// CredentialPlaceholder, so the entry is present and obviously unfinished
+// rather than absent and easy to miss.
+func (d Draft) environmentVars() *yaml.Node {
+	entries := sequence()
+
+	for _, v := range d.EnvVars {
+		value := scalar(v.Value)
+		entry := []field{{key: keyName, value: scalar(v.Name)}}
+
+		if v.Secret {
+			value = scalar(credentialShorthandPrefix + CredentialPlaceholder + "/" + credentialKey)
+			entry = append(entry, field{
+				key:     keyValue,
+				value:   value,
+				comment: "replace " + CredentialPlaceholder + " with the credential id",
+			})
+		} else {
+			entry = append(entry, field{key: keyValue, value: value})
+		}
+
+		entries.Content = append(entries.Content, mapping(entry...))
+	}
+
+	if len(entries.Content) == 0 {
+		return nil
+	}
+
+	return entries
+}
+
+// buildFields renders the one key that says where the image comes from.
+func (d Draft) buildFields() (field, error) {
+	switch d.Build.Mode {
+	case BuildModeDockerfile:
+		return field{
+			key: keyImageBuildConfig,
+			value: mapping(field{key: keyDockerfile, value: mapping(
+				field{key: keySource, value: scalar(sourceProvided)},
+			)}),
+			comment: "built from this repository's " + dockerfileName,
+		}, nil
+
+	case BuildModeGenerated:
+		entrypoint := sequence()
+
+		for _, arg := range d.Build.Entrypoint {
+			// Quote every argument, including the ones that would be legal
+			// bare: an entrypoint reads as a command line, and 0.0.0.0 or
+			// 8080 sitting unquoted next to quoted neighbours invites an
+			// editor to wonder which ones are strings.
+			arg := scalar(arg)
+			arg.Style = yaml.DoubleQuotedStyle
+
+			entrypoint.Content = append(entrypoint.Content, arg)
+		}
+
+		entrypoint.Style = yaml.FlowStyle
+
+		return field{
+			key: keyImageBuildConfig,
+			value: mapping(field{key: keyDockerfile, value: mapping(
+				field{key: keySource, value: scalar(sourceGenerated)},
+				field{key: keyExecEnvID, value: scalar(d.Build.ExecutionEnvironmentID)},
+				field{key: keyExecEnvVersionID, value: scalar(d.Build.ExecutionEnvironmentVersionID)},
+				field{key: keyEntrypoint, value: entrypoint},
+			)}),
+			comment: "generated from an execution environment",
+		}, nil
+
+	case BuildModeImage:
+		return field{key: keyImageURI, value: scalar(d.Build.ImageURI), comment: "already published; no build"}, nil
+
+	case BuildModeUnchanged:
+		// Only a live workload can carry this, and that path renders through
+		// Live, which keeps the block it came from.
+		return field{}, errors.New("cannot render a build mode of " + BuildModeUnchanged + " from scratch")
+
+	default:
+		return field{}, fmt.Errorf("unknown build mode %q: want %s, %s or %s",
+			d.Build.Mode, BuildModeDockerfile, BuildModeGenerated, BuildModeImage)
+	}
+}
+
+// field is one key/value pair of a rendered mapping, with the comment that
+// earns its place next to it.
+type field struct {
+	key   string
+	value *yaml.Node
+	// comment sits at the end of the key's own line.
+	comment string
+}
+
+func mapping(fields ...field) *yaml.Node {
+	node := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+
+	for _, f := range fields {
+		key := scalar(f.key)
+		key.LineComment = f.comment
+
+		node.Content = append(node.Content, key, f.value)
+	}
+
+	return node
+}
+
+func sequence(items ...*yaml.Node) *yaml.Node {
+	return &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq", Content: items}
+}
+
+// yaml11Booleans are the plain scalars a YAML 1.1 reader resolves to
+// booleans. yaml.v3 follows YAML 1.2 and leaves them as strings, so it sees
+// no reason to quote them, but this file is read by more than one parser and
+// a workload named "no" must not arrive at the platform as false.
+var yaml11Booleans = map[string]bool{"y": true, "yes": true, "n": true, "no": true, "on": true, "off": true}
+
+// scalar renders a string, quoting it when a plain scalar would read back as
+// something other than this string. The encoder already handles the YAML 1.2
+// cases (a name of "8080" or "null" comes back quoted); the map above covers
+// what only older readers would misread. "my-app" stays bare.
+func scalar(value string) *yaml.Node {
+	node := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+	if yaml11Booleans[strings.ToLower(value)] {
+		node.Style = yaml.DoubleQuotedStyle
+	}
+
+	return node
+}
+
+func number(value int) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: intTag, Value: strconv.Itoa(value)}
+}
+
+// decimal renders a CPU allocation. A whole number is written plainly (1, not
+// 1.0 and not the !!float tag yaml.v3 would otherwise emit to keep the type):
+// the spec's examples write cpu: 1, and a tagged scalar in a generated file
+// reads like a mistake.
+func decimal(value float64) *yaml.Node {
+	if value == math.Trunc(value) && math.Abs(value) < 1e15 {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: intTag, Value: strconv.FormatInt(int64(value), 10)}
+	}
+
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: strconv.FormatFloat(value, 'f', -1, 64)}
+}
+
+func boolean(value bool) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: boolTag, Value: strconv.FormatBool(value)}
+}
+
+// blockKeys are the top-level keys that open a nested block. The encoder
+// packs the whole document together; a blank line before each of these is
+// what makes the two halves of the file readable at a glance.
+var blockKeys = []string{keyArtifact + ":", keyRuntime + ":"}
+
+func spaceTopLevelBlocks(data []byte) []byte {
+	lines := strings.Split(string(data), "\n")
+	out := make([]string, 0, len(lines)+len(blockKeys))
+
+	for _, line := range lines {
+		if opensBlock(line) && len(out) > 0 && out[len(out)-1] != "" {
+			out = append(out, "")
+		}
+
+		out = append(out, line)
+	}
+
+	return []byte(strings.Join(out, "\n"))
+}
+
+func opensBlock(line string) bool {
+	for _, key := range blockKeys {
+		if strings.HasPrefix(line, key) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/workload/manifest/write_test.go
+++ b/internal/workload/manifest/write_test.go
@@ -1,0 +1,392 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// serviceDraft is the Dockerfile happy path: what a user gets by pressing
+// Enter through every screen in a directory that has a Dockerfile.
+func serviceDraft() Draft {
+	return Draft{
+		WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0",
+		Name:       "my-app",
+		Type:       TypeService,
+		Build:      Build{Mode: BuildModeDockerfile},
+		Port:       DefaultPort,
+		HealthPath: DefaultHealthPath,
+		Runtime:    Runtime{Replicas: DefaultReplicas, CPU: DefaultCPU, Memory: DefaultMemory},
+	}
+}
+
+// TestRender_DockerfileService pins the whole file, not a field at a time:
+// the confirm screen shows these exact bytes, so a change in layout, comments
+// or key order is a change to what the user reads and agrees to.
+func TestRender_DockerfileService(t *testing.T) {
+	out, err := serviceDraft().Render()
+	require.NoError(t, err)
+
+	assert.Equal(t, `workloadId: 68b0c1d2e3f4a5b6c7d8e9f0 # managed by the CLI
+name: my-app
+importance: low # low | moderate | high | critical
+
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080 # must be 1024 or above
+            imageBuildConfig: # built from this repository's Dockerfile
+              dockerfile:
+                source: provided
+            readinessProbe:
+              path: /health
+              port: 8080
+
+runtime:
+  containerGroups:
+    - name: default # matches the artifact group
+      replicaCount: 1
+      containers:
+        - name: primary
+          resourceAllocation: {cpu: 0.5, memory: 512MB}
+`, string(out))
+}
+
+// An unbound draft writes no workloadId at all, so the first up knows the
+// workload has to be created rather than found.
+func TestRender_UnboundOmitsWorkloadID(t *testing.T) {
+	draft := serviceDraft()
+	draft.WorkloadID = ""
+
+	out, err := draft.Render()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(out), keyWorkloadID)
+	assert.Contains(t, string(out), "name: my-app\n")
+}
+
+func TestRender_GeneratedAgent(t *testing.T) {
+	draft := serviceDraft()
+	draft.Type = TypeAgent
+	draft.A2AEnabled = true
+	draft.Build = Build{
+		Mode:                          BuildModeGenerated,
+		ExecutionEnvironmentID:        "68a1b2c3d4e5f6a7b8c9d0e1",
+		ExecutionEnvironmentVersionID: "68a1b2c3d4e5f6a7b8c9d0e2",
+		Entrypoint:                    []string{"uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"},
+	}
+
+	out, err := draft.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "type: agent")
+	assert.Contains(t, string(out), "a2aEnabled: true")
+	assert.Contains(t, string(out), "source: generated")
+	assert.Contains(t, string(out), "executionEnvironmentId: 68a1b2c3d4e5f6a7b8c9d0e1")
+	assert.Contains(t, string(out), "executionEnvironmentVersionId: 68a1b2c3d4e5f6a7b8c9d0e2")
+	// Quoted throughout, so an entrypoint reads as the command line it is.
+	assert.Contains(t, string(out), `entrypoint: ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]`)
+}
+
+// An agent that does not serve an A2A card writes only the type: false is the
+// platform's default and saying it adds nothing.
+func TestRender_AgentWithoutA2A(t *testing.T) {
+	draft := serviceDraft()
+	draft.Type = TypeAgent
+
+	out, err := draft.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "type: agent")
+	assert.NotContains(t, string(out), "a2aEnabled")
+}
+
+func TestRender_PublishedImage(t *testing.T) {
+	draft := serviceDraft()
+	draft.Build = Build{Mode: BuildModeImage, ImageURI: "registry.example.com/team/my-app:v1"}
+
+	out, err := draft.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "imageUri: registry.example.com/team/my-app:v1")
+	assert.NotContains(t, string(out), keyImageBuildConfig)
+}
+
+func TestRender_UnknownBuildMode(t *testing.T) {
+	draft := serviceDraft()
+	draft.Build = Build{Mode: "magic"}
+
+	_, err := draft.Render()
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), `unknown build mode "magic"`)
+}
+
+// A name that YAML would read back as a number or a boolean comes out quoted,
+// so the file still says what the user typed.
+func TestRender_QuotesAmbiguousNames(t *testing.T) {
+	for _, name := range []string{"8080", "yes", "null"} {
+		t.Run(name, func(t *testing.T) {
+			draft := serviceDraft()
+			draft.Name = name
+
+			out, err := draft.Render()
+			require.NoError(t, err)
+
+			assert.Contains(t, string(out), `name: "`+name+`"`)
+
+			m, err := Parse(out, "")
+			require.NoError(t, err)
+			assert.Equal(t, name, m.Name())
+		})
+	}
+}
+
+// Everything Render writes has to survive the reader that consumes it: a
+// generated file parses, validates clean, and compiles to a create payload.
+func TestRender_RoundTripsThroughValidate(t *testing.T) {
+	generated := Build{
+		Mode:                          BuildModeGenerated,
+		ExecutionEnvironmentID:        "68a1b2c3d4e5f6a7b8c9d0e1",
+		ExecutionEnvironmentVersionID: "68a1b2c3d4e5f6a7b8c9d0e2",
+		Entrypoint:                    []string{"python", "main.py"},
+	}
+
+	for name, build := range map[string]Build{
+		"dockerfile": {Mode: BuildModeDockerfile},
+		"generated":  generated,
+		"image":      {Mode: BuildModeImage, ImageURI: "nginx:latest"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, dockerfileName), []byte("FROM scratch\n"), 0o600))
+
+			draft := serviceDraft()
+			draft.Build = build
+
+			out, err := draft.Render()
+			require.NoError(t, err)
+
+			m, err := Parse(out, dir)
+			require.NoError(t, err)
+			require.NoError(t, m.Validate())
+
+			compiled, err := m.Compile()
+			require.NoError(t, err)
+
+			assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", compiled.WorkloadID)
+			assert.NotContains(t, string(compiled.Payload), keyWorkloadID)
+		})
+	}
+}
+
+func TestWrite_CreatesFile(t *testing.T) {
+	path := Path(t.TempDir())
+
+	require.NoError(t, Write(path, []byte("name: my-app\n")))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "name: my-app\n", string(got))
+
+	if runtime.GOOS != "windows" {
+		// Compared against a file the standard library just wrote the same
+		// way, so the assertion holds under any umask and the manifest is
+		// never wider than what the user's own tools produce.
+		reference := filepath.Join(t.TempDir(), "reference")
+		require.NoError(t, os.WriteFile(reference, nil, 0o644))
+
+		want, err := os.Stat(reference)
+		require.NoError(t, err)
+
+		got, err := os.Stat(path)
+		require.NoError(t, err)
+
+		assert.Equal(t, want.Mode().Perm(), got.Mode().Perm())
+	}
+}
+
+// A write that fails part way must leave no file at all: the refuse-to-
+// overwrite rule would otherwise make a truncated manifest unrepairable by
+// the CLI that produced it.
+func TestWrite_FailureLeavesNoFile(t *testing.T) {
+	original := atomicWrite
+	atomicWrite = func(string, []byte) error { return errors.New("disk full") }
+
+	t.Cleanup(func() { atomicWrite = original })
+
+	path := Path(t.TempDir())
+
+	err := Write(path, []byte("name: my-app\n"))
+	require.Error(t, err)
+
+	assert.NoFileExists(t, path, "a failed write must not leave a manifest behind")
+}
+
+// Setup never rewrites a manifest: the file is the interface after the first
+// write, so a second config against the same directory has to stop.
+func TestWrite_RefusesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := writeManifest(t, dir, validManifest)
+
+	err := Write(path, []byte("name: replaced\n"))
+	require.ErrorIs(t, err, ErrExists)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, validManifest, string(got), "the existing manifest must be left alone")
+}
+
+func TestWriteWorkloadID_ReplacesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := writeManifest(t, dir, validManifest)
+
+	require.NoError(t, WriteWorkloadID(path, "68b0ffff0000000000000009"))
+
+	m, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "68b0ffff0000000000000009", m.WorkloadID())
+}
+
+// The write-back is a single-key edit, not a regeneration: comments, unknown
+// keys and their order are the user's, and up leaves them alone.
+func TestWriteWorkloadID_PreservesTheRestOfTheFile(t *testing.T) {
+	original := `name: my-app          # the workload
+somethingTheApiAddedLater: true
+artifact:
+  # how the image is built
+  name: my-app-artifact
+  spec:
+    type: service
+`
+
+	path := writeManifest(t, t.TempDir(), original)
+
+	require.NoError(t, WriteWorkloadID(path, "68b0ffff0000000000000009"))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, `workloadId: 68b0ffff0000000000000009 # managed by the CLI
+name: my-app # the workload
+somethingTheApiAddedLater: true
+artifact:
+  # how the image is built
+  name: my-app-artifact
+  spec:
+    type: service
+`, string(got))
+}
+
+// A banner at the top of the file belongs to the file, not to the key that
+// happened to be first, so the insert goes underneath it.
+func TestWriteWorkloadID_KeepsFileBannerOnTop(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), `# Deploy config for my-app. Edit freely.
+name: my-app
+`)
+
+	require.NoError(t, WriteWorkloadID(path, "68b0ffff0000000000000009"))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, `# Deploy config for my-app. Edit freely.
+workloadId: 68b0ffff0000000000000009 # managed by the CLI
+name: my-app
+`, string(got))
+}
+
+func TestWriteWorkloadID_RejectsNonMapping(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), "- name: my-app\n")
+
+	err := WriteWorkloadID(path, "68b0ffff0000000000000009")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "root must be a YAML mapping")
+}
+
+func TestWriteWorkloadID_MissingFile(t *testing.T) {
+	err := WriteWorkloadID(Path(t.TempDir()), "68b0ffff0000000000000009")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "cannot read")
+}
+
+func TestArtifactName(t *testing.T) {
+	assert.Equal(t, "my-app-artifact", ArtifactName("my-app"))
+}
+
+// A value that is not a secret is written as the literal it is. A secret is
+// written as a reference carrying the placeholder, so the entry is present
+// and visibly unfinished: a deploy then fails naming the variable, where a
+// missing entry would deploy cleanly and leave the container without it.
+func TestRender_SecretsCarryThePlaceholder(t *testing.T) {
+	draft := serviceDraft()
+	draft.EnvVars = []EnvVar{
+		{Name: "LOG_LEVEL", Value: "debug"},
+		{Name: "OPENAI_API_KEY", Secret: true},
+	}
+
+	out, err := draft.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(out), "- name: LOG_LEVEL\n                value: debug")
+	assert.Contains(t, string(out), "- name: OPENAI_API_KEY\n                value: dr-credential:PLACEHOLDER/apiToken")
+	assert.Contains(t, string(out), "# replace PLACEHOLDER with the credential id")
+
+	// Nothing is commented out: the whole block is live.
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.Contains(line, "OPENAI_API_KEY") {
+			assert.False(t, strings.HasPrefix(strings.TrimSpace(line), "#"), "the entry is live: %q", line)
+		}
+	}
+
+	m, err := Parse(out, "")
+	require.NoError(t, err)
+	require.NoError(t, m.Validate(), "a placeholder is syntactically a reference, so the file is writable")
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(compiled.Payload), "LOG_LEVEL")
+
+	// The reference is collected, so the deploy resolves it and fails naming
+	// the variable rather than starting a container without its secret.
+	require.Len(t, compiled.CredentialRefs, 1)
+	assert.Equal(t, CredentialPlaceholder, compiled.CredentialRefs[0].CredentialID)
+	assert.Equal(t, "OPENAI_API_KEY", compiled.CredentialRefs[0].EnvName)
+}
+
+func TestRender_NoEnvKeysWritesNoBlock(t *testing.T) {
+	out, err := serviceDraft().Render()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(out), "environmentVars")
+	assert.NotContains(t, string(out), ".env")
+}

--- a/internal/workload/wapi/config.go
+++ b/internal/workload/wapi/config.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/datarobot/cli/internal/fsutil"
 )
 
 // Config is the parsed representation of the project's config.json — the identity and
@@ -87,7 +89,7 @@ func writeConfig(projectDir string, c Config) error {
 		return fmt.Errorf("marshal config: %w", err)
 	}
 
-	return atomicWriteFile(configPath(projectDir), data)
+	return fsutil.AtomicWriteFile(configPath(projectDir), data)
 }
 
 // stringPtr lets callers express "absent" as nil so optional Config fields

--- a/internal/workload/wapi/history.go
+++ b/internal/workload/wapi/history.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+
+	"github.com/datarobot/cli/internal/fsutil"
 )
 
 // HistoryEntry is one JSONL record in the project's history.log. It is deliberately
@@ -47,7 +49,7 @@ func AppendHistory(projectDir string, entry HistoryEntry) error {
 		return fmt.Errorf("marshal history entry: %w", err)
 	}
 
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, atomicFileMode)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, fsutil.DefaultFileMode)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return ErrNotInitialized

--- a/internal/workload/wapi/init.go
+++ b/internal/workload/wapi/init.go
@@ -81,12 +81,12 @@ func Initialize(projectDir string, opts InitOptions) error {
 		return err
 	}
 
-	if err := atomicWriteFile(gitignorePath(projectDir), []byte(gitignoreContents)); err != nil {
+	if err := fsutil.AtomicWriteFile(gitignorePath(projectDir), []byte(gitignoreContents)); err != nil {
 		return err
 	}
 
 	if !fsutil.FileExists(wapiignorePath(projectDir)) {
-		if err := atomicWriteFile(wapiignorePath(projectDir), wapiignoreTemplate); err != nil {
+		if err := fsutil.AtomicWriteFile(wapiignorePath(projectDir), wapiignoreTemplate); err != nil {
 			return err
 		}
 	}

--- a/internal/workload/wapi/manifest.go
+++ b/internal/workload/wapi/manifest.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/datarobot/cli/internal/fsutil"
 )
 
 // FileMeta is the per-file entry in the BASE manifest. Hash is SHA-256 hex
@@ -104,5 +106,5 @@ func writeManifest(projectDir string, m Manifest) error {
 		return fmt.Errorf("marshal manifest: %w", err)
 	}
 
-	return atomicWriteFile(manifestPath(projectDir), data)
+	return fsutil.AtomicWriteFile(manifestPath(projectDir), data)
 }


### PR DESCRIPTION
## RATIONALE

`dr dotenv setup --if-needed` was skipping the wizard when `.env` existed but was missing core variables, as long as those variables were set via OS environment. This left `.env` incomplete and caused downstream failures (e.g., deployment issues reported in CFX-6414).

The root cause: `shouldSkipSetup` used `ValidateEnvironment`, which checks both `.env` file values and `os.LookupEnv`. Environment variables satisfied validation even when `.env` was missing core variables, so the wizard never ran and `.env` was never populated.

## CHANGES

- Added `ValidateEnvironmentFileOnly` and `GatherUserPromptsFromFile` to validate `.env` contents only, ignoring OS environment variables.
- Updated `shouldSkipSetup` to use `ValidateEnvironmentFileOnly` so `--if-needed` skips only when `.env` itself is complete.
- Refactored `promptsWithValues` to accept an `includeEnv` flag and extracted `resolvePromptValue` to reduce cyclomatic complexity.
- Added regression test covering the env-var-only core variables scenario.

## TESTING

- `go test ./cmd/dotenv/... ./internal/envbuilder/... -count=1 -race` — all pass.
- `task lint` — clean across linux/darwin/windows.

## RELATED

- JIRA: CFX-6414
- Slack thread: https://datarobot.slack.com/archives/C0AKJ3SUF55/p1786416272909369
