### PR TITLE
[RAPTOR-18975] feat(workload): add dr workload config, flags-only

### DIFF
--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -75,6 +75,7 @@ func TestTelemetryWiring_AllCoreCommandsTracked(t *testing.T) {
 // findCommandByPath matches against the root's Name(), which is
 // "workload" for the standalone subtree.
 var expectedWorkloadTrackedCommands = []string{
+	"workload config",
 	"workload create",
 	"workload get",
 	"workload list",

--- a/cmd/workload/cmd.go
+++ b/cmd/workload/cmd.go
@@ -15,6 +15,7 @@
 package workload
 
 import (
+	"github.com/datarobot/cli/cmd/workload/config"
 	"github.com/datarobot/cli/cmd/workload/create"
 	"github.com/datarobot/cli/cmd/workload/del"
 	"github.com/datarobot/cli/cmd/workload/endpoint"
@@ -44,6 +45,7 @@ Manage and monitor workloads in your deployment infrastructure.`,
 	cmd.AddCommand(
 		// The workload itself is the primary resource: direct verbs, like
 		// `dr pipeline create|get|...`.
+		config.Cmd(),
 		create.Cmd(),
 		del.Cmd(),
 		endpoint.Cmd(),

--- a/cmd/workload/cmd.go
+++ b/cmd/workload/cmd.go
@@ -43,9 +43,13 @@ Manage and monitor workloads in your deployment infrastructure.`,
 	features.SetGate(cmd, "workload")
 
 	cmd.AddCommand(
+		// Setup, and the one subcommand here that never calls the API: it
+		// writes the committed .datarobot.yaml that `up` deploys from. Listed
+		// apart from the verbs below so it does not read as one of them.
+		config.Cmd(),
+
 		// The workload itself is the primary resource: direct verbs, like
 		// `dr pipeline create|get|...`.
-		config.Cmd(),
 		create.Cmd(),
 		del.Cmd(),
 		endpoint.Cmd(),

--- a/cmd/workload/config/cmd.go
+++ b/cmd/workload/config/cmd.go
@@ -21,8 +21,10 @@ package config
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config/viperx"
@@ -45,6 +47,15 @@ type configResult struct {
 	// Action is created, unchanged or planned. A caller keying on it has to be
 	// able to tell a dry run's planned from a file that now exists.
 	Action string `json:"action"`
+	// EnvKeysListed is how many .env variables the file carries and
+	// EnvSecretsPending how many of those still name the placeholder instead
+	// of a credential id. Without them a pipeline reading only this envelope
+	// would see a created manifest and no sign that it cannot deploy yet.
+	EnvKeysListed     int `json:"envKeysListed"`
+	EnvSecretsPending int `json:"envSecretsPending"`
+	// EnvLiterals names the variables whose values the file carries in the
+	// clear, so an audit step can check them without parsing the YAML.
+	EnvLiterals []string `json:"envLiterals"`
 }
 
 // flags is the flag set, held together so the run path reads as one answer
@@ -124,7 +135,14 @@ Examples:
 
 func addFlags(cmd *cobra.Command, f *flags) {
 	cmd.Flags().StringVar(&f.dir, "dir", "", "Project directory (default: current directory).")
-	cmd.Flags().BoolVarP(&f.yes, "yes", "y", false, "Do not prompt; answer every question from flags and defaults.")
+	// Not the --yes of `dr dotenv setup`, which invents an answer for
+	// everything it was not given. Here the flags are the answers, and the
+	// only guessing is what the project directory can be read for, so the
+	// help text has to say that rather than leave "defaults" to be read as
+	// the other command's meaning.
+	cmd.Flags().BoolVarP(&f.yes, "yes", "y", false,
+		"Do not prompt; answer every question from flags and what the project directory shows. "+
+			"A question neither of those answers is an error naming the flag that would settle it.")
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "Print the manifest and write nothing.")
 	cmd.Flags().BoolVar(&f.answers.SkipEnv, "skip-env", false,
 		"Do not carry the project's .env into the manifest. By default its variables are written there: "+
@@ -212,12 +230,15 @@ func checkDockerfileFlag(cmd *cobra.Command, path string) error {
 func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, result wizard.Result) error {
 	if format == outputformat.OutputFormatJSON {
 		return outputformat.PrintJSONEnvelope(cmd.OutOrStdout(), "config", configResult{
-			Path:       result.Path,
-			Name:       result.Draft.Name,
-			WorkloadID: result.Draft.WorkloadID,
-			CreateOnUp: result.Draft.WorkloadID == "",
-			BuildMode:  result.Draft.Build.Mode,
-			Action:     result.Action,
+			Path:              result.Path,
+			Name:              result.Draft.Name,
+			WorkloadID:        result.Draft.WorkloadID,
+			CreateOnUp:        result.Draft.WorkloadID == "",
+			BuildMode:         result.Draft.Build.Mode,
+			Action:            result.Action,
+			EnvKeysListed:     result.EnvKeysListed,
+			EnvSecretsPending: result.EnvSecretsPending,
+			EnvLiterals:       literalNames(result.Draft.EnvVars),
 		})
 	}
 
@@ -236,6 +257,8 @@ func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, resul
 			fmt.Fprintf(stderr, "  %d %s from %s added%s.\n",
 				result.EnvKeysListed, wizard.Plural(result.EnvKeysListed, "variable", "variables"),
 				wizard.EnvFileName, secretSuffix(result.EnvSecretsPending))
+
+			warnLiterals(stderr, result.Draft.EnvVars)
 		}
 
 		fmt.Fprint(stderr, "\nNext: dr workload up\n")
@@ -245,6 +268,48 @@ func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, resul
 	fmt.Fprintln(cmd.OutOrStdout(), result.Path)
 
 	return nil
+}
+
+// literalListLimit caps how many names are printed, because a long .env
+// would bury the summary the list is there to qualify.
+const literalListLimit = 8
+
+// literalNames is the variables whose values the manifest carries in the
+// clear. The classifier prefers to call a doubtful value secret, but it is
+// still a heuristic: a short secret under an ordinary name reads as
+// configuration, and its value goes into a file meant to be committed.
+func literalNames(vars []manifest.EnvVar) []string {
+	names := make([]string, 0, len(vars))
+
+	for _, v := range vars {
+		if !v.Secret {
+			names = append(names, v.Name)
+		}
+	}
+
+	return names
+}
+
+// warnLiterals names those variables. Nothing prompts on a headless run and
+// the classifier's verdict is final there, so this listing is the only chance
+// the user gets to catch a misread before the file is committed. Names only:
+// the values are the thing being protected.
+func warnLiterals(stderr io.Writer, vars []manifest.EnvVar) {
+	names := literalNames(vars)
+	if len(names) == 0 {
+		return
+	}
+
+	shown := names
+	suffix := ""
+
+	if len(names) > literalListLimit {
+		shown = names[:literalListLimit]
+		suffix = fmt.Sprintf(" and %d more", len(names)-literalListLimit)
+	}
+
+	fmt.Fprintf(stderr, "  Values written in the clear: %s%s. Anything secret among them belongs in a %s reference instead.\n",
+		strings.Join(shown, ", "), suffix, manifest.CredentialShorthandPrefix)
 }
 
 // secretSuffix names the entries that still need a credential id, because a

--- a/cmd/workload/config/cmd.go
+++ b/cmd/workload/config/cmd.go
@@ -42,7 +42,8 @@ type configResult struct {
 	// is created by the first `dr workload up`.
 	CreateOnUp bool   `json:"createOnUp"`
 	BuildMode  string `json:"buildMode"`
-	// Action is created or unchanged.
+	// Action is created, unchanged or planned. A caller keying on it has to be
+	// able to tell a dry run's planned from a file that now exists.
 	Action string `json:"action"`
 }
 

--- a/cmd/workload/config/cmd.go
+++ b/cmd/workload/config/cmd.go
@@ -1,0 +1,258 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config implements `dr workload config`: the setup wizard that
+// writes the committed .datarobot.yaml `dr workload up` deploys from. The
+// command is the shell; the flow itself lives in internal/workload/wizard so
+// `up` can run the identical wizard when it finds no manifest.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/datarobot/cli/internal/workload/wizard"
+	"github.com/spf13/cobra"
+)
+
+// configResult is the stable JSON shape emitted by --output-format json.
+type configResult struct {
+	Path       string `json:"path"`
+	Name       string `json:"name"`
+	WorkloadID string `json:"workloadId"`
+	// CreateOnUp is true when no existing workload was bound, so the workload
+	// is created by the first `dr workload up`.
+	CreateOnUp bool   `json:"createOnUp"`
+	BuildMode  string `json:"buildMode"`
+	// Action is created or unchanged.
+	Action string `json:"action"`
+}
+
+// flags is the flag set, held together so the run path reads as one answer
+// set rather than eighteen lookups.
+type flags struct {
+	dir        string
+	dockerfile string
+	dryRun     bool
+	yes        bool
+	answers    wizard.Answers
+}
+
+func Cmd() *cobra.Command {
+	var (
+		outputFormat outputformat.OutputFormat
+		f            flags
+	)
+
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Set up this project for `dr workload up`.",
+		Long: `Answer a handful of questions and write the committed .datarobot.yaml
+that 'dr workload up' deploys from.
+
+The file is the platform's own workload-create spec, plus the workloadId
+binding the CLI manages for you. Setup is a one-time act: with a manifest
+already present, this command prints its path and exits, because editing
+twelve lines of YAML beats re-answering eight questions. Delete the file to
+start over.
+
+Defaults come from wherever the truth already lives: a Dockerfile and its
+EXPOSE line for a fresh project, the workload's own live spec when you bind
+to one. Binding downloads that spec into the file, so a deploy from it
+cannot quietly downgrade something already running.
+
+Without a terminal, or with --yes or --output-format json, nothing prompts:
+the flags answer every question and a missing one is an error that names it.
+The Dockerfile track needs no flags at all when ./Dockerfile exists.
+
+Examples:
+  dr workload config
+  dr workload config --yes --name my-app
+  dr workload config --yes --build-mode image --image registry/team/app:v1
+  dr workload config --yes --build-mode generated \
+    --execution-environment "[DataRobot] Python 3.12 Applications Base" \
+    --entrypoint "uvicorn app:app --host 0.0.0.0 --port 8080"`,
+		Args:         cobra.NoArgs,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			return run(cmd, f, outputFormat)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+	addFlags(cmd, &f)
+
+	// Only the env var binds to viper; --yes is read from cobra so it never
+	// persists into drconfig.yaml.
+	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		return map[string]any{
+			"yes":           f.yes || viperx.GetBool("yes"),
+			"type":          f.answers.Type,
+			"build_mode":    f.answers.BuildMode,
+			"bound":         f.answers.WorkloadID != "",
+			"dry_run":       f.dryRun,
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}
+
+func addFlags(cmd *cobra.Command, f *flags) {
+	cmd.Flags().StringVar(&f.dir, "dir", "", "Project directory (default: current directory).")
+	cmd.Flags().BoolVarP(&f.yes, "yes", "y", false, "Do not prompt; answer every question from flags and defaults.")
+	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "Print the manifest and write nothing.")
+	cmd.Flags().BoolVar(&f.answers.SkipEnv, "skip-env", false,
+		"Do not carry the project's .env into the manifest. By default its variables are written there: "+
+			"ordinary values as literals, secrets as credential references you complete later.")
+
+	cmd.Flags().StringVar(&f.answers.WorkloadID, "workload-id", "", "Bind an existing workload by id. Exclusive with --name.")
+	cmd.Flags().StringVar(&f.answers.Name, "name", "", "Name a new workload, created by the first `dr workload up`.")
+	cmd.Flags().StringVar(&f.answers.Type, "type", "", "Workload kind: service or agent (default service).")
+	cmd.Flags().BoolVar(&f.answers.A2AEnabled, "a2a-enabled", false,
+		"Agent only: publish the app's A2A agent card to the tenant-wide agent registry.")
+
+	cmd.Flags().StringVar(&f.answers.BuildMode, "build-mode", "", "Image source: dockerfile, generated or image.")
+	cmd.Flags().StringVar(&f.dockerfile, "dockerfile", wizard.DefaultDockerfilePath,
+		"Dockerfile to build. Only the project root's ./Dockerfile is supported.")
+	cmd.Flags().StringVar(&f.answers.ExecutionEnvironment, "execution-environment", "",
+		"Base image, by name or id. Required with --build-mode generated.")
+	cmd.Flags().StringVar(&f.answers.Entrypoint, "entrypoint", "",
+		"Command that starts the app, parsed shell-style. Required with --build-mode generated.")
+	cmd.Flags().StringVar(&f.answers.Image, "image", "", "Published image URI. Required with --build-mode image.")
+
+	cmd.Flags().IntVar(&f.answers.Port, "port", 0, "Container port (default: the Dockerfile's EXPOSE, else 8080).")
+	cmd.Flags().StringVar(&f.answers.HealthPath, "health", "", "Readiness path (default /health).")
+
+	cmd.Flags().IntVar(&f.answers.Replicas, "replicas", 0, "Replica count (default 1).")
+	cmd.Flags().Float64Var(&f.answers.CPU, "cpu", 0, "CPU per replica (default 0.5).")
+	cmd.Flags().StringVar(&f.answers.Memory, "memory", "", "Memory per replica (default 512MB).")
+}
+
+func run(cmd *cobra.Command, f flags, format outputformat.OutputFormat) error {
+	if err := checkDockerfileFlag(cmd, f.dockerfile); err != nil {
+		return err
+	}
+
+	dir := f.dir
+	if dir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("cannot determine the current directory: %w", err)
+		}
+
+		dir = cwd
+	}
+
+	// JSON output implies non-interactive: a wizard on stderr alongside a
+	// machine-readable stdout is a trap for whoever is parsing it.
+	yes := f.yes || viperx.GetBool("yes")
+
+	result, err := wizard.Run(wizard.Options{
+		Dir:            dir,
+		NonInteractive: yes || format == outputformat.OutputFormatJSON,
+		DryRun:         f.dryRun,
+		Answers:        f.answers,
+		Stderr:         cmd.ErrOrStderr(),
+	})
+	if err != nil {
+		if errors.Is(err, wizard.ErrCancelled) {
+			// Nothing was written, and the nonzero exit is what stops
+			// `dr workload config && dr workload up`.
+			return errors.New("cancelled: nothing was written")
+		}
+
+		return err
+	}
+
+	return render(cmd, f, format, result)
+}
+
+// checkDockerfileFlag holds --dockerfile to the one path a build can use.
+// The flag exists so the answer is explicit rather than mysteriously
+// ineffective, and so pointing it elsewhere fails here instead of at build
+// time.
+func checkDockerfileFlag(cmd *cobra.Command, path string) error {
+	if !cmd.Flags().Changed("dockerfile") || path == wizard.DefaultDockerfilePath {
+		return nil
+	}
+
+	if filepath.Clean(path) == wizard.DockerfileName {
+		return nil
+	}
+
+	return fmt.Errorf("--dockerfile %q is not supported: builds use the %s at the project root. "+
+		"Point --dir at the directory that holds it", path, wizard.DockerfileName)
+}
+
+func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, result wizard.Result) error {
+	if format == outputformat.OutputFormatJSON {
+		return outputformat.PrintJSONEnvelope(cmd.OutOrStdout(), "config", configResult{
+			Path:       result.Path,
+			Name:       result.Draft.Name,
+			WorkloadID: result.Draft.WorkloadID,
+			CreateOnUp: result.Draft.WorkloadID == "",
+			BuildMode:  result.Draft.Build.Mode,
+			Action:     result.Action,
+		})
+	}
+
+	stderr := cmd.ErrOrStderr()
+
+	switch {
+	case result.Action == wizard.ActionUnchanged:
+		fmt.Fprintf(stderr, "%s already exists; edit it directly. Delete it to run setup again.\n", result.Path)
+	case f.dryRun:
+		fmt.Fprintf(stderr, "Dry run: %s was not written.\n\n", result.Path)
+		fmt.Fprint(stderr, string(result.Content))
+	default:
+		fmt.Fprintf(stderr, "✓ Wrote %s\n", wizard.ShortPath(result.Path))
+
+		if result.EnvKeysListed > 0 {
+			fmt.Fprintf(stderr, "  %d %s from %s added%s.\n",
+				result.EnvKeysListed, wizard.Plural(result.EnvKeysListed, "variable", "variables"),
+				wizard.EnvFileName, secretSuffix(result.EnvSecretsPending))
+		}
+
+		fmt.Fprint(stderr, "\nNext: dr workload up\n")
+	}
+
+	// stdout carries the path and nothing else, so it can be piped.
+	fmt.Fprintln(cmd.OutOrStdout(), result.Path)
+
+	return nil
+}
+
+// secretSuffix names the entries that still need a credential id, because a
+// bare count would read as "everything is ready to deploy".
+func secretSuffix(secrets int) string {
+	if secrets == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("; %d %s a credential id in place of %s",
+		secrets, wizard.Plural(secrets, "needs", "need"), manifest.CredentialPlaceholder)
+}

--- a/cmd/workload/config/cmd_test.go
+++ b/cmd/workload/config/cmd_test.go
@@ -18,8 +18,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/datarobot/cli/internal/workload/manifest"
@@ -222,4 +224,87 @@ func TestCmd_YesImpliesNonInteractive(t *testing.T) {
 	_, _, err := runCmd(t, "--dir", project(t), "--yes", "--name", "my-app")
 	require.NoError(t, err)
 	assert.False(t, ran)
+}
+
+// projectWithEnv is a buildable project carrying a .env, which is what puts
+// the classifier and the reporting below in play.
+func projectWithEnv(t *testing.T, env string) string {
+	t.Helper()
+
+	dir := project(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, wizard.EnvFileName), []byte(env), 0o600))
+
+	return dir
+}
+
+// A pipeline reading only the envelope has to be able to see that the file it
+// just generated names a placeholder rather than a credential, or it will
+// deploy something that cannot start.
+func TestCmd_JSONEnvelopeCarriesTheEnvCounts(t *testing.T) {
+	dir := projectWithEnv(t, "LOG_LEVEL=debug\nAPI_TOKEN=sk-live-51H8xQvZmNpKdRt7YwLbG3JfA9\n")
+
+	stdout, _, err := runCmd(t, "--dir", dir, "--name", "my-app", "--output-format", "json")
+	require.NoError(t, err)
+
+	var envelope struct {
+		Config struct {
+			EnvKeysListed     int      `json:"envKeysListed"`
+			EnvSecretsPending int      `json:"envSecretsPending"`
+			EnvLiterals       []string `json:"envLiterals"`
+		} `json:"config"`
+	}
+
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+
+	assert.Equal(t, 2, envelope.Config.EnvKeysListed)
+	assert.Equal(t, 1, envelope.Config.EnvSecretsPending)
+	assert.Equal(t, []string{"LOG_LEVEL"}, envelope.Config.EnvLiterals)
+}
+
+// The classifier prefers to call a doubtful value secret, but it is a
+// heuristic and nothing prompts on a headless run. Naming what went in as a
+// literal is the only chance to catch a misread before the file is committed.
+func TestCmd_NamesTheValuesWrittenInTheClear(t *testing.T) {
+	dir := projectWithEnv(t, "LOG_LEVEL=debug\nREGION=eu-west-1\nAPI_TOKEN=sk-live-51H8xQvZmNpKdRt7YwLbG3JfA9\n")
+
+	_, stderr, err := runCmd(t, "--dir", dir, "--yes", "--name", "my-app")
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), "Values written in the clear: LOG_LEVEL, REGION.")
+	assert.Contains(t, stderr.String(), manifest.CredentialShorthandPrefix)
+
+	// The secret is named nowhere, and its value nowhere at all.
+	assert.NotContains(t, stderr.String(), "in the clear: LOG_LEVEL, REGION, API_TOKEN")
+	assert.NotContains(t, stderr.String(), "sk-live-51H8xQvZmNpKdRt7YwLbG3JfA9")
+}
+
+// A long .env would bury the summary the listing qualifies, so it is capped
+// and the remainder counted.
+func TestCmd_CapsTheListOfLiterals(t *testing.T) {
+	var env strings.Builder
+
+	for i := range 12 {
+		fmt.Fprintf(&env, "PLAIN_%d=value%d\n", i, i)
+	}
+
+	_, stderr, err := runCmd(t, "--dir", projectWithEnv(t, env.String()), "--yes", "--name", "my-app")
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), "PLAIN_7 and 4 more.")
+	assert.NotContains(t, stderr.String(), "PLAIN_8")
+}
+
+// A .env the parser chokes on still reaches the user as a warning. The
+// parser's own message carries the rest of the file, values included, so the
+// property under test is that none of it survives to stderr.
+func TestCmd_UnparseableEnvFileLeaksNoValues(t *testing.T) {
+	dir := projectWithEnv(t, "GOOD=1\nBAD-NAME=x\nAPI_TOKEN=sk-live-do-not-print\nDB_PASSWORD=hunter2\n")
+
+	_, stderr, err := runCmd(t, "--dir", dir, "--yes", "--name", "my-app")
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), "Warning:")
+	assert.Contains(t, stderr.String(), "on line 2")
+	assert.NotContains(t, stderr.String(), "sk-live-do-not-print")
+	assert.NotContains(t, stderr.String(), "hunter2")
 }

