### PR TITLE
[RAPTOR-18976] feat(workload): read the manifest and the live workload

### DIFF
--- a/internal/workload/up/diff.go
+++ b/internal/workload/up/diff.go
@@ -1,0 +1,228 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+)
+
+// Change is one field the manifest asks for that the live object does not
+// already agree with.
+type Change struct {
+	// Path is where the field sits, in the file's own spelling, with
+	// name-keyed lists addressed by name rather than by index:
+	// artifact.spec.containerGroups[default].containers[primary].port.
+	Path string
+
+	// Want is the value the manifest asks for.
+	Want any
+
+	// Have is the live value, nil when Absent.
+	Have any
+
+	// Absent distinguishes a field the live object does not carry at all
+	// from one that carries a different value. The plan renders the first
+	// as an addition and the second as a change, and a reader needs to see
+	// the difference: adding a probe is not the same act as moving one.
+	Absent bool
+}
+
+// String renders a change the way the plan prints it.
+func (c Change) String() string {
+	if c.Absent {
+		return fmt.Sprintf("%s: %v", c.Path, format(c.Want))
+	}
+
+	return fmt.Sprintf("%s: %v -> %v", c.Path, format(c.Have), format(c.Want))
+}
+
+// Subset reports every leaf in want that the live side does not already
+// match. It is deliberately one-directional: whatever the file says, `up`
+// makes true, and whatever the file leaves out, `up` leaves alone.
+//
+// That asymmetry is the whole contract. A workload can carry a GPU bundle, a
+// sidecar and an autoscaling policy that the manifest has never heard of, and
+// none of it is drift. Deleting a line from the file stops managing a field;
+// it does not revert it. And because the comparison runs against the live
+// object rather than against a stored hash, an edit made in the UI shows up
+// here and is restored on the next run, which a hash of the last applied
+// spec could never see.
+func Subset(want, have map[string]any) []Change {
+	var changes []Change
+
+	walk("", want, have, true, &changes)
+
+	return changes
+}
+
+// walk compares one node. present says whether have was actually there, so a
+// key holding an explicit null is not confused with a key that is missing.
+func walk(path string, want, have any, present bool, out *[]Change) {
+	if !present {
+		*out = append(*out, Change{Path: path, Want: want, Absent: true})
+
+		return
+	}
+
+	switch w := want.(type) {
+	case map[string]any:
+		walkMap(path, w, have, out)
+	case []any:
+		walkList(path, w, have, out)
+	default:
+		if !equal(want, have) {
+			*out = append(*out, Change{Path: path, Want: want, Have: have})
+		}
+	}
+}
+
+// walkMap recurses into an object, in key order so the plan reads the same
+// way twice.
+func walkMap(path string, want map[string]any, have any, out *[]Change) {
+	h, ok := have.(map[string]any)
+	if !ok {
+		*out = append(*out, Change{Path: path, Want: want, Have: have})
+
+		return
+	}
+
+	for _, key := range slices.Sorted(maps.Keys(want)) {
+		hv, present := h[key]
+
+		walk(join(path, key), want[key], hv, present, out)
+	}
+}
+
+// walkList compares a list. The API's own lists come in two shapes and they
+// need opposite treatment: containerGroups, containers and environmentVars
+// are keyed by name and reorder freely, so matching them by index would
+// report a reordered file as a wholesale rewrite. Everything else, a
+// resourceBundles of plain strings or an autoscaling policy with no name to
+// key on, is compared whole, because a partial match of an unkeyed list
+// means nothing.
+func walkList(path string, want []any, have any, out *[]Change) {
+	h, ok := have.([]any)
+	if !ok {
+		*out = append(*out, Change{Path: path, Want: want, Have: have})
+
+		return
+	}
+
+	if !nameKeyed(want) {
+		if !equal(want, h) {
+			*out = append(*out, Change{Path: path, Want: want, Have: h})
+		}
+
+		return
+	}
+
+	live := byName(h)
+
+	for _, item := range want {
+		element, _ := item.(map[string]any)
+		name, _ := element["name"].(string)
+		at := fmt.Sprintf("%s[%s]", path, name)
+
+		counterpart, found := live[name]
+		if !found {
+			*out = append(*out, Change{Path: at, Want: element, Absent: true})
+
+			continue
+		}
+
+		walkMap(at, element, counterpart, out)
+	}
+}
+
+// nameKeyed reports whether every element is an object carrying a non-empty
+// name, which is what makes matching by name safe. An empty list is not
+// name-keyed: there is nothing to key on, and comparing it whole is right.
+func nameKeyed(list []any) bool {
+	if len(list) == 0 {
+		return false
+	}
+
+	for _, item := range list {
+		element, ok := item.(map[string]any)
+		if !ok {
+			return false
+		}
+
+		if name, ok := element["name"].(string); !ok || name == "" {
+			return false
+		}
+	}
+
+	return true
+}
+
+// byName indexes a live list so want's elements can find their counterparts.
+// Elements without a usable name are skipped rather than guessed at; they
+// simply have nothing for want to match, and want's own element then reads
+// as an addition.
+func byName(list []any) map[string]map[string]any {
+	indexed := make(map[string]map[string]any, len(list))
+
+	for _, item := range list {
+		element, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if name, ok := element["name"].(string); ok && name != "" {
+			indexed[name] = element
+		}
+	}
+
+	return indexed
+}
+
+// equal compares two decoded JSON values. Both sides reach here through
+// encoding/json, so numbers are already float64 on both and reflect is
+// enough; there is no int-versus-float mismatch to normalise away.
+func equal(a, b any) bool {
+	return reflect.DeepEqual(a, b)
+}
+
+// join builds a dotted path, skipping the leading dot at the root.
+func join(path, key string) string {
+	if path == "" {
+		return key
+	}
+
+	return path + "." + key
+}
+
+// format renders a value for the plan. Composite values are summarised
+// rather than dumped: a plan is a summary, and a reader who wants the whole
+// object has the file open next to it.
+func format(v any) string {
+	switch value := v.(type) {
+	case nil:
+		return "unset"
+	case string:
+		return value
+	case map[string]any:
+		return "{" + strings.Join(slices.Sorted(maps.Keys(value)), ", ") + "}"
+	case []any:
+		return fmt.Sprintf("[%d item(s)]", len(value))
+	default:
+		return fmt.Sprintf("%v", value)
+	}
+}

