### PR TITLE
[CFX-6414] fix(dotenv): make --if-needed skip only when .env is complete

### DIFF
--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -246,13 +246,9 @@ func init() {
 }
 
 // shouldSkipSetup checks if setup should be skipped when --if-needed flag is set.
-// Returns true if .env file exists and all required variables are valid.
-//
-// Note: This uses ParseVariablesOnly to read only what's in the .env file, but
-// ValidateEnvironment also checks OS environment variables via os.LookupEnv.
-// This means validation can pass if required variables are set as environment
-// variables even if they're not in the .env file. This is intentional - if the
-// app can run (because vars are available from any source), setup can be skipped.
+// Returns true if .env file exists and all required variables are present in the
+// .env file itself. OS environment variables are intentionally ignored for the
+// skip decision so that an incomplete .env file still triggers the wizard.
 func shouldSkipSetup(repositoryRoot, dotenvFile string) (bool, error) {
 	if _, err := os.Stat(dotenvFile); err != nil {
 		// .env doesn't exist, don't skip
@@ -262,7 +258,7 @@ func shouldSkipSetup(repositoryRoot, dotenvFile string) (bool, error) {
 	dotenvFileLines, _ := readDotenvFile(dotenvFile)
 	variables := envbuilder.ParseVariablesOnly(dotenvFileLines)
 
-	result := envbuilder.ValidateEnvironment(repositoryRoot, variables)
+	result := envbuilder.ValidateEnvironmentFileOnly(repositoryRoot, variables)
 
 	return !result.HasErrors(), nil
 }

--- a/cmd/dotenv/if_needed_test.go
+++ b/cmd/dotenv/if_needed_test.go
@@ -173,4 +173,31 @@ DATAROBOT_API_TOKEN=test-token
 		require.NoError(t, err)
 		require.False(t, shouldSkip, "Should not skip when DATAROBOT_ENDPOINT is missing")
 	})
+
+	t.Run("should not skip when core variables are set via environment but missing from .env", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		err := os.MkdirAll(filepath.Join(tmpDir, ".datarobot", "cli"), 0o755)
+		require.NoError(t, err)
+
+		err = os.WriteFile(filepath.Join(tmpDir, ".datarobot", "cli", "parakeet.yaml"), []byte("root: []"), 0o644)
+		require.NoError(t, err)
+
+		// Create .env with template variables but no core DataRobot variables
+		dotenvFile := filepath.Join(tmpDir, ".env")
+		envContent := `INFRA_ENABLE_LLM=deployed_llm.py
+LLM_DEPLOYMENT_ID=6a21895b92a225e438d83cc2
+USE_DATAROBOT_LLM_GATEWAY=0
+`
+		err = os.WriteFile(dotenvFile, []byte(envContent), 0o644)
+		require.NoError(t, err)
+
+		// Core variables are set via environment, but should be ignored for skip decision
+		t.Setenv("DATAROBOT_ENDPOINT", "https://app.datarobot.com/api/v2")
+		t.Setenv("DATAROBOT_API_TOKEN", "test-token")
+
+		shouldSkip, err := shouldSkipSetup(tmpDir, dotenvFile)
+		require.NoError(t, err)
+		require.False(t, shouldSkip, "Should not skip when .env is missing core variables even if env vars provide them")
+	})
 }

--- a/cmd/dotenv/if_needed_test.go
+++ b/cmd/dotenv/if_needed_test.go
@@ -201,3 +201,76 @@ USE_DATAROBOT_LLM_GATEWAY=0
 		require.False(t, shouldSkip, "Should not skip when .env is missing core variables even if env vars provide them")
 	})
 }
