### PR TITLE
[RAPTOR-18976] feat(workload): render the deploy plan

### DIFF
--- a/internal/workload/up/render.go
+++ b/internal/workload/up/render.go
@@ -1,0 +1,272 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Summary names what a plan is about. It comes from the live workload when
+// there is one and from the manifest when there is not, which is why the
+// renderer is handed it rather than digging for it.
+type Summary struct {
+	Name       string
+	WorkloadID string
+}
+
+// shortIDLen is how much of an id is enough to recognise it. The platform's
+// ids are 24 hex characters and nobody reads past the first few; the full id
+// is in the JSON envelope for anything that needs to act on it.
+const shortIDLen = 8
+
+// detailLimit caps how many individual changes a plan spells out. Past this
+// the reader is not reading any more, and the file itself is the better
+// place to look. Whatever is dropped is counted out loud rather than
+// silently, so the plan never understates what it is about to do.
+const detailLimit = 6
+
+// envVarsSegment marks a path whose values must not be printed. A literal
+// environment variable can be a secret someone pasted in plaintext, and a
+// plan that echoed it would put it in terminal scrollback and CI logs. Names
+// are enough to see what changed.
+const envVarsSegment = ".environmentVars["
+
+// Render writes the plan block that `up` prints before it acts, and that
+// --dry-run prints instead of acting.
+func Render(w io.Writer, s Summary, plan Plan) error {
+	var b strings.Builder
+
+	b.WriteString(header(s, plan))
+	b.WriteString("\n")
+
+	if plan.Empty() {
+		b.WriteString("\nAlready up to date\n")
+
+		_, err := io.WriteString(w, b.String())
+
+		return err
+	}
+
+	b.WriteString("\n")
+
+	for _, line := range lines(plan) {
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+
+	_, err := io.WriteString(w, b.String())
+
+	return err
+}
+
+// header names the workload and says what state it is in.
+func header(s Summary, plan Plan) string {
+	name := s.Name
+	if name == "" {
+		name = "workload"
+	}
+
+	if plan.Creates || s.WorkloadID == "" {
+		return fmt.Sprintf("%s, %s", name, plan.State)
+	}
+
+	return fmt.Sprintf("%s (%s), %s", name, shortID(s.WorkloadID), plan.State)
+}
+
+// shortID trims an id to something a person can compare at a glance.
+func shortID(id string) string {
+	if len(id) <= shortIDLen {
+		return id
+	}
+
+	return id[:shortIDLen]
+}
+
+// lines is the body of the plan, one entry per class of change plus the
+// details each one carries.
+func lines(plan Plan) []string {
+	var out []string
+
+	if plan.Creates {
+		out = append(out, entry("+", "workload", "created on this run, with its first artifact"))
+	}
+
+	// A stopped workload is the one plan whose reason to act is the state
+	// rather than a difference. Without a line for it the body is empty and
+	// the block reads as though nothing is about to happen, while the JSON
+	// beside it says the action is "started".
+	if plan.State == StateStopped {
+		out = append(out, entry("~", "workload", "started, having been stopped"))
+	}
+
+	if plan.Code.Changed() {
+		out = append(out, entry("~", "code", codeDetail(plan.Code)))
+	}
+
+	out = append(out, artifactLines(plan)...)
+	out = append(out, runtimeLines(plan)...)
+
+	return out
+}
+
+// codeDetail says how much of the tree is going up.
+func codeDetail(code CodeChange) string {
+	if code.FirstDeploy {
+		return "first sync of this project"
+	}
+
+	return fmt.Sprintf("%d %s changed since the last deploy", code.Files, plural(code.Files, "file", "files"))
+}
+
+// artifactLines describes the new immutable version, when there is one. Code
+// and spec both produce one, and they are reported as a single entry because
+// they are a single act: one version, built and rolled once.
+func artifactLines(plan Plan) []string {
+	if !plan.RollsArtifact() {
+		return nil
+	}
+
+	reason := "rebuilt from the synced code"
+	if len(plan.Artifact) > 0 {
+		reason = fmt.Sprintf("new version, %d spec %s",
+			len(plan.Artifact), plural(len(plan.Artifact), "change", "changes"))
+	}
+
+	return append([]string{entry("+", "artifact", reason)}, details(plan.Artifact)...)
+}
+
+// runtimeLines describes a sizing change, which needs no new version. A
+// single change reads better on the entry line itself than under it.
+func runtimeLines(plan Plan) []string {
+	if len(plan.Runtime) == 0 {
+		return nil
+	}
+
+	if len(plan.Runtime) == 1 {
+		return []string{entry("~", "runtime", describe(plan.Runtime[0]))}
+	}
+
+	head := entry("~", "runtime", fmt.Sprintf("%d %s",
+		len(plan.Runtime), plural(len(plan.Runtime), "change", "changes")))
+
+	return append([]string{head}, details(plan.Runtime)...)
+}
+
+// entry formats one plan line: a marker, the class, and what happens to it.
+func entry(marker, class, detail string) string {
+	return fmt.Sprintf("  %s %-10s %s", marker, class, detail)
+}
+
+// details lists individual changes under their entry, capped, saying out loud
+// how many it left out.
+func details(changes []Change) []string {
+	shown := changes
+	if len(shown) > detailLimit {
+		shown = shown[:detailLimit]
+	}
+
+	out := make([]string, 0, len(shown)+1)
+	for _, c := range shown {
+		out = append(out, "      "+describe(c))
+	}
+
+	if dropped := len(changes) - len(shown); dropped > 0 {
+		out = append(out, fmt.Sprintf("      and %d more", dropped))
+	}
+
+	return out
+}
+
+// describe renders one change, redacting the values of environment variables.
+func describe(c Change) string {
+	if redacted(c.Path) {
+		if c.Absent {
+			return c.Path + ": set"
+		}
+
+		return c.Path + ": changed"
+	}
+
+	return c.String()
+}
+
+// redacted reports whether a path sits inside an environmentVars list, whose
+// values never reach the output.
+func redacted(path string) bool {
+	return strings.Contains(path, envVarsSegment)
+}
+
+// plural picks the right noun for a count.
+func plural(n int, one, many string) string {
+	if n == 1 {
+		return one
+	}
+
+	return many
+}
+
+// PlanJSON is the plan as --dry-run reports it in JSON mode. Change values
+// are carried as rendered strings rather than raw values so the same
+// redaction applies to both outputs: a machine-readable plan that leaked a
+// secret would be worse than a human-readable one, since it ends up in CI
+// artifacts.
+type PlanJSON struct {
+	Action   string   `json:"action"`
+	State    string   `json:"state"`
+	Creates  bool     `json:"creates"`
+	Code     CodeJSON `json:"code"`
+	Artifact []string `json:"artifact"`
+	Runtime  []string `json:"runtime"`
+}
+
+// CodeJSON is the working tree's part of the answer.
+type CodeJSON struct {
+	// Applies is false for a manifest that names a published image, where
+	// there is no code to sync and Files means nothing.
+	Applies     bool `json:"applies"`
+	Changed     bool `json:"changed"`
+	Files       int  `json:"files"`
+	FirstDeploy bool `json:"firstDeploy"`
+}
+
+// JSON projects the plan into its machine-readable shape.
+func (p Plan) JSON() PlanJSON {
+	return PlanJSON{
+		Action:  p.Action(),
+		State:   p.State.String(),
+		Creates: p.Creates,
+		Code: CodeJSON{
+			Applies:     p.Code.Applies,
+			Changed:     p.Code.Changed(),
+			Files:       p.Code.Files,
+			FirstDeploy: p.Code.FirstDeploy,
+		},
+		Artifact: describeAll(p.Artifact),
+		Runtime:  describeAll(p.Runtime),
+	}
+}
+
+// describeAll renders every change, always to a non-nil slice so the JSON
+// carries [] rather than null for "nothing changed".
+func describeAll(changes []Change) []string {
+	out := make([]string, 0, len(changes))
+	for _, c := range changes {
+		out = append(out, describe(c))
+	}
+
+	return out
+}

--- a/internal/workload/up/render_test.go
+++ b/internal/workload/up/render_test.go
@@ -1,0 +1,264 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func render(t *testing.T, s Summary, plan Plan) string {
+	t.Helper()
+
+	var b strings.Builder
+
+	require.NoError(t, Render(&b, s, plan))
+
+	return b.String()
+}
+
+var appSummary = Summary{Name: "my-app", WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"}
+
+func TestRender_Empty(t *testing.T) {
+	out := render(t, appSummary, Plan{State: StateRunning, Code: builtCode(0)})
+
+	assert.Equal(t, "my-app (68b0c1d2), running\n\nAlready up to date\n", out)
+}
+
+func TestRender_TheThreeClasses(t *testing.T) {
+	plan := Plan{
+		State:    StateRunning,
+		Code:     builtCode(14),
+		Artifact: []Change{{Path: "containerGroups[default].containers[primary].port", Have: 8080.0, Want: 9090.0}},
+		Runtime:  []Change{{Path: "containerGroups[default].replicaCount", Have: 1.0, Want: 3.0}},
+	}
+
+	out := render(t, appSummary, plan)
+
+	assert.Contains(t, out, "my-app (68b0c1d2), running")
+	assert.Contains(t, out, "~ code       14 files changed since the last deploy")
+	assert.Contains(t, out, "+ artifact   new version, 1 spec change")
+	assert.Contains(t, out, "~ runtime    containerGroups[default].replicaCount: 1 -> 3")
+	assert.NotContains(t, out, "Already up to date")
+}
+
+// TestRender_SingleRuntimeChangeSitsOnItsOwnLine: the common case is one
+// number moving, and pushing it onto a sub-line for consistency's sake would
+// cost a line to say nothing.
+func TestRender_SingleRuntimeChangeSitsOnItsOwnLine(t *testing.T) {
+	out := render(t, appSummary, Plan{
+		State:   StateRunning,
+		Runtime: []Change{{Path: "containerGroups[default].replicaCount", Have: 1.0, Want: 3.0}},
+	})
+
+	assert.Contains(t, out, "~ runtime    containerGroups[default].replicaCount: 1 -> 3")
+	assert.NotContains(t, out, "2 changes")
+}
+
+func TestRender_SeveralRuntimeChangesAreListed(t *testing.T) {
+	out := render(t, appSummary, Plan{
+		State: StateRunning,
+		Runtime: []Change{
+			{Path: "containerGroups[default].replicaCount", Have: 1.0, Want: 3.0},
+			{Path: "containerGroups[default].containers[primary].resourceAllocation.cpu", Have: 0.5, Want: 2.0},
+		},
+	})
+
+	assert.Contains(t, out, "~ runtime    2 changes")
+	assert.Contains(t, out, "      containerGroups[default].replicaCount: 1 -> 3")
+	assert.Contains(t, out, "      containerGroups[default].containers[primary].resourceAllocation.cpu: 0.5 -> 2")
+}
+
+func TestRender_FirstDeploy(t *testing.T) {
+	out := render(t, Summary{Name: "my-app"}, Plan{
+		State:   StateUnbound,
+		Creates: true,
+		Code:    CodeChange{Applies: true, FirstDeploy: true},
+	})
+
+	assert.Contains(t, out, "my-app, not created yet")
+	assert.NotContains(t, out, "(", "there is no id to show yet")
+	assert.Contains(t, out, "+ workload   created on this run, with its first artifact")
+	assert.Contains(t, out, "~ code       first sync of this project")
+}
+
+// TestRender_PublishedImageNeverMentionsCode: a manifest naming an image has
+// no code to sync, and a "0 files changed" line would invite the reader to
+// expect a rebuild that is never going to happen.
+func TestRender_PublishedImageNeverMentionsCode(t *testing.T) {
+	out := render(t, appSummary, Plan{
+		State:    StateRunning,
+		Code:     CodeChange{Applies: false, Files: 12},
+		Artifact: []Change{{Path: "containerGroups[default].containers[primary].imageUri", Have: "a:1", Want: "a:2"}},
+	})
+
+	assert.NotContains(t, out, "code")
+	assert.Contains(t, out, "+ artifact")
+}
+
+// TestRender_ArtifactFromCodeAloneSaysWhy covers a rebuild with no spec
+// change: the version is new because the code is, and the plan has to say so
+// rather than print an artifact entry with nothing under it.
+func TestRender_ArtifactFromCodeAloneSaysWhy(t *testing.T) {
+	out := render(t, appSummary, Plan{State: StateRunning, Code: builtCode(3)})
+
+	assert.Contains(t, out, "+ artifact   rebuilt from the synced code")
+}
+
+// TestRender_NeverPrintsEnvironmentVariableValues is the one hard rule in
+// here. A literal can be a secret someone pasted in plaintext, and a plan
+// that echoed it would put it in scrollback and CI logs.
+func TestRender_NeverPrintsEnvironmentVariableValues(t *testing.T) {
+	const secret = "sk-abcdefghijklmnopqrstuvwxyz0123"
+
+	plan := Plan{
+		State: StateRunning,
+		Artifact: []Change{
+			{
+				Path: "containerGroups[default].containers[primary].environmentVars[OPENAI_API_KEY].value",
+				Have: "sk-oldvalue", Want: secret,
+			},
+			{
+				Path:   "containerGroups[default].containers[primary].environmentVars[NEW_TOKEN]",
+				Absent: true, Want: map[string]any{"name": "NEW_TOKEN", "value": secret},
+			},
+		},
+	}
+
+	out := render(t, appSummary, plan)
+
+	assert.NotContains(t, out, secret)
+	assert.NotContains(t, out, "sk-oldvalue")
+	assert.Contains(t, out, "environmentVars[OPENAI_API_KEY].value: changed")
+	assert.Contains(t, out, "environmentVars[NEW_TOKEN]: set")
+	assert.Contains(t, out, "OPENAI_API_KEY", "the name is the whole point of showing the line")
+}
+
+// TestRender_CapsTheDetailListOutLoud: a truncated plan that did not say it
+// was truncated would read as a complete account of what is about to happen.
+func TestRender_CapsTheDetailListOutLoud(t *testing.T) {
+	changes := make([]Change, 0, 10)
+	for _, name := range []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"} {
+		changes = append(changes, Change{Path: "spec." + name, Have: 1.0, Want: 2.0})
+	}
+
+	out := render(t, appSummary, Plan{State: StateRunning, Artifact: changes})
+
+	assert.Contains(t, out, "+ artifact   new version, 10 spec changes")
+	assert.Contains(t, out, "      spec.a: 1 -> 2")
+	assert.Contains(t, out, "      spec.f: 1 -> 2")
+	assert.NotContains(t, out, "spec.g")
+	assert.Contains(t, out, "and 4 more")
+}
+
+// A stopped workload with nothing else to change is the one plan whose reason
+// to act is the state rather than a difference, so the body has to say so:
+// a header and nothing under it reads as a plan to do nothing, which would
+// disagree with the "started" the JSON envelope reports.
+func TestRender_StoppedWorkloadWithNothingToChange(t *testing.T) {
+	plan := Plan{State: StateStopped, Code: builtCode(0)}
+	out := render(t, appSummary, plan)
+
+	assert.Contains(t, out, "my-app (68b0c1d2), stopped")
+	assert.Contains(t, out, "~ workload")
+	assert.Contains(t, out, "started")
+	assert.NotContains(t, out, "Already up to date", "the user asked for it to be running")
+	assert.Equal(t, ActionStarted, plan.Action(), "the text and the envelope have to agree")
+}
+
+// The start line is about the workload's state, so it survives alongside the
+// differences rather than only appearing when there are none.
+func TestRender_StoppedWorkloadWithDriftSaysBoth(t *testing.T) {
+	out := render(t, appSummary, Plan{
+		State:   StateStopped,
+		Runtime: []Change{{Path: "containerGroups[default].replicaCount", Have: 1.0, Want: 3.0}},
+	})
+
+	assert.Contains(t, out, "started")
+	assert.Contains(t, out, "containerGroups[default].replicaCount: 1 -> 3")
+}
+
+func TestRender_ShortIDLeavesShortIDsAlone(t *testing.T) {
+	out := render(t, Summary{Name: "my-app", WorkloadID: "abc"}, Plan{State: StateRunning, Code: builtCode(1)})
+
+	assert.Contains(t, out, "my-app (abc), running")
+}
+
+func TestRender_UnnamedWorkloadStillRenders(t *testing.T) {
+	out := render(t, Summary{}, Plan{State: StateUnbound, Creates: true})
+
+	assert.Contains(t, out, "workload, not created yet")
+}
+
+func TestPlanJSON_Shape(t *testing.T) {
+	plan := Plan{
+		State:    StateRunning,
+		Code:     builtCode(14),
+		Artifact: []Change{{Path: "containerGroups[default].containers[primary].port", Have: 8080.0, Want: 9090.0}},
+		Runtime:  []Change{{Path: "containerGroups[default].replicaCount", Have: 1.0, Want: 3.0}},
+	}
+
+	encoded, err := json.Marshal(plan.JSON())
+	require.NoError(t, err)
+
+	var decoded map[string]any
+
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	assert.Equal(t, "rolled", decoded["action"])
+	assert.Equal(t, "running", decoded["state"])
+	assert.Equal(t, false, decoded["creates"])
+
+	code, _ := decoded["code"].(map[string]any)
+	assert.Equal(t, true, code["changed"])
+	assert.InDelta(t, 14.0, code["files"], 0)
+
+	artifact, _ := decoded["artifact"].([]any)
+	assert.Len(t, artifact, 1)
+}
+
+// TestPlanJSON_EmptyListsAreNotNull keeps a consumer from having to special
+// case null: an empty plan has empty arrays, not missing ones.
+func TestPlanJSON_EmptyListsAreNotNull(t *testing.T) {
+	encoded, err := json.Marshal(Plan{State: StateRunning}.JSON())
+	require.NoError(t, err)
+
+	assert.Contains(t, string(encoded), `"artifact":[]`)
+	assert.Contains(t, string(encoded), `"runtime":[]`)
+	assert.Contains(t, string(encoded), `"action":"unchanged"`)
+}
+
+// TestPlanJSON_RedactsToo: the machine-readable plan is the one that ends up
+// in CI artifacts, so it cannot be the leaky one.
+func TestPlanJSON_RedactsToo(t *testing.T) {
+	const secret = "sk-abcdefghijklmnopqrstuvwxyz0123"
+
+	plan := Plan{
+		State: StateRunning,
+		Artifact: []Change{{
+			Path: "containerGroups[default].containers[primary].environmentVars[OPENAI_API_KEY].value",
+			Have: "old", Want: secret,
+		}},
+	}
+
+	encoded, err := json.Marshal(plan.JSON())
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(encoded), secret)
+	assert.Contains(t, string(encoded), "OPENAI_API_KEY")
+}