--- a/internal/workload/up/diff_test.go
+++ b/internal/workload/up/diff_test.go
@@ -1,0 +1,344 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// obj decodes a JSON literal the way both sides of a real comparison arrive:
+// the manifest through Compile's payload, the live object through the API.
+// Going via encoding/json in the test too is the point, since it is what
+// makes every number a float64 on both sides.
+func obj(t *testing.T, raw string) map[string]any {
+	t.Helper()
+
+	var m map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(raw), &m))
+
+	return m
+}
+
+// paths is the set of changed paths, which is what most cases care about.
+func paths(changes []Change) []string {
+	out := make([]string, 0, len(changes))
+	for _, c := range changes {
+		out = append(out, c.Path)
+	}
+
+	return out
+}
+
+func TestSubset_IdenticalIsNoDrift(t *testing.T) {
+	same := `{"type":"service","port":8080,"probe":{"path":"/health"}}`
+
+	assert.Empty(t, Subset(obj(t, same), obj(t, same)))
+}
+
+func TestSubset_ScalarDifference(t *testing.T) {
+	changes := Subset(
+		obj(t, `{"port":9090}`),
+		obj(t, `{"port":8080}`),
+	)
+
+	require.Len(t, changes, 1)
+	assert.Equal(t, "port", changes[0].Path)
+	assert.InDelta(t, 9090.0, changes[0].Want, 0)
+	assert.InDelta(t, 8080.0, changes[0].Have, 0)
+	assert.False(t, changes[0].Absent)
+}
+
+func TestSubset_MissingLiveFieldIsAnAddition(t *testing.T) {
+	changes := Subset(
+		obj(t, `{"readinessProbe":{"path":"/health"}}`),
+		obj(t, `{}`),
+	)
+
+	require.Len(t, changes, 1)
+	assert.Equal(t, "readinessProbe", changes[0].Path)
+	assert.True(t, changes[0].Absent, "a field the live object never had is an addition, not a change")
+	assert.Nil(t, changes[0].Have)
+}
+
+// TestSubset_LiveExtrasAreNotDrift is the contract the whole command rests
+// on. A workload can carry a GPU bundle, a sidecar and an autoscaling policy
+// the manifest has never heard of, and none of that is a reason to redeploy.
+func TestSubset_LiveExtrasAreNotDrift(t *testing.T) {
+	changes := Subset(
+		obj(t, `{"type":"service"}`),
+		obj(t, `{"type":"service","resourceBundles":["gpu.medium"],"storage":{"mode":"nimCache"}}`),
+	)
+
+	assert.Empty(t, changes)
+}
+
+// TestSubset_ExplicitNullLiveIsAChangeNotAnAddition separates "the key is
+// there holding null" from "the key is not there", which walk tracks with
+// its present flag. Both render differently in a plan.
+func TestSubset_ExplicitNullLiveIsAChangeNotAnAddition(t *testing.T) {
+	changes := Subset(
+		obj(t, `{"entrypoint":["uvicorn"]}`),
+		obj(t, `{"entrypoint":null}`),
+	)
+
+	require.Len(t, changes, 1)
+	assert.False(t, changes[0].Absent)
+	assert.Nil(t, changes[0].Have)
+}
+
+// TestSubset_NameKeyedListsMatchByNameNotIndex is why walkList exists. The
+// platform returns container groups in whatever order it likes; matching by
+// index would report a reordered live object as a wholesale rewrite and
+// trigger a rollout that changes nothing.
+func TestSubset_NameKeyedListsMatchByNameNotIndex(t *testing.T) {
+	want := obj(t, `{"containers":[
+		{"name":"primary","port":8080},
+		{"name":"sidecar","port":9000}
+	]}`)
+	have := obj(t, `{"containers":[
+		{"name":"sidecar","port":9000},
+		{"name":"primary","port":8080}
+	]}`)
+
+	assert.Empty(t, Subset(want, have), "reordering a name-keyed list is not drift")
+}
+
+func TestSubset_NameKeyedPathUsesTheName(t *testing.T) {
+	changes := Subset(
+		obj(t, `{"containerGroups":[{"name":"default","containers":[{"name":"primary","port":9090}]}]}`),
+		obj(t, `{"containerGroups":[{"name":"default","containers":[{"name":"primary","port":8080}]}]}`),
+	)
+
+	assert.Equal(t, []string{"containerGroups[default].containers[primary].port"}, paths(changes))
+}
+
+func TestSubset_NameKeyedElementMissingLiveIsOneAddition(t *testing.T) {
+	changes := Subset(
+		obj(t, `{"containers":[{"name":"primary","port":8080},{"name":"sidecar","port":9000}]}`),
+		obj(t, `{"containers":[{"name":"primary","port":8080}]}`),
+	)
+
+	require.Len(t, changes, 1, "a whole new container is one addition, not one per field")
+	assert.Equal(t, "containers[sidecar]", changes[0].Path)
+	assert.True(t, changes[0].Absent)
+}
+
+// TestSubset_UnkeyedListsCompareWhole covers resourceBundles (plain strings)
+// and autoscaling policies (objects with no name). Neither has anything to
+// key on, so a partial match would be meaningless.
+func TestSubset_UnkeyedListsCompareWhole(t *testing.T) {
+	unchanged := Subset(
+		obj(t, `{"resourceBundles":["gpu.medium"]}`),
+		obj(t, `{"resourceBundles":["gpu.medium"]}`),
+	)
+	assert.Empty(t, unchanged)
+
+	changed := Subset(
+		obj(t, `{"resourceBundles":["gpu.large"]}`),
+		obj(t, `{"resourceBundles":["gpu.medium"]}`),
+	)
+	assert.Equal(t, []string{"resourceBundles"}, paths(changed))
+
+	policies := Subset(
+		obj(t, `{"policies":[{"scalingMetric":"gpuCacheUtilization","target":80}]}`),
+		obj(t, `{"policies":[{"scalingMetric":"gpuCacheUtilization","target":70}]}`),
+	)
+	assert.Equal(t, []string{"policies"}, paths(policies))
+}
+
+func TestSubset_EmptyListsAreCompatible(t *testing.T) {
+	assert.Empty(t, Subset(obj(t, `{"containers":[]}`), obj(t, `{"containers":[]}`)))
+
+	changes := Subset(obj(t, `{"containers":[]}`), obj(t, `{"containers":[{"name":"primary"}]}`))
+	assert.Equal(t, []string{"containers"}, paths(changes),
+		"an empty list has nothing to key on, so it is compared whole")
+}
+
+func TestSubset_TypeMismatchIsOneChange(t *testing.T) {
+	changes := Subset(
+		obj(t, `{"probe":{"path":"/health"}}`),
+		obj(t, `{"probe":"/health"}`),
+	)
+
+	require.Len(t, changes, 1)
+	assert.Equal(t, "probe", changes[0].Path)
+
+	listVsScalar := Subset(
+		obj(t, `{"entrypoint":["uvicorn","app:app"]}`),
+		obj(t, `{"entrypoint":"uvicorn app:app"}`),
+	)
+	assert.Equal(t, []string{"entrypoint"}, paths(listVsScalar))
+}
+
+// TestSubset_OrderIsStable keeps a plan from reading differently on two runs
+// over the same inputs, which would make a diffed CI log useless.
+func TestSubset_OrderIsStable(t *testing.T) {
+	want := obj(t, `{"zebra":1,"alpha":2,"middle":3,"beta":4}`)
+	have := obj(t, `{"zebra":0,"alpha":0,"middle":0,"beta":0}`)
+
+	expected := []string{"alpha", "beta", "middle", "zebra"}
+
+	for range 5 {
+		assert.Equal(t, expected, paths(Subset(want, have)))
+	}
+}
+
+// liveSpecJSON is the artifact spec as manifest.NewLive hands it over: server
+// keys stripped, and crucially no imageUri or codeRef on the container that
+// says how to build itself, so a server-built image can never read as drift.
+const liveSpecJSON = `{
+  "type": "service",
+  "containerGroups": [
+    {
+      "name": "default",
+      "containers": [
+        {
+          "name": "vllm-server",
+          "primary": true,
+          "port": 8000,
+          "imageBuildConfig": {"dockerfile": {"source": "provided"}},
+          "environmentVars": [
+            {"name": "HF_HOME", "value": "/tmp/hf"},
+            {"name": "HUGGING_FACE_HUB_TOKEN", "source": "dr-credential",
+             "drCredentialId": "66f1a2b3c4d5e6f7a8b9c0d1", "key": "apiToken"}
+          ],
+          "readinessProbe": {"path": "/health", "port": 8000, "periodSeconds": 10},
+          "startupProbe": {"path": "/health", "port": 8000, "periodSeconds": 15, "failureThreshold": 60}
+        },
+        {"name": "metrics-bridge", "imageUri": "registry/vllm-metrics-bridge:v1"}
+      ]
+    }
+  ]
+}`
+
+// TestSubset_RealSpecUnchanged runs a manifest that says less than the live
+// object against that object. The sidecar, the second probe and the extra
+// probe timings are all things the file never mentions, and every one of
+// them must stay invisible.
+func TestSubset_RealSpecUnchanged(t *testing.T) {
+	file := obj(t, `{
+	  "type": "service",
+	  "containerGroups": [
+	    {
+	      "name": "default",
+	      "containers": [
+	        {
+	          "name": "vllm-server",
+	          "primary": true,
+	          "port": 8000,
+	          "imageBuildConfig": {"dockerfile": {"source": "provided"}},
+	          "readinessProbe": {"path": "/health", "port": 8000}
+	        }
+	      ]
+	    }
+	  ]
+	}`)
+
+	assert.Empty(t, Subset(file, obj(t, liveSpecJSON)))
+}
+
+// TestSubset_RealSpecDrift changes exactly two things and expects exactly two
+// findings, addressed by name rather than by position.
+func TestSubset_RealSpecDrift(t *testing.T) {
+	file := obj(t, `{
+	  "type": "service",
+	  "containerGroups": [
+	    {
+	      "name": "default",
+	      "containers": [
+	        {
+	          "name": "vllm-server",
+	          "port": 8080,
+	          "readinessProbe": {"path": "/ready", "port": 8000}
+	        }
+	      ]
+	    }
+	  ]
+	}`)
+
+	assert.Equal(t, []string{
+		"containerGroups[default].containers[vllm-server].port",
+		"containerGroups[default].containers[vllm-server].readinessProbe.path",
+	}, paths(Subset(file, obj(t, liveSpecJSON))))
+}
+
+// TestSubset_CredentialRefComparesAsAnObject checks the compiled form of the
+// dr-credential shorthand round-trips against what the platform stores. The
+// manifest is compiled before it gets here, so both sides are the expanded
+// object and the secret's value is nowhere near the comparison.
+func TestSubset_CredentialRefComparesAsAnObject(t *testing.T) {
+	file := obj(t, `{"containers":[{"name":"vllm-server","environmentVars":[
+		{"name":"HUGGING_FACE_HUB_TOKEN","source":"dr-credential",
+		 "drCredentialId":"66f1a2b3c4d5e6f7a8b9c0d1","key":"apiToken"}
+	]}]}`)
+	live := obj(t, `{"containers":[{"name":"vllm-server","environmentVars":[
+		{"name":"HF_HOME","value":"/tmp/hf"},
+		{"name":"HUGGING_FACE_HUB_TOKEN","source":"dr-credential",
+		 "drCredentialId":"66f1a2b3c4d5e6f7a8b9c0d1","key":"apiToken"}
+	]}]}`)
+
+	assert.Empty(t, Subset(file, live),
+		"a variable the file does not mention, and a matching credential ref, are both quiet")
+
+	rotated := obj(t, `{"containers":[{"name":"vllm-server","environmentVars":[
+		{"name":"HUGGING_FACE_HUB_TOKEN","source":"dr-credential",
+		 "drCredentialId":"aaaaaaaaaaaaaaaaaaaaaaaa","key":"apiToken"}
+	]}]}`)
+
+	assert.Equal(t,
+		[]string{"containers[vllm-server].environmentVars[HUGGING_FACE_HUB_TOKEN].drCredentialId"},
+		paths(Subset(rotated, live)))
+}
+
+func TestSubset_RuntimeHalf(t *testing.T) {
+	live := obj(t, `{"containerGroups":[{
+		"name":"default",
+		"resourceBundles":["gpu.medium"],
+		"autoscaling":{"enabled":true,"minReplicaCount":1,"maxReplicaCount":4},
+		"containers":[
+			{"name":"vllm-server","resourceAllocation":{"cpu":3,"memory":"22GB","gpu":1}},
+			{"name":"metrics-bridge","resourceAllocation":{"cpu":0.5,"memory":"2GB"}}
+		]
+	}]}`)
+
+	file := obj(t, `{"containerGroups":[{
+		"name":"default",
+		"containers":[{"name":"vllm-server","resourceAllocation":{"cpu":4,"memory":"22GB"}}]
+	}]}`)
+
+	assert.Equal(t,
+		[]string{"containerGroups[default].containers[vllm-server].resourceAllocation.cpu"},
+		paths(Subset(file, live)),
+		"the bundle, the autoscaling block and the sidecar are all unmentioned, so all quiet")
+}
+
+func TestChange_String(t *testing.T) {
+	assert.Equal(t, "runtime.replicaCount: 1 -> 3",
+		Change{Path: "runtime.replicaCount", Have: 1, Want: 3}.String())
+
+	assert.Equal(t, "readinessProbe: {path, port}",
+		Change{Path: "readinessProbe", Absent: true, Want: map[string]any{"path": "/health", "port": 8080}}.String())
+
+	assert.Equal(t, "importance: unset -> low",
+		Change{Path: "importance", Have: nil, Want: "low"}.String())
+
+	assert.Equal(t, "entrypoint: [1 item(s)] -> [2 item(s)]",
+		Change{Path: "entrypoint", Have: []any{"a"}, Want: []any{"a", "b"}}.String())
+}

