### PR TITLE
Add assist plugin v0.1.35

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.35",
+          "url": "assist/assist-0.1.35.tar.xz",
+          "sha256": "16112f61778656f9b9e57c64ce87534cc482b1679650ad2d91d30639c85f8484",
+          "releaseDate": "2026-08-12"
+        },
+        {
           "version": "0.1.34",
           "url": "assist/assist-0.1.34.tar.xz",
           "sha256": "bbeec0796302b1ef586187cea371d15cab99f2bea0815a64ce9c86df6647dbf6",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.35 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.35
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.35
- **SHA256:** `16112f61778656f9b9e57c64ce87534cc482b1679650ad2d91d30639c85f8484`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1786556098.673659 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only index metadata with no runtime or application code changes; incorrect SHA256 would only affect plugin install verification for this version.
> 
> **Overview**
> **Adds `assist` v0.1.35** to the CLI plugin catalog in `docs/plugins/index.json`, prepended to the existing `assist` version list so installs resolve to the latest release.
> 
> The new entry points at `assist/assist-0.1.35.tar.xz` and includes the release **SHA256** and **releaseDate** (`2026-08-12`), matching the pattern used for prior `assist` versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ae158d595a61aa766a7bfebd25e1e545d4e7f64. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->