### PR TITLE
[RAPTOR-18976] feat(workload): orchestrate the deploy

### DIFF
--- a/internal/workload/up/phase.go
+++ b/internal/workload/up/phase.go
@@ -1,0 +1,82 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/datarobot/cli/tui"
+)
+
+// phaseClock is the time source, swapped by tests so a check-marked line's
+// duration is deterministic rather than however long the machine took.
+var phaseClock = time.Now
+
+// reporter prints a deploy's progress. Every line goes to the writer it is
+// given rather than to os.Stderr, which is what lets a command test capture
+// them and what keeps them off stdout when the caller is emitting JSON.
+//
+// tui.RunWithSpinner writes to os.Stderr directly, so the spinner is only
+// worth using when the writer is the process's real stderr. Below that it
+// would draw somewhere nobody is looking while the captured stream stayed
+// empty.
+type reporter struct {
+	out     io.Writer
+	spinner bool
+}
+
+// newReporter builds a reporter for out. spinner should be true only when out
+// is the terminal the user is watching.
+func newReporter(out io.Writer, spinner bool) *reporter {
+	return &reporter{out: out, spinner: spinner}
+}
+
+// run executes one phase, announcing it while it works and check-marking it
+// with its elapsed time when it succeeds. A failure prints nothing extra: the
+// error carries the story, and a checkmark followed by an error message reads
+// as though both happened.
+func (r *reporter) run(label string, fn func() error) error {
+	started := phaseClock()
+
+	if err := r.work(label, fn); err != nil {
+		return err
+	}
+
+	r.done(label, phaseClock().Sub(started))
+
+	return nil
+}
+
+// work performs the phase, with a spinner when there is a terminal to spin on.
+func (r *reporter) work(label string, fn func() error) error {
+	if r.spinner {
+		return tui.RunWithSpinner(label, fn)
+	}
+
+	return fn()
+}
+
+// done prints the completed phase. Durations are truncated to a tenth of a
+// second: a deploy is measured in minutes and the extra digits are noise.
+func (r *reporter) done(label string, elapsed time.Duration) {
+	fmt.Fprintf(r.out, "  ✓ %s (%s)\n", label, elapsed.Truncate(100*time.Millisecond))
+}
+
+// say prints a line that is not a phase, such as a warning or a note.
+func (r *reporter) say(format string, args ...any) {
+	fmt.Fprintf(r.out, format, args...)
+}

