### PR TITLE
[RAPTOR-18976] feat(workload): add the dr workload up command

### DIFF
--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -76,6 +76,7 @@ func TestTelemetryWiring_AllCoreCommandsTracked(t *testing.T) {
 // "workload" for the standalone subtree.
 var expectedWorkloadTrackedCommands = []string{
 	"workload config",
+	"workload up",
 	"workload create",
 	"workload get",
 	"workload list",

--- a/cmd/workload/cmd.go
+++ b/cmd/workload/cmd.go
@@ -25,6 +25,7 @@ import (
 	"github.com/datarobot/cli/cmd/workload/start"
 	"github.com/datarobot/cli/cmd/workload/status"
 	"github.com/datarobot/cli/cmd/workload/stop"
+	"github.com/datarobot/cli/cmd/workload/up"
 	"github.com/datarobot/cli/internal/features"
 	"github.com/spf13/cobra"
 )
@@ -59,6 +60,7 @@ Manage and monitor workloads in your deployment infrastructure.`,
 		start.Cmd(),
 		status.Cmd(),
 		stop.Cmd(),
+		up.Cmd(),
 	)
 
 	return cmd

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -1,0 +1,273 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package up implements `dr workload up`: read the committed manifest, work
+// out what differs from what is running, and apply only that. The command is
+// the shell; the deploy lives in internal/workload/up.
+package up
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/datarobot/cli/cmd/internal/pollflags"
+	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload/up"
+	"github.com/spf13/cobra"
+)
+
+// Per-phase wait defaults. A deploy is slower than the shared defaults
+// assume: an image build routinely runs for minutes.
+const (
+	defaultPollInterval = 5 * time.Second
+	defaultPollTimeout  = 30 * time.Minute
+)
+
+// runFn is the deploy, swapped by this package's tests so the shell's own
+// behaviour (flag refusal, stream separation, envelope shape) can be checked
+// without a network.
+var runFn = up.Run
+
+// upResult is the stable JSON shape emitted by --output-format json. BuildID
+// is a pointer so it is null rather than empty when no build happened, which
+// is the difference between "skipped" and "produced nothing".
+type upResult struct {
+	WorkloadID string      `json:"workloadId"`
+	Name       string      `json:"name"`
+	Status     string      `json:"status"`
+	Endpoint   string      `json:"endpoint"`
+	ArtifactID string      `json:"artifactId"`
+	BuildID    *string     `json:"buildId"`
+	Action     string      `json:"action"`
+	Locked     bool        `json:"locked"`
+	Plan       up.PlanJSON `json:"plan"`
+}
+
+type flags struct {
+	dir    string
+	yes    bool
+	dryRun bool
+	detach bool
+	lock   bool
+
+	// bindingFlags exist only to be refused. Cobra's own "unknown flag"
+	// message would leave the user guessing where binding lives, and these
+	// two are the obvious things to reach for.
+	workloadID string
+	name       string
+}
+
+func Cmd() *cobra.Command {
+	var (
+		outputFormat outputformat.OutputFormat
+		f            flags
+		poll         pollflags.Set
+	)
+
+	cmd := &cobra.Command{
+		Use:   "up",
+		Short: "Deploy this project, applying only what changed.",
+		Long: `Read the committed .datarobot.yaml, compare it and the working tree against
+what is running, and apply the difference.
+
+The plan is printed, then carried out. Nothing to do is "Already up to date"
+and exit 0. Use --dry-run to see the plan and stop, which is also the answer
+to "what would this deploy" in CI.
+
+Only fields the manifest mentions are managed. A setting the file never names
+survives every deploy, and deleting a line stops managing that field rather
+than reverting it. Change something in the UI that the file does name and the
+next run puts it back, and says so.
+
+With no manifest, a terminal opens the same setup wizard 'dr workload config'
+runs and continues straight into the deploy. Without a terminal it is an
+error: this command never deploys by guessing.
+
+Examples:
+  dr workload up
+  dr workload up --dry-run
+  dr workload up --yes --output-format json`,
+		Args:         cobra.NoArgs,
+		PreRunE:      auth.EnsureAuthenticatedE,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			outputFormat = outputformat.GetFormat(cmd)
+
+			return run(cmd, f, poll, outputFormat)
+		},
+	}
+
+	outputformat.AddFlag(cmd, &outputFormat)
+	addFlags(cmd, &f, &poll)
+
+	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+		return map[string]any{
+			"yes":           f.yes || viperx.GetBool("yes"),
+			"dry_run":       f.dryRun,
+			"detach":        f.detach,
+			"lock":          f.lock,
+			"output_format": string(outputFormat),
+		}
+	})
+
+	return cmd
+}
+
+func addFlags(cmd *cobra.Command, f *flags, poll *pollflags.Set) {
+	cmd.Flags().StringVar(&f.dir, "dir", "", "Project directory; the manifest is searched upward from here.")
+	cmd.Flags().BoolVarP(&f.yes, "yes", "y", false, "Do not prompt. With no manifest this is an error rather than a wizard.")
+	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "Print the plan and change nothing.")
+	cmd.Flags().BoolVar(&f.detach, "detach", false, "Return once the deploy is requested; do not wait for it to serve.")
+	cmd.Flags().BoolVar(&f.lock, "lock", false,
+		"Lock the artifact that ends up live, making it permanent. Locking is one-way.")
+
+	cmd.Flags().StringVar(&f.workloadID, "workload-id", "", "")
+	cmd.Flags().StringVar(&f.name, "name", "", "")
+	_ = cmd.Flags().MarkHidden("workload-id")
+	_ = cmd.Flags().MarkHidden("name")
+
+	// Deliberately not pollflags.Register: it would add a --wait that
+	// contradicts --detach.
+	cmd.Flags().Var(pollflags.PositiveDuration(&poll.Interval, defaultPollInterval),
+		"poll-interval", "How often to check on a deploy in progress.")
+	cmd.Flags().Var(pollflags.PositiveDuration(&poll.Timeout, defaultPollTimeout),
+		"poll-timeout", "How long to wait for a deploy before giving up.")
+	_ = cmd.Flags().MarkHidden("poll-interval")
+	_ = cmd.Flags().MarkHidden("poll-timeout")
+}
+
+func run(cmd *cobra.Command, f flags, poll pollflags.Set, format outputformat.OutputFormat) error {
+	if err := checkFlags(cmd, f); err != nil {
+		return err
+	}
+
+	dir, err := resolveDir(f.dir)
+	if err != nil {
+		return err
+	}
+
+	json := format == outputformat.OutputFormatJSON
+
+	// JSON output implies non-interactive: a wizard drawn on stderr while
+	// stdout is being parsed is a trap for whoever is parsing it.
+	nonInteractive := f.yes || viperx.GetBool("yes") || json || !reader.IsStdinTerminal()
+
+	result, runErr := runFn(up.Options{
+		Dir:            dir,
+		NonInteractive: nonInteractive,
+		DryRun:         f.dryRun,
+		Detach:         f.detach,
+		Lock:           f.lock,
+		PollInterval:   poll.Interval,
+		PollTimeout:    poll.Timeout,
+		Stderr:         cmd.ErrOrStderr(),
+		Spinner:        !json && !nonInteractive,
+	})
+
+	if runErr != nil && !reportable(result) {
+		return runErr
+	}
+
+	if err := render(cmd, f, format, result); err != nil {
+		return err
+	}
+
+	return runErr
+}
+
+// resolveDir defaults --dir to where the shell is standing.
+func resolveDir(dir string) (string, error) {
+	if dir != "" {
+		return dir, nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine the current directory: %w", err)
+	}
+
+	return cwd, nil
+}
+
+// checkFlags refuses what the flags cannot mean.
+//
+// --workload-id and --name are the two people reach for out of habit. Binding
+// a manifest to a workload is setup's job, and doing it here would mean two
+// places that decide what a project deploys to.
+//
+// --lock with --detach is the one contradictory pair: an artifact is locked
+// only once the workload it serves is running, and --detach returns before
+// that, so accepting both would drop the lock in silence and hand back an
+// artifact the caller believes is permanent.
+func checkFlags(cmd *cobra.Command, f flags) error {
+	for _, flag := range []string{"workload-id", "name"} {
+		if cmd.Flags().Changed(flag) {
+			return fmt.Errorf(
+				"--%s is not a flag of this command: which workload a project deploys to is recorded in "+
+					".datarobot.yaml. Use 'dr workload config --%s ...' to set it", flag, flag)
+		}
+	}
+
+	if f.detach && f.lock {
+		return errors.New(
+			"--lock cannot be combined with --detach: an artifact is locked only after the workload it serves is running")
+	}
+
+	return nil
+}
+
+// reportable says whether a failed run left behind anything worth printing.
+// A failure after the workload exists still reports it: losing the id because
+// the wait timed out is how a deploy becomes unfindable. With no id at all an
+// envelope of empty strings would be noise.
+func reportable(result up.Result) bool {
+	return result.WorkloadID != ""
+}
+
+func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, result up.Result) error {
+	if format == outputformat.OutputFormatJSON {
+		return outputformat.PrintJSONEnvelope(cmd.OutOrStdout(), "up", upResult{
+			WorkloadID: result.WorkloadID,
+			Name:       result.Name,
+			Status:     result.Status,
+			Endpoint:   result.Endpoint,
+			ArtifactID: result.ArtifactID,
+			BuildID:    nil,
+			Action:     result.Action,
+			Locked:     result.Locked,
+			Plan:       result.Plan.JSON(),
+		})
+	}
+
+	if f.dryRun {
+		fmt.Fprintln(cmd.ErrOrStderr(), "\nDry run: nothing was changed.")
+
+		return nil
+	}
+
+	// stdout carries the endpoint and nothing else, so it can be piped.
+	if result.Endpoint != "" {
+		fmt.Fprintln(cmd.OutOrStdout(), result.Endpoint)
+	}
+
+	return nil
+}

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -1,0 +1,260 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload/up"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubRun replaces the deploy and hands back what the caller asked for,
+// recording the options the shell built.
+func stubRun(t *testing.T, result up.Result, err error) *up.Options {
+	t.Helper()
+
+	seen := &up.Options{}
+	prev := runFn
+
+	runFn = func(opts up.Options) (up.Result, error) {
+		*seen = opts
+
+		return result, err
+	}
+
+	t.Cleanup(func() { runFn = prev })
+
+	return seen
+}
+
+// runCmd executes the command with stdout and stderr captured separately,
+// which is the only way to hold the JSON purity rule honestly.
+func runCmd(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+
+	cmd := Cmd()
+
+	var out, errOut bytes.Buffer
+
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+
+	// The command's own PreRunE authenticates, which a unit test must not do.
+	cmd.PreRunE = nil
+
+	err = cmd.Execute()
+
+	return out.String(), errOut.String(), err
+}
+
+func deployed() up.Result {
+	return up.Result{
+		WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0",
+		Name:       "my-app",
+		Status:     "running",
+		Endpoint:   "https://app.datarobot.com/workloads/68b0/",
+		ArtifactID: "68a0000000000000000000a1",
+		Action:     up.ActionCreated,
+	}
+}
+
+// TestCmd_StdoutCarriesOnlyTheEndpoint keeps `dr workload up | xargs curl`
+// working: the plan and every progress line belong on stderr.
+func TestCmd_StdoutCarriesOnlyTheEndpoint(t *testing.T) {
+	stubRun(t, deployed(), nil)
+
+	stdout, _, err := runCmd(t)
+	require.NoError(t, err)
+	assert.Equal(t, "https://app.datarobot.com/workloads/68b0/\n", stdout)
+}
+
+// TestCmd_JSONEnvelopeIsTheWholeOfStdout is the purity rule. Anything else on
+// the stream breaks whoever is parsing it.
+func TestCmd_JSONEnvelopeIsTheWholeOfStdout(t *testing.T) {
+	stubRun(t, deployed(), nil)
+
+	stdout, _, err := runCmd(t, "--output-format", "json")
+	require.NoError(t, err)
+
+	var envelope map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(stdout), &envelope), "stdout must be one JSON document and nothing else")
+
+	body, ok := envelope["up"].(map[string]any)
+	require.True(t, ok, "the envelope is keyed on the command name")
+
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", body["workloadId"])
+	assert.Equal(t, "my-app", body["name"])
+	assert.Equal(t, "running", body["status"])
+	assert.Equal(t, "created", body["action"])
+	assert.Equal(t, false, body["locked"])
+	assert.Contains(t, body, "plan", "a dry run in JSON is useless without the plan")
+}
+
+// TestCmd_BuildIDIsNullNotEmpty: a consumer has to be able to tell "no build
+// happened" from "a build happened and produced nothing".
+func TestCmd_BuildIDIsNullNotEmpty(t *testing.T) {
+	stubRun(t, deployed(), nil)
+
+	stdout, _, err := runCmd(t, "--output-format", "json")
+	require.NoError(t, err)
+
+	var envelope map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(stdout), &envelope))
+
+	body, _ := envelope["up"].(map[string]any)
+
+	value, present := body["buildId"]
+	assert.True(t, present, "the key has to be there so a consumer can read it")
+	assert.Nil(t, value, "no build happened, which is not the same as a build that produced nothing")
+}
+
+// TestCmd_JSONImpliesNonInteractive stops a wizard being drawn on stderr
+// while stdout is being parsed.
+func TestCmd_JSONImpliesNonInteractive(t *testing.T) {
+	seen := stubRun(t, deployed(), nil)
+
+	_, _, err := runCmd(t, "--output-format", "json")
+	require.NoError(t, err)
+	assert.True(t, seen.NonInteractive)
+	assert.False(t, seen.Spinner, "nothing may draw over a machine-readable stream")
+}
+
+func TestCmd_YesImpliesNonInteractive(t *testing.T) {
+	seen := stubRun(t, deployed(), nil)
+
+	_, _, err := runCmd(t, "--yes")
+	require.NoError(t, err)
+	assert.True(t, seen.NonInteractive)
+}
+
+// TestCmd_RefusesBindingFlags points at where binding actually lives instead
+// of letting cobra say "unknown flag", which leaves the user guessing.
+func TestCmd_RefusesBindingFlags(t *testing.T) {
+	for _, flag := range []string{"--workload-id", "--name"} {
+		t.Run(flag, func(t *testing.T) {
+			stubRun(t, deployed(), nil)
+
+			_, _, err := runCmd(t, flag, "whatever")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), ".datarobot.yaml")
+			assert.Contains(t, err.Error(), "dr workload config")
+		})
+	}
+}
+
+func TestCmd_DryRunSaysSoAndPrintsNoEndpoint(t *testing.T) {
+	result := deployed()
+	result.Endpoint = ""
+
+	seen := stubRun(t, result, nil)
+
+	stdout, stderr, err := runCmd(t, "--dry-run")
+	require.NoError(t, err)
+	assert.True(t, seen.DryRun)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "nothing was changed")
+}
+
+func TestCmd_PassesTheFlagsThrough(t *testing.T) {
+	seen := stubRun(t, deployed(), nil)
+
+	_, _, err := runCmd(t, "--detach", "--dir", "/tmp/project")
+	require.NoError(t, err)
+	assert.True(t, seen.Detach)
+	assert.Equal(t, "/tmp/project", seen.Dir)
+
+	locking := stubRun(t, deployed(), nil)
+
+	_, _, err = runCmd(t, "--lock")
+	require.NoError(t, err)
+	assert.True(t, locking.Lock)
+}
+
+// Locking happens after the workload is serving and --detach returns before
+// that, so honouring both would drop the lock without saying so and leave the
+// caller believing an artifact is permanent when it is still deletable.
+func TestCmd_DetachAndLockCannotBeCombined(t *testing.T) {
+	stubRun(t, deployed(), nil)
+
+	_, _, err := runCmd(t, "--detach", "--lock")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--lock cannot be combined with --detach")
+}
+
+// TestCmd_PollDefaultsApplyWithoutTheFlag guards the prototype's bug, where a
+// flag that was never parsed left the wait at zero.
+func TestCmd_PollDefaultsApplyWithoutTheFlag(t *testing.T) {
+	seen := stubRun(t, deployed(), nil)
+
+	_, _, err := runCmd(t)
+	require.NoError(t, err)
+	assert.Equal(t, defaultPollInterval, seen.PollInterval)
+	assert.Equal(t, defaultPollTimeout, seen.PollTimeout)
+}
+
+func TestCmd_PollFlagsOverrideTheDefaults(t *testing.T) {
+	seen := stubRun(t, deployed(), nil)
+
+	_, _, err := runCmd(t, "--poll-interval", "1s", "--poll-timeout", "2m")
+	require.NoError(t, err)
+	assert.Equal(t, "1s", seen.PollInterval.String())
+	assert.Equal(t, "2m0s", seen.PollTimeout.String())
+}
+
+// TestCmd_FailureAfterTheWorkloadExistsStillEmitsTheEnvelope: losing the id
+// because a later phase failed is how a deploy becomes unfindable.
+func TestCmd_FailureAfterTheWorkloadExistsStillEmitsTheEnvelope(t *testing.T) {
+	stubRun(t, deployed(), errors.New("timed out waiting"))
+
+	stdout, _, err := runCmd(t, "--output-format", "json")
+	require.Error(t, err)
+
+	var envelope map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(stdout), &envelope),
+		"the envelope has to be emitted before the failure surfaces")
+
+	body, _ := envelope["up"].(map[string]any)
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", body["workloadId"])
+}
+
+// TestCmd_FailureBeforeAnythingExistsJustFails: there is no id to report, so
+// an envelope of empty strings would be noise.
+func TestCmd_FailureBeforeAnythingExistsJustFails(t *testing.T) {
+	stubRun(t, up.Result{}, errors.New("no .datarobot.yaml manifest"))
+
+	stdout, _, err := runCmd(t, "--output-format", "json")
+	require.Error(t, err)
+	assert.Empty(t, stdout)
+	assert.Contains(t, err.Error(), "manifest")
+}
+
+func TestCmd_IsRegisteredUnderWorkload(t *testing.T) {
+	cmd := Cmd()
+
+	assert.Equal(t, "up", cmd.Name())
+	assert.NotNil(t, cmd.Flags().Lookup("dry-run"))
+	assert.NotNil(t, cmd.Flags().Lookup("detach"))
+	assert.NotNil(t, cmd.Flags().Lookup("lock"))
+	assert.True(t, cmd.Flags().Lookup("poll-interval").Hidden)
+}


### PR DESCRIPTION
# RATIONALE

Last of four in the `dr workload up` stack ([RAPTOR-18976](https://datarobot.atlassian.net/browse/RAPTOR-18976)). The shell over the deploy: flags, streams and the JSON envelope. This is the PR that makes `dr workload up` (`dr wl up`) exist, behind the existing `workload` feature gate.

## CHANGES

- `cmd/workload/up/cmd.go` — the command, its flags and the envelope
- `cmd/workload/up/cmd_test.go`
- `cmd/workload/cmd.go` — registration
- `cmd/telemetry_wiring_test.go` — one line

## NOTES

**stdout carries the endpoint and nothing else**, so `dr workload up | xargs curl` works, or exactly one JSON document. The plan, the progress and every warning go to stderr. JSON implies non-interactive, because a wizard drawn on stderr while stdout is being parsed is a trap for whoever is parsing it, and it suppresses the spinner for the same reason.

**A failure after the workload exists still emits the envelope** before the error surfaces. Losing the id because a wait timed out is how a deploy becomes unfindable. `buildId` is a pointer so it is `null` rather than `""`: no build happened is not the same as a build that produced nothing.

**`--workload-id` and `--name` are defined only to be refused.** They are the obvious things to reach for, and cobra's own "unknown flag" would leave the user guessing; the error says binding lives in the manifest and names the command that sets it. Two places deciding what a project deploys to would be one too many.

**The poll flags are registered directly** rather than through `pollflags.Register`, which would add a `--wait` that contradicts `--detach`. Their defaults are longer than the shared ones because an image build routinely runs for minutes.

**Two known gaps against the ticket's flag contract, both deliberate here.** `--force-build` is not implemented; it belongs with the build phase, which is the same follow-up that wires `dockerfile` and `generated` first deploys. And the spec asks for a `-o` shorthand alongside `--output-format`, but `outputformat.AddFlag` registers none, so no command in this repo accepts `-o` — left alone rather than changed underneath the fifteen commands that share it.

## TESTING

Driven against staging end to end: the wizard runs inline with no manifest, resolves a real execution environment, writes the manifest, and the plan renders correctly before the apply stops at the documented not-wired message for `generated` mode.

## RELATED

[RAPTOR-18976](https://datarobot.atlassian.net/browse/RAPTOR-18976), sub-task 5 of [RAPTOR-18970](https://datarobot.atlassian.net/browse/RAPTOR-18970). Stack: 1 read → 2 render → 3 orchestrate → **4/4 (this)**. Based on #761. Follow-ups: [RAPTOR-18978](https://datarobot.atlassian.net/browse/RAPTOR-18978) build logs, [RAPTOR-18979](https://datarobot.atlassian.net/browse/RAPTOR-18979) rollout, [RAPTOR-18971](https://datarobot.atlassian.net/browse/RAPTOR-18971) docs and smoke.

Made with [Cursor](https://cursor.com)