--- a/internal/workload/up/doc.go
+++ b/internal/workload/up/doc.go
@@ -1,0 +1,51 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package up is the deploy behind `dr workload up`: read the manifest and the
+// live workload, work out what differs, and later apply only that.
+//
+// A deploy is a function of the repository checkout and nothing else. This
+// package never reads .env and never expands shell variables into a deploy.
+// Anything a container needs at runtime is in the manifest, as a literal or
+// as a credential reference; anything kept only in .env would not reach the
+// container, which is why importing it is the setup wizard's job and happens
+// once, not on every deploy.
+//
+// Drift is measured against the running object, not against a record of the
+// last deploy, and it is one-directional. Whatever the file says, `up` makes
+// true; whatever the file leaves out, `up` leaves alone. So a workload can
+// carry a GPU bundle, a sidecar and an autoscaling policy this CLI has no
+// vocabulary for and none of it is drift, while an edit made in the UI to a
+// field the file does name is reported and restored. Deleting a line stops
+// managing a field rather than reverting it. A stored hash of the last
+// applied spec could satisfy none of that: it cannot see the UI edit, and it
+// is absent in a fresh CI clone.
+//
+// Reading is split from deciding. Load turns a directory into a validated,
+// compiled manifest; Look turns a workload id into the live spec, the live
+// runtime and a State. Neither judges what it finds: a manifest that is
+// missing and a workload that has been deleted are both reported as facts,
+// because whether either is fatal depends on what the caller is permitted to
+// do about it, and only the command knows that.
+//
+// The comparison is done on the compiled payload rather than the file, so the
+// dr-credential shorthand is already expanded and a credential reference does
+// not read as a permanent difference against the object form the platform
+// stores. It is done on the server's own documents rather than typed structs,
+// because a typed round trip silently drops every field this release has not
+// heard of, and half the point is that those survive.
+//
+// Non-scope: no terminal output and no cobra. Rendering a plan and running
+// the phases belong to the command; this package hands back values.
+package up

--- a/internal/workload/up/load.go
+++ b/internal/workload/up/load.go
@@ -1,0 +1,145 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/datarobot/cli/internal/workload/manifest"
+)
+
+// ErrNoManifest reports that no manifest was found on the walk upward from
+// the starting directory. It is a sentinel rather than a failure because the
+// two callers want opposite things from it: on a terminal `up` opens the
+// setup wizard and carries on, while a non-interactive one stops and names
+// `dr workload config`. Deciding which is the command's job, not this
+// package's.
+var ErrNoManifest = errors.New("no " + manifest.FileName + " manifest")
+
+// Loaded is everything the deploy needs from disk, read and checked once.
+type Loaded struct {
+	// Path is the manifest itself.
+	Path string
+
+	// ProjectDir is the directory holding it, which is the root of the code
+	// that gets synced and where the local state directory lives. It is not
+	// necessarily the directory `up` was pointed at: the manifest is found by
+	// walking upward, the same way git finds its repository, so running from
+	// a subdirectory deploys the whole project rather than the fragment the
+	// shell happened to be sitting in.
+	ProjectDir string
+
+	// Manifest is the parse tree, kept so later stages can ask it questions
+	// without re-reading the file.
+	Manifest *manifest.Manifest
+
+	// Compiled is the create payload with the CLI's two conveniences resolved:
+	// workloadId lifted out, and every dr-credential shorthand expanded.
+	Compiled *manifest.Compiled
+}
+
+// WorkloadID is the binding the file carries, "" when the workload has not
+// been created yet.
+func (l Loaded) WorkloadID() string {
+	return l.Compiled.WorkloadID
+}
+
+// Spec is the artifact spec the file asks for, in the same shape the live
+// artifact comes back in, so the two can be compared directly. Reading it off
+// the compiled payload rather than the file is what makes the comparison fair:
+// the shorthand is already expanded, so a credential reference does not look
+// like drift against the object form the platform stores.
+func (l Loaded) Spec() (map[string]any, error) {
+	payload, err := l.payload()
+	if err != nil {
+		return nil, err
+	}
+
+	artifact, _ := payload["artifact"].(map[string]any)
+	spec, _ := artifact["spec"].(map[string]any)
+
+	return spec, nil
+}
+
+// Runtime is the sizing half of the file, again in the live object's shape.
+func (l Loaded) Runtime() (map[string]any, error) {
+	payload, err := l.payload()
+	if err != nil {
+		return nil, err
+	}
+
+	runtime, _ := payload["runtime"].(map[string]any)
+
+	return runtime, nil
+}
+
+// payload decodes the compiled request. It is decoded per call rather than
+// cached because a plan asks for each half exactly once, and a cache here
+// would be a mutable field on a value type that is copied freely.
+func (l Loaded) payload() (map[string]any, error) {
+	var payload map[string]any
+
+	if err := json.Unmarshal(l.Compiled.Payload, &payload); err != nil {
+		return nil, fmt.Errorf("cannot read the compiled manifest: %w", err)
+	}
+
+	return payload, nil
+}
+
+// Load finds the manifest at or above dir, then parses, validates and
+// compiles it. Validation runs before anything reaches the network, so a
+// mistyped key costs milliseconds rather than a build.
+//
+// A missing manifest comes back as ErrNoManifest. A malformed one comes back
+// as *manifest.ValidationError, whose findings each carry the line they sit
+// on, so the caller can print the file's own coordinates rather than a
+// paraphrase.
+func Load(dir string) (Loaded, error) {
+	path, err := manifest.Locate(dir)
+	if err != nil {
+		if errors.Is(err, manifest.ErrNotFound) {
+			// Locate's own message says the same thing in different words, so
+			// it is restated here rather than nested, and the sentinel stays
+			// the thing callers match on.
+			return Loaded{}, fmt.Errorf("%w in %s or any parent directory", ErrNoManifest, dir)
+		}
+
+		return Loaded{}, err
+	}
+
+	m, err := manifest.Load(path)
+	if err != nil {
+		return Loaded{}, err
+	}
+
+	if err := m.Validate(); err != nil {
+		return Loaded{}, err
+	}
+
+	compiled, err := m.Compile()
+	if err != nil {
+		return Loaded{}, err
+	}
+
+	return Loaded{
+		Path:       path,
+		ProjectDir: filepath.Dir(path),
+		Manifest:   m,
+		Compiled:   compiled,
+	}, nil
+}