### PR DESCRIPTION
# RATIONALE

Second of four in the `dr workload up` stack ([RAPTOR-18976](https://datarobot.atlassian.net/browse/RAPTOR-18976)). PR 1 computes a `Plan`; this prints it. It is what `up` shows before it acts, and what `--dry-run` shows instead of acting. An empty plan is "Already up to date" and nothing else.

The plan is announced, never confirmed: `up`'s stated purpose is to deploy, so it does not ask permission to do the thing it was invoked to do.

## CHANGES

- `internal/workload/up/render.go` — the text rendering and the JSON projection
- `internal/workload/up/render_test.go`

## NOTES

**No environment variable value ever reaches the output.** A literal in the manifest can be a secret someone pasted in plaintext, and a plan that echoed one would put it in terminal scrollback and in CI logs. Any change inside an `environmentVars` list prints the variable's name and whether it was set or changed, and nothing else. The JSON projection carries the same rendered strings rather than raw values, deliberately: that is the output that ends up in CI artifacts, so it cannot be the leaky one.

**Code and spec drift are one entry, not two.** They are one act — both mint a single new immutable version, which is built and rolled once — so reporting them separately would imply two rollouts.

**A manifest naming a published image never mentions code.** There is nothing to sync, and a "0 files changed" line would promise a rebuild that is not coming.

**The detail list is capped and says how many entries it dropped.** A truncated plan that did not admit to being truncated would read as a complete account of what is about to happen to a running workload.

## RELATED

[RAPTOR-18976](https://datarobot.atlassian.net/browse/RAPTOR-18976), sub-task 5 of [RAPTOR-18970](https://datarobot.atlassian.net/browse/RAPTOR-18970). Stack: 1 read → **2/4 (this)** → 3 orchestrate → 4 command. Based on #759; review that first. The diff shown here is only this PR's commit once #759 merges.

Made with [Cursor](https://cursor.com)