### PR TITLE
[RAPTOR-18977] feat(workload): the replacement and credential clients

### DIFF
--- a/internal/workload/credential.go
+++ b/internal/workload/credential.go
@@ -1,0 +1,51 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// Credential is the slice of a stored DataRobot credential this CLI needs:
+// enough to confirm one exists and to name it back to the user. The secret
+// itself is never returned by the API and never wanted here.
+type Credential struct {
+	CredentialID   string `json:"credentialId"`
+	Name           string `json:"name"`
+	CredentialType string `json:"credentialType"`
+}
+
+// GetCredential fetches a stored credential by id. A missing id comes back as
+// a 404 wrapped in *drapi.HTTPError.
+//
+// This is what verifies a dr-credential:<id>/<key> reference before it is
+// written into an artifact spec. Without the check a mistyped id survives
+// every local validation and only surfaces when the container fails to
+// start, long after the build has been paid for.
+func GetCredential(credentialID string) (*Credential, error) {
+	url, err := config.GetEndpointURL("/api/v2/credentials/" + escapeID(credentialID) + "/")
+	if err != nil {
+		return nil, err
+	}
+
+	var cred Credential
+
+	if err := drapi.GetJSON(url, "credential", &cred); err != nil {
+		return nil, err
+	}
+
+	return &cred, nil
+}

--- a/internal/workload/credential_test.go
+++ b/internal/workload/credential_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCredential_Decodes(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v2/credentials/66f1a2b3c4d5e6f7a8b9c0d1/", r.URL.Path)
+		fmt.Fprint(w, `{"credentialId":"66f1a2b3c4d5e6f7a8b9c0d1","name":"my-app/OPENAI_API_KEY","credentialType":"api_token"}`)
+	}))
+
+	cred, err := GetCredential("66f1a2b3c4d5e6f7a8b9c0d1")
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+	assert.Equal(t, "66f1a2b3c4d5e6f7a8b9c0d1", cred.CredentialID)
+	assert.Equal(t, "my-app/OPENAI_API_KEY", cred.Name)
+	assert.Equal(t, "api_token", cred.CredentialType)
+}
+
+// TestGetCredential_MissingIsAnError is the whole point of the call: a
+// reference to a credential that does not exist has to fail here, at plan
+// time, rather than when the container tries to start.
+func TestGetCredential_MissingIsAnError(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	_, err := GetCredential("does-not-exist")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+}
+
+// TestGetCredential_EscapesID keeps a pasted id with a slash in it from
+// walking out of the credentials route and hitting some other resource.
+func TestGetCredential_EscapesID(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/credentials/a%2Fb/", r.URL.EscapedPath())
+		fmt.Fprint(w, `{"credentialId":"x"}`)
+	}))
+
+	_, err := GetCredential("a/b")
+	require.NoError(t, err)
+}

--- a/internal/workload/replacement.go
+++ b/internal/workload/replacement.go
@@ -213,6 +213,16 @@ func GuardNoActiveReplacement(workloadID string) error {
 		return confirmWorkloadExists(workloadID)
 	}
 