--- a/cmd/workload/config/cmd_test.go
+++ b/cmd/workload/config/cmd_test.go
@@ -1,0 +1,225 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/datarobot/cli/internal/workload/wizard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runCmd executes the command with the auth check removed, capturing the two
+// streams separately: keeping them apart is the point of several tests below.
+func runCmd(t *testing.T, args ...string) (stdout, stderr *bytes.Buffer, err error) {
+	t.Helper()
+
+	stdout, stderr = &bytes.Buffer{}, &bytes.Buffer{}
+
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs(args)
+
+	return stdout, stderr, cmd.Execute()
+}
+
+func project(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\nEXPOSE 8080\n"), 0o600))
+
+	return dir
+}
+
+func TestCmd_WritesTheManifest(t *testing.T) {
+	dir := project(t)
+
+	stdout, stderr, err := runCmd(t, "--dir", dir, "--yes", "--name", "my-app")
+	require.NoError(t, err)
+
+	path := manifest.Path(dir)
+
+	// stdout is the path and nothing else, so it can be piped.
+	assert.Equal(t, path+"\n", stdout.String())
+	assert.Contains(t, stderr.String(), "Wrote")
+	assert.FileExists(t, path)
+}
+
+// JSON mode means stdout is JSON and only JSON: every human-facing word goes
+// to stderr, including the wizard that JSON mode suppresses entirely.
+func TestCmd_JSONEnvelope(t *testing.T) {
+	dir := project(t)
+
+	stdout, _, err := runCmd(t, "--dir", dir, "--name", "my-app", "--output-format", "json")
+	require.NoError(t, err)
+
+	var envelope struct {
+		Config struct {
+			Path       string `json:"path"`
+			Name       string `json:"name"`
+			WorkloadID string `json:"workloadId"`
+			CreateOnUp bool   `json:"createOnUp"`
+			BuildMode  string `json:"buildMode"`
+			Action     string `json:"action"`
+		} `json:"config"`
+	}
+
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+
+	assert.Equal(t, manifest.Path(dir), envelope.Config.Path)
+	assert.Equal(t, "my-app", envelope.Config.Name)
+	assert.Empty(t, envelope.Config.WorkloadID)
+	assert.True(t, envelope.Config.CreateOnUp)
+	assert.Equal(t, manifest.BuildModeDockerfile, envelope.Config.BuildMode)
+	assert.Equal(t, "created", envelope.Config.Action)
+}
+
+func TestCmd_ExistingManifestReportsUnchanged(t *testing.T) {
+	dir := project(t)
+	require.NoError(t, os.WriteFile(manifest.Path(dir), []byte("name: already-here\nartifactId: 68b0\n"), 0o600))
+
+	stdout, _, err := runCmd(t, "--dir", dir, "--name", "ignored", "--output-format", "json")
+	require.NoError(t, err)
+
+	var envelope struct {
+		Config struct {
+			Action string `json:"action"`
+		} `json:"config"`
+	}
+
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &envelope))
+	assert.Equal(t, "unchanged", envelope.Config.Action)
+}
+
+func TestCmd_DryRunWritesNothing(t *testing.T) {
+	dir := project(t)
+
+	_, stderr, err := runCmd(t, "--dir", dir, "--yes", "--name", "my-app", "--dry-run")
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), "Dry run")
+	assert.Contains(t, stderr.String(), "name: my-app")
+	assert.NoFileExists(t, manifest.Path(dir))
+}
+
+// The flag exists so pointing it elsewhere fails here, with the reason,
+// rather than being quietly ignored.
+func TestCmd_DockerfileFlagIsPinned(t *testing.T) {
+	dir := project(t)
+
+	_, _, err := runCmd(t, "--dir", dir, "--yes", "--name", "my-app", "--dockerfile", "docker/Dockerfile")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "is not supported")
+	assert.NoFileExists(t, manifest.Path(dir))
+
+	// The value it does accept is the one it defaults to.
+	_, _, err = runCmd(t, "--dir", dir, "--yes", "--name", "my-app", "--dockerfile", "./Dockerfile")
+	require.NoError(t, err)
+}
+
+func TestCmd_RejectsBadFlagCombinations(t *testing.T) {
+	dir := project(t)
+
+	tests := map[string][]string{
+		"id and name":       {"--workload-id", "68b0", "--name", "my-app"},
+		"unsupported type":  {"--name", "my-app", "--type", "nim"},
+		"bad build mode":    {"--name", "my-app", "--build-mode", "magic"},
+		"relative health":   {"--name", "my-app", "--health", "health"},
+		"privileged port":   {"--name", "my-app", "--port", "80"},
+		"image mode no uri": {"--name", "my-app", "--build-mode", "image"},
+	}
+
+	for name, args := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := runCmd(t, append([]string{"--dir", dir, "--yes"}, args...)...)
+			require.Error(t, err)
+			assert.NoFileExists(t, manifest.Path(dir))
+		})
+	}
+}
+
+func TestCmd_RejectsPositionalArgs(t *testing.T) {
+	_, _, err := runCmd(t, "extra")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "unknown command")
+}
+
+func TestCmd_InvalidOutputFormat(t *testing.T) {
+	_, _, err := runCmd(t, "--output-format", "yaml")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), `invalid output format "yaml"`)
+}
+
+// JSON output must suppress the wizard outright. A wizard drawing alongside a
+// machine-readable stdout is a trap for whoever is parsing it, and the guard
+// is invisible under `go test` unless the terminal seam is forced.
+func TestCmd_JSONImpliesNonInteractive(t *testing.T) {
+	restoreTerminal := wizard.SetStdinTerminalForTest(true)
+	defer restoreTerminal()
+
+	var ran bool
+
+	restoreFlow := wizard.SetInteractiveFlowForTest(
+		func(wizard.Options, wizard.Detected) ([]byte, manifest.Draft, error) {
+			ran = true
+
+			return nil, manifest.Draft{}, errors.New("the wizard must not run")
+		})
+	defer restoreFlow()
+
+	_, _, err := runCmd(t, "--dir", project(t), "--name", "my-app", "--output-format", "json")
+	require.NoError(t, err)
+	assert.False(t, ran, "--output-format json must not open the wizard")
+
+	// The same run without JSON does reach it, so the assertion above is not
+	// passing for some unrelated reason.
+	ran = false
+	_, _, err = runCmd(t, "--dir", project(t), "--name", "my-app")
+	require.Error(t, err)
+	assert.True(t, ran, "an interactive run with a terminal opens the wizard")
+}
+
+// --yes suppresses it too, terminal or not.
+func TestCmd_YesImpliesNonInteractive(t *testing.T) {
+	restoreTerminal := wizard.SetStdinTerminalForTest(true)
+	defer restoreTerminal()
+
+	var ran bool
+
+	restoreFlow := wizard.SetInteractiveFlowForTest(
+		func(wizard.Options, wizard.Detected) ([]byte, manifest.Draft, error) {
+			ran = true
+
+			return nil, manifest.Draft{}, errors.New("the wizard must not run")
+		})
+	defer restoreFlow()
+
+	_, _, err := runCmd(t, "--dir", project(t), "--yes", "--name", "my-app")
+	require.NoError(t, err)
+	assert.False(t, ran)
+}