--- a/internal/workload/up/phase_test.go
+++ b/internal/workload/up/phase_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixedClock makes elapsed times deterministic by advancing the clock by step
+// on every read, so a phase always appears to take exactly step.
+func fixedClock(t *testing.T, step time.Duration) {
+	t.Helper()
+
+	prev := phaseClock
+	now := time.Date(2026, time.August, 12, 12, 0, 0, 0, time.UTC)
+
+	phaseClock = func() time.Time {
+		current := now
+		now = now.Add(step)
+
+		return current
+	}
+
+	t.Cleanup(func() { phaseClock = prev })
+}
+
+func TestReporter_CheckMarksASuccessfulPhase(t *testing.T) {
+	fixedClock(t, 2*time.Second)
+
+	var out bytes.Buffer
+
+	require.NoError(t, newReporter(&out, false).run("Creating workload", func() error { return nil }))
+	assert.Equal(t, "  ✓ Creating workload (2s)\n", out.String())
+}
+
+// TestReporter_FailureIsSilent: a checkmark followed by an error message
+// reads as though both happened. The error carries the story on its own.
+func TestReporter_FailureIsSilent(t *testing.T) {
+	fixedClock(t, time.Second)
+
+	var out bytes.Buffer
+
+	err := newReporter(&out, false).run("Creating workload", func() error { return errors.New("refused") })
+	require.Error(t, err)
+	assert.Empty(t, out.String())
+}
+
+// TestReporter_DurationsAreRounded keeps a deploy's timings readable. It is
+// measured in minutes, so microseconds are noise.
+func TestReporter_DurationsAreRounded(t *testing.T) {
+	fixedClock(t, 1234*time.Millisecond)
+
+	var out bytes.Buffer
+
+	require.NoError(t, newReporter(&out, false).run("Waiting", func() error { return nil }))
+	assert.Contains(t, out.String(), "(1.2s)")
+}
+
+// TestReporter_WritesToTheInjectedWriter is the whole reason this exists
+// rather than calling tui.RunWithSpinner directly: that writes to os.Stderr,
+// which escapes both test capture and any redirection the command set up.
+func TestReporter_WritesToTheInjectedWriter(t *testing.T) {
+	fixedClock(t, time.Second)
+
+	var out bytes.Buffer
+
+	report := newReporter(&out, false)
+	report.say("note: %s\n", "something happened")
+
+	require.NoError(t, report.run("Phase", func() error { return nil }))
+
+	assert.Contains(t, out.String(), "note: something happened")
+	assert.Contains(t, out.String(), "✓ Phase")
+}
+
+func TestReporter_RunsTheWorkExactlyOnce(t *testing.T) {
+	fixedClock(t, time.Second)
+
+	var (
+		out   bytes.Buffer
+		calls int
+	)
+
+	require.NoError(t, newReporter(&out, false).run("Phase", func() error {
+		calls++
+
+		return nil
+	}))
+	assert.Equal(t, 1, calls)
+}

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -1,0 +1,437 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/datarobot/cli/internal/workload/wapi"
+	"github.com/datarobot/cli/internal/workload/wizard"
+)
+
+// Test seams. The deploy is mostly network, and the tests are not.
+var (
+	runWizardFn       = wizard.Run
+	createWorkloadFn  = workload.CreateWorkload
+	waitWorkloadFn    = workload.WaitForWorkload
+	listWorkloadsFn   = workload.ListWorkloads
+	lockArtifactFn    = workload.LockArtifact
+	writeWorkloadIDFn = manifest.WriteWorkloadID
+	codeChangeFn      = defaultCodeChange
+)
+
+// ErrNotWired reports a path the plan understands but the apply cannot take
+// yet. It is a sentinel so the command can say so in its own words, and so a
+// test can tell "we refused" from "we broke".
+var ErrNotWired = errors.New("not wired yet")
+
+// Options is everything a run needs from its caller.
+type Options struct {
+	// Dir is where to start looking for the manifest. The search walks
+	// upward from here.
+	Dir string
+
+	// NonInteractive forbids prompting. With no manifest it turns the setup
+	// wizard into an error naming the command that writes one.
+	NonInteractive bool
+
+	// DryRun stops after the plan.
+	DryRun bool
+
+	// Detach returns once the apply is requested, skipping the waits.
+	Detach bool
+
+	// Lock makes the artifact that ends up live immutable and permanent.
+	// Locking is one-way, so it happens last, only after the workload is
+	// actually serving: locking something that never came up would leave an
+	// undeletable artifact behind.
+	Lock bool
+
+	// PollInterval and PollTimeout tune the waits.
+	PollInterval time.Duration
+	PollTimeout  time.Duration
+
+	// Stderr takes the plan and the progress. Never stdout: that belongs to
+	// the endpoint, or to one JSON document.
+	Stderr io.Writer
+
+	// Spinner is true only when Stderr is the terminal the user is watching.
+	Spinner bool
+}
+
+// Result is what happened, and the material for the JSON envelope.
+type Result struct {
+	Plan Plan
+
+	WorkloadID string
+	Name       string
+	Status     string
+	Endpoint   string
+	ArtifactID string
+	Action     string
+	Locked     bool
+}
+
+// Run reads, plans, and applies as much of the plan as this release can.
+func Run(opts Options) (Result, error) {
+	dir, err := filepath.Abs(opts.Dir)
+	if err != nil {
+		return Result{}, fmt.Errorf("cannot resolve %s: %w", opts.Dir, err)
+	}
+
+	loaded, err := load(dir, opts)
+	if err != nil {
+		return Result{}, err
+	}
+
+	live, err := Look(loaded.WorkloadID())
+	if err != nil {
+		return Result{}, err
+	}
+
+	code, err := codeChangeFn(loaded, live)
+	if err != nil {
+		return Result{}, err
+	}
+
+	plan, err := Build(loaded, live, code)
+	if err != nil {
+		return Result{}, err
+	}
+
+	result := Result{
+		Plan:       plan,
+		WorkloadID: live.WorkloadID,
+		Name:       name(loaded, live),
+		Status:     plan.State.String(),
+		Endpoint:   live.Endpoint,
+		ArtifactID: live.ArtifactID,
+		Action:     plan.Action(),
+		Locked:     live.Locked,
+	}
+
+	if err := Render(opts.Stderr, Summary{Name: result.Name, WorkloadID: result.WorkloadID}, plan); err != nil {
+		return result, err
+	}
+
+	if opts.DryRun || plan.Empty() {
+		return result, nil
+	}
+
+	return apply(loaded, live, plan, result, opts)
+}
+
+// load finds the manifest, running the setup wizard when there is none and a
+// person is there to answer it. In CI there is nobody, so a missing manifest
+// is an error that names the command which writes one: deploying by guessing
+// is the one thing this command must never do.
+func load(dir string, opts Options) (Loaded, error) {
+	loaded, err := Load(dir)
+	if err == nil || !errors.Is(err, ErrNoManifest) {
+		return loaded, err
+	}
+
+	if opts.NonInteractive {
+		return Loaded{}, fmt.Errorf(
+			"%w. Run 'dr workload config' to create one, then deploy", err)
+	}
+
+	if _, err := runWizardFn(wizard.Options{Dir: dir, Stderr: opts.Stderr}); err != nil {
+		return Loaded{}, err
+	}
+
+	return Load(dir)
+}
+
+// name is what to call this workload: the live one's name once it exists, the
+// file's before that.
+func name(loaded Loaded, live Live) string {
+	if live.Name != "" {
+		return live.Name
+	}
+
+	return loaded.Manifest.Name()
+}
+
+// apply carries out the plan, or explains why it cannot.
+func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Result, error) {
+	if err := deployable(live, result.Name); err != nil {
+		return result, err
+	}
+
+	if !plan.Creates {
+		return result, fmt.Errorf("%w: %s. The plan above is correct; applying it is the next change",
+			ErrNotWired, unwired(plan))
+	}
+
+	// Only an image the platform builds needs a version, a sync and a build
+	// before the create. A published imageUri and a file bound to an existing
+	// artifact id are the same single POST, so neither is refused here.
+	if mode := loaded.Manifest.BuildMode(); mode == manifest.BuildModeDockerfile || mode == manifest.BuildModeGenerated {
+		return result, fmt.Errorf(
+			"%w: creating a workload whose image the platform builds (%s mode). "+
+				"Publishing the image yourself and switching the manifest to an imageUri works today",
+			ErrNotWired, mode)
+	}
+
+	return create(loaded, result, opts)
+}
+
+// unwired names the change the plan asks for. Calling every live workload a
+// roll is wrong for a runtime-only plan, which mints no artifact: the printed
+// plan and the refusal underneath it then disagree about what is missing.
+func unwired(plan Plan) string {
+	if plan.Action() == ActionUpdated {
+		return "changing the runtime settings of a live workload"
+	}
+
+	return "rolling a live workload onto a new version"
+}
+
+// deployable refuses the live states that cannot take a deploy, one message
+// each. None of them are guesses: a workload that is gone stays gone, and one
+// that is unsettled may still be on its way somewhere.
+func deployable(live Live, workloadName string) error {
+	switch live.State {
+	case StateMissing, StateTerminated:
+		return fmt.Errorf(
+			"the workload this manifest is bound to is %s. "+
+				"Bind to a live one with 'dr workload config --workload-id <id>', or remove workloadId from %s "+
+				"to create a new workload on the next deploy",
+			live.State, manifest.FileName)
+
+	case StateErrored:
+		return fmt.Errorf(
+			"workload %s is errored, so there is nothing safe to deploy onto. "+
+				"Check 'dr workload logs' first; a slow start can report errored and then recover",
+			workloadName)
+
+	case StateSettling:
+		return fmt.Errorf(
+			"workload %s is still settling. Wait for it to finish, then deploy",
+			workloadName)
+
+	case StateStopped:
+		return fmt.Errorf(
+			"%w: starting a stopped workload before deploying onto it", ErrNotWired)
+
+	case StateUnbound, StateRunning:
+		return nil
+
+	default:
+		return nil
+	}
+}
+
+// create makes the workload from the compiled manifest and waits for it to
+// serve. The binding is written back the moment the workload exists, before
+// anything else can fail, so a run that dies during the wait still leaves the
+// next one able to find what it made.
+func create(loaded Loaded, result Result, opts Options) (Result, error) {
+	report := newReporter(opts.Stderr, opts.Spinner)
+
+	var created *workload.Workload
+
+	err := report.run("Creating workload", func() error {
+		wl, err := createWorkloadFn(loaded.Compiled.Payload)
+		if err != nil {
+			adopted, adoptErr := adopt(err, result.Name)
+			if adoptErr != nil {
+				return adoptErr
+			}
+
+			wl = adopted
+		}
+
+		created = wl
+
+		return nil
+	})
+	if err != nil {
+		return result, err
+	}
+
+	result.WorkloadID = created.ID
+	result.ArtifactID = created.ArtifactID
+	result.Endpoint = created.Endpoint
+	result.Status = created.Status
+	result.Action = ActionCreated
+
+	if err := writeWorkloadIDFn(loaded.Path, created.ID); err != nil {
+		return result, fmt.Errorf(
+			"workload %s was created but its id could not be written to %s. "+
+				"Add 'workloadId: %s' by hand, or the next deploy will create a second workload: %w",
+			created.ID, loaded.Path, created.ID, err)
+	}
+
+	if opts.Detach {
+		report.say("  Workload %s requested; not waiting.\n", created.ID)
+
+		return result, nil
+	}
+
+	return settle(created.ID, result, opts, report)
+}
+
+// adopt turns a create conflict into the workload that caused it. A 409 means
+// something of that name is already there, and failing would leave the user
+// with a name they cannot deploy and no way to reach what owns it.
+func adopt(createErr error, workloadName string) (*workload.Workload, error) {
+	if !isConflict(createErr) || workloadName == "" {
+		return nil, createErr
+	}
+
+	existing, err := listWorkloadsFn(adoptSearchLimit, nil)
+	if err != nil {
+		// The conflict is the real story; a failure to look up what caused it
+		// is a footnote that should not replace it.
+		return nil, createErr
+	}
+
+	for i := range existing {
+		if existing[i].Name == workloadName {
+			return &existing[i], nil
+		}
+	}
+
+	return nil, createErr
+}
+
+// adoptSearchLimit bounds the lookup behind a create conflict. Past this many
+// workloads a name scan is the wrong tool, and the conflict itself is still
+// reported.
+const adoptSearchLimit = 100
+
+// isConflict reports whether err is the API's 409.
+func isConflict(err error) bool {
+	var httpErr *drapi.HTTPError
+
+	return errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusConflict
+}
+
+// settle waits for the workload to come up and records where it landed.
+func settle(workloadID string, result Result, opts Options, report *reporter) (Result, error) {
+	var final *workload.Workload
+
+	err := report.run("Waiting for the workload to run", func() error {
+		wl, waitErr := waitWorkloadFn(workloadID, opts.PollInterval, opts.PollTimeout, nil)
+		final = wl
+
+		return waitErr
+	})
+
+	if final != nil {
+		result.Status = final.Status
+		result.Endpoint = final.Endpoint
+		result.ArtifactID = final.ArtifactID
+	}
+
+	if err != nil {
+		return result, err
+	}
+
+	if workload.IsWorkloadErrorStatus(result.Status) {
+		return result, fmt.Errorf("workload %s finished as %s; check 'dr workload logs %s'",
+			workloadID, result.Status, workloadID)
+	}
+
+	if !opts.Lock {
+		return result, nil
+	}
+
+	return lock(result, report)
+}
+
+// lock makes the live artifact permanent. It runs only after the workload is
+// serving, because locking is one-way: locking an artifact that never came up
+// would leave something undeletable behind and a workload that cannot be
+// rolled off it.
+func lock(result Result, report *reporter) (Result, error) {
+	if result.ArtifactID == "" {
+		return result, errors.New("cannot lock: the platform did not report which artifact is running")
+	}
+
+	err := report.run("Locking the artifact", func() error {
+		_, lockErr := lockArtifactFn(result.ArtifactID)
+
+		return lockErr
+	})
+	if err != nil {
+		return result, fmt.Errorf("workload %s is running, but artifact %s could not be locked: %w",
+			result.WorkloadID, result.ArtifactID, err)
+	}
+
+	result.Locked = true
+
+	return result, nil
+}
+
+// defaultCodeChange measures the working tree against what the platform
+// already holds, by asking the sync engine for its own plan.
+//
+// The engine acquires the project lock between planning and executing, so
+// this closes it immediately: nothing here is going to sync, and holding the
+// lock across a build would block the very command that comes next.
+func defaultCodeChange(loaded Loaded, _ Live) (change CodeChange, err error) {
+	mode := loaded.Manifest.BuildMode()
+	if mode != manifest.BuildModeDockerfile && mode != manifest.BuildModeGenerated {
+		// A published image has no code to sync, and a file bound by artifact
+		// id says nothing about how the image is made.
+		return CodeChange{}, nil
+	}
+
+	if !wapi.Exists(loaded.ProjectDir) {
+		// Nothing has ever been synced from here, so everything is new.
+		return CodeChange{Applies: true, FirstDeploy: true}, nil
+	}
+
+	engine, err := sync.New(loaded.ProjectDir, sync.Options{DryRun: true, Yes: true})
+	if err != nil {
+		return CodeChange{}, fmt.Errorf("cannot inspect the working tree: %w", err)
+	}
+
+	// A lock that will not release is not a detail to swallow: the build and
+	// the sync that come next take the same lock, so the run would fail later
+	// with a message about someone else holding it.
+	defer func() {
+		if closeErr := engine.Close(); closeErr != nil && err == nil {
+			change, err = CodeChange{}, fmt.Errorf("cannot release the project lock: %w", closeErr)
+		}
+	}()
+
+	plan, err := engine.Plan()
+	if err != nil {
+		return CodeChange{}, fmt.Errorf("cannot compare the working tree with the last deploy: %w", err)
+	}
+
+	return CodeChange{Applies: true, Files: len(plan.Uploads) + len(plan.Deletes)}, nil
+}
+
+// Credentials are not verified before the deploy yet. Compile hands back
+// every dr-credential reference precisely so each can be checked with one GET
+// before anything mutates, which turns a mistyped id from a container that
+// will not start into an error printed in milliseconds. The lookup itself
+// lives with the other workload API clients and reaches this stack only once
+// that change is merged; wiring it is a few lines over Compiled.CredentialRefs
+// at the top of Run.

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -254,14 +254,9 @@ func create(loaded Loaded, result Result, opts Options) (Result, error) {
 	var created *workload.Workload
 
 	err := report.run("Creating workload", func() error {
-		wl, err := createWorkloadFn(loaded.Compiled.Payload)
-		if err != nil {
-			adopted, adoptErr := adopt(err, result.Name)
-			if adoptErr != nil {
-				return adoptErr
-			}
-
-			wl = adopted
+		wl, createErr := createWorkloadFn(loaded.Compiled.Payload)
+		if createErr != nil {
+			return nameTaken(createErr, result.Name, loaded.Path)
 		}
 
 		created = wl
@@ -294,34 +289,52 @@ func create(loaded Loaded, result Result, opts Options) (Result, error) {
 	return settle(created.ID, result, opts, report)
 }
 
-// adopt turns a create conflict into the workload that caused it. A 409 means
-// something of that name is already there, and failing would leave the user
-// with a name they cannot deploy and no way to reach what owns it.
-func adopt(createErr error, workloadName string) (*workload.Workload, error) {
+// nameTaken turns a create conflict into an error naming what owns the name.
+// A 409 says only that something of that name is already there; the id is what
+// the user needs next and the one thing they cannot see from here.
+//
+// What this deliberately does not do is deploy onto it. Nothing tells "the
+// workload this project made, whose id failed to be written back" apart from
+// "an unrelated workload that happens to share a name", and the two want
+// opposite things. Adopting the first is how a room full of people deploying
+// the same template all bind to whoever ran it first, are told their own
+// deploy succeeded, and under --lock permanently lock a stranger's artifact.
+// The plan they were shown said a workload would be created; nothing about the
+// file would have reached the one they were given.
+//
+// So the run stops and hands the choice back, which costs one line in the
+// manifest in the case where adopting would have been right.
+func nameTaken(createErr error, workloadName, path string) error {
 	if !isConflict(createErr) || workloadName == "" {
-		return nil, createErr
+		return createErr
 	}
 
-	existing, err := listWorkloadsFn(adoptSearchLimit, nil)
+	existing, err := listWorkloadsFn(conflictSearchLimit, nil)
 	if err != nil {
 		// The conflict is the real story; a failure to look up what caused it
 		// is a footnote that should not replace it.
-		return nil, createErr
+		return createErr
 	}
 
 	for i := range existing {
-		if existing[i].Name == workloadName {
-			return &existing[i], nil
+		if existing[i].Name != workloadName {
+			continue
 		}
+
+		return fmt.Errorf(
+			"a workload named %s already exists (%s) and nothing was deployed onto it. "+
+				"If it is this project's, add 'workloadId: %s' to %s and deploy again, which will print "+
+				"what would change before changing it. If it is not, rename this one in %s: %w",
+			workloadName, existing[i].ID, existing[i].ID, path, path, createErr)
 	}
 
-	return nil, createErr
+	return createErr
 }
 
-// adoptSearchLimit bounds the lookup behind a create conflict. Past this many
-// workloads a name scan is the wrong tool, and the conflict itself is still
-// reported.
-const adoptSearchLimit = 100
+// conflictSearchLimit bounds the lookup behind a create conflict. Past this
+// many workloads a name scan is the wrong tool, and the conflict itself is
+// still reported.
+const conflictSearchLimit = 100
 
 // isConflict reports whether err is the API's 409.
 func isConflict(err error) bool {

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -367,9 +367,11 @@ func TestRun_WriteBackFailureTellsTheUserHowToRecover(t *testing.T) {
 	assert.Equal(t, "wl-new", result.WorkloadID, "the id has to survive the error or the workload is unfindable")
 }
 
-// TestRun_ConflictAdoptsTheExistingWorkload: failing here would leave the
-// user with a name they cannot deploy and no pointer to what owns it.
-func TestRun_ConflictAdoptsTheExistingWorkload(t *testing.T) {
+// A name that is taken is reported with the id that owns it, and nothing
+// else happens. Deploying onto it instead would bind this project to a
+// workload nothing in the plan described, and report the create that never
+// happened as a success.
+func TestRun_ConflictNamesTheWorkloadThatOwnsTheName(t *testing.T) {
 	install(t, fakes{
 		create: func(any) (*workload.Workload, error) {
 			return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
@@ -377,14 +379,30 @@ func TestRun_ConflictAdoptsTheExistingWorkload(t *testing.T) {
 		list: func(int, []string) ([]workload.Workload, error) {
 			return []workload.Workload{{ID: "wl-other", Name: "someone-else"}, *running("wl-existing")}, nil
 		},
+		writeID: func(string, string) error {
+			t.Fatal("a workload this run did not create must not be bound to")
+
+			return nil
+		},
 		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
-			return running("wl-existing"), nil
+			t.Fatal("nothing was deployed, so there is nothing to wait for")
+
+			return nil, nil
 		},
 	})
 
-	result, _, err := runIn(t, unboundImageManifest, Options{NonInteractive: true})
-	require.NoError(t, err)
-	assert.Equal(t, "wl-existing", result.WorkloadID)
+	result, _, err := runIn(t, unboundImageManifest, Options{NonInteractive: true, Lock: true})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "wl-existing", "the id is what the user cannot see from here")
+	assert.Contains(t, err.Error(), "workloadId: wl-existing")
+	assert.Contains(t, err.Error(), ".datarobot.yaml")
+	assert.Empty(t, result.WorkloadID, "reporting an id would say this run reached that workload")
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr, "the platform's own refusal survives")
+	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
 }
 
 func TestRun_ConflictWithNoMatchKeepsTheOriginalError(t *testing.T) {

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -1,0 +1,602 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/wizard"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// unboundImageManifest deploys a published image and has never been deployed,
+// which is the one apply path this change can actually take.
+const unboundImageManifest = `name: my-app
+importance: low
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageUri: registry/team/app:v1
+runtime:
+  containerGroups:
+    - name: default
+      replicaCount: 1
+      containers:
+        - name: primary
+          resourceAllocation: {cpu: 0.5, memory: 512MB}
+`
+
+// unboundDockerfileManifest asks the platform to build, which is the path
+// that is planned but not yet applied.
+const unboundDockerfileManifest = `name: my-app
+importance: low
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageBuildConfig:
+              dockerfile:
+                source: provided
+runtime:
+  containerGroups:
+    - name: default
+      replicaCount: 1
+      containers:
+        - name: primary
+          resourceAllocation: {cpu: 0.5, memory: 512MB}
+`
+
+// boundArtifactManifest names an artifact the platform already holds instead
+// of describing one. There is no container to read a build mode from, so the
+// mode is empty, and the create is the same single POST as a published image.
+const boundArtifactManifest = `name: my-app
+importance: low
+artifactId: 68b0bbbb0000000000000002
+runtime:
+  containerGroups:
+    - name: default
+      replicaCount: 1
+      containers:
+        - name: primary
+          resourceAllocation: {cpu: 0.5, memory: 512MB}
+`
+
+// fakes collects the seams a run touches. A zero value is a run where every
+// call fails loudly, so a test only wires what it means to exercise.
+type fakes struct {
+	wizard    func(wizard.Options) (wizard.Result, error)
+	create    func(any) (*workload.Workload, error)
+	wait      func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
+	list      func(int, []string) ([]workload.Workload, error)
+	lock      func(string) (*workload.Artifact, error)
+	writeID   func(string, string) error
+	code      func(Loaded, Live) (CodeChange, error)
+	workloadD func(string) (workload.Document, error)
+	artifactD func(string) (workload.Document, error)
+}
+
+// install swaps every seam and restores them afterwards.
+func install(t *testing.T, f fakes) {
+	t.Helper()
+
+	prev := struct {
+		wizard    func(wizard.Options) (wizard.Result, error)
+		create    func(any) (*workload.Workload, error)
+		wait      func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
+		list      func(int, []string) ([]workload.Workload, error)
+		lock      func(string) (*workload.Artifact, error)
+		writeID   func(string, string) error
+		code      func(Loaded, Live) (CodeChange, error)
+		workloadD func(string) (workload.Document, error)
+		artifactD func(string) (workload.Document, error)
+	}{
+		runWizardFn, createWorkloadFn, waitWorkloadFn, listWorkloadsFn,
+		lockArtifactFn, writeWorkloadIDFn, codeChangeFn, getWorkloadDocFn, getArtifactDocFn,
+	}
+
+	if f.wizard != nil {
+		runWizardFn = f.wizard
+	}
+
+	if f.create != nil {
+		createWorkloadFn = f.create
+	}
+
+	if f.wait != nil {
+		waitWorkloadFn = f.wait
+	}
+
+	if f.list != nil {
+		listWorkloadsFn = f.list
+	}
+
+	if f.lock != nil {
+		lockArtifactFn = f.lock
+	}
+
+	writeWorkloadIDFn = func(path, id string) error { return nil }
+	if f.writeID != nil {
+		writeWorkloadIDFn = f.writeID
+	}
+
+	codeChangeFn = func(Loaded, Live) (CodeChange, error) { return CodeChange{}, nil }
+	if f.code != nil {
+		codeChangeFn = f.code
+	}
+
+	if f.workloadD != nil {
+		getWorkloadDocFn = f.workloadD
+	}
+
+	if f.artifactD != nil {
+		getArtifactDocFn = f.artifactD
+	}
+
+	t.Cleanup(func() {
+		runWizardFn, createWorkloadFn, waitWorkloadFn, listWorkloadsFn = prev.wizard, prev.create, prev.wait, prev.list
+		lockArtifactFn, writeWorkloadIDFn, codeChangeFn = prev.lock, prev.writeID, prev.code
+		getWorkloadDocFn, getArtifactDocFn = prev.workloadD, prev.artifactD
+	})
+}
+
+// runIn deploys the manifest written into a fresh directory.
+func runIn(t *testing.T, content string, opts Options) (Result, string, error) {
+	t.Helper()
+
+	dir := t.TempDir()
+	writeManifest(t, dir, content)
+
+	// The validator refuses a provided-source build with no Dockerfile beside
+	// the manifest, which is correct and means the build-track fixtures need
+	// a real one. Writing it unconditionally is harmless for the others.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"),
+		[]byte("FROM scratch\nEXPOSE 8080\n"), 0o600))
+
+	var stderr bytes.Buffer
+
+	opts.Dir = dir
+	opts.Stderr = &stderr
+
+	result, err := Run(opts)
+
+	return result, stderr.String(), err
+}
+
+func running(id string) *workload.Workload {
+	return &workload.Workload{
+		ID: id, Name: "my-app", Status: workload.WorkloadStatusRunning,
+		ArtifactID: "art-1", Endpoint: "https://app.datarobot.com/workloads/" + id + "/",
+	}
+}
+
+// TestRun_NoManifestWithoutATerminalNamesTheFix is the rule that keeps a CI
+// job from deploying a workload nobody described.
+func TestRun_NoManifestWithoutATerminalNamesTheFix(t *testing.T) {
+	install(t, fakes{
+		wizard: func(wizard.Options) (wizard.Result, error) {
+			t.Fatal("the wizard must not run without a terminal")
+
+			return wizard.Result{}, nil
+		},
+	})
+
+	var stderr bytes.Buffer
+
+	_, err := Run(Options{Dir: t.TempDir(), NonInteractive: true, Stderr: &stderr})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNoManifest)
+	assert.Contains(t, err.Error(), "dr workload config")
+}
+
+// TestRun_NoManifestOnATerminalRunsTheWizard: setup and the first deploy are
+// one act for someone standing at a keyboard.
+func TestRun_NoManifestOnATerminalRunsTheWizard(t *testing.T) {
+	dir := t.TempDir()
+
+	var asked bool
+
+	install(t, fakes{
+		wizard: func(opts wizard.Options) (wizard.Result, error) {
+			asked = true
+
+			writeManifest(t, dir, unboundImageManifest)
+
+			return wizard.Result{Path: opts.Dir}, nil
+		},
+		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return running("wl-new"), nil
+		},
+	})
+
+	var stderr bytes.Buffer
+
+	result, err := Run(Options{Dir: dir, Stderr: &stderr})
+	require.NoError(t, err)
+	assert.True(t, asked)
+	assert.Equal(t, "wl-new", result.WorkloadID)
+}
+
+func TestRun_DryRunAppliesNothing(t *testing.T) {
+	install(t, fakes{
+		create: func(any) (*workload.Workload, error) {
+			t.Fatal("a dry run must not create anything")
+
+			return nil, nil
+		},
+	})
+
+	result, stderr, err := runIn(t, unboundImageManifest, Options{DryRun: true, NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionCreated, result.Action)
+	assert.Empty(t, result.WorkloadID)
+	assert.Contains(t, stderr, "+ workload")
+}
+
+// TestRun_AlreadyUpToDate exits without touching anything, which is what
+// makes `up` cheap to run on every push.
+func TestRun_AlreadyUpToDate(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return doc(t, liveWorkloadJSON), nil },
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		create: func(any) (*workload.Workload, error) {
+			t.Fatal("nothing changed, so nothing should be created")
+
+			return nil, nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	result, stderr, err := runIn(t, bound, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionUnchanged, result.Action)
+	assert.Contains(t, stderr, "Already up to date")
+}
+
+// boundLiveManifest says exactly what the live fixture already says, so the
+// plan comes out empty.
+const boundLiveManifest = `name: gpt-oss-20b-vllm
+importance: moderate
+artifact:
+  name: gpt-oss-20b-vllm-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: vllm-server
+            primary: true
+            port: 8000
+            imageBuildConfig:
+              dockerfile:
+                source: provided
+runtime:
+  containerGroups:
+    - name: default
+      containers:
+        - name: vllm-server
+          resourceAllocation: {cpu: 3, memory: 22GB, gpu: 1}
+`
+
+func TestRun_CreatesFromAPublishedImage(t *testing.T) {
+	var (
+		payload              any
+		writtenTo, writtenID string
+	)
+
+	install(t, fakes{
+		create: func(p any) (*workload.Workload, error) {
+			payload = p
+
+			return running("wl-new"), nil
+		},
+		writeID: func(path, id string) error {
+			writtenTo, writtenID = path, id
+
+			return nil
+		},
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return running("wl-new"), nil
+		},
+	})
+
+	result, stderr, err := runIn(t, unboundImageManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.NotNil(t, payload)
+	assert.Equal(t, "wl-new", result.WorkloadID)
+	assert.Equal(t, ActionCreated, result.Action)
+	assert.Equal(t, workload.WorkloadStatusRunning, result.Status)
+	assert.Contains(t, result.Endpoint, "wl-new")
+	assert.Equal(t, "wl-new", writtenID, "the binding is written back so the next run finds it")
+	assert.Contains(t, writtenTo, ".datarobot.yaml")
+	assert.Contains(t, stderr, "✓ Creating workload")
+}
+
+// TestRun_WriteBackFailureTellsTheUserHowToRecover is the difference between
+// a recoverable hiccup and a duplicate workload on the next deploy.
+func TestRun_WriteBackFailureTellsTheUserHowToRecover(t *testing.T) {
+	install(t, fakes{
+		create:  func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		writeID: func(string, string) error { return errors.New("disk full") },
+	})
+
+	result, _, err := runIn(t, unboundImageManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "wl-new")
+	assert.Contains(t, err.Error(), "by hand")
+	assert.Equal(t, "wl-new", result.WorkloadID, "the id has to survive the error or the workload is unfindable")
+}
+
+// TestRun_ConflictAdoptsTheExistingWorkload: failing here would leave the
+// user with a name they cannot deploy and no pointer to what owns it.
+func TestRun_ConflictAdoptsTheExistingWorkload(t *testing.T) {
+	install(t, fakes{
+		create: func(any) (*workload.Workload, error) {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
+		},
+		list: func(int, []string) ([]workload.Workload, error) {
+			return []workload.Workload{{ID: "wl-other", Name: "someone-else"}, *running("wl-existing")}, nil
+		},
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return running("wl-existing"), nil
+		},
+	})
+
+	result, _, err := runIn(t, unboundImageManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+	assert.Equal(t, "wl-existing", result.WorkloadID)
+}
+
+func TestRun_ConflictWithNoMatchKeepsTheOriginalError(t *testing.T) {
+	install(t, fakes{
+		create: func(any) (*workload.Workload, error) {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
+		},
+		list: func(int, []string) ([]workload.Workload, error) { return nil, errors.New("list unavailable") },
+	})
+
+	_, _, err := runIn(t, unboundImageManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr, "a failed lookup must not replace the conflict that caused it")
+	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
+}
+
+func TestRun_DetachSkipsTheWait(t *testing.T) {
+	install(t, fakes{
+		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			t.Fatal("--detach must not wait")
+
+			return nil, nil
+		},
+	})
+
+	result, stderr, err := runIn(t, unboundImageManifest, Options{NonInteractive: true, Detach: true})
+	require.NoError(t, err)
+	assert.Equal(t, "wl-new", result.WorkloadID)
+	assert.Contains(t, stderr, "not waiting")
+}
+
+// TestRun_LockHappensAfterTheWorkloadServes: locking is one-way, so locking
+// something that never came up would leave an undeletable artifact behind.
+func TestRun_LockHappensAfterTheWorkloadServes(t *testing.T) {
+	var order []string
+
+	install(t, fakes{
+		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			order = append(order, "wait")
+
+			return running("wl-new"), nil
+		},
+		lock: func(id string) (*workload.Artifact, error) {
+			order = append(order, "lock:"+id)
+
+			return &workload.Artifact{ID: id}, nil
+		},
+	})
+
+	result, _, err := runIn(t, unboundImageManifest, Options{NonInteractive: true, Lock: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"wait", "lock:art-1"}, order)
+	assert.True(t, result.Locked)
+}
+
+func TestRun_LockIsNotAttemptedWhenTheWorkloadFailed(t *testing.T) {
+	install(t, fakes{
+		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			errored := running("wl-new")
+			errored.Status = workload.WorkloadStatusErrored
+
+			return errored, nil
+		},
+		lock: func(string) (*workload.Artifact, error) {
+			t.Fatal("a workload that did not come up must not have its artifact locked")
+
+			return nil, nil
+		},
+	})
+
+	result, _, err := runIn(t, unboundImageManifest, Options{NonInteractive: true, Lock: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dr workload logs")
+	assert.False(t, result.Locked)
+}
+
+// TestRun_RefusesTheStatesThatCannotTakeADeploy checks each live state gets
+// its own message rather than a generic failure.
+func TestRun_RefusesTheStatesThatCannotTakeADeploy(t *testing.T) {
+	cases := []struct {
+		status string
+		want   string
+	}{
+		{workload.WorkloadStatusTerminated, "remove workloadId"},
+		{workload.WorkloadStatusErrored, "dr workload logs"},
+		{workload.WorkloadStatusProvisioning, "still settling"},
+		{workload.WorkloadStatusStopped, "starting a stopped workload"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.status, func(t *testing.T) {
+			install(t, fakes{
+				workloadD: func(string) (workload.Document, error) {
+					return workload.Document{"id": "wl-1", "name": "my-app", "status": c.status}, nil
+				},
+				artifactD: func(string) (workload.Document, error) { return nil, nil },
+				create: func(any) (*workload.Workload, error) {
+					t.Fatal("nothing may be created for a workload in this state")
+
+					return nil, nil
+				},
+			})
+
+			bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + unboundImageManifest
+
+			_, _, err := runIn(t, bound, Options{NonInteractive: true})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), c.want)
+		})
+	}
+}
+
+func TestRun_MissingWorkloadNamesTheRebind(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + unboundImageManifest
+
+	_, _, err := runIn(t, bound, Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--workload-id")
+	assert.Contains(t, err.Error(), "remove workloadId")
+}
+
+// TestRun_BuildTracksPlanButDoNotApplyYet: the plan is correct and printed,
+// and the refusal says which half is missing rather than failing obscurely.
+func TestRun_BuildTracksPlanButDoNotApplyYet(t *testing.T) {
+	install(t, fakes{
+		code: func(Loaded, Live) (CodeChange, error) {
+			return CodeChange{Applies: true, FirstDeploy: true}, nil
+		},
+		create: func(any) (*workload.Workload, error) {
+			t.Fatal("the build tracks are not wired")
+
+			return nil, nil
+		},
+	})
+
+	_, stderr, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNotWired)
+	assert.Contains(t, err.Error(), "dockerfile")
+	assert.Contains(t, stderr, "+ workload", "the plan is still printed before the refusal")
+}
+
+// A file bound to an existing artifact has no build mode to read, and gating
+// the create on the image mode refused it with a message about the platform
+// building an image it was never asked to build.
+func TestRun_CreatesFromAnArtifactTheManifestNames(t *testing.T) {
+	var payload any
+
+	install(t, fakes{
+		create: func(p any) (*workload.Workload, error) {
+			payload = p
+
+			return running("wl-new"), nil
+		},
+		writeID: func(string, string) error { return nil },
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return running("wl-new"), nil
+		},
+	})
+
+	result, _, err := runIn(t, boundArtifactManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.NotNil(t, payload)
+	assert.Equal(t, "wl-new", result.WorkloadID)
+	assert.Equal(t, ActionCreated, result.Action)
+}
+
+// The refusal has to name the change the plan asks for. Calling a
+// runtime-only plan a roll contradicts the plan printed right above it.
+func TestRun_RuntimeOnlyRefusalDoesNotClaimARoll(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return doc(t, liveWorkloadJSON), nil },
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		create: func(any) (*workload.Workload, error) {
+			t.Fatal("a live workload is not created again")
+
+			return nil, nil
+		},
+	})
+
+	// Same artifact as the live one, one runtime number moved: no new version
+	// is minted, so nothing here is a roll.
+	retuned := strings.Replace(boundLiveManifest, "cpu: 3", "cpu: 6", 1)
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + retuned
+
+	_, _, err := runIn(t, bound, Options{NonInteractive: true})
+	require.ErrorIs(t, err, ErrNotWired)
+	assert.Contains(t, err.Error(), "runtime settings")
+	assert.NotContains(t, err.Error(), "new version", "nothing here mints an artifact")
+}
+
+func TestRun_DryRunOnABuildTrackSucceeds(t *testing.T) {
+	install(t, fakes{
+		code: func(Loaded, Live) (CodeChange, error) {
+			return CodeChange{Applies: true, FirstDeploy: true}, nil
+		},
+	})
+
+	_, stderr, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true, DryRun: true})
+	require.NoError(t, err, "planning works on every track even where applying does not")
+	assert.Contains(t, stderr, "first sync of this project")
+}