+	// A settled replacement stays readable for a while after it ends, and
+	// WaitForReplacement returns the moment it sees a terminal status, so the
+	// record is usually still there when the next command looks. Refusing on
+	// it would block a retry, or a follow-up deploy, on a rollout that is
+	// already over, with a message that contradicts itself by reporting the
+	// status as "completed" while calling it in progress.
+	if IsTerminalReplacementStatus(active.Status) {
+		return nil
+	}
+
 	return fmt.Errorf(
 		"workload %s already has a replacement in progress (to artifact %s, status %s); wait for it to settle before starting another",
 		workloadID, active.ArtifactID, active.Status,
@@ -277,7 +287,10 @@ func WaitForReplacement(
 
 		if replacement == nil {
 			if lastSeen == nil {
-				return nil, fmt.Errorf("no active replacement found for workload %s immediately after starting one", workloadID)
+				// Only reachable when started was nil, since lastSeen begins
+				// as started: this is the attach path, and the caller asked
+				// to follow a rollout that is not running.
+				return nil, fmt.Errorf("no replacement is in flight for workload %s", workloadID)
 			}
 
 			return lastSeen, nil

--- a/internal/workload/replacement.go
+++ b/internal/workload/replacement.go
@@ -266,6 +266,13 @@ func confirmWorkloadExists(workloadID string) error {
 // an error unconditionally, which was wrong whenever the platform settled a
 // fast rollout before the first poll landed: passing started lets the wait
 // tell "it finished before I looked" from "it was never there".
+//
+// A settled rollout does not guarantee a terminal Status on the way out. When
+// the record is collected before the first poll lands, the seed is the only
+// record there is, so what comes back is started itself, carrying whatever
+// the POST answered, typically "submitted". A caller that renders a final
+// status should ask IsTerminalReplacementStatus rather than read a nil error
+// as "completed".
 func WaitForReplacement(
 	workloadID string,
 	started *Replacement,

--- a/internal/workload/replacement.go
+++ b/internal/workload/replacement.go
@@ -1,0 +1,329 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// Replacement statuses observed to be terminal. The platform's own docs name
+// only "completed" and "failed"; live testing against staging also produced
+// "errored", a candidate that never became healthy, which the platform then
+// clears with a 404 like any other settled replacement. Without treating
+// "errored" as a failure here, that 404 would read as a quiet success (see
+// WaitForReplacement).
+//
+// The non-terminal vocabulary is not documented anywhere, so
+// IsTerminalReplacementStatus treats an unrecognised status as still in
+// progress rather than guessing, the same stance IsTerminalBuildStatus takes.
+//
+// Known limitation, and the reason that stance is not free. A failure status
+// the platform adds later would be classified as still in progress, and if
+// the record is then cleared, WaitForReplacement reports the rollout as a
+// success. That "errored" had to be added at all is proof the vocabulary was
+// incomplete once already. Closing the hole properly means confirming after
+// the fact which artifact the workload ended up running, which needs a
+// verified answer about how quickly the workload reflects a completed
+// replacement; guessing at that would trade a rare false success for a
+// routine false failure. Worth settling the first time a rollout is driven
+// against a live instance.
+const (
+	ReplacementStatusCompleted = "completed"
+	ReplacementStatusFailed    = "failed"
+	ReplacementStatusErrored   = "errored"
+)
+
+// rollingStrategy is the only strategy the platform ships. Blue-green and
+// canary are on its roadmap, at which point this becomes a parameter.
+const rollingStrategy = "rolling"
+
+// Replacement is the resource behind GET, POST and DELETE on
+// /workloads/{id}/replacement/. The shape was confirmed live against staging:
+// the target artifact comes back as candidateArtifactId, not as artifactId,
+// which is what the platform's own example code implies. ArtifactID and
+// Status carry the polling and rollout logic; the rest are display fields.
+type Replacement struct {
+	ID         string    `json:"id"`
+	WorkloadID string    `json:"workloadId"`
+	ArtifactID string    `json:"candidateArtifactId"`
+	Status     string    `json:"status"`
+	Strategy   string    `json:"strategy,omitempty"`
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+}
+
+// IsTerminalReplacementStatus reports whether s is a status the replacement
+// will not progress from.
+func IsTerminalReplacementStatus(s string) bool {
+	switch s {
+	case ReplacementStatusCompleted, ReplacementStatusFailed, ReplacementStatusErrored:
+		return true
+	}
+
+	return false
+}
+
+// IsFailedReplacementStatus reports whether s is a terminal failure. On
+// failure the workload reverts to the artifact it was running before the
+// replacement started, so a failed rollout never promotes.
+func IsFailedReplacementStatus(s string) bool {
+	return s == ReplacementStatusFailed || s == ReplacementStatusErrored
+}
+
+// replacementURL builds the single route all three verbs share.
+func replacementURL(workloadID string) (string, error) {
+	return config.GetEndpointURL("/api/v2/workloads/" + escapeID(workloadID) + "/replacement/")
+}
+
+// GetActiveReplacement fetches the in-flight replacement for workloadID, if
+// there is one. The server answers 404 when none is active, which is the
+// expected "nothing to guard against" answer rather than an error, so it
+// becomes (nil, nil).
+//
+// That 404 is ambiguous and this function does not resolve it: the route
+// answers the same way for a workload that does not exist, and the body
+// saying which never reaches this layer, because drapi.Get discards it. A
+// caller that has not already established the workload exists should use
+// GuardNoActiveReplacement, which pays for one extra request to tell the two
+// apart, rather than reading (nil, nil) as proof of anything.
+func GetActiveReplacement(workloadID string) (*Replacement, error) {
+	url, err := replacementURL(workloadID)
+	if err != nil {
+		return nil, err
+	}
+
+	var replacement Replacement
+
+	if err := drapi.GetJSON(url, "replacement", &replacement); err != nil {
+		if isNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return &replacement, nil
+}
+
+// StartReplacement rolls workloadID's running artifact onto artifactID and
+// returns the created replacement, which should be handed to
+// WaitForReplacement so the wait knows a rollout really was started.
+//
+// It is not idempotent: called while a replacement is already in flight it
+// queues a second swap rather than rejecting, so callers guard with
+// GuardNoActiveReplacement first.
+//
+// Both artifacts must share draft or locked status; the platform rejects a
+// mismatch, which is why a locked workload has to have its successor locked
+// before this is called. That is not enforced here because the caller is the
+// one holding both statuses, and the lock has to happen between the guard and
+// this call.
+func StartReplacement(workloadID, artifactID string) (*Replacement, error) {
+	url, err := replacementURL(workloadID)
+	if err != nil {
+		return nil, err
+	}
+
+	body := map[string]string{
+		"artifactId": artifactID,
+		"strategy":   rollingStrategy,
+	}
+
+	var replacement Replacement
+
+	if err := drapi.PostJSON(url, "replacement", body, &replacement); err != nil {
+		return nil, err
+	}
+
+	return &replacement, nil
+}
+
+// CancelReplacement tears down an in-flight candidate, leaving the previous
+// version serving.
+//
+// A 404 means either that there was nothing to cancel or that the workload
+// does not exist, and the route does not say which, so this checks. Nothing
+// to cancel is success, since cancelling twice should be harmless and a
+// rollout that settled on its own has already reached the state the caller
+// wanted. A workload that does not exist is an error, because reporting a
+// successful cancel for a mistyped id would leave the real rollout running
+// while the user believes they stopped it.
+//
+// The response body is discarded, matching DeleteArtifact and DeleteWorkload.
+// This route is documented but, unlike the rest of this file, has not been
+// exercised against a live instance; if the platform answers 202 with a
+// "cancelling" status rather than tearing down synchronously, the first
+// caller will need to poll, and should confirm that on staging.
+func CancelReplacement(workloadID string) error {
+	url, err := replacementURL(workloadID)
+	if err != nil {
+		return err
+	}
+
+	if err := drapi.DeleteJSON(url, "replacement", nil, nil); err != nil {
+		if isNotFound(err) {
+			return confirmWorkloadExists(workloadID)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// GuardNoActiveReplacement refuses to proceed when workloadID already has a
+// replacement in flight, because POSTing another queues a second swap instead
+// of erroring. Callers should run it twice: once up front, so a doomed
+// command fails before it mutates anything, and once immediately before
+// StartReplacement, which is the guard that actually holds, since the live
+// state can change in between.
+//
+// Being the up-front check is why it does not simply trust an empty answer.
+// The replacement route returns the same 404 for "nothing in flight" and for
+// "no such workload", so an unchecked guard would wave through exactly the
+// mistyped id it exists to catch, and the command would go on to create and
+// possibly lock an artifact before discovering the target was never real.
+// One extra request on the quiet path buys that, and the quiet path is about
+// to spend minutes rolling a workload.
+func GuardNoActiveReplacement(workloadID string) error {
+	active, err := GetActiveReplacement(workloadID)
+	if err != nil {
+		return err
+	}
+
+	if active == nil {
+		return confirmWorkloadExists(workloadID)
+	}
+
+	return fmt.Errorf(
+		"workload %s already has a replacement in progress (to artifact %s, status %s); wait for it to settle before starting another",
+		workloadID, active.ArtifactID, active.Status,
+	)
+}
+
+// confirmWorkloadExists turns the replacement route's ambiguous 404 into a
+// definite answer. The message stays factual; naming the remedy is the
+// command layer's job, since only it knows whether the id came from a flag or
+// from a manifest.
+func confirmWorkloadExists(workloadID string) error {
+	if _, err := GetWorkload(workloadID); err != nil {
+		if isNotFound(err) {
+			return fmt.Errorf("workload %s does not exist or is not visible to this account", workloadID)
+		}
+
+		return fmt.Errorf("confirm workload %s exists: %w", workloadID, err)
+	}
+
+	return nil
+}
+
+// WaitForReplacement polls until the replacement reaches a terminal status,
+// is cleared after having been seen, or timeout expires. started is what
+// StartReplacement returned, and may be nil when attaching to a rollout this
+// process did not begin. onTick, if non-nil, is called with every poll's
+// result so a caller can show progress; it is never called with nil.
+//
+// It returns:
+//
+//   - the settled replacement and nil, when the rollout completed
+//   - the settled replacement and an error, when it failed, so the caller can
+//     still show what happened
+//   - the last-seen replacement and an error, on timeout, for the same reason
+//   - nil and an error, when a poll failed or nothing was ever active
+//
+// The two 404 cases mean opposite things, which is why this is not a plain
+// poll loop. Seen after a status, a 404 means the platform settled the
+// rollout and collected the record, which is success. Seen before any status,
+// it means nothing was ever active. That second case used to be reported as
+// an error unconditionally, which was wrong whenever the platform settled a
+// fast rollout before the first poll landed: passing started lets the wait
+// tell "it finished before I looked" from "it was never there".
+func WaitForReplacement(
+	workloadID string,
+	started *Replacement,
+	interval, timeout time.Duration,
+	onTick func(*Replacement),
+) (*Replacement, error) {
+	if interval <= 0 {
+		interval = defaultReplacementPollInterval
+	}
+
+	deadline := time.Now().Add(timeout)
+	lastSeen := started
+
+	for {
+		replacement, err := GetActiveReplacement(workloadID)
+		if err != nil {
+			return nil, fmt.Errorf("poll replacement for workload %s: %w", workloadID, err)
+		}
+
+		if replacement == nil {
+			if lastSeen == nil {
+				return nil, fmt.Errorf("no active replacement found for workload %s immediately after starting one", workloadID)
+			}
+
+			return lastSeen, nil
+		}
+
+		lastSeen = replacement
+
+		if onTick != nil {
+			onTick(replacement)
+		}
+
+		if IsTerminalReplacementStatus(replacement.Status) {
+			return replacement, terminalReplacementErr(workloadID, replacement.Status)
+		}
+
+		if time.Now().After(deadline) {
+			return replacement, fmt.Errorf("timeout waiting for replacement on workload %s after %s", workloadID, timeout)
+		}
+
+		time.Sleep(interval)
+	}
+}
+
+// defaultReplacementPollInterval keeps an exported poller from busy-spinning
+// when handed a non-positive interval. The CLI's own flags cannot produce one
+// (pollflags rejects it), but nothing about this function's signature says so.
+const defaultReplacementPollInterval = 2 * time.Second
+
+// terminalReplacementErr turns a terminal status into the error the caller
+// should return, or nil when the rollout succeeded. It is only meaningful for
+// a status IsTerminalReplacementStatus accepts; anything else reads as
+// success, which is why the single call site is behind that check.
+func terminalReplacementErr(workloadID, status string) error {
+	if !IsFailedReplacementStatus(status) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"replacement for workload %s ended with status %s; the workload reverted to its previous artifact",
+		workloadID, status,
+	)
+}
+
+// isNotFound reports whether err is the API's 404.
+func isNotFound(err error) bool {
+	var httpErr *drapi.HTTPError
+
+	return errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound
+}

--- a/internal/workload/replacement_test.go
+++ b/internal/workload/replacement_test.go
@@ -37,7 +37,9 @@ const (
 	workloadPath    = "/api/v2/workloads/wl-1/"
 )
 
-// notFound writes the platform's empty-replacement answer.
+// notFound writes the platform's empty-replacement answer: the 404 and the
+// notActiveBody that comes with it, so a test reading the response sees the
+// same pair the route sends.
 func notFound(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusNotFound)
 	fmt.Fprint(w, notActiveBody)
@@ -429,6 +431,13 @@ func TestWaitForReplacement_NotFoundOnFirstPollIsError(t *testing.T) {
 // record before the very first poll lands, so the wait never observes a
 // status. Handed what StartReplacement returned, it knows the rollout was
 // real and reports success instead of failing a deploy that worked.
+//
+// It also pins the two things that follow from the seed being the only record
+// there is. The status that comes back is the seed's own, non-terminal one,
+// which is why the docstring sends callers to IsTerminalReplacementStatus
+// before rendering it. And onTick stays silent, because it reports poll
+// results and this wait had none, rather than replaying the seed as if it
+// were an observation.
 func TestWaitForReplacement_StartedSeedsTheWait(t *testing.T) {
 	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
 		notFound(w)
@@ -436,10 +445,14 @@ func TestWaitForReplacement_StartedSeedsTheWait(t *testing.T) {
 
 	started := &Replacement{ArtifactID: "art-2", Status: "submitted"}
 
-	replacement, err := WaitForReplacement("wl-1", started, time.Millisecond, time.Second, nil)
+	replacement, err := WaitForReplacement("wl-1", started, time.Millisecond, time.Second, func(*Replacement) {
+		t.Error("onTick must not fire when the seed carries the wait")
+	})
 	require.NoError(t, err)
 	require.NotNil(t, replacement)
 	assert.Equal(t, "art-2", replacement.ArtifactID)
+	assert.Equal(t, "submitted", replacement.Status,
+		"the seed comes back as it was; a nil error here does not mean the status is terminal")
 }
 
 // TestWaitForReplacement_NonTerminalClearedViaNotFoundIsSuccess is the other

--- a/internal/workload/replacement_test.go
+++ b/internal/workload/replacement_test.go
@@ -320,6 +320,28 @@ func TestGuardNoActiveReplacement_SkipsTheExistenceCheckWhenOneIsActive(t *testi
 	assert.Zero(t, atomic.LoadInt32(&workloadFetches))
 }
 
+// TestGuardNoActiveReplacement_SettledReplacementDoesNotBlock covers the gap
+// between a rollout ending and the platform collecting its record.
+// WaitForReplacement returns the instant it sees a terminal status, so that
+// record is usually still readable when the next command looks. Treating it
+// as in-flight would refuse a retry, and would say so with a message naming
+// the status as "completed" while calling it in progress.
+func TestGuardNoActiveReplacement_SettledReplacementDoesNotBlock(t *testing.T) {
+	for _, status := range []string{
+		ReplacementStatusCompleted,
+		ReplacementStatusFailed,
+		ReplacementStatusErrored,
+	} {
+		t.Run(status, func(t *testing.T) {
+			serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+				fmt.Fprintf(w, `{"candidateArtifactId":"art-2","status":"%s"}`, status)
+			})
+
+			assert.NoError(t, GuardNoActiveReplacement("wl-1"))
+		})
+	}
+}
+
 func TestGuardNoActiveReplacement_PropagatesLookupFailure(t *testing.T) {
 	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -397,7 +419,9 @@ func TestWaitForReplacement_NotFoundOnFirstPollIsError(t *testing.T) {
 	replacement, err := WaitForReplacement("wl-1", nil, time.Millisecond, time.Second, nil)
 	require.Error(t, err)
 	assert.Nil(t, replacement)
-	assert.Contains(t, err.Error(), "no active replacement")
+	assert.Contains(t, err.Error(), "no replacement is in flight")
+	assert.NotContains(t, err.Error(), "after starting one",
+		"this branch is only reachable when the caller did not start one")
 }
 
 // TestWaitForReplacement_StartedSeedsTheWait covers the race the unseeded

--- a/internal/workload/replacement_test.go
+++ b/internal/workload/replacement_test.go
@@ -1,0 +1,525 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// notActiveBody is what the platform answers when nothing is in flight.
+	// The same 404 also means "no such workload", which is the ambiguity
+	// GuardNoActiveReplacement and CancelReplacement have to resolve.
+	notActiveBody = `{"detail":"There is no active replacement for this workload."}`
+
+	replacementPath = "/api/v2/workloads/wl-1/replacement/"
+	workloadPath    = "/api/v2/workloads/wl-1/"
+)
+
+// notFound writes the platform's empty-replacement answer.
+func notFound(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNotFound)
+	fmt.Fprint(w, notActiveBody)
+}
+
+// serveReplacement answers the replacement route with handler, and the
+// workload route as a workload that exists. Tests that care about a missing
+// workload override the second route themselves.
+func serveReplacement(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.Handle(replacementPath, handler)
+	mux.HandleFunc(workloadPath, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":"wl-1","name":"my-app","status":"running"}`)
+	})
+
+	serveAPI(t, mux)
+}
+
+func TestIsTerminalReplacementStatus(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{ReplacementStatusCompleted, true},
+		{ReplacementStatusFailed, true},
+		{ReplacementStatusErrored, true},
+		{"submitted", false},
+		{"initializing", false},
+		{"candidate-warming", false},
+		{"switching", false},
+		{"", false},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, IsTerminalReplacementStatus(c.status), "status %q", c.status)
+	}
+}
+
+func TestIsFailedReplacementStatus(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{ReplacementStatusFailed, true},
+		{ReplacementStatusErrored, true},
+		{ReplacementStatusCompleted, false},
+		{"submitted", false},
+		{"", false},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, IsFailedReplacementStatus(c.status), "status %q", c.status)
+	}
+}
+
+// TestReplacement_TimestampsMarshalPlainly guards against reintroducing
+// omitempty on the time.Time fields. encoding/json never treats a struct as
+// empty, so the tag does nothing and a zero timestamp would print as year 1
+// the moment a renderer exists.
+func TestReplacement_TimestampsMarshalPlainly(t *testing.T) {
+	var r Replacement
+
+	require.NoError(t, json.Unmarshal([]byte(`{"candidateArtifactId":"art-2","status":"submitted"}`), &r))
+
+	encoded, err := json.Marshal(r)
+	require.NoError(t, err)
+	assert.Contains(t, string(encoded), `"createdAt":"0001-01-01T00:00:00Z"`,
+		"the zero value must be visible rather than silently omitted, matching Build and Artifact")
+}
+
+// TestGetActiveReplacement_Decodes pins the field name the platform actually
+// uses. Its own example code says artifactId; the wire says
+// candidateArtifactId, and reading the wrong one leaves the rollout unable to
+// tell which artifact it is waiting for.
+func TestGetActiveReplacement_Decodes(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		fmt.Fprint(w, `{"id":"rep-1","workloadId":"wl-1","candidateArtifactId":"art-2","status":"submitted","strategy":"rolling"}`)
+	})
+
+	replacement, err := GetActiveReplacement("wl-1")
+	require.NoError(t, err)
+	require.NotNil(t, replacement)
+	assert.Equal(t, "art-2", replacement.ArtifactID)
+	assert.Equal(t, "submitted", replacement.Status)
+}
+
+func TestGetActiveReplacement_404ReturnsNilNil(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		notFound(w)
+	})
+
+	replacement, err := GetActiveReplacement("wl-1")
+	require.NoError(t, err)
+	assert.Nil(t, replacement)
+}
+
+func TestGetActiveReplacement_OtherErrorPropagates(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := GetActiveReplacement("wl-1")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+}
+
+// TestReplacementRoute_EscapesID keeps a pasted id from walking out of the
+// replacement route. It matters more here than elsewhere because the same
+// route carries all three verbs, one of which mutates.
+func TestReplacementRoute_EscapesID(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/workloads/a%2Fb/replacement/", r.URL.EscapedPath())
+		fmt.Fprint(w, `{"candidateArtifactId":"art-2","status":"submitted"}`)
+	}))
+
+	_, err := GetActiveReplacement("a/b")
+	require.NoError(t, err)
+}
+
+func TestStartReplacement_PostsArtifactIDAndRollingStrategy(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var body map[string]any
+
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "art-2", body["artifactId"])
+		assert.Equal(t, "rolling", body["strategy"])
+
+		fmt.Fprint(w, `{"candidateArtifactId":"art-2","status":"submitted"}`)
+	})
+
+	replacement, err := StartReplacement("wl-1", "art-2")
+	require.NoError(t, err)
+	assert.Equal(t, "art-2", replacement.ArtifactID)
+	assert.Equal(t, "submitted", replacement.Status)
+}
+
+// TestStartReplacement_ErrorPropagates covers the only call in this file that
+// changes production state. A 409 here is the platform refusing the swap, for
+// instance because the two artifacts disagree on draft-versus-locked status,
+// and the caller has to see it rather than press on.
+func TestStartReplacement_ErrorPropagates(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprint(w, `{"detail":"candidate artifact must be locked"}`)
+	})
+
+	replacement, err := StartReplacement("wl-1", "art-2")
+	require.Error(t, err)
+	assert.Nil(t, replacement)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "must be locked", "the server's reason has to survive to the user")
+}
+
+func TestCancelReplacement_DeletesTheRoute(t *testing.T) {
+	var called int32
+
+	serveReplacement(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&called, 1)
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	require.NoError(t, CancelReplacement("wl-1"))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&called), "cancel must actually reach the server")
+}
+
+// TestCancelReplacement_AcceptsEverySuccessCode pins all three, because the
+// route has never been driven live and the platform may well answer 202 for
+// an asynchronous teardown rather than 204.
+func TestCancelReplacement_AcceptsEverySuccessCode(t *testing.T) {
+	for _, code := range []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(code)
+
+				if code != http.StatusNoContent {
+					fmt.Fprint(w, `{"status":"cancelling"}`)
+				}
+			})
+
+			assert.NoError(t, CancelReplacement("wl-1"))
+		})
+	}
+}
+
+// TestCancelReplacement_NothingToCancelIsSuccess keeps cancelling idempotent:
+// a rollout that settled between the decision to cancel and the call itself
+// leaves nothing to tear down, which is the outcome the caller wanted anyway.
+func TestCancelReplacement_NothingToCancelIsSuccess(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		notFound(w)
+	})
+
+	assert.NoError(t, CancelReplacement("wl-1"))
+}
+
+// TestCancelReplacement_MissingWorkloadIsAnError is the other half of the
+// same 404. Reporting a clean cancel for a mistyped id would tell the user
+// they stopped a rollout that is in fact still running.
+func TestCancelReplacement_MissingWorkloadIsAnError(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		notFound(w)
+	}))
+
+	err := CancelReplacement("wl-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+func TestCancelReplacement_OtherErrorPropagates(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	})
+
+	err := CancelReplacement("wl-1")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
+}
+
+func TestGuardNoActiveReplacement_PassesWhenNoneActive(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		notFound(w)
+	})
+
+	assert.NoError(t, GuardNoActiveReplacement("wl-1"))
+}
+
+// TestGuardNoActiveReplacement_MissingWorkloadFailsFast is the whole reason
+// the guard pays for a second request. Without it the mistyped id sails
+// through the up-front check, and the command goes on to create and possibly
+// lock an artifact, which cannot be undone, before finding out the target was
+// never real.
+func TestGuardNoActiveReplacement_MissingWorkloadFailsFast(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		notFound(w)
+	}))
+
+	err := GuardNoActiveReplacement("wl-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+}
+
+// TestGuardNoActiveReplacement_SkipsTheExistenceCheckWhenOneIsActive: a
+// replacement in flight is proof enough that the workload is there.
+func TestGuardNoActiveReplacement_SkipsTheExistenceCheckWhenOneIsActive(t *testing.T) {
+	var workloadFetches int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(replacementPath, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"candidateArtifactId":"art-9","status":"switching"}`)
+	})
+	mux.HandleFunc(workloadPath, func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&workloadFetches, 1)
+		fmt.Fprint(w, `{"id":"wl-1"}`)
+	})
+
+	serveAPI(t, mux)
+
+	err := GuardNoActiveReplacement("wl-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "art-9")
+	assert.Contains(t, err.Error(), "switching")
+	assert.Zero(t, atomic.LoadInt32(&workloadFetches))
+}
+
+func TestGuardNoActiveReplacement_PropagatesLookupFailure(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := GuardNoActiveReplacement("wl-1")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr, "a transport failure must not be reported as an in-flight replacement")
+	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+}
+
+func TestWaitForReplacement_TerminalCompletedReturnsNoError(t *testing.T) {
+	var hits int32
+
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		status := "submitted"
+		if atomic.AddInt32(&hits, 1) >= 2 {
+			status = ReplacementStatusCompleted
+		}
+
+		fmt.Fprintf(w, `{"candidateArtifactId":"art-2","status":"%s"}`, status)
+	})
+
+	replacement, err := WaitForReplacement("wl-1", nil, time.Millisecond, time.Second, nil)
+	require.NoError(t, err)
+	assert.Equal(t, ReplacementStatusCompleted, replacement.Status)
+}
+
+func TestWaitForReplacement_FailedReturnsError(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"candidateArtifactId":"art-2","status":"failed"}`)
+	})
+
+	replacement, err := WaitForReplacement("wl-1", nil, time.Millisecond, time.Second, nil)
+	require.Error(t, err)
+	require.NotNil(t, replacement, "a failure returns the final replacement alongside the error")
+	assert.Equal(t, ReplacementStatusFailed, replacement.Status)
+	assert.Contains(t, err.Error(), "reverted")
+}
+
+// TestWaitForReplacement_ErroredClearedViaNotFound guards the exact bug found
+// against staging: a candidate can settle as "errored", which is not one of
+// the two documented terminal statuses, and then have its record cleared with
+// a 404 moments later. If "errored" were not recognised as terminal, the
+// 404-after-seen branch would report the failure as a success.
+func TestWaitForReplacement_ErroredClearedViaNotFound(t *testing.T) {
+	var hits int32
+
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&hits, 1) == 1 {
+			fmt.Fprint(w, `{"candidateArtifactId":"art-2","status":"errored"}`)
+
+			return
+		}
+
+		notFound(w)
+	})
+
+	replacement, err := WaitForReplacement("wl-1", nil, time.Millisecond, time.Second, nil)
+	require.Error(t, err, "an errored candidate must not read as success just because it was later cleared")
+	require.NotNil(t, replacement)
+	assert.Equal(t, ReplacementStatusErrored, replacement.Status)
+}
+
+// TestWaitForReplacement_NotFoundOnFirstPollIsError still holds when the
+// caller has nothing to seed the wait with, which is the attach case.
+func TestWaitForReplacement_NotFoundOnFirstPollIsError(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		notFound(w)
+	})
+
+	replacement, err := WaitForReplacement("wl-1", nil, time.Millisecond, time.Second, nil)
+	require.Error(t, err)
+	assert.Nil(t, replacement)
+	assert.Contains(t, err.Error(), "no active replacement")
+}
+
+// TestWaitForReplacement_StartedSeedsTheWait covers the race the unseeded
+// version got wrong: the platform settles a fast rollout and collects the
+// record before the very first poll lands, so the wait never observes a
+// status. Handed what StartReplacement returned, it knows the rollout was
+// real and reports success instead of failing a deploy that worked.
+func TestWaitForReplacement_StartedSeedsTheWait(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		notFound(w)
+	})
+
+	started := &Replacement{ArtifactID: "art-2", Status: "submitted"}
+
+	replacement, err := WaitForReplacement("wl-1", started, time.Millisecond, time.Second, nil)
+	require.NoError(t, err)
+	require.NotNil(t, replacement)
+	assert.Equal(t, "art-2", replacement.ArtifactID)
+}
+
+// TestWaitForReplacement_NonTerminalClearedViaNotFoundIsSuccess is the other
+// side of the same coin: the platform settles a rollout and collects the
+// record between two polls, which is the ordinary happy path.
+func TestWaitForReplacement_NonTerminalClearedViaNotFoundIsSuccess(t *testing.T) {
+	var hits int32
+
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&hits, 1) == 1 {
+			fmt.Fprint(w, `{"candidateArtifactId":"art-2","status":"switching"}`)
+
+			return
+		}
+
+		notFound(w)
+	})
+
+	replacement, err := WaitForReplacement("wl-1", nil, time.Millisecond, time.Second, nil)
+	require.NoError(t, err)
+	require.NotNil(t, replacement)
+	assert.Equal(t, "switching", replacement.Status)
+}
+
+// TestWaitForReplacement_TimeoutReturnsTheLastSeen pins both halves of the
+// timeout contract. The error is obvious; the non-nil result is not, and it
+// is what lets a caller render what the rollout was doing when it gave up
+// instead of printing nothing.
+func TestWaitForReplacement_TimeoutReturnsTheLastSeen(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"candidateArtifactId":"art-2","status":"candidate-warming"}`)
+	})
+
+	replacement, err := WaitForReplacement("wl-1", nil, 5*time.Millisecond, 25*time.Millisecond, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+	require.NotNil(t, replacement, "a timeout must still say what the rollout was doing")
+	assert.Equal(t, "candidate-warming", replacement.Status)
+}
+
+// TestWaitForReplacement_PollsAtLeastOnce fixes the deadline check in place.
+// Moving it above the terminal check would make an already-settled rollout
+// with an exhausted budget report a timeout instead of its real outcome.
+func TestWaitForReplacement_PollsAtLeastOnce(t *testing.T) {
+	var hits int32
+
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		fmt.Fprint(w, `{"candidateArtifactId":"art-2","status":"completed"}`)
+	})
+
+	replacement, err := WaitForReplacement("wl-1", nil, time.Millisecond, 0, nil)
+	require.NoError(t, err)
+	assert.Equal(t, ReplacementStatusCompleted, replacement.Status)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&hits), "a zero budget still buys one look")
+}
+
+// TestWaitForReplacement_NonPositiveIntervalDoesNotSpin stops an exported
+// poller from hammering the API when handed a zero interval. The CLI's flags
+// cannot produce one, but the signature does not say so.
+func TestWaitForReplacement_NonPositiveIntervalDoesNotSpin(t *testing.T) {
+	var hits int32
+
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		fmt.Fprint(w, `{"candidateArtifactId":"art-2","status":"switching"}`)
+	})
+
+	_, err := WaitForReplacement("wl-1", nil, 0, 10*time.Millisecond, nil)
+	require.Error(t, err)
+	assert.LessOrEqual(t, atomic.LoadInt32(&hits), int32(2),
+		"a non-positive interval must fall back to the default, not busy-spin")
+}
+
+func TestWaitForReplacement_OnTickSeesEveryPoll(t *testing.T) {
+	var hits int32
+
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		status := "switching"
+		if atomic.AddInt32(&hits, 1) >= 3 {
+			status = ReplacementStatusCompleted
+		}
+
+		fmt.Fprintf(w, `{"candidateArtifactId":"art-2","status":"%s"}`, status)
+	})
+
+	var seen []string
+
+	_, err := WaitForReplacement("wl-1", nil, time.Millisecond, time.Second, func(r *Replacement) {
+		require.NotNil(t, r, "onTick is never handed a nil")
+
+		seen = append(seen, r.Status)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"switching", "switching", "completed"}, seen)
+}
+
+func TestWaitForReplacement_PropagatesPollFailure(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	})
+
+	_, err := WaitForReplacement("wl-1", nil, time.Millisecond, time.Second, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "poll replacement")
+}

--- a/internal/workload/testhelpers_test.go
+++ b/internal/workload/testhelpers_test.go
@@ -15,11 +15,33 @@
 package workload
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 )
+
+// serveAPI stands up an httptest server and points the CLI's endpoint at it,
+// with auth stubbed out. Pass an http.HandlerFunc to answer every route the
+// same way, or a *http.ServeMux when a test needs two routes to disagree.
+//
+// The cleanup order matters and is why this is one helper rather than three
+// lines repeated: cleanups run last-registered-first, so the endpoint is
+// reset before the server closes, and the server's Close blocks on any
+// outstanding request, so no handler is still running when the test ends.
+func serveAPI(t *testing.T, handler http.Handler) {
+	t.Helper()
+
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(handler)
+
+	t.Cleanup(srv.Close)
+
+	installEndpoint(t, srv.URL)
+}
 
 // installSkipAuth configures viper so drapi.AuthorizeRequest does not
 // attempt to verify a token over the network. Mirrors the helper in


### PR DESCRIPTION
# RATIONALE

`dr workload up` will apply an artifact change by rolling the workload onto a new immutable version, and will verify every `dr-credential:` reference before it mutates anything. Neither call exists in the CLI. This adds both, ported from the hackathon branch and narrowed by the decision that artifacts are never edited in place.

Nothing calls it yet, so there is no user-visible change. It is a PR of its own because it is the only part of the `up` work that does not sit on the unmerged `dr workload config` stack, so it can land while that is still in review.

## CHANGES

`replacement.go` covers one route three ways: GET the in-flight replacement, POST to start a rolling swap, DELETE to cancel. `credential.go` is the GET behind the manifest compiler's `CredentialRefs`. `GuardNoActiveReplacement` moves here from the prototype's command-level `rollout` package, since POSTing a second replacement queues another swap rather than rejecting, so every caller needs it.

Dropped as dead under immutability: the env-var reconcile, the in-place draft edit, `CreateArtifactClone`, `PatchPrimaryContainer`.

## NOTES

**The 404 is overloaded and each caller resolves it differently.** That route answers 404 for "nothing in flight", "already settled and collected", and "no such workload", and `drapi.Get` discards the body that says which. `GetActiveReplacement` stays cheap and documents the ambiguity. `GuardNoActiveReplacement` and `CancelReplacement` spend one extra GET, because waving a mistyped id through the fail-fast guard lets the command create and irreversibly lock an artifact against a workload that never existed, and a clean cancel for a typo tells the user they stopped a rollout that is still running.

**`WaitForReplacement` takes what `StartReplacement` returned.** Without that seed a first-poll 404 cannot be told from a rollout that finished before the wait looked, and the platform settling a fast swap in that window failed a deploy that worked.

**Two narrowings against the ticket.** The rolling strategy is posted bare, with no warmup or keep-old fields, because the prototype never sent them and their names are unverified. The draft-versus-locked rule is documented on `StartReplacement` rather than enforced: the caller holds both statuses and the locked path has to lock the successor between the guard and the start.

**One hole left open on purpose**, written up where the terminal statuses are declared. A failure status the platform adds later reads as in-progress, and once its record is cleared the wait reports success. Closing it means confirming which artifact the workload ended up running, which needs a verified answer on how fast a workload reflects a completed replacement; guessing trades a rare false success for a routine false failure. `CancelReplacement` is also the one function never driven live, so its tests pin all three success codes.

## RELATED

RAPTOR-18977. First of the `dr workload up` series; the rest stack on the `dr workload config` branches.