+
+// TestShouldSkipSetup_PresenceOnly covers the synthesis leaks that the file-only mode
+// must not paper over: YAML defaults, auto-generated secrets, and commented-out entries
+// must not satisfy the skip check. The wizard should run whenever the .env file itself
+// does not contain an effective, uncommented value for every required variable.
+func TestShouldSkipSetup_PresenceOnly(t *testing.T) {
+	// helper to scaffold a repo with a parakeet.yaml and a .env, then assert skip.
+	assertSkip := func(t *testing.T, parakeetYaml, envContent string, wantSkip bool, msg string) {
+		t.Helper()
+
+		tmpDir := t.TempDir()
+
+		require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, ".datarobot", "cli"), 0o755))
+
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".datarobot", "cli", "parakeet.yaml"), []byte(parakeetYaml), 0o644))
+
+		dotenvFile := filepath.Join(tmpDir, ".env")
+		require.NoError(t, os.WriteFile(dotenvFile, []byte(envContent), 0o644))
+
+		shouldSkip, err := shouldSkipSetup(tmpDir, dotenvFile)
+		require.NoError(t, err)
+		require.Equal(t, wantSkip, shouldSkip, msg)
+	}
+
+	t.Run("does not skip when a required var is satisfied only by a YAML default", func(t *testing.T) {
+		parakeetYaml := `root:
+  - env: REQUIRED_WITH_DEFAULT
+    default: some-default-value
+    help: A required variable that has a default`
+		envContent := `DATAROBOT_ENDPOINT=https://app.datarobot.com/api/v2
+DATAROBOT_API_TOKEN=test-token
+`
+		assertSkip(t, parakeetYaml, envContent, false,
+			"Should not skip when REQUIRED_WITH_DEFAULT is absent from .env even though it has a YAML default")
+	})
+
+	t.Run("does not skip when a required secret is satisfied only by generate:true", func(t *testing.T) {
+		parakeetYaml := `root:
+  - env: GENERATED_SECRET
+    type: secret_string
+    generate: true
+    help: A required generated secret`
+		envContent := `DATAROBOT_ENDPOINT=https://app.datarobot.com/api/v2
+DATAROBOT_API_TOKEN=test-token
+`
+		assertSkip(t, parakeetYaml, envContent, false,
+			"Should not skip when GENERATED_SECRET is absent from .env even though it would be auto-generated")
+	})
+
+	t.Run("does not skip when a required var is commented out in .env", func(t *testing.T) {
+		parakeetYaml := `root:
+  - env: REQUIRED_VAR
+    help: A required variable`
+		envContent := `DATAROBOT_ENDPOINT=https://app.datarobot.com/api/v2
+DATAROBOT_API_TOKEN=test-token
+# REQUIRED_VAR=commented-out-value
+`
+		assertSkip(t, parakeetYaml, envContent, false,
+			"Should not skip when REQUIRED_VAR is commented out in .env")
+	})
+
+	t.Run("skips when a required var is present and uncommented in .env", func(t *testing.T) {
+		parakeetYaml := `root:
+  - env: REQUIRED_VAR
+    help: A required variable`
+		envContent := `DATAROBOT_ENDPOINT=https://app.datarobot.com/api/v2
+DATAROBOT_API_TOKEN=test-token
+REQUIRED_VAR=value
+`
+		assertSkip(t, parakeetYaml, envContent, true,
+			"Should skip when all required vars are present and uncommented in .env")
+	})
+}

--- a/internal/envbuilder/builder.go
+++ b/internal/envbuilder/builder.go
@@ -256,17 +256,17 @@ func ApplyGeneratedValues(prompts []UserPrompt) ([]UserPrompt, error) {
 }
 
 func GatherUserPrompts(rootDir string, variables Variables) ([]UserPrompt, error) {
-	return gatherUserPrompts(rootDir, variables, true)
+	return gatherUserPrompts(rootDir, variables, true, true)
 }
 