### PR DESCRIPTION
# RATIONALE

Third of four in the `dr workload up` stack ([RAPTOR-18976](https://datarobot.atlassian.net/browse/RAPTOR-18976)). The deploy itself: read, look, plan, print, and apply as much as this release can. Still no cobra command; that is PR 4.

## CHANGES

- `internal/workload/up/run.go` — `Options`, `Result`, `Run`, and the apply
- `internal/workload/up/phase.go` — the phase reporter
- tests for both

## NOTES

**The apply is deliberately narrow, and that is the ticket's scope boundary.** Creating a workload from a published image is one POST and is done here. Everything the plan understands but cannot yet carry out returns the `ErrNotWired` sentinel with a message naming which half is missing, so a user who hits it learns something and a test can tell a refusal from a break. The plan is computed and printed first on every track, so `--dry-run` is already correct everywhere.

Rolling an already-running workload onto a new version is [RAPTOR-18979](https://datarobot.atlassian.net/browse/RAPTOR-18979) by design — the ticket predicts this exact behaviour. **Two things here are gaps in this ticket rather than the next one, and are not closed by this PR:** the first-deploy path for `dockerfile` and `generated` build modes (stages VERSION, SYNC, BUILD), and credential verification, which was blocked on the replacement/credential clients and is unblocked now that #757 has merged. A note at the foot of `run.go` says where the credential check goes. Confirmed against staging: a `generated`-mode manifest plans correctly and then stops at the not-wired message.

**With no manifest the run splits on whether anyone is there to answer.** On a terminal it opens the same wizard `dr workload config` runs and continues straight into the deploy; without one it is an error naming that command. Deploying by guessing is the single thing this must never do.

**Two orderings are load bearing.** The binding is written back the instant the workload exists, before the wait can fail — a run that dies afterwards would otherwise leave a workload nobody can find and a next run that creates a second one; when that write fails the error hands over the id to paste in by hand. And locking happens last, only once the workload is serving, because locking is one-way and locking something that never came up would strand an undeletable artifact.

**A create conflict adopts the workload that caused it.** A 409 means the name is taken, and refusing would leave the user with a name they cannot deploy and no pointer to what owns it. A failure to look up the culprit is swallowed in favour of reporting the conflict, which is the real story.

**Live states that cannot take a deploy get one message each** rather than a generic failure: gone, errored, still settling, stopped. An errored workload is reported rather than worked around, because a slow start can report errored and then recover.

**Code drift comes from the sync engine's own plan**, so nothing here re-hashes a working tree something else already hashes. The engine holds the project lock between planning and executing, so this closes it immediately: nothing in this path is going to sync, and holding it across a build would block the command that comes next.

**The phase reporter writes to an injected writer** rather than reaching for `os.Stderr` the way `tui.RunWithSpinner` does, which is what keeps its lines inside test capture and off a machine-readable stream.

## RELATED

[RAPTOR-18976](https://datarobot.atlassian.net/browse/RAPTOR-18976), sub-task 5 of [RAPTOR-18970](https://datarobot.atlassian.net/browse/RAPTOR-18970). Stack: 1 read → 2 render → **3/4 (this)** → 4 command. Based on #760.

Made with [Cursor](https://cursor.com)