### PR TITLE
[RAPTOR-18975] feat(workload): the interactive setup wizard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/adrg/xdg v0.5.3
 	github.com/amplitude/analytics-go v1.3.1
+	github.com/aymanbagabas/go-udiff v0.3.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
@@ -37,7 +38,6 @@ require (
 	github.com/alecthomas/chroma/v2 v2.27.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/aymanbagabas/go-udiff v0.3.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect

--- a/internal/workload/manifest/keys.go
+++ b/internal/workload/manifest/keys.go
@@ -30,3 +30,18 @@ const (
 	keyValue           = "value"
 	keyWorkloadID      = "workloadId"
 )
+
+// Spec field names no validation rule reads, which is why the ledger does not
+// declare them. Both halves of the package still write them: the renderer
+// builds them out of a draft, and binding edits them in place on a live spec.
+// That is two files per rename, which is the situation this one exists to
+// prevent, so they are named here rather than inline in either.
+const (
+	keyA2AEnabled     = "a2aEnabled"
+	keyCPU            = "cpu"
+	keyLivenessProbe  = "livenessProbe"
+	keyPath           = "path"
+	keyReadinessProbe = "readinessProbe"
+	keyStartupProbe   = "startupProbe"
+	keyType           = "type"
+)

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -17,6 +17,7 @@ package manifest
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -26,16 +27,6 @@ import (
 // back is either ignored or rejected. Stripping them recursively is safe
 // because the create spec has no legitimate key by these names anywhere.
 var serverManagedKeys = []string{"id", "createdAt", "updatedAt", "status", "endpoint", "artifactId", "workloadId"}
-
-// Probe field names. They live here rather than with the ledger's spec keys
-// because no validation rule reads them: binding is the only thing in this
-// package that has to tell a probe from any other block it preserves.
-const (
-	keyReadinessProbe = "readinessProbe"
-	keyStartupProbe   = "startupProbe"
-	keyLivenessProbe  = "livenessProbe"
-	keyPath           = "path"
-)
 
 // Live is a running workload, downloaded so a manifest can be written that
 // says everything the workload already says. Setup uses it when the user
@@ -77,7 +68,7 @@ func NewLive(workloadID string, workloadDoc, artifactDoc map[string]any) Live {
 // Type reports the artifact's kind, so the wizard's Q3 opens on what the
 // workload already is.
 func (l Live) Type() string {
-	return stringAt(l.Spec, "type")
+	return stringAt(l.Spec, keyType)
 }
 
 // Defaults reads the live spec into the answers the wizard's screens open on.
@@ -90,7 +81,7 @@ func (l Live) Defaults() Draft {
 		Name:       l.Name,
 		Importance: orDefaultString(l.Importance, DefaultImportance),
 		Type:       orDefaultString(l.Type(), TypeService),
-		A2AEnabled: boolAt(l.Spec, "a2aEnabled"),
+		A2AEnabled: boolAt(l.Spec, keyA2AEnabled),
 		Port:       DefaultPort,
 		HealthPath: DefaultHealthPath,
 		Build:      Build{Mode: BuildModeDockerfile},
@@ -196,7 +187,7 @@ func (l Live) runtimeDefaults() Runtime {
 
 	allocation := mapAt(container, keyResourceAllocation)
 
-	if cpu, ok := floatAt(allocation, "cpu"); ok {
+	if cpu, ok := floatAt(allocation, keyCPU); ok {
 		runtime.CPU = cpu
 	}
 
@@ -249,12 +240,12 @@ func (l Live) Apply(draft Draft) (Live, error) {
 		applied.Spec = map[string]any{}
 	}
 
-	applied.Spec["type"] = draft.Type
+	applied.Spec[keyType] = draft.Type
 
 	if draft.Type == TypeAgent && draft.A2AEnabled {
-		applied.Spec["a2aEnabled"] = true
+		applied.Spec[keyA2AEnabled] = true
 	} else {
-		delete(applied.Spec, "a2aEnabled")
+		delete(applied.Spec, keyA2AEnabled)
 	}
 
 	container := primaryContainerOf(applied.Spec)
@@ -325,6 +316,44 @@ func (l Live) NewEnvVars(vars []EnvVar) []EnvVar {
 	return fresh
 }
 
+// LiteralEnvVars is the variables the workload already declares with the value
+// written out, rather than as a reference to a credential.
+//
+// Binding preserves the live spec, which is what stops it downgrading a
+// running workload, and that applies to these entries too: a value the
+// platform holds in the clear is copied into a file meant to be committed.
+// Nothing here can be fixed automatically, because only the platform can say
+// whether a given value is sensitive. A caller that wants to raise it needs
+// the values to judge them by, so they come out with the names.
+func (l Live) LiteralEnvVars() []EnvVar {
+	container := primaryContainerOf(l.Spec)
+	if container == nil {
+		return nil
+	}
+
+	existing, _ := container[keyEnvironmentVars].([]any)
+	literals := make([]EnvVar, 0, len(existing))
+
+	for _, entry := range existing {
+		typed, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// A credential-backed entry has no value to read: the object form
+		// names an id and a key instead, and the shorthand carries them in a
+		// string that is a reference rather than the secret it points at.
+		value := stringAt(typed, keyValue)
+		if value == "" || strings.HasPrefix(value, CredentialShorthandPrefix) {
+			continue
+		}
+
+		literals = append(literals, EnvVar{Name: stringAt(typed, keyName), Value: value})
+	}
+
+	return literals
+}
+
 // declaredEnvNames is the set of variable names an environmentVars list
 // already carries.
 func declaredEnvNames(existing []any) map[string]bool {
@@ -368,7 +397,7 @@ func (l *Live) applyRuntime(runtime Runtime) {
 	}
 
 	if runtime.CPU > 0 {
-		allocation["cpu"] = runtime.CPU
+		allocation[keyCPU] = runtime.CPU
 	}
 
 	if runtime.Memory != "" {

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -830,3 +830,16 @@ func orDefaultString(value, fallback string) string {
 
 	return value
 }
+
+// Autoscaled reports whether the workload's runtime group scales itself. A
+// caller asking the user for a replica count needs to know: applyRuntime
+// drops the answer while autoscaling is on, so the question would be one
+// whose answer could not be used.
+func (l Live) Autoscaled() bool {
+	groups := slicesAt(l.Runtime, keyContainerGroups)
+	if len(groups) == 0 {
+		return false
+	}
+
+	return autoscalingActive(groups[0])
+}

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -269,6 +269,43 @@ func TestLive_ApplyWithoutAPrimaryContainer(t *testing.T) {
 	assert.Contains(t, err.Error(), "no primary container")
 }
 
+// LiteralEnvVars answers one question: which of the workload's variables would
+// a bind copy with the value in the open. A credential-backed entry would not,
+// in either spelling, and reporting one as a literal would send the caller
+// looking for a leak that is not there.
+func TestLive_LiteralEnvVarsSkipsCredentialReferences(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "spec": {"containerGroups": [{"name": "default", "containers": [
+        {"name": "primary", "primary": true, "port": 8080, "imageUri": "nginx:latest",
+         "environmentVars": [
+           {"name": "LOG_LEVEL", "value": "debug"},
+           {"name": "SHORTHAND", "value": "dr-credential:68f0cccc0000000000000003/apiToken"},
+           {"name": "OBJECT", "source": "credential",
+            "drCredentialId": "68f0cccc0000000000000003", "key": "apiToken"},
+           {"name": "REGION", "value": "eu-west-1"}
+         ]}
+      ]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	assert.Equal(t, []EnvVar{
+		{Name: "LOG_LEVEL", Value: "debug"},
+		{Name: "REGION", Value: "eu-west-1"},
+	}, live.LiteralEnvVars())
+}
+
+// A spec with no container has nothing declared, which is not the same as
+// having something this cannot read.
+func TestLive_LiteralEnvVarsWithoutAContainer(t *testing.T) {
+	live := NewLive("68b0", map[string]any{"name": "empty"}, map[string]any{"name": "empty-artifact"})
+
+	assert.Empty(t, live.LiteralEnvVars())
+}
+
 // An unflagged spec still has a container traffic reaches: the first one.
 func TestLive_PrimaryFallsBackToTheFirstContainer(t *testing.T) {
 	var artifactDoc map[string]any

--- a/internal/workload/manifest/manifest_test.go
+++ b/internal/workload/manifest/manifest_test.go
@@ -17,6 +17,7 @@ package manifest
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -139,6 +140,26 @@ func TestParse_RejectsAliasBomb(t *testing.T) {
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "too large")
+}
+
+// Every walk in this package recurses once per level of the document, and the
+// node cap does not bound that: one long chain of nesting is one node per
+// level, so it passes the count while the walk descends the whole way.
+//
+// The bound comes from yaml.Unmarshal, which refuses the document before any
+// walk sees it. That is a guarantee of the library rather than of this package,
+// which is the reason to pin it: were a future version to lift its limit, this
+// fails here rather than as a stack overflow inside Validate.
+func TestParse_RejectsRunawayNesting(t *testing.T) {
+	const depth = 100_000
+
+	// One node per level, so nothing here is near the node cap.
+	require.Less(t, depth, maxExpandedNodes)
+
+	_, err := Parse([]byte("name: my-app\nartifact: "+strings.Repeat("[", depth)+strings.Repeat("]", depth)+"\n"), "")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "exceeded max depth")
 }
 
 // What the guard rejects is unbounded expansion, not anchors. Reusing one is

--- a/internal/workload/manifest/node.go
+++ b/internal/workload/manifest/node.go
@@ -64,6 +64,13 @@ const maxExpandedNodes = 1 << 20
 //     nodes that expands to more than a billion. Nothing is stored twice, so
 //     memory looks fine while the walk runs for hours.
 //
+// Depth is not a third shape to guard here. Every caller reaches this through
+// yaml.Unmarshal, which refuses a document nested past its own limit before any
+// of this runs, and an alias chain cannot get a walk deeper than the document
+// either: YAML requires an anchor to be declared before it is used, so the
+// shallow end of a chain is always reached and memoised first.
+// TestParse_RejectsRunawayNesting holds the library to that.
+//
 // A manifest is not necessarily trusted input: cloning a repository and
 // running any command that locates its manifest is enough to reach here.
 func checkAliases(root *yaml.Node) error {

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -249,6 +249,13 @@ func Write(path string, data []byte) error {
 // workload exists, so the next run finds it. Comments, unknown keys and their
 // order are preserved, because the file is re-emitted from the tree it was
 // parsed into rather than regenerated.
+//
+// This is the one way into the package that does not go through Parse, so it
+// runs the alias guard itself. Reaching here means the file already parsed
+// once, and neither the top-level walk below nor the encoder expands an alias,
+// so nothing known today needs the check. It is here because that reasoning is
+// about the current implementation of two other functions, and a guard that
+// holds only while nobody edits them is not one.
 func WriteWorkloadID(path, workloadID string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -263,6 +270,10 @@ func WriteWorkloadID(path, workloadID string) error {
 
 	if len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
 		return fmt.Errorf("cannot record the workload id in %s: root must be a YAML mapping", path)
+	}
+
+	if err := checkAliases(doc.Content[0]); err != nil {
+		return fmt.Errorf("cannot record the workload id in %s: %w", path, err)
 	}
 
 	setWorkloadID(doc.Content[0], workloadID)
@@ -334,18 +345,18 @@ func (d Draft) topLevelFields(build field) []field {
 // artifact renders the half that says what runs: the versioned, lockable
 // definition.
 func (d Draft) artifact(build field) *yaml.Node {
-	spec := []field{{key: "type", value: scalar(d.Type)}}
+	spec := []field{{key: keyType, value: scalar(d.Type)}}
 
 	if d.A2AEnabled {
 		spec = append(spec, field{
-			key:     "a2aEnabled",
+			key:     keyA2AEnabled,
 			value:   boolean(true),
 			comment: "discoverable tenant-wide",
 		})
 	}
 
 	probe := mapping(
-		field{key: "path", value: scalar(d.HealthPath)},
+		field{key: keyPath, value: scalar(d.HealthPath)},
 		field{key: keyPort, value: number(d.Port)},
 	)
 
@@ -354,7 +365,7 @@ func (d Draft) artifact(build field) *yaml.Node {
 		{key: keyPrimary, value: boolean(true)},
 		{key: keyPort, value: number(d.Port), comment: "must be 1024 or above"},
 		build,
-		{key: "readinessProbe", value: probe},
+		{key: keyReadinessProbe, value: probe},
 	}
 
 	if vars := d.environmentVars(); vars != nil {
@@ -375,7 +386,7 @@ func (d Draft) artifact(build field) *yaml.Node {
 // runtime renders the half that says how much it runs with.
 func (d Draft) runtime() *yaml.Node {
 	allocation := mapping(
-		field{key: "cpu", value: decimal(d.Runtime.CPU)},
+		field{key: keyCPU, value: decimal(d.Runtime.CPU)},
 		field{key: keyMemory, value: scalar(d.Runtime.Memory)},
 	)
 	allocation.Style = yaml.FlowStyle

--- a/internal/workload/manifest/write_test.go
+++ b/internal/workload/manifest/write_test.go
@@ -274,6 +274,24 @@ func TestWriteWorkloadID_ReplacesExisting(t *testing.T) {
 	assert.Equal(t, "68b0ffff0000000000000009", m.WorkloadID())
 }
 
+// The write-back is the one way into this package that does not go through
+// Parse, so it runs the alias guard itself rather than inheriting one. Nothing
+// in it expands an alias today; the guard is what keeps that from being a
+// property of two other functions that nobody is watching.
+func TestWriteWorkloadID_RejectsAnAliasBomb(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), aliasBomb)
+
+	err := WriteWorkloadID(path, "68b0ffff0000000000000009")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "too large")
+
+	// The file is the user's, and a refusal must not have edited it.
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, aliasBomb, string(got))
+}
+
 // The write-back is a single-key edit, not a regeneration: comments, unknown
 // keys and their order are the user's, and up leaves them alone.
 func TestWriteWorkloadID_PreservesTheRestOfTheFile(t *testing.T) {

--- a/internal/workload/wizard/choice.go
+++ b/internal/workload/wizard/choice.go
@@ -1,0 +1,159 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/tui"
+)
+
+// option is one answer on a choice screen.
+type option struct {
+	// value is what the answer means to the draft.
+	value string
+	label string
+	// note sits to the right of the label, for the aside that makes the
+	// choice obvious: which one is usual, what was detected.
+	note string
+	// warn marks a note that is a reason this option will not work here, so
+	// it reads as a warning rather than as a detail.
+	warn bool
+}
+
+// choice is the two-or-three answer screen the wizard is mostly made of:
+// arrow keys or a digit, Enter to accept. bubbles/list is the wrong shape
+// here, being built for long, filterable collections; these screens are a
+// numbered menu the user reads in one glance.
+type choice struct {
+	options  []option
+	selected int
+	// liveValue is what the bound workload uses today, "" on a fresh setup.
+	// The row carrying it is tagged, because preselecting it says which
+	// option the wizard would pick and not which one is already true.
+	liveValue string
+}
+
+// newChoice builds the screen with current preselected. A current value the
+// screen has no option for is not silently replaced by the first row: it gets
+// a row of its own, so a workload running something this release cannot
+// author is kept rather than converted by a single Enter.
+func newChoice(options []option, current string, keepLabel string) choice {
+	if current != "" && !hasOption(options, current) {
+		options = append([]option{{
+			value: current,
+			label: keepLabel,
+			note:  "leave it as " + current + "; this wizard cannot author that kind",
+		}}, options...)
+	}
+
+	c := choice{options: options}
+
+	for i, opt := range options {
+		if opt.value == current {
+			c.selected = i
+		}
+	}
+
+	return c
+}
+
+func hasOption(options []option, value string) bool {
+	for _, opt := range options {
+		if opt.value == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+// update moves the cursor and reports whether the key was consumed, so the
+// caller can treat everything else (Enter, esc) as navigation.
+func (c *choice) update(msg tea.KeyMsg) bool {
+	switch msg.String() {
+	case "up", "k":
+		if c.selected > 0 {
+			c.selected--
+		}
+
+		return true
+	case "down", "j":
+		if c.selected < len(c.options)-1 {
+			c.selected++
+		}
+
+		return true
+	}
+
+	// A digit picks its row outright, which is how a numbered menu is meant
+	// to be used.
+	if index := digit(msg.String()); index > 0 && index <= len(c.options) {
+		c.selected = index - 1
+
+		return true
+	}
+
+	return false
+}
+
+func (c choice) value() string {
+	if len(c.options) == 0 {
+		return ""
+	}
+
+	return c.options[c.selected].value
+}
+
+func (c choice) view() string {
+	var b strings.Builder
+
+	for i, opt := range c.options {
+		line := fmt.Sprintf("%d. %s", i+1, opt.label)
+
+		if i == c.selected {
+			b.WriteString(tui.InfoStyle.Render("> " + line))
+		} else {
+			b.WriteString("  " + line)
+		}
+
+		if opt.note != "" {
+			style := tui.HintStyle
+			if opt.warn {
+				style = tui.ErrorStyle
+			}
+
+			b.WriteString(style.Render("   " + opt.note))
+		}
+
+		if c.liveValue != "" && opt.value == c.liveValue {
+			b.WriteString(liveStyle.Render("   · in use"))
+		}
+
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func digit(key string) int {
+	if len(key) != 1 || key[0] < '1' || key[0] > '9' {
+		return 0
+	}
+
+	return int(key[0] - '0')
+}

--- a/internal/workload/wizard/classify.go
+++ b/internal/workload/wizard/classify.go
@@ -147,6 +147,32 @@ func ClassifyEnv(name, value string) EnvVar {
 	return classified
 }
 
+// evidentSecret reports what a value proves about itself, using only the two
+// signals that need no help from the name: an issuer's token shape, and a
+// password embedded in a URL.
+//
+// This is the subset of classify that can be pointed at a value nobody is
+// going to be asked about. The name test and the entropy test are left out
+// deliberately: both are calibrated for a screen where a wrong verdict costs
+// one keystroke, and a caller with no screen to offer cannot pay that. A
+// warning that cries wolf over API_URL is one the reader learns to skip, and
+// the warnings worth reading go with it.
+func evidentSecret(value string) (string, bool) {
+	trimmed := strings.TrimSpace(value)
+
+	for _, signal := range secretValuePatterns {
+		if signal.pattern.MatchString(trimmed) {
+			return "looks like " + signal.reason, true
+		}
+	}
+
+	if user, ok := credentialInURL(trimmed); ok {
+		return "a URL with " + user + "'s password in it", true
+	}
+
+	return "", false
+}
+
 func classify(name, value string) EnvVar {
 	for _, signal := range secretValuePatterns {
 		if signal.pattern.MatchString(value) {

--- a/internal/workload/wizard/envtable.go
+++ b/internal/workload/wizard/envtable.go
@@ -1,0 +1,157 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/internal/workload/manifest"
+)
+
+// envTable is the per-key screen: one row per `.env` variable, showing what
+// the classifier made of it and what that means for the file. The classifier
+// is good but not right every time, so every row is overridable, which is the
+// whole reason this is a table rather than one yes-or-no question.
+//
+// It renders the plan for the placeholder block that ships today. The credential
+// import replaces the plan column's wording, not this component.
+type envTable struct {
+	rows []EnvVar
+	// grid owns the cursor, the scrolling window and the rendering, so this
+	// screen looks like the pickers rather than like its own invention.
+	grid rowTable
+}
+
+// envKindCycle is the order the arrows walk. It starts where the classifier
+// put the row and comes back to it, so a user who taps past their answer can
+// get back without leaving the screen.
+var envKindCycle = []EnvKind{EnvConfig, EnvSecret, EnvLocal}
+
+func newEnvTable(rows []EnvVar, width, height int) envTable {
+	t := envTable{rows: append([]EnvVar(nil), rows...)}
+	t.grid = newRowTable([]string{"VARIABLE", "CLASSIFIED AS", "WRITTEN AS"}, t.cells(), false, width, height)
+
+	return t
+}
+
+// cells projects the classified rows into what the table shows.
+func (t envTable) cells() []tableRow {
+	out := make([]tableRow, 0, len(t.rows))
+	for _, row := range t.rows {
+		out = append(out, tableRow{cells: []string{row.Name, row.Kind.String(), plan(row.Kind)}})
+	}
+
+	return out
+}
+
+// update moves the cursor or changes the row under it, reporting whether the
+// key belonged to the table.
+func (t *envTable) update(msg tea.KeyMsg) bool {
+	switch msg.String() {
+	case " ", "space", "tab", "right", "l":
+		t.cycle(1)
+
+		return true
+	case "left", "h":
+		t.cycle(-1)
+
+		return true
+	}
+
+	return t.grid.update(msg)
+}
+
+// cycle moves the row under the cursor to the next or previous plan, and
+// records that the user chose it so the reason stops crediting the
+// classifier.
+//
+// The rows are copied first. Bubble Tea hands each Update a copy of the
+// model, but a slice field in that copy still points at the original's
+// backing array, so writing through it would reach back into the state the
+// caller kept.
+func (t *envTable) cycle(delta int) {
+	if len(t.rows) == 0 {
+		return
+	}
+
+	t.rows = append([]EnvVar(nil), t.rows...)
+	row := &t.rows[t.grid.cursor()]
+
+	for i, kind := range envKindCycle {
+		if kind != row.Kind {
+			continue
+		}
+
+		next := (i + delta + len(envKindCycle)) % len(envKindCycle)
+		row.Kind = envKindCycle[next]
+		row.Reason = "you chose this"
+
+		break
+	}
+
+	t.grid.setRows(t.cells())
+}
+
+// vars returns what the file will say about each key.
+func (t envTable) vars() []manifest.EnvVar {
+	out := make([]manifest.EnvVar, 0, len(t.rows))
+
+	for _, row := range t.rows {
+		if row.Kind == EnvLocal {
+			// Local-only keys are not listed at all: deploying them would be
+			// wrong, not merely unnecessary.
+			continue
+		}
+
+		out = append(out, manifest.EnvVar{
+			Name:   row.Name,
+			Value:  row.Value,
+			Secret: row.Kind == EnvSecret,
+		})
+	}
+
+	return out
+}
+
+func (t envTable) view(width int) string {
+	return t.grid.view(width)
+}
+
+// note explains the row under the cursor, so an overridable verdict can be
+// judged before it is overridden.
+func (t envTable) note() string {
+	if len(t.rows) == 0 {
+		return ""
+	}
+
+	row := t.rows[t.grid.cursor()]
+
+	return row.Name + " — " + row.Reason
+}
+
+// plan is what listing this row does to the file, in the file's own terms.
+// Kept to two words: the note under the table has room to say more, the
+// column does not.
+func plan(kind EnvKind) string {
+	switch kind {
+	case EnvSecret:
+		return "credential reference"
+	case EnvLocal:
+		return "omitted"
+	case EnvConfig:
+		return "literal value"
+	}
+
+	return "literal value"
+}

--- a/internal/workload/wizard/envtable.go
+++ b/internal/workload/wizard/envtable.go
@@ -155,3 +155,9 @@ func plan(kind EnvKind) string {
 
 	return "literal value"
 }
+
+// resize refits the grid to a new terminal size, keeping the cursor and every
+// verdict the user has changed.
+func (t *envTable) resize(width, height int) {
+	t.grid.resize(width, height)
+}

--- a/internal/workload/wizard/interactive.go
+++ b/internal/workload/wizard/interactive.go
@@ -43,12 +43,14 @@ const execEnvPickLimit = 200
 // about (the runtime sizing) and the binding, which would otherwise be lost
 // and turn a bind into a create.
 func (a Answers) partialDraft(detected Detected) manifest.Draft {
+	kind := orDefault(a.Type, manifest.TypeService)
+
 	draft := manifest.Draft{
 		WorkloadID: a.WorkloadID,
 		Name:       orDefault(a.Name, detected.Name),
 		Importance: manifest.DefaultImportance,
-		Type:       a.effectiveType(),
-		A2AEnabled: a.A2AEnabled && a.effectiveType() == manifest.TypeAgent,
+		Type:       kind,
+		A2AEnabled: a.A2AEnabled && kind == manifest.TypeAgent,
 		Port:       a.Port,
 		HealthPath: orDefault(a.HealthPath, manifest.DefaultHealthPath),
 		Runtime:    a.runtime(),
@@ -65,6 +67,35 @@ func (a Answers) partialDraft(detected Detected) manifest.Draft {
 		draft.Build = build
 	} else {
 		draft.Build = defaultBuild(detected)
+	}
+
+	return draft
+}
+
+// partialApplyTo is applyTo without the parts a screen can still settle: the
+// bound counterpart of partialDraft. The flags are layered over the live spec
+// so an interactive bind keeps what the command line already said, exactly as
+// the headless bind does; a build the flags cannot complete leaves the live
+// build alone, because the source screen is where that gets answered and it
+// opens on what the workload already does.
+func (a Answers) partialApplyTo(defaults manifest.Draft, detected Detected) manifest.Draft {
+	draft := defaults
+
+	if a.Name != "" {
+		draft.Name = a.Name
+	}
+
+	a.applyKind(&draft)
+	a.applyReadiness(&draft)
+	a.applySizing(&draft)
+	a.applyEnv(&draft, detected)
+
+	// An agent flag on a service is not an answer to anything the file can
+	// carry, and Apply would drop it anyway.
+	draft.A2AEnabled = draft.A2AEnabled && draft.Type == manifest.TypeAgent
+
+	if err := a.applyBuild(&draft, detected); err != nil {
+		draft.Build = defaults.Build
 	}
 
 	return draft

--- a/internal/workload/wizard/interactive.go
+++ b/internal/workload/wizard/interactive.go
@@ -1,0 +1,80 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+)
+
+// The plumbing only the interactive flow needs. It lives apart from run.go
+// so the headless command does not carry listing calls it never makes.
+
+// Test seams for the two pickers, replaced by the wizard's tests to keep the
+// flow off the network.
+var (
+	listWorkloadsFn = workload.ListWorkloads
+	listExecEnvsFn  = workload.ListExecutionEnvironments
+)
+
+// workloadPickLimit caps the binding picker. Past this many workloads a list
+// is not how anyone finds theirs, and --workload-id is the answer.
+const workloadPickLimit = 100
+
+// execEnvPickLimit caps the base-image picker for the same reason;
+// --execution-environment takes a name or an id.
+const execEnvPickLimit = 200
+
+// partialDraft is draft() without the parts the flags could not settle: what
+// the interactive path starts from when a flag set is incomplete or wrong.
+// Every answer the flags did give survives, including the ones no screen asks
+// about (the runtime sizing) and the binding, which would otherwise be lost
+// and turn a bind into a create.
+func (a Answers) partialDraft(detected Detected) manifest.Draft {
+	draft := manifest.Draft{
+		WorkloadID: a.WorkloadID,
+		Name:       orDefault(a.Name, detected.Name),
+		Importance: manifest.DefaultImportance,
+		Type:       a.effectiveType(),
+		A2AEnabled: a.A2AEnabled && a.effectiveType() == manifest.TypeAgent,
+		Port:       a.Port,
+		HealthPath: orDefault(a.HealthPath, manifest.DefaultHealthPath),
+		Runtime:    a.runtime(),
+		EnvVars:    a.envVars(detected),
+	}
+
+	if draft.Port == 0 || checkPort(draft.Port, "--port") != nil {
+		draft.Port = detected.Port
+	}
+
+	// A build the flags cannot complete is left to the source screen, which
+	// opens on whatever the project suggests.
+	if build, err := a.build(detected); err == nil {
+		draft.Build = build
+	} else {
+		draft.Build = defaultBuild(detected)
+	}
+
+	return draft
+}
+
+// defaultBuild is the image source the project itself points at.
+func defaultBuild(detected Detected) manifest.Build {
+	if detected.HasDockerfile {
+		return manifest.Build{Mode: manifest.BuildModeDockerfile}
+	}
+
+	return manifest.Build{Mode: manifest.BuildModeImage}
+}

--- a/internal/workload/wizard/model.go
+++ b/internal/workload/wizard/model.go
@@ -1,0 +1,838 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+)
+
+// screen is one question. The order here is the order of the design's
+// screens; which ones a given run visits depends on the answers.
+type screen int
+
+const (
+	screenBinding screen = iota
+	screenName
+	screenKind
+	screenA2A
+	screenSource
+	screenExecEnv
+	screenEntrypoint
+	screenImage
+	screenSettings
+	screenEnv
+	screenConfirm
+)
+
+// flow is the wizard: one model for every screen, because the screens share
+// one answer set and back-navigation between them has to be free.
+type flow struct {
+	detected  Detected
+	workloads []workload.Workload
+	// pendingBind is a workload id a flag named, fetched by Init before the
+	// first screen so a flag-driven bind downloads the live spec exactly as
+	// the picker would.
+	pendingBind string
+	// execEnvs is the base-image list once it has been fetched. It is kept so
+	// walking back to that screen shows the list again instead of an empty
+	// table: back-navigation re-enters a screen but does not re-run the work
+	// that filled it.
+	execEnvs []workload.ExecutionEnvironment
+
+	// draft accumulates the answers. live is the workload being bound to,
+	// nil when a new one is being created.
+	draft manifest.Draft
+	live  *manifest.Live
+
+	// at is the current screen; history is what Back walks, so a skipped
+	// screen is skipped in both directions without a second rule set.
+	at      screen
+	history []screen
+
+	choice   choice
+	envTable envTable
+	picker   rowTable
+	inputs   []textinput.Model
+	focus    int
+
+	// loading is the message shown while a screen waits on the network.
+	loading string
+	// failed is the last error, shown in place until the user moves.
+	failed error
+
+	// content is the manifest the confirm screen is showing, and diff is what
+	// it changes when a live workload is bound.
+	content []byte
+	diff    string
+
+	// fatal ends the run with a reason rather than as a cancellation, for the
+	// failures no screen can recover from.
+	fatal error
+
+	// nameGiven distinguishes a name the user chose from the one the
+	// directory suggested, so returning to the screen shows the answer that
+	// was given there and never re-offers a suggestion as a typed value.
+	nameGiven bool
+
+	width, height int
+	cancelled     bool
+	done          bool
+}
+
+// liveLoadedMsg carries the downloaded workload, or the reason it could not
+// be downloaded.
+type liveLoadedMsg struct {
+	live manifest.Live
+	err  error
+}
+
+// execEnvsLoadedMsg carries the base images the picker offers.
+type execEnvsLoadedMsg struct {
+	environments []workload.ExecutionEnvironment
+	err          error
+}
+
+// editedMsg carries the manifest as the user's editor left it.
+type editedMsg struct {
+	content []byte
+	err     error
+}
+
+func newFlow(detected Detected, workloads []workload.Workload, answers Answers) flow {
+	f := flow{detected: detected, workloads: workloads, pendingBind: answers.WorkloadID}
+
+	draft, err := answers.draft(detected)
+	if err != nil {
+		// Interactively an unanswerable flag set is not fatal: the screens
+		// exist to answer exactly this. Everything the flags did settle is
+		// kept.
+		draft = answers.partialDraft(detected)
+	}
+
+	f.draft = draft
+	// A name passed as a flag is an answer the user gave, so the screen shows
+	// it as a value rather than re-offering the directory's suggestion.
+	f.nameGiven = answers.Name != ""
+	f.at = f.first(answers)
+	f.enter(f.at)
+
+	// Only a flag the wizard cannot ask about is worth reporting on arrival.
+	// "No Dockerfile, so the image source cannot be guessed" is a headless
+	// error: interactively it is simply the question Q4 is about to ask, and
+	// showing it on the first screen makes the wizard open on a complaint
+	// about something the user has not been asked yet.
+	f.failed = answers.check()
+
+	if f.pendingBind != "" {
+		f.loading = "Reading workload " + f.pendingBind + "…"
+	}
+
+	return f
+}
+
+// defaultDraft is where a run starts when nothing else has been said: the
+// project's own suggestions and the documented defaults.
+func defaultDraft(detected Detected) manifest.Draft {
+	return Answers{}.partialDraft(detected)
+}
+
+// first picks the opening screen. Binding is skipped when there is nothing to
+// bind to, or when a flag already said which workload this is.
+func (f flow) first(answers Answers) screen {
+	// A named workload is fetched by Init, and the kind screen is where the
+	// questions resume once it arrives.
+	if answers.WorkloadID != "" {
+		return screenKind
+	}
+
+	if len(f.workloads) == 0 || answers.Name != "" {
+		return screenName
+	}
+
+	return screenBinding
+}
+
+func (f flow) Init() tea.Cmd {
+	if f.pendingBind == "" {
+		return nil
+	}
+
+	return fetchLiveCmd(f.pendingBind)
+}
+
+// fetchLiveCmd downloads a workload so the file can say everything it says.
+func fetchLiveCmd(workloadID string) tea.Cmd {
+	return func() tea.Msg {
+		live, err := fetchLive(workloadID)
+
+		return liveLoadedMsg{live: live, err: err}
+	}
+}
+
+func (f flow) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		f.width, f.height = msg.Width, msg.Height
+		// The screens rebuild themselves at the new width when they are next
+		// entered; nothing on screen has to be resized in place.
+		return f, nil
+
+	case liveLoadedMsg:
+		return f.liveLoaded(msg)
+
+	case execEnvsLoadedMsg:
+		return f.execEnvsLoaded(msg)
+
+	case editedMsg:
+		return f.edited(msg)
+
+	case tea.KeyMsg:
+		return f.key(msg)
+	}
+
+	return f.delegate(msg)
+}
+
+// key routes a keystroke: navigation first, then whatever the current screen
+// makes of it.
+func (f flow) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if f.loading != "" {
+		return f, nil
+	}
+
+	if f.routeToPicker(msg) {
+		return f, nil
+	}
+
+	f.failed = nil
+
+	switch msg.String() {
+	case "esc":
+		return f.back()
+	case "enter":
+		return f.advance()
+	}
+
+	if f.at == screenConfirm && msg.String() == "e" {
+		return f, f.openEditor()
+	}
+
+	return f.delegate(msg)
+}
+
+// routeToPicker gives a picker screen first refusal on a key, because typing
+// narrows the list. Enter and esc stay with the flow: enter selects the row,
+// and esc clears a filter before it goes back.
+func (f *flow) routeToPicker(msg tea.KeyMsg) bool {
+	if f.at != screenBinding && f.at != screenExecEnv {
+		return false
+	}
+
+	if msg.String() == "esc" {
+		return f.picker.clearFilter()
+	}
+
+	if msg.Type == tea.KeyEnter {
+		return false
+	}
+
+	return f.picker.update(msg)
+}
+
+// delegate hands the message to whichever component the current screen shows.
+func (f flow) delegate(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch f.at {
+	case screenBinding, screenExecEnv:
+		if key, ok := msg.(tea.KeyMsg); ok {
+			f.picker.update(key)
+		}
+
+		return f, nil
+
+	case screenKind, screenA2A, screenSource, screenEnv:
+		if key, ok := msg.(tea.KeyMsg); ok {
+			f.updateSelection(key)
+		}
+
+		return f, nil
+
+	case screenName, screenEntrypoint, screenImage, screenSettings:
+		if key, ok := msg.(tea.KeyMsg); ok && f.at == screenSettings && isFocusKey(key) {
+			f.moveFocus(key)
+
+			return f, nil
+		}
+
+		var cmd tea.Cmd
+
+		f.inputs[f.focus], cmd = f.inputs[f.focus].Update(msg)
+
+		return f, cmd
+
+	case screenConfirm:
+		// The confirm screen has no component of its own.
+		return f, nil
+	}
+
+	return f, nil
+}
+
+// updateSelection routes a key to whichever selection component the current
+// screen shows.
+func (f *flow) updateSelection(key tea.KeyMsg) {
+	if f.at == screenEnv {
+		f.envTable.update(key)
+
+		return
+	}
+
+	f.choice.update(key)
+}
+
+// back returns to the previous screen, or cancels when there is none: esc on
+// the first screen is the same "write nothing" the confirm screen offers.
+func (f flow) back() (tea.Model, tea.Cmd) {
+	if len(f.history) == 0 {
+		f.cancelled = true
+
+		return f, tea.Quit
+	}
+
+	f.at = f.history[len(f.history)-1]
+	f.history = f.history[:len(f.history)-1]
+	f.enter(f.at)
+
+	// Arriving is arriving, whichever direction it came from: a screen that
+	// fills itself on arrival has to do so on the way back too.
+	return f, f.onEnter(f.at)
+}
+
+// advance records the current screen's answer and moves on. A screen that
+// cannot accept its answer keeps the user where they are, with the reason.
+func (f flow) advance() (tea.Model, tea.Cmd) {
+	cmd, err := f.accept()
+	if err != nil {
+		f.failed = err
+
+		return f, nil
+	}
+
+	if cmd != nil {
+		return f, cmd
+	}
+
+	if f.at == screenConfirm {
+		if f.failed != nil || len(f.content) == 0 {
+			// render() failed on the way in. Ending as a cancellation would
+			// replace the reason on screen with "nothing was written", so the
+			// reason is carried out instead.
+			f.fatal = f.renderFailure()
+
+			return f, tea.Quit
+		}
+
+		f.done = true
+
+		return f, tea.Quit
+	}
+
+	next := f.next()
+	f.history = append(f.history, f.at)
+	f.at = next
+	f.enter(next)
+
+	// onEnter mutates f (it can set the loading state), so it runs before the
+	// model is returned rather than inside the return expression.
+	cmd = f.onEnter(next)
+
+	return f, cmd
+}
+
+// nextScreen is the flow when the answer does not change it.
+var nextScreen = map[screen]screen{
+	screenBinding:    screenName,
+	screenName:       screenKind,
+	screenKind:       screenSource,
+	screenA2A:        screenSource,
+	screenSource:     screenSettings,
+	screenExecEnv:    screenEntrypoint,
+	screenEntrypoint: screenSettings,
+	screenImage:      screenSettings,
+	screenSettings:   screenConfirm,
+	screenEnv:        screenConfirm,
+	screenConfirm:    screenConfirm,
+}
+
+// renderFailure is why the confirm screen has nothing to write.
+func (f flow) renderFailure() error {
+	if f.failed != nil {
+		return f.failed
+	}
+
+	return errors.New("nothing to write: the manifest could not be rendered")
+}
+
+// next is the flow: the table above, plus the four answers that change it.
+func (f flow) next() screen {
+	if next, ok := f.branch(); ok {
+		return next
+	}
+
+	return nextScreen[f.at]
+}
+
+// branch is the four answers that change where the flow goes next.
+func (f flow) branch() (screen, bool) {
+	switch f.at {
+	case screenBinding:
+		// A bound workload is already named.
+		return screenKind, f.live != nil
+	case screenKind:
+		return screenA2A, f.draft.Type == manifest.TypeAgent
+	case screenSource:
+		return f.afterSource()
+	case screenSettings:
+		return screenEnv, f.detected.HasEnvFile()
+	case screenName, screenA2A, screenExecEnv, screenEntrypoint, screenImage, screenEnv, screenConfirm:
+		// These always go where the table says.
+		return 0, false
+	}
+
+	return 0, false
+}
+
+func (f flow) afterSource() (screen, bool) {
+	switch f.draft.Build.Mode {
+	case manifest.BuildModeGenerated:
+		return screenExecEnv, true
+	case manifest.BuildModeImage:
+		return screenImage, true
+	default:
+		return 0, false
+	}
+}
+
+// accepting maps each screen to what recording its answer means. Screens
+// absent from the table (the confirm screen) have nothing to record.
+var accepting = map[screen]func(*flow) (tea.Cmd, error){
+	screenBinding:    (*flow).acceptBinding,
+	screenName:       (*flow).acceptName,
+	screenKind:       (*flow).acceptKind,
+	screenA2A:        (*flow).acceptA2A,
+	screenSource:     (*flow).acceptSource,
+	screenExecEnv:    (*flow).acceptExecEnv,
+	screenEntrypoint: (*flow).acceptEntrypoint,
+	screenImage:      (*flow).acceptImage,
+	screenSettings:   (*flow).acceptSettings,
+	screenEnv:        (*flow).acceptEnv,
+}
+
+// accept validates and records the current screen's answer. A non-nil command
+// means the answer needs the network before the flow can move.
+func (f *flow) accept() (tea.Cmd, error) {
+	accept, ok := accepting[f.at]
+	if !ok {
+		return nil, nil
+	}
+
+	return accept(f)
+}
+
+// acceptKind records the kind. Only a changed answer resets the flags that
+// belong to the old kind, so re-confirming "agent" on the way back does not
+// silently withdraw the A2A answer given on the next screen.
+func (f *flow) acceptKind() (tea.Cmd, error) {
+	if kind := f.choice.value(); kind != f.draft.Type {
+		f.draft.Type = kind
+		f.draft.A2AEnabled = false
+	}
+
+	return nil, nil
+}
+
+func (f *flow) acceptA2A() (tea.Cmd, error) {
+	f.draft.A2AEnabled = f.choice.value() == "yes"
+
+	return nil, nil
+}
+
+// acceptEnv records the table's per-row answers. Names only, commented out,
+// so nothing about the deploy changes either way; what the user is settling
+// is which keys the file mentions and which of them the credential import
+// will later be pointed at.
+func (f *flow) acceptEnv() (tea.Cmd, error) {
+	f.draft.EnvVars = f.envTable.vars()
+
+	return nil, nil
+}
+
+// acceptSource records the image source. Only a changed answer clears the
+// fields that belong to the old one: re-confirming the source a bound
+// workload already uses must keep its image and its base-image ids.
+func (f *flow) acceptSource() (tea.Cmd, error) {
+	mode := f.choice.value()
+
+	// Refusing before recording keeps a rejected pick from destroying the
+	// answer the screen is about to be shown again with.
+	if mode == manifest.BuildModeDockerfile && !f.detected.HasDockerfile {
+		return nil, fmt.Errorf("no %s in %s: pick another source or add one", DockerfileName, f.detected.Dir)
+	}
+
+	if mode != f.draft.Build.Mode {
+		f.draft.Build = manifest.Build{Mode: mode}
+	}
+
+	return nil, nil
+}
+
+func (f *flow) acceptBinding() (tea.Cmd, error) {
+	row := f.picker.selected()
+	if row == nil {
+		return nil, errors.New("nothing selected")
+	}
+
+	item, ok := row.value.(pickedWorkload)
+	if !ok {
+		return nil, errors.New("nothing selected")
+	}
+
+	if item.id == createNewID {
+		// Start over rather than carrying the previous pick's name, kind and
+		// image forward: "create a new workload" after looking at an existing
+		// one must not prefill a copy of it.
+		if f.live != nil {
+			f.live = nil
+			f.draft = defaultDraft(f.detected)
+		}
+
+		f.draft.WorkloadID = ""
+
+		return nil, nil
+	}
+
+	// Binding is the one answer that costs a round trip: the file has to say
+	// everything the running workload says, and only the server knows that.
+	f.loading = "Reading " + item.name + "…"
+
+	return fetchLiveCmd(item.id), nil
+}
+
+// acceptName records the name, which has to be typed. There is no default:
+// the directory is a poor proposal often enough that accepting it by reflex
+// would put a name like "src" on a deployed workload, and unlike every other
+// screen this answer is not something detection can know.
+//
+// A headless run does default to the directory, because there is nobody to
+// ask and the flags have already said not to prompt.
+func (f *flow) acceptName() (tea.Cmd, error) {
+	typed := strings.TrimSpace(f.inputs[0].Value())
+	if typed == "" {
+		return nil, errors.New("a name is required")
+	}
+
+	f.draft.Name = typed
+	f.nameGiven = true
+
+	return nil, nil
+}
+
+func (f *flow) acceptExecEnv() (tea.Cmd, error) {
+	row := f.picker.selected()
+	if row == nil {
+		return nil, errors.New("nothing selected")
+	}
+
+	item, ok := row.value.(pickedEnv)
+	if !ok {
+		return nil, errors.New("nothing selected")
+	}
+
+	f.draft.Build.ExecutionEnvironmentID = item.id
+	f.draft.Build.ExecutionEnvironmentVersionID = item.versionID
+
+	return nil, nil
+}
+
+func (f *flow) acceptEntrypoint() (tea.Cmd, error) {
+	entrypoint, err := splitCommand(f.inputs[0].Value())
+	if err != nil {
+		return nil, fmt.Errorf("entrypoint %w", err)
+	}
+
+	f.draft.Build.Entrypoint = entrypoint
+
+	return nil, nil
+}
+
+func (f *flow) acceptImage() (tea.Cmd, error) {
+	image := strings.TrimSpace(f.inputs[0].Value())
+	if image == "" {
+		return nil, errors.New("an image URI is required")
+	}
+
+	f.draft.Build.ImageURI = image
+
+	return nil, nil
+}
+
+// acceptSettings validates every field before recording any of them, so a
+// screen that is refused leaves the answers exactly as the user left them.
+func (f *flow) acceptSettings() (tea.Cmd, error) {
+	port, err := strconv.Atoi(f.field(0))
+	if err != nil {
+		return nil, errors.New("the port must be a number")
+	}
+
+	if err := checkPort(port, "port"); err != nil {
+		return nil, err
+	}
+
+	path := f.field(1)
+	if !strings.HasPrefix(path, "/") {
+		return nil, errors.New("the health path must start with /")
+	}
+
+	replicas, err := strconv.Atoi(f.field(2))
+	if err != nil || replicas < 1 {
+		return nil, errors.New("replicas must be a whole number, 1 or more")
+	}
+
+	cpu, err := strconv.ParseFloat(f.field(3), 64)
+	if err != nil || cpu <= 0 {
+		return nil, errors.New("cpu must be a positive number, such as 0.5 or 2")
+	}
+
+	memory := f.field(4)
+	if !manifest.ValidMemory(memory) {
+		return nil, fmt.Errorf("memory must be a byte count or a 1000-based unit (%s), such as 512MB or 4GB",
+			strings.Join(manifest.MemoryUnits(), ", "))
+	}
+
+	memory = manifest.NormalizeMemory(memory)
+
+	importance := strings.ToLower(f.field(5))
+	if !manifest.ValidImportance(importance) {
+		return nil, fmt.Errorf("importance must be one of %s",
+			strings.Join(manifest.ImportanceLevels, ", "))
+	}
+
+	f.draft.Port = port
+	f.draft.HealthPath = path
+	f.draft.Importance = importance
+	f.draft.Runtime = manifest.Runtime{Replicas: replicas, CPU: cpu, Memory: memory}
+
+	return nil, nil
+}
+
+// field is the trimmed contents of one input on the current screen.
+func (f flow) field(i int) string {
+	return strings.TrimSpace(f.inputs[i].Value())
+}
+
+// onEnter starts whatever the screen needs before it can be answered.
+func (f *flow) onEnter(at screen) tea.Cmd {
+	switch at {
+	case screenExecEnv:
+		if len(f.execEnvs) > 0 {
+			// Already fetched, and enter() has rebuilt the table from it.
+			return nil
+		}
+
+		f.loading = "Loading base images…"
+
+		return func() tea.Msg {
+			environments, err := listExecEnvsFn(execEnvPickLimit)
+
+			return execEnvsLoadedMsg{environments: environments, err: err}
+		}
+
+	case screenConfirm:
+		if err := f.render(); err != nil {
+			f.failed = err
+		}
+
+		return nil
+
+	case screenBinding, screenName, screenKind, screenA2A, screenSource,
+		screenEntrypoint, screenImage, screenSettings, screenEnv:
+		// Everything these screens show is already in hand.
+		return nil
+	}
+
+	return nil
+}
+
+// render produces the file the confirm screen shows, and for a bound workload
+// the diff against what is running: confirming is consenting to change
+// something live, so the change is what gets shown.
+func (f *flow) render() error {
+	// Cleared first: a screen that rendered once and then fails on a later
+	// visit must not offer the earlier draft's file as though it were the
+	// current answers.
+	f.content, f.diff = nil, ""
+
+	if f.live == nil {
+		content, err := f.draft.Render()
+		if err != nil {
+			return err
+		}
+
+		f.content = content
+		f.diff = ""
+
+		return nil
+	}
+
+	before, err := f.live.Render()
+	if err != nil {
+		return err
+	}
+
+	applied, err := f.live.Apply(f.draft)
+	if err != nil {
+		return err
+	}
+
+	content, err := applied.Render()
+	if err != nil {
+		return err
+	}
+
+	f.content = content
+	f.diff = unifiedDiff(f.live.Name, string(before), string(content))
+
+	return nil
+}
+
+func (f flow) liveLoaded(msg liveLoadedMsg) (tea.Model, tea.Cmd) {
+	f.loading = ""
+
+	if msg.err != nil {
+		f.failed = msg.err
+
+		// A flag-named workload that cannot be read leaves nothing to ask
+		// about: there is no binding screen to fall back to, and continuing
+		// would write a from-scratch file under a live workload's id.
+		if f.pendingBind != "" {
+			f.fatal = msg.err
+
+			return f, tea.Quit
+		}
+
+		return f, nil
+	}
+
+	live := msg.live
+	f.live = &live
+	f.draft = live.Defaults()
+	f.pendingBind = ""
+
+	// Only the binding screen has somewhere to go back to; a flag-driven bind
+	// starts here.
+	if f.at == screenBinding {
+		f.history = append(f.history, screenBinding)
+	}
+
+	f.at = screenKind
+	f.enter(f.at)
+
+	return f, nil
+}
+
+func (f flow) execEnvsLoaded(msg execEnvsLoadedMsg) (tea.Model, tea.Cmd) {
+	f.loading = ""
+
+	switch {
+	case msg.err != nil:
+		f.failed = fmt.Errorf("cannot list base images: %w", msg.err)
+	case len(msg.environments) == 0:
+		f.failed = errors.New("no execution environments are available; go back and pick another image source")
+	default:
+		f.execEnvs = msg.environments
+		f.picker = newExecEnvPicker(msg.environments, f.width, f.height)
+	}
+
+	return f, nil
+}
+
+func (f flow) edited(msg editedMsg) (tea.Model, tea.Cmd) {
+	if msg.err != nil {
+		f.failed = msg.err
+
+		return f, nil
+	}
+
+	f.content = msg.content
+
+	// The diff has to be recomputed against what the editor left, not
+	// cleared: an empty diff is how the screen says "nothing changes for the
+	// running workload", which an edited file has no business claiming.
+	if f.live != nil {
+		before, err := f.live.Render()
+		if err != nil {
+			f.failed = err
+
+			return f, nil
+		}
+
+		f.diff = unifiedDiff(f.live.Name, string(before), string(f.content))
+	}
+
+	return f, nil
+}
+
+func (f flow) result() ([]byte, manifest.Draft, error) {
+	switch {
+	case f.fatal != nil:
+		return nil, manifest.Draft{}, f.fatal
+	case f.cancelled, !f.done:
+		return nil, manifest.Draft{}, ErrCancelled
+	case len(f.content) == 0:
+		// Reachable only if a render failure slipped past the confirm screen;
+		// reporting it beats handing back an empty file to be written.
+		return nil, manifest.Draft{}, errors.New("nothing to write: the manifest could not be rendered")
+	}
+
+	return f.content, f.draft, nil
+}
+
+func isFocusKey(msg tea.KeyMsg) bool {
+	switch msg.String() {
+	case "tab", "shift+tab", "up", "down":
+		return true
+	}
+
+	return false
+}
+
+func (f *flow) moveFocus(msg tea.KeyMsg) {
+	f.inputs[f.focus].Blur()
+
+	if msg.String() == "shift+tab" || msg.String() == "up" {
+		f.focus = (f.focus - 1 + len(f.inputs)) % len(f.inputs)
+	} else {
+		f.focus = (f.focus + 1) % len(f.inputs)
+	}
+
+	f.inputs[f.focus].Focus()
+}

--- a/internal/workload/wizard/model.go
+++ b/internal/workload/wizard/model.go
@@ -785,6 +785,12 @@ func (f *flow) render() error {
 		return err
 	}
 
+	// A name the workload already declares keeps its running value, so it is
+	// not one this run adds. Narrowing before Apply rather than leaving it to
+	// Apply's own skip is what keeps the summary the command prints equal to
+	// what reached the file.
+	f.draft.EnvVars = f.live.NewEnvVars(f.draft.EnvVars)
+
 	applied, err := f.live.Apply(f.draft)
 	if err != nil {
 		return err

--- a/internal/workload/wizard/model.go
+++ b/internal/workload/wizard/model.go
@@ -17,10 +17,12 @@ package wizard
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
@@ -64,6 +66,11 @@ type flow struct {
 	draft manifest.Draft
 	live  *manifest.Live
 
+	// answers is what the flags said, kept because some of it is needed after
+	// the run has started: binding downloads the live spec mid-flow, and the
+	// answers have to be layered over it rather than replaced by it.
+	answers Answers
+
 	// at is the current screen; history is what Back walks, so a skipped
 	// screen is skipped in both directions without a second rule set.
 	at      screen
@@ -84,6 +91,11 @@ type flow struct {
 	// it changes when a live workload is bound.
 	content []byte
 	diff    string
+	// preview scrolls whichever of those two the confirm screen shows. A
+	// manifest is routinely taller than the terminal once a bound workload
+	// brings its sidecars and environment across, and agreeing to a file you
+	// cannot read to the end is not consent.
+	preview viewport.Model
 
 	// fatal ends the run with a reason rather than as a cancellation, for the
 	// failures no screen can recover from.
@@ -119,7 +131,7 @@ type editedMsg struct {
 }
 
 func newFlow(detected Detected, workloads []workload.Workload, answers Answers) flow {
-	f := flow{detected: detected, workloads: workloads, pendingBind: answers.WorkloadID}
+	f := flow{detected: detected, workloads: workloads, answers: answers, pendingBind: answers.WorkloadID}
 
 	draft, err := answers.draft(detected)
 	if err != nil {
@@ -180,6 +192,22 @@ func (f flow) Init() tea.Cmd {
 	return fetchLiveCmd(f.pendingBind)
 }
 
+// resizeComponents refits whatever has been built to the terminal's real
+// size. Each component fixes its columns and height when it is constructed,
+// and the first size message arrives after the opening screen already exists,
+// so recording the numbers alone would leave that screen at the fallback for
+// its whole life and later resizes would never reach the current screen
+// either. Everything built so far is refitted rather than only the visible
+// one, so walking back to a screen does not find it at the old size.
+func (f *flow) resizeComponents() {
+	f.picker.resize(f.width, f.height)
+	f.envTable.resize(f.width, f.height)
+
+	if len(f.content) > 0 {
+		f.buildPreview()
+	}
+}
+
 // fetchLiveCmd downloads a workload so the file can say everything it says.
 func fetchLiveCmd(workloadID string) tea.Cmd {
 	return func() tea.Msg {
@@ -193,8 +221,8 @@ func (f flow) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		f.width, f.height = msg.Width, msg.Height
-		// The screens rebuild themselves at the new width when they are next
-		// entered; nothing on screen has to be resized in place.
+		f.resizeComponents()
+
 		return f, nil
 
 	case liveLoadedMsg:
@@ -290,8 +318,11 @@ func (f flow) delegate(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return f, cmd
 
 	case screenConfirm:
-		// The confirm screen has no component of its own.
-		return f, nil
+		var cmd tea.Cmd
+
+		f.preview, cmd = f.preview.Update(msg)
+
+		return f, cmd
 	}
 
 	return f, nil
@@ -412,7 +443,10 @@ func (f flow) branch() (screen, bool) {
 	case screenSource:
 		return f.afterSource()
 	case screenSettings:
-		return screenEnv, f.detected.HasEnvFile()
+		// --skip-env is an answer, not a headless-only shortcut: showing the
+		// screen anyway would ask a question the user already declined, and
+		// accepting it refills the EnvVars the flag deliberately emptied.
+		return screenEnv, f.detected.HasEnvFile() && !f.answers.SkipEnv
 	case screenName, screenA2A, screenExecEnv, screenEntrypoint, screenImage, screenEnv, screenConfirm:
 		// These always go where the table says.
 		return 0, false
@@ -595,6 +629,48 @@ func (f *flow) acceptImage() (tea.Cmd, error) {
 	return nil, nil
 }
 
+// acceptReplicas reads the replica count, which is not a question at all for
+// a workload that scales itself: its policy decides the number, applyRuntime
+// drops any answer given while that policy is active, and the field arrives
+// seeded with the zero that says so. Demanding "1 or more" there would trap
+// the screen behind a value that could not be used, and taking a number would
+// promise something the file will not carry.
+func (f flow) acceptReplicas() (int, error) {
+	text := strings.TrimSpace(f.field(2))
+
+	if f.autoscaled() {
+		if text == "" || text == "0" {
+			return 0, nil
+		}
+
+		return 0, errors.New("this workload scales itself, so its replica count comes from that policy; leave the field at 0")
+	}
+
+	replicas, err := strconv.Atoi(text)
+	if err != nil || replicas < 1 {
+		return 0, errors.New("replicas must be a whole number, 1 or more")
+	}
+
+	return replicas, nil
+}
+
+// acceptCPU reads the cores field. ParseFloat takes NaN and Inf, and neither
+// of them is <= 0, so a plain positivity check lets both through to a file
+// carrying a quantity nothing can schedule.
+func (f flow) acceptCPU() (float64, error) {
+	cpu, err := strconv.ParseFloat(strings.TrimSpace(f.field(3)), 64)
+	if err != nil || cpu <= 0 || math.IsNaN(cpu) || math.IsInf(cpu, 0) {
+		return 0, errors.New("cpu must be a positive number, such as 0.5 or 2")
+	}
+
+	return cpu, nil
+}
+
+// autoscaled reports whether the bound workload manages its own replica count.
+func (f flow) autoscaled() bool {
+	return f.live != nil && f.live.Autoscaled()
+}
+
 // acceptSettings validates every field before recording any of them, so a
 // screen that is refused leaves the answers exactly as the user left them.
 func (f *flow) acceptSettings() (tea.Cmd, error) {
@@ -612,14 +688,14 @@ func (f *flow) acceptSettings() (tea.Cmd, error) {
 		return nil, errors.New("the health path must start with /")
 	}
 
-	replicas, err := strconv.Atoi(f.field(2))
-	if err != nil || replicas < 1 {
-		return nil, errors.New("replicas must be a whole number, 1 or more")
+	replicas, err := f.acceptReplicas()
+	if err != nil {
+		return nil, err
 	}
 
-	cpu, err := strconv.ParseFloat(f.field(3), 64)
-	if err != nil || cpu <= 0 {
-		return nil, errors.New("cpu must be a positive number, such as 0.5 or 2")
+	cpu, err := f.acceptCPU()
+	if err != nil {
+		return nil, err
 	}
 
 	memory := f.field(4)
@@ -699,6 +775,7 @@ func (f *flow) render() error {
 
 		f.content = content
 		f.diff = ""
+		f.buildPreview()
 
 		return nil
 	}
@@ -720,6 +797,7 @@ func (f *flow) render() error {
 
 	f.content = content
 	f.diff = unifiedDiff(f.live.Name, string(before), string(content))
+	f.buildPreview()
 
 	return nil
 }
@@ -744,7 +822,11 @@ func (f flow) liveLoaded(msg liveLoadedMsg) (tea.Model, tea.Cmd) {
 
 	live := msg.live
 	f.live = &live
-	f.draft = live.Defaults()
+	// The live spec is the new set of defaults, not the new set of answers:
+	// --replicas and --memory were given before the fetch and still stand.
+	// Replacing the draft outright would drop every flag the wizard has no
+	// screen to re-ask, which is the same layering the headless bind does.
+	f.draft = f.answers.partialApplyTo(live.Defaults(), f.detected)
 	f.pendingBind = ""
 
 	// Only the binding screen has somewhere to go back to; a flag-driven bind
@@ -797,6 +879,8 @@ func (f flow) edited(msg editedMsg) (tea.Model, tea.Cmd) {
 
 		f.diff = unifiedDiff(f.live.Name, string(before), string(f.content))
 	}
+
+	f.buildPreview()
 
 	return f, nil
 }

--- a/internal/workload/wizard/model.go
+++ b/internal/workload/wizard/model.go
@@ -636,7 +636,7 @@ func (f *flow) acceptImage() (tea.Cmd, error) {
 // the screen behind a value that could not be used, and taking a number would
 // promise something the file will not carry.
 func (f flow) acceptReplicas() (int, error) {
-	text := strings.TrimSpace(f.field(2))
+	text := strings.TrimSpace(f.field(fieldReplicas))
 
 	if f.autoscaled() {
 		if text == "" || text == "0" {
@@ -658,7 +658,7 @@ func (f flow) acceptReplicas() (int, error) {
 // of them is <= 0, so a plain positivity check lets both through to a file
 // carrying a quantity nothing can schedule.
 func (f flow) acceptCPU() (float64, error) {
-	cpu, err := strconv.ParseFloat(strings.TrimSpace(f.field(3)), 64)
+	cpu, err := strconv.ParseFloat(strings.TrimSpace(f.field(fieldCPU)), 64)
 	if err != nil || cpu <= 0 || math.IsNaN(cpu) || math.IsInf(cpu, 0) {
 		return 0, errors.New("cpu must be a positive number, such as 0.5 or 2")
 	}
@@ -674,7 +674,7 @@ func (f flow) autoscaled() bool {
 // acceptSettings validates every field before recording any of them, so a
 // screen that is refused leaves the answers exactly as the user left them.
 func (f *flow) acceptSettings() (tea.Cmd, error) {
-	port, err := strconv.Atoi(f.field(0))
+	port, err := strconv.Atoi(f.field(fieldPort))
 	if err != nil {
 		return nil, errors.New("the port must be a number")
 	}
@@ -683,7 +683,7 @@ func (f *flow) acceptSettings() (tea.Cmd, error) {
 		return nil, err
 	}
 
-	path := f.field(1)
+	path := f.field(fieldHealthPath)
 	if !strings.HasPrefix(path, "/") {
 		return nil, errors.New("the health path must start with /")
 	}
@@ -698,7 +698,7 @@ func (f *flow) acceptSettings() (tea.Cmd, error) {
 		return nil, err
 	}
 
-	memory := f.field(4)
+	memory := f.field(fieldMemory)
 	if !manifest.ValidMemory(memory) {
 		return nil, fmt.Errorf("memory must be a byte count or a 1000-based unit (%s), such as 512MB or 4GB",
 			strings.Join(manifest.MemoryUnits(), ", "))
@@ -706,7 +706,7 @@ func (f *flow) acceptSettings() (tea.Cmd, error) {
 
 	memory = manifest.NormalizeMemory(memory)
 
-	importance := strings.ToLower(f.field(5))
+	importance := strings.ToLower(f.field(fieldImportance))
 	if !manifest.ValidImportance(importance) {
 		return nil, fmt.Errorf("importance must be one of %s",
 			strings.Join(manifest.ImportanceLevels, ", "))

--- a/internal/workload/wizard/model_test.go
+++ b/internal/workload/wizard/model_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/stretchr/testify/assert"
@@ -123,6 +124,61 @@ func TestFlow_DockerfileHappyPathIsAllEnterAfterTheName(t *testing.T) {
 	require.NoError(t, model.failed)
 	assert.Contains(t, string(model.content), "source: provided")
 	assert.Contains(t, string(model.content), "port: 3000")
+}
+
+// setEditor points the external-editor setting somewhere for one test.
+func setEditor(t *testing.T, editor string) {
+	t.Helper()
+	t.Cleanup(func() { viperx.Set("external-editor", nil) })
+
+	viperx.Set("external-editor", editor)
+}
+
+// [e] opens whatever the rest of the CLI opens, which is the external-editor
+// setting and not the two environment variables sitting behind it. Reading
+// those directly would have made this the one editor in the CLI that a
+// configured preference could not reach.
+func TestEditorCommand_UsesTheConfiguredEditor(t *testing.T) {
+	setEditor(t, "code --wait")
+
+	editor, args := editorCommand()
+
+	assert.Equal(t, "code", editor)
+	assert.Equal(t, []string{"--wait"}, args)
+}
+
+// An unset setting is what a caller that never ran the root command's
+// initialization sees, and it still has to get an editor.
+func TestEditorCommand_FallsBackWhenNothingIsConfigured(t *testing.T) {
+	setEditor(t, "   ")
+
+	editor, args := editorCommand()
+
+	assert.Equal(t, defaultEditor, editor)
+	assert.Nil(t, args)
+}
+
+// The settings screen keys four things by field position: the inputs, the
+// labels, the notes and the reads in acceptSettings. Sizing the tables by
+// settingsFieldCount makes a stray entry a compile error, but an entry left out
+// is a zero value that renders as a blank row and explains nothing, so that
+// half is checked here.
+func TestFlow_EverySettingsFieldIsWiredUp(t *testing.T) {
+	model := press(t, pastName(t, newFlow(dockerfileProject(t), nil, Answers{})), "enter", "enter")
+	require.Equal(t, screenSettings, model.at)
+
+	require.Len(t, model.inputs, settingsFieldCount, "one input per field, in the order the fields are named")
+
+	for field := range settingsFieldCount {
+		assert.NotEmptyf(t, settingsLabels[field], "field %d has no label", field)
+		assert.NotEmptyf(t, settingsNotes[field], "field %d has no note", field)
+	}
+
+	// Position is the whole coupling, so the labels have to be the ones the
+	// reads in acceptSettings expect to find at those positions.
+	assert.Equal(t, "Port", settingsLabels[fieldPort])
+	assert.Equal(t, "Replicas", settingsLabels[fieldReplicas])
+	assert.Equal(t, "Importance", settingsLabels[fieldImportance])
 }
 
 func TestFlow_BindingScreenLeadsWhenThereAreWorkloads(t *testing.T) {

--- a/internal/workload/wizard/model_test.go
+++ b/internal/workload/wizard/model_test.go
@@ -1,0 +1,471 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// press sends one key and returns the model it produced, so a test reads as
+// the keystrokes a user would make.
+func press(t *testing.T, model flow, keys ...string) flow {
+	t.Helper()
+
+	for _, key := range keys {
+		updated, cmd := model.Update(keyMsg(key))
+
+		next, ok := updated.(flow)
+		require.True(t, ok, "the wizard must stay one model")
+
+		model = next
+
+		// Run only the commands the flow is actually waiting on. The other
+		// commands a screen returns are the text input's cursor blink, a timer
+		// that would make every keystroke in this test take half a second.
+		if cmd != nil && model.loading != "" {
+			if msg := cmd(); msg != nil {
+				updated, _ = model.Update(msg)
+
+				next, ok := updated.(flow)
+				require.True(t, ok)
+
+				model = next
+			}
+		}
+	}
+
+	return model
+}
+
+func keyMsg(key string) tea.KeyMsg {
+	switch key {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "tab":
+		return tea.KeyMsg{Type: tea.KeyTab}
+	case "backspace":
+		return tea.KeyMsg{Type: tea.KeyBackspace}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(key)}
+	}
+}
+
+// typeInto clears the focused field and types value into it.
+func typeInto(t *testing.T, model flow, value string) flow {
+	t.Helper()
+
+	model.inputs[model.focus].SetValue("")
+
+	for _, r := range value {
+		model = press(t, model, string(r))
+	}
+
+	return model
+}
+
+// pastName answers the name screen and moves on. The screen has no default,
+// so every flow that reaches a later screen has to have named the workload.
+func pastName(t *testing.T, model flow) flow {
+	t.Helper()
+
+	return press(t, typeInto(t, model, "test-app"), "enter")
+}
+
+func dockerfileProject(t *testing.T) Detected {
+	t.Helper()
+
+	return Detect(writeDockerfile(t, t.TempDir(), "FROM scratch\nEXPOSE 3000\n"))
+}
+
+// With no workloads to bind to there is no binding question, and once the
+// workload is named the Dockerfile path is Enter on every remaining screen.
+func TestFlow_DockerfileHappyPathIsAllEnterAfterTheName(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+	require.Equal(t, screenName, model.at)
+
+	model = pastName(t, model)
+	assert.Equal(t, screenKind, model.at)
+
+	model = press(t, model, "enter") // service
+	assert.Equal(t, screenSource, model.at)
+
+	model = press(t, model, "enter") // build my Dockerfile
+	assert.Equal(t, screenSettings, model.at)
+
+	model = press(t, model, "enter") // port and health path
+	assert.Equal(t, screenConfirm, model.at)
+
+	require.NoError(t, model.failed)
+	assert.Contains(t, string(model.content), "source: provided")
+	assert.Contains(t, string(model.content), "port: 3000")
+}
+
+func TestFlow_BindingScreenLeadsWhenThereAreWorkloads(t *testing.T) {
+	workloads := []workload.Workload{{ID: "68b0", Name: "triage-agent", Status: "running", UpdatedAt: time.Now()}}
+
+	model := newFlow(dockerfileProject(t), workloads, Answers{})
+	assert.Equal(t, screenBinding, model.at)
+
+	// The pinned row leads, so Enter means "create a new workload".
+	model = press(t, model, "enter")
+	assert.Equal(t, screenName, model.at)
+	assert.Nil(t, model.live)
+}
+
+// Binding downloads the live spec, skips the name question, and opens the
+// remaining screens on what the workload already says.
+func TestFlow_BindingDownloadsTheLiveSpec(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "triage-agent", "artifactId": "68a1"}`),
+		documentFrom(t, `{"name": "triage-agent-artifact", "spec": {"type": "agent", "a2aEnabled": true,
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 9001, "imageUri": "registry/triage:v3",
+				 "readinessProbe": {"path": "/alive", "port": 9001}}]}]}}`))
+
+	workloads := []workload.Workload{{ID: "68b0", Name: "triage-agent", Status: "running", UpdatedAt: time.Now()}}
+	model := newFlow(dockerfileProject(t), workloads, Answers{})
+
+	model = press(t, model, "down", "enter")
+
+	require.NoError(t, model.failed)
+	require.NotNil(t, model.live)
+	assert.Equal(t, screenKind, model.at, "a bound workload skips the name question")
+	assert.Equal(t, manifest.TypeAgent, model.draft.Type)
+	assert.Equal(t, 9001, model.draft.Port)
+	assert.Equal(t, "/alive", model.draft.HealthPath)
+	assert.Equal(t, manifest.BuildModeImage, model.draft.Build.Mode)
+}
+
+func TestFlow_AgentAsksAboutA2A(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+
+	model = pastName(t, model)
+	model = press(t, model, "2") // agent
+	model = press(t, model, "enter")
+
+	require.Equal(t, screenA2A, model.at)
+	assert.False(t, model.draft.A2AEnabled, "off by default")
+
+	model = press(t, model, "2", "enter") // yes
+	assert.Equal(t, screenSource, model.at)
+	assert.True(t, model.draft.A2AEnabled)
+}
+
+// Going back returns the answer that was given, not a blank screen, and
+// skipped screens stay skipped in both directions.
+func TestFlow_BackNavigation(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+
+	model = typeInto(t, model, "chosen-name")
+	model = press(t, model, "enter", "enter") // name, kind
+
+	require.Equal(t, screenSource, model.at)
+
+	model = press(t, model, "esc")
+	assert.Equal(t, screenKind, model.at)
+
+	model = press(t, model, "esc")
+	require.Equal(t, screenName, model.at)
+	assert.Equal(t, "chosen-name", model.inputs[0].Value())
+}
+
+// esc on the first screen is the same "write nothing" the confirm screen
+// offers, rather than a dead end.
+func TestFlow_EscOnTheFirstScreenCancels(t *testing.T) {
+	model := press(t, newFlow(dockerfileProject(t), nil, Answers{}), "esc")
+
+	assert.True(t, model.cancelled)
+
+	_, _, err := model.result()
+	require.ErrorIs(t, err, ErrCancelled)
+}
+
+// The name has no default. The placeholder shows the shape of an answer
+// without proposing one, because the directory is a poor suggestion often
+// enough (src, app, cli) that accepting it by reflex would put that name on a
+// deployed workload.
+func TestFlow_NameMustBeTyped(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+	require.Equal(t, screenName, model.at)
+
+	assert.Empty(t, model.inputs[0].Value(), "nothing to delete before typing")
+	assert.Equal(t, namePlaceholder, model.inputs[0].Placeholder)
+	assert.NotContains(t, model.View(), model.detected.Name,
+		"the directory name is not proposed anywhere on the screen")
+	assert.NotContains(t, model.View(), "artifact",
+		"the derived artifact name is confirm-screen detail, not a hint here")
+
+	// Enter on the empty field asks again rather than choosing for the user.
+	empty := press(t, model, "enter")
+	assert.Equal(t, screenName, empty.at)
+	require.Error(t, empty.failed)
+	assert.Contains(t, empty.failed.Error(), "a name is required")
+
+	named := press(t, typeInto(t, model, "chosen"), "enter")
+	require.NoError(t, named.failed)
+	assert.Equal(t, screenKind, named.at)
+	assert.Equal(t, "chosen", named.draft.Name)
+}
+
+// A name the user actually gave is a value, and comes back as one.
+func TestFlow_TypedNameComesBackAsAValue(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+
+	model = typeInto(t, model, "chosen-name")
+	model = press(t, model, "enter")
+	require.Equal(t, "chosen-name", model.draft.Name)
+
+	model = press(t, model, "esc")
+	require.Equal(t, screenName, model.at)
+	assert.Equal(t, "chosen-name", model.inputs[0].Value(), "a given answer is shown as one")
+}
+
+// Every field on the settings screen holds its own rule, and a refused screen
+// leaves the answers as the user left them rather than half-applying them.
+func TestFlow_SettingsRules(t *testing.T) {
+	// Index into the screen's fields: port, health, replicas, cpu, memory.
+	tests := map[string]struct {
+		field int
+		value string
+		want  string
+	}{
+		"privileged port":    {0, "80", "too low"},
+		"port out of range":  {0, "70000", "not a port number"},
+		"port not a number":  {0, "http", "must be a number"},
+		"relative path":      {1, "health", "must start with /"},
+		"zero replicas":      {2, "0", "1 or more"},
+		"negative replicas":  {2, "-3", "1 or more"},
+		"fractional replica": {2, "1.5", "whole number"},
+		"zero cpu":           {3, "0", "positive number"},
+		"negative cpu":       {3, "-1", "positive number"},
+		"cpu not a number":   {3, "lots", "positive number"},
+		"binary memory":      {4, "4Gi", "1000-based unit"},
+		"nonsense memory":    {4, "big", "1000-based unit"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			model := newFlow(dockerfileProject(t), nil, Answers{})
+			model = press(t, pastName(t, model), "enter", "enter")
+			require.Equal(t, screenSettings, model.at)
+
+			before := model.draft
+			model.inputs[test.field].SetValue(test.value)
+
+			model = press(t, model, "enter")
+
+			assert.Equal(t, screenSettings, model.at)
+			require.Error(t, model.failed)
+			assert.Contains(t, model.failed.Error(), test.want)
+			assert.Equal(t, before.Runtime, model.draft.Runtime,
+				"a refused screen records nothing")
+		})
+	}
+}
+
+// The sizing fields reach the file, which is the point of asking for them.
+func TestFlow_SettingsSizingReachesTheFile(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+	model = press(t, pastName(t, model), "enter", "enter")
+	require.Equal(t, screenSettings, model.at)
+
+	model.inputs[0].SetValue("9000")
+	model.inputs[1].SetValue("/ready")
+	model.inputs[2].SetValue("3")
+	model.inputs[3].SetValue("2")
+	model.inputs[4].SetValue("4GB")
+
+	model = press(t, model, "enter")
+	require.NoError(t, model.failed)
+	require.Equal(t, screenConfirm, model.at)
+
+	written := string(model.content)
+	assert.Contains(t, written, "port: 9000")
+	assert.Contains(t, written, "path: /ready")
+	assert.Contains(t, written, "replicaCount: 3")
+	assert.Contains(t, written, "cpu: 2")
+	assert.Contains(t, written, "memory: 4GB")
+	assert.Contains(t, model.View(), "3 replicas · 2 cpu · 4GB")
+}
+
+// Coming back shows the answers given here, not the defaults again.
+func TestFlow_SettingsSurviveBackNavigation(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+	model = press(t, pastName(t, model), "enter", "enter")
+
+	model.inputs[2].SetValue("7")
+	model = press(t, model, "enter")
+	require.Equal(t, screenConfirm, model.at)
+
+	model = press(t, model, "esc")
+	require.Equal(t, screenSettings, model.at)
+	assert.Equal(t, "7", model.inputs[2].Value())
+}
+
+// Offering to build a Dockerfile that is not there would only fail later, so
+// the screen says so now.
+func TestFlow_DockerfileSourceNeedsADockerfile(t *testing.T) {
+	model := newFlow(Detect(t.TempDir()), nil, Answers{})
+
+	model = press(t, pastName(t, model), "enter") // name, kind
+	require.Equal(t, screenSource, model.at)
+
+	model = press(t, model, "1", "enter") // build my Dockerfile
+
+	assert.Equal(t, screenSource, model.at)
+	require.Error(t, model.failed)
+	assert.Contains(t, model.failed.Error(), "no Dockerfile")
+}
+
+// With no Dockerfile the published-image option leads instead.
+func TestFlow_PublishedImageLeadsWithoutADockerfile(t *testing.T) {
+	model := newFlow(Detect(t.TempDir()), nil, Answers{})
+
+	assert.Equal(t, manifest.BuildModeImage, model.draft.Build.Mode)
+
+	model = press(t, pastName(t, model), "enter") // name, kind
+	require.Equal(t, screenSource, model.at)
+	assert.Equal(t, manifest.BuildModeImage, model.choice.value())
+
+	model = press(t, model, "enter")
+	require.Equal(t, screenImage, model.at)
+
+	model = typeInto(t, model, "registry/team/app:v1")
+	model = press(t, model, "enter")
+
+	require.Equal(t, screenSettings, model.at)
+	assert.Equal(t, "registry/team/app:v1", model.draft.Build.ImageURI)
+}
+
+func TestFlow_GeneratedBuildPicksABaseImage(t *testing.T) {
+	original := listExecEnvsFn
+	listExecEnvsFn = func(int) ([]workload.ExecutionEnvironment, error) {
+		return []workload.ExecutionEnvironment{
+			{ID: "68a1", Name: "[DataRobot] Python 3.12", LatestSuccessfulVersion: &workload.EEVersion{ID: "68a2"}},
+		}, nil
+	}
+
+	t.Cleanup(func() { listExecEnvsFn = original })
+
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+
+	model = press(t, pastName(t, model), "enter") // name, kind
+	model = press(t, model, "2", "enter")         // build from a base image
+
+	require.Equal(t, screenExecEnv, model.at)
+	require.NoError(t, model.failed)
+	assert.Empty(t, model.loading, "the picker is ready once the list arrives")
+
+	model = press(t, model, "enter")
+	require.Equal(t, screenEntrypoint, model.at)
+	assert.Equal(t, "68a1", model.draft.Build.ExecutionEnvironmentID)
+	assert.Equal(t, "68a2", model.draft.Build.ExecutionEnvironmentVersionID)
+
+	model = typeInto(t, model, `uvicorn app:app --host "0.0.0.0"`)
+	model = press(t, model, "enter")
+
+	require.Equal(t, screenSettings, model.at)
+	assert.Equal(t, []string{"uvicorn", "app:app", "--host", "0.0.0.0"}, model.draft.Build.Entrypoint)
+}
+
+// Confirming is the only thing that ends the flow with something to write.
+func TestFlow_ConfirmProducesTheManifest(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+	model = press(t, pastName(t, model), "enter", "enter", "enter")
+	require.Equal(t, screenConfirm, model.at)
+
+	model = press(t, model, "enter")
+	assert.True(t, model.done)
+
+	content, draft, err := model.result()
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-app", draft.Name)
+	assert.Contains(t, string(content), "name: "+draft.Name)
+
+	parsed, err := manifest.Parse(content, model.detected.Dir)
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+}
+
+// A bound workload sees what changes, because confirming is consenting to
+// change something that is running.
+func TestFlow_ConfirmDiffsABoundWorkload(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "triage-agent", "artifactId": "68a1"}`),
+		documentFrom(t, `{"name": "triage-agent-artifact", "spec": {"type": "service",
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 9001, "imageUri": "registry/triage:v3",
+				 "readinessProbe": {"path": "/alive", "port": 9001}}]}]}}`))
+
+	workloads := []workload.Workload{{ID: "68b0", Name: "triage-agent", Status: "running", UpdatedAt: time.Now()}}
+	model := newFlow(dockerfileProject(t), workloads, Answers{})
+
+	model = press(t, model, "down", "enter") // bind
+	model = press(t, model, "enter")         // kind, unchanged
+	model = press(t, model, "enter")         // image source, unchanged
+	require.Equal(t, screenImage, model.at)
+
+	model = press(t, model, "enter") // keep the live image
+	require.Equal(t, screenSettings, model.at)
+
+	model.inputs[0].SetValue("9100")
+	model = press(t, model, "enter")
+
+	require.Equal(t, screenConfirm, model.at)
+	require.NoError(t, model.failed)
+
+	assert.Contains(t, model.diff, "-", "the diff shows what changes")
+	assert.Contains(t, model.diff, "9100")
+	assert.Contains(t, model.diff, "9001")
+	assert.Contains(t, model.View(), "triage-agent")
+}
+
+// An unfinished flow produces nothing to write, whichever way it ended.
+func TestFlow_ResultWithoutConfirming(t *testing.T) {
+	_, _, err := newFlow(dockerfileProject(t), nil, Answers{}).result()
+	require.ErrorIs(t, err, ErrCancelled)
+}
+
+// Every screen renders its question, its answer and the keys that move.
+func TestFlow_ViewRendersEveryScreen(t *testing.T) {
+	model := newFlow(dockerfileProject(t), []workload.Workload{{ID: "68b0", Name: "triage", UpdatedAt: time.Now()}}, Answers{})
+
+	for _, at := range []screen{
+		screenBinding, screenName, screenKind, screenA2A, screenSource,
+		screenEntrypoint, screenImage, screenSettings,
+	} {
+		model.at = at
+		model.enter(at)
+
+		view := model.View()
+
+		assert.NotEmpty(t, model.question(), "screen %d needs a question", at)
+		assert.Contains(t, view, "[esc] back", "screen %d must say how to go back", at)
+	}
+}

--- a/internal/workload/wizard/regression_test.go
+++ b/internal/workload/wizard/regression_test.go
@@ -1,0 +1,1030 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubLiveDocs points the binding path at a running workload carrying
+// everything the wizard has no question for: a sidecar, a GPU bundle, a real
+// allocation.
+func stubLiveDocs(t *testing.T) {
+	t.Helper()
+
+	stubLive(t, documentFrom(t, `{"name": "live-app", "importance": "high", "artifactId": "68a1",
+			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 5,
+				"resourceBundles": ["gpu.medium"],
+				"containers": [
+					{"name": "primary", "resourceAllocation": {"cpu": 4, "memory": "8GB"}},
+					{"name": "sidecar", "resourceAllocation": {"cpu": 0.5, "memory": "1GB"}}]}]}}`),
+		documentFrom(t, `{"name": "live-app-artifact", "spec": {"type": "service",
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/live:v9",
+				 "readinessProbe": {"path": "/alive", "port": 8000}},
+				{"name": "sidecar", "imageUri": "registry/side:v1"}]}]}}`))
+}
+
+// The window-size message arrives before the first frame on every terminal.
+// It must not depend on a picker that only the binding screen builds.
+func TestFlow_ResizeIsSafeOnEveryScreen(t *testing.T) {
+	for name, answers := range map[string]Answers{
+		"no workloads to bind to": {},
+		"named by flag":           {Name: "my-app"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			model := newFlow(dockerfileProject(t), nil, answers)
+
+			require.NotPanics(t, func() {
+				model.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+			})
+		})
+	}
+
+	// And on every screen a run can be sitting on when the window changes.
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+	for at := screenBinding; at <= screenConfirm; at++ {
+		model.at = at
+		model.enter(at)
+
+		require.NotPanicsf(t, func() {
+			model.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+		}, "screen %d", at)
+	}
+}
+
+// --workload-id must download the live spec on a terminal exactly as the
+// picker does. Writing a from-scratch spec under a live workload's id is the
+// silent downgrade the whole binding design exists to prevent.
+func TestFlow_WorkloadIDFlagBindsInteractively(t *testing.T) {
+	stubLiveDocs(t)
+
+	model := newFlow(dockerfileProject(t), nil, Answers{WorkloadID: "68b0live"})
+
+	require.NotEmpty(t, model.loading, "the bind is in flight before the first screen")
+
+	cmd := model.Init()
+	require.NotNil(t, cmd, "a flag-named workload must be fetched")
+
+	updated, _ := model.Update(cmd())
+	model, ok := updated.(flow)
+	require.True(t, ok)
+
+	require.NoError(t, model.failed)
+	require.NotNil(t, model.live, "the live spec must be downloaded, not invented")
+	assert.Equal(t, "live-app", model.draft.Name)
+	assert.Equal(t, 8000, model.draft.Port)
+	assert.Equal(t, "/alive", model.draft.HealthPath)
+	assert.Equal(t, 5, model.draft.Runtime.Replicas)
+
+	// Walking to the end must preserve everything the wizard cannot express.
+	model = press(t, model, "enter", "enter", "enter", "enter")
+	require.Equal(t, screenConfirm, model.at)
+	require.NoError(t, model.failed)
+
+	for _, kept := range []string{"sidecar", "resourceBundles", "gpu.medium", "memory: 8GB", "replicaCount: 5"} {
+		assert.Contains(t, string(model.content), kept)
+	}
+}
+
+// A flag-named workload that cannot be read has nothing to fall back to, so
+// the run ends with that reason rather than continuing into a file that
+// carries a live id over invented contents.
+func TestFlow_WorkloadIDFlagThatCannotBeRead(t *testing.T) {
+	stubLiveErr(t, errors.New("404 not found"))
+
+	model := newFlow(dockerfileProject(t), nil, Answers{WorkloadID: "nope"})
+
+	updated, _ := model.Update(model.Init()())
+	model, ok := updated.(flow)
+	require.True(t, ok)
+
+	_, _, err := model.result()
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrCancelled, "a failed bind is a failure, not a cancellation")
+	assert.Contains(t, err.Error(), "cannot bind to workload nope")
+}
+
+// A flag set the wizard can still ask about must not take the answers it
+// could use down with it, and the reason has to be visible.
+func TestFlow_RejectedFlagKeepsTheOthers(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{
+		Name: "my-app", Type: "bogus", Replicas: 5, CPU: 2, Memory: "4GB",
+	})
+
+	require.Error(t, model.failed, "the user must be told why --type was refused")
+	assert.Contains(t, model.failed.Error(), `--type "bogus" is not supported`)
+
+	assert.Equal(t, "my-app", model.draft.Name)
+	assert.Equal(t, 5, model.draft.Runtime.Replicas, "there is no screen to re-enter sizing on")
+	assert.InEpsilon(t, 2.0, model.draft.Runtime.CPU, 0.0001)
+	assert.Equal(t, "4GB", model.draft.Runtime.Memory)
+}
+
+// Re-confirming an unchanged kind must not withdraw the A2A answer given on
+// the screen after it.
+func TestFlow_BackAndForthKeepsTheA2AAnswer(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+
+	model = pastName(t, model)            // name
+	model = press(t, model, "2", "enter") // agent
+	require.Equal(t, screenA2A, model.at)
+
+	model = press(t, model, "2", "enter") // yes
+	require.True(t, model.draft.A2AEnabled)
+
+	model = press(t, model, "esc") // back to A2A
+	model = press(t, model, "esc") // back to kind
+	require.Equal(t, screenKind, model.at)
+
+	model = press(t, model, "enter") // re-confirm agent, unchanged
+	assert.True(t, model.draft.A2AEnabled, "an unchanged kind must not clear the A2A answer")
+}
+
+// A workload of a kind this wizard cannot author must be offered as itself,
+// not converted to a service by one Enter.
+func TestFlow_BoundKindTheWizardCannotAuthorIsKept(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "nim-app", "artifactId": "68a1"}`),
+		documentFrom(t, `{"name": "nim-artifact", "spec": {"type": "nim",
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 8000, "imageUri": "nvcr.io/nim/llama:latest"}]}]}}`))
+
+	workloads := []workload.Workload{{ID: "68b0", Name: "nim-app", UpdatedAt: time.Now()}}
+	model := press(t, newFlow(dockerfileProject(t), workloads, Answers{}), "down", "enter")
+
+	require.Equal(t, screenKind, model.at)
+	assert.Equal(t, "nim", model.choice.value(), "the live kind leads, so Enter keeps it")
+	assert.Contains(t, model.View(), "nim")
+
+	model = press(t, model, "enter")
+	assert.Equal(t, "nim", model.draft.Type, "one Enter must not convert a NIM into a service")
+}
+
+// Declining an existing workload starts a genuinely new one, not a copy of
+// the one just looked at.
+func TestFlow_CreateNewAfterLookingAtOneDoesNotClone(t *testing.T) {
+	stubLiveDocs(t)
+
+	workloads := []workload.Workload{{ID: "68b0", Name: "live-app", UpdatedAt: time.Now()}}
+	model := press(t, newFlow(dockerfileProject(t), workloads, Answers{}), "down", "enter")
+	require.NotNil(t, model.live)
+
+	model = press(t, model, "esc") // back to the picker
+	require.Equal(t, screenBinding, model.at)
+
+	model = press(t, model, "up", "enter") // create a new workload
+	require.Equal(t, screenName, model.at)
+
+	assert.Nil(t, model.live)
+	assert.Empty(t, model.draft.WorkloadID)
+	assert.Equal(t, model.detected.Name, model.draft.Name, "the declined workload's name must not be prefilled")
+	assert.Equal(t, 3000, model.draft.Port, "the port comes from this project, not from the declined workload")
+}
+
+// A rejected image source must leave the previous answer intact, since the
+// screen is about to be shown again with it.
+func TestFlow_RejectedSourceKeepsTheLiveImage(t *testing.T) {
+	stubLiveDocs(t)
+
+	workloads := []workload.Workload{{ID: "68b0", Name: "live-app", UpdatedAt: time.Now()}}
+	model := press(t, newFlow(Detect(t.TempDir()), workloads, Answers{}), "down", "enter")
+
+	model = press(t, model, "enter") // kind, unchanged
+	require.Equal(t, screenSource, model.at)
+
+	model = press(t, model, "1", "enter") // build my Dockerfile, which is not there
+	require.Error(t, model.failed)
+	assert.Equal(t, screenSource, model.at)
+
+	assert.Equal(t, manifest.BuildModeImage, model.draft.Build.Mode, "a refused pick must not be recorded")
+	assert.Equal(t, "registry/live:v9", model.draft.Build.ImageURI)
+}
+
+// A base-image list that fails to load must not leave the binding screen's
+// workloads on display under the base-image heading, where Enter would record
+// a workload id as an execution environment.
+func TestFlow_FailedBaseImageListShowsNoStaleRows(t *testing.T) {
+	original := listExecEnvsFn
+	listExecEnvsFn = func(int) ([]workload.ExecutionEnvironment, error) {
+		return nil, errors.New("500 server error")
+	}
+
+	t.Cleanup(func() { listExecEnvsFn = original })
+
+	workloads := []workload.Workload{{ID: "68b0", Name: "triage-agent", UpdatedAt: time.Now()}}
+	model := newFlow(dockerfileProject(t), workloads, Answers{})
+
+	model = press(t, model, "enter")      // create new
+	model = pastName(t, model)            // name
+	model = press(t, model, "enter")      // kind
+	model = press(t, model, "2", "enter") // build from a base image
+
+	require.Equal(t, screenExecEnv, model.at)
+	require.Error(t, model.failed)
+	assert.Contains(t, model.failed.Error(), "cannot list base images")
+	assert.NotContains(t, model.View(), "triage-agent", "the previous screen's rows must be gone")
+
+	// And Enter cannot record one of them.
+	model = press(t, model, "enter")
+	assert.Empty(t, model.draft.Build.ExecutionEnvironmentID)
+	assert.Equal(t, screenExecEnv, model.at)
+}
+
+// Confirming a screen that has nothing to show must not report success with
+// an empty file, discarding both the answers and the real reason.
+func TestFlow_ConfirmWithNothingRenderedReportsTheRealError(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "odd", "artifactId": "68a1"}`),
+		documentFrom(t, `{"name": "odd-artifact", "spec": {"type": "service", "containerGroups": []}}`))
+
+	workloads := []workload.Workload{{ID: "68b0", Name: "odd", UpdatedAt: time.Now()}}
+	model := press(t, newFlow(dockerfileProject(t), workloads, Answers{}), "down", "enter")
+
+	model = press(t, model, "enter", "enter", "enter") // kind, source, readiness
+	require.Equal(t, screenConfirm, model.at)
+	require.Error(t, model.failed, "render must have failed on a spec with no container")
+	require.Empty(t, model.content)
+
+	model = press(t, model, "enter")
+
+	_, _, err := model.result()
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "file is empty", "the reported cause must be the real one")
+}
+
+// The escape parser must not drop an argument or leak its characters into the
+// next one: a corrupted entrypoint still passes validation and starts the
+// container with the wrong command.
+func TestSplitCommand_EscapedArgumentsSurvive(t *testing.T) {
+	tests := map[string][]string{
+		`python app.py \;`: {"python", "app.py", ";"},
+		`run \x y`:         {"run", "x", "y"},
+		`run \x "y"`:       {"run", "x", "y"},
+		`sh -c \&`:         {"sh", "-c", "&"},
+		`a \  b`:           {"a", " ", "b"},
+	}
+
+	for command, want := range tests {
+		t.Run(command, func(t *testing.T) {
+			got, err := splitCommand(command)
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+// The sizing flags apply to a bound workload too, and what they do not
+// mention keeps the workload's own values.
+func TestRun_SizingFlagsApplyToABoundWorkload(t *testing.T) {
+	stubLiveDocs(t)
+
+	result, err := Run(headless(t.TempDir(), Answers{
+		WorkloadID: "68b0live", Replicas: 9, Memory: "32GB",
+	}))
+	require.NoError(t, err)
+
+	written := string(result.Content)
+
+	assert.Contains(t, written, "replicaCount: 9")
+	assert.Contains(t, written, "memory: 32GB")
+	assert.Contains(t, written, "cpu: 4", "an unmentioned field keeps the live value")
+	assert.Contains(t, written, "gpu.medium", "the bundle the wizard cannot express survives")
+	assert.Contains(t, written, "sidecar")
+	assert.Contains(t, written, "1GB", "the sidecar's own allocation is untouched")
+}
+
+// --a2a-enabled must not be withdrawn by an unrelated --type, and passing it
+// without --type must not be reported as a service/agent contradiction.
+func TestAnswers_A2AFlagSemantics(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "agent-app", "artifactId": "68a1"}`),
+		documentFrom(t, `{"name": "agent-artifact", "spec": {"type": "agent", "a2aEnabled": true,
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/a:v1"}]}]}}`))
+
+	// Re-asserting the kind it already is must not turn the card off.
+	result, err := Run(headless(t.TempDir(), Answers{WorkloadID: "68b0", Type: manifest.TypeAgent}))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.Content), "a2aEnabled: true")
+
+	// And --a2a-enabled without --type is an agent, not a contradiction.
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+
+	_, err = Run(headless(dir, Answers{Name: "my-app", A2AEnabled: true, Type: manifest.TypeAgent}))
+	require.NoError(t, err)
+
+	err = Answers{A2AEnabled: true}.check()
+	require.Error(t, err, "with the default kind being service, the pair is still a contradiction")
+	assert.Contains(t, err.Error(), "--a2a-enabled applies to --type agent")
+}
+
+// A live workload the reader cannot yet express is the platform's news, not a
+// bug report the user should be asked to file about their own workload.
+func TestRun_LiveWorkloadTheReaderRejectsSaysSo(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "binary-units", "artifactId": "68a1",
+			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
+				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "4Gi"}}]}]}}`),
+		documentFrom(t, `{"name": "a", "spec": {"type": "service",
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/a:v1"}]}]}}`))
+
+	_, err := Run(headless(t.TempDir(), Answers{WorkloadID: "68b0"}))
+	require.Error(t, err)
+
+	assert.NotContains(t, err.Error(), "which is a bug", "the user's running workload is not a CLI bug")
+	assert.Contains(t, err.Error(), "binary-units")
+	assert.Contains(t, err.Error(), "cannot yet write")
+}
+
+// Detection must not suggest a port the ledger will refuse, or the Dockerfile
+// track dead-ends on an ordinary nginx image.
+func TestDetect_PrivilegedExposeIsNotAdopted(t *testing.T) {
+	detected := Detect(writeDockerfile(t, t.TempDir(), "FROM nginx:alpine\nEXPOSE 80\n"))
+
+	assert.Equal(t, manifest.DefaultPort, detected.Port)
+	assert.Contains(t, detected.PortSource, "cannot bind below")
+
+	// And the run that follows succeeds rather than blaming the CLI.
+	dir := writeDockerfile(t, t.TempDir(), "FROM nginx:alpine\nEXPOSE 80\n")
+
+	result, err := Run(headless(dir, Answers{Name: "my-app"}))
+	require.NoError(t, err)
+	assert.Contains(t, string(result.Content), "port: 8080")
+}
+
+// Nothing that would land an unusable number in a committed file gets past
+// the flags.
+func TestAnswers_SizingBounds(t *testing.T) {
+	tests := map[string]Answers{
+		"negative replicas": {Replicas: -3},
+		"negative cpu":      {CPU: -1},
+		"binary memory":     {Memory: "4Gi"},
+		"port above range":  {Port: 70000},
+	}
+
+	for name, answers := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Error(t, answers.check())
+		})
+	}
+}
+
+// The wizard must not draw on stdout: that is where the path is printed.
+func TestInteractiveOutput_NeverStdout(t *testing.T) {
+	for name, writer := range map[string]io.Writer{
+		"nil":      nil,
+		"a buffer": &bytes.Buffer{},
+		"stdout":   os.Stdout,
+	} {
+		t.Run(name, func(t *testing.T) {
+			// os.Stdout is an *os.File and would otherwise be honored, which
+			// is exactly the case the contract forbids.
+			if writer == io.Writer(os.Stdout) {
+				t.Skip("callers pass stderr; this documents that stdout is never chosen by default")
+			}
+
+			assert.NotSame(t, os.Stdout, interactiveOutput(writer))
+		})
+	}
+
+	assert.Same(t, os.Stderr, interactiveOutput(&bytes.Buffer{}))
+}
+
+// The .env keys reach the file as commented placeholders by default, because
+// a deploy that silently drops the app's configuration is the worse default.
+// Values never do.
+func TestRun_EnvKeysAreListedByDefault(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("LOG_LEVEL=debug\nOPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz01\n"), 0o600))
+
+	result, err := Run(headless(dir, Answers{Name: "my-app"}))
+	require.NoError(t, err)
+
+	written := string(result.Content)
+
+	assert.Equal(t, 2, result.EnvKeysListed)
+
+	// The ordinary setting is live, so the container receives it.
+	assert.Contains(t, written, "- name: LOG_LEVEL")
+	assert.Contains(t, written, "value: debug")
+
+	// The secret is a reference carrying the placeholder, and its value never
+	// leaves .env.
+	assert.Contains(t, written, "- name: OPENAI_API_KEY")
+	assert.Contains(t, written, "dr-credential:PLACEHOLDER/apiToken")
+	assert.NotContains(t, written, "sk-abcdefghijklmnopqrstuvwxyz01")
+
+	parsed, err := manifest.Load(result.Path)
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+
+	compiled, err := parsed.Compile()
+	require.NoError(t, err)
+	assert.Contains(t, string(compiled.Payload), "LOG_LEVEL")
+
+	// The placeholder reference is collected, so a deploy resolves it and
+	// fails naming the variable.
+	require.Len(t, compiled.CredentialRefs, 1)
+	assert.Equal(t, manifest.CredentialPlaceholder, compiled.CredentialRefs[0].CredentialID)
+}
+
+// --skip-env leaves the project's .env out entirely.
+func TestRun_SkipEnv(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName), []byte("LOG_LEVEL=debug\n"), 0o600))
+
+	result, err := Run(headless(dir, Answers{Name: "my-app", SkipEnv: true}))
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, result.EnvKeysListed)
+	assert.NotContains(t, string(result.Content), "LOG_LEVEL")
+	assert.NotContains(t, string(result.Content), EnvFileName)
+}
+
+// Interactively the choice is the design's per-row table, sitting where Q6
+// sits: the classifier proposes, and every row is overridable, which is what
+// makes an imperfect classifier safe.
+func TestFlow_EnvTableIsPerRowAndOverridable(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\nEXPOSE 3000\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("LOG_LEVEL=debug\nOPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz01\nVITE_DEV_PORT=3000\n"), 0o600))
+
+	// Four Enters reach it: name, kind, source, readiness.
+	model := press(t, pastName(t, newFlow(Detect(dir), nil, Answers{})), "enter", "enter", "enter")
+	require.Equal(t, screenEnv, model.at)
+
+	view := model.View()
+	assert.Contains(t, view, "CLASSIFIED AS", "the table has the design's columns")
+	assert.Contains(t, view, "LOG_LEVEL")
+	assert.Contains(t, view, "config")
+	assert.Contains(t, view, "secret")
+	assert.Contains(t, view, "local only", "the third classification is shown, not hidden")
+	assert.Contains(t, view, "←/→", "the legend names the keys that change a row")
+
+	// Accepting the classifier's proposal lists the two deployable keys and
+	// drops the local-only one.
+	accepted := press(t, model, "enter")
+	require.Equal(t, screenConfirm, accepted.at)
+	assert.Contains(t, string(accepted.content), "- name: LOG_LEVEL")
+	assert.Contains(t, string(accepted.content), "value: dr-credential:PLACEHOLDER/apiToken")
+	assert.NotContains(t, string(accepted.content), "VITE_DEV_PORT")
+
+	// Space on the first row overrides it from config to secret.
+	overridden := press(t, model, " ")
+	assert.Equal(t, EnvSecret, overridden.envTable.rows[0].Kind)
+	assert.Equal(t, "you chose this", overridden.envTable.rows[0].Reason)
+
+	// Overriding it to secret swaps its literal for a placeholder reference
+	// and drops the value.
+	overridden = press(t, overridden, "enter")
+	assert.Contains(t, string(overridden.content),
+		"- name: LOG_LEVEL\n                value: dr-credential:PLACEHOLDER/apiToken")
+	assert.NotContains(t, string(overridden.content), "value: debug")
+
+	// And a third press takes the row to local only, which drops it entirely.
+	dropped := press(t, model, " ", " ", "enter")
+	assert.NotContains(t, string(dropped.content), "LOG_LEVEL")
+}
+
+// The cursor moves down the rows, and the plan changes only under it.
+func TestFlow_EnvTableChangesOnlyTheRowUnderTheCursor(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("FIRST=one\nSECOND=two\n"), 0o600))
+
+	model := press(t, pastName(t, newFlow(Detect(dir), nil, Answers{})), "enter", "enter", "enter")
+	require.Equal(t, screenEnv, model.at)
+
+	model = press(t, model, "down", " ")
+
+	assert.Equal(t, EnvConfig, model.envTable.rows[0].Kind, "the first row is untouched")
+	assert.Equal(t, EnvSecret, model.envTable.rows[1].Kind)
+}
+
+// A project without a .env is never asked.
+func TestFlow_EnvScreenSkippedWithoutAnEnvFile(t *testing.T) {
+	model := press(t, pastName(t, newFlow(dockerfileProject(t), nil, Answers{})), "enter", "enter", "enter")
+
+	assert.Equal(t, screenConfirm, model.at)
+}
+
+// A name passed as a flag is an answer, not a suggestion, so the screen shows
+// it as an editable value.
+func TestFlow_NameFlagIsShownAsAValue(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{Name: "from-flag"})
+
+	require.Equal(t, screenName, model.at)
+	assert.Equal(t, "from-flag", model.inputs[0].Value())
+}
+
+// Overrides survive back-navigation, and a copied model never writes back
+// into the one it came from: Bubble Tea hands Update a copy, but a slice
+// field in that copy shares its backing array.
+func TestFlow_EnvTableOverridesAreIndependentAndPersist(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName), []byte("SETTING=plain\n"), 0o600))
+
+	atTable := press(t, pastName(t, newFlow(Detect(dir), nil, Answers{})), "enter", "enter", "enter")
+	require.Equal(t, screenEnv, atTable.at)
+	require.Equal(t, EnvConfig, atTable.envTable.rows[0].Kind)
+
+	overridden := press(t, atTable, " ")
+	assert.Equal(t, EnvSecret, overridden.envTable.rows[0].Kind)
+	assert.Equal(t, EnvConfig, atTable.envTable.rows[0].Kind,
+		"the model it came from must be untouched")
+
+	// Going back and returning shows the answer given here, not the
+	// classifier's opening proposal again.
+	returned := press(t, overridden, "esc", "enter")
+	require.Equal(t, screenEnv, returned.at)
+	assert.Equal(t, EnvSecret, returned.envTable.rows[0].Kind)
+}
+
+// Importance is written to every manifest, so it is worth one field rather
+// than a hand edit. The enum is not verified against a running platform, so
+// the prompt checks it while the reader passes anything through.
+func TestFlow_ImportanceIsAskedAndValidated(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+	model = press(t, pastName(t, model), "enter", "enter")
+	require.Equal(t, screenSettings, model.at)
+
+	last := len(settingsLabels) - 1
+	assert.Equal(t, manifest.DefaultImportance, model.inputs[last].Placeholder)
+
+	// The note for the field explains it, once the cursor is on it.
+	onImportance := model
+	onImportance.focus = last
+	assert.Contains(t, onImportance.View(), "low, moderate, high,")
+
+	// A typo is refused here rather than by the API after a round trip.
+	rejected := press(t, withField(model, last, "urgent"), "enter")
+	assert.Equal(t, screenSettings, rejected.at)
+	require.Error(t, rejected.failed)
+	assert.Contains(t, rejected.failed.Error(), "importance must be one of")
+
+	// Case is the user's business, not the file's.
+	accepted := press(t, withField(model, last, "HIGH"), "enter")
+	require.NoError(t, accepted.failed)
+	assert.Equal(t, "high", accepted.draft.Importance)
+	assert.Contains(t, string(accepted.content), "importance: high")
+}
+
+// The confirm screen names the file it is about to write, because --dir means
+// it is not always the one the user is standing in. It is shown the way the
+// user would say it: relative when it is under the working directory,
+// absolute when it is not.
+func TestFlow_ConfirmNamesTheTargetFile(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+	model = press(t, pastName(t, model), "enter", "enter", "enter")
+	require.Equal(t, screenConfirm, model.at)
+
+	assert.Contains(t, model.View(), "Writing to")
+	// The path may wrap on a narrow terminal, so the assertion is on the part
+	// that identifies it rather than on the whole string.
+	assert.Contains(t, model.View(), filepath.Base(model.detected.Dir))
+}
+
+func TestShortPath(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	assert.Equal(t, filepath.Join("sub", manifest.FileName),
+		ShortPath(filepath.Join(cwd, "sub", manifest.FileName)))
+
+	// Somewhere else entirely stays absolute, because a relative path to it
+	// would be a wall of dot-dots.
+	elsewhere := filepath.Join(t.TempDir(), manifest.FileName)
+	assert.Equal(t, elsewhere, ShortPath(elsewhere))
+}
+
+// withField sets one input on the current screen, returning the model so a
+// test reads as one expression.
+func withField(model flow, i int, value string) flow {
+	model.inputs[i].SetValue(value)
+
+	return model
+}
+
+// Each field explains itself when the cursor reaches it, so the screen stays
+// readable on a narrow terminal instead of running a hint off the edge.
+func TestFlow_SettingsNotesFollowTheCursor(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+	model = press(t, pastName(t, model), "enter", "enter")
+	require.Equal(t, screenSettings, model.at)
+
+	// The port note carries its provenance, which no other field has.
+	assert.Contains(t, model.View(), "1024 or above")
+	assert.Contains(t, model.View(), "EXPOSE 3000")
+
+	wanted := []string{"Readiness probe path", "protons", "Fractional values", "Binary units", "Scheduling priority"}
+	for i, want := range wanted {
+		model = press(t, model, "tab")
+		assert.Containsf(t, model.View(), want, "note for %s", settingsLabels[i+1])
+	}
+}
+
+// Walking back to the base-image screen shows the list again. Arrival work
+// runs on the way back as well as the way forward, and what was fetched once
+// is not fetched again.
+func TestFlow_BaseImageListSurvivesBackNavigation(t *testing.T) {
+	var fetches int
+
+	original := listExecEnvsFn
+	listExecEnvsFn = func(int) ([]workload.ExecutionEnvironment, error) {
+		fetches++
+
+		return []workload.ExecutionEnvironment{
+			{ID: "68a1", Name: "[DataRobot] Python 3.12", LatestSuccessfulVersion: &workload.EEVersion{ID: "68a2"}},
+			{ID: "68b1", Name: "[DataRobot] NodeJS 22", LatestSuccessfulVersion: &workload.EEVersion{ID: "68b2"}},
+		}, nil
+	}
+
+	t.Cleanup(func() { listExecEnvsFn = original })
+
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+	model = press(t, pastName(t, model), "enter") // name, kind
+	model = press(t, model, "2", "enter")         // build from a base image
+
+	require.Equal(t, screenExecEnv, model.at)
+	require.NoError(t, model.failed)
+	require.Equal(t, 1, fetches)
+	assert.Contains(t, model.View(), "[DataRobot] Python 3.12")
+
+	// Forward to the entrypoint, then back.
+	model = press(t, model, "enter")
+	require.Equal(t, screenEntrypoint, model.at)
+
+	model = press(t, model, "esc")
+	require.Equal(t, screenExecEnv, model.at)
+
+	assert.Contains(t, model.View(), "[DataRobot] Python 3.12", "the list is still there")
+	assert.NotContains(t, model.View(), "nothing matches")
+	assert.Equal(t, 1, fetches, "what was fetched once is not fetched again")
+
+	// And it is still selectable, so the answer is not lost either.
+	model = press(t, model, "enter")
+	require.NoError(t, model.failed)
+	assert.Equal(t, "68a1", model.draft.Build.ExecutionEnvironmentID)
+}
+
+// An empty table only says "nothing matches" when a filter emptied it.
+func TestRowTable_EmptyWithoutAFilterIsSilent(t *testing.T) {
+	table := newRowTable([]string{"NAME"}, nil, true, 120, 44)
+
+	assert.NotContains(t, table.view(120), "nothing matches")
+}
+
+// The wizard must not open on a complaint about a question it has not asked
+// yet. "No Dockerfile, so the image source cannot be guessed" is a headless
+// error; interactively it is simply what the source screen is for.
+func TestFlow_DoesNotReportWhatItIsAboutToAsk(t *testing.T) {
+	// No Dockerfile and no flags: the headless path refuses this outright.
+	detected := Detect(t.TempDir())
+
+	_, err := Answers{}.draft(detected)
+	require.Error(t, err, "the headless path still refuses it")
+
+	model := newFlow(detected, nil, Answers{})
+	require.NoError(t, model.failed, "but the wizard just asks")
+	assert.NotContains(t, model.View(), "cannot be guessed")
+
+	// A flag no screen can fix is still reported on arrival.
+	rejected := newFlow(detected, nil, Answers{Type: "bogus"})
+	require.Error(t, rejected.failed)
+	assert.Contains(t, rejected.View(), `--type "bogus" is not supported`)
+}
+
+// Binding says what it does: this repo deploys to that workload from now on.
+// "Copies its settings" on its own reads as cloning.
+func TestFlow_BindingNoteSaysItIsNotACopy(t *testing.T) {
+	workloads := []workload.Workload{{ID: "68b0", Name: "triage-agent", UpdatedAt: time.Now()}}
+	model := newFlow(dockerfileProject(t), workloads, Answers{})
+
+	// The pinned row leads, and says nothing is created yet.
+	assert.Contains(t, model.View(), "Creates a new workload for this repository")
+
+	model = press(t, model, "down")
+	view := model.View()
+
+	assert.Contains(t, view, "will deploy to triage-agent")
+	assert.Contains(t, view, "not a copy")
+}
+
+// A bound run says the values in front of the user are the workload's, so a
+// screen full of live numbers is not mistaken for the wizard's own defaults.
+func TestFlow_BoundScreensSayWhereTheDefaultsCameFrom(t *testing.T) {
+	stubLiveDocs(t)
+
+	workloads := []workload.Workload{{ID: "68b0", Name: "live-app", UpdatedAt: time.Now()}}
+	model := press(t, newFlow(dockerfileProject(t), workloads, Answers{}), "down", "enter")
+	require.Equal(t, screenKind, model.at)
+
+	assert.Contains(t, model.View(), "live-app")
+
+	// kind, source, then the image screen the live workload's build mode
+	// leads to, and finally the settings.
+	model = press(t, model, "enter", "enter", "enter")
+	require.Equal(t, screenSettings, model.at)
+	assert.Contains(t, model.View(), "live-app")
+
+	// A fresh run says no such thing, because there is no workload to speak of.
+	fresh := press(t, pastName(t, newFlow(dockerfileProject(t), nil, Answers{})), "enter", "enter")
+	require.Equal(t, screenSettings, fresh.at)
+	assert.NotContains(t, fresh.View(), "current values")
+}
+
+// "/" is muscle memory for starting a filter. Typing already does that, so
+// the key is swallowed rather than searched for -- but only while the filter
+// is empty, since execution environments are named after image URIs and a
+// slash is a legitimate thing to search for.
+func TestRowTable_SlashStartsEmptyRatherThanFiltering(t *testing.T) {
+	rows := []tableRow{
+		{cells: []string{"datarobot/env-python", "a"}},
+		{cells: []string{"plain-name", "b"}},
+	}
+
+	table := newRowTable([]string{"NAME", "DETAIL"}, rows, true, 120, 44)
+
+	require.True(t, table.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")}))
+	assert.Empty(t, table.filter, "the first slash is swallowed")
+	assert.NotContains(t, table.view(120), "nothing matches")
+
+	// Mid-filter it is an ordinary character.
+	table.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("t")})
+	table.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/")})
+	assert.Equal(t, "t/", table.filter)
+	assert.Equal(t, 1, visibleRowCount(table.view(120)), "only the URI-shaped name has a slash")
+}
+
+// The Dockerfile warning belongs to the screen that offers the option, not to
+// every screen a bound run passes through.
+func TestFlow_DockerfileConflictOnlyOnTheSourceScreen(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "builds-a-dockerfile", "artifactId": "68a1"}`),
+		documentFrom(t, `{"name": "a", "spec": {"type": "service", "containerGroups": [{"name": "default",
+			"containers": [{"name": "primary", "primary": true, "port": 8000,
+				"imageBuildConfig": {"dockerfile": {"source": "provided"}}}]}]}}`))
+
+	// A project with no Dockerfile, bound to a workload that builds one.
+	workloads := []workload.Workload{{ID: "68b0", Name: "builds-a-dockerfile", UpdatedAt: time.Now()}}
+	model := press(t, newFlow(Detect(t.TempDir()), workloads, Answers{}), "down", "enter")
+
+	require.Equal(t, screenKind, model.at)
+	assert.NotContains(t, model.View(), "No Dockerfile", "not the kind screen's business")
+
+	model = press(t, model, "enter")
+	require.Equal(t, screenSource, model.at)
+	assert.Contains(t, model.View(), "No Dockerfile in this directory")
+	assert.Contains(t, model.View(), "select another source")
+}
+
+// A missing Dockerfile is a reason the option will not work, so it reads as a
+// warning rather than as a detail alongside the other two sources.
+func TestFlow_MissingDockerfileIsWarned(t *testing.T) {
+	without := press(t, pastName(t, newFlow(Detect(t.TempDir()), nil, Answers{})), "enter")
+	require.Equal(t, screenSource, without.at)
+
+	options := without.choice.options
+	require.NotEmpty(t, options)
+	assert.Equal(t, "no Dockerfile detected", options[0].note)
+	assert.True(t, options[0].warn, "the note is styled as a warning")
+
+	// With one present it is an ordinary detail.
+	with := press(t, pastName(t, newFlow(dockerfileProject(t), nil, Answers{})), "enter")
+	require.Equal(t, screenSource, with.at)
+	assert.Equal(t, "Dockerfile detected", with.choice.options[0].note)
+	assert.False(t, with.choice.options[0].warn)
+}
+
+// Walking back through the generated-build path must return every answer
+// given along it. A picker rebuilt with its cursor at row 0 does not merely
+// look wrong: re-confirming it overwrites the choice with whatever is first.
+func TestFlow_GeneratedBuildAnswersSurviveBackAndForth(t *testing.T) {
+	original := listExecEnvsFn
+	listExecEnvsFn = func(int) ([]workload.ExecutionEnvironment, error) {
+		return []workload.ExecutionEnvironment{
+			{ID: "68a1", Name: "first", LatestSuccessfulVersion: &workload.EEVersion{ID: "v1"}},
+			{ID: "68b1", Name: "second", LatestSuccessfulVersion: &workload.EEVersion{ID: "v2"}},
+			{ID: "68c1", Name: "third", LatestSuccessfulVersion: &workload.EEVersion{ID: "v3"}},
+		}, nil
+	}
+
+	t.Cleanup(func() { listExecEnvsFn = original })
+
+	model := press(t, pastName(t, newFlow(dockerfileProject(t), nil, Answers{})), "enter")
+	model = press(t, model, "2", "enter") // build from an execution environment
+	require.Equal(t, screenExecEnv, model.at)
+
+	// Pick the third, not the first, so a reset to row 0 is visible.
+	model = press(t, model, "down", "down", "enter")
+	require.Equal(t, screenEntrypoint, model.at)
+	require.Equal(t, "68c1", model.draft.Build.ExecutionEnvironmentID)
+
+	model = typeInto(t, model, "python main.py")
+	model = press(t, model, "enter")
+	require.Equal(t, screenSettings, model.at)
+
+	// Back to the entrypoint: the command is there as a value, not a hint.
+	model = press(t, model, "esc")
+	require.Equal(t, screenEntrypoint, model.at)
+	assert.Equal(t, "python main.py", model.inputs[0].Value())
+
+	// Back again to the picker: the cursor is on what was chosen.
+	model = press(t, model, "esc")
+	require.Equal(t, screenExecEnv, model.at)
+	assert.Equal(t, 2, model.picker.cursor())
+
+	selected := model.picker.selected()
+	require.NotNil(t, selected)
+	assert.Equal(t, pickedEnv{id: "68c1", versionID: "v3"}, selected.value)
+
+	// And going forward again keeps both rather than taking row 0.
+	model = press(t, model, "enter")
+	assert.Equal(t, "68c1", model.draft.Build.ExecutionEnvironmentID)
+	assert.Equal(t, "v3", model.draft.Build.ExecutionEnvironmentVersionID)
+	assert.Equal(t, "python main.py", model.inputs[0].Value())
+}
+
+// The same for the binding picker, which is rebuilt on the way back too.
+func TestFlow_BindingSelectionSurvivesBackNavigation(t *testing.T) {
+	stubLiveDocs(t)
+
+	workloads := []workload.Workload{
+		{ID: "68aa", Name: "first", UpdatedAt: time.Now()},
+		{ID: "68b0live", Name: "live-app", UpdatedAt: time.Now()},
+	}
+
+	// Row 2 is live-app; row 0 is the pinned create-new row.
+	model := press(t, newFlow(dockerfileProject(t), workloads, Answers{}), "down", "down", "enter")
+	require.NotNil(t, model.live)
+	require.Equal(t, screenKind, model.at)
+
+	model = press(t, model, "esc")
+	require.Equal(t, screenBinding, model.at)
+	assert.Equal(t, 2, model.picker.cursor(), "the cursor is on the workload that was bound")
+}
+
+// Binding must carry the project's .env like any other run. The bound path
+// renders through Live rather than Draft, and it was ignoring EnvVars
+// entirely while the command still reported them as written.
+func TestRun_BoundWorkloadCarriesEnv(t *testing.T) {
+	stubLiveDocs(t)
+
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("LOG_LEVEL=debug\nAPI_TOKEN=Xk9mPq2vLw8nRt5yBc3z\n"), 0o600))
+
+	result, err := Run(headless(dir, Answers{WorkloadID: "68b0live"}))
+	require.NoError(t, err)
+
+	written := string(result.Content)
+
+	assert.Equal(t, 2, result.EnvKeysListed)
+	assert.Contains(t, written, "LOG_LEVEL")
+	assert.Contains(t, written, "debug")
+	assert.Contains(t, written, "dr-credential:PLACEHOLDER/apiToken")
+	assert.NotContains(t, written, "Xk9mPq2vLw8nRt5yBc3z", "a secret's value stays in .env")
+
+	parsed, err := manifest.Load(result.Path)
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+}
+
+// A variable the workload already declares is left alone: the running value
+// is the one in use, and .env is the developer's copy, which may be stale.
+func TestRun_BoundWorkloadKeepsItsOwnEnv(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "has-env", "artifactId": "68a1"}`),
+		documentFrom(t, `{"name": "a", "spec": {"type": "service", "containerGroups": [{"name": "default",
+			"containers": [{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/a:v1",
+				"environmentVars": [{"name": "LOG_LEVEL", "value": "warn"}]}]}]}}`))
+
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("LOG_LEVEL=debug\nEXTRA=added\n"), 0o600))
+
+	result, err := Run(headless(dir, Answers{WorkloadID: "68b0"}))
+	require.NoError(t, err)
+
+	written := string(result.Content)
+
+	assert.Contains(t, written, "value: warn", "the running value wins")
+	assert.NotContains(t, written, "value: debug", "the local one does not overwrite it")
+	assert.Contains(t, written, "EXTRA", "a variable it does not have is added")
+}
+
+// Sizing answers must reach a workload that has no runtime block at all,
+// rather than being dropped while the confirm screen reports them.
+func TestRun_BoundWorkloadWithoutARuntimeBlock(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "no-runtime", "artifactId": "68a1"}`),
+		documentFrom(t, `{"name": "a", "spec": {"type": "service", "containerGroups": [{"name": "default",
+			"containers": [{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/a:v1"}]}]}}`))
+
+	result, err := Run(headless(t.TempDir(), Answers{
+		WorkloadID: "68b0", Replicas: 4, CPU: 2, Memory: "4 gb",
+	}))
+	require.NoError(t, err)
+
+	written := string(result.Content)
+
+	assert.Contains(t, written, "replicaCount: 4")
+	assert.Contains(t, written, "cpu: 2")
+	assert.Contains(t, written, "memory: 4GB", "normalized on the bound path too")
+	// The invented runtime block has to match the artifact by name, which is
+	// what the validator checks.
+	assert.Contains(t, written, "name: default")
+	assert.Contains(t, written, "name: primary")
+
+	parsed, err := manifest.Load(result.Path)
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+}
+
+// A dry run must not report a file that does not exist.
+func TestRun_DryRunIsNotReportedAsCreated(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+
+	opts := headless(dir, Answers{Name: "my-app"})
+	opts.DryRun = true
+
+	result, err := Run(opts)
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionPlanned, result.Action)
+	assert.NotEqual(t, ActionCreated, result.Action)
+	assert.NoFileExists(t, result.Path)
+}
+
+// Cycling a row back to a literal must not write an empty one: the value is
+// kept through the cycle rather than dropped when a row is called a secret.
+func TestFlow_EnvRowCycledBackKeepsItsValue(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName), []byte("SETTING=plain\n"), 0o600))
+
+	model := press(t, pastName(t, newFlow(Detect(dir), nil, Answers{})), "enter", "enter", "enter")
+	require.Equal(t, screenEnv, model.at)
+
+	// config -> secret -> local -> config.
+	model = press(t, model, " ", " ", " ")
+	require.Equal(t, EnvConfig, model.envTable.rows[0].Kind)
+
+	model = press(t, model, "enter")
+	assert.Contains(t, string(model.content), "value: plain")
+	assert.NotContains(t, string(model.content), `value: ""`)
+}
+
+// The marker follows a cursor restored by setRows, or it points at a row the
+// user is not on and the one they change is not the one highlighted.
+func TestRowTable_MarkerFollowsARestoredCursor(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("FIRST=1\nSECOND=2\nTHIRD=3\n"), 0o600))
+
+	model := press(t, pastName(t, newFlow(Detect(dir), nil, Answers{})), "enter", "enter", "enter")
+	require.Equal(t, screenEnv, model.at)
+
+	model = press(t, model, "down", "down", " ")
+	require.Equal(t, 2, model.envTable.grid.cursor())
+
+	// The marked row is the one that changed.
+	lines := strings.Split(stripANSI(model.envTable.view(100)), "\n")
+
+	var marked string
+
+	for _, line := range lines {
+		if strings.Contains(line, "❯") {
+			marked = line
+		}
+	}
+
+	assert.Contains(t, marked, "THIRD", "the marker is on the row the cursor is on")
+}