-// GatherUserPromptsFromFile gathers user prompts using only .env file values,
-// ignoring OS environment variables. This is used for --if-needed skip checks
-// where we want to know whether the .env file itself is complete.
-func GatherUserPromptsFromFile(rootDir string, variables Variables) ([]UserPrompt, error) {
-	return gatherUserPrompts(rootDir, variables, false)
-}
-
-func gatherUserPrompts(rootDir string, variables Variables, includeEnv bool) ([]UserPrompt, error) {
+// gatherUserPrompts collects and resolves user prompts from the repository.
+// When includeEnv is true, OS environment variables override .env file values.
+// When synthesize is true, YAML defaults are applied and secret values are
+// auto-generated for prompts with generate: true. When synthesize is false
+// (presence-only mode), only effective, uncommented .env file entries count —
+// defaults are not applied and no values are generated. The PULUMI_CONFIG_PASSPHRASE
+// viper-config exception applies in both modes (see resolvePulumiPassphrase).
+func gatherUserPrompts(rootDir string, variables Variables, includeEnv, synthesize bool) ([]UserPrompt, error) {
 	yamlFiles, err := Discover(rootDir, 5)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to discover task yaml files: %w", err)
@@ -285,11 +285,13 @@ func gatherUserPrompts(rootDir string, variables Variables, includeEnv bool) ([]
 		allPrompts = append(allPrompts, prompts...)
 	}
 
-	allPrompts = promptsWithValues(allPrompts, variables, includeEnv)
+	allPrompts = promptsWithValues(allPrompts, variables, includeEnv, synthesize)
 
-	allPrompts, err = ApplyGeneratedValues(allPrompts)
-	if err != nil {
-		return nil, err
+	if synthesize {
+		allPrompts, err = ApplyGeneratedValues(allPrompts)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	allPrompts = DetermineRequiredSections(allPrompts)

--- a/internal/envbuilder/builder.go
+++ b/internal/envbuilder/builder.go
@@ -256,6 +256,17 @@ func ApplyGeneratedValues(prompts []UserPrompt) ([]UserPrompt, error) {
 }
 
 func GatherUserPrompts(rootDir string, variables Variables) ([]UserPrompt, error) {
+	return gatherUserPrompts(rootDir, variables, true)
+}
+
+// GatherUserPromptsFromFile gathers user prompts using only .env file values,
+// ignoring OS environment variables. This is used for --if-needed skip checks
+// where we want to know whether the .env file itself is complete.
+func GatherUserPromptsFromFile(rootDir string, variables Variables) ([]UserPrompt, error) {
+	return gatherUserPrompts(rootDir, variables, false)
+}
+
+func gatherUserPrompts(rootDir string, variables Variables, includeEnv bool) ([]UserPrompt, error) {
 	yamlFiles, err := Discover(rootDir, 5)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to discover task yaml files: %w", err)
@@ -274,7 +285,7 @@ func GatherUserPrompts(rootDir string, variables Variables) ([]UserPrompt, error
 		allPrompts = append(allPrompts, prompts...)
 	}
 
-	allPrompts = promptsWithValues(allPrompts, variables)
+	allPrompts = promptsWithValues(allPrompts, variables, includeEnv)
 
 	allPrompts, err = ApplyGeneratedValues(allPrompts)
 	if err != nil {

--- a/internal/envbuilder/validator.go
+++ b/internal/envbuilder/validator.go
@@ -86,12 +86,23 @@ func (r EnvironmentValidationError) Error() string {
 // 2. Validates all required UserPrompts in active sections
 // 3. Validates core DataRobot variables (DATAROBOT_ENDPOINT, DATAROBOT_API_TOKEN).
 func ValidateEnvironment(repoRoot string, variables Variables) EnvironmentValidationError {
+	return validateEnvironment(repoRoot, variables, true)
+}
+
+// ValidateEnvironmentFileOnly validates that all required environment variables are set
+// using only the .env file contents, ignoring OS environment variables. This is used
+// for --if-needed skip checks where we want to know whether the .env file itself is complete.
+func ValidateEnvironmentFileOnly(repoRoot string, variables Variables) EnvironmentValidationError {
+	return validateEnvironment(repoRoot, variables, false)
+}
+
+func validateEnvironment(repoRoot string, variables Variables, includeEnv bool) EnvironmentValidationError {
 	result := EnvironmentValidationError{
 		Results: make([]ValidationResult, 0),
 	}
 
 	// Gather all user prompts from the repository
-	userPrompts, err := GatherUserPrompts(repoRoot, variables)
+	userPrompts, err := gatherUserPrompts(repoRoot, variables, includeEnv)
 	if err != nil {
 		result.Results = append(result.Results, ValidationResult{
 			Field:   "prompts",
@@ -110,7 +121,9 @@ func ValidateEnvironment(repoRoot string, variables Variables) EnvironmentValida
 
 // promptsWithValues updates slice of prompts with values from .env file contents
 // and environment variables (environment variables take precedence).
-func promptsWithValues(prompts []UserPrompt, variables Variables) []UserPrompt {
+// When includeEnv is false, OS environment variables are ignored and only
+// .env file values (plus defaults and viper config) are used.
+func promptsWithValues(prompts []UserPrompt, variables Variables, includeEnv bool) []UserPrompt {
 	// Special handling for PULUMI_CONFIG_PASSPHRASE from viper config
 	// This happens regardless of whether variables exist
 	for p := range prompts {
@@ -130,22 +143,38 @@ func promptsWithValues(prompts []UserPrompt, variables Variables) []UserPrompt {
 	}
 
 	for p, prompt := range prompts {
-		// Capture existing env var values (highest priority)
-		if existingEnvValue, ok := os.LookupEnv(prompt.Env); ok {
-			prompt.Value = existingEnvValue
-		} else if v, found := variables.find(prompt); found {
-			// .env file value overrides viper config
-			prompt.Value = v.Value
-			prompt.Commented = v.Commented
-		} else if prompt.Value == "" {
-			// Only fall back to default if nothing else (including viper config) set a value
-			prompt.Value = prompt.Default
-		}
-
-		prompts[p] = prompt
+		prompts[p] = resolvePromptValue(prompt, variables, includeEnv)
 	}
 
 	return prompts
+}
+
+// resolvePromptValue determines the effective value for a prompt based on
+// .env file contents and optionally OS environment variables.
+func resolvePromptValue(prompt UserPrompt, variables Variables, includeEnv bool) UserPrompt {
+	if includeEnv {
+		// Capture existing env var values (highest priority)
+		if existingEnvValue, ok := os.LookupEnv(prompt.Env); ok {
+			prompt.Value = existingEnvValue
+
+			return prompt
+		}
+	}
+
+	if v, found := variables.find(prompt); found {
+		// .env file value overrides viper config
+		prompt.Value = v.Value
+		prompt.Commented = v.Commented
+
+		return prompt
+	}
+
+	if prompt.Value == "" {
+		// Only fall back to default if nothing else (including viper config) set a value
+		prompt.Value = prompt.Default
+	}
+
+	return prompt
 }
 
 func indexByName(value string) func(v Variable) bool {

--- a/internal/envbuilder/validator.go
+++ b/internal/envbuilder/validator.go
@@ -128,13 +128,7 @@ func promptsWithValues(prompts []UserPrompt, variables Variables, includeEnv boo
 	// This happens regardless of whether variables exist
 	for p := range prompts {
 		if prompts[p].Env == "PULUMI_CONFIG_PASSPHRASE" {
-			// Check if already set in environment
-			if _, ok := os.LookupEnv(prompts[p].Env); !ok {
-				// Not in environment, check viper config
-				if configValue := viperx.GetString("pulumi_config_passphrase"); configValue != "" {
-					prompts[p].Value = configValue
-				}
-			}
+			prompts[p].Value = resolvePulumiPassphrase(prompts[p].Value, includeEnv)
 		}
 	}
 
@@ -147,6 +141,30 @@ func promptsWithValues(prompts []UserPrompt, variables Variables, includeEnv boo
 	}
 
 	return prompts
+}
+
+// resolvePulumiPassphrase determines the PULUMI_CONFIG_PASSPHRASE value.
+// In file-only mode, always check viper config. Otherwise, prefer OS env over viper.
+func resolvePulumiPassphrase(currentValue string, includeEnv bool) string {
+	if !includeEnv {
+		// File-only mode: ignore OS env, always check viper config
+		if configValue := viperx.GetString("pulumi_config_passphrase"); configValue != "" {
+			return configValue
+		}
+
+		return currentValue
+	}
+
+	// Normal mode: check OS env first, then viper config
+	if _, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE"); ok {
+		return currentValue
+	}
+
+	if configValue := viperx.GetString("pulumi_config_passphrase"); configValue != "" {
+		return configValue
+	}
+
+	return currentValue
 }
 
 // resolvePromptValue determines the effective value for a prompt based on

--- a/internal/envbuilder/validator.go
+++ b/internal/envbuilder/validator.go
@@ -86,23 +86,29 @@ func (r EnvironmentValidationError) Error() string {
 // 2. Validates all required UserPrompts in active sections
 // 3. Validates core DataRobot variables (DATAROBOT_ENDPOINT, DATAROBOT_API_TOKEN).
 func ValidateEnvironment(repoRoot string, variables Variables) EnvironmentValidationError {
-	return validateEnvironment(repoRoot, variables, true)
+	return validateEnvironment(repoRoot, variables, true, true)
 }
 
-// ValidateEnvironmentFileOnly validates that all required environment variables are set
-// using only the .env file contents, ignoring OS environment variables. This is used
-// for --if-needed skip checks where we want to know whether the .env file itself is complete.
+// ValidateEnvironmentFileOnly validates that all required environment variables are present
+// as effective, uncommented entries in the .env file. It ignores OS environment variables,
+// YAML defaults, and auto-generated secrets, so a variable that is satisfied only by a
+// default or a generated value does not count as present. This is used for --if-needed
+// skip checks where we want to know whether the .env file itself is complete.
+//
+// The PULUMI_CONFIG_PASSPHRASE viper-config value is an intentional non-file exception
+// (see resolvePulumiPassphrase); it counts as present even though it is stored in the CLI
+// config rather than the .env file.
 func ValidateEnvironmentFileOnly(repoRoot string, variables Variables) EnvironmentValidationError {
-	return validateEnvironment(repoRoot, variables, false)
+	return validateEnvironment(repoRoot, variables, false, false)
 }
 
-func validateEnvironment(repoRoot string, variables Variables, includeEnv bool) EnvironmentValidationError {
+func validateEnvironment(repoRoot string, variables Variables, includeEnv, synthesize bool) EnvironmentValidationError {
 	result := EnvironmentValidationError{
 		Results: make([]ValidationResult, 0),
 	}
 
 	// Gather all user prompts from the repository
-	userPrompts, err := gatherUserPrompts(repoRoot, variables, includeEnv)
+	userPrompts, err := gatherUserPrompts(repoRoot, variables, includeEnv, synthesize)
 	if err != nil {
 		result.Results = append(result.Results, ValidationResult{
 			Field:   "prompts",
@@ -123,7 +129,9 @@ func validateEnvironment(repoRoot string, variables Variables, includeEnv bool) 
 // and environment variables (environment variables take precedence).
 // When includeEnv is false, OS environment variables are ignored and only
 // .env file values (plus defaults and viper config) are used.
-func promptsWithValues(prompts []UserPrompt, variables Variables, includeEnv bool) []UserPrompt {
+// When synthesize is false (presence-only mode), commented .env entries count as
+// absent and YAML defaults are not applied.
+func promptsWithValues(prompts []UserPrompt, variables Variables, includeEnv, synthesize bool) []UserPrompt {
 	// Special handling for PULUMI_CONFIG_PASSPHRASE from viper config
 	// This happens regardless of whether variables exist
 	for p := range prompts {
@@ -137,7 +145,7 @@ func promptsWithValues(prompts []UserPrompt, variables Variables, includeEnv boo
 	}
 
 	for p, prompt := range prompts {
-		prompts[p] = resolvePromptValue(prompt, variables, includeEnv)
+		prompts[p] = resolvePromptValue(prompt, variables, includeEnv, synthesize)
 	}
 
 	return prompts
@@ -169,7 +177,10 @@ func resolvePulumiPassphrase(currentValue string, includeEnv bool) string {
 
 // resolvePromptValue determines the effective value for a prompt based on
 // .env file contents and optionally OS environment variables.
-func resolvePromptValue(prompt UserPrompt, variables Variables, includeEnv bool) UserPrompt {
+// In presence-only mode (synthesize false), commented .env entries are treated as
+// absent and YAML defaults are not applied, so only an uncommented file entry (or the
+// PULUMI_CONFIG_PASSPHRASE viper-config exception) can satisfy the prompt.
+func resolvePromptValue(prompt UserPrompt, variables Variables, includeEnv, synthesize bool) UserPrompt {
 	if includeEnv {
 		// Capture existing env var values (highest priority)
 		if existingEnvValue, ok := os.LookupEnv(prompt.Env); ok {
@@ -180,6 +191,13 @@ func resolvePromptValue(prompt UserPrompt, variables Variables, includeEnv bool)
 	}
 
 	if v, found := variables.find(prompt); found {
+		// In presence-only mode, a commented .env entry counts as absent: leave Value
+		// unset so the prompt fails validation. Any prior value (e.g. the PULUMI
+		// passphrase from viper config) is preserved.
+		if !synthesize && v.Commented {
+			return prompt
+		}
+
 		// .env file value overrides viper config
 		prompt.Value = v.Value
 		prompt.Commented = v.Commented
@@ -187,8 +205,9 @@ func resolvePromptValue(prompt UserPrompt, variables Variables, includeEnv bool)
 		return prompt
 	}
 
-	if prompt.Value == "" {
-		// Only fall back to default if nothing else (including viper config) set a value
+	// Only apply YAML defaults when synthesizing; in presence-only mode an absent
+	// variable stays absent.
+	if synthesize && prompt.Value == "" {
 		prompt.Value = prompt.Default
 	}
 

--- a/internal/envbuilder/validator_test.go
+++ b/internal/envbuilder/validator_test.go
@@ -152,7 +152,7 @@ func TestPromptsWithValues(t *testing.T) {
 			{Env: "VAR2"},
 		}
 
-		result := promptsWithValues(prompts, variables, true)
+		result := promptsWithValues(prompts, variables, true, true)
 
 		if result[0].Value != "value1" {
 			t.Errorf("Expected VAR1 to be 'value1', got '%s'", result[0].Value)
@@ -177,7 +177,7 @@ func TestPromptsWithValues(t *testing.T) {
 			{Env: "TEST_OVERRIDE"},
 		}
 
-		result := promptsWithValues(prompts, variables, true)
+		result := promptsWithValues(prompts, variables, true, true)
 
 		if result[0].Value != "from-env" {
 			t.Errorf("Expected TEST_OVERRIDE to be overridden to 'from-env', got '%s'", result[0].Value)
@@ -194,7 +194,7 @@ func TestPromptsWithValues(t *testing.T) {
 			{Env: "PULUMI_CONFIG_PASSPHRASE", Default: "default-pass"},
 		}
 
-		result := promptsWithValues(prompts, variables, true)
+		result := promptsWithValues(prompts, variables, true, true)
 
 		// When variables is empty and viper config is not set, should remain empty
 		// This allows proper validation - the value will be filled from viper when it exists
@@ -213,7 +213,7 @@ func TestPromptsWithValues(t *testing.T) {
 			{Name: "PULUMI_CONFIG_PASSPHRASE", Value: "from-dotenv"},
 		}
 
-		result := promptsWithValues(prompts, variables, true)
+		result := promptsWithValues(prompts, variables, true, true)
 
 		if result[0].Value != "from-dotenv" {
 			t.Errorf("Expected .env value 'from-dotenv' to override viper config, got '%s'", result[0].Value)
@@ -234,7 +234,7 @@ func TestPromptsWithValues(t *testing.T) {
 			{Name: "PULUMI_CONFIG_PASSPHRASE", Value: "from-dotenv"},
 		}
 
-		result := promptsWithValues(prompts, variables, true)
+		result := promptsWithValues(prompts, variables, true, true)
 
 		if result[0].Value != "from-env" {
 			t.Errorf("Expected env var 'from-env' to take highest priority, got '%s'", result[0].Value)
@@ -355,7 +355,7 @@ func TestValidatePrompts(t *testing.T) {
 
 		prompts = promptsWithValues(prompts, []Variable{
 			{Name: "REQUIRED_VAR", Value: "value"},
-		}, true)
+		}, true, true)
 
 		result := &EnvironmentValidationError{
 			Results: make([]ValidationResult, 0),

--- a/internal/envbuilder/validator_test.go
+++ b/internal/envbuilder/validator_test.go
@@ -152,7 +152,7 @@ func TestPromptsWithValues(t *testing.T) {
 			{Env: "VAR2"},
 		}
 
-		result := promptsWithValues(prompts, variables)
+		result := promptsWithValues(prompts, variables, true)
 
 		if result[0].Value != "value1" {
 			t.Errorf("Expected VAR1 to be 'value1', got '%s'", result[0].Value)
@@ -177,7 +177,7 @@ func TestPromptsWithValues(t *testing.T) {
 			{Env: "TEST_OVERRIDE"},
 		}
 
-		result := promptsWithValues(prompts, variables)
+		result := promptsWithValues(prompts, variables, true)
 
 		if result[0].Value != "from-env" {
 			t.Errorf("Expected TEST_OVERRIDE to be overridden to 'from-env', got '%s'", result[0].Value)
@@ -194,7 +194,7 @@ func TestPromptsWithValues(t *testing.T) {
 			{Env: "PULUMI_CONFIG_PASSPHRASE", Default: "default-pass"},
 		}
 
-		result := promptsWithValues(prompts, variables)
+		result := promptsWithValues(prompts, variables, true)
 
 		// When variables is empty and viper config is not set, should remain empty
 		// This allows proper validation - the value will be filled from viper when it exists
@@ -213,7 +213,7 @@ func TestPromptsWithValues(t *testing.T) {
 			{Name: "PULUMI_CONFIG_PASSPHRASE", Value: "from-dotenv"},
 		}
 
-		result := promptsWithValues(prompts, variables)
+		result := promptsWithValues(prompts, variables, true)
 
 		if result[0].Value != "from-dotenv" {
 			t.Errorf("Expected .env value 'from-dotenv' to override viper config, got '%s'", result[0].Value)
@@ -234,7 +234,7 @@ func TestPromptsWithValues(t *testing.T) {
 			{Name: "PULUMI_CONFIG_PASSPHRASE", Value: "from-dotenv"},
 		}
 
-		result := promptsWithValues(prompts, variables)
+		result := promptsWithValues(prompts, variables, true)
 
 		if result[0].Value != "from-env" {
 			t.Errorf("Expected env var 'from-env' to take highest priority, got '%s'", result[0].Value)
@@ -355,7 +355,7 @@ func TestValidatePrompts(t *testing.T) {
 
 		prompts = promptsWithValues(prompts, []Variable{
 			{Name: "REQUIRED_VAR", Value: "value"},
-		})
+		}, true)
 
 		result := &EnvironmentValidationError{
 			Results: make([]ValidationResult, 0),


### PR DESCRIPTION
## RATIONALE

`dr dotenv setup --if-needed` was skipping the wizard when `.env` existed but was incomplete, leaving `.env` incomplete and causing downstream failures (e.g., deployment issues reported in CFX-6414).

Two root causes, both in the skip check (`shouldSkipSetup`):

1. **OS environment leak:** `shouldSkipSetup` used `ValidateEnvironment`, which checks both `.env` file values and `os.LookupEnv`. Environment variables satisfied validation even when `.env` was missing core variables, so the wizard never ran and `.env` was never populated.
2. **Synthesis leak:** even after switching to a file-only validator, `gatherUserPrompts` still applied YAML `default` values, ran `ApplyGeneratedValues` (auto-generating secrets), and `Valid()` accepted non-empty commented entries. A required variable satisfied only by a default, a generated secret, or a commented-out `.env` line could make the skip check pass, leaving `.env` incomplete.

## CHANGES

- Added `ValidateEnvironmentFileOnly` to validate `.env` contents only, ignoring OS environment variables.
- Updated `shouldSkipSetup` to use `ValidateEnvironmentFileOnly` so `--if-needed` skips only when `.env` itself is complete.
- Made `ValidateEnvironmentFileOnly` **presence-only**: it no longer applies YAML defaults, does not run `ApplyGeneratedValues`, and treats commented-out `.env` entries as absent. A required variable now counts as present only if it has an effective, uncommented value in the `.env` file.
- Threaded a `synthesize` flag through `gatherUserPrompts` / `validateEnvironment` / `promptsWithValues` / `resolvePromptValue`. `GatherUserPrompts` and `ValidateEnvironment` keep `synthesize=true` (unchanged behavior); `ValidateEnvironmentFileOnly` uses `synthesize=false`.
- Removed the unused `GatherUserPromptsFromFile` public wrapper; the `includeEnv`/`synthesize` distinction stays private to the `envbuilder` package.
- Refactored `promptsWithValues` to accept `includeEnv`/`synthesize` flags and extracted `resolvePromptValue` to reduce cyclomatic complexity.
- The `PULUMI_CONFIG_PASSPHRASE` viper-config value remains an intentional non-file exception (`resolvePulumiPassphrase`), documented as such.
- Regression tests cover the OS-env case and the three synthesis leaks (YAML default, generated secret, commented entry) plus a positive control.

## BEHAVIOR CHANGE NOTE

`dr dotenv setup --if-needed` now runs the wizard in three cases where it previously skipped (exit 0): a required var satisfied only by a YAML `default`, a required `generate: true` secret absent from `.env`, and a required var commented out in `.env`. This is a bug fix (the `.env` was incomplete), but it is an observable change to a user-facing flag.

For **automation/CI** that runs `dr dotenv setup --if-needed` non-interactively, pair it with `--yes` (or `DATAROBOT_CLI_NON_INTERACTIVE=true`) so the wizard runs headless and writes the missing values, then exits 0. A script using `--if-needed` without `--yes` that previously got a silent skip for one of these cases will now launch the wizard and block on a prompt.

`dr dotenv validate` is unchanged — it still uses `ValidateEnvironment` (`synthesize=true`), so a var satisfied only by a default still passes `validate`.

## TESTING

- `go test ./cmd/dotenv/... ./internal/envbuilder/... -count=1 -race` — all pass, including `TestShouldSkipSetup_PresenceOnly` (3 leak cases + positive control).
- `task lint` — clean across linux/darwin/windows.
- Manual CLI exercise of 7 scenarios (baseline skip, missing core var, OS-env-doesn't-satisfy, YAML-default-doesn't-satisfy, commented-doesn't-satisfy, `validate` unchanged) — all pass.

## RELATED

- JIRA: CFX-6414
- Slack thread: https://datarobot.slack.com/archives/C0AKJ3SUF55/p1786416272909369
- Related: CFX-7263 / PR #751 (fail on bad env credentials) — complementary at the auth layer; #750 makes the `.env` genuinely complete so #751's "complete env pair = authoritative" rule fires on correct data.

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1786484545.831279 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when dotenv setup is skipped in automation paths; incorrect skip behavior previously caused deployment failures, so regressions here could reintroduce incomplete `.env` files or force unexpected wizard runs.
>
> **Overview**
> Fixes `dr dotenv setup --if-needed` skipping the wizard when required vars were present only in the OS environment, leaving `.env` incomplete and breaking downstream deploys.
>
> `shouldSkipSetup` now uses new **file-only** validation (`ValidateEnvironmentFileOnly` / `GatherUserPromptsFromFile`) that ignores `os.LookupEnv`, so an incomplete `.env` still triggers setup. Prompt value resolution was refactored with an `includeEnv` flag and `resolvePromptValue`, and a regression test covers the env-var-only case.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac8d5d7d6267ccfbd456f2bcd83d9b46a0f7e490. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