--- a/internal/workload/up/load_test.go
+++ b/internal/workload/up/load_test.go
@@ -1,0 +1,258 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// boundManifest is a complete, valid file carrying both credential value
+// forms, so compilation has something real to expand.
+const boundManifest = `workloadId: 68b0aaaa0000000000000001
+name: my-app
+importance: low
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageUri: nginx:latest
+            environmentVars:
+              - name: LOG_LEVEL
+                value: debug
+              - name: OPENAI_API_KEY
+                value: dr-credential:68f0cccc0000000000000003/apiToken
+runtime:
+  containerGroups:
+    - name: default
+      replicaCount: 2
+      containers:
+        - name: primary
+          resourceAllocation:
+            cpu: 0.5
+            memory: 512MB
+`
+
+// writeManifest drops content at dir/.datarobot.yaml and returns the path.
+func writeManifest(t *testing.T, dir, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, manifest.FileName)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+func TestLoad_ReadsValidatesAndCompiles(t *testing.T) {
+	dir := t.TempDir()
+	path := writeManifest(t, dir, boundManifest)
+
+	loaded, err := Load(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, path, loaded.Path)
+	assert.Equal(t, dir, loaded.ProjectDir)
+	assert.Equal(t, "68b0aaaa0000000000000001", loaded.WorkloadID())
+	assert.Equal(t, "my-app", loaded.Manifest.Name())
+	require.Len(t, loaded.Compiled.CredentialRefs, 1)
+	assert.Equal(t, "68f0cccc0000000000000003", loaded.Compiled.CredentialRefs[0].CredentialID)
+}
+
+// TestLoad_WalksUpward is why ProjectDir exists as a separate field. Running
+// `up` from a subdirectory has to deploy the whole project, not the fragment
+// the shell happened to be in.
+func TestLoad_WalksUpward(t *testing.T) {
+	root := t.TempDir()
+	writeManifest(t, root, boundManifest)
+
+	nested := filepath.Join(root, "services", "api")
+	require.NoError(t, os.MkdirAll(nested, 0o750))
+
+	loaded, err := Load(nested)
+	require.NoError(t, err)
+	assert.Equal(t, root, loaded.ProjectDir, "the project root is where the manifest is, not where up was run")
+}
+
+// TestLoad_MissingIsASentinel keeps the wizard-or-error decision with the
+// command. Returning a plain error here would force every caller to match on
+// a message.
+func TestLoad_MissingIsASentinel(t *testing.T) {
+	_, err := Load(t.TempDir())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoManifest)
+}
+
+// TestLoad_InvalidCarriesLineNumbers is the whole reason validation runs
+// before anything touches the network: the user gets the file's own
+// coordinates, in milliseconds, instead of a server rejection after a build.
+func TestLoad_InvalidCarriesLineNumbers(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 80
+            imageUri: nginx:latest
+runtime:
+  containerGroups:
+    - name: default
+      replicaCount: 1
+      containers:
+        - name: primary
+          resourceAllocation: {cpu: 0.5, memory: 512MB}
+`)
+
+	_, err := Load(dir)
+	require.Error(t, err)
+
+	var invalid *manifest.ValidationError
+
+	require.ErrorAs(t, err, &invalid, "a bad manifest must arrive as the line-numbered type")
+	require.NotEmpty(t, invalid.Errors)
+	assert.Positive(t, invalid.Errors[0].Line, "every finding names the line it sits on")
+}
+
+func TestLoad_ForeignFileIsRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "version: 3\nservices:\n  web:\n    image: nginx\n")
+
+	_, err := Load(dir)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrNoManifest, "a file that is there but wrong is not the same as no file")
+}
+
+// TestLoaded_SpecAndRuntimeComeFromTheCompiledPayload is the pairing that
+// makes drift detection fair. Reading the spec off the raw file would leave
+// the credential shorthand unexpanded, and every bound workload would then
+// report a permanent, unfixable difference on that one variable.
+func TestLoaded_SpecAndRuntimeComeFromTheCompiledPayload(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, boundManifest)
+
+	loaded, err := Load(dir)
+	require.NoError(t, err)
+
+	spec, err := loaded.Spec()
+	require.NoError(t, err)
+	assert.Equal(t, "service", spec["type"])
+
+	groups, _ := spec["containerGroups"].([]any)
+	require.Len(t, groups, 1)
+
+	group, _ := groups[0].(map[string]any)
+	containers, _ := group["containers"].([]any)
+	require.Len(t, containers, 1)
+
+	container, _ := containers[0].(map[string]any)
+	vars, _ := container["environmentVars"].([]any)
+	require.Len(t, vars, 2)
+
+	secret, _ := vars[1].(map[string]any)
+	assert.Equal(t, "dr-credential", secret["source"])
+	assert.Equal(t, "68f0cccc0000000000000003", secret["drCredentialId"])
+	assert.Equal(t, "apiToken", secret["key"])
+	assert.NotContains(t, secret, "value", "the shorthand is replaced, not kept alongside")
+
+	runtime, err := loaded.Runtime()
+	require.NoError(t, err)
+
+	runtimeGroups, _ := runtime["containerGroups"].([]any)
+	require.Len(t, runtimeGroups, 1)
+}
+
+// TestLoaded_WorkloadIDIsStrippedFromThePayload: the binding is the CLI's own
+// key and the platform rejects it, so it has to be lifted out of the request
+// while staying readable on Loaded.
+func TestLoaded_WorkloadIDIsStrippedFromThePayload(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, boundManifest)
+
+	loaded, err := Load(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, "68b0aaaa0000000000000001", loaded.WorkloadID())
+	assert.NotContains(t, string(loaded.Compiled.Payload), "workloadId")
+}
+
+func TestLoaded_UnboundManifestHasNoWorkloadID(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, `name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageUri: nginx:latest
+runtime:
+  containerGroups:
+    - name: default
+      replicaCount: 1
+      containers:
+        - name: primary
+          resourceAllocation: {cpu: 0.5, memory: 512MB}
+`)
+
+	loaded, err := Load(dir)
+	require.NoError(t, err)
+	assert.Empty(t, loaded.WorkloadID())
+}
+
+func TestLoaded_PayloadDecodeFailureIsReported(t *testing.T) {
+	broken := Loaded{Compiled: &manifest.Compiled{Payload: []byte("{not json")}}
+
+	_, err := broken.Spec()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "compiled manifest")
+
+	_, err = broken.Runtime()
+	require.Error(t, err)
+}
+
+// TestLoad_ADirectoryAtThePathIsNotAManifest documents a surprise worth
+// knowing about: Locate tests for a regular file, so a directory with the
+// manifest's name is stepped over and the walk carries on upward. The effect
+// is that `up` reports no manifest rather than an unreadable one. That is the
+// manifest package's choice and the safer of the two, since it keeps a stray
+// directory from breaking a project whose real manifest is one level up.
+func TestLoad_ADirectoryAtThePathIsNotAManifest(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, manifest.FileName), 0o750))
+
+	_, err := Load(dir)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoManifest)
+}

--- a/internal/workload/up/look.go
+++ b/internal/workload/up/look.go
@@ -1,0 +1,146 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+)
+
+// Test seams for the two reads, replaced by this package's tests to keep the
+// plan off the network.
+var (
+	getWorkloadDocFn = workload.GetWorkloadDocument
+	getArtifactDocFn = workload.GetArtifactDocument
+)
+
+// Keys read off the raw documents. They are read before manifest.NewLive
+// cleans the spec and runtime blocks, because the cleaning strips exactly
+// these names as server bookkeeping.
+const (
+	keyStatus     = "status"
+	keyEndpoint   = "endpoint"
+	keyArtifactID = "artifactId"
+)
+
+// Live is the workload as the platform currently has it: the two cleaned
+// documents that drift is measured against, plus the few scalars the command
+// branches on or prints.
+//
+// The embedded manifest.Live is what the setup wizard already uses to bind to
+// a running workload, and it is the right shape here for the same reason. Its
+// Spec and Runtime are the server's own documents with the server's own
+// bookkeeping removed, so a block no release of this CLI has heard of still
+// takes part in the comparison instead of being silently dropped.
+type Live struct {
+	manifest.Live
+
+	// State is what the workload is doing, reduced to the branches that
+	// change the deploy.
+	State State
+
+	// ArtifactID is the artifact currently running, "" when there is none.
+	ArtifactID string
+
+	// Endpoint is the workload's stable URL. The platform assigns it at
+	// creation and it survives every rollout, so it is safe to print before
+	// the workload is actually serving.
+	Endpoint string
+
+	// Locked reports whether the running artifact is immutable. A locked
+	// artifact means production, and its successor has to be locked too
+	// before the platform will accept a replacement.
+	Locked bool
+}
+
+// Look fetches the live workload and the artifact it runs.
+//
+// An empty workloadID is not an error: it is a manifest that has never been
+// deployed, which reports StateUnbound and nothing else. A workload the
+// platform does not have is not an error either, only StateMissing. Both are
+// ordinary situations with different right answers, and choosing between them
+// belongs to the apply step, which is the part that knows whether it is
+// allowed to create something.
+func Look(workloadID string) (Live, error) {
+	if workloadID == "" {
+		return Live{State: StateUnbound}, nil
+	}
+
+	workloadDoc, err := getWorkloadDocFn(workloadID)
+	if err != nil {
+		if isNotFound(err) {
+			return Live{State: StateMissing}, nil
+		}
+
+		return Live{}, fmt.Errorf("cannot read workload %s: %w", workloadID, err)
+	}
+
+	artifactID := workloadDoc.String(keyArtifactID)
+
+	artifactDoc, err := artifactFor(artifactID)
+	if err != nil {
+		return Live{}, err
+	}
+
+	return Live{
+		Live:       manifest.NewLive(workloadID, workloadDoc, artifactDoc),
+		State:      stateFor(workloadDoc.String(keyStatus)),
+		ArtifactID: artifactID,
+		Endpoint:   workloadDoc.String(keyEndpoint),
+		Locked:     isLocked(artifactDoc.String(keyStatus)),
+	}, nil
+}
+
+// artifactFor reads the artifact a workload runs. A workload without one is
+// possible only in the moments around creation, and it is not a failure: the
+// spec simply compares as absent, which reads as "everything the file says is
+// an addition", which is exactly right for something not yet built.
+func artifactFor(artifactID string) (workload.Document, error) {
+	if artifactID == "" {
+		return nil, nil
+	}
+
+	doc, err := getArtifactDocFn(artifactID)
+	if err != nil {
+		if isNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("cannot read artifact %s: %w", artifactID, err)
+	}
+
+	return doc, nil
+}
+
+// isLocked compares case-insensitively because the platform's own docs
+// disagree with themselves about the casing of status enums.
+func isLocked(status string) bool {
+	return strings.EqualFold(status, workload.ArtifactStatusLocked)
+}
+
+// isNotFound reports whether err is the API's 404. The same three lines
+// appear at twenty-odd call sites across this repo; retiring them behind a
+// drapi helper is worth doing, but not from here.
+func isNotFound(err error) bool {
+	var httpErr *drapi.HTTPError
+
+	return errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound
+}

--- a/internal/workload/up/look_test.go
+++ b/internal/workload/up/look_test.go
@@ -1,0 +1,311 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// liveWorkloadJSON and liveArtifactJSON are shaped like the server's own
+// answers, carrying the things the CLI has no vocabulary for: autoscaling, a
+// GPU bundle, a sidecar, a credential-backed variable. Those are exactly what
+// a plan must not mistake for drift.
+const (
+	liveWorkloadJSON = `{
+  "id": "68b0c1d2e3f4a5b6c7d8e9f0",
+  "name": "gpt-oss-20b-vllm",
+  "status": "running",
+  "importance": "moderate",
+  "artifactId": "68a0000000000000000000a1",
+  "endpoint": "https://app.datarobot.com/workloads/68b0/",
+  "runtime": {
+    "containerGroups": [
+      {
+        "name": "default",
+        "resourceBundles": ["gpu.medium"],
+        "autoscaling": {"enabled": true, "minReplicaCount": 1, "maxReplicaCount": 4},
+        "containers": [
+          {"name": "vllm-server", "resourceAllocation": {"cpu": 3, "memory": "22GB", "gpu": 1}},
+          {"name": "metrics-bridge", "resourceAllocation": {"cpu": 0.5, "memory": "2GB"}}
+        ]
+      }
+    ]
+  }
+}`
+
+	liveArtifactJSON = `{
+  "id": "68a0000000000000000000a1",
+  "name": "gpt-oss-20b-vllm-artifact",
+  "status": "locked",
+  "spec": {
+    "type": "service",
+    "containerGroups": [
+      {
+        "name": "default",
+        "containers": [
+          {
+            "name": "vllm-server",
+            "primary": true,
+            "port": 8000,
+            "imageUri": "registry.internal/built-by-the-server:sha-abc123",
+            "imageBuildConfig": {
+              "dockerfile": {"source": "provided"},
+              "codeRef": {"datarobot": {"catalogId": "cat1", "catalogVersionId": "ver1"}}
+            },
+            "readinessProbe": {"path": "/health", "port": 8000}
+          },
+          {"name": "metrics-bridge", "imageUri": "registry/vllm-metrics-bridge:v1"}
+        ]
+      }
+    ]
+  }
+}`
+)
+
+func doc(t *testing.T, raw string) workload.Document {
+	t.Helper()
+
+	var d workload.Document
+
+	require.NoError(t, json.Unmarshal([]byte(raw), &d))
+
+	return d
+}
+
+// stubLive points both reads at canned documents and restores them after.
+func stubLive(t *testing.T, workloadJSON, artifactJSON string) {
+	t.Helper()
+
+	prevWorkload, prevArtifact := getWorkloadDocFn, getArtifactDocFn
+
+	getWorkloadDocFn = func(string) (workload.Document, error) { return doc(t, workloadJSON), nil }
+	getArtifactDocFn = func(string) (workload.Document, error) { return doc(t, artifactJSON), nil }
+
+	t.Cleanup(func() {
+		getWorkloadDocFn, getArtifactDocFn = prevWorkload, prevArtifact
+	})
+}
+
+// stubLiveErr points both reads at the same failure.
+func stubLiveErr(t *testing.T, err error) {
+	t.Helper()
+
+	prevWorkload, prevArtifact := getWorkloadDocFn, getArtifactDocFn
+
+	getWorkloadDocFn = func(string) (workload.Document, error) { return nil, err }
+	getArtifactDocFn = func(string) (workload.Document, error) { return nil, err }
+
+	t.Cleanup(func() {
+		getWorkloadDocFn, getArtifactDocFn = prevWorkload, prevArtifact
+	})
+}
+
+func notFoundErr() error {
+	return &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "https://example.invalid"}
+}
+
+// TestLook_UnboundNeedsNoRequests: a manifest that has never deployed has
+// nothing to look at, and asking the platform about an empty id would be a
+// guaranteed 404 dressed up as a lookup.
+func TestLook_UnboundNeedsNoRequests(t *testing.T) {
+	stubLiveErr(t, errors.New("no request should have been made"))
+
+	live, err := Look("")
+	require.NoError(t, err)
+	assert.Equal(t, StateUnbound, live.State)
+	assert.Empty(t, live.ArtifactID)
+}
+
+func TestLook_ReadsBothDocuments(t *testing.T) {
+	stubLive(t, liveWorkloadJSON, liveArtifactJSON)
+
+	live, err := Look("68b0c1d2e3f4a5b6c7d8e9f0")
+	require.NoError(t, err)
+
+	assert.Equal(t, StateRunning, live.State)
+	assert.Equal(t, "gpt-oss-20b-vllm", live.Name)
+	assert.Equal(t, "moderate", live.Importance)
+	assert.Equal(t, "68a0000000000000000000a1", live.ArtifactID)
+	assert.Equal(t, "gpt-oss-20b-vllm-artifact", live.ArtifactName)
+	assert.Equal(t, "https://app.datarobot.com/workloads/68b0/", live.Endpoint)
+	assert.True(t, live.Locked)
+	assert.NotEmpty(t, live.Spec)
+	assert.NotEmpty(t, live.Runtime)
+}
+
+// TestLook_StripsBuildOutputsFromTheSpec is the property that keeps a
+// server-built image from reading as drift forever. The container says how to
+// build itself, so the image the server produced and the code ref it produced
+// it from are both the server's business, not the file's.
+func TestLook_StripsBuildOutputsFromTheSpec(t *testing.T) {
+	stubLive(t, liveWorkloadJSON, liveArtifactJSON)
+
+	live, err := Look("wl-1")
+	require.NoError(t, err)
+
+	primary := primaryContainer(t, live.Spec)
+	assert.NotContains(t, primary, "imageUri", "the built image belongs to the server, not the manifest")
+
+	build, _ := primary["imageBuildConfig"].(map[string]any)
+	assert.NotContains(t, build, "codeRef")
+	assert.Contains(t, build, "dockerfile", "how to build is the file's business and must survive")
+}
+
+// TestLook_SpecSurvivesUnknownBlocks: the sidecar has no counterpart in
+// anything the CLI can express, and it still has to come through, because
+// Subset compares against it and a plan that dropped it would propose
+// deleting a running container.
+func TestLook_SpecSurvivesUnknownBlocks(t *testing.T) {
+	stubLive(t, liveWorkloadJSON, liveArtifactJSON)
+
+	live, err := Look("wl-1")
+	require.NoError(t, err)
+
+	groups, _ := live.Spec["containerGroups"].([]any)
+	require.Len(t, groups, 1)
+
+	group, _ := groups[0].(map[string]any)
+	containers, _ := group["containers"].([]any)
+	assert.Len(t, containers, 2, "the sidecar has to survive the trip")
+
+	runtimeGroups, _ := live.Runtime["containerGroups"].([]any)
+	require.Len(t, runtimeGroups, 1)
+
+	runtimeGroup, _ := runtimeGroups[0].(map[string]any)
+	assert.Contains(t, runtimeGroup, "resourceBundles")
+	assert.Contains(t, runtimeGroup, "autoscaling")
+}
+
+// TestLook_MissingWorkloadIsAStateNotAnError: whether a vanished workload is
+// fatal depends on what the caller is allowed to do about it, which this
+// layer does not know.
+func TestLook_MissingWorkloadIsAStateNotAnError(t *testing.T) {
+	stubLiveErr(t, notFoundErr())
+
+	live, err := Look("wl-gone")
+	require.NoError(t, err)
+	assert.Equal(t, StateMissing, live.State)
+	assert.Empty(t, live.Endpoint)
+}
+
+func TestLook_TransportFailurePropagates(t *testing.T) {
+	stubLiveErr(t, &drapi.HTTPError{StatusCode: http.StatusInternalServerError})
+
+	_, err := Look("wl-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot read workload wl-1")
+}
+
+// TestLook_MissingArtifactIsNotFatal covers the window around creation where
+// a workload exists but its artifact does not answer yet. An absent spec
+// makes every field the file names read as an addition, which is the right
+// description of something not built.
+func TestLook_MissingArtifactIsNotFatal(t *testing.T) {
+	prevWorkload, prevArtifact := getWorkloadDocFn, getArtifactDocFn
+
+	getWorkloadDocFn = func(string) (workload.Document, error) { return doc(t, liveWorkloadJSON), nil }
+	getArtifactDocFn = func(string) (workload.Document, error) { return nil, notFoundErr() }
+
+	t.Cleanup(func() { getWorkloadDocFn, getArtifactDocFn = prevWorkload, prevArtifact })
+
+	live, err := Look("wl-1")
+	require.NoError(t, err)
+	assert.Equal(t, StateRunning, live.State)
+	assert.Empty(t, live.Spec)
+	assert.NotEmpty(t, live.Runtime, "the runtime half lives on the workload and is unaffected")
+	assert.False(t, live.Locked)
+}
+
+func TestLook_ArtifactFailurePropagates(t *testing.T) {
+	prevWorkload, prevArtifact := getWorkloadDocFn, getArtifactDocFn
+
+	getWorkloadDocFn = func(string) (workload.Document, error) { return doc(t, liveWorkloadJSON), nil }
+	getArtifactDocFn = func(string) (workload.Document, error) {
+		return nil, &drapi.HTTPError{StatusCode: http.StatusBadGateway}
+	}
+
+	t.Cleanup(func() { getWorkloadDocFn, getArtifactDocFn = prevWorkload, prevArtifact })
+
+	_, err := Look("wl-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot read artifact")
+}
+
+func TestLook_WorkloadWithNoArtifactSkipsTheSecondRead(t *testing.T) {
+	var artifactReads int
+
+	prevWorkload, prevArtifact := getWorkloadDocFn, getArtifactDocFn
+
+	getWorkloadDocFn = func(string) (workload.Document, error) {
+		return doc(t, `{"id":"wl-1","name":"fresh","status":"submitted"}`), nil
+	}
+	getArtifactDocFn = func(string) (workload.Document, error) {
+		artifactReads++
+
+		return nil, nil
+	}
+
+	t.Cleanup(func() { getWorkloadDocFn, getArtifactDocFn = prevWorkload, prevArtifact })
+
+	live, err := Look("wl-1")
+	require.NoError(t, err)
+	assert.Equal(t, StateSettling, live.State)
+	assert.Zero(t, artifactReads, "there is no artifact id to look up")
+}
+
+// TestLook_LockedIsCaseInsensitive: the platform's docs disagree with
+// themselves on status casing, and reading a locked artifact as a draft would
+// let a rollout be attempted that the platform will refuse.
+func TestLook_LockedIsCaseInsensitive(t *testing.T) {
+	for _, status := range []string{"locked", "LOCKED", "Locked"} {
+		t.Run(status, func(t *testing.T) {
+			stubLive(t, liveWorkloadJSON, `{"id":"art-1","status":"`+status+`","spec":{"type":"service"}}`)
+
+			live, err := Look("wl-1")
+			require.NoError(t, err)
+			assert.True(t, live.Locked)
+		})
+	}
+
+	stubLive(t, liveWorkloadJSON, `{"id":"art-1","status":"draft","spec":{"type":"service"}}`)
+
+	live, err := Look("wl-1")
+	require.NoError(t, err)
+	assert.False(t, live.Locked)
+}
+
+// primaryContainer digs the flagged container out of a live spec.
+func primaryContainer(t *testing.T, spec map[string]any) map[string]any {
+	t.Helper()
+
+	groups, _ := spec["containerGroups"].([]any)
+	require.NotEmpty(t, groups)
+
+	group, _ := groups[0].(map[string]any)
+	containers, _ := group["containers"].([]any)
+	require.NotEmpty(t, containers)
+
+	container, _ := containers[0].(map[string]any)
+
+	return container
+}

--- a/internal/workload/up/plan.go
+++ b/internal/workload/up/plan.go
@@ -1,0 +1,138 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+// Actions are what a run will do, and what the JSON envelope reports. A run
+// does exactly one of them, so when several could apply the most significant
+// wins: creating beats rolling, rolling beats retuning, retuning beats
+// starting.
+const (
+	ActionCreated   = "created"
+	ActionRolled    = "rolled"
+	ActionUpdated   = "updated"
+	ActionStarted   = "started"
+	ActionUnchanged = "unchanged"
+)
+
+// CodeChange is the working tree measured against what the platform already
+// holds. It only means anything when the manifest asks the platform to build
+// the image; a container that names a published image has no code to sync,
+// and reporting file counts for it would invite the reader to expect a
+// rebuild that is never going to happen.
+type CodeChange struct {
+	// Applies is false when the manifest names an image rather than a build,
+	// in which case the rest of this struct is meaningless.
+	Applies bool
+
+	// Files is how many differ. Zero with Applies true means the tree matches.
+	Files int
+
+	// FirstDeploy marks a project with nothing to compare against yet, so
+	// every file is new rather than changed.
+	FirstDeploy bool
+}
+
+// Changed reports whether the code needs syncing and rebuilding.
+func (c CodeChange) Changed() bool {
+	return c.Applies && (c.FirstDeploy || c.Files > 0)
+}
+
+// Plan is what a run intends to do, computed before it does any of it.
+type Plan struct {
+	// State is the live workload, so a plan can be printed for something that
+	// cannot actually be deployed onto.
+	State State
+
+	// Creates is a workload that does not exist yet, in which case Artifact
+	// and Runtime are empty: everything in the file is new, and listing it
+	// field by field would be noise rather than a plan.
+	Creates bool
+
+	Code     CodeChange
+	Artifact []Change
+	Runtime  []Change
+}
+
+// Empty reports that the live state already matches the file. `up` prints
+// "Already up to date" and exits 0, having touched nothing.
+//
+// A stopped workload is never empty even when nothing differs: the user asked
+// to deploy, and a workload that is not running has not been deployed.
+func (p Plan) Empty() bool {
+	return !p.Creates &&
+		!p.Code.Changed() &&
+		len(p.Artifact) == 0 &&
+		len(p.Runtime) == 0 &&
+		p.State != StateStopped
+}
+
+// RollsArtifact reports whether a new artifact version has to be minted and
+// rolled in. Code and spec are one question here because they have one
+// answer: both produce a new immutable version, and a run that has to rebuild
+// also has to replace.
+func (p Plan) RollsArtifact() bool {
+	return !p.Creates && (p.Code.Changed() || len(p.Artifact) > 0)
+}
+
+// Action names the outcome, for the summary line and the JSON envelope.
+func (p Plan) Action() string {
+	switch {
+	case p.Creates:
+		return ActionCreated
+	case p.RollsArtifact():
+		return ActionRolled
+	case len(p.Runtime) > 0:
+		return ActionUpdated
+	case p.State == StateStopped:
+		return ActionStarted
+	default:
+		return ActionUnchanged
+	}
+}
+
+// Build works out what differs between the file and the live workload.
+//
+// code is passed in rather than computed here so this package never acquires
+// the project lock the sync engine holds between plan and execute, and so the
+// tests never touch a filesystem. The caller runs the sync engine's own plan
+// and hands over the count.
+func Build(loaded Loaded, live Live, code CodeChange) (Plan, error) {
+	plan := Plan{
+		State:   live.State,
+		Creates: live.State == StateUnbound,
+		Code:    code,
+	}
+
+	// Nothing exists to compare against, so every field is trivially an
+	// addition. Saying so once is a plan; saying it per field is a wall.
+	if plan.Creates {
+		return plan, nil
+	}
+
+	spec, err := loaded.Spec()
+	if err != nil {
+		return Plan{}, err
+	}
+
+	runtime, err := loaded.Runtime()
+	if err != nil {
+		return Plan{}, err
+	}
+
+	plan.Artifact = Subset(spec, live.Spec)
+	plan.Runtime = Subset(runtime, live.Runtime)
+
+	return plan, nil
+}

--- a/internal/workload/up/plan_test.go
+++ b/internal/workload/up/plan_test.go
@@ -1,0 +1,327 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loadedFrom builds a Loaded around a compiled payload, which is the only
+// part of it Build reads.
+func loadedFrom(payload string) Loaded {
+	return Loaded{Compiled: &manifest.Compiled{Payload: json.RawMessage(payload)}}
+}
+
+// liveFrom builds the live side from the two cleaned documents.
+func liveFrom(t *testing.T, state State, specJSON, runtimeJSON string) Live {
+	t.Helper()
+
+	live := Live{State: state}
+
+	if specJSON != "" {
+		live.Spec = obj(t, specJSON)
+	}
+
+	if runtimeJSON != "" {
+		live.Runtime = obj(t, runtimeJSON)
+	}
+
+	return live
+}
+
+// builtCode is a code answer for a project whose image the platform builds.
+func builtCode(files int) CodeChange {
+	return CodeChange{Applies: true, Files: files}
+}
+
+func TestCodeChange_Changed(t *testing.T) {
+	cases := []struct {
+		name string
+		code CodeChange
+		want bool
+	}{
+		{"a published image has no code to sync", CodeChange{Applies: false}, false},
+		{"a published image is unaffected by a dirty tree", CodeChange{Applies: false, Files: 9}, false},
+		{"nothing differs", builtCode(0), false},
+		{"files differ", builtCode(3), true},
+		{"a first deploy has everything to send", CodeChange{Applies: true, FirstDeploy: true}, true},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, c.code.Changed(), c.name)
+	}
+}
+
+// TestPlan_EmptyIsExactlyNothingToDo guards the "Already up to date" exit.
+// Reporting empty when something did differ skips a deploy the user asked
+// for; reporting non-empty when nothing differs rebuilds and rolls a running
+// workload for no reason.
+func TestPlan_EmptyIsExactlyNothingToDo(t *testing.T) {
+	cases := []struct {
+		name string
+		plan Plan
+		want bool
+	}{
+		{"running and identical", Plan{State: StateRunning, Code: builtCode(0)}, true},
+		{"a published image with a dirty tree", Plan{State: StateRunning, Code: CodeChange{Files: 5}}, true},
+		{"code differs", Plan{State: StateRunning, Code: builtCode(1)}, false},
+		{"spec differs", Plan{State: StateRunning, Artifact: []Change{{Path: "port"}}}, false},
+		{"sizing differs", Plan{State: StateRunning, Runtime: []Change{{Path: "replicaCount"}}}, false},
+		{"nothing exists yet", Plan{State: StateUnbound, Creates: true}, false},
+		{"stopped and identical", Plan{State: StateStopped, Code: builtCode(0)}, false},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, c.plan.Empty(), c.name)
+	}
+}
+
+// TestPlan_StoppedIsNeverEmpty states the reasoning outright: the user asked
+// to deploy, and a workload that is not running has not been deployed, so
+// matching the file is not enough to call the job done.
+func TestPlan_StoppedIsNeverEmpty(t *testing.T) {
+	plan := Plan{State: StateStopped, Code: builtCode(0)}
+
+	assert.False(t, plan.Empty())
+	assert.Equal(t, ActionStarted, plan.Action())
+}
+
+func TestPlan_RollsArtifact(t *testing.T) {
+	cases := []struct {
+		name string
+		plan Plan
+		want bool
+	}{
+		{"code differs", Plan{Code: builtCode(2)}, true},
+		{"spec differs", Plan{Artifact: []Change{{Path: "port"}}}, true},
+		{"sizing alone never mints a version", Plan{Runtime: []Change{{Path: "replicaCount"}}}, false},
+		{"a creation is not a roll", Plan{Creates: true, Code: builtCode(2)}, false},
+		{"nothing differs", Plan{Code: builtCode(0)}, false},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, c.plan.RollsArtifact(), c.name)
+	}
+}
+
+// TestPlan_ActionPicksTheMostSignificant pins the priority order that the
+// JSON envelope reports. A run does one thing, so when several apply the
+// headline has to be the one that changed the most.
+func TestPlan_ActionPicksTheMostSignificant(t *testing.T) {
+	cases := []struct {
+		name string
+		plan Plan
+		want string
+	}{
+		{"nothing", Plan{State: StateRunning}, ActionUnchanged},
+		{"first deploy", Plan{State: StateUnbound, Creates: true}, ActionCreated},
+		{"creating outranks everything", Plan{
+			State: StateUnbound, Creates: true, Code: builtCode(4),
+			Artifact: []Change{{Path: "port"}}, Runtime: []Change{{Path: "replicaCount"}},
+		}, ActionCreated},
+		{"code", Plan{State: StateRunning, Code: builtCode(4)}, ActionRolled},
+		{"spec", Plan{State: StateRunning, Artifact: []Change{{Path: "port"}}}, ActionRolled},
+		{"rolling outranks retuning", Plan{
+			State: StateRunning, Code: builtCode(4), Runtime: []Change{{Path: "replicaCount"}},
+		}, ActionRolled},
+		{"sizing only", Plan{State: StateRunning, Runtime: []Change{{Path: "replicaCount"}}}, ActionUpdated},
+		{"retuning outranks starting", Plan{
+			State: StateStopped, Runtime: []Change{{Path: "replicaCount"}},
+		}, ActionUpdated},
+		{"stopped with nothing to change", Plan{State: StateStopped}, ActionStarted},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, c.plan.Action(), c.name)
+	}
+}
+
+const planPayload = `{
+  "name": "my-app",
+  "artifact": {
+    "name": "my-app-artifact",
+    "spec": {
+      "type": "service",
+      "containerGroups": [
+        {"name": "default", "containers": [
+          {"name": "primary", "primary": true, "port": 8080,
+           "readinessProbe": {"path": "/health", "port": 8080}}
+        ]}
+      ]
+    }
+  },
+  "runtime": {
+    "containerGroups": [
+      {"name": "default", "replicaCount": 1,
+       "containers": [{"name": "primary", "resourceAllocation": {"cpu": 0.5, "memory": "512MB"}}]}
+    ]
+  }
+}`
+
+const planLiveSpec = `{
+  "type": "service",
+  "containerGroups": [
+    {"name": "default", "containers": [
+      {"name": "primary", "primary": true, "port": 8080,
+       "readinessProbe": {"path": "/health", "port": 8080}},
+      {"name": "metrics", "imageUri": "registry/metrics:v1"}
+    ]}
+  ]
+}`
+
+const planLiveRuntime = `{
+  "containerGroups": [
+    {"name": "default", "replicaCount": 1, "resourceBundles": ["cpu.small"],
+     "containers": [
+       {"name": "primary", "resourceAllocation": {"cpu": 0.5, "memory": "512MB"}},
+       {"name": "metrics", "resourceAllocation": {"cpu": 0.1, "memory": "128MB"}}
+     ]}
+  ]
+}`
+
+// TestBuild_MatchingLiveStateIsEmpty runs a manifest that says less than the
+// workload against that workload. The sidecar and the resource bundle are
+// unmentioned, so neither is drift, and the run is a no-op.
+func TestBuild_MatchingLiveStateIsEmpty(t *testing.T) {
+	plan, err := Build(
+		loadedFrom(planPayload),
+		liveFrom(t, StateRunning, planLiveSpec, planLiveRuntime),
+		builtCode(0),
+	)
+	require.NoError(t, err)
+
+	assert.True(t, plan.Empty())
+	assert.Equal(t, ActionUnchanged, plan.Action())
+	assert.Empty(t, plan.Artifact)
+	assert.Empty(t, plan.Runtime)
+}
+
+func TestBuild_SplitsDriftIntoItsTwoHalves(t *testing.T) {
+	drifted := `{
+	  "name": "my-app",
+	  "artifact": {"name": "my-app-artifact", "spec": {
+	    "type": "service",
+	    "containerGroups": [{"name": "default", "containers": [
+	      {"name": "primary", "primary": true, "port": 9090,
+	       "readinessProbe": {"path": "/health", "port": 8080}}
+	    ]}]
+	  }},
+	  "runtime": {"containerGroups": [
+	    {"name": "default", "replicaCount": 3,
+	     "containers": [{"name": "primary", "resourceAllocation": {"cpu": 0.5, "memory": "512MB"}}]}
+	  ]}
+	}`
+
+	plan, err := Build(
+		loadedFrom(drifted),
+		liveFrom(t, StateRunning, planLiveSpec, planLiveRuntime),
+		builtCode(0),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]string{"containerGroups[default].containers[primary].port"},
+		paths(plan.Artifact))
+	assert.Equal(t,
+		[]string{"containerGroups[default].replicaCount"},
+		paths(plan.Runtime))
+	assert.Equal(t, ActionRolled, plan.Action(), "a spec change mints a version even with sizing alongside")
+}
+
+func TestBuild_RuntimeOnlyDriftDoesNotRoll(t *testing.T) {
+	resized := `{
+	  "name": "my-app",
+	  "artifact": {"name": "my-app-artifact", "spec": {
+	    "type": "service",
+	    "containerGroups": [{"name": "default", "containers": [
+	      {"name": "primary", "primary": true, "port": 8080,
+	       "readinessProbe": {"path": "/health", "port": 8080}}
+	    ]}]
+	  }},
+	  "runtime": {"containerGroups": [
+	    {"name": "default", "replicaCount": 3,
+	     "containers": [{"name": "primary", "resourceAllocation": {"cpu": 0.5, "memory": "512MB"}}]}
+	  ]}
+	}`
+
+	plan, err := Build(
+		loadedFrom(resized),
+		liveFrom(t, StateRunning, planLiveSpec, planLiveRuntime),
+		builtCode(0),
+	)
+	require.NoError(t, err)
+
+	assert.False(t, plan.RollsArtifact(), "sizing is tunable without a new artifact version")
+	assert.Equal(t, ActionUpdated, plan.Action())
+}
+
+// TestBuild_UnboundDoesNotDiff: with nothing to compare against, every field
+// is trivially an addition. Saying that once is a plan; saying it per field
+// is a wall of text that hides what the run will actually do.
+func TestBuild_UnboundDoesNotDiff(t *testing.T) {
+	plan, err := Build(
+		loadedFrom(planPayload),
+		Live{State: StateUnbound},
+		CodeChange{Applies: true, FirstDeploy: true},
+	)
+	require.NoError(t, err)
+
+	assert.True(t, plan.Creates)
+	assert.Empty(t, plan.Artifact)
+	assert.Empty(t, plan.Runtime)
+	assert.False(t, plan.Empty())
+	assert.Equal(t, ActionCreated, plan.Action())
+	assert.True(t, plan.Code.Changed())
+}
+
+// TestBuild_MissingWorkloadStillPlans: a workload deleted from under the
+// manifest is refused at apply time, but --dry-run still has to say what
+// would have happened, so the plan is computed rather than short-circuited.
+func TestBuild_MissingWorkloadStillPlans(t *testing.T) {
+	plan, err := Build(
+		loadedFrom(planPayload),
+		Live{State: StateMissing},
+		builtCode(0),
+	)
+	require.NoError(t, err)
+
+	assert.False(t, plan.Creates, "a vanished workload is not a licence to create a second one")
+	assert.Equal(t, StateMissing, plan.State)
+	assert.NotEmpty(t, plan.Artifact, "with no live spec, everything the file names is an addition")
+}
+
+func TestBuild_CarriesCodeAndStateThrough(t *testing.T) {
+	plan, err := Build(
+		loadedFrom(planPayload),
+		liveFrom(t, StateStopped, planLiveSpec, planLiveRuntime),
+		builtCode(7),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, StateStopped, plan.State)
+	assert.Equal(t, 7, plan.Code.Files)
+	assert.Equal(t, ActionRolled, plan.Action(), "a stopped workload with changed code still rolls")
+}
+
+func TestBuild_BadPayloadIsReported(t *testing.T) {
+	_, err := Build(loadedFrom("{not json"), Live{State: StateRunning}, builtCode(0))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "compiled manifest")
+}

--- a/internal/workload/up/state.go
+++ b/internal/workload/up/state.go
@@ -1,0 +1,118 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import "github.com/datarobot/cli/internal/workload"
+
+// State is the live workload reduced to the cases that change what `up` does
+// next. The platform has eleven statuses; only these distinctions matter to a
+// deploy, and collapsing them here keeps the branch table in one place
+// instead of spread across the apply path.
+type State int
+
+const (
+	// StateUnbound is a manifest with no workloadId. The first `up` creates
+	// the workload and writes the id back.
+	StateUnbound State = iota
+
+	// StateMissing is a manifest naming a workload the platform does not
+	// have, usually because it was deleted from the UI. `up` errors and
+	// names the fix rather than quietly creating a second workload, because
+	// creating one would leave the user with two things called the same and
+	// no idea which one their URL points at.
+	StateMissing
+
+	// StateTerminated is the end of a workload's life and is not restartable.
+	// Treated like StateMissing: rebind or clear the id.
+	StateTerminated
+
+	// StateStopped covers stopped, suspended and interrupted. `up` starts it
+	// and then reconciles, since the user asking to deploy is asking for it
+	// to be running.
+	StateStopped
+
+	// StateSettling is a workload still moving under its own power. `up`
+	// waits for it rather than acting on a state that is about to change.
+	StateSettling
+
+	// StateRunning is the ordinary case: reconcile against it.
+	StateRunning
+
+	// StateErrored is a workload the platform could not bring up. `up` prints
+	// the plan, refuses to roll onto it and points at the logs. It does not
+	// guess, because a slow start can report errored and then recover.
+	StateErrored
+)
+
+// String names the state for a plan line or an error message.
+func (s State) String() string {
+	switch s {
+	case StateUnbound:
+		return "not created yet"
+	case StateMissing:
+		return "missing"
+	case StateTerminated:
+		return workload.WorkloadStatusTerminated
+	case StateStopped:
+		return "stopped"
+	case StateSettling:
+		return "settling"
+	case StateRunning:
+		return workload.WorkloadStatusRunning
+	case StateErrored:
+		return workload.WorkloadStatusErrored
+	default:
+		return "unknown"
+	}
+}
+
+// Deployable reports whether `up` can apply a plan against this state
+// directly. StateStopped is deployable only after a start, which is why it is
+// excluded here rather than folded into StateRunning.
+func (s State) Deployable() bool {
+	return s == StateRunning
+}
+
+// stateFor maps a platform status onto the branch `up` takes.
+//
+// Two of these are judgement calls rather than transcription. "unknown" is
+// treated as settling rather than as an error, because it is what the server
+// reports before it has decided anything and erroring on it would fail
+// deploys that were merely early. "interrupted" is grouped with stopped
+// rather than with errored, because it is a workload the platform took down
+// and will let you start again, not one that broke.
+func stateFor(status string) State {
+	switch status {
+	case workload.WorkloadStatusRunning:
+		return StateRunning
+
+	case workload.WorkloadStatusStopped,
+		workload.WorkloadStatusSuspended,
+		workload.WorkloadStatusInterrupted:
+		return StateStopped
+
+	case workload.WorkloadStatusTerminated:
+		return StateTerminated
+
+	case workload.WorkloadStatusErrored:
+		return StateErrored
+
+	default:
+		// submitted, provisioning, launching, stopping, unknown, and
+		// anything the platform adds later. Waiting is always safe; guessing
+		// is not.
+		return StateSettling
+	}
+}

--- a/internal/workload/up/state_test.go
+++ b/internal/workload/up/state_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStateFor(t *testing.T) {
+	cases := []struct {
+		status string
+		want   State
+	}{
+		{workload.WorkloadStatusRunning, StateRunning},
+		{workload.WorkloadStatusStopped, StateStopped},
+		{workload.WorkloadStatusSuspended, StateStopped},
+		{workload.WorkloadStatusInterrupted, StateStopped},
+		{workload.WorkloadStatusTerminated, StateTerminated},
+		{workload.WorkloadStatusErrored, StateErrored},
+		{workload.WorkloadStatusSubmitted, StateSettling},
+		{workload.WorkloadStatusProvisioning, StateSettling},
+		{workload.WorkloadStatusLaunching, StateSettling},
+		{workload.WorkloadStatusStopping, StateSettling},
+		{workload.WorkloadStatusUnknown, StateSettling},
+		{"a-status-the-platform-added-later", StateSettling},
+		{"", StateSettling},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, stateFor(c.status), "status %q", c.status)
+	}
+}
+
+// TestStateFor_EveryPlatformStatusIsMapped fails if the platform's status
+// enum grows and nobody revisits this file. The default arm means a new
+// status silently becomes StateSettling, which is the safe answer but not
+// necessarily the right one, so the reminder is worth having.
+func TestStateFor_EveryPlatformStatusIsMapped(t *testing.T) {
+	known := []string{
+		workload.WorkloadStatusUnknown,
+		workload.WorkloadStatusSubmitted,
+		workload.WorkloadStatusProvisioning,
+		workload.WorkloadStatusLaunching,
+		workload.WorkloadStatusRunning,
+		workload.WorkloadStatusSuspended,
+		workload.WorkloadStatusInterrupted,
+		workload.WorkloadStatusStopping,
+		workload.WorkloadStatusStopped,
+		workload.WorkloadStatusErrored,
+		workload.WorkloadStatusTerminated,
+	}
+
+	assert.Len(t, known, 11, "the platform's status enum changed; revisit stateFor")
+
+	for _, status := range known {
+		assert.NotEmpty(t, stateFor(status).String(), "status %q maps to a nameless state", status)
+	}
+}
+
+// TestState_OnlyRunningIsDeployable pins the distinction that matters most:
+// a stopped workload has to be started first, so folding it into running
+// would apply a plan against something that is not there.
+func TestState_OnlyRunningIsDeployable(t *testing.T) {
+	all := []State{
+		StateUnbound, StateMissing, StateTerminated,
+		StateStopped, StateSettling, StateRunning, StateErrored,
+	}
+
+	for _, s := range all {
+		assert.Equal(t, s == StateRunning, s.Deployable(), "state %s", s)
+	}
+}
+
+func TestState_String(t *testing.T) {
+	assert.Equal(t, "not created yet", StateUnbound.String())
+	assert.Equal(t, "missing", StateMissing.String())
+	assert.Equal(t, "terminated", StateTerminated.String())
+	assert.Equal(t, "stopped", StateStopped.String())
+	assert.Equal(t, "settling", StateSettling.String())
+	assert.Equal(t, "running", StateRunning.String())
+	assert.Equal(t, "errored", StateErrored.String())
+	assert.Equal(t, "unknown", State(99).String())
+}


### PR DESCRIPTION
# RATIONALE

First of four in the `dr workload up` stack ([RAPTOR-18976](https://datarobot.atlassian.net/browse/RAPTOR-18976)). `up` is plan-then-apply, and this is the reading and the deciding: turn a directory and a workload id into facts, then work out what differs. No output, no cobra, no API mutation. Nothing calls it yet, so there is no user-visible change.

Splitting reading from deciding is deliberate. `Load` turns a directory into a validated, compiled manifest; `Look` turns a workload id into the live spec, the live runtime and a `State`. Neither judges what it finds: a missing manifest and a deleted workload are both reported as facts, because whether either is fatal depends on what the caller is allowed to do about it, and only the command knows that.

## CHANGES

`internal/workload/up`, new package:

- `load.go` — find the manifest by walking upward the way git does, validate and compile it
- `look.go` — two GETs for the live workload and its artifact, reduced to a `Live`
- `state.go` — the live status vocabulary as a `State` the plan can switch on
- `diff.go` — `Subset`, the one-directional comparison
- `plan.go` — `Plan`, `Build`, `Action()`, `Empty()`
- `doc.go` — the package contract, including why none of this is a hash

## NOTES

**Drift is one-directional and measured against the running object.** Whatever the file says, `up` makes true; whatever the file leaves out, `up` leaves alone. So a workload can carry a GPU bundle, a sidecar and an autoscaling policy this CLI has no vocabulary for and none of it is drift, while a UI edit to a field the file does name is reported and restored. Deleting a line stops managing a field rather than reverting it.

**Not a stored hash of the last applied spec**, which is the obvious cheaper design. It cannot see the UI edit, and it is absent in a fresh CI clone. Comparing against the live object costs two GETs and is correct in both cases.

**Compared on the compiled payload, not the file**, so the `dr-credential:` shorthand is already expanded and a credential reference does not read as a permanent difference against the object form the platform stores. And on the server's own documents rather than typed structs, because a typed round trip silently drops every field this release has not heard of, and half the point of the manifest format is that those survive.

**Lists are matched by name, not by index**, so reordering `containerGroups` or `environmentVars` in the file is not drift.

## RELATED

[RAPTOR-18976](https://datarobot.atlassian.net/browse/RAPTOR-18976), sub-task 5 of [RAPTOR-18970](https://datarobot.atlassian.net/browse/RAPTOR-18970). Stack: **1/4 (this)** → 2 render → 3 orchestrate → 4 command. Each PR is based on the one before it, so review this one first and merge in order.

Made with [Cursor](https://cursor.com)