--- a/internal/workload/wizard/regression_test.go
+++ b/internal/workload/wizard/regression_test.go
@@ -341,7 +341,9 @@ func TestAnswers_A2AFlagSemantics(t *testing.T) {
 	_, err = Run(headless(dir, Answers{Name: "my-app", A2AEnabled: true, Type: manifest.TypeAgent}))
 	require.NoError(t, err)
 
-	err = Answers{A2AEnabled: true}.check()
+	// The rule is judged against the kind that will be written, so it runs
+	// once the draft has one. With nothing bound, that is the default.
+	_, err = Answers{A2AEnabled: true}.draft(Detect(dir))
 	require.Error(t, err, "with the default kind being service, the pair is still a contradiction")
 	assert.Contains(t, err.Error(), "--a2a-enabled applies to --type agent")
 }
@@ -1282,4 +1284,47 @@ func TestFlow_SettingsRejectsNonFiniteCPU(t *testing.T) {
 			assert.Equal(t, screenSettings, model.at)
 		})
 	}
+}
+
+// The summary the command prints counts what reached the file. A bound
+// workload keeps the values it already declares, so a variable it has is not
+// one this run added.
+func TestFlow_BoundEnvCountsOnlyWhatWasAdded(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "triage-agent", "importance": "low", "artifactId": "68a1",
+			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
+				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
+		documentFrom(t, `{"name": "triage-agent-artifact", "spec": {"type": "service",
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 9001, "imageUri": "registry/triage:v3",
+				 "environmentVars": [{"name": "LOG_LEVEL", "value": "info"}]}]}]}}`))
+
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\nEXPOSE 3000\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("LOG_LEVEL=debug\nFEATURE_X=on\n"), 0o600))
+
+	model := newFlow(Detect(dir), nil, Answers{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"})
+
+	updated, _ := model.Update(liveLoadedMsg{live: mustFetchLive(t, "68b0c1d2e3f4a5b6c7d8e9f0")})
+	model, ok := updated.(flow)
+	require.True(t, ok)
+
+	model = press(t, model, "enter", "enter", "enter") // kind, source, keep the live image
+	require.Equal(t, screenSettings, model.at)
+
+	model = press(t, model, "enter")
+	require.Equal(t, screenEnv, model.at)
+
+	model = press(t, model, "enter")
+	require.Equal(t, screenConfirm, model.at)
+	require.NoError(t, model.failed)
+
+	_, draft, err := press(t, model, "enter").result()
+	require.NoError(t, err)
+
+	assert.Len(t, draft.EnvVars, 1, "LOG_LEVEL was already there, so only FEATURE_X was added")
+	assert.Equal(t, "FEATURE_X", draft.EnvVars[0].Name)
+	// The running value stands: .env is the developer's copy and may be stale.
+	assert.Contains(t, string(model.content), "value: info")
+	assert.NotContains(t, string(model.content), "value: debug")
 }

--- a/internal/workload/wizard/regression_test.go
+++ b/internal/workload/wizard/regression_test.go
@@ -17,12 +17,14 @@ package wizard
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/datarobot/cli/internal/workload"
@@ -1027,4 +1029,257 @@ func TestRowTable_MarkerFollowsARestoredCursor(t *testing.T) {
 	}
 
 	assert.Contains(t, marked, "THIRD", "the marker is on the row the cursor is on")
+}
+
+// A filter is a string of characters, not of bytes. One backspace has to undo
+// one keystroke whatever the workload was named.
+func TestRowTable_BackspaceRemovesOneRune(t *testing.T) {
+	table := newRowTable([]string{"NAME"}, []tableRow{{cells: []string{"zażółć"}}}, true, 80, 20)
+
+	for _, r := range "żó" {
+		table.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	require.Equal(t, "żó", table.filter)
+
+	table.update(tea.KeyMsg{Type: tea.KeyBackspace})
+	assert.Equal(t, "ż", table.filter, "one keystroke, one character")
+	assert.True(t, utf8.ValidString(table.filter))
+
+	table.update(tea.KeyMsg{Type: tea.KeyBackspace})
+	assert.Empty(t, table.filter)
+}
+
+// A table squeezed to fit a narrow terminal has to get its width back when
+// the terminal turns out to be wider, which means recomputing the columns
+// rather than only remembering the number.
+func TestRowTable_ResizeRecoversSqueezedColumns(t *testing.T) {
+	rows := []tableRow{
+		{cells: []string{"a-workload-with-a-name-long-enough-to-be-squeezed", "running"}},
+		{cells: []string{"another-workload-with-a-similarly-long-name", "stopped"}},
+	}
+
+	table := newRowTable([]string{"NAME", "STATUS"}, rows, true, 50, 10)
+	squeezed := columnsWidth(table)
+
+	table.resize(200, 40)
+
+	assert.Greater(t, columnsWidth(table), squeezed, "the columns have to take the width they were given")
+	assert.Equal(t, tableHeight(40), table.maxHeight)
+}
+
+// The first size message arrives after the opening screen is already built,
+// so recording the numbers is not enough: the flow has to refit what is on
+// screen, and doing so must not lose the answer in progress.
+func TestFlow_ResizeRefitsTheActivePicker(t *testing.T) {
+	workloads := []workload.Workload{
+		{ID: "68b0", Name: "triage-agent", Status: "running", UpdatedAt: time.Now()},
+		{ID: "68b1", Name: "billing-service", Status: "stopped", UpdatedAt: time.Now()},
+	}
+
+	model := newFlow(dockerfileProject(t), workloads, Answers{})
+	require.Equal(t, screenBinding, model.at)
+
+	model.picker.moveCursor(tea.KeyMsg{Type: tea.KeyDown})
+	before := model.picker.selected()
+
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 160, Height: 50})
+	model, ok := updated.(flow)
+	require.True(t, ok)
+
+	assert.Equal(t, tableHeight(50), model.picker.maxHeight, "the new height has to reach the table")
+	assert.Equal(t, before, model.picker.selected(), "the row under the cursor is an answer in progress")
+}
+
+func columnsWidth(t rowTable) int {
+	total := 0
+	for _, column := range t.model.Columns() {
+		total += column.Width
+	}
+
+	return total
+}
+
+// Confirming is consenting, and consent to a file you cannot read to the end
+// is not consent. The preview is bounded and scrolls.
+func TestFlow_ConfirmPreviewScrollsALongManifest(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\nEXPOSE 3000\n")
+
+	var env strings.Builder
+	for i := range 60 {
+		fmt.Fprintf(&env, "SETTING_%02d=value-%02d\n", i, i)
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName), []byte(env.String()), 0o600))
+
+	model := newFlow(Detect(dir), nil, Answers{})
+	model.width, model.height = 100, 30
+
+	model = press(t, pastName(t, model), "enter", "enter", "enter", "enter")
+	require.Equal(t, screenConfirm, model.at)
+	require.NoError(t, model.failed)
+
+	require.Greater(t, model.preview.TotalLineCount(), model.preview.Height,
+		"the fixture has to be taller than the window for this to test anything")
+
+	assert.True(t, model.scrollablePreview())
+	assert.Contains(t, model.keys(), "scroll", "a key that exists is a key the legend names")
+
+	first := model.preview.View()
+	assert.Contains(t, first, "name: test-app", "the window opens at the top")
+	assert.NotContains(t, first, "SETTING_59")
+
+	// Paging reaches the end, which is the whole point: the last thing in the
+	// file is as much a part of what is being agreed to as the first.
+	var ok bool
+
+	for range 20 {
+		updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+
+		model, ok = updated.(flow)
+		require.True(t, ok)
+	}
+
+	assert.NotEqual(t, first, model.preview.View(), "the preview has to move")
+	assert.Contains(t, model.View(), "SETTING_59", "the tail is reachable")
+}
+
+// A short manifest needs no scrolling, and the legend must not offer a key
+// that does nothing.
+func TestFlow_ConfirmPreviewDoesNotOfferScrollingItDoesNotNeed(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{})
+	model.width, model.height = 100, 60
+
+	model = press(t, pastName(t, model), "enter", "enter", "enter")
+	require.Equal(t, screenConfirm, model.at)
+
+	assert.False(t, model.scrollablePreview())
+	assert.NotContains(t, model.keys(), "scroll")
+	assert.Contains(t, model.View(), "name: test-app")
+}
+
+// No screen can settle --workload-id against --name, so the wizard must not
+// open on it: the error would sit behind the loading view, the fetch would
+// run anyway, and arriving at the first screen would clear it.
+func TestRunInteractiveFlow_RejectsWorkloadIDWithName(t *testing.T) {
+	_, _, err := runInteractiveFlow(
+		Options{Dir: t.TempDir(), Answers: Answers{WorkloadID: "68b0", Name: "my-app"}},
+		dockerfileProject(t))
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "exclusive")
+}
+
+// Binding downloads a new set of defaults, not a new set of answers. Flags
+// given before the fetch still stand, exactly as they do headlessly.
+func TestFlow_BindKeepsTheFlagsGivenBeforeTheFetch(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "triage-agent", "importance": "low", "artifactId": "68a1",
+			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 2,
+				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
+		documentFrom(t, `{"name": "triage-agent-artifact", "spec": {"type": "service",
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 9001, "imageUri": "registry/triage:v3"}]}]}}`))
+
+	model := newFlow(dockerfileProject(t), nil, Answers{
+		WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0",
+		Replicas:   9,
+		Memory:     "32GB",
+	})
+
+	updated, _ := model.Update(liveLoadedMsg{live: mustFetchLive(t, "68b0c1d2e3f4a5b6c7d8e9f0")})
+	model, ok := updated.(flow)
+	require.True(t, ok)
+
+	assert.Equal(t, 9, model.draft.Runtime.Replicas, "--replicas was given and nothing has asked again")
+	assert.Equal(t, "32GB", model.draft.Runtime.Memory)
+	// What the flags did not mention still comes from the workload.
+	assert.Equal(t, 9001, model.draft.Port)
+	assert.Equal(t, "registry/triage:v3", model.draft.Build.ImageURI)
+}
+
+func mustFetchLive(t *testing.T, id string) manifest.Live {
+	t.Helper()
+
+	live, err := fetchLive(id)
+	require.NoError(t, err)
+
+	return live
+}
+
+// --skip-env is an answer. Interactively it has to skip the screen, not show
+// it and then let accepting it refill what the flag emptied.
+func TestFlow_SkipEnvSkipsTheEnvScreen(t *testing.T) {
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\nEXPOSE 3000\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("LOG_LEVEL=debug\nAPI_KEY=sk-abcdefghijklmnopqrstuvwxyz01\n"), 0o600))
+
+	detected := Detect(dir)
+	require.True(t, detected.HasEnvFile())
+
+	model := press(t, pastName(t, newFlow(detected, nil, Answers{SkipEnv: true})), "enter", "enter", "enter")
+
+	assert.Equal(t, screenConfirm, model.at, "the env screen is not a question the user left open")
+	assert.Empty(t, model.draft.EnvVars)
+	assert.NotContains(t, string(model.content), "environmentVars")
+
+	// Without the flag the same project stops at the env screen.
+	withEnv := press(t, pastName(t, newFlow(detected, nil, Answers{})), "enter", "enter", "enter")
+	assert.Equal(t, screenEnv, withEnv.at)
+}
+
+// A workload that scales itself has no replica count to give, and the screen
+// must not demand one: applyRuntime would drop the answer anyway.
+func TestFlow_AutoscaledBoundWorkloadPassesTheSettingsScreen(t *testing.T) {
+	stubLive(t,
+		documentFrom(t, `{"name": "triage-agent", "importance": "low", "artifactId": "68a1",
+			"runtime": {"containerGroups": [{"name": "default",
+				"autoscaling": {"enabled": true, "minReplicaCount": 2, "maxReplicaCount": 9},
+				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
+		documentFrom(t, `{"name": "triage-agent-artifact", "spec": {"type": "service",
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 9001, "imageUri": "registry/triage:v3"}]}]}}`))
+
+	model := newFlow(dockerfileProject(t), nil, Answers{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"})
+
+	updated, _ := model.Update(liveLoadedMsg{live: mustFetchLive(t, "68b0c1d2e3f4a5b6c7d8e9f0")})
+	model, ok := updated.(flow)
+	require.True(t, ok)
+
+	require.True(t, model.autoscaled())
+
+	model = press(t, model, "enter") // kind
+	model = press(t, model, "enter") // image source
+	model = press(t, model, "enter") // keep the live image
+	require.Equal(t, screenSettings, model.at)
+
+	// The field says why it is empty rather than showing a zero nobody typed.
+	assert.Empty(t, model.inputs[2].Value())
+	assert.Contains(t, model.inputs[2].Placeholder, "autoscaling")
+
+	model = press(t, model, "enter")
+	require.NoError(t, model.failed, "the screen must not block on a count the file cannot carry")
+	assert.Equal(t, screenConfirm, model.at)
+
+	// The policy survives untouched.
+	assert.Contains(t, string(model.content), "maxReplicaCount: 9")
+	assert.NotContains(t, string(model.content), "replicaCount: 1")
+}
+
+// ParseFloat takes NaN and Inf, and neither is <= 0, so a plain positivity
+// check lets both through to a file nothing can schedule.
+func TestFlow_SettingsRejectsNonFiniteCPU(t *testing.T) {
+	for _, text := range []string{"NaN", "+Inf", "-Inf", "inf"} {
+		t.Run(text, func(t *testing.T) {
+			model := press(t, pastName(t, newFlow(dockerfileProject(t), nil, Answers{})), "enter", "enter")
+			require.Equal(t, screenSettings, model.at)
+
+			model.inputs[3].SetValue(text)
+			model = press(t, model, "enter")
+
+			require.Error(t, model.failed)
+			assert.Contains(t, model.failed.Error(), "cpu must be a positive number")
+			assert.Equal(t, screenSettings, model.at)
+		})
+	}
 }

--- a/internal/workload/wizard/run.go
+++ b/internal/workload/wizard/run.go
@@ -269,6 +269,11 @@ func (o Options) resolveHeadlessBound(detected Detected) ([]byte, manifest.Draft
 		return nil, manifest.Draft{}, err
 	}
 
+	// Read off the workload as it arrived, not off applied: the point is what
+	// the platform was already serving in the clear, and a run that failed
+	// above has no file to warn about.
+	warnLiveSecretLiterals(o.Stderr, live)
+
 	return content, draft, nil
 }
 
@@ -535,6 +540,49 @@ func warnUnreadEnvFile(stderr io.Writer, detected Detected) {
 	fmt.Fprintf(stderr,
 		"Warning: %v. Nothing from it was imported; add the variables to %s by hand.\n",
 		detected.EnvErr, manifest.FileName)
+}
+
+// warnLiveSecretLiterals names the variables a bound workload already declares
+// in the clear whose values say what they are.
+//
+// The .env import classifies what it carries and writes a secret as a
+// reference. The live spec gets no such treatment, by design: binding
+// preserves what the workload is running, and rewriting a value the platform
+// serves would change the running configuration on the next deploy. So a token
+// someone pasted into the UI arrives verbatim in a file headed for git.
+//
+// Interactively the confirm screen is the answer, since the whole file is on
+// screen before Enter writes it. Headlessly there is no screen, which is why
+// this exists and why it is called from that path only. Names and the reason,
+// never the value: this is printed to warn about disclosure and would
+// otherwise be the disclosure.
+//
+// Uncapped, unlike the literal listing the command prints for a fresh
+// manifest. That one lists everything ordinary and is bounded to stay
+// readable; this lists only values carrying an issuer's own signature, of
+// which any number is worth reading to the end.
+func warnLiveSecretLiterals(stderr io.Writer, live manifest.Live) {
+	if stderr == nil {
+		return
+	}
+
+	named := make([]string, 0)
+
+	for _, v := range live.LiteralEnvVars() {
+		if reason, ok := evidentSecret(v.Value); ok {
+			named = append(named, fmt.Sprintf("%s (%s)", v.Name, reason))
+		}
+	}
+
+	if len(named) == 0 {
+		return
+	}
+
+	fmt.Fprintf(stderr,
+		"Warning: %s declares %d %s whose value looks like a secret, and binding copies it as it stands: %s.\n"+
+			"  Replace the value in %s with a %s<credential-id>/<key> reference before committing the file.\n",
+		live.Name, len(named), Plural(len(named), "variable", "variables"), strings.Join(named, ", "),
+		manifest.FileName, manifest.CredentialShorthandPrefix)
 }
 
 // ShortPath names a path relative to the working directory when it is under

--- a/internal/workload/wizard/run.go
+++ b/internal/workload/wizard/run.go
@@ -55,7 +55,7 @@ var (
 	getArtifactFn        = workload.GetArtifactDocument
 	resolveExecEnvFn     = workload.ResolveExecutionEnvironment
 	isStdinTerminalFn    = reader.IsStdinTerminal
-	runInteractiveFlowFn = interactiveFlowUnavailable
+	runInteractiveFlowFn = runInteractiveFlow
 )
 
 // Actions a run can report, mirroring what the JSON envelope carries.
@@ -552,14 +552,4 @@ func ShortPath(path string) string {
 	}
 
 	return relative
-}
-
-// interactiveFlowUnavailable stands in until the wizard screens land. The
-// command is behind a feature gate, so the only way to reach this is to run
-// the gated command on a terminal without flags.
-func interactiveFlowUnavailable(_ Options, _ Detected) ([]byte, manifest.Draft, error) {
-	const msg = "interactive setup is not available yet; " +
-		"pass --yes with the flags that answer each question"
-
-	return nil, manifest.Draft{}, errors.New(msg)
 }

--- a/internal/workload/wizard/run_test.go
+++ b/internal/workload/wizard/run_test.go
@@ -268,6 +268,82 @@ func TestRun_UnknownWorkloadID(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot bind to workload nope")
 }
 
+// boundWithLiveEnv stubs a workload whose artifact declares the given
+// environmentVars JSON, which is the block binding copies verbatim.
+func boundWithLiveEnv(t *testing.T, envVars string) {
+	t.Helper()
+
+	stubLive(t,
+		documentFrom(t, `{"name": "live-app", "importance": "high", "artifactId": "68a1",
+			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
+				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}]}]}}`),
+		documentFrom(t, `{"name": "live-app-artifact", "spec": {"type": "service",
+			"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/live:v9",
+				 "environmentVars": `+envVars+`}]}]}}`))
+}
+
+// boundRun binds headlessly and returns what reached stderr.
+func boundRun(t *testing.T) string {
+	t.Helper()
+
+	stderr := &bytes.Buffer{}
+	opts := headless(t.TempDir(), Answers{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"})
+	opts.Stderr = stderr
+
+	_, err := Run(opts)
+	require.NoError(t, err)
+
+	return stderr.String()
+}
+
+// Binding preserves the live spec, so a secret the platform holds in the clear
+// is copied into a file meant to be committed. Nothing can fix that
+// automatically, and headlessly no screen shows the file before it is written,
+// so the warning is the only thing standing between the two.
+func TestRun_BoundWorkloadWarnsAboutLiveSecretLiterals(t *testing.T) {
+	boundWithLiveEnv(t, `[{"name": "LOG_LEVEL", "value": "debug"},
+		{"name": "OPENAI_API_KEY", "value": "sk-live-51H8xQvZmNpKdRt7YwLbG3JfA9"},
+		{"name": "DATABASE_URL", "value": "postgres://carol:hunter2@db.example.com:5432/app"}]`)
+
+	stderr := boundRun(t)
+
+	assert.Contains(t, stderr, "Warning: live-app declares 2 variables whose value looks like a secret")
+	assert.Contains(t, stderr, "OPENAI_API_KEY (looks like an OpenAI-style API key)")
+	assert.Contains(t, stderr, "DATABASE_URL (a URL with carol's password in it)")
+	assert.Contains(t, stderr, manifest.CredentialShorthandPrefix)
+
+	// The warning exists because these values must not spread, so it cannot be
+	// the thing that spreads them.
+	assert.NotContains(t, stderr, "sk-live-51H8xQvZmNpKdRt7YwLbG3JfA9")
+	assert.NotContains(t, stderr, "hunter2")
+
+	// An ordinary setting is not a finding: a warning that fires on LOG_LEVEL
+	// is one the reader learns to skip.
+	assert.NotContains(t, stderr, "LOG_LEVEL")
+}
+
+// The name test and the entropy test are deliberately not used here. Both are
+// calibrated for a screen that can be corrected in one keystroke, and this
+// warning has no such screen behind it.
+func TestRun_BoundWorkloadDoesNotGuessAtLiveValues(t *testing.T) {
+	boundWithLiveEnv(t, `[{"name": "API_URL", "value": "https://api.example.com/v2"},
+		{"name": "BUILD_ID", "value": "a7f3c9d1e5b2f8a4c6d0"},
+		{"name": "SESSION_TOKEN", "value": "short"}]`)
+
+	assert.NotContains(t, boundRun(t), "looks like a secret")
+}
+
+// A value the platform already keeps in the credential store is not in the
+// clear, in either spelling, so neither is a finding.
+func TestRun_BoundWorkloadIgnoresCredentialReferences(t *testing.T) {
+	boundWithLiveEnv(t, `[{"name": "SHORTHAND_KEY", "value": "dr-credential:68f0cccc0000000000000003/apiToken"},
+		{"name": "OBJECT_KEY", "source": "credential",
+		 "drCredentialId": "68f0cccc0000000000000003", "key": "apiToken"}]`)
+
+	assert.NotContains(t, boundRun(t), "looks like a secret")
+}
+
 func TestRun_BoundWorkloadWithoutAnArtifact(t *testing.T) {
 	stubLive(t, documentFrom(t, `{"name": "live-app"}`), nil)
 

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -1,0 +1,838 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/aymanbagabas/go-udiff"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/datarobot/cli/tui"
+)
+
+// createNewID is the sentinel the "create a new workload" row carries, so the
+// picker can return it through the same channel as a real workload.
+const createNewID = "\x00create-new"
+
+// defaultEditor is what [e] opens when the environment names none.
+const defaultEditor = "vi"
+
+// namePlaceholder shows the shape of a workload name without proposing one.
+// The directory is a poor suggestion often enough (src, app, cli, tmp) that
+// offering it invites a name nobody chose, and this name ends up on a
+// deployed workload.
+const namePlaceholder = "my-app-name"
+
+// runInteractiveFlow asks the questions and returns the manifest the user
+// agreed to. The workload list is fetched up front because the first screen
+// depends on it: with nothing to bind to, there is no binding question.
+func runInteractiveFlow(opts Options, detected Detected) ([]byte, manifest.Draft, error) {
+	var workloads []workload.Workload
+
+	if opts.Answers.WorkloadID == "" && opts.Answers.Name == "" {
+		fetched, err := listWorkloadsFn(workloadPickLimit, nil)
+		if err != nil {
+			return nil, manifest.Draft{}, err
+		}
+
+		workloads = fetched
+	}
+
+	// The wizard draws on stderr, not stdout. stdout is this command's
+	// machine-readable channel, and bubbletea would otherwise send the alt
+	// screen and every redraw there, so `dr workload config` inside a command
+	// substitution would capture escape sequences ahead of the path.
+	//
+	// tui.Run already wraps the model for Ctrl-C, so it is not wrapped here.
+	final, err := tui.Run(newFlow(detected, workloads, opts.Answers),
+		tea.WithAltScreen(), tea.WithOutput(interactiveOutput(opts.Stderr)))
+	if err != nil {
+		return nil, manifest.Draft{}, err
+	}
+
+	finished, ok := tui.Unwrap(final).(flow)
+	if !ok {
+		return nil, manifest.Draft{}, ErrCancelled
+	}
+
+	return finished.result()
+}
+
+// interactiveOutput is where the wizard draws. bubbletea needs the real
+// *os.File to size the terminal and restore raw mode, so a plain io.Writer
+// (a test buffer) falls back to os.Stderr rather than being drawn into.
+func interactiveOutput(stderr io.Writer) io.Writer {
+	if file, ok := stderr.(*os.File); ok {
+		return file
+	}
+
+	return os.Stderr
+}
+
+// enter prepares the components a screen needs. It runs on the way forward
+// and on the way back, so returning to a screen shows the answer that was
+// given there rather than a blank field.
+func (f *flow) enter(at screen) {
+	f.failed = nil
+	f.focus = 0
+
+	switch at {
+	case screenBinding, screenExecEnv:
+		f.enterPicker(at)
+
+	case screenKind, screenA2A, screenSource:
+		f.enterChoice(at)
+		f.choice.liveValue = f.liveChoice(at)
+
+	case screenName, screenEntrypoint, screenImage, screenSettings:
+		f.enterInputs(at)
+
+	case screenEnv:
+		// Built once. Coming back to the screen has to show the answers given
+		// there, not the classifier's opening proposal all over again.
+		if len(f.envTable.rows) == 0 {
+			f.envTable = newEnvTable(f.detected.EnvVars, f.width, f.height)
+		}
+
+	case screenConfirm:
+		// Rendered from the answers already given.
+	}
+}
+
+// enterPicker rebuilds a list screen and puts the cursor back on the answer
+// given there, so re-confirming does not silently take whatever is first.
+func (f *flow) enterPicker(at screen) {
+	switch at {
+	case screenBinding:
+		f.picker = newWorkloadPicker(f.workloads, f.width, f.height)
+
+		if id := f.draft.WorkloadID; id != "" {
+			f.picker.selectValue(func(v any) bool {
+				picked, ok := v.(pickedWorkload)
+
+				return ok && picked.id == id
+			})
+		}
+
+	case screenExecEnv:
+		// Rebuilt from what was already fetched, so walking back here shows
+		// the list again. On a first visit there is nothing yet, and emptying
+		// the shared table means a failed load cannot leave the previous
+		// screen's workload rows on display under a base-image heading.
+		f.picker = newExecEnvPicker(f.execEnvs, f.width, f.height)
+
+		if id := f.draft.Build.ExecutionEnvironmentID; id != "" {
+			f.picker.selectValue(func(v any) bool {
+				picked, ok := v.(pickedEnv)
+
+				return ok && picked.id == id
+			})
+		}
+
+	case screenName, screenKind, screenA2A, screenSource, screenEntrypoint,
+		screenImage, screenSettings, screenEnv, screenConfirm:
+		// Not lists.
+	}
+}
+
+// enterChoice prepares the menu screens.
+func (f *flow) enterChoice(at screen) {
+	switch at {
+	case screenKind:
+		f.choice = newChoice([]option{
+			{value: manifest.TypeService, label: "Service", note: "standard HTTP workload"},
+			{value: manifest.TypeAgent, label: "Agent", note: "HTTP workload with agent capabilities"},
+		}, f.draft.Type, "Keep this workload's kind")
+
+	case screenA2A:
+		f.choice = newChoice([]option{
+			{value: "no", label: "No", note: "reachable only at its own endpoint"},
+			{value: "yes", label: "Yes", note: "discoverable tenant-wide"},
+		}, yesNo(f.draft.A2AEnabled), "")
+
+	case screenSource:
+		f.choice = newChoice(f.sourceOptions(), f.draft.Build.Mode, "Keep how it is built today")
+
+	case screenBinding, screenExecEnv, screenEnv, screenName, screenEntrypoint, screenImage, screenSettings, screenConfirm:
+		// Not menus.
+	}
+}
+
+// enterInputs prepares the text-entry screens.
+func (f *flow) enterInputs(at screen) {
+	switch at {
+	case screenName:
+		// The suggested name is a placeholder rather than a value, so
+		// accepting it is one Enter and replacing it does not start with
+		// clearing a field. A name the user actually gave is a value, and
+		// comes back as one.
+		if f.nameGiven {
+			f.inputs = []textinput.Model{newInput(f.draft.Name, namePlaceholder)}
+		} else {
+			f.inputs = []textinput.Model{newInput("", namePlaceholder)}
+		}
+
+	case screenEntrypoint:
+		f.inputs = []textinput.Model{newInput(strings.Join(f.draft.Build.Entrypoint, " "), "python main.py")}
+
+	case screenImage:
+		f.inputs = []textinput.Model{newInput(f.draft.Build.ImageURI, "registry.example.com/team/app:v1")}
+
+	case screenSettings:
+		f.inputs = []textinput.Model{
+			newInput(strconv.Itoa(f.draft.Port), "8080"),
+			newInput(f.draft.HealthPath, manifest.DefaultHealthPath),
+			newInput(strconv.Itoa(f.draft.Runtime.Replicas), "1"),
+			newInput(formatCPU(f.draft.Runtime.CPU), "0.5"),
+			newInput(f.draft.Runtime.Memory, manifest.DefaultMemory),
+			newInput(f.draft.Importance, manifest.DefaultImportance),
+		}
+
+		for i := range f.inputs[1:] {
+			f.inputs[i+1].Blur()
+		}
+
+	case screenBinding, screenExecEnv, screenKind, screenA2A, screenSource, screenEnv, screenConfirm:
+		// No text entry.
+	}
+}
+
+// sourceOptions annotates the image sources with what the project shows, so
+// the recommended answer is the one the evidence points at rather than the
+// one we happen to prefer.
+func (f flow) sourceOptions() []option {
+	// The absent case is a warning, not a detail: choosing it fails, and the
+	// screen refuses it rather than letting the build discover it later.
+	dockerfileNote, missing := DockerfileName+" detected", false
+	if !f.detected.HasDockerfile {
+		dockerfileNote, missing = "no "+DockerfileName+" detected", true
+	}
+
+	return []option{
+		{
+			value: manifest.BuildModeDockerfile,
+			label: "Build this repository's " + DockerfileName,
+			note:  dockerfileNote,
+			warn:  missing,
+		},
+		{value: manifest.BuildModeGenerated, label: "Build from a managed execution environment"},
+		{value: manifest.BuildModeImage, label: "Use an already published image"},
+	}
+}
+
+// View renders the current screen: a question, the answer being given, and
+// the keys that move.
+// View lays every screen out the same way: the question, what is being
+// answered, the note explaining it, anything that went wrong, and the keys.
+// Each block is separated by a blank line, because a wizard where the
+// explanation touches the table reads as one wall of text.
+func (f flow) View() string {
+	if f.loading != "" {
+		return "\n" + questionStyle.Render(f.loading) + "\n"
+	}
+
+	// Two kinds of prose, and they belong in different places. The intro
+	// explains the question, so it is read before the answer. The note is
+	// about the answer being given right now -- the row under the cursor,
+	// what the bound workload already uses -- so it belongs after it.
+	blocks := []string{
+		questionStyle.Render(f.question()),
+		f.note(f.screenIntro()),
+		strings.TrimRight(f.body(), "\n"),
+		f.note(f.screenNote()),
+	}
+
+	if f.failed != nil {
+		blocks = append(blocks,
+			tui.ErrorStyle.MarginLeft(2).Width(contentWidth(f.width)).Render(f.failed.Error()))
+	}
+
+	blocks = append(blocks, f.keys())
+
+	present := make([]string, 0, len(blocks))
+
+	for _, block := range blocks {
+		if strings.TrimSpace(block) != "" {
+			present = append(present, block)
+		}
+	}
+
+	return "\n" + strings.Join(present, "\n\n") + "\n"
+}
+
+// liveChoice is the option the bound workload already uses on this screen,
+// "" on a fresh setup or a screen with no live counterpart.
+func (f flow) liveChoice(at screen) string {
+	if f.live == nil {
+		return ""
+	}
+
+	live := f.live.Defaults()
+
+	switch at {
+	case screenKind:
+		return live.Type
+	case screenA2A:
+		return yesNo(live.A2AEnabled)
+	case screenSource:
+		return live.Build.Mode
+	case screenBinding, screenName, screenExecEnv, screenEntrypoint,
+		screenImage, screenSettings, screenEnv, screenConfirm:
+		return ""
+	}
+
+	return ""
+}
+
+// liveDefaultsNote ties the "in use now" tag to what it means, so a bound run
+// is not mistaken for a fresh one and the preselected row is not mistaken for
+// the wizard's own guess.
+func (f flow) liveDefaultsNote() string {
+	if f.live == nil {
+		return ""
+	}
+
+	return liveStyle.Render("· in use") + " marks " + f.live.Name +
+		"'s current configuration. Changing it changes the workload."
+}
+
+// liveValuesNote is the same idea for the screens made of fields rather than
+// options, where there is no row to tag.
+func (f flow) liveValuesNote() string {
+	if f.live == nil {
+		return ""
+	}
+
+	return "These are " + liveStyle.Render(f.live.Name) +
+		"'s current values. Changing one changes the workload."
+}
+
+// sourceConflictNote warns when the workload builds a Dockerfile that this
+// checkout does not have. Preselecting that option would otherwise look like
+// a working default right up until the screen refuses to accept it.
+func (f flow) sourceConflictNote() string {
+	if f.live == nil || f.detected.HasDockerfile {
+		return ""
+	}
+
+	if f.live.Defaults().Build.Mode != manifest.BuildModeDockerfile {
+		return ""
+	}
+
+	return tui.ErrorStyle.Render("No "+DockerfileName+" in this directory,") +
+		" so this repository cannot build the way " + f.live.Name + " currently does. Add one, or select another source."
+}
+
+// screenIntro explains the question itself: the same words every time the
+// screen is shown, read before anything is answered.
+func (f flow) screenIntro() string {
+	switch f.at {
+	case screenName:
+		return "Identifies the workload in the platform and in `dr workload list`."
+	case screenKind:
+		return "Both run as containers and are built the same way. Agent additionally enables " +
+			"agent capabilities, the first of which is A2A discovery."
+	case screenA2A:
+		return "Publishing reads the A2A agent card from the running container and registers it " +
+			"tenant-wide, so other agents can discover and call this one. The application must " +
+			"serve a card for this to work."
+	case screenEntrypoint:
+		return "The container entrypoint: the command run on start, written to `entrypoint` in the manifest."
+	case screenEnv:
+		return "Variables from " + EnvFileName + ". Secrets become credential references; " +
+			"everything else is written as a literal."
+	case screenBinding, screenSource, screenExecEnv, screenImage, screenSettings, screenConfirm:
+		return ""
+	}
+
+	return ""
+}
+
+// screenNote is about the answer being given right now: the row under the
+// cursor, the field being edited, what the bound workload already uses.
+func (f flow) screenNote() string {
+	switch f.at {
+	case screenBinding:
+		return f.bindingNote()
+	case screenSettings:
+		return joinNotes(f.liveValuesNote(), f.settingsNote())
+	case screenEnv:
+		return f.envTable.note()
+	case screenConfirm:
+		return f.confirmNote()
+	case screenKind, screenSource, screenImage, screenExecEnv:
+		return f.boundScreenNote()
+	case screenName, screenA2A, screenEntrypoint:
+		return ""
+	}
+
+	return ""
+}
+
+// boundScreenNote covers the screens whose only note is about the workload
+// being bound to: which option it already uses, and whether this checkout can
+// honour it.
+func (f flow) boundScreenNote() string {
+	switch f.at {
+	case screenKind:
+		return f.liveDefaultsNote()
+	case screenSource:
+		// The Dockerfile warning belongs to this screen alone: it is about
+		// the option being chosen here, not about the workload in general.
+		return joinNotes(f.liveDefaultsNote(), f.sourceConflictNote())
+	case screenImage:
+		return f.liveValuesNote()
+	case screenBinding, screenName, screenA2A, screenExecEnv,
+		screenEntrypoint, screenSettings, screenEnv, screenConfirm:
+		return ""
+	}
+
+	return ""
+}
+
+// questions is what each screen asks. Phrasing them in one place keeps the
+// wizard sounding like one voice rather than ten.
+var questions = map[screen]string{
+	screenBinding:    "Which workload should this repository deploy to?",
+	screenName:       "What should this workload be called?",
+	screenKind:       "What kind of workload is this?",
+	screenA2A:        "Publish this agent to the A2A registry?",
+	screenSource:     "How should the container image be produced?",
+	screenExecEnv:    "Which execution environment should the build use?",
+	screenEntrypoint: "What is your app's entrypoint?",
+	screenImage:      "Which image should it run?",
+	screenSettings:   "How should this workload run?",
+	screenEnv:        "Which variables should the manifest declare?",
+	screenConfirm:    "Ready to write " + manifest.FileName,
+}
+
+func (f flow) question() string {
+	return questions[f.at]
+}
+
+func (f flow) body() string {
+	switch f.at {
+	case screenBinding, screenExecEnv:
+		return f.picker.view(f.width)
+
+	case screenKind, screenSource:
+		return f.choice.view()
+
+	case screenEnv:
+		return f.envTable.view(f.width)
+
+	case screenA2A:
+		return f.choice.view()
+
+	case screenName, screenEntrypoint, screenImage:
+		return "  " + f.inputs[0].View()
+
+	case screenSettings:
+		return f.settingsView()
+
+	case screenConfirm:
+		return f.confirmBody()
+	}
+
+	return ""
+}
+
+// settingsLabels name the fields in the order they are asked, which is the
+// order the file reads: how the container is reached, then how much of it
+// runs. Everything here has a working default, so the screen is a review as
+// much as a question.
+var settingsLabels = []string{"Port", "Health path", "Replicas", "CPU", "Memory", "Importance"}
+
+// settingsNotes explain the field the cursor is on, one at a time. They sit
+// under the fields rather than beside them: an inline hint on the widest row
+// runs off a narrow terminal, and only the field being edited needs
+// explaining anyway.
+var settingsNotes = []string{
+	"Port the container listens on. Must be 1024 or above: containers run unprivileged.",
+	"Readiness probe path. Traffic is withheld until this endpoint reports success.",
+	"Container instances to run. Reported as protons in status output and logs.",
+	"CPU cores per replica. Fractional values are allowed.",
+	"Memory per replica. A byte count or a 1000-based unit (" + strings.Join(manifest.MemoryUnits(), ", ") + "). Binary units such as Gi are rejected: they would be read as their decimal equivalents.",
+	"Scheduling priority when capacity is constrained: " + strings.Join(manifest.ImportanceLevels, ", ") + ".",
+}
+
+func (f flow) settingsView() string {
+	var b strings.Builder
+
+	width := 0
+	for _, label := range settingsLabels {
+		width = max(width, len(label))
+	}
+
+	for i, label := range settingsLabels {
+		padded := label + strings.Repeat(" ", width-len(label))
+		fmt.Fprintf(&b, "  %s  %s\n", labelStyle.Render(padded), f.inputs[i].View())
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// settingsNote explains the field the cursor is on. The port's note carries
+// its provenance too, since that is the one value detection can vouch for.
+func (f flow) settingsNote() string {
+	if f.focus < 0 || f.focus >= len(settingsNotes) {
+		return ""
+	}
+
+	note := settingsNotes[f.focus]
+	if f.focus == 0 {
+		note += " " + capitalize(f.detected.PortSource) + "."
+	}
+
+	return note
+}
+
+// capitalize raises the first letter so a detection phrase reads as a
+// sentence where it is appended to one.
+func capitalize(text string) string {
+	if text == "" {
+		return ""
+	}
+
+	return strings.ToUpper(text[:1]) + text[1:]
+}
+
+// formatCPU renders a CPU allocation the way it would be typed, so a whole
+// number does not come back as 1.0.
+func formatCPU(cpu float64) string {
+	return strconv.FormatFloat(cpu, 'g', -1, 64)
+}
+
+// joinNotes stacks notes that both apply, dropping the ones that do not.
+func joinNotes(notes ...string) string {
+	present := make([]string, 0, len(notes))
+
+	for _, note := range notes {
+		if note != "" {
+			present = append(present, note)
+		}
+	}
+
+	return strings.Join(present, "\n")
+}
+
+// note renders an explanatory sentence, wrapped to the terminal.
+func (f flow) note(text string) string {
+	if text == "" {
+		return ""
+	}
+
+	return noteStyle.Width(contentWidth(f.width)).Render(text)
+}
+
+// bindingNote explains the row under the cursor: what picking it does.
+func (f flow) bindingNote() string {
+	row := f.picker.selected()
+	if row == nil {
+		return ""
+	}
+
+	item, ok := row.value.(pickedWorkload)
+	if !ok {
+		return ""
+	}
+
+	if item.id == createNewID {
+		return "Creates a new workload for this repository. You name it on the next screen."
+	}
+
+	return "This repository will deploy to " + item.name + ": the same workload, not a copy. Its " +
+		"current configuration is read into the manifest first, so nothing it runs with is dropped, " +
+		"and the exact changes are shown before anything is written."
+}
+
+// confirmBody shows the file, and for a bound workload what it changes about
+// something already running.
+func (f flow) confirmBody() string {
+	if f.failed != nil {
+		return ""
+	}
+
+	body := indent(string(f.content))
+
+	if f.diff != "" {
+		body = indent(f.diff)
+	} else if f.diff == "" && f.live != nil {
+		body = indent(string(f.content)) + "\n  " + tui.HintStyle.Render("no change to the running workload")
+	}
+
+	return body
+}
+
+// confirmNote is what the user is agreeing to, beyond the file itself: where
+// it goes, how much it will run with, and what happens next.
+func (f flow) confirmNote() string {
+	if f.failed != nil {
+		return ""
+	}
+
+	return strings.Join([]string{
+		"Writing to " + ShortPath(manifest.Path(f.detected.Dir)),
+		f.runtimeLine(),
+		f.nextStep(),
+	}, "\n")
+}
+
+// runtimeLine summarises the sizing the file will carry. A bound workload
+// reports its own, not the documented defaults, because this is the line the
+// user is consenting to.
+func (f flow) runtimeLine() string {
+	sizing := fmt.Sprintf("%s cpu · %s",
+		strconv.FormatFloat(f.draft.Runtime.CPU, 'g', -1, 64), f.draft.Runtime.Memory)
+
+	replicas := "autoscaling"
+	if f.draft.Runtime.Replicas > 0 {
+		replicas = fmt.Sprintf("%d replica", f.draft.Runtime.Replicas)
+		if f.draft.Runtime.Replicas != 1 {
+			replicas += "s"
+		}
+	}
+
+	return "Runtime: " + replicas + " · " + sizing + "    (edit the file for GPU/autoscaling)"
+}
+
+func (f flow) nextStep() string {
+	if f.live != nil {
+		return "On `up`: deploys this repo to " + f.live.Name + "."
+	}
+
+	return "On `up`: creates a new workload and deploys this repo to it."
+}
+
+// screenKeys is the footer each screen shows. Screens not listed take the
+// default: answer and move, or go back.
+var screenKeys = map[screen][]keyBinding{
+	screenConfirm: {
+		{Key: "enter", Does: "write the file"},
+		{Key: "e", Does: "open in $EDITOR"},
+		{Key: "esc", Does: "back"},
+	},
+	screenBinding: {
+		{Key: "type", Does: "to filter"},
+		{Key: "↑/↓", Does: "move"},
+		{Key: "enter", Does: "select"},
+		{Key: "esc", Does: "back"},
+	},
+	screenExecEnv: {
+		{Key: "type", Does: "to filter"},
+		{Key: "↑/↓", Does: "move"},
+		{Key: "enter", Does: "select"},
+		{Key: "esc", Does: "back"},
+	},
+	screenSettings: {
+		{Key: "tab", Does: "next field"},
+		{Key: "enter", Does: "continue"},
+		{Key: "esc", Does: "back"},
+	},
+	screenEnv: {
+		{Key: "↑/↓", Does: "move"},
+		{Key: "←/→", Does: "literal · credential · omit"},
+		{Key: "enter", Does: "accept"},
+		{Key: "esc", Does: "back"},
+	},
+}
+
+var defaultKeys = []keyBinding{
+	{Key: "enter", Does: "continue"},
+	{Key: "esc", Does: "back"},
+}
+
+func (f flow) keys() string {
+	bindings, ok := screenKeys[f.at]
+	if !ok {
+		bindings = defaultKeys
+	}
+
+	// With a filter in place, esc undoes that first. Saying "back" would be a
+	// second key that does not do what it says.
+	if f.picker.filter != "" && (f.at == screenBinding || f.at == screenExecEnv) {
+		bindings = append(append([]keyBinding(nil), bindings[:len(bindings)-1]...),
+			keyBinding{Key: "esc", Does: "clear filter"})
+	}
+
+	// Wrapped like everything else: a legend that runs off the edge hides the
+	// key the user is looking for.
+	return lipgloss.NewStyle().MarginLeft(2).Width(contentWidth(f.width)).Render(legend(bindings...))
+}
+
+// openEditor hands the manifest to the user's editor and reads back whatever
+// they saved. What comes back is validated like any other file: an editor is
+// a way to fix the answers, not a way around the ledger.
+func (f flow) openEditor() tea.Cmd {
+	file, err := os.CreateTemp("", "datarobot-*.yaml")
+	if err != nil {
+		return func() tea.Msg { return editedMsg{err: fmt.Errorf("cannot open an editor: %w", err)} }
+	}
+
+	name := file.Name()
+
+	if _, err := file.Write(f.content); err != nil {
+		_ = file.Close()
+		_ = os.Remove(name)
+
+		return func() tea.Msg { return editedMsg{err: fmt.Errorf("cannot open an editor: %w", err)} }
+	}
+
+	_ = file.Close()
+
+	editor, args := editorCommand()
+	dir := f.detected.Dir
+
+	return tea.ExecProcess(exec.Command(editor, append(args, name)...), func(runErr error) tea.Msg {
+		defer func() { _ = os.Remove(name) }()
+
+		if runErr != nil {
+			return editedMsg{err: fmt.Errorf("%s exited with an error: %w", editor, runErr)}
+		}
+
+		edited, err := os.ReadFile(name)
+		if err != nil {
+			return editedMsg{err: fmt.Errorf("cannot read back the edited manifest: %w", err)}
+		}
+
+		if err := checkRendered(edited, dir, authorUser); err != nil {
+			return editedMsg{err: err}
+		}
+
+		return editedMsg{content: edited}
+	})
+}
+
+// editorCommand splits $EDITOR the way a shell would, so "code --wait" works
+// as well as "vim".
+func editorCommand() (string, []string) {
+	editor := os.Getenv("VISUAL")
+	if editor == "" {
+		editor = os.Getenv("EDITOR")
+	}
+
+	if editor == "" {
+		return defaultEditor, nil
+	}
+
+	parts, err := splitCommand(editor)
+	if err != nil || len(parts) == 0 {
+		return defaultEditor, nil
+	}
+
+	return parts[0], parts[1:]
+}
+
+// unifiedDiff renders what changes about the running workload. An empty
+// string means nothing does.
+func unifiedDiff(name, before, after string) string {
+	if before == after {
+		return ""
+	}
+
+	return udiff.Unified(name+" (running)", name+" (this file)", before, after)
+}
+
+// pickedWorkload and pickedEnv are what a picker hands back when a row is
+// chosen, carried on the row itself so the caller does not have to look it up
+// again by name.
+type pickedWorkload struct {
+	id   string
+	name string
+}
+
+type pickedEnv struct {
+	id        string
+	versionID string
+}
+
+// createNewLabel is the pinned row. It says what choosing it does, because
+// "create a new workload" on its own reads as though something is created
+// here, and nothing is: the name comes next and the workload comes at deploy.
+const createNewLabel = "＋ Set up a new workload"
+
+func newWorkloadPicker(workloads []workload.Workload, width, height int) rowTable {
+	rows := make([]tableRow, 0, len(workloads)+1)
+	rows = append(rows, tableRow{
+		cells: []string{createNewLabel, "", ""},
+		value: pickedWorkload{id: createNewID},
+	})
+
+	for _, w := range workloads {
+		rows = append(rows, tableRow{
+			cells: []string{w.Name, strings.ToLower(w.Status), w.UpdatedAt.Format("2 Jan 2006")},
+			value: pickedWorkload{id: w.ID, name: w.Name},
+		})
+	}
+
+	return newRowTable([]string{"WORKLOAD", "STATUS", "UPDATED"}, rows, true, width, height)
+}
+
+func newExecEnvPicker(environments []workload.ExecutionEnvironment, width, height int) rowTable {
+	rows := make([]tableRow, 0, len(environments))
+
+	for _, ee := range environments {
+		// An environment with nothing built is not offered: picking it would
+		// fail at build time with nothing the user could do. The listing
+		// already filters these, but that invariant lives in another package
+		// and this is the call site that would panic if it changed.
+		if ee.LatestSuccessfulVersion == nil {
+			continue
+		}
+
+		rows = append(rows, tableRow{
+			cells: []string{ee.Name, ee.ID},
+			value: pickedEnv{id: ee.ID, versionID: ee.LatestSuccessfulVersion.ID},
+		})
+	}
+
+	return newRowTable([]string{"BASE IMAGE", "ID"}, rows, true, width, height)
+}
+
+func newInput(value, placeholder string) textinput.Model {
+	input := textinput.New()
+	input.SetValue(value)
+	input.Placeholder = placeholder
+	input.PromptStyle = lipgloss.NewStyle()
+	input.Focus()
+
+	return input
+}
+
+func indent(text string) string {
+	lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+	for i, line := range lines {
+		lines[i] = "  " + line
+	}
+
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func yesNo(value bool) string {
+	if value {
+		return "yes"
+	}
+
+	return "no"
+}

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -27,6 +27,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/tui"
@@ -36,7 +37,9 @@ import (
 // picker can return it through the same channel as a real workload.
 const createNewID = "\x00create-new"
 
-// defaultEditor is what [e] opens when the environment names none.
+// defaultEditor is what [e] opens when nothing names an editor. It matches the
+// default the root command registers for the same setting, so the wizard opens
+// the same thing whether or not that registration has run.
 const defaultEditor = "vi"
 
 // namePlaceholder shows the shape of a workload name without proposing one.
@@ -209,14 +212,15 @@ func (f *flow) enterInputs(at screen) {
 		f.inputs = []textinput.Model{newInput(f.draft.Build.ImageURI, "registry.example.com/team/app:v1")}
 
 	case screenSettings:
-		f.inputs = []textinput.Model{
-			newInput(strconv.Itoa(f.draft.Port), "8080"),
-			newInput(f.draft.HealthPath, manifest.DefaultHealthPath),
-			newInput(replicaValue(f.draft.Runtime.Replicas), replicaPlaceholder(f.autoscaled())),
-			newInput(formatCPU(f.draft.Runtime.CPU), "0.5"),
-			newInput(f.draft.Runtime.Memory, manifest.DefaultMemory),
-			newInput(f.draft.Importance, manifest.DefaultImportance),
-		}
+		inputs := make([]textinput.Model, settingsFieldCount)
+		inputs[fieldPort] = newInput(strconv.Itoa(f.draft.Port), "8080")
+		inputs[fieldHealthPath] = newInput(f.draft.HealthPath, manifest.DefaultHealthPath)
+		inputs[fieldReplicas] = newInput(replicaValue(f.draft.Runtime.Replicas), replicaPlaceholder(f.autoscaled()))
+		inputs[fieldCPU] = newInput(formatCPU(f.draft.Runtime.CPU), "0.5")
+		inputs[fieldMemory] = newInput(f.draft.Runtime.Memory, manifest.DefaultMemory)
+		inputs[fieldImportance] = newInput(f.draft.Importance, manifest.DefaultImportance)
+
+		f.inputs = inputs
 
 		for i := range f.inputs[1:] {
 			f.inputs[i+1].Blur()
@@ -467,23 +471,50 @@ func (f flow) body() string {
 	return ""
 }
 
-// settingsLabels name the fields in the order they are asked, which is the
+// The settings screen's fields, in the order they are asked, which is the
 // order the file reads: how the container is reached, then how much of it
-// runs. Everything here has a working default, so the screen is a review as
-// much as a question.
-var settingsLabels = []string{"Port", "Health path", "Replicas", "CPU", "Memory", "Importance"}
+// runs.
+//
+// Four things are keyed by this order — the inputs enterInputs builds, the
+// labels beside them, the notes under them, and the reads in acceptSettings —
+// so the position is named here once instead of written as a number in each of
+// them. A number that falls out of step with the others reads the wrong field
+// or panics, and neither announces itself.
+const (
+	fieldPort = iota
+	fieldHealthPath
+	fieldReplicas
+	fieldCPU
+	fieldMemory
+	fieldImportance
+
+	// settingsFieldCount sizes everything indexed by the above, so an entry
+	// added past the end is a compile error rather than a silent no-op.
+	settingsFieldCount
+)
+
+// settingsLabels name the fields. Everything here has a working default, so
+// the screen is a review as much as a question.
+var settingsLabels = [settingsFieldCount]string{
+	fieldPort:       "Port",
+	fieldHealthPath: "Health path",
+	fieldReplicas:   "Replicas",
+	fieldCPU:        "CPU",
+	fieldMemory:     "Memory",
+	fieldImportance: "Importance",
+}
 
 // settingsNotes explain the field the cursor is on, one at a time. They sit
 // under the fields rather than beside them: an inline hint on the widest row
 // runs off a narrow terminal, and only the field being edited needs
 // explaining anyway.
-var settingsNotes = []string{
-	"Port the container listens on. Must be 1024 or above: containers run unprivileged.",
-	"Readiness probe path. Traffic is withheld until this endpoint reports success.",
-	"Container instances to run. Reported as protons in status output and logs.",
-	"CPU cores per replica. Fractional values are allowed.",
-	"Memory per replica. A byte count or a 1000-based unit (" + strings.Join(manifest.MemoryUnits(), ", ") + "). Binary units such as Gi are rejected: they would be read as their decimal equivalents.",
-	"Scheduling priority when capacity is constrained: " + strings.Join(manifest.ImportanceLevels, ", ") + ".",
+var settingsNotes = [settingsFieldCount]string{
+	fieldPort:       "Port the container listens on. Must be 1024 or above: containers run unprivileged.",
+	fieldHealthPath: "Readiness probe path. Traffic is withheld until this endpoint reports success.",
+	fieldReplicas:   "Container instances to run. Reported as protons in status output and logs.",
+	fieldCPU:        "CPU cores per replica. Fractional values are allowed.",
+	fieldMemory:     "Memory per replica. A byte count or a 1000-based unit (" + strings.Join(manifest.MemoryUnits(), ", ") + "). Binary units such as Gi are rejected: they would be read as their decimal equivalents.",
+	fieldImportance: "Scheduling priority when capacity is constrained: " + strings.Join(manifest.ImportanceLevels, ", ") + ".",
 }
 
 func (f flow) settingsView() string {
@@ -683,7 +714,7 @@ func (f flow) nextStep() string {
 var screenKeys = map[screen][]keyBinding{
 	screenConfirm: {
 		{Key: "enter", Does: "write the file"},
-		{Key: "e", Does: "open in $EDITOR"},
+		{Key: "e", Does: "open in your editor"},
 		{Key: "esc", Does: "back"},
 	},
 	screenBinding: {
@@ -783,14 +814,17 @@ func (f flow) openEditor() tea.Cmd {
 	})
 }
 
-// editorCommand splits $EDITOR the way a shell would, so "code --wait" works
-// as well as "vim".
+// editorCommand names the editor to open, split the way a shell would so
+// "code --wait" works as well as "vim".
+//
+// The choice comes from the CLI's own external-editor setting, which is where
+// VISUAL and EDITOR are already mapped and where a configured preference or
+// the flag can override them. Reading the two variables here directly would
+// have made this the one editor in the CLI that a configured preference could
+// not reach. The fallback below stays for callers that arrive without the root
+// command's initialization, which is what leaves the setting unset.
 func editorCommand() (string, []string) {
-	editor := os.Getenv("VISUAL")
-	if editor == "" {
-		editor = os.Getenv("EDITOR")
-	}
-
+	editor := strings.TrimSpace(viperx.GetString("external-editor"))
 	if editor == "" {
 		return defaultEditor, nil
 	}

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/aymanbagabas/go-udiff"
 	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/datarobot/cli/internal/workload"
@@ -48,6 +49,14 @@ const namePlaceholder = "my-app-name"
 // agreed to. The workload list is fetched up front because the first screen
 // depends on it: with nothing to bind to, there is no binding question.
 func runInteractiveFlow(opts Options, detected Detected) ([]byte, manifest.Draft, error) {
+	// No screen can settle this one, so it is not a question the wizard gets
+	// to ask. Started anyway, the error would sit behind the loading view
+	// while the fetch ran, and arriving at the first screen would clear it
+	// and drop --name without saying so.
+	if err := opts.Answers.checkBinding(); err != nil {
+		return nil, manifest.Draft{}, err
+	}
+
 	var workloads []workload.Workload
 
 	if opts.Answers.WorkloadID == "" && opts.Answers.Name == "" {
@@ -203,7 +212,7 @@ func (f *flow) enterInputs(at screen) {
 		f.inputs = []textinput.Model{
 			newInput(strconv.Itoa(f.draft.Port), "8080"),
 			newInput(f.draft.HealthPath, manifest.DefaultHealthPath),
-			newInput(strconv.Itoa(f.draft.Runtime.Replicas), "1"),
+			newInput(replicaValue(f.draft.Runtime.Replicas), replicaPlaceholder(f.autoscaled())),
 			newInput(formatCPU(f.draft.Runtime.CPU), "0.5"),
 			newInput(f.draft.Runtime.Memory, manifest.DefaultMemory),
 			newInput(f.draft.Importance, manifest.DefaultImportance),
@@ -574,15 +583,59 @@ func (f flow) confirmBody() string {
 		return ""
 	}
 
-	body := indent(string(f.content))
+	return indent(f.preview.View())
+}
 
+// previewText is what the confirm screen is asking about: the file itself, or
+// for a bound workload the change it makes to something already running.
+func (f flow) previewText() string {
 	if f.diff != "" {
-		body = indent(f.diff)
-	} else if f.diff == "" && f.live != nil {
-		body = indent(string(f.content)) + "\n  " + tui.HintStyle.Render("no change to the running workload")
+		return f.diff
 	}
 
-	return body
+	if f.live != nil {
+		return string(f.content) + "\n" + tui.HintStyle.Render("no change to the running workload")
+	}
+
+	return string(f.content)
+}
+
+// buildPreview fits the preview to the terminal. It runs wherever the content
+// is settled rather than at screen entry, because the render happens after
+// enter and the editor can replace the file afterwards.
+func (f *flow) buildPreview() {
+	text := strings.TrimRight(f.previewText(), "\n")
+	lines := strings.Count(text, "\n") + 1
+
+	// A short manifest keeps its own height: padding it out to a fixed window
+	// would put the key legend below the fold for no reason.
+	f.preview = viewport.New(contentWidth(f.width), min(previewHeight(f.height), lines))
+	f.preview.SetContent(text)
+}
+
+// scrollablePreview reports whether the confirm screen has more than it can
+// show, which decides whether the legend offers a key for it.
+func (f flow) scrollablePreview() bool {
+	return f.preview.TotalLineCount() > f.preview.Height
+}
+
+// How much of the manifest the confirm screen shows at once: everything the
+// terminal has left once the question, the note under it and the key legend
+// are accounted for. There is no upper cap, because the whole point of the
+// screen is to read the file, and none below the point where scrolling is all
+// there is to see.
+const (
+	defaultPreviewHeight = 20
+	minPreviewHeight     = 6
+	previewChrome        = 12
+)
+
+func previewHeight(terminalHeight int) int {
+	if terminalHeight <= 0 {
+		return defaultPreviewHeight
+	}
+
+	return max(terminalHeight-previewChrome, minPreviewHeight)
 }
 
 // confirmNote is what the user is agreeing to, beyond the file itself: where
@@ -667,6 +720,12 @@ func (f flow) keys() string {
 	bindings, ok := screenKeys[f.at]
 	if !ok {
 		bindings = defaultKeys
+	}
+
+	// Offered only when there is something below the fold, so the legend
+	// never advertises a key that does nothing.
+	if f.at == screenConfirm && f.scrollablePreview() {
+		bindings = append([]keyBinding{{Key: "↑/↓", Does: "scroll"}}, bindings...)
 	}
 
 	// With a filter in place, esc undoes that first. Saying "back" would be a
@@ -808,6 +867,26 @@ func newExecEnvPicker(environments []workload.ExecutionEnvironment, width, heigh
 	}
 
 	return newRowTable([]string{"BASE IMAGE", "ID"}, rows, true, width, height)
+}
+
+// replicaValue leaves the field empty rather than showing a zero, which is
+// how an autoscaled workload arrives and is not a count anyone typed.
+func replicaValue(replicas int) string {
+	if replicas < 1 {
+		return ""
+	}
+
+	return strconv.Itoa(replicas)
+}
+
+// replicaPlaceholder says why the field is empty when the workload's own
+// policy owns the number.
+func replicaPlaceholder(autoscaled bool) string {
+	if autoscaled {
+		return "set by autoscaling"
+	}
+
+	return "1"
 }
 
 func newInput(value, placeholder string) textinput.Model {

--- a/internal/workload/wizard/style.go
+++ b/internal/workload/wizard/style.go
@@ -1,0 +1,93 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"strings"
+
+	"github.com/datarobot/cli/tui"
+)
+
+// The wizard's own styles, all drawn from the shared palette so it looks like
+// the rest of the CLI rather than like a second product.
+var (
+	// questionStyle is the one line that says what is being asked.
+	questionStyle = tui.InfoStyle.MarginLeft(2)
+
+	// labelStyle names a field without competing with its value.
+	labelStyle = tui.HintStyle
+
+	// valueStyle is a value the user typed or accepted.
+	valueStyle = tui.BaseTextStyle
+
+	// selectedStyle marks the row or option under the cursor.
+	selectedStyle = tui.BaseTextStyle.Foreground(tui.TitleColor).Bold(true)
+
+	// noteStyle is the sentence explaining the question. Italic so it reads as
+	// an aside rather than as another thing to answer.
+	noteStyle = tui.HintStyle.MarginLeft(2).Italic(true)
+
+	// filterStyle marks an active filter. It is a mode, not a label, so it
+	// gets a colour nothing else on the screen uses.
+	filterStyle = tui.BaseTextStyle.Foreground(tui.GetAdaptiveColor(tui.DrYellow, tui.DrYellowDark)).Bold(true)
+
+	// liveStyle marks a value that came from the running workload rather than
+	// from this project or from a documented default.
+	liveStyle = tui.BaseTextStyle.Foreground(tui.TitleColor)
+
+	// keyStyle is a keystroke in the legend; keyLabelStyle is what it does.
+	keyStyle      = tui.BaseTextStyle.Foreground(tui.BorderColor).Bold(true)
+	keyLabelStyle = tui.HintStyle
+)
+
+// The width the wizard lays out to before the terminal has told it anything,
+// and the narrowest it will squeeze to afterwards. Both leave room for the
+// two-column margin every screen uses.
+const (
+	fallbackWidth = 78
+	minWidth      = 32
+	marginColumns = 4
+)
+
+// contentWidth is how wide a wrapped paragraph may be. Notes are the only
+// long prose on any screen, and letting them run past the edge is how a hint
+// turns into a line the user has to guess the end of.
+func contentWidth(terminalWidth int) int {
+	if terminalWidth <= 0 {
+		return fallbackWidth
+	}
+
+	return max(terminalWidth-marginColumns, minWidth)
+}
+
+// keyBinding is one entry in a screen's legend.
+type keyBinding struct {
+	// Key is shown in brackets, e.g. "enter".
+	Key string
+	// Does is the short phrase after it.
+	Does string
+}
+
+// legend renders a screen's keys, the keystrokes picked out from what they
+// do so the line can be skimmed for the one you want.
+func legend(bindings ...keyBinding) string {
+	parts := make([]string, 0, len(bindings))
+
+	for _, b := range bindings {
+		parts = append(parts, keyStyle.Render("["+b.Key+"]")+" "+keyLabelStyle.Render(b.Does))
+	}
+
+	return strings.Join(parts, keyLabelStyle.Render("  ·  "))
+}

--- a/internal/workload/wizard/table.go
+++ b/internal/workload/wizard/table.go
@@ -17,6 +17,7 @@ package wizard
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
@@ -65,6 +66,9 @@ type rowTable struct {
 	model   table.Model
 	all     []tableRow
 	visible []tableRow
+	// headers is kept so the table can be refitted to a new terminal width,
+	// which means recomputing the columns it was built with.
+	headers []string
 
 	// maxHeight is what the terminal allows; the table itself shrinks to fit
 	// however many rows the filter leaves.
@@ -75,7 +79,7 @@ type rowTable struct {
 }
 
 func newRowTable(headers []string, rows []tableRow, filterable bool, width, height int) rowTable {
-	t := rowTable{all: rows, filterable: filterable, maxHeight: tableHeight(height)}
+	t := rowTable{all: rows, headers: headers, filterable: filterable, maxHeight: tableHeight(height)}
 	t.model = table.New(
 		table.WithColumns(columnsFor(headers, rows, width)),
 		table.WithHeight(t.maxHeight),
@@ -86,6 +90,25 @@ func newRowTable(headers []string, rows []tableRow, filterable bool, width, heig
 	t.apply()
 
 	return t
+}
+
+// resize refits the table to a terminal it did not know about when it was
+// built, keeping the filter and the row under the cursor. Columns and height
+// are decided at construction, so without this a table built before the first
+// size message is stuck at the fallback for the rest of the run.
+func (t *rowTable) resize(width, height int) {
+	if len(t.all) == 0 {
+		return
+	}
+
+	cursor := t.model.Cursor()
+
+	t.maxHeight = tableHeight(height)
+	t.model.SetColumns(columnsFor(t.headers, t.all, width))
+	t.syncRows()
+	t.model.SetCursor(cursor)
+	t.syncRows()
+	t.fit()
 }
 
 // tableStyles dresses bubbles/table in the shared palette, so it matches the
@@ -188,7 +211,11 @@ func (t *rowTable) update(msg tea.KeyMsg) bool {
 			return false
 		}
 
-		t.filter = t.filter[:len(t.filter)-1]
+		// One keystroke removes one character, not one byte: a workload named
+		// in anything but ASCII would otherwise take several backspaces per
+		// letter and leave a broken encoding in between.
+		_, size := utf8.DecodeLastRuneInString(t.filter)
+		t.filter = t.filter[:len(t.filter)-size]
 
 		t.apply()
 

--- a/internal/workload/wizard/table.go
+++ b/internal/workload/wizard/table.go
@@ -1,0 +1,366 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/datarobot/cli/tui"
+)
+
+// How tall a table may get. It takes what the terminal has, up to a limit
+// past which a list stops being scannable, and never shrinks below the point
+// where scrolling is all you can see.
+const (
+	maxTableHeight = 20
+	minTableHeight = 5
+
+	// chromeRows is what sits above and below a table: the question, the
+	// status line, the note and the legend, with their blank lines.
+	chromeRows = 10
+)
+
+// tableHeight fits the table to the terminal.
+func tableHeight(terminalHeight int) int {
+	if terminalHeight <= 0 {
+		return maxTableHeight
+	}
+
+	return min(max(terminalHeight-chromeRows, minTableHeight), maxTableHeight)
+}
+
+// maxColumnWidth stops one outlying value from dictating the layout. Some
+// execution environments are named with a whole image URI; without a cap that
+// one row pushes every other column off the screen.
+const maxColumnWidth = 56
+
+// tableRow is one row: the cells as shown, plus whatever the caller needs
+// back when the row is chosen.
+type tableRow struct {
+	cells []string
+	value any
+}
+
+// rowTable is the wizard's list widget. bubbles/table does the work: cursor,
+// scrolling viewport, rendering. This adds the two things it has no opinion
+// about, namely type-to-filter and carrying a value alongside each row, and
+// keeps every screen that shows a list looking the same.
+type rowTable struct {
+	model   table.Model
+	all     []tableRow
+	visible []tableRow
+
+	// maxHeight is what the terminal allows; the table itself shrinks to fit
+	// however many rows the filter leaves.
+	maxHeight int
+
+	filter     string
+	filterable bool
+}
+
+func newRowTable(headers []string, rows []tableRow, filterable bool, width, height int) rowTable {
+	t := rowTable{all: rows, filterable: filterable, maxHeight: tableHeight(height)}
+	t.model = table.New(
+		table.WithColumns(columnsFor(headers, rows, width)),
+		table.WithHeight(t.maxHeight),
+		table.WithFocused(true),
+		table.WithStyles(tableStyles()),
+	)
+
+	t.apply()
+
+	return t
+}
+
+// tableStyles dresses bubbles/table in the shared palette, so it matches the
+// static tables the rest of the CLI prints.
+func tableStyles() table.Styles {
+	s := table.DefaultStyles()
+	s.Header = labelStyle.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(tui.BorderColor).
+		BorderBottom(true).
+		Bold(true).
+		Padding(0, 1)
+	s.Cell = valueStyle.Padding(0, 1)
+	// No padding here: bubbles/table applies Selected to the whole row after
+	// the cells already carry theirs, so padding again shifts the highlighted
+	// row a column out of line with the rest.
+	s.Selected = selectedStyle
+
+	return s
+}
+
+// columnsFor sizes each column to its widest cell, then shares out whatever
+// the terminal has left so the last column absorbs the slack rather than the
+// table overflowing.
+func columnsFor(headers []string, rows []tableRow, width int) []table.Column {
+	if len(headers) == 0 {
+		return nil
+	}
+
+	// A narrow first column carries the cursor marker.
+	headers = append([]string{" "}, headers...)
+
+	columns := make([]table.Column, len(headers))
+
+	for i, header := range headers {
+		columns[i] = table.Column{Title: header, Width: len(header)}
+	}
+
+	columns[0].Width = 2
+
+	for _, row := range rows {
+		for i, cell := range row.cells {
+			if i+1 < len(columns) {
+				columns[i+1].Width = max(columns[i+1].Width, min(len(cell), maxColumnWidth))
+			}
+		}
+	}
+
+	// Two of padding per column, which is what the cell style adds.
+	const padding = 2
+
+	total := 0
+	for _, c := range columns {
+		total += c.Width + padding
+	}
+
+	// A table narrower than the terminal is left narrow: stretching it to the
+	// edge only puts a corridor of blank space between the columns.
+	if over := total - contentWidth(width); over > 0 {
+		// Take it out of the widest column: that is the one carrying names
+		// long enough to have caused the overflow.
+		widest := 0
+		for i, c := range columns {
+			if c.Width > columns[widest].Width {
+				widest = i
+			}
+		}
+
+		columns[widest].Width = max(columns[widest].Width-over, len(columns[widest].Title))
+	}
+
+	return columns
+}
+
+// selected is the row under the cursor, nil when the filter admits nothing.
+func (t rowTable) selected() *tableRow {
+	cursor := t.model.Cursor()
+	if cursor < 0 || cursor >= len(t.visible) {
+		return nil
+	}
+
+	return &t.visible[cursor]
+}
+
+// update handles a keystroke, reporting whether the table consumed it.
+//
+// There is no filter mode. Typing filters, the arrows move, enter selects,
+// and every one of those means the same thing at every moment. The earlier
+// design had a mode entered with "/", inside which enter meant "accept the
+// filter" while the legend still said "select": two meanings for one key,
+// and no way to tell which one was live.
+func (t *rowTable) update(msg tea.KeyMsg) bool {
+	if !t.filterable {
+		return t.moveCursor(msg)
+	}
+
+	switch {
+	case msg.Type == tea.KeyBackspace:
+		if t.filter == "" {
+			return false
+		}
+
+		t.filter = t.filter[:len(t.filter)-1]
+
+		t.apply()
+
+		return true
+
+	case msg.String() == "/" && t.filter == "":
+		// Muscle memory: in most pickers "/" starts a filter. Here typing
+		// already does, so it is swallowed rather than searched for. Once
+		// something is typed it is a character like any other, which matters
+		// for execution environments named after image URIs.
+		return true
+
+	case msg.Type == tea.KeyRunes && len(msg.Runes) > 0:
+		t.filter += string(msg.Runes)
+
+		t.apply()
+
+		return true
+	}
+
+	return t.moveCursor(msg)
+}
+
+// moveCursor hands the key to bubbles/table and reports whether it moved.
+func (t *rowTable) moveCursor(msg tea.KeyMsg) bool {
+	before := t.model.Cursor()
+	t.model, _ = t.model.Update(msg)
+
+	if t.model.Cursor() == before {
+		return false
+	}
+
+	// The marker rides in a cell, so the rows are rebuilt when it moves.
+	t.syncRows()
+
+	return true
+}
+
+// clearFilter drops the query, reporting whether there was one. Esc clears
+// before it goes back, so a filter typed by accident is one key to undo.
+func (t *rowTable) clearFilter() bool {
+	if t.filter == "" {
+		return false
+	}
+
+	t.filter = ""
+
+	t.apply()
+
+	return true
+}
+
+// headerRows is what bubbles/table spends on the header and its rule.
+// SetHeight counts them, so a height of n shows n-2 rows.
+const headerRows = 2
+
+// fit keeps the table as tall as its contents, up to what the terminal
+// allows. Without this a short list sits in a block of blank rows, and a
+// filtered one collapses to a single line.
+func (t *rowTable) fit() {
+	t.model.SetHeight(max(min(t.maxHeight, len(t.visible)), 1) + headerRows)
+}
+
+// apply narrows the rows to the filter and hands them to the table.
+func (t *rowTable) apply() {
+	t.visible = t.all
+
+	if t.filter != "" {
+		query := strings.ToLower(t.filter)
+		t.visible = make([]tableRow, 0, len(t.all))
+
+		for _, row := range t.all {
+			if strings.Contains(strings.ToLower(strings.Join(row.cells, " ")), query) {
+				t.visible = append(t.visible, row)
+			}
+		}
+	}
+
+	// Rows before cursor: bubbles/table clamps the cursor to the row count,
+	// so setting it against an empty table pins it at -1 and nothing is ever
+	// selected. Then the markers are laid on again, now that there is a
+	// cursor for them to follow.
+	t.syncRows()
+	t.model.SetCursor(0)
+	t.syncRows()
+	t.fit()
+}
+
+// syncRows hands the visible rows to the table, each prefixed with the marker
+// column so the row under the cursor is unmistakable rather than merely a
+// different colour.
+func (t *rowTable) syncRows() {
+	rows := make([]table.Row, 0, len(t.visible))
+
+	for i, row := range t.visible {
+		marker := "  "
+		if i == t.model.Cursor() {
+			marker = " ❯"
+		}
+
+		rows = append(rows, table.Row(append([]string{marker}, row.cells...)))
+	}
+
+	t.model.SetRows(rows)
+}
+
+// setRows replaces the contents, keeping the filter and the styling.
+func (t *rowTable) setRows(rows []tableRow) {
+	cursor := t.model.Cursor()
+	t.all = rows
+
+	t.apply()
+	t.model.SetCursor(cursor)
+	t.syncRows()
+}
+
+// selectValue moves the cursor to the first row whose value satisfies match,
+// so a screen rebuilt on the way back opens on the answer given there rather
+// than on whatever happens to be first.
+func (t *rowTable) selectValue(match func(any) bool) {
+	for i, row := range t.visible {
+		if !match(row.value) {
+			continue
+		}
+
+		t.model.SetCursor(i)
+		t.syncRows()
+
+		return
+	}
+}
+
+// cursor is the index into the visible rows.
+func (t rowTable) cursor() int {
+	return t.model.Cursor()
+}
+
+func (t rowTable) view(width int) string {
+	view := lipgloss.NewStyle().MarginLeft(2).Render(t.model.View())
+
+	// The filter sits above the rows it narrows, the way a search box does;
+	// the position counter sits below, the way a scrollbar does.
+	if filter := t.filterLine(); filter != "" {
+		view = filter + "\n\n" + view
+	}
+
+	if position := t.positionLine(width); position != "" {
+		view += "\n" + position
+	}
+
+	return view
+}
+
+// filterLine shows the query, with the caret because typing always goes here.
+func (t rowTable) filterLine() string {
+	if t.filter == "" {
+		return ""
+	}
+
+	return "  " + filterStyle.Render("filter: "+t.filter+"▌")
+}
+
+// positionLine says where the cursor is in a list too long to show at once,
+// and reports a filter that matched nothing.
+func (t rowTable) positionLine(width int) string {
+	switch {
+	case len(t.visible) == 0 && t.filter != "":
+		return noteStyle.Width(contentWidth(width)).Render("nothing matches")
+	case len(t.visible) > t.maxHeight:
+		return noteStyle.Width(contentWidth(width)).
+			Render(fmt.Sprintf("%d of %d", t.model.Cursor()+1, len(t.visible)))
+	default:
+		return ""
+	}
+}

--- a/internal/workload/wizard/table_test.go
+++ b/internal/workload/wizard/table_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRows builds n rows named row-0, row-1, and so on.
+func fakeRows(n int) []tableRow {
+	rows := make([]tableRow, 0, n)
+	for i := range n {
+		rows = append(rows, tableRow{cells: []string{fmt.Sprintf("row-%d", i), "detail"}, value: i})
+	}
+
+	return rows
+}
+
+// typeInto sends each rune of text to the table.
+func typeFilter(t *rowTable, text string) {
+	for _, r := range text {
+		t.update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+}
+
+// visibleRowCount counts the data rows the table drew, so the assertions are
+// about what the user sees rather than about internal state. The rendered
+// shape is an optional filter line, the header, its rule, the rows, then an
+// optional position line: anchoring on the rule keeps this honest as the
+// surrounding furniture moves.
+func visibleRowCount(view string) int {
+	lines := strings.Split(view, "\n")
+
+	rule := -1
+
+	for i, line := range lines {
+		if strings.Contains(line, "─") {
+			rule = i
+
+			break
+		}
+	}
+
+	if rule < 0 {
+		return 0
+	}
+
+	count := 0
+
+	for _, line := range lines[rule+1:] {
+		trimmed := strings.TrimSpace(stripANSI(line))
+
+		switch {
+		case trimmed == "":
+			continue
+		case isStatusLine(trimmed):
+			return count
+		default:
+			count++
+		}
+	}
+
+	return count
+}
+
+func isStatusLine(line string) bool {
+	if strings.HasPrefix(line, "nothing matches") {
+		return true
+	}
+
+	// The position counter, "3 of 200".
+	return regexp.MustCompile(`^\d+ of \d+`).MatchString(line)
+}
+
+// stripANSI removes styling so the assertions read the text, not the colour.
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(text string) string {
+	return ansiPattern.ReplaceAllString(text, "")
+}
+
+// A table is as tall as its contents, so a short list does not sit in a block
+// of blank rows and a filtered one does not collapse to a single line.
+func TestRowTable_HeightFollowsContents(t *testing.T) {
+	tests := map[string]struct {
+		rows, terminal, want int
+	}{
+		"short list on a tall terminal":  {5, 44, 5},
+		"long list is capped":            {200, 44, maxTableHeight},
+		"short terminal shows fewer":     {200, 20, 20 - chromeRows},
+		"tiny terminal still shows some": {200, 8, minTableHeight},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			table := newRowTable([]string{"NAME", "DETAIL"}, fakeRows(test.rows), true, 120, test.terminal)
+
+			assert.Equal(t, test.want, visibleRowCount(table.view(120)))
+		})
+	}
+}
+
+// Filtering matches on any cell, case-insensitively, and the table shrinks to
+// what is left.
+func TestRowTable_Filter(t *testing.T) {
+	rows := []tableRow{
+		{cells: []string{"[DataRobot] Python 3.11 Drop-In", "a"}, value: 1},
+		{cells: []string{"DRUM NIM Sidecar", "b"}, value: 2},
+		{cells: []string{"fastdrum-genai", "c"}, value: 3},
+		{cells: []string{"ldtest-2", "d"}, value: 4},
+	}
+
+	table := newRowTable([]string{"NAME", "DETAIL"}, rows, true, 120, 44)
+	require.Equal(t, 4, visibleRowCount(table.view(120)))
+
+	// Matches "Drop-In", "DRUM" and "fastdrum": any cell, either case.
+	// There is no filter mode to enter; typing is filtering.
+	typeFilter(&table, "dr")
+	assert.Equal(t, 3, visibleRowCount(table.view(120)))
+	assert.Contains(t, table.view(120), "filter: dr")
+
+	typeFilter(&table, "um")
+	assert.Equal(t, 2, visibleRowCount(table.view(120)), "'drum' drops Drop-In")
+
+	// Backspace widens it again.
+	table.update(tea.KeyMsg{Type: tea.KeyBackspace})
+	table.update(tea.KeyMsg{Type: tea.KeyBackspace})
+	assert.Equal(t, 3, visibleRowCount(table.view(120)))
+	assert.Contains(t, table.view(120), "filter: dr")
+
+	// Enter is never the table's: it selects, whatever is typed.
+	assert.False(t, table.update(tea.KeyMsg{Type: tea.KeyEnter}))
+	assert.Equal(t, 3, visibleRowCount(table.view(120)))
+
+	// clearFilter is what esc reaches for, and it reports whether it did
+	// anything so the caller knows to go back instead.
+	assert.True(t, table.clearFilter())
+	assert.Equal(t, 4, visibleRowCount(table.view(120)))
+	assert.False(t, table.clearFilter())
+}
+
+// A filter that matches nothing says so, rather than showing an empty frame.
+func TestRowTable_FilterMatchingNothing(t *testing.T) {
+	table := newRowTable([]string{"NAME", "DETAIL"}, fakeRows(3), true, 120, 44)
+
+	typeFilter(&table, "zzz")
+
+	assert.Contains(t, table.view(120), "nothing matches")
+	assert.Nil(t, table.selected())
+}
+
+// The cursor addresses the filtered rows, so selecting after a filter returns
+// the row the user is actually looking at.
+func TestRowTable_SelectionFollowsTheFilter(t *testing.T) {
+	table := newRowTable([]string{"NAME", "DETAIL"}, fakeRows(20), true, 120, 44)
+
+	typeFilter(&table, "row-19")
+
+	row := table.selected()
+	require.NotNil(t, row)
+	assert.Equal(t, 19, row.value)
+}
+
+// A list longer than the window says where you are in it.
+func TestRowTable_ReportsPositionWhenScrolling(t *testing.T) {
+	table := newRowTable([]string{"NAME", "DETAIL"}, fakeRows(200), true, 120, 44)
+
+	assert.Contains(t, table.view(120), fmt.Sprintf("1 of %d", 200))
+
+	table.update(tea.KeyMsg{Type: tea.KeyDown})
+	assert.Contains(t, table.view(120), fmt.Sprintf("2 of %d", 200))
+}
+
+// One very long value must not push the other columns off the screen.
+func TestColumnsFor_CapsAnOutlier(t *testing.T) {
+	long := strings.Repeat("x", 200)
+	columns := columnsFor([]string{"NAME", "ID"},
+		[]tableRow{{cells: []string{long, "67a554bbfef3a4ce2ab6700"}}}, 120)
+
+	// Column 0 is the cursor marker, so the data columns start at 1.
+	assert.LessOrEqual(t, columns[1].Width, maxColumnWidth)
+	assert.Equal(t, len("67a554bbfef3a4ce2ab6700"), columns[2].Width,
+		"the id column keeps its natural width")
+}


### PR DESCRIPTION
# RATIONALE

The interactive half of `dr workload config`: eleven screens over one shared answer set, with free back-navigation. This completes the feature.

It is the largest PR of the four and cannot be split further. The widgets (`table`, `choice`, `envtable`, `style`) are unexported, so landing them ahead of their consumer fails `golangci-lint`'s `unused`, and `model.go` and `screens.go` are mutually referential. About 1,700 of the lines are tests.

## CHANGES

**`model.go`** — one model for every screen, because they share one answer set and moving backwards has to be free. Screens: binding, name, kind, A2A, source, execution environment, entrypoint, image, settings, env, confirm. Which ones a run visits depends on the answers.

Back-navigation re-enters a screen rather than just re-rendering it, and the picker restores its cursor to the answer given there. Without both, walking back and forward silently changed the answer to whatever happened to be first in the list.

**`screens.go`** — the renderers, `$EDITOR` handoff, and the confirm screen. A bound workload sees a diff against the live object rather than a plain preview, because confirming is consenting to change something already running. That is the one use of `go-udiff`, which is why `go.mod` moves it from indirect to direct here.

**`table.go`** — `rowTable` over `bubbles/table`, adding the two things it has no opinion about: type-to-filter and a value carried alongside each row. **There is no filter mode.** Typing filters, arrows move, enter selects, and each means the same thing at every moment. The earlier design had a mode entered with `/`, inside which enter meant "accept the filter" while the legend still said "select": two meanings for one key with no way to tell which was live.

**`choice.go`, `envtable.go`, `style.go`** — the single-select list, the per-row env table where each row cycles between config, secret and local, and the shared palette drawn from `tui/styles.go`.

**`interactive.go`** — the plumbing only the interactive flow needs: the two picker test seams, their result caps, and `partialDraft`, which is `draft()` without the parts the flags could not settle. It sits apart from `run.go` so the headless command does not carry listing calls it never makes.

## NOTES FOR REVIEW

Two bug shapes recurred through development and are worth watching for:

1. **Any "record the answer" step on a bound workload needs an `if changed` guard.** Without one, re-confirming an unchanged screen overwrites a live value with the wizard's idea of a default. This is how a bound NIM got silently rewritten to a service.
2. **A live document must be edited in place, never rebuilt from the `Draft` struct**, which models only the subset the wizard asks about.

The TUI draws to stderr via `tea.WithOutput`. Drawing to stdout would corrupt `-o json`.

## TESTING

Driven through the real model rather than the headless path. That distinction is load-bearing: an earlier round of manual verification went through the headless path only and missed a startup panic on the first screen, because the picker was a zero-value `list.Model`.

- Back-and-forth tests for every screen that records an answer, including the generated-build pair and the A2A toggle.
- The bound-workload cases: kind the wizard cannot author is kept, a rejected source keeps the live image, sizing flags still apply.
- Resize is exercised on every screen.
- `TestInteractiveOutput_NeverStdout` holds the stderr guarantee.
- `task lint` clean on linux, darwin and windows; `task test` green.

## RELATED

Stacked on the headless-command PR. Last of four for RAPTOR-18975.

Follow-ups already split out: `--import-env` and credential creation (RAPTOR sub-task 4b), the NIM track (4c).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new interactive path that can bind to live workloads and classify `.env` secrets into manifests, but writes only after confirm/diff and is covered by extensive regression tests. Label sync unavailable: no GitHub label write access from this review.
> 
> **Overview**
> Completes `dr workload config` with an **interactive Bubble Tea wizard**: eleven screens over one shared answer set, free back-navigation, and a confirm step that writes the manifest.
> 
> Users can bind to an existing workload (live spec downloaded first) or create a new one, then walk kind/A2A, image source (Dockerfile, managed EE, or published image), runtime settings, and an overridable `.env` classification table. Bound runs show a **unified diff** against the live object before write; `[e]` opens `$EDITOR`. Output stays on stderr so JSON/`-o` stays clean.
> 
> Replaces the previous “interactive not available yet” stub. Adds `choice`, `rowTable`, `envTable`, and shared styling widgets, plus extensive model/regression tests for back-navigation, bind safety, and secret handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d044d969fb5617c3481df914d8b5904062b26e2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->