--- a/internal/workload/manifest/compile.go
+++ b/internal/workload/manifest/compile.go
@@ -23,11 +23,11 @@ import (
 )
 
 const (
-	// credentialShorthandPrefix starts the manifest's compact credential
+	// CredentialShorthandPrefix starts the manifest's compact credential
 	// value form, dr-credential:<credential-id>/<key>. The compiler rewrites
 	// it into the API's object form; the object form is accepted in the file
 	// as well.
-	credentialShorthandPrefix = "dr-credential:"
+	CredentialShorthandPrefix = "dr-credential:"
 
 	// credentialSource is the API's source discriminator for
 	// credential-backed environment variables. It mirrors the workload
@@ -127,7 +127,7 @@ func expandVarsList(value any) {
 		}
 
 		raw, ok := entry[keyValue].(string)
-		if !ok || !strings.HasPrefix(raw, credentialShorthandPrefix) {
+		if !ok || !strings.HasPrefix(raw, CredentialShorthandPrefix) {
 			continue
 		}
 
@@ -149,7 +149,7 @@ func expandVarsList(value any) {
 // its parts; ok is false when either part is empty. The key may itself
 // contain slashes: only the first one separates.
 func parseCredentialShorthand(value string) (id, key string, ok bool) {
-	rest := strings.TrimPrefix(value, credentialShorthandPrefix)
+	rest := strings.TrimPrefix(value, CredentialShorthandPrefix)
 
 	id, key, found := strings.Cut(rest, "/")
 	if !found || id == "" || key == "" {
@@ -210,7 +210,7 @@ func (c *refCollector) collectFromVars(vars *yaml.Node, path string) {
 		entryPath := fmt.Sprintf("%s[%d]", path, i)
 		name, _ := scalarString(mapValue(entry, keyName))
 
-		if value, ok := scalarString(mapValue(entry, keyValue)); ok && strings.HasPrefix(value, credentialShorthandPrefix) {
+		if value, ok := scalarString(mapValue(entry, keyValue)); ok && strings.HasPrefix(value, CredentialShorthandPrefix) {
 			c.addShorthand(mapValue(entry, keyValue), entryPath, name, value)
 			continue
 		}
@@ -227,7 +227,7 @@ func (c *refCollector) addShorthand(node *yaml.Node, path, name, value string) {
 		c.errs = append(c.errs, FieldError{
 			Path: path + "." + keyValue,
 			Line: node.Line,
-			Msg:  fmt.Sprintf("credential reference %q must be %s<credential-id>/<key>", value, credentialShorthandPrefix),
+			Msg:  fmt.Sprintf("credential reference %q must be %s<credential-id>/<key>", value, CredentialShorthandPrefix),
 		})
 
 		return

--- a/internal/workload/manifest/compile_test.go
+++ b/internal/workload/manifest/compile_test.go
@@ -112,7 +112,7 @@ artifact:
 	var payload map[string]any
 
 	require.NoError(t, json.Unmarshal(compiled.Payload, &payload))
-	assert.NotContains(t, string(compiled.Payload), credentialShorthandPrefix+"68f0")
+	assert.NotContains(t, string(compiled.Payload), CredentialShorthandPrefix+"68f0")
 
 	require.Len(t, compiled.CredentialRefs, 1)
 	assert.Equal(t, "68f0cccc0000000000000003", compiled.CredentialRefs[0].CredentialID)

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -292,7 +292,7 @@ func applyEnvVars(container map[string]any, vars []EnvVar) {
 
 		value := v.Value
 		if v.Secret {
-			value = credentialShorthandPrefix + CredentialPlaceholder + "/" + credentialKey
+			value = CredentialShorthandPrefix + CredentialPlaceholder + "/" + credentialKey
 		}
 
 		existing = append(existing, map[string]any{keyName: v.Name, keyValue: value})

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -283,14 +283,7 @@ func applyEnvVars(container map[string]any, vars []EnvVar) {
 	}
 
 	existing, _ := container[keyEnvironmentVars].([]any)
-
-	declared := make(map[string]bool, len(existing))
-
-	for _, entry := range existing {
-		if typed, ok := entry.(map[string]any); ok {
-			declared[stringAt(typed, keyName)] = true
-		}
-	}
+	declared := declaredEnvNames(existing)
 
 	for _, v := range vars {
 		if declared[v.Name] {
@@ -306,6 +299,44 @@ func applyEnvVars(container map[string]any, vars []EnvVar) {
 	}
 
 	container[keyEnvironmentVars] = existing
+}
+
+// NewEnvVars is the subset of vars that Apply would actually add: the names
+// the workload does not already declare. A caller reporting what a bind did
+// has to count these rather than everything it classified, or it claims to
+// have added variables that kept their running values.
+func (l Live) NewEnvVars(vars []EnvVar) []EnvVar {
+	container := primaryContainerOf(l.Spec)
+	if container == nil {
+		return vars
+	}
+
+	existing, _ := container[keyEnvironmentVars].([]any)
+
+	declared := declaredEnvNames(existing)
+	fresh := make([]EnvVar, 0, len(vars))
+
+	for _, v := range vars {
+		if !declared[v.Name] {
+			fresh = append(fresh, v)
+		}
+	}
+
+	return fresh
+}
+
+// declaredEnvNames is the set of variable names an environmentVars list
+// already carries.
+func declaredEnvNames(existing []any) map[string]bool {
+	declared := make(map[string]bool, len(existing))
+
+	for _, entry := range existing {
+		if typed, ok := entry.(map[string]any); ok {
+			declared[stringAt(typed, keyName)] = true
+		}
+	}
+
+	return declared
 }
 
 // applyRuntime writes the sizing answers onto the live runtime block, leaving

--- a/internal/workload/manifest/manifest.go
+++ b/internal/workload/manifest/manifest.go
@@ -95,7 +95,12 @@ func Parse(data []byte, dir string) (*Manifest, error) {
 	}
 
 	if root.Kind == 0 {
-		return nil, errors.New("file is empty")
+		// Named with its remedy because the likeliest way to get here is a
+		// write that was killed between reserving the path and filling it.
+		// The reservation is what stops two setups racing, so it is kept, and
+		// what it can leave behind is a file the user has to be told to
+		// delete rather than one they are left guessing at.
+		return nil, errors.New("file is empty, which an interrupted write can leave behind: delete it and run the command again")
 	}
 
 	if root.Kind != yaml.MappingNode {

--- a/internal/workload/manifest/manifest_test.go
+++ b/internal/workload/manifest/manifest_test.go
@@ -55,6 +55,11 @@ func TestLoad_EmptyFileRejected(t *testing.T) {
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "file is empty")
+
+	// Write reserves the path before it fills it, so a crash in between
+	// leaves exactly this file. Naming the fix is what keeps that a
+	// self-service recovery rather than a support question.
+	assert.Contains(t, err.Error(), "delete it and run the command again")
 }
 
 func TestLoad_CommentOnlyFileRejected(t *testing.T) {

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -206,14 +206,21 @@ func (d Draft) Render() ([]byte, error) {
 }
 
 // Write creates the manifest at path. It refuses to overwrite an existing
-// one, and it is all-or-nothing: a failed write leaves no file at all, rather
-// than a truncated manifest that the refuse-to-overwrite rule would then stop
-// anyone from repairing.
+// one, and no caller ever sees a truncated manifest: the content arrives
+// through an atomic rename, so the file either has all of it or does not
+// exist, and a write that fails takes its own reservation back.
 //
 // The exclusive create is what makes the refusal a check rather than a race:
 // two processes configuring the same directory cannot both believe they wrote
 // the file. It is a reservation, immediately released, so the content still
 // arrives through the atomic rename.
+//
+// The one residue this cannot clean up is a crash between the two steps,
+// which leaves the empty reservation on disk. Collapsing them into a single
+// rename would fix that and lose the exclusive create, trading a file Parse
+// rejects by name for the chance of silently replacing a manifest someone
+// else just wrote. The empty file is the better failure, so it is the one
+// kept, and Parse names the fix.
 func Write(path string, data []byte) error {
 	reservation, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, fsutil.DefaultFileMode)
 	if err != nil {
@@ -395,7 +402,7 @@ func (d Draft) environmentVars() *yaml.Node {
 		entry := []field{{key: keyName, value: scalar(v.Name)}}
 
 		if v.Secret {
-			value = scalar(credentialShorthandPrefix + CredentialPlaceholder + "/" + credentialKey)
+			value = scalar(CredentialShorthandPrefix + CredentialPlaceholder + "/" + credentialKey)
 			entry = append(entry, field{
 				key:     keyValue,
 				value:   value,

--- a/internal/workload/wizard/answers.go
+++ b/internal/workload/wizard/answers.go
@@ -1,0 +1,455 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/datarobot/cli/internal/workload/manifest"
+)
+
+// Answers is what the flags already said. Every field that is set answers its
+// question and skips that screen; what is left over is either asked or, with
+// no terminal, reported as a missing flag.
+type Answers struct {
+	// WorkloadID binds an existing workload. Exclusive with Name.
+	WorkloadID string
+	// Name names a new workload, created by the first up.
+	Name string
+	// Type is manifest.TypeService or manifest.TypeAgent.
+	Type string
+	// A2AEnabled publishes an agent's A2A card to the tenant-wide registry.
+	A2AEnabled bool
+	// BuildMode is one of the manifest.BuildMode* values.
+	BuildMode string
+	// Image is the published image URI, for BuildModeImage.
+	Image string
+	// ExecutionEnvironment names a base image by name or id, for
+	// BuildModeGenerated. It is resolved to both ids before anything is
+	// written.
+	ExecutionEnvironment string
+	// Entrypoint is the raw command line, parsed shell-style so quoted
+	// arguments survive.
+	Entrypoint string
+	Port       int
+	HealthPath string
+	Replicas   int
+	CPU        float64
+	Memory     string
+	// SkipEnv leaves the project's .env out of the manifest entirely. By
+	// default the variables are carried across, because a deploy that
+	// silently drops the app's configuration is the worse default.
+	SkipEnv bool
+}
+
+// ErrCancelled reports that the user backed out. Nothing is written and the
+// command exits nonzero, so `dr workload config && dr workload up` stops
+// here rather than deploying something nobody agreed to.
+var ErrCancelled = errors.New("cancelled")
+
+// check holds the flag combinations that cannot be resolved into a manifest,
+// whether or not a terminal is available. Combinations that are merely
+// incomplete are the headless path's business: interactively they are just
+// questions that have not been answered yet.
+func (a Answers) check() error {
+	for _, check := range []func() error{a.checkBinding, a.checkKind, a.checkImageSource, a.checkReadiness, a.checkSizing} {
+		if err := check(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (a Answers) checkBinding() error {
+	if a.WorkloadID != "" && a.Name != "" {
+		return errors.New("--workload-id and --name are exclusive: bind an existing workload or name a new one")
+	}
+
+	return nil
+}
+
+func (a Answers) checkKind() error {
+	if a.Type != "" && a.Type != manifest.TypeService && a.Type != manifest.TypeAgent {
+		return fmt.Errorf("--type %q is not supported: use %s or %s",
+			a.Type, manifest.TypeService, manifest.TypeAgent)
+	}
+
+	// The check is against the type that will be written, not against the
+	// flag: omitting --type does not turn --a2a-enabled into a service flag,
+	// it just means the default applies.
+	if a.A2AEnabled && a.effectiveType() != manifest.TypeAgent {
+		return fmt.Errorf("--a2a-enabled applies to --type %s, not %s",
+			manifest.TypeAgent, a.effectiveType())
+	}
+
+	return nil
+}
+
+// effectiveType is the kind that will be written when nothing else changes it.
+func (a Answers) effectiveType() string {
+	return orDefault(a.Type, manifest.TypeService)
+}
+
+func (a Answers) checkImageSource() error {
+	switch a.BuildMode {
+	case "", manifest.BuildModeDockerfile, manifest.BuildModeGenerated, manifest.BuildModeImage:
+		return nil
+	default:
+		return fmt.Errorf("--build-mode %q is not supported: use %s, %s or %s",
+			a.BuildMode, manifest.BuildModeDockerfile, manifest.BuildModeGenerated, manifest.BuildModeImage)
+	}
+}
+
+func (a Answers) checkReadiness() error {
+	if a.HealthPath != "" && !strings.HasPrefix(a.HealthPath, "/") {
+		return fmt.Errorf("--health %q must start with /", a.HealthPath)
+	}
+
+	if a.Port != 0 {
+		if err := checkPort(a.Port, "--port"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// checkPort holds both ends of the range. The floor is the ledger's, checked
+// here too so a bad flag is rejected by the flag rather than by the file it
+// would have produced; the ceiling is simply what a port number is.
+func checkPort(port int, source string) error {
+	switch {
+	case port > maxPort:
+		return fmt.Errorf("%s %d is not a port number: the highest is %d", source, port, maxPort)
+	case port < minPort:
+		return fmt.Errorf("%s %d is too low: the primary container runs unprivileged and must listen on %d or above",
+			source, port, minPort)
+	}
+
+	return nil
+}
+
+// checkSizing holds the runtime numbers to what a replica can be. The
+// platform would refuse these too, but only after a round trip, and a
+// negative replica count written into a committed file is a confusing thing
+// to find later.
+func (a Answers) checkSizing() error {
+	if a.Replicas < 0 {
+		return fmt.Errorf("--replicas %d is negative", a.Replicas)
+	}
+
+	if a.CPU < 0 {
+		return fmt.Errorf("--cpu %v is negative", a.CPU)
+	}
+
+	if a.Memory != "" && !manifest.ValidMemory(a.Memory) {
+		return fmt.Errorf("--memory %q is not a valid size: use a byte count or a 1000-based unit (B, KB, MB, GB)",
+			a.Memory)
+	}
+
+	return nil
+}
+
+// The range a primary container's port may fall in. The floor is the
+// manifest ledger's; below it an unprivileged container cannot bind, so the
+// workload never becomes ready.
+const (
+	minPort = 1024
+	maxPort = 65535
+)
+
+// draft answers every question from the flags and the project, and reports
+// what neither could answer. This is the headless path in full: no prompt is
+// ever attempted, and the error names the flag that would have settled it.
+func (a Answers) draft(detected Detected) (manifest.Draft, error) {
+	if err := a.check(); err != nil {
+		return manifest.Draft{}, err
+	}
+
+	name := a.Name
+	if name == "" {
+		name = detected.Name
+	}
+
+	draft := manifest.Draft{
+		WorkloadID: a.WorkloadID,
+		Name:       name,
+		Importance: manifest.DefaultImportance,
+		Type:       orDefault(a.Type, manifest.TypeService),
+		A2AEnabled: a.A2AEnabled,
+		Port:       a.Port,
+		HealthPath: orDefault(a.HealthPath, manifest.DefaultHealthPath),
+		Runtime:    a.runtime(),
+		EnvVars:    a.envVars(detected),
+	}
+
+	if draft.Port == 0 {
+		draft.Port = detected.Port
+	}
+
+	build, err := a.build(detected)
+	if err != nil {
+		return manifest.Draft{}, err
+	}
+
+	draft.Build = build
+
+	return draft, nil
+}
+
+// envVars is the .env listing the file will carry: everything the classifier
+// found by default, none when the user opted out. Local-only variables are
+// dropped, because deploying them would be wrong rather than unnecessary.
+func (a Answers) envVars(detected Detected) []manifest.EnvVar {
+	if a.SkipEnv {
+		return nil
+	}
+
+	out := make([]manifest.EnvVar, 0, len(detected.EnvVars))
+
+	for _, v := range detected.EnvVars {
+		if v.Kind == EnvLocal {
+			continue
+		}
+
+		out = append(out, manifest.EnvVar{
+			Name:   v.Name,
+			Value:  v.Value,
+			Secret: v.Kind == EnvSecret,
+		})
+	}
+
+	return out
+}
+
+func (a Answers) runtime() manifest.Runtime {
+	runtime := manifest.Runtime{
+		Replicas: a.Replicas,
+		CPU:      a.CPU,
+		Memory:   manifest.NormalizeMemory(orDefault(a.Memory, manifest.DefaultMemory)),
+	}
+
+	if runtime.Replicas == 0 {
+		runtime.Replicas = manifest.DefaultReplicas
+	}
+
+	if runtime.CPU == 0 {
+		runtime.CPU = manifest.DefaultCPU
+	}
+
+	return runtime
+}
+
+// build resolves the image source. With no --build-mode the mode follows what
+// the flags imply and then what the project shows, so the Dockerfile track
+// needs no flags at all when there is a Dockerfile to build.
+func (a Answers) build(detected Detected) (manifest.Build, error) {
+	switch a.buildMode(detected) {
+	case manifest.BuildModeDockerfile:
+		if !detected.HasDockerfile {
+			return manifest.Build{}, fmt.Errorf("--build-mode %s needs a %s in %s",
+				manifest.BuildModeDockerfile, DockerfileName, detected.Dir)
+		}
+
+		return manifest.Build{Mode: manifest.BuildModeDockerfile}, nil
+
+	case manifest.BuildModeImage:
+		if a.Image == "" {
+			return manifest.Build{}, fmt.Errorf("--image is required with --build-mode %s", manifest.BuildModeImage)
+		}
+
+		return manifest.Build{Mode: manifest.BuildModeImage, ImageURI: a.Image}, nil
+
+	case manifest.BuildModeGenerated:
+		return a.generatedBuild()
+
+	default:
+		return manifest.Build{}, fmt.Errorf(
+			"no %s found in %s, so the image source cannot be guessed: pass --build-mode %s with --image, "+
+				"or --build-mode %s with --execution-environment and --entrypoint",
+			DockerfileName, detected.Dir, manifest.BuildModeImage, manifest.BuildModeGenerated)
+	}
+}
+
+// buildMode picks the mode the flags describe. An explicit --build-mode wins;
+// otherwise a lone --image or --execution-environment says plainly enough
+// which track the user is on, and a Dockerfile in the directory settles the
+// rest. An empty return means nothing decided it.
+func (a Answers) buildMode(detected Detected) string {
+	switch {
+	case a.BuildMode != "":
+		return a.BuildMode
+	case a.Image != "":
+		return manifest.BuildModeImage
+	case a.ExecutionEnvironment != "" || a.Entrypoint != "":
+		return manifest.BuildModeGenerated
+	case detected.HasDockerfile:
+		return manifest.BuildModeDockerfile
+	default:
+		return ""
+	}
+}
+
+func (a Answers) generatedBuild() (manifest.Build, error) {
+	var missing []string
+
+	if a.ExecutionEnvironment == "" {
+		missing = append(missing, "--execution-environment")
+	}
+
+	if a.Entrypoint == "" {
+		missing = append(missing, "--entrypoint")
+	}
+
+	if len(missing) > 0 {
+		return manifest.Build{}, fmt.Errorf("%s %s required with --build-mode %s",
+			strings.Join(missing, " and "), Plural(len(missing), "is", "are"), manifest.BuildModeGenerated)
+	}
+
+	entrypoint, err := splitCommand(a.Entrypoint)
+	if err != nil {
+		return manifest.Build{}, fmt.Errorf("--entrypoint %q: %w", a.Entrypoint, err)
+	}
+
+	// Resolved at setup, not at deploy: the file records both ids so the same
+	// manifest builds the same image after the environment moves on, and a
+	// name that does not exist fails now rather than after a sync.
+	id, versionID, err := resolveExecEnvFn(a.ExecutionEnvironment)
+	if err != nil {
+		return manifest.Build{}, err
+	}
+
+	return manifest.Build{
+		Mode:                          manifest.BuildModeGenerated,
+		ExecutionEnvironmentID:        id,
+		ExecutionEnvironmentVersionID: versionID,
+		Entrypoint:                    entrypoint,
+	}, nil
+}
+
+// splitCommand parses a command line the way a shell would, so quoted
+// arguments survive as single arguments. It handles single quotes (literal),
+// double quotes (backslash escapes honored) and backslash escapes outside
+// quotes, which covers every entrypoint anyone writes; anything needing more
+// than that belongs in a script the entrypoint calls.
+func splitCommand(command string) ([]string, error) {
+	var splitter commandSplitter
+
+	for _, r := range command {
+		splitter.step(r)
+	}
+
+	return splitter.done()
+}
+
+// commandSplitter is splitCommand's state: which argument is being built and
+// what the last character did to the parse.
+type commandSplitter struct {
+	args    []string
+	current strings.Builder
+	// quote is the open quote character, 0 outside quotes.
+	quote rune
+	// escaped means the previous character was a backslash.
+	escaped bool
+	// started distinguishes an argument that is empty because nothing has
+	// been read from one that is empty because it was written as "".
+	started bool
+}
+
+func (s *commandSplitter) step(r rune) {
+	switch {
+	case s.escaped:
+		s.current.WriteRune(r)
+
+		// An escaped character starts an argument like any other. Without
+		// this, an argument built only from escapes is dropped and its
+		// characters leak into the next one.
+		s.started = true
+		s.escaped = false
+	case s.quote != 0:
+		s.inQuote(r)
+	default:
+		s.unquoted(r)
+	}
+}
+
+// inQuote consumes a character inside quotes, where only the matching quote
+// and, in double quotes, a backslash mean anything.
+func (s *commandSplitter) inQuote(r rune) {
+	switch {
+	case r == s.quote:
+		s.quote = 0
+	case r == '\\' && s.quote == '"':
+		s.escaped = true
+	default:
+		s.current.WriteRune(r)
+	}
+}
+
+// unquoted consumes a character outside quotes, where whitespace separates
+// arguments and a quote opens one.
+func (s *commandSplitter) unquoted(r rune) {
+	switch r {
+	case '\\':
+		s.escaped = true
+	case '\'', '"':
+		s.quote = r
+		s.started = true
+	case ' ', '\t', '\n':
+		s.endArg()
+	default:
+		s.current.WriteRune(r)
+
+		s.started = true
+	}
+}
+
+func (s *commandSplitter) endArg() {
+	if !s.started {
+		return
+	}
+
+	s.args = append(s.args, s.current.String())
+	s.current.Reset()
+	s.started = false
+}
+
+func (s *commandSplitter) done() ([]string, error) {
+	switch {
+	case s.quote != 0:
+		return nil, errors.New("unbalanced quote")
+	case s.escaped:
+		return nil, errors.New("trailing backslash")
+	}
+
+	s.endArg()
+
+	if len(s.args) == 0 {
+		return nil, errors.New("is empty")
+	}
+
+	return s.args, nil
+}
+
+func orDefault(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+
+	return value
+}

--- a/internal/workload/wizard/answers.go
+++ b/internal/workload/wizard/answers.go
@@ -17,6 +17,7 @@ package wizard
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/datarobot/cli/internal/workload/manifest"
@@ -89,20 +90,21 @@ func (a Answers) checkKind() error {
 			a.Type, manifest.TypeService, manifest.TypeAgent)
 	}
 
-	// The check is against the type that will be written, not against the
-	// flag: omitting --type does not turn --a2a-enabled into a service flag,
-	// it just means the default applies.
-	if a.A2AEnabled && a.effectiveType() != manifest.TypeAgent {
-		return fmt.Errorf("--a2a-enabled applies to --type %s, not %s",
-			manifest.TypeAgent, a.effectiveType())
-	}
-
 	return nil
 }
 
-// effectiveType is the kind that will be written when nothing else changes it.
-func (a Answers) effectiveType() string {
-	return orDefault(a.Type, manifest.TypeService)
+// checkA2A runs against the type that will be written rather than against the
+// flag, and so it runs once the draft has one. Omitting --type does not turn
+// --a2a-enabled into a service flag, it means whatever the draft started from
+// stands: the documented default for a new workload, the live kind for a bound
+// one. Checking the flag alone would reject --a2a-enabled on a bound agent
+// unless the caller redundantly repeated --type agent.
+func (a Answers) checkA2A(draftType string) error {
+	if a.A2AEnabled && draftType != manifest.TypeAgent {
+		return fmt.Errorf("--a2a-enabled applies to --type %s, not %s", manifest.TypeAgent, draftType)
+	}
+
+	return nil
 }
 
 func (a Answers) checkImageSource() error {
@@ -153,6 +155,14 @@ func (a Answers) checkSizing() error {
 		return fmt.Errorf("--replicas %d is negative", a.Replicas)
 	}
 
+	// ParseFloat accepts NaN and Inf, and neither compares as negative, so
+	// without this they reach the file as `cpu: !!float NaN`, which the
+	// manifest's own validator has no opinion about and the platform cannot
+	// schedule.
+	if math.IsNaN(a.CPU) || math.IsInf(a.CPU, 0) {
+		return fmt.Errorf("--cpu %v is not a number of cores", a.CPU)
+	}
+
 	if a.CPU < 0 {
 		return fmt.Errorf("--cpu %v is negative", a.CPU)
 	}
@@ -196,6 +206,10 @@ func (a Answers) draft(detected Detected) (manifest.Draft, error) {
 		HealthPath: orDefault(a.HealthPath, manifest.DefaultHealthPath),
 		Runtime:    a.runtime(),
 		EnvVars:    a.envVars(detected),
+	}
+
+	if err := a.checkA2A(draft.Type); err != nil {
+		return manifest.Draft{}, err
 	}
 
 	if draft.Port == 0 {

--- a/internal/workload/wizard/answers_test.go
+++ b/internal/workload/wizard/answers_test.go
@@ -58,9 +58,9 @@ func TestSplitCommand(t *testing.T) {
 
 func TestSplitCommand_Rejects(t *testing.T) {
 	tests := map[string]string{
-		"unbalanced quote":  `sh -c "echo hello`,
-		"trailing backlash": `run \`,
-		"empty":             "   ",
+		"unbalanced quote":   `sh -c "echo hello`,
+		"trailing backslash": `run \`,
+		"empty":              "   ",
 	}
 
 	for name, command := range tests {
@@ -82,9 +82,6 @@ func TestAnswers_Check(t *testing.T) {
 		"unsupported type": {
 			Answers{Type: "nim"}, `--type "nim" is not supported`,
 		},
-		"a2a on a service": {
-			Answers{Type: manifest.TypeService, A2AEnabled: true}, "--a2a-enabled applies to --type agent",
-		},
 		"unsupported build mode": {
 			Answers{BuildMode: "magic"}, `--build-mode "magic" is not supported`,
 		},
@@ -103,6 +100,20 @@ func TestAnswers_Check(t *testing.T) {
 			assert.Contains(t, err.Error(), test.want)
 		})
 	}
+}
+
+// --a2a-enabled is judged against the kind that will be written rather than
+// against the flag, so the check runs once the draft has a type. On a new
+// workload that is the documented default; binding covers the other half.
+func TestAnswers_A2AIsCheckedAgainstTheDraftType(t *testing.T) {
+	detected := Detect(writeDockerfile(t, t.TempDir(), "FROM scratch\n"))
+
+	_, err := Answers{Name: "my-app", A2AEnabled: true}.draft(detected)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--a2a-enabled applies to --type agent")
+
+	_, err = Answers{Name: "my-app", Type: manifest.TypeAgent, A2AEnabled: true}.draft(detected)
+	require.NoError(t, err)
 }
 
 // The Dockerfile track needs no flags at all: this is the headless half of

--- a/internal/workload/wizard/answers_test.go
+++ b/internal/workload/wizard/answers_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubExecEnv points the resolver at a fixed answer for one test.
+func stubExecEnv(t *testing.T, id, versionID string, err error) {
+	t.Helper()
+
+	original := resolveExecEnvFn
+	resolveExecEnvFn = func(string) (string, string, error) { return id, versionID, err }
+
+	t.Cleanup(func() { resolveExecEnvFn = original })
+}
+
+func TestSplitCommand(t *testing.T) {
+	tests := map[string]struct {
+		command string
+		want    []string
+	}{
+		"plain":            {"python main.py", []string{"python", "main.py"}},
+		"extra spaces":     {"  python   main.py  ", []string{"python", "main.py"}},
+		"double quotes":    {`sh -c "echo hello world"`, []string{"sh", "-c", "echo hello world"}},
+		"single quotes":    {`sh -c 'echo $HOME'`, []string{"sh", "-c", "echo $HOME"}},
+		"escaped space":    {`/opt/my\ app/run`, []string{"/opt/my app/run"}},
+		"empty quoted arg": {`run ""`, []string{"run", ""}},
+		"quote inside":     {`echo "it's here"`, []string{"echo", "it's here"}},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := splitCommand(test.command)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestSplitCommand_Rejects(t *testing.T) {
+	tests := map[string]string{
+		"unbalanced quote":  `sh -c "echo hello`,
+		"trailing backlash": `run \`,
+		"empty":             "   ",
+	}
+
+	for name, command := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := splitCommand(command)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestAnswers_Check(t *testing.T) {
+	tests := map[string]struct {
+		answers Answers
+		want    string
+	}{
+		"id and name together": {
+			Answers{WorkloadID: "68b0", Name: "my-app"}, "exclusive",
+		},
+		"unsupported type": {
+			Answers{Type: "nim"}, `--type "nim" is not supported`,
+		},
+		"a2a on a service": {
+			Answers{Type: manifest.TypeService, A2AEnabled: true}, "--a2a-enabled applies to --type agent",
+		},
+		"unsupported build mode": {
+			Answers{BuildMode: "magic"}, `--build-mode "magic" is not supported`,
+		},
+		"health without a slash": {
+			Answers{HealthPath: "health"}, "must start with /",
+		},
+		"privileged port": {
+			Answers{Port: 80}, "--port 80 is too low",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := test.answers.check()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.want)
+		})
+	}
+}
+
+// The Dockerfile track needs no flags at all: this is the headless half of
+// the Enter-through-every-screen path.
+func TestAnswers_DraftFromDetectionAlone(t *testing.T) {
+	detected := Detect(writeDockerfile(t, t.TempDir(), "FROM scratch\nEXPOSE 3000\n"))
+
+	draft, err := Answers{}.draft(detected)
+	require.NoError(t, err)
+
+	assert.Equal(t, manifest.BuildModeDockerfile, draft.Build.Mode)
+	assert.Equal(t, detected.Name, draft.Name)
+	assert.Equal(t, 3000, draft.Port)
+	assert.Equal(t, manifest.DefaultHealthPath, draft.HealthPath)
+	assert.Equal(t, manifest.TypeService, draft.Type)
+	assert.Equal(t, manifest.DefaultImportance, draft.Importance)
+	assert.Equal(t, manifest.DefaultReplicas, draft.Runtime.Replicas)
+	assert.InEpsilon(t, manifest.DefaultCPU, draft.Runtime.CPU, 0.0001)
+	assert.Equal(t, manifest.DefaultMemory, draft.Runtime.Memory)
+}
+
+func TestAnswers_FlagsWinOverDetection(t *testing.T) {
+	detected := Detect(writeDockerfile(t, t.TempDir(), "FROM scratch\nEXPOSE 3000\n"))
+
+	draft, err := Answers{
+		Name:       "chosen",
+		Type:       manifest.TypeAgent,
+		A2AEnabled: true,
+		Port:       9999,
+		HealthPath: "/healthz",
+		Replicas:   3,
+		CPU:        2,
+		Memory:     "4GB",
+	}.draft(detected)
+	require.NoError(t, err)
+
+	assert.Equal(t, "chosen", draft.Name)
+	assert.Equal(t, manifest.TypeAgent, draft.Type)
+	assert.True(t, draft.A2AEnabled)
+	assert.Equal(t, 9999, draft.Port)
+	assert.Equal(t, "/healthz", draft.HealthPath)
+	assert.Equal(t, 3, draft.Runtime.Replicas)
+	assert.InEpsilon(t, 2.0, draft.Runtime.CPU, 0.0001)
+	assert.Equal(t, "4GB", draft.Runtime.Memory)
+}
+
+// With nothing to build and nothing said, the error names the flags that
+// would settle it rather than guessing at an image source.
+func TestAnswers_NoDockerfileAndNoFlags(t *testing.T) {
+	_, err := Answers{}.draft(Detect(t.TempDir()))
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "--build-mode image")
+	assert.Contains(t, err.Error(), "--build-mode generated")
+}
+
+func TestAnswers_ImageMode(t *testing.T) {
+	detected := Detect(t.TempDir())
+
+	// A lone --image says which track this is; --build-mode is not needed.
+	draft, err := Answers{Image: "registry/team/app:v1"}.draft(detected)
+	require.NoError(t, err)
+
+	assert.Equal(t, manifest.BuildModeImage, draft.Build.Mode)
+	assert.Equal(t, "registry/team/app:v1", draft.Build.ImageURI)
+
+	_, err = Answers{BuildMode: manifest.BuildModeImage}.draft(detected)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--image is required")
+}
+
+func TestAnswers_GeneratedMode(t *testing.T) {
+	stubExecEnv(t, "68a1", "68a2", nil)
+
+	detected := Detect(t.TempDir())
+
+	draft, err := Answers{
+		BuildMode:            manifest.BuildModeGenerated,
+		ExecutionEnvironment: "[DataRobot] Python 3.12 Applications Base",
+		Entrypoint:           `uvicorn app:app --host "0.0.0.0"`,
+	}.draft(detected)
+	require.NoError(t, err)
+
+	assert.Equal(t, "68a1", draft.Build.ExecutionEnvironmentID)
+	assert.Equal(t, "68a2", draft.Build.ExecutionEnvironmentVersionID)
+	assert.Equal(t, []string{"uvicorn", "app:app", "--host", "0.0.0.0"}, draft.Build.Entrypoint)
+}
+
+func TestAnswers_GeneratedModeMissingFlags(t *testing.T) {
+	_, err := Answers{BuildMode: manifest.BuildModeGenerated}.draft(Detect(t.TempDir()))
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "--execution-environment and --entrypoint are required")
+}
+
+// A base image that does not resolve fails at setup, where the user is
+// looking at it, not at the first deploy.
+func TestAnswers_GeneratedModeUnknownEnvironment(t *testing.T) {
+	stubExecEnv(t, "", "", errors.New(`execution environment "nope" not found`))
+
+	_, err := Answers{
+		BuildMode:            manifest.BuildModeGenerated,
+		ExecutionEnvironment: "nope",
+		Entrypoint:           "python main.py",
+	}.draft(Detect(t.TempDir()))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// A Dockerfile track asked for explicitly still needs a Dockerfile.
+func TestAnswers_DockerfileModeWithoutOne(t *testing.T) {
+	_, err := Answers{BuildMode: manifest.BuildModeDockerfile}.draft(Detect(t.TempDir()))
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "needs a Dockerfile")
+}
+
+// Binding layers flags over the live values, and leaves alone what the
+// command line did not mention.
+func TestAnswers_ApplyToKeepsLiveDefaults(t *testing.T) {
+	defaults := manifest.Draft{
+		WorkloadID: "68b0",
+		Name:       "live-app",
+		Type:       manifest.TypeAgent,
+		Port:       9000,
+		HealthPath: "/live",
+		Build:      manifest.Build{Mode: manifest.BuildModeImage, ImageURI: "registry/live:v9"},
+	}
+
+	// A Dockerfile in the checkout must not switch a running workload's build
+	// mode on its own.
+	detected := Detect(writeDockerfile(t, t.TempDir(), "FROM scratch\n"))
+
+	draft, err := Answers{Port: 8081}.applyTo(defaults, detected)
+	require.NoError(t, err)
+
+	assert.Equal(t, 8081, draft.Port)
+	assert.Equal(t, "live-app", draft.Name)
+	assert.Equal(t, manifest.TypeAgent, draft.Type)
+	assert.Equal(t, "/live", draft.HealthPath)
+	assert.Equal(t, manifest.BuildModeImage, draft.Build.Mode)
+
+	// An explicit build flag does switch it.
+	draft, err = Answers{BuildMode: manifest.BuildModeDockerfile}.applyTo(defaults, detected)
+	require.NoError(t, err)
+	assert.Equal(t, manifest.BuildModeDockerfile, draft.Build.Mode)
+}

--- a/internal/workload/wizard/classify.go
+++ b/internal/workload/wizard/classify.go
@@ -1,0 +1,327 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"math"
+	"math/bits"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// EnvKind is what a `.env` entry looks like, and therefore where it belongs.
+type EnvKind int
+
+const (
+	// EnvConfig is an ordinary setting: it belongs in the manifest as a
+	// literal, and there is nothing to hide about it.
+	EnvConfig EnvKind = iota
+	// EnvSecret must not be committed. It belongs in the credential store,
+	// referenced from the manifest by id.
+	EnvSecret
+	// EnvLocal only means something on a developer's machine, so deploying it
+	// would be wrong rather than merely unnecessary.
+	EnvLocal
+)
+
+func (k EnvKind) String() string {
+	switch k {
+	case EnvSecret:
+		return "secret"
+	case EnvLocal:
+		return "local only"
+	case EnvConfig:
+		return "config"
+	}
+
+	return "config"
+}
+
+// EnvVar is one classified `.env` entry.
+//
+// Value is kept so an ordinary setting can be written into the manifest as
+// the literal it is, which is what makes the deploy carry the app's
+// configuration. It is kept for a secret too, because the table lets a row be
+// reclassified and a value dropped on the way through could not come back;
+// what stops a secret reaching the file is the render, which writes a
+// credential reference for one and never its value.
+type EnvVar struct {
+	Name  string
+	Kind  EnvKind
+	Value string
+	// Reason is the short phrase the table shows, so the user can tell a
+	// confident verdict from a guess before overriding it.
+	Reason string
+}
+
+// Classification is deliberately conservative in one direction: it would
+// rather call an ordinary setting a secret than the reverse, because the cost
+// of the first is one keystroke on the table and the cost of the second is a
+// credential in git. Every verdict is overridable, which is what makes an
+// imperfect classifier safe.
+//
+// The signals below run in confidence order, strongest first.
+
+// secretValuePatterns are issuer-specific token shapes. A value matching one
+// of these is a secret whatever it is called, and these are the only signals
+// strong enough to overrule a name that says otherwise.
+var secretValuePatterns = []struct {
+	pattern *regexp.Regexp
+	reason  string
+}{
+	{regexp.MustCompile(`^-----BEGIN [A-Z ]*PRIVATE KEY-----`), "a private key"},
+	{regexp.MustCompile(`^sk-ant-[A-Za-z0-9_-]{20,}`), "an Anthropic API key"},
+	{regexp.MustCompile(`^sk-[A-Za-z0-9_-]{20,}`), "an OpenAI-style API key"},
+	{regexp.MustCompile(`^(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{30,}`), "a GitHub token"},
+	{regexp.MustCompile(`^github_pat_[A-Za-z0-9_]{20,}`), "a GitHub token"},
+	{regexp.MustCompile(`^glpat-[A-Za-z0-9_-]{15,}`), "a GitLab token"},
+	{regexp.MustCompile(`^xox[baprs]-[A-Za-z0-9-]{10,}`), "a Slack token"},
+	{regexp.MustCompile(`^hf_[A-Za-z0-9]{20,}`), "a Hugging Face token"},
+	{regexp.MustCompile(`^AKIA[0-9A-Z]{16}$`), "an AWS access key id"},
+	{regexp.MustCompile(`^AIza[0-9A-Za-z_-]{35}$`), "a Google API key"},
+	{regexp.MustCompile(`^SG\.[A-Za-z0-9_-]{20,}`), "a SendGrid key"},
+	{regexp.MustCompile(`^dop_v1_[a-f0-9]{64}$`), "a DigitalOcean token"},
+	{regexp.MustCompile(`^eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.`), "a JSON web token"},
+}
+
+// secretNamePattern is the design's name test. On its own it is a hint, not a
+// verdict: SSH_KEY_PATH and LOG_LEVEL_KEY both match and neither is a secret,
+// which is why the value has to corroborate.
+var secretNamePattern = regexp.MustCompile(
+	`(?i)(^|[_.-])(KEY|TOKEN|SECRET|PASSWORD|PASSWD|PWD|CREDENTIALS?|AUTH|APIKEY|PRIVATE|SALT|SIGNATURE|CERT)($|[_.-])`)
+
+// pathishNamePattern marks names whose value is a location rather than the
+// thing at that location. SSH_KEY_PATH names a file; the file is the secret,
+// the path is not.
+var pathishNamePattern = regexp.MustCompile(`(?i)(^|_)(PATH|FILE|DIR|LOCATION|URL|URI|ENDPOINT|HOST)$`)
+
+// localNamePattern marks variables that only mean something while developing.
+// The frontend prefixes are build-time and public by construction, so a
+// secret in one is already a different problem.
+var localNamePattern = regexp.MustCompile(`(?i)^(VITE_|REACT_APP_|NEXT_PUBLIC_|STORYBOOK_|EXPO_PUBLIC_)`)
+
+// devNamePattern marks the dev-only half of a name that is otherwise ordinary.
+var devNamePattern = regexp.MustCompile(`(?i)(^|_)(DEV|LOCAL|DEBUG|MOCK|FIXTURE|SANDBOX)($|_)`)
+
+// localHostPattern matches values that point at the developer's own machine.
+var localHostPattern = regexp.MustCompile(`(?i)(^|//|@|\b)(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|host\.docker\.internal)(\b|:|/|$)`)
+
+// plainValuePattern matches values that cannot be a secret whatever they are
+// called: booleans, numbers, and short bare words such as log levels.
+var plainValuePattern = regexp.MustCompile(`^(?i)(true|false|yes|no|on|off|null|none|debug|info|warn|warning|error|trace|fatal|silent|dev|development|prod|production|staging|test)$`)
+
+// minSecretLength is the shortest value entropy is allowed to convict. Below
+// it, a high score says more about the sample size than the value.
+const minSecretLength = 16
+
+// minSecretEntropy is Shannon entropy per character. English prose sits near
+// 2.5 and a random token near 4.5, so this sits between them and closer to
+// the token, because a false secret costs a keystroke and a false config
+// costs a leak.
+const minSecretEntropy = 3.4
+
+// ClassifyEnv decides where one `.env` entry belongs. name and value are both
+// read; only the verdict is returned.
+func ClassifyEnv(name, value string) EnvVar {
+	value = strings.TrimSpace(value)
+
+	for _, signal := range secretValuePatterns {
+		if signal.pattern.MatchString(value) {
+			return EnvVar{Name: name, Kind: EnvSecret, Reason: "looks like " + signal.reason}
+		}
+	}
+
+	if user, ok := credentialInURL(value); ok {
+		return EnvVar{Name: name, Kind: EnvSecret, Reason: "a URL with " + user + "'s password in it"}
+	}
+
+	if kind, reason, ok := classifyLocal(name, value); ok {
+		return EnvVar{Name: name, Kind: kind, Value: value, Reason: reason}
+	}
+
+	return classifyBySecrecy(name, value)
+}
+
+// classifyLocal catches what only matters on this machine. It runs before the
+// name test so a VITE_ variable is not called a secret for containing KEY,
+// and before entropy so a localhost URL is not convicted for looking random.
+func classifyLocal(name, value string) (EnvKind, string, bool) {
+	switch {
+	case localNamePattern.MatchString(name):
+		return EnvLocal, "a build-time frontend variable", true
+	case localHostPattern.MatchString(value):
+		return EnvLocal, "points at this machine", true
+	case devNamePattern.MatchString(name) && !secretNamePattern.MatchString(name):
+		return EnvLocal, "named for local development", true
+	default:
+		return EnvConfig, "", false
+	}
+}
+
+// classifyBySecrecy weighs the name against the value, which is the case the
+// design's name-pattern test gets wrong on its own.
+func classifyBySecrecy(name, value string) EnvVar {
+	if secretNamePattern.MatchString(name) && !pathishNamePattern.MatchString(name) {
+		return classifyNamedSecret(name, value)
+	}
+
+	if looksGenerated(value) {
+		// A DATABASE_URL-style name with an opaque token inside it.
+		return EnvVar{Name: name, Kind: EnvSecret, Reason: "the value looks like a random token"}
+	}
+
+	return EnvVar{Name: name, Kind: EnvConfig, Value: value, Reason: "an ordinary setting"}
+}
+
+// classifyNamedSecret settles a name that matched the secret pattern, which
+// is a hint the value can confirm or contradict.
+func classifyNamedSecret(name, value string) EnvVar {
+	switch {
+	case plainValuePattern.MatchString(value):
+		// LOG_LEVEL_KEY=debug. The name matched; the value cannot be a secret.
+		return EnvVar{Name: name, Kind: EnvConfig, Value: value, Reason: "named like a secret, but the value is a plain setting"}
+	case value == "":
+		return EnvVar{Name: name, Kind: EnvSecret, Reason: "named like a secret, and empty here"}
+	case looksGenerated(value):
+		return EnvVar{Name: name, Kind: EnvSecret, Reason: "named like a secret, and the value looks random"}
+	default:
+		return EnvVar{Name: name, Kind: EnvSecret, Reason: "named like a secret"}
+	}
+}
+
+// looksGenerated reports whether a value looks machine-generated rather than
+// chosen. A URL is judged by its parts rather than as a whole: scheme, host
+// and ordinary path segments are structure and score high on character
+// distribution without being secret, but an opaque segment inside the path is
+// exactly how webhook URLs carry theirs.
+func looksGenerated(value string) bool {
+	if parsed, err := url.Parse(value); err == nil && parsed.Scheme != "" && parsed.Host != "" {
+		return anySegmentGenerated(parsed)
+	}
+
+	return isRandomToken(value)
+}
+
+// anySegmentGenerated looks for an opaque token inside a URL's path or query.
+func anySegmentGenerated(parsed *url.URL) bool {
+	for _, segment := range strings.Split(parsed.Path, "/") {
+		if isRandomToken(segment) {
+			return true
+		}
+	}
+
+	for _, values := range parsed.Query() {
+		for _, value := range values {
+			if isRandomToken(value) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// isRandomToken is the entropy test proper: long enough to measure, surprising
+// enough per character, and drawing on more than one class of character.
+func isRandomToken(value string) bool {
+	return len(value) >= minSecretLength &&
+		shannonEntropy(value) >= minSecretEntropy &&
+		mixedCharset(value)
+}
+
+// credentialInURL reports a password embedded in a connection string, which
+// is a secret however innocuous DATABASE_URL sounds.
+func credentialInURL(value string) (string, bool) {
+	if !strings.Contains(value, "://") {
+		return "", false
+	}
+
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.User == nil {
+		return "", false
+	}
+
+	password, set := parsed.User.Password()
+	if !set || password == "" {
+		return "", false
+	}
+
+	user := parsed.User.Username()
+	if user == "" {
+		user = "a user"
+	}
+
+	return user, true
+}
+
+// shannonEntropy is bits per character over the value's own distribution: how
+// surprising the next character is, which is what separates a generated token
+// from a word someone chose.
+func shannonEntropy(value string) float64 {
+	if value == "" {
+		return 0
+	}
+
+	counts := make(map[rune]int, len(value))
+	for _, r := range value {
+		counts[r]++
+	}
+
+	total := float64(len([]rune(value)))
+
+	var entropy float64
+
+	for _, count := range counts {
+		p := float64(count) / total
+		entropy -= p * math.Log2(p)
+	}
+
+	return entropy
+}
+
+// mixedCharset guards entropy against long structured values. A file path or
+// a sentence can score well on character distribution alone, so a value only
+// counts as random if it also draws on more than one class of character and
+// is not something as ordinary as a number.
+func mixedCharset(value string) bool {
+	if _, err := strconv.ParseFloat(value, 64); err == nil {
+		return false
+	}
+
+	const (
+		lower = 1 << iota
+		upper
+		digit
+	)
+
+	var seen int
+
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			seen |= lower
+		case r >= 'A' && r <= 'Z':
+			seen |= upper
+		case r >= '0' && r <= '9':
+			seen |= digit
+		}
+	}
+
+	// Two classes is the bar: hex digests and mixed-case tokens both clear
+	// it, while /usr/local/share/some-long-path and a plain sentence do not.
+	return bits.OnesCount(uint(seen)) >= 2
+}

--- a/internal/workload/wizard/classify.go
+++ b/internal/workload/wizard/classify.go
@@ -136,9 +136,18 @@ const minSecretEntropy = 3.4
 
 // ClassifyEnv decides where one `.env` entry belongs. Every verdict carries
 // the value, secrets included, for the reason EnvVar.Value gives.
+//
+// Surrounding whitespace is ignored when reading the value and kept when
+// writing it. A quoted `GREETING=" hello "` means those spaces, and a
+// classifier is no place to decide otherwise.
 func ClassifyEnv(name, value string) EnvVar {
-	value = strings.TrimSpace(value)
+	classified := classify(name, strings.TrimSpace(value))
+	classified.Value = value
 
+	return classified
+}
+
+func classify(name, value string) EnvVar {
 	for _, signal := range secretValuePatterns {
 		if signal.pattern.MatchString(value) {
 			return EnvVar{Name: name, Kind: EnvSecret, Value: value, Reason: "looks like " + signal.reason}

--- a/internal/workload/wizard/classify.go
+++ b/internal/workload/wizard/classify.go
@@ -134,19 +134,19 @@ const minSecretLength = 16
 // costs a leak.
 const minSecretEntropy = 3.4
 
-// ClassifyEnv decides where one `.env` entry belongs. name and value are both
-// read; only the verdict is returned.
+// ClassifyEnv decides where one `.env` entry belongs. Every verdict carries
+// the value, secrets included, for the reason EnvVar.Value gives.
 func ClassifyEnv(name, value string) EnvVar {
 	value = strings.TrimSpace(value)
 
 	for _, signal := range secretValuePatterns {
 		if signal.pattern.MatchString(value) {
-			return EnvVar{Name: name, Kind: EnvSecret, Reason: "looks like " + signal.reason}
+			return EnvVar{Name: name, Kind: EnvSecret, Value: value, Reason: "looks like " + signal.reason}
 		}
 	}
 
 	if user, ok := credentialInURL(value); ok {
-		return EnvVar{Name: name, Kind: EnvSecret, Reason: "a URL with " + user + "'s password in it"}
+		return EnvVar{Name: name, Kind: EnvSecret, Value: value, Reason: "a URL with " + user + "'s password in it"}
 	}
 
 	if kind, reason, ok := classifyLocal(name, value); ok {
@@ -181,7 +181,7 @@ func classifyBySecrecy(name, value string) EnvVar {
 
 	if looksGenerated(value) {
 		// A DATABASE_URL-style name with an opaque token inside it.
-		return EnvVar{Name: name, Kind: EnvSecret, Reason: "the value looks like a random token"}
+		return EnvVar{Name: name, Kind: EnvSecret, Value: value, Reason: "the value looks like a random token"}
 	}
 
 	return EnvVar{Name: name, Kind: EnvConfig, Value: value, Reason: "an ordinary setting"}
@@ -195,11 +195,11 @@ func classifyNamedSecret(name, value string) EnvVar {
 		// LOG_LEVEL_KEY=debug. The name matched; the value cannot be a secret.
 		return EnvVar{Name: name, Kind: EnvConfig, Value: value, Reason: "named like a secret, but the value is a plain setting"}
 	case value == "":
-		return EnvVar{Name: name, Kind: EnvSecret, Reason: "named like a secret, and empty here"}
+		return EnvVar{Name: name, Kind: EnvSecret, Value: value, Reason: "named like a secret, and empty here"}
 	case looksGenerated(value):
-		return EnvVar{Name: name, Kind: EnvSecret, Reason: "named like a secret, and the value looks random"}
+		return EnvVar{Name: name, Kind: EnvSecret, Value: value, Reason: "named like a secret, and the value looks random"}
 	default:
-		return EnvVar{Name: name, Kind: EnvSecret, Reason: "named like a secret"}
+		return EnvVar{Name: name, Kind: EnvSecret, Value: value, Reason: "named like a secret"}
 	}
 }
 

--- a/internal/workload/wizard/classify_test.go
+++ b/internal/workload/wizard/classify_test.go
@@ -91,12 +91,38 @@ func TestClassifyEnv(t *testing.T) {
 	}
 }
 
-// Whatever the verdict, the value never travels with it.
-func TestClassifyEnv_CarriesNoValue(t *testing.T) {
+// The reason is shown on a screen and can end up in a debug log, so it
+// describes the value without ever quoting it.
+func TestClassifyEnv_ReasonNeverEchoesTheValue(t *testing.T) {
 	got := ClassifyEnv("OPENAI_API_KEY", "sk-abcdefghijklmnopqrstuvwxyz012345")
 
 	assert.NotContains(t, got.Reason, "sk-")
 	assert.NotContains(t, got.Name, "sk-")
+}
+
+// A secret keeps its value like any other verdict. The table lets the user
+// disagree with the classifier, and a value dropped here could not come back:
+// the row would reach the manifest with an empty value and the container would
+// start without it. Nothing writes a secret's value to the file; the render
+// substitutes a credential reference.
+func TestClassifyEnv_EveryVerdictKeepsItsValue(t *testing.T) {
+	for name, test := range map[string]struct {
+		name, value string
+		want        EnvKind
+	}{
+		"issuer prefix":       {"OPENAI_API_KEY", "sk-abcdefghijklmnopqrstuvwxyz012345", EnvSecret},
+		"password in a URL":   {"DATABASE_URL", "postgres://app:hunter2@db.internal:5432/prod", EnvSecret},
+		"named like a secret": {"SESSION_SECRET", "ZmFrZS1zZXNzaW9uLXNlY3JldA", EnvSecret},
+		"ordinary setting":    {"LOG_LEVEL", "debug", EnvConfig},
+		"local only":          {"VITE_API_URL", "http://localhost:3000", EnvLocal},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := ClassifyEnv(test.name, test.value)
+
+			assert.Equal(t, test.want, got.Kind, "reason given: %s", got.Reason)
+			assert.Equal(t, test.value, got.Value)
+		})
+	}
 }
 
 func TestEnvKind_String(t *testing.T) {

--- a/internal/workload/wizard/classify_test.go
+++ b/internal/workload/wizard/classify_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The values below are shaped like the real thing but are not real
+// credentials; the point is the shape, which is what the classifier reads.
+func TestClassifyEnv(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  EnvKind
+		why   string
+	}{
+		// Issuer-specific shapes are the strongest signal there is.
+		{"MODEL_PROVIDER", "sk-abcdefghijklmnopqrstuvwxyz012345", EnvSecret, "an OpenAI-style key is a secret whatever the variable is called"},
+		{"ANTHROPIC", "sk-ant-api03-abcdefghijklmnopqrstuvwxyz", EnvSecret, ""},
+		{"GH", "ghp_abcdefghijklmnopqrstuvwxyz0123456789", EnvSecret, ""},
+		{"HF", "hf_abcdefghijklmnopqrstuvwxyz012345", EnvSecret, ""},
+		{"AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE", EnvSecret, ""},
+		{"SLACK", "xoxb-1234567890-abcdefghijkl", EnvSecret, ""},
+		{"SIGNING", "-----BEGIN RSA PRIVATE KEY-----\nMIIE", EnvSecret, ""},
+		{"SESSION", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc", EnvSecret, "a JWT is a bearer credential"},
+
+		// A password inside a connection string, however innocuous the name.
+		{"DATABASE_URL", "postgres://app:hunter2@db.internal:5432/prod", EnvSecret, "the password is in the value"},
+		{"DATABASE_URL", "postgres://db.internal:5432/prod", EnvConfig, "no credentials, so nothing to hide"},
+
+		// The name test, corroborated by the value.
+		{"OPENAI_API_KEY", "abc123XYZdef456GHIjkl789", EnvSecret, ""},
+		{"STRIPE_SECRET", "", EnvSecret, "empty here, but it is still the slot for a secret"},
+
+		// The name test, contradicted by the value. This is what a
+		// name-only classifier gets wrong.
+		{"LOG_LEVEL_KEY", "debug", EnvConfig, "the value cannot be a secret"},
+		{"DEBUG_TOKEN_ENABLED", "true", EnvConfig, ""},
+		{"SSH_KEY_PATH", "/home/dev/.ssh/id_rsa", EnvConfig, "a path names a secret, it is not one"},
+		{"CERT_FILE", "/etc/ssl/cert.pem", EnvConfig, ""},
+		{"AUTH_URL", "https://auth.example.com/oauth", EnvConfig, ""},
+
+		// Entropy, for the secrets nobody named helpfully.
+		{"UPLOAD", "f3a9c2e17b40d85639ae0c71f2b84d5e", EnvSecret, "a hex digest is a random token"},
+		{"SESSION_STORE", "Xk9mPq2vLw8nRt5yBc3zFh6jDg4sAe7U", EnvSecret, ""},
+
+		// Ordinary settings that entropy must not convict.
+		{"LOG_LEVEL", "debug", EnvConfig, ""},
+		{"PORT", "8080", EnvConfig, ""},
+		{"TIMEOUT_SECONDS", "30.5", EnvConfig, "a number is not a token"},
+		{"REGION", "us-east-1", EnvConfig, ""},
+		{"STATIC_ROOT", "/var/www/static/assets/images", EnvConfig, "a long path is structured, not random"},
+		{"GREETING", "hello there how are you today", EnvConfig, "prose is not random"},
+		{"FEATURE_FLAGS", "alpha,beta,gamma", EnvConfig, ""},
+
+		// Local-only, which is neither config nor secret.
+		{"VITE_DEV_PORT", "3000", EnvLocal, "a build-time frontend variable"},
+		{"NEXT_PUBLIC_API_URL", "https://api.example.com", EnvLocal, ""},
+		{"REDIS_URL", "redis://localhost:6379", EnvLocal, "points at this machine"},
+		{"API_BASE", "http://127.0.0.1:8000", EnvLocal, ""},
+		{"DEV_MODE", "on", EnvLocal, ""},
+
+		// A frontend prefix wins over a name that looks secret, because those
+		// variables are public by construction.
+		{"VITE_API_KEY", "abc123XYZdef456GHI", EnvLocal, "a public build-time variable is already not a secret"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name+"="+truncate(test.value), func(t *testing.T) {
+			got := ClassifyEnv(test.name, test.value)
+
+			assert.Equalf(t, test.want, got.Kind, "%s (reason given: %s)", test.why, got.Reason)
+			assert.NotEmpty(t, got.Reason, "every verdict explains itself")
+			assert.Equal(t, test.name, got.Name)
+		})
+	}
+}
+
+// Whatever the verdict, the value never travels with it.
+func TestClassifyEnv_CarriesNoValue(t *testing.T) {
+	got := ClassifyEnv("OPENAI_API_KEY", "sk-abcdefghijklmnopqrstuvwxyz012345")
+
+	assert.NotContains(t, got.Reason, "sk-")
+	assert.NotContains(t, got.Name, "sk-")
+}
+
+func TestEnvKind_String(t *testing.T) {
+	assert.Equal(t, "config", EnvConfig.String())
+	assert.Equal(t, "secret", EnvSecret.String())
+	assert.Equal(t, "local only", EnvLocal.String())
+}
+
+func truncate(value string) string {
+	const limit = 24
+	if len(value) <= limit {
+		return value
+	}
+
+	return value[:limit] + "…"
+}
+
+// A URL is judged by its parts. Structure is not randomness, but an opaque
+// segment inside a path is how webhook URLs carry their secret.
+func TestClassifyEnv_URLsAreJudgedByTheirParts(t *testing.T) {
+	tests := map[string]struct {
+		name, value string
+		want        EnvKind
+	}{
+		"plain connection string": {"DATABASE_URL", "postgres://db.internal:5432/prod", EnvConfig},
+		"long ordinary path":      {"ASSET_BASE", "https://cdn.example.com/static/images/products/large", EnvConfig},
+		"query with plain values": {"SEARCH_URL", "https://api.example.com/v1/search?limit=100&sort=name", EnvConfig},
+		// A real provider host here would be blocked by secret scanning
+		// on push, so the host is fictional. The rule under test is
+		// structural and does not look at the host.
+		"webhook with a token":    {"NOTIFY_WEBHOOK", "https://hooks.example.com/services/T00000000/B00000000/XyZ9aBc3DeF6gHi2JkL5mNoP", EnvSecret},
+		"token in a query string": {"CALLBACK", "https://api.example.com/hook?token=Xk9mPq2vLw8nRt5yBc3zFh6j", EnvSecret},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := ClassifyEnv(test.name, test.value)
+			assert.Equalf(t, test.want, got.Kind, "reason given: %s", got.Reason)
+		})
+	}
+}

--- a/internal/workload/wizard/detect.go
+++ b/internal/workload/wizard/detect.go
@@ -180,8 +180,9 @@ func exposedPort(path string) (int, bool) {
 // verdicts: an ordinary setting is written to the manifest as it stands, and a
 // secret's value is what a later credential is created from.
 //
-// The file is read a second time for order, because godotenv returns a map and
-// a scrambled list would not match what the user sees in their editor.
+// One read serves both purposes: godotenv returns a map, so the same bytes are
+// walked again for the order it loses, a scrambled list being one the user
+// could not match against their editor.
 func envVars(path string) ([]EnvVar, error) {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -200,24 +201,80 @@ func envVars(path string) ([]EnvVar, error) {
 		return nil, fmt.Errorf("%s is %d bytes, larger than the %d this reads", path, info.Size(), maxEnvFileSize)
 	}
 
-	values, err := godotenv.Read(path)
-	if err != nil {
-		// A .env this parser cannot read is still a .env, but listing keys we
-		// are not sure of would be worse than listing none.
-		return nil, fmt.Errorf("cannot parse %s: %w", path, err)
-	}
-
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read %s: %w", path, err)
 	}
 
+	text := string(content)
+
+	// Parsed from the bytes already in hand rather than from the path again,
+	// so the keys and the order they are recovered in come from one read.
+	values, err := godotenv.Unmarshal(text)
+	if err != nil {
+		// A .env this parser cannot read is still a .env, but listing keys we
+		// are not sure of would be worse than listing none. The parser's own
+		// error is deliberately not wrapped; see parseProblem.
+		return nil, fmt.Errorf("cannot parse %s: %s", path, parseProblem(err, text))
+	}
+
 	classified := make([]EnvVar, 0, len(values))
-	for _, name := range orderedKeys(string(content), values) {
+	for _, name := range orderedKeys(text, values) {
 		classified = append(classified, ClassifyEnv(name, values[name]))
 	}
 
 	return classified, nil
+}
+
+// parseProblem says why a .env would not parse without repeating any of it.
+// The parser reports the unparsed remainder of the input as part of its
+// message, so a malformed name on the second line would print every value
+// below it, and a headless run prints that to stderr and from there into
+// whatever log is capturing the build. Only the fixed half of a message this
+// code recognizes is repeated; anything else is described generically,
+// because a message it has not seen cannot be assumed free of file content.
+func parseProblem(err error, content string) string {
+	msg := err.Error()
+
+	// Tested before the split below, and by its opening rather than by any
+	// substring: this message ends in the raw value, so a value that happened
+	// to contain " near " would otherwise be cut in half and the first half
+	// printed.
+	if strings.HasPrefix(msg, unterminatedQuotedValue) {
+		return "a quoted value is never closed"
+	}
+
+	// "unexpected character %q in variable name near %q". What precedes
+	// " near " holds only the offending character, which comes from a name
+	// and is the one detail worth repeating; the rest is the payload.
+	if strings.HasPrefix(msg, unexpectedCharacter) {
+		if fixed, remainder, found := strings.Cut(msg, " near "); found {
+			return fixed + atLine(content, remainder)
+		}
+	}
+
+	return "it is not in KEY=value form"
+}
+
+// The godotenv messages this code repeats any part of. Each continues with
+// text lifted out of the file, so each is recognized by its fixed opening;
+// a message that matches neither is described in this package's own words.
+const (
+	unterminatedQuotedValue = "unterminated quoted value"
+	unexpectedCharacter     = "unexpected character "
+)
+
+// atLine converts the remainder the parser choked on into the line number it
+// begins at, which is the one part of that payload worth showing. The
+// remainder is a suffix of the file, so everything before it is what parsed.
+// An unrecognizable payload yields no line rather than a guessed one.
+func atLine(content, quotedRemainder string) string {
+	remainder, err := strconv.Unquote(quotedRemainder)
+	if err != nil || !strings.HasSuffix(content, remainder) {
+		return ""
+	}
+
+	return fmt.Sprintf(" on line %d", strings.Count(content[:len(content)-len(remainder)], "\n")+1)
 }
 
 // orderedKeys walks the file to recover the order godotenv's map loses, so

--- a/internal/workload/wizard/detect.go
+++ b/internal/workload/wizard/detect.go
@@ -15,6 +15,7 @@
 package wizard
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,9 +38,11 @@ const DockerfileName = "Dockerfile"
 // that says so.
 const DefaultDockerfilePath = "./" + DockerfileName
 
-// EnvFileName is the local environment file the wizard looks for. It is not
-// read for values, only counted: deploys come from the manifest, and saying
-// so is the point of noticing the file at all.
+// EnvFileName is the local environment file the wizard looks for. It is read
+// in full: `up` deploys the manifest and never reads .env, so anything kept
+// only there would not reach the container. Ordinary settings are copied into
+// the manifest as literals and secrets become credential references, which is
+// why the values are classified rather than merely counted.
 const EnvFileName = ".env"
 
 // maxDockerfileSize bounds the read. A Dockerfile is a few kilobytes; a
@@ -74,6 +77,11 @@ type Detected struct {
 	// written: an ordinary value as a literal, a secret as a credential
 	// reference whose id the user fills in. Every row is overridable.
 	EnvVars []EnvVar
+	// EnvErr is why a .env that is present contributed nothing. Setup still
+	// proceeds, because a manifest without the import is a working manifest,
+	// but it must be reported: silence here reads as "there was nothing to
+	// import" and the missing variables surface as a runtime failure instead.
+	EnvErr error
 }
 
 // HasEnvFile reports whether the project has a .env worth asking about.
@@ -101,8 +109,9 @@ func Detect(dir string) Detected {
 		HasDockerfile: fsutil.FileExists(filepath.Join(dir, DockerfileName)),
 		Port:          manifest.DefaultPort,
 		PortSource:    "the default for a web service; edit if yours differs",
-		EnvVars:       envVars(filepath.Join(dir, EnvFileName)),
 	}
+
+	detected.EnvVars, detected.EnvErr = envVars(filepath.Join(dir, EnvFileName))
 
 	if !detected.HasDockerfile {
 		return detected
@@ -165,27 +174,42 @@ func exposedPort(path string) (int, bool) {
 	return 0, false
 }
 
-// envVars reads and classifies a .env, nil when there is none or it cannot be
-// read. The values are used here and dropped: only names and verdicts leave
-// this function, so nothing downstream is holding a secret it could write out.
+// envVars reads and classifies a .env, and reports separately why a file that
+// exists yielded nothing. Both returns are empty when there is no .env at all,
+// which is not a problem and has nothing to say. The values travel with the
+// verdicts: an ordinary setting is written to the manifest as it stands, and a
+// secret's value is what a later credential is created from.
+//
 // The file is read a second time for order, because godotenv returns a map and
 // a scrambled list would not match what the user sees in their editor.
-func envVars(path string) []EnvVar {
+func envVars(path string) ([]EnvVar, error) {
 	info, err := os.Stat(path)
-	if err != nil || info.IsDir() || info.Size() > maxEnvFileSize {
-		return nil
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("cannot read %s: %w", path, err)
+	}
+
+	if info.IsDir() {
+		return nil, fmt.Errorf("%s is a directory, not a file", path)
+	}
+
+	if info.Size() > maxEnvFileSize {
+		return nil, fmt.Errorf("%s is %d bytes, larger than the %d this reads", path, info.Size(), maxEnvFileSize)
 	}
 
 	values, err := godotenv.Read(path)
-	if err != nil || len(values) == 0 {
+	if err != nil {
 		// A .env this parser cannot read is still a .env, but listing keys we
 		// are not sure of would be worse than listing none.
-		return nil
+		return nil, fmt.Errorf("cannot parse %s: %w", path, err)
 	}
 
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("cannot read %s: %w", path, err)
 	}
 
 	classified := make([]EnvVar, 0, len(values))
@@ -193,7 +217,7 @@ func envVars(path string) []EnvVar {
 		classified = append(classified, ClassifyEnv(name, values[name]))
 	}
 
-	return classified
+	return classified, nil
 }
 
 // orderedKeys walks the file to recover the order godotenv's map loses, so

--- a/internal/workload/wizard/detect.go
+++ b/internal/workload/wizard/detect.go
@@ -1,0 +1,258 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/datarobot/cli/internal/fsutil"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/joho/godotenv"
+)
+
+// DockerfileName is the only Dockerfile setup looks for, at the root of the
+// project directory. A build elsewhere is a hand edit, not an answer the
+// wizard offers.
+const DockerfileName = "Dockerfile"
+
+// DefaultDockerfilePath is how the --dockerfile flag spells that same file.
+// The flag takes no other value: the platform builds the project root's
+// Dockerfile, and a flag that quietly did nothing would be worse than one
+// that says so.
+const DefaultDockerfilePath = "./" + DockerfileName
+
+// EnvFileName is the local environment file the wizard looks for. It is not
+// read for values, only counted: deploys come from the manifest, and saying
+// so is the point of noticing the file at all.
+const EnvFileName = ".env"
+
+// maxDockerfileSize bounds the read. A Dockerfile is a few kilobytes; a
+// hundred is either not a Dockerfile or not one worth scanning for EXPOSE.
+const maxDockerfileSize = 1 << 20
+
+// maxEnvFileSize bounds the same way. A .env is a handful of lines; anything
+// larger is not one, and the count is only used for a one-line notice.
+const maxEnvFileSize = 1 << 20
+
+// Detected is what the project says about itself before anything is asked.
+// Every field here is a default the user can override on the screen it
+// belongs to.
+type Detected struct {
+	// Dir is the absolute project directory the manifest will be written to.
+	Dir string
+	// Name is the suggested workload name, taken from the directory.
+	Name string
+	// HasDockerfile decides which image source leads on the Q4 screen.
+	HasDockerfile bool
+	// Port is the suggested container port.
+	Port int
+	// PortSource explains where Port came from, shown next to the answer so
+	// the user can tell a detected value from a guess.
+	PortSource string
+	// EnvVars are the variables the project's .env defines, classified, in
+	// the order the file defines them; empty when there is no .env.
+	//
+	// `up` deploys the manifest and never reads .env, so a project that keeps
+	// its configuration there would otherwise deploy without any of it and
+	// find out at runtime. The classification decides how each one is
+	// written: an ordinary value as a literal, a secret as a credential
+	// reference whose id the user fills in. Every row is overridable.
+	EnvVars []EnvVar
+}
+
+// HasEnvFile reports whether the project has a .env worth asking about.
+func (d Detected) HasEnvFile() bool {
+	return len(d.EnvVars) > 0
+}
+
+// Plural picks the singular or plural word for count. Exported so the
+// command's summary reads the same way the screens do.
+func Plural(count int, one, many string) string {
+	if count == 1 {
+		return one
+	}
+
+	return many
+}
+
+// Detect reads the project directory. It never fails: anything it cannot
+// determine falls back to a documented default, and the screens make every
+// value visible before it is written.
+func Detect(dir string) Detected {
+	detected := Detected{
+		Dir:           dir,
+		Name:          sanitizeName(filepath.Base(dir)),
+		HasDockerfile: fsutil.FileExists(filepath.Join(dir, DockerfileName)),
+		Port:          manifest.DefaultPort,
+		PortSource:    "the default for a web service; edit if yours differs",
+		EnvVars:       envVars(filepath.Join(dir, EnvFileName)),
+	}
+
+	if !detected.HasDockerfile {
+		return detected
+	}
+
+	port, ok := exposedPort(filepath.Join(dir, DockerfileName))
+	if !ok {
+		return detected
+	}
+
+	// A privileged port cannot be honored: containers run unprivileged, so a
+	// primary container below 1024 never binds and the workload never becomes
+	// ready. Suggesting it would only produce a file the ledger rejects, so
+	// the default stands and the screen says why.
+	if port < manifest.MinPrimaryPort {
+		detected.PortSource = fmt.Sprintf(
+			"your %s says EXPOSE %d, but containers run unprivileged and cannot bind below %d",
+			DockerfileName, port, manifest.MinPrimaryPort)
+
+		return detected
+	}
+
+	detected.Port = port
+	detected.PortSource = fmt.Sprintf("found EXPOSE %d in your %s", port, DockerfileName)
+
+	return detected
+}
+
+// exposedPort returns the first port an EXPOSE line names. Later EXPOSE lines
+// are ignored: a multi-port image still has one port traffic arrives on, and
+// guessing among them would be worse than showing the first and letting the
+// user correct it.
+func exposedPort(path string) (int, bool) {
+	info, err := os.Stat(path)
+	if err != nil || info.Size() > maxDockerfileSize {
+		return 0, false
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+
+	for _, line := range strings.Split(string(content), "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 2 || !strings.EqualFold(fields[0], "EXPOSE") {
+			continue
+		}
+
+		// EXPOSE 8080/tcp is legal, and so is EXPOSE $PORT, which tells us
+		// nothing because the value only exists at build time.
+		port, err := strconv.Atoi(strings.SplitN(fields[1], "/", 2)[0])
+		if err != nil {
+			continue
+		}
+
+		return port, true
+	}
+
+	return 0, false
+}
+
+// envVars reads and classifies a .env, nil when there is none or it cannot be
+// read. The values are used here and dropped: only names and verdicts leave
+// this function, so nothing downstream is holding a secret it could write out.
+// The file is read a second time for order, because godotenv returns a map and
+// a scrambled list would not match what the user sees in their editor.
+func envVars(path string) []EnvVar {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() || info.Size() > maxEnvFileSize {
+		return nil
+	}
+
+	values, err := godotenv.Read(path)
+	if err != nil || len(values) == 0 {
+		// A .env this parser cannot read is still a .env, but listing keys we
+		// are not sure of would be worse than listing none.
+		return nil
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	classified := make([]EnvVar, 0, len(values))
+	for _, name := range orderedKeys(string(content), values) {
+		classified = append(classified, ClassifyEnv(name, values[name]))
+	}
+
+	return classified
+}
+
+// orderedKeys walks the file to recover the order godotenv's map loses, so
+// the listing matches what the user sees in their editor. Only names the
+// parser agreed on are kept, which is what filters comments and blank lines.
+func orderedKeys(content string, values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	seen := make(map[string]bool, len(values))
+
+	for _, line := range strings.Split(content, "\n") {
+		name, ok := assignedName(line)
+		if !ok || seen[name] {
+			continue
+		}
+
+		if _, declared := values[name]; !declared {
+			continue
+		}
+
+		seen[name] = true
+
+		keys = append(keys, name)
+	}
+
+	return keys
+}
+
+// assignedName returns the variable a line assigns, if it assigns one.
+func assignedName(line string) (string, bool) {
+	name, _, found := strings.Cut(strings.TrimSpace(line), "=")
+	if !found {
+		return "", false
+	}
+
+	return strings.TrimSpace(strings.TrimPrefix(name, "export ")), true
+}
+
+// sanitizeName turns a directory name into a plausible workload name. The
+// platform's own rules are enforced server-side; this only removes what a
+// directory can carry and a name should not, so the suggestion is usable
+// without editing.
+func sanitizeName(dir string) string {
+	name := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r + ('a' - 'A')
+		case r == ' ', r == '.':
+			return '-'
+		default:
+			return -1
+		}
+	}, dir)
+
+	name = strings.Trim(name, "-_")
+	if name == "" {
+		return "my-app"
+	}
+
+	return name
+}

--- a/internal/workload/wizard/detect_test.go
+++ b/internal/workload/wizard/detect_test.go
@@ -93,10 +93,11 @@ func TestDetect_SuggestsANameFromTheDirectory(t *testing.T) {
 
 	for dirName, want := range tests {
 		t.Run(dirName, func(t *testing.T) {
-			dir := filepath.Join(t.TempDir(), dirName)
-			require.NoError(t, os.Mkdir(dir, 0o755))
-
-			assert.Equal(t, want, Detect(dir).Name)
+			// The directory is deliberately not created. The name comes from
+			// the path, so nothing here needs one to exist, and "..." is a
+			// name Windows refuses to create: it strips trailing dots, so the
+			// path resolves to the parent and the mkdir fails as EEXIST.
+			assert.Equal(t, want, Detect(filepath.Join(t.TempDir(), dirName)).Name)
 		})
 	}
 }

--- a/internal/workload/wizard/detect_test.go
+++ b/internal/workload/wizard/detect_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeDockerfile puts a Dockerfile in dir and returns dir, so a test reads
+// as the project it is describing.
+func writeDockerfile(t *testing.T, dir, content string) string {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, DockerfileName), []byte(content), 0o600))
+
+	return dir
+}
+
+func TestDetect_NoDockerfile(t *testing.T) {
+	detected := Detect(t.TempDir())
+
+	assert.False(t, detected.HasDockerfile)
+	assert.Equal(t, manifest.DefaultPort, detected.Port)
+	assert.NotContains(t, detected.PortSource, "EXPOSE")
+}
+
+func TestDetect_ReadsExpose(t *testing.T) {
+	tests := map[string]struct {
+		dockerfile string
+		wantPort   int
+		wantSource bool
+	}{
+		"plain":            {"FROM scratch\nEXPOSE 3000\n", 3000, true},
+		"with protocol":    {"FROM scratch\nEXPOSE 9000/tcp\n", 9000, true},
+		"lowercase":        {"FROM scratch\nexpose 5000\n", 5000, true},
+		"indented":         {"FROM scratch\n  EXPOSE 7000\n", 7000, true},
+		"first of several": {"FROM scratch\nEXPOSE 3000\nEXPOSE 9090\n", 3000, true},
+		// A build-time variable says nothing we can act on, so the default
+		// stands rather than a guess.
+		"build arg":  {"FROM scratch\nEXPOSE $PORT\n", manifest.DefaultPort, false},
+		"no expose":  {"FROM scratch\nCMD [\"/app\"]\n", manifest.DefaultPort, false},
+		"bare word":  {"FROM scratch\nEXPOSE\n", manifest.DefaultPort, false},
+		"not a port": {"FROM scratch\nEXPOSE http\n", manifest.DefaultPort, false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			detected := Detect(writeDockerfile(t, t.TempDir(), test.dockerfile))
+
+			assert.True(t, detected.HasDockerfile)
+			assert.Equal(t, test.wantPort, detected.Port)
+
+			if test.wantSource {
+				assert.Contains(t, detected.PortSource, "EXPOSE")
+			} else {
+				assert.NotContains(t, detected.PortSource, "EXPOSE")
+			}
+		})
+	}
+}
+
+// The suggested name has to be usable as typed, because the happy path is
+// pressing Enter through it.
+func TestDetect_SuggestsANameFromTheDirectory(t *testing.T) {
+	tests := map[string]string{
+		"my-app":        "my-app",
+		"My App":        "my-app",
+		"my.app.v2":     "my-app-v2",
+		"_private_":     "private",
+		"señor-café":    "seor-caf",
+		"...":           "my-app",
+		"UPPERCASE":     "uppercase",
+		"trailing-dash": "trailing-dash",
+	}
+
+	for dirName, want := range tests {
+		t.Run(dirName, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), dirName)
+			require.NoError(t, os.Mkdir(dir, 0o755))
+
+			assert.Equal(t, want, Detect(dir).Name)
+		})
+	}
+}
+
+// Only the key names are read. The values are the user's secrets and have no
+// business in a wizard that is not importing them.
+func TestDetect_ReadsEnvKeyNamesInOrder(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("# a comment\nLOG_LEVEL=debug\nOPENAI_API_KEY=sk-secret\n\nexport DATABASE_URL=postgres://x\n"), 0o600))
+
+	detected := Detect(dir)
+
+	names := make([]string, 0, len(detected.EnvVars))
+	for _, v := range detected.EnvVars {
+		names = append(names, v.Name)
+	}
+
+	assert.Equal(t, []string{"LOG_LEVEL", "OPENAI_API_KEY", "DATABASE_URL"}, names,
+		"order matches the file, and export is not part of the name")
+	assert.True(t, detected.HasEnvFile())
+}
+
+func TestDetect_NoEnvFileIsSilent(t *testing.T) {
+	detected := Detect(t.TempDir())
+
+	assert.Empty(t, detected.EnvVars)
+	assert.False(t, detected.HasEnvFile())
+}
+
+func TestDetect_EmptyEnvFileIsSilent(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName), []byte("# nothing set yet\n"), 0o600))
+
+	assert.False(t, Detect(dir).HasEnvFile())
+}
+
+func TestDetect_SingularKey(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName), []byte("ONLY=one\n"), 0o600))
+
+	require.Len(t, Detect(dir).EnvVars, 1)
+}

--- a/internal/workload/wizard/detect_test.go
+++ b/internal/workload/wizard/detect_test.go
@@ -15,6 +15,7 @@
 package wizard
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -140,4 +141,84 @@ func TestDetect_SingularKey(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName), []byte("ONLY=one\n"), 0o600))
 
 	require.Len(t, Detect(dir).EnvVars, 1)
+}
+
+// writeEnv puts a .env in dir, which is all Detect needs to try parsing it.
+func writeEnv(t *testing.T, dir, content string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName), []byte(content), 0o600))
+}
+
+// godotenv reports the whole unparsed remainder of the input as part of its
+// message, so an unfiltered wrap would print every value below the bad line.
+// The reason and the position are worth showing; nothing else from the file
+// is, and a headless run puts this straight into a build log.
+func TestEnvVars_ParseErrorNamesTheLineWithoutTheFile(t *testing.T) {
+	dir := t.TempDir()
+	writeEnv(t, dir, "GOOD=1\nBAD-NAME=x\nAPI_TOKEN=sk-live-do-not-print\nDB_PASSWORD=hunter2\n")
+
+	detected := Detect(dir)
+
+	require.Error(t, detected.EnvErr)
+	assert.Empty(t, detected.EnvVars)
+
+	msg := detected.EnvErr.Error()
+
+	assert.Contains(t, msg, "unexpected character")
+	assert.Contains(t, msg, "on line 2")
+	assert.NotContains(t, msg, "sk-live-do-not-print")
+	assert.NotContains(t, msg, "hunter2")
+	assert.NotContains(t, msg, "API_TOKEN")
+}
+
+// The blank lines matter: the line number is counted from the file, not from
+// the variables in it.
+func TestEnvVars_ParseErrorCountsBlankLines(t *testing.T) {
+	dir := t.TempDir()
+	writeEnv(t, dir, "A=1\n\n# a comment\n\nB-C=3\nZ=sk-tail\n")
+
+	detected := Detect(dir)
+
+	require.Error(t, detected.EnvErr)
+	assert.Contains(t, detected.EnvErr.Error(), "on line 5")
+	assert.NotContains(t, detected.EnvErr.Error(), "sk-tail")
+}
+
+// This is the message that ends in the raw value rather than a quoted one,
+// so it is reported by class and never quoted back.
+func TestEnvVars_UnterminatedQuoteIsNotEchoed(t *testing.T) {
+	dir := t.TempDir()
+	writeEnv(t, dir, "TOKEN=\"unclosed-sk-live-secret\nNEXT=2\n")
+
+	detected := Detect(dir)
+
+	require.Error(t, detected.EnvErr)
+	assert.Contains(t, detected.EnvErr.Error(), "quoted value is never closed")
+	assert.NotContains(t, detected.EnvErr.Error(), "sk-live-secret")
+}
+
+// A value carrying the separator the other branch splits on must not reach
+// that branch: matching by opening rather than by substring is what stops
+// half the value being printed.
+func TestParseProblem_UnterminatedQuoteWinsOverTheNearSplit(t *testing.T) {
+	err := errors.New(`unterminated quoted value "sk near live-secret`)
+
+	assert.Equal(t, "a quoted value is never closed", parseProblem(err, ""))
+}
+
+// An unrecognized message cannot be assumed free of file content, so none of
+// it is repeated.
+func TestParseProblem_UnknownMessageIsDescribedGenerically(t *testing.T) {
+	err := errors.New("some future parser complaint about sk-live-secret")
+
+	assert.Equal(t, "it is not in KEY=value form", parseProblem(err, ""))
+}
+
+// A payload that is not a suffix of the file yields no line rather than a
+// wrong one.
+func TestParseProblem_UnrecognizablePayloadYieldsNoLine(t *testing.T) {
+	err := errors.New(`unexpected character "-" in variable name near "not-from-this-file"`)
+
+	assert.Equal(t, `unexpected character "-" in variable name`, parseProblem(err, "A=1\n"))
 }

--- a/internal/workload/wizard/doc.go
+++ b/internal/workload/wizard/doc.go
@@ -32,8 +32,13 @@
 // serves a laptop and CI. Without a terminal nothing prompts: a missing
 // required answer is an error that names the flag.
 //
+// A project's .env is read here and its variables are classified by name and
+// by value, because `up` deploys the manifest and never reads .env: anything
+// kept only there would not reach the container. Ordinary settings are copied
+// in as literals; a secret becomes a credential reference with a placeholder
+// id, since creating the credential needs an API the CLI does not have yet.
+//
 // Non-scope: the manifest format itself (that is the manifest package, which
-// renders, validates and writes the file), the .env import and its
-// credentials (a separate command flag and a separate ticket), and the NIM
-// track.
+// renders, validates and writes the file), creating the credentials those
+// placeholders stand in for, and the NIM track.
 package wizard

--- a/internal/workload/wizard/doc.go
+++ b/internal/workload/wizard/doc.go
@@ -1,0 +1,39 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package wizard is the setup flow behind `dr workload config`: the handful
+// of questions that turn a directory into a committed .datarobot.yaml, and
+// the headless path that answers the same questions from flags.
+//
+// Setup is a one-time act. Run refuses to touch an existing manifest and
+// points at it instead, because after the first write the file is the
+// interface and editing twelve lines of YAML beats re-answering eight
+// questions. Deleting the file re-arms the wizard.
+//
+// The flow lives here rather than in the command so `dr workload up` can
+// embed the identical wizard when it finds no manifest, instead of growing a
+// second, subtly different one.
+//
+// Defaults come from wherever the truth already lives: Detect reads the
+// project (a Dockerfile, its EXPOSE), and binding to an existing workload
+// reads that workload's own spec. Answers carries what the flags already
+// said, and every answered question skips its screen, so the same code path
+// serves a laptop and CI. Without a terminal nothing prompts: a missing
+// required answer is an error that names the flag.
+//
+// Non-scope: the manifest format itself (that is the manifest package, which
+// renders, validates and writes the file), the .env import and its
+// credentials (a separate command flag and a separate ticket), and the NIM
+// track.
+package wizard

--- a/internal/workload/wizard/run.go
+++ b/internal/workload/wizard/run.go
@@ -126,6 +126,10 @@ func Run(opts Options) (Result, error) {
 
 	detected := Detect(dir)
 
+	if !opts.Answers.SkipEnv {
+		warnUnreadEnvFile(opts.Stderr, detected)
+	}
+
 	content, draft, err := opts.resolve(detected)
 	if err != nil {
 		return Result{}, err
@@ -249,6 +253,12 @@ func (o Options) resolveHeadlessBound(detected Detected) ([]byte, manifest.Draft
 		return nil, manifest.Draft{}, err
 	}
 
+	// A name the workload already declares keeps its running value, so it is
+	// not something this run added. Narrowing the draft here rather than
+	// leaving it to Apply's own skip is what keeps the reported counts equal
+	// to what reached the file.
+	draft.EnvVars = live.NewEnvVars(draft.EnvVars)
+
 	applied, err := live.Apply(draft)
 	if err != nil {
 		return nil, manifest.Draft{}, err
@@ -281,6 +291,10 @@ func (a Answers) applyTo(defaults manifest.Draft, detected Detected) (manifest.D
 	a.applyReadiness(&draft)
 	a.applySizing(&draft)
 	a.applyEnv(&draft, detected)
+
+	if err := a.checkA2A(draft.Type); err != nil {
+		return manifest.Draft{}, err
+	}
 
 	if err := a.applyBuild(&draft, detected); err != nil {
 		return manifest.Draft{}, err
@@ -337,9 +351,20 @@ func (a Answers) applySizing(draft *manifest.Draft) {
 	}
 }
 
+// applyBuild layers the image-source flags. Staying on the mode the workload
+// already uses is an edit to that build, so only the fields actually passed
+// change and the rest keep their live values: --entrypoint alone changes a
+// generated build's command without demanding its environment be repeated.
+// Switching modes is the other thing entirely, and there the mode's companion
+// flags are required, because nothing in the old build answers for the new one.
 func (a Answers) applyBuild(draft *manifest.Draft, detected Detected) error {
-	if !a.explicitBuild() || a.buildMode(detected) == "" {
+	mode := a.buildMode(detected)
+	if !a.explicitBuild() || mode == "" {
 		return nil
+	}
+
+	if mode == draft.Build.Mode {
+		return a.mergeBuild(&draft.Build)
 	}
 
 	build, err := a.build(detected)
@@ -348,6 +373,40 @@ func (a Answers) applyBuild(draft *manifest.Draft, detected Detected) error {
 	}
 
 	draft.Build = build
+
+	return nil
+}
+
+// mergeBuild edits a build already in the requested mode, field by field.
+func (a Answers) mergeBuild(build *manifest.Build) error {
+	switch build.Mode {
+	case manifest.BuildModeImage:
+		if a.Image != "" {
+			build.ImageURI = a.Image
+		}
+
+	case manifest.BuildModeGenerated:
+		if a.Entrypoint != "" {
+			entrypoint, err := splitCommand(a.Entrypoint)
+			if err != nil {
+				return fmt.Errorf("--entrypoint %q: %w", a.Entrypoint, err)
+			}
+
+			build.Entrypoint = entrypoint
+		}
+
+		if a.ExecutionEnvironment != "" {
+			id, versionID, err := resolveExecEnvFn(a.ExecutionEnvironment)
+			if err != nil {
+				return err
+			}
+
+			build.ExecutionEnvironmentID, build.ExecutionEnvironmentVersionID = id, versionID
+		}
+
+	case manifest.BuildModeDockerfile:
+		// The mode is the whole answer; there is nothing else to carry.
+	}
 
 	return nil
 }
@@ -461,6 +520,21 @@ func warnShadowedManifest(stderr io.Writer, dir string) {
 	fmt.Fprintf(stderr,
 		"Warning: a manifest already exists at %s. Writing one in %s means a deploy from either directory reads a different file.\n",
 		found, dir)
+}
+
+// warnUnreadEnvFile says so when a .env is there but contributed nothing.
+// Setup continues, because the import is a convenience and the manifest is
+// valid without it, but it cannot pass in silence: the whole reason the file
+// is read is that `up` never reads it, so an import that quietly did not
+// happen surfaces as a container missing its configuration at runtime.
+func warnUnreadEnvFile(stderr io.Writer, detected Detected) {
+	if stderr == nil || detected.EnvErr == nil {
+		return
+	}
+
+	fmt.Fprintf(stderr,
+		"Warning: %v. Nothing from it was imported; add the variables to %s by hand.\n",
+		detected.EnvErr, manifest.FileName)
 }
 
 // ShortPath names a path relative to the working directory when it is under

--- a/internal/workload/wizard/run.go
+++ b/internal/workload/wizard/run.go
@@ -1,0 +1,491 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/datarobot/cli/internal/fsutil"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+)
+
+// SetStdinTerminalForTest makes the wizard believe it has, or does not have,
+// a terminal. It exists so a command-level test can prove that JSON output
+// suppresses the wizard: under `go test` stdin is never a terminal, so
+// without this the guard is unobservable and could be deleted unnoticed.
+func SetStdinTerminalForTest(isTerminal bool) func() {
+	original := isStdinTerminalFn
+	isStdinTerminalFn = func() bool { return isTerminal }
+
+	return func() { isStdinTerminalFn = original }
+}
+
+// SetInteractiveFlowForTest replaces the wizard itself, so a command-level
+// test can tell whether it would have run.
+func SetInteractiveFlowForTest(flow func(Options, Detected) ([]byte, manifest.Draft, error)) func() {
+	original := runInteractiveFlowFn
+	runInteractiveFlowFn = flow
+
+	return func() { runInteractiveFlowFn = original }
+}
+
+// Test seams: the wizard's tests replace these to keep the flow off the
+// network and off the terminal.
+var (
+	getWorkloadFn        = workload.GetWorkloadDocument
+	getArtifactFn        = workload.GetArtifactDocument
+	resolveExecEnvFn     = workload.ResolveExecutionEnvironment
+	isStdinTerminalFn    = reader.IsStdinTerminal
+	runInteractiveFlowFn = interactiveFlowUnavailable
+)
+
+// Actions a run can report, mirroring what the JSON envelope carries.
+const (
+	// ActionCreated means the manifest was written.
+	ActionCreated = "created"
+	// ActionUnchanged means one was already there and nothing was touched.
+	ActionUnchanged = "unchanged"
+	// ActionPlanned means the run was a dry run: the content is what would
+	// have been written, and nothing was. A caller keying on the action must
+	// be able to tell that apart from a file that now exists.
+	ActionPlanned = "planned"
+)
+
+// Options is one setup run.
+type Options struct {
+	// Dir is the project directory the manifest is written to.
+	Dir string
+	// NonInteractive answers everything from Answers and never prompts. It is
+	// implied by the absence of a terminal and by JSON output.
+	NonInteractive bool
+	// DryRun renders the manifest and writes nothing.
+	DryRun  bool
+	Answers Answers
+	// Stderr carries the wizard and its summary. Nothing the wizard says
+	// belongs on stdout, which is the command's machine-readable channel.
+	Stderr io.Writer
+}
+
+// Result is what a run settled.
+type Result struct {
+	// Path is the manifest, written or already present.
+	Path string
+	// Action is ActionCreated, ActionUnchanged or ActionPlanned.
+	Action string
+	// Content is the manifest as written, or as it would be written under
+	// DryRun. Empty when the run changed nothing.
+	Content []byte
+	// EnvKeysListed is how many .env variables the written file carries, 0
+	// when there was no .env or the user opted out, and EnvSecretsPending is
+	// how many of those are commented out awaiting a credential. The command
+	// reports both, so a headless run says what it actually did.
+	EnvKeysListed     int
+	EnvSecretsPending int
+	// Draft is the answer set behind Content. For a bound workload it
+	// describes the fields the wizard asked about, not the whole file.
+	Draft manifest.Draft
+}
+
+// Run executes setup: it answers the questions from the flags, the project
+// and, on a terminal, the user, then writes the manifest.
+//
+// An existing manifest ends the run untouched. That is the whole of setup's
+// relationship with a configured project: the file is the interface, every
+// later change is a hand edit, and deleting the file re-arms the wizard.
+func Run(opts Options) (Result, error) {
+	dir, err := filepath.Abs(opts.Dir)
+	if err != nil {
+		return Result{}, fmt.Errorf("cannot resolve %s: %w", opts.Dir, err)
+	}
+
+	path := manifest.Path(dir)
+	if fsutil.FileExists(path) {
+		return existing(path)
+	}
+
+	warnShadowedManifest(opts.Stderr, dir)
+
+	detected := Detect(dir)
+
+	content, draft, err := opts.resolve(detected)
+	if err != nil {
+		return Result{}, err
+	}
+
+	// A file that came from a running workload is judged as the platform's
+	// news, not as a bug in the wizard.
+	author := authorWizard
+	if draft.WorkloadID != "" {
+		author = authorLive
+	}
+
+	if err := checkRendered(content, dir, author); err != nil {
+		return Result{}, err
+	}
+
+	action := ActionCreated
+	if opts.DryRun {
+		action = ActionPlanned
+	}
+
+	result := Result{
+		Path:              path,
+		Action:            action,
+		Content:           content,
+		Draft:             draft,
+		EnvKeysListed:     len(draft.EnvVars),
+		EnvSecretsPending: countSecrets(draft.EnvVars),
+	}
+
+	if opts.DryRun {
+		return result, nil
+	}
+
+	if err := manifest.Write(path, content); err != nil {
+		return Result{}, err
+	}
+
+	return result, nil
+}
+
+// countSecrets is how many entries are waiting on a credential.
+func countSecrets(vars []manifest.EnvVar) int {
+	pending := 0
+
+	for _, v := range vars {
+		if v.Secret {
+			pending++
+		}
+	}
+
+	return pending
+}
+
+// existing reports the manifest that is already there, and reads it rather
+// than only noting its presence: the run's answer describes the project as it
+// stands, not as it would have been configured. A file that cannot be read or
+// does not validate is reported as the line-numbered error it is, because
+// telling the user everything is fine and letting up discover otherwise is
+// the worse of the two answers.
+func existing(path string) (Result, error) {
+	parsed, err := manifest.Load(path)
+	if err != nil {
+		return Result{}, err
+	}
+
+	if err := parsed.Validate(); err != nil {
+		return Result{}, err
+	}
+
+	return Result{
+		Path:   path,
+		Action: ActionUnchanged,
+		Draft: manifest.Draft{
+			WorkloadID: parsed.WorkloadID(),
+			Name:       parsed.Name(),
+			Build:      manifest.Build{Mode: parsed.BuildMode()},
+		},
+	}, nil
+}
+
+// resolve produces the manifest bytes, from flags alone when nothing may
+// prompt and from the wizard otherwise.
+func (o Options) resolve(detected Detected) ([]byte, manifest.Draft, error) {
+	if o.NonInteractive || !isStdinTerminalFn() {
+		return o.resolveHeadless(detected)
+	}
+
+	return runInteractiveFlowFn(o, detected)
+}
+
+func (o Options) resolveHeadless(detected Detected) ([]byte, manifest.Draft, error) {
+	if o.Answers.WorkloadID != "" {
+		return o.resolveHeadlessBound(detected)
+	}
+
+	draft, err := o.Answers.draft(detected)
+	if err != nil {
+		return nil, manifest.Draft{}, err
+	}
+
+	content, err := draft.Render()
+	if err != nil {
+		return nil, manifest.Draft{}, err
+	}
+
+	return content, draft, nil
+}
+
+// resolveHeadlessBound binds to a live workload without prompting: the live
+// spec is downloaded and the flags are applied on top, so a headless bind is
+// the same operation the picker performs.
+func (o Options) resolveHeadlessBound(detected Detected) ([]byte, manifest.Draft, error) {
+	live, err := fetchLive(o.Answers.WorkloadID)
+	if err != nil {
+		return nil, manifest.Draft{}, err
+	}
+
+	draft, err := o.Answers.applyTo(live.Defaults(), detected)
+	if err != nil {
+		return nil, manifest.Draft{}, err
+	}
+
+	applied, err := live.Apply(draft)
+	if err != nil {
+		return nil, manifest.Draft{}, err
+	}
+
+	content, err := applied.Render()
+	if err != nil {
+		return nil, manifest.Draft{}, err
+	}
+
+	return content, draft, nil
+}
+
+// applyTo layers the flags over defaults that already came from somewhere
+// truthful, which for a bound workload is the workload itself. Only fields
+// the user actually passed are overwritten, so binding keeps the live values
+// for everything the command line did not mention.
+func (a Answers) applyTo(defaults manifest.Draft, detected Detected) (manifest.Draft, error) {
+	if err := a.check(); err != nil {
+		return manifest.Draft{}, err
+	}
+
+	draft := defaults
+
+	if a.Name != "" {
+		draft.Name = a.Name
+	}
+
+	a.applyKind(&draft)
+	a.applyReadiness(&draft)
+	a.applySizing(&draft)
+	a.applyEnv(&draft, detected)
+
+	if err := a.applyBuild(&draft, detected); err != nil {
+		return manifest.Draft{}, err
+	}
+
+	return draft, nil
+}
+
+// applyKind layers the kind flags. Only a changed kind resets the flags
+// belonging to the old one, and --a2a-enabled is a set-only flag: its absence
+// is "not asked", not "off".
+func (a Answers) applyKind(draft *manifest.Draft) {
+	if a.Type != "" && a.Type != draft.Type {
+		draft.Type = a.Type
+		draft.A2AEnabled = false
+	}
+
+	if a.A2AEnabled {
+		draft.A2AEnabled = true
+	}
+}
+
+func (a Answers) applyReadiness(draft *manifest.Draft) {
+	if a.Port != 0 {
+		draft.Port = a.Port
+	}
+
+	if a.HealthPath != "" {
+		draft.HealthPath = a.HealthPath
+	}
+}
+
+// applyEnv layers the .env listing onto a bound workload. A live workload
+// already carries its own environmentVars, so the placeholders are additive
+// commentary and the opt-out still removes them.
+func (a Answers) applyEnv(draft *manifest.Draft, detected Detected) {
+	draft.EnvVars = a.envVars(detected)
+}
+
+// applySizing layers the runtime flags, which apply to a bound workload too.
+// Anything left at zero keeps what the workload is already running with,
+// rather than resetting it to the documented default.
+func (a Answers) applySizing(draft *manifest.Draft) {
+	if a.Replicas != 0 {
+		draft.Runtime.Replicas = a.Replicas
+	}
+
+	if a.CPU != 0 {
+		draft.Runtime.CPU = a.CPU
+	}
+
+	if a.Memory != "" {
+		draft.Runtime.Memory = manifest.NormalizeMemory(a.Memory)
+	}
+}
+
+func (a Answers) applyBuild(draft *manifest.Draft, detected Detected) error {
+	if !a.explicitBuild() || a.buildMode(detected) == "" {
+		return nil
+	}
+
+	build, err := a.build(detected)
+	if err != nil {
+		return err
+	}
+
+	draft.Build = build
+
+	return nil
+}
+
+// explicitBuild reports whether the flags actually asked for an image source,
+// as opposed to the detector noticing a Dockerfile. Binding must not switch a
+// running workload's build mode just because the checkout happens to have a
+// Dockerfile in it.
+func (a Answers) explicitBuild() bool {
+	return a.BuildMode != "" || a.Image != "" || a.ExecutionEnvironment != "" || a.Entrypoint != ""
+}
+
+// fetchLive downloads a workload and the artifact it runs. The workload is
+// fetched by id, so a typo fails here, at setup, rather than at the first
+// deploy.
+func fetchLive(workloadID string) (manifest.Live, error) {
+	workloadDoc, err := getWorkloadFn(workloadID)
+	if err != nil {
+		return manifest.Live{}, fmt.Errorf("cannot bind to workload %s: %w", workloadID, err)
+	}
+
+	artifactID := workloadDoc.String("artifactId")
+	if artifactID == "" {
+		return manifest.Live{}, fmt.Errorf("workload %s has no artifact to copy; create a new workload instead", workloadID)
+	}
+
+	artifactDoc, err := getArtifactFn(artifactID)
+	if err != nil {
+		return manifest.Live{}, fmt.Errorf("cannot read the artifact of workload %s: %w", workloadID, err)
+	}
+
+	return manifest.NewLive(workloadID, workloadDoc, artifactDoc), nil
+}
+
+// checkRendered parses and validates what is about to be written, so a file
+// this CLI would refuse to read is never left on disk.
+//
+// The wording matters, because the content has three possible authors. A file
+// the wizard composed from its own answers failing here is a bug in the
+// wizard. A file that came from a running workload failing here means the
+// workload uses something the reader has not caught up with, which is the
+// platform's news, not the user's mistake. And a file the user just edited is
+// simply theirs to fix.
+func checkRendered(content []byte, dir string, author contentAuthor) error {
+	parsed, err := manifest.Parse(content, dir)
+	if err == nil {
+		err = parsed.Validate()
+	}
+
+	if err == nil {
+		return nil
+	}
+
+	switch author {
+	case authorWizard:
+		return fmt.Errorf("the generated manifest is not valid, which is a bug: %w", err)
+	case authorLive:
+		return fmt.Errorf("workload %s uses settings this CLI cannot yet write to a manifest.\n"+
+			"Nothing was written. Please report this with the detail below:\n%w", manifestName(parsed), err)
+	case authorUser:
+		// The user just edited it, so the finding speaks for itself.
+		return err
+	}
+
+	return err
+}
+
+// contentAuthor says who wrote the bytes being checked, which decides whose
+// problem a failure is.
+type contentAuthor int
+
+const (
+	// authorWizard is the wizard's own rendering of its own answers.
+	authorWizard contentAuthor = iota
+	// authorLive came from a running workload.
+	authorLive
+	// authorUser came from the user's editor.
+	authorUser
+)
+
+func manifestName(parsed *manifest.Manifest) string {
+	if parsed == nil || parsed.Name() == "" {
+		return "this"
+	}
+
+	return parsed.Name()
+}
+
+// warnShadowedManifest names an ancestor manifest rather than letting two
+// files quietly shadow each other: up searches upward, so a nested file
+// changes which one a deploy from the parent directory reads.
+func warnShadowedManifest(stderr io.Writer, dir string) {
+	if stderr == nil {
+		return
+	}
+
+	parent := filepath.Dir(dir)
+	if parent == dir {
+		return
+	}
+
+	found, err := manifest.Locate(parent)
+	if err != nil {
+		if !errors.Is(err, manifest.ErrNotFound) {
+			fmt.Fprintf(stderr, "Warning: cannot check for a manifest above %s: %v\n", dir, err)
+		}
+
+		return
+	}
+
+	fmt.Fprintf(stderr,
+		"Warning: a manifest already exists at %s. Writing one in %s means a deploy from either directory reads a different file.\n",
+		found, dir)
+}
+
+// ShortPath names a path relative to the working directory when it is under
+// it, which is how the user would say it themselves. Exported so the command
+// and the screens render the same path the same way.
+func ShortPath(path string) string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return path
+	}
+
+	relative, err := filepath.Rel(cwd, path)
+	if err != nil || strings.HasPrefix(relative, "..") {
+		return path
+	}
+
+	return relative
+}
+
+// interactiveFlowUnavailable stands in until the wizard screens land. The
+// command is behind a feature gate, so the only way to reach this is to run
+// the gated command on a terminal without flags.
+func interactiveFlowUnavailable(_ Options, _ Detected) ([]byte, manifest.Draft, error) {
+	const msg = "interactive setup is not available yet; " +
+		"pass --yes with the flags that answer each question"
+
+	return nil, manifest.Draft{}, errors.New(msg)
+}

--- a/internal/workload/wizard/run_test.go
+++ b/internal/workload/wizard/run_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -107,6 +108,9 @@ func TestRun_DryRunWritesNothing(t *testing.T) {
 
 	assert.NotEmpty(t, result.Content)
 	assert.NoFileExists(t, result.Path)
+	// The action is what a script keys on to tell a plan from a file that now
+	// exists, so a dry run reporting ActionCreated would be a silent lie.
+	assert.Equal(t, ActionPlanned, result.Action)
 }
 
 // Setup is a one-time act. A configured project gets a pointer at its file,
@@ -315,4 +319,195 @@ func TestRun_NoTerminalNeverPrompts(t *testing.T) {
 
 	_, err := Run(Options{Dir: dir, Answers: Answers{Name: "my-app"}, Stderr: &bytes.Buffer{}})
 	require.NoError(t, err)
+}
+
+// writeEnvFile puts a .env in dir and hands back the directory, so a test
+// reads as one line of setup.
+func writeEnvFile(t *testing.T, dir, content string) string {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName), []byte(content), 0o600))
+
+	return dir
+}
+
+// liveGeneratedAgent is a running agent built from an execution environment,
+// which is the case where binding has live values worth keeping.
+func liveGeneratedAgent(t *testing.T) {
+	t.Helper()
+	stubLive(t,
+		documentFrom(t, `{"name": "live-agent", "importance": "low", "artifactId": "68a1",
+			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
+				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
+		documentFrom(t, `{"name": "live-agent-artifact", "spec": {"type": "agent",
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 8000,
+				 "imageBuildConfig": {"dockerfile": {"source": "generated",
+				   "entrypoint": ["python", "old.py"],
+				   "executionEnvironmentId": "68e1", "executionEnvironmentVersionId": "68e2"}}}]}]}}`))
+}
+
+// Staying on the mode the workload already uses is an edit to that build, so
+// the flags that were not passed keep their live values. Demanding
+// --execution-environment again to change the entrypoint would contradict the
+// rest of binding, where an omitted field means "leave it alone".
+func TestRun_BoundBuildKeepsWhatTheFlagsDidNotMention(t *testing.T) {
+	liveGeneratedAgent(t)
+
+	result, err := Run(headless(t.TempDir(), Answers{
+		WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0",
+		Entrypoint: "python new.py",
+	}))
+	require.NoError(t, err)
+
+	written := string(result.Content)
+
+	assert.Contains(t, written, "- new.py")
+	assert.NotContains(t, written, "old.py")
+	assert.Contains(t, written, `executionEnvironmentId: "68e1"`)
+	assert.Contains(t, written, `executionEnvironmentVersionId: "68e2"`)
+	assert.Contains(t, written, "source: generated")
+}
+
+// Switching modes is the other thing entirely: nothing in the old build
+// answers for the new one, so the new mode's own flags are required.
+func TestRun_BoundBuildModeSwitchNeedsItsOwnFlags(t *testing.T) {
+	liveGeneratedAgent(t)
+
+	_, err := Run(headless(t.TempDir(), Answers{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0", BuildMode: "image"}))
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "--image is required")
+}
+
+func TestRun_BoundBuildModeSwitchReplacesTheBuild(t *testing.T) {
+	liveGeneratedAgent(t)
+
+	result, err := Run(headless(t.TempDir(), Answers{
+		WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0",
+		BuildMode:  "image",
+		Image:      "registry/new:v1",
+	}))
+	require.NoError(t, err)
+
+	written := string(result.Content)
+
+	assert.Contains(t, written, "imageUri: registry/new:v1")
+	assert.NotContains(t, written, "imageBuildConfig")
+}
+
+// --a2a-enabled is judged against the kind that will be written. For a bound
+// agent that is the live kind, so the caller does not have to repeat --type.
+func TestRun_BoundAgentTakesA2AWithoutRepeatingTheType(t *testing.T) {
+	liveGeneratedAgent(t)
+
+	result, err := Run(headless(t.TempDir(), Answers{
+		WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0",
+		A2AEnabled: true,
+	}))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(result.Content), "a2aEnabled: true")
+}
+
+// A service is still a service, bound or not.
+func TestRun_BoundServiceRejectsA2A(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "live-app", "importance": "low", "artifactId": "68a1",
+			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
+				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
+		documentFrom(t, `{"name": "live-app-artifact", "spec": {"type": "service",
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/live:v9"}]}]}}`))
+
+	_, err := Run(headless(t.TempDir(), Answers{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0", A2AEnabled: true}))
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "--a2a-enabled applies to --type agent")
+}
+
+// The summary counts what reached the file. A name the workload already
+// declares keeps its running value, so claiming it was added would describe a
+// run that did not happen.
+func TestRun_BoundEnvCountsOnlyWhatWasAdded(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "live-app", "importance": "low", "artifactId": "68a1",
+			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
+				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
+		documentFrom(t, `{"name": "live-app-artifact", "spec": {"type": "service",
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/live:v9",
+				 "environmentVars": [{"name": "LOG_LEVEL", "value": "info"},
+				                     {"name": "OPENAI_API_KEY", "value": "live"}]}]}]}}`))
+
+	dir := writeEnvFile(t, t.TempDir(),
+		"LOG_LEVEL=debug\nOPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz012345\nFEATURE_X=on\n")
+
+	result, err := Run(headless(dir, Answers{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"}))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, result.EnvKeysListed)
+	assert.Equal(t, 0, result.EnvSecretsPending)
+
+	written := string(result.Content)
+
+	assert.Contains(t, written, "FEATURE_X")
+	// The live values stand: .env is the developer's copy and may be stale.
+	assert.Contains(t, written, "value: info")
+	assert.Contains(t, written, "value: live")
+}
+
+// A .env that cannot be parsed is the one case where saying nothing is worst:
+// the manifest looks complete and the container starts without its
+// configuration.
+func TestRun_WarnsAboutAnUnreadableEnvFile(t *testing.T) {
+	dir := writeEnvFile(t, writeDockerfile(t, t.TempDir(), "FROM scratch\n"),
+		"LOG_LEVEL=debug\n\"unterminated\n")
+
+	stderr := &bytes.Buffer{}
+	opts := headless(dir, Answers{Name: "my-app"})
+	opts.Stderr = stderr
+
+	result, err := Run(opts)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), EnvFileName)
+	assert.Contains(t, stderr.String(), "Nothing from it was imported")
+	assert.Equal(t, 0, result.EnvKeysListed)
+	assert.NotContains(t, string(result.Content), "environmentVars")
+}
+
+// Non-finite is not a quantity of cores. Both parse as float64, and neither
+// compares as negative, so the sizing check has to name them.
+func TestRun_RejectsNonFiniteCPU(t *testing.T) {
+	for name, cpu := range map[string]float64{
+		"NaN":  math.NaN(),
+		"+Inf": math.Inf(1),
+		"-Inf": math.Inf(-1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+
+			_, err := Run(headless(dir, Answers{Name: "my-app", CPU: cpu}))
+			require.Error(t, err)
+
+			assert.Contains(t, err.Error(), "--cpu")
+			assert.NoFileExists(t, manifest.Path(dir))
+		})
+	}
+}
+
+// Declining the import means the file is not the wizard's business, broken or
+// not.
+func TestRun_SkipEnvSilencesTheUnreadableEnvWarning(t *testing.T) {
+	dir := writeEnvFile(t, writeDockerfile(t, t.TempDir(), "FROM scratch\n"),
+		"LOG_LEVEL=debug\n\"unterminated\n")
+
+	stderr := &bytes.Buffer{}
+	opts := headless(dir, Answers{Name: "my-app", SkipEnv: true})
+	opts.Stderr = stderr
+
+	_, err := Run(opts)
+	require.NoError(t, err)
+
+	assert.Empty(t, stderr.String())
 }

--- a/internal/workload/wizard/run_test.go
+++ b/internal/workload/wizard/run_test.go
@@ -1,0 +1,318 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// headless is a run that never prompts, which is what every test here wants:
+// the terminal path is exercised through the flow model instead.
+func headless(dir string, answers Answers) Options {
+	return Options{Dir: dir, NonInteractive: true, Answers: answers, Stderr: &bytes.Buffer{}}
+}
+
+// stubLive points the binding path at fixed documents.
+func stubLive(t *testing.T, workloadDoc, artifactDoc workload.Document) {
+	t.Helper()
+
+	swapLiveFns(t,
+		func(string) (workload.Document, error) { return workloadDoc, nil },
+		func(string) (workload.Document, error) { return artifactDoc, nil })
+}
+
+// stubLiveErr makes the workload fetch fail.
+func stubLiveErr(t *testing.T, err error) {
+	t.Helper()
+
+	swapLiveFns(t,
+		func(string) (workload.Document, error) { return nil, err },
+		func(string) (workload.Document, error) { return nil, nil })
+}
+
+func swapLiveFns(t *testing.T, getWorkload, getArtifact func(string) (workload.Document, error)) {
+	t.Helper()
+
+	originalWorkload, originalArtifact := getWorkloadFn, getArtifactFn
+
+	getWorkloadFn, getArtifactFn = getWorkload, getArtifact
+
+	t.Cleanup(func() { getWorkloadFn, getArtifactFn = originalWorkload, originalArtifact })
+}
+
+func documentFrom(t *testing.T, raw string) workload.Document {
+	t.Helper()
+
+	var doc workload.Document
+
+	require.NoError(t, json.Unmarshal([]byte(raw), &doc))
+
+	return doc
+}
+
+func TestRun_WritesTheManifest(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\nEXPOSE 3000\n")
+
+	result, err := Run(headless(dir, Answers{Name: "my-app"}))
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionCreated, result.Action)
+	assert.Equal(t, manifest.Path(dir), result.Path)
+
+	written, err := os.ReadFile(result.Path)
+	require.NoError(t, err)
+	assert.Equal(t, string(result.Content), string(written))
+
+	// What lands on disk is what the reader accepts: this is the property the
+	// whole command exists to hold.
+	parsed, err := manifest.Load(result.Path)
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+
+	assert.Equal(t, "my-app", parsed.Name())
+	assert.Empty(t, parsed.WorkloadID())
+	assert.Contains(t, string(written), "port: 3000")
+}
+
+func TestRun_DryRunWritesNothing(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+
+	opts := headless(dir, Answers{Name: "my-app"})
+	opts.DryRun = true
+
+	result, err := Run(opts)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, result.Content)
+	assert.NoFileExists(t, result.Path)
+}
+
+// Setup is a one-time act. A configured project gets a pointer at its file,
+// not a second opinion about what should be in it.
+func TestRun_ExistingManifestIsLeftAlone(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+	path := manifest.Path(dir)
+
+	original := "name: hand-written\nartifactId: 68b0bbbb0000000000000002\n"
+	require.NoError(t, os.WriteFile(path, []byte(original), 0o600))
+
+	result, err := Run(headless(dir, Answers{Name: "something-else"}))
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionUnchanged, result.Action)
+	assert.Equal(t, path, result.Path)
+	assert.Empty(t, result.Content)
+
+	// The answer describes the project as it stands, not as the flags would
+	// have configured it.
+	assert.Equal(t, "hand-written", result.Draft.Name)
+
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(after))
+}
+
+// Reporting an existing manifest means reading it, so a bound project is not
+// reported as one that will create a workload on the first up.
+func TestRun_ExistingManifestIsReadBack(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+
+	first, err := Run(headless(dir, Answers{Name: "my-app"}))
+	require.NoError(t, err)
+	require.NoError(t, manifest.WriteWorkloadID(first.Path, "68b0ffff0000000000000009"))
+
+	again, err := Run(headless(dir, Answers{}))
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionUnchanged, again.Action)
+	assert.Equal(t, "my-app", again.Draft.Name)
+	assert.Equal(t, "68b0ffff0000000000000009", again.Draft.WorkloadID)
+	assert.Equal(t, manifest.BuildModeDockerfile, again.Draft.Build.Mode)
+}
+
+// A manifest that no longer validates is the news, not the fact that a file
+// exists: up would fail on it too, and this way the line number arrives now.
+func TestRun_ExistingManifestThatDoesNotValidate(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+
+	require.NoError(t, os.WriteFile(manifest.Path(dir), []byte(`name: broken
+artifact:
+  name: broken-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 80
+            imageUri: nginx:latest
+`), 0o600))
+
+	_, err := Run(headless(dir, Answers{}))
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "line 11")
+	assert.Contains(t, err.Error(), "must listen on 1024 or above")
+}
+
+// Two manifests on one upward walk mean a deploy reads a different file
+// depending on where it was run, so the shadowed one is named.
+func TestRun_WarnsAboutAManifestAbove(t *testing.T) {
+	parent := t.TempDir()
+	require.NoError(t, os.WriteFile(manifest.Path(parent), []byte("name: parent-app\nartifactId: 68b0\n"), 0o600))
+
+	child := filepath.Join(parent, "service")
+	require.NoError(t, os.Mkdir(child, 0o755))
+	writeDockerfile(t, child, "FROM scratch\n")
+
+	stderr := &bytes.Buffer{}
+	opts := headless(child, Answers{Name: "child-app"})
+	opts.Stderr = stderr
+
+	_, err := Run(opts)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), manifest.Path(parent))
+	assert.Contains(t, stderr.String(), "reads a different file")
+}
+
+func TestRun_NoWarningWithoutAManifestAbove(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+
+	stderr := &bytes.Buffer{}
+	opts := headless(dir, Answers{Name: "my-app"})
+	opts.Stderr = stderr
+
+	_, err := Run(opts)
+	require.NoError(t, err)
+
+	assert.Empty(t, stderr.String())
+}
+
+func TestRun_ReportsMissingAnswers(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := Run(headless(dir, Answers{Name: "my-app"}))
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "--build-mode")
+	assert.NoFileExists(t, manifest.Path(dir))
+}
+
+// Binding headlessly is the same operation the picker performs: the live spec
+// is downloaded and the file is written from it.
+func TestRun_BindsToALiveWorkload(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "live-app", "importance": "high", "artifactId": "68a1",
+			"runtime": {"containerGroups": [{"name": "default", "autoscaling": {"enabled": true, "maxReplicaCount": 9},
+				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 2, "memory": "4GB"}}]}]}}`),
+		documentFrom(t, `{"name": "live-app-artifact", "spec": {"type": "service",
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/live:v9"}]}]}}`))
+
+	dir := t.TempDir()
+
+	result, err := Run(headless(dir, Answers{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"}))
+	require.NoError(t, err)
+
+	written := string(result.Content)
+
+	assert.Contains(t, written, "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0")
+	assert.Contains(t, written, "name: live-app")
+	assert.Contains(t, written, "importance: high")
+	// The sizing the wizard has no question for survives the round trip.
+	assert.Contains(t, written, "maxReplicaCount: 9")
+	assert.Contains(t, written, "memory: 4GB")
+
+	parsed, err := manifest.Load(result.Path)
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", parsed.WorkloadID())
+}
+
+// A workload id that does not resolve fails at setup, which is the whole
+// point of resolving it here instead of at deploy time.
+func TestRun_UnknownWorkloadID(t *testing.T) {
+	stubLiveErr(t, errors.New("404 not found"))
+
+	_, err := Run(headless(t.TempDir(), Answers{WorkloadID: "nope"}))
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "cannot bind to workload nope")
+}
+
+func TestRun_BoundWorkloadWithoutAnArtifact(t *testing.T) {
+	stubLive(t, documentFrom(t, `{"name": "live-app"}`), nil)
+
+	_, err := Run(headless(t.TempDir(), Answers{WorkloadID: "68b0"}))
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "no artifact to copy")
+}
+
+// Cancelling writes nothing and says so, so `config && up` stops here.
+func TestRun_CancelledWritesNothing(t *testing.T) {
+	original := runInteractiveFlowFn
+	runInteractiveFlowFn = func(Options, Detected) ([]byte, manifest.Draft, error) {
+		return nil, manifest.Draft{}, ErrCancelled
+	}
+
+	t.Cleanup(func() { runInteractiveFlowFn = original })
+
+	originalTerminal := isStdinTerminalFn
+	isStdinTerminalFn = func() bool { return true }
+
+	t.Cleanup(func() { isStdinTerminalFn = originalTerminal })
+
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+
+	_, err := Run(Options{Dir: dir, Stderr: &bytes.Buffer{}})
+	require.ErrorIs(t, err, ErrCancelled)
+
+	assert.NoFileExists(t, manifest.Path(dir))
+}
+
+// Without a terminal nothing prompts, even when --yes was not passed.
+func TestRun_NoTerminalNeverPrompts(t *testing.T) {
+	originalFlow := runInteractiveFlowFn
+	runInteractiveFlowFn = func(Options, Detected) ([]byte, manifest.Draft, error) {
+		t.Fatal("the wizard must not run without a terminal")
+
+		return nil, manifest.Draft{}, nil
+	}
+
+	t.Cleanup(func() { runInteractiveFlowFn = originalFlow })
+
+	originalTerminal := isStdinTerminalFn
+	isStdinTerminalFn = func() bool { return false }
+
+	t.Cleanup(func() { isStdinTerminalFn = originalTerminal })
+
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+
+	_, err := Run(Options{Dir: dir, Answers: Answers{Name: "my-app"}, Stderr: &bytes.Buffer{}})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
# RATIONALE

`dr workload config` writes the root `.datarobot.yaml` so `dr workload up` has something to deploy. This PR is the command plus everything that does not need a terminal: flag handling, project detection, `.env` classification, and the conversion from answers to a manifest. The Bubble Tea screens stack on top in the next PR.

The split is here because the two halves fail differently. Everything in this PR is deterministic and unit-testable from a flag set. The screens are only testable by driving a terminal. Reviewed together, the interesting logic gets skimmed on the way to the UI.

The command is behind the `workload` feature gate. Until the screens land, running it on a TTY with no flags reports that interactive setup is not available yet, which is what the gate is for.

## CHANGES

**`cmd/workload/config/cmd.go`**

The flag surface, each flag pre-answering one question: `--dir`, `-y/--yes`, `--workload-id`, `--name`, `--type`, `--a2a-enabled`, `--build-mode`, `--dockerfile`, `--execution-environment`, `--entrypoint`, `--image`, `--port`, `--health`, `--replicas`, `--cpu`, `--memory`, `--skip-env`, `--dry-run`, and the inherited `-o/--output-format`. A missing required flag is an error naming it, and a prompt is never attempted without a TTY.

Per the config-binding rules, `--yes` is read from cobra and ORed with `viperx.GetBool("yes")` after `BindEnv` for `DATAROBOT_CLI_NON_INTERACTIVE`. Nothing else is bound to viper, so no transient flag can leak into `drconfig.yaml`.

JSON output purity: under `-o json` stdout carries only the `{"config": {...}}` envelope and everything else goes to stderr. `-o json` also implies non-interactive, since a wizard drawing over the envelope would corrupt it.

**`wizard/detect.go`**

`./Dockerfile` presence, and the first numeric `EXPOSE` with a provenance string so the port question can say where its default came from. A privileged `EXPOSE` below 1024 is deliberately **not** adopted: the primary container runs unprivileged, so inheriting it would hand the user a manifest their own validator rejects.

**`wizard/answers.go`**

Flags to `manifest.Draft`, including the fields never asked (`importance: low`, group `default`, container `primary`). The entrypoint is split shell-style so quoted arguments survive as single arguments rather than being cut at spaces.

**`wizard/classify.go`**

Sorts `.env` keys into config, secret and local-only. Layered signals, most confident first: issuer prefixes (`sk-`, `sk-ant-`, `ghp_`, `hf_`, `AKIA`, `xoxb-`, PEM blocks, JWTs), credentials embedded in a URL, local-only markers (`VITE_`, `NEXT_PUBLIC_`, localhost), name patterns **corroborated by the value**, then Shannon entropy with a mixed-charset check.

Name matching alone is not enough, which is the reason for the layering: `API_URL` and `API_KEY` differ by one word and only one of them is a secret. Every classification carries a reason string, so the next PR's table can say why and let the user override it.

Non-secret values are written literally, so the manifest is usable as-is. Secret values never leave `.env`; the manifest gets `dr-credential:PLACEHOLDER/apiToken` and a comment naming the substitution. The generated file is therefore safe to commit.

**`wizard/run.go`**

`Run(Options) (Result, error)`, the headless-versus-interactive choice, and the write and dry-run paths. Also holds `ShortPath`, moved off the screens file because the command needs it and should not pull the TUI in to get it.

One doc fix rides along: `Result.Action` claimed the value is `ActionCreated` or `ActionUnchanged`, omitting `ActionPlanned`, which is what `--dry-run` reports.

## TESTING

- Headless runs for each build mode, asserting the exact rendered manifest.
- `--dry-run` writes nothing and reports `planned`, not `created`, so a script keying on the action cannot mistake it for a file that now exists.
- Missing-flag errors name the flag.
- JSON mode emits only the envelope on stdout, with a test seam that fakes a terminal, since under `go test` stdin never is one and the guard would otherwise be unobservable.
- Classification tests cover the `API_URL` versus `API_KEY` case and the entropy fallback.
- `task lint` clean on linux, darwin and windows; `task test` green.

## RELATED

Stacked on the live-spec PR. The wizard screens stack on this one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new setup surface that writes committed manifests, classifies `.env` secrets, and can bind live workloads via API; mitigated by the workload feature gate and headless-only path in this PR.
> 
> **Overview**
> Adds **`dr workload config`**, a gated one-time setup command that writes the committed `.datarobot.yaml` `dr workload up` deploys from. This PR ships the **flags-only / headless path**; interactive screens are stubbed and land next.
> 
> The new `wizard` package detects project defaults (`Dockerfile` / `EXPOSE`, directory name, `.env`), converts flag answers into a validated manifest draft, and supports binding an existing workload by id so the live spec is downloaded rather than guessed. Ordinary `.env` values are written as literals; secrets become credential placeholders so the file stays safe to commit.
> 
> `--yes`, JSON output, and non-TTY runs never prompt; missing required flags fail by name. Existing manifests are left untouched, with dry-run and JSON envelope support for scripting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef7f93b5eb388ea089094831cc18991728da97f0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->