### PR TITLE
[RAPTOR-18976] feat(workload): verify credentials before the deploy mutates

### DIFF
--- a/internal/workload/up/credentials.go
+++ b/internal/workload/up/credentials.go
@@ -1,0 +1,99 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/datarobot/cli/internal/workload/manifest"
+)
+
+// verifyCredentials confirms that every credential the manifest references
+// actually exists, and is the last check before anything mutates.
+//
+// A credential reference is the one part of the manifest local validation
+// cannot judge. The ledger checks that the shorthand parses; whether the id
+// behind it names a real credential is a fact only the platform holds. Left
+// unchecked, a mistyped id survives the whole deploy and surfaces as a
+// container that will not start, minutes and one paid-for build later, with
+// a runtime error that does not mention the manifest.
+//
+// Every problem is reported at once rather than one per run. The refs come
+// from a file the user is about to edit, and finding out about the second bad
+// id only after fixing the first is two round trips through a build pipeline
+// for what is one edit.
+func verifyCredentials(refs []manifest.CredentialRef) error {
+	var (
+		problems []string
+		seen     = make(map[string]bool, len(refs))
+	)
+
+	for _, ref := range refs {
+		if ref.CredentialID == manifest.CredentialPlaceholder {
+			problems = append(problems, placeholderProblem(ref))
+
+			continue
+		}
+
+		// One GET per credential, not per reference: several variables
+		// commonly read different keys of the same stored credential.
+		if seen[ref.CredentialID] {
+			continue
+		}
+
+		seen[ref.CredentialID] = true
+
+		if _, err := getCredentialFn(ref.CredentialID); err != nil {
+			if !isNotFound(err) {
+				// A transport failure means the references were not checked,
+				// which is not the same as their being wrong. Saying so and
+				// stopping beats reporting a credential as missing because
+				// the platform was briefly unreachable.
+				return fmt.Errorf("cannot verify credential %s referenced by %s: %w",
+					ref.CredentialID, ref.EnvName, err)
+			}
+
+			problems = append(problems, missingProblem(ref))
+		}
+	}
+
+	if len(problems) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("the manifest references credentials that cannot be used:\n  %s",
+		strings.Join(problems, "\n  "))
+}
+
+// placeholderProblem describes a reference the setup wizard wrote and nobody
+// finished. The wizard writes the placeholder in full, rather than commenting
+// the entry out, precisely so it fails here instead of deploying a container
+// without its secret.
+func placeholderProblem(ref manifest.CredentialRef) string {
+	return fmt.Sprintf(
+		"line %d: %s still references the %s written by setup. "+
+			"Create the credential, then replace %s with its id",
+		ref.Line, ref.EnvName, manifest.CredentialPlaceholder, manifest.CredentialPlaceholder)
+}
+
+// missingProblem describes an id the platform does not know. It names the
+// variable as well as the id, because the id alone is a hex string the reader
+// has to go looking for in the file.
+func missingProblem(ref manifest.CredentialRef) string {
+	return fmt.Sprintf(
+		"line %d: %s references credential %s, which does not exist or is not visible to this account",
+		ref.Line, ref.EnvName, ref.CredentialID)
+}

--- a/internal/workload/up/credentials_test.go
+++ b/internal/workload/up/credentials_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubCredentials swaps the lookup for one that answers from ids, recording
+// what it was asked for.
+func stubCredentials(t *testing.T, present map[string]bool, failWith error) *[]string {
+	t.Helper()
+
+	asked := make([]string, 0, 4)
+
+	force(t, &getCredentialFn, func(id string) (*workload.Credential, error) {
+		asked = append(asked, id)
+
+		if failWith != nil {
+			return nil, failWith
+		}
+
+		if !present[id] {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
+		}
+
+		return &workload.Credential{CredentialID: id, Name: "cred-" + id}, nil
+	})
+
+	return &asked
+}
+
+func TestVerifyCredentials_NoRefsAsksNothing(t *testing.T) {
+	asked := stubCredentials(t, nil, nil)
+
+	require.NoError(t, verifyCredentials(nil))
+	assert.Empty(t, *asked, "a manifest with no references must not touch the network")
+}
+
+func TestVerifyCredentials_PresentPasses(t *testing.T) {
+	asked := stubCredentials(t, map[string]bool{"cred-1": true}, nil)
+
+	err := verifyCredentials([]manifest.CredentialRef{
+		{CredentialID: "cred-1", Key: "apiToken", EnvName: "OPENAI_API_KEY", Line: 12},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"cred-1"}, *asked)
+}
+
+// One GET per credential, not per reference: several variables commonly read
+// different keys of the same stored credential, and a deploy should not pay
+// for the same lookup twice.
+func TestVerifyCredentials_DeduplicatesByID(t *testing.T) {
+	asked := stubCredentials(t, map[string]bool{"cred-1": true}, nil)
+
+	err := verifyCredentials([]manifest.CredentialRef{
+		{CredentialID: "cred-1", Key: "apiToken", EnvName: "TOKEN_A", Line: 12},
+		{CredentialID: "cred-1", Key: "password", EnvName: "TOKEN_B", Line: 15},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"cred-1"}, *asked)
+}
+
+// The missing-id error has to name the variable and the line, not only the
+// id: the id is a hex string the reader would otherwise have to go hunting
+// for in the file.
+func TestVerifyCredentials_MissingNamesVariableAndLine(t *testing.T) {
+	stubCredentials(t, map[string]bool{}, nil)
+
+	err := verifyCredentials([]manifest.CredentialRef{
+		{CredentialID: "cred-gone", Key: "apiToken", EnvName: "OPENAI_API_KEY", Line: 12},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OPENAI_API_KEY")
+	assert.Contains(t, err.Error(), "cred-gone")
+	assert.Contains(t, err.Error(), "line 12")
+}
+
+// The wizard writes the placeholder in full rather than commenting the entry
+// out, precisely so the deploy stops here instead of starting a container
+// without its secret. It never reaches the network.
+func TestVerifyCredentials_PlaceholderIsRefusedWithoutALookup(t *testing.T) {
+	asked := stubCredentials(t, nil, nil)
+
+	err := verifyCredentials([]manifest.CredentialRef{
+		{CredentialID: manifest.CredentialPlaceholder, Key: "apiToken", EnvName: "OPENAI_API_KEY", Line: 12},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), manifest.CredentialPlaceholder)
+	assert.Contains(t, err.Error(), "OPENAI_API_KEY")
+	assert.Empty(t, *asked, "a placeholder is known to be unusable without asking the platform")
+}
+
+// Every problem is reported at once. The refs come from a file the user is
+// about to edit, and learning about the second bad id only after fixing the
+// first is two trips through a build pipeline for one edit.
+func TestVerifyCredentials_ReportsEveryProblem(t *testing.T) {
+	stubCredentials(t, map[string]bool{"cred-ok": true}, nil)
+
+	err := verifyCredentials([]manifest.CredentialRef{
+		{CredentialID: manifest.CredentialPlaceholder, EnvName: "FIRST", Line: 10},
+		{CredentialID: "cred-ok", EnvName: "SECOND", Line: 13},
+		{CredentialID: "cred-gone", EnvName: "THIRD", Line: 16},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "FIRST")
+	assert.Contains(t, err.Error(), "THIRD")
+	assert.NotContains(t, err.Error(), "SECOND", "the reference that resolved is not a problem")
+}
+
+// A transport failure means the references were not checked, which is not the
+// same as their being wrong. Reporting a credential as missing because the
+// platform was briefly unreachable would send the user editing a correct file.
+func TestVerifyCredentials_TransportFailureIsNotAMissingCredential(t *testing.T) {
+	stubCredentials(t, nil, &drapi.HTTPError{StatusCode: http.StatusBadGateway})
+
+	err := verifyCredentials([]manifest.CredentialRef{
+		{CredentialID: "cred-1", EnvName: "OPENAI_API_KEY", Line: 12},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot verify")
+	assert.NotContains(t, err.Error(), "does not exist")
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr, "the underlying failure has to survive for the caller to inspect")
+	assert.Equal(t, http.StatusBadGateway, httpErr.StatusCode)
+}
+
+func TestVerifyCredentials_NonHTTPErrorPropagates(t *testing.T) {
+	stubCredentials(t, nil, errors.New("no endpoint configured"))
+
+	err := verifyCredentials([]manifest.CredentialRef{{CredentialID: "cred-1", EnvName: "X", Line: 1}})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no endpoint configured")
+}

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -37,6 +37,7 @@ var (
 	waitWorkloadFn    = workload.WaitForWorkload
 	listWorkloadsFn   = workload.ListWorkloads
 	lockArtifactFn    = workload.LockArtifact
+	getCredentialFn   = workload.GetCredential
 	writeWorkloadIDFn = manifest.WriteWorkloadID
 	codeChangeFn      = defaultCodeChange
 )
@@ -193,6 +194,12 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 			"%w: creating a workload whose image the platform builds (%s mode). "+
 				"Publishing the image yourself and switching the manifest to an imageUri works today",
 			ErrNotWired, mode)
+	}
+
+	// Last check before the first mutation, and the only one that needs the
+	// network: a credential id is the one thing the local ledger cannot judge.
+	if err := verifyCredentials(loaded.Compiled.CredentialRefs); err != nil {
+		return result, err
 	}
 
 	return create(loaded, result, opts)
@@ -440,11 +447,3 @@ func defaultCodeChange(loaded Loaded, _ Live) (change CodeChange, err error) {
 
 	return CodeChange{Applies: true, Files: len(plan.Uploads) + len(plan.Deletes)}, nil
 }
-
-// Credentials are not verified before the deploy yet. Compile hands back
-// every dr-credential reference precisely so each can be checked with one GET
-// before anything mutates, which turns a mistyped id from a container that
-// will not start into an error printed in milliseconds. The lookup itself
-// lives with the other workload API clients and reaches this stack only once
-// that change is merged; wiring it is a few lines over Compiled.CredentialRefs
-// at the top of Run.

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -96,6 +97,33 @@ runtime:
           resourceAllocation: {cpu: 0.5, memory: 512MB}
 `
 
+// unboundCredentialManifest names a stored credential, which is the one thing
+// in the file no local check can judge.
+const unboundCredentialManifest = `name: my-app
+importance: low
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageUri: registry/team/app:v1
+            environmentVars:
+              - name: OPENAI_API_KEY
+                value: dr-credential:68b0cccc0000000000000003/apiToken
+runtime:
+  containerGroups:
+    - name: default
+      replicaCount: 1
+      containers:
+        - name: primary
+          resourceAllocation: {cpu: 0.5, memory: 512MB}
+`
+
 // fakes collects the seams a run touches. A zero value is a run where every
 // call fails loudly, so a test only wires what it means to exercise.
 type fakes struct {
@@ -104,74 +132,58 @@ type fakes struct {
 	wait      func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
 	list      func(int, []string) ([]workload.Workload, error)
 	lock      func(string) (*workload.Artifact, error)
+	cred      func(string) (*workload.Credential, error)
 	writeID   func(string, string) error
 	code      func(Loaded, Live) (CodeChange, error)
 	workloadD func(string) (workload.Document, error)
 	artifactD func(string) (workload.Document, error)
 }
 
-// install swaps every seam and restores them afterwards.
+// install swaps in the seams the test supplied and restores them afterwards.
 func install(t *testing.T, f fakes) {
 	t.Helper()
 
-	prev := struct {
-		wizard    func(wizard.Options) (wizard.Result, error)
-		create    func(any) (*workload.Workload, error)
-		wait      func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
-		list      func(int, []string) ([]workload.Workload, error)
-		lock      func(string) (*workload.Artifact, error)
-		writeID   func(string, string) error
-		code      func(Loaded, Live) (CodeChange, error)
-		workloadD func(string) (workload.Document, error)
-		artifactD func(string) (workload.Document, error)
-	}{
-		runWizardFn, createWorkloadFn, waitWorkloadFn, listWorkloadsFn,
-		lockArtifactFn, writeWorkloadIDFn, codeChangeFn, getWorkloadDocFn, getArtifactDocFn,
+	// Two seams default to doing nothing rather than to the real thing. A
+	// test that cares about neither the write-back nor the working tree
+	// should not have to say so, and neither may touch a real project.
+	force(t, &writeWorkloadIDFn, func(string, string) error { return nil })
+	force(t, &codeChangeFn, func(Loaded, Live) (CodeChange, error) { return CodeChange{}, nil })
+
+	swap(t, &runWizardFn, f.wizard)
+	swap(t, &createWorkloadFn, f.create)
+	swap(t, &waitWorkloadFn, f.wait)
+	swap(t, &listWorkloadsFn, f.list)
+	swap(t, &lockArtifactFn, f.lock)
+	swap(t, &getCredentialFn, f.cred)
+	swap(t, &writeWorkloadIDFn, f.writeID)
+	swap(t, &codeChangeFn, f.code)
+	swap(t, &getWorkloadDocFn, f.workloadD)
+	swap(t, &getArtifactDocFn, f.artifactD)
+}
+
+// swap installs fake over the seam at target, and does nothing when the test
+// did not supply one. reflect is what makes that distinction possible: a nil
+// func in a type parameter is still a value, so there is no way to compare it
+// against nil directly.
+func swap[F any](t *testing.T, target *F, fake F) {
+	t.Helper()
+
+	if reflect.ValueOf(fake).IsNil() {
+		return
 	}
 
-	if f.wizard != nil {
-		runWizardFn = f.wizard
-	}
+	force(t, target, fake)
+}
 
-	if f.create != nil {
-		createWorkloadFn = f.create
-	}
+// force installs value unconditionally, restoring what was there when the
+// test ends.
+func force[F any](t *testing.T, target *F, value F) {
+	t.Helper()
 
-	if f.wait != nil {
-		waitWorkloadFn = f.wait
-	}
+	prev := *target
+	*target = value
 
-	if f.list != nil {
-		listWorkloadsFn = f.list
-	}
-
-	if f.lock != nil {
-		lockArtifactFn = f.lock
-	}
-
-	writeWorkloadIDFn = func(path, id string) error { return nil }
-	if f.writeID != nil {
-		writeWorkloadIDFn = f.writeID
-	}
-
-	codeChangeFn = func(Loaded, Live) (CodeChange, error) { return CodeChange{}, nil }
-	if f.code != nil {
-		codeChangeFn = f.code
-	}
-
-	if f.workloadD != nil {
-		getWorkloadDocFn = f.workloadD
-	}
-
-	if f.artifactD != nil {
-		getArtifactDocFn = f.artifactD
-	}
-
-	t.Cleanup(func() {
-		runWizardFn, createWorkloadFn, waitWorkloadFn, listWorkloadsFn = prev.wizard, prev.create, prev.wait, prev.list
-		lockArtifactFn, writeWorkloadIDFn, codeChangeFn = prev.lock, prev.writeID, prev.code
-		getWorkloadDocFn, getArtifactDocFn = prev.workloadD, prev.artifactD
-	})
+	t.Cleanup(func() { *target = prev })
 }
 
 // runIn deploys the manifest written into a fresh directory.
@@ -617,4 +629,58 @@ func TestRun_DryRunOnABuildTrackSucceeds(t *testing.T) {
 	_, stderr, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true, DryRun: true})
 	require.NoError(t, err, "planning works on every track even where applying does not")
 	assert.Contains(t, stderr, "first sync of this project")
+}
+
+// TestRun_BadCredentialStopsBeforeTheCreate is the whole point of the check:
+// the reference is syntactically fine, so nothing local can catch it, and
+// without the lookup the mistake would surface as a container that will not
+// start once the deploy has already been paid for.
+func TestRun_BadCredentialStopsBeforeTheCreate(t *testing.T) {
+	install(t, fakes{
+		cred: func(string) (*workload.Credential, error) {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
+		},
+		create: func(any) (*workload.Workload, error) {
+			t.Fatal("nothing may be created before the credentials are known to resolve")
+
+			return nil, nil
+		},
+	})
+
+	_, stderr, err := runIn(t, unboundCredentialManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OPENAI_API_KEY")
+	assert.Contains(t, err.Error(), "does not exist")
+	assert.Contains(t, stderr, "+ workload", "the plan is printed before the refusal, as on any other track")
+}
+
+// A dry run reaches no mutation, so it never spends the lookups. Verifying
+// would make --dry-run fail on a file it was asked only to describe.
+func TestRun_DryRunDoesNotVerifyCredentials(t *testing.T) {
+	install(t, fakes{
+		cred: func(string) (*workload.Credential, error) {
+			t.Fatal("a dry run mutates nothing, so it has nothing to verify against")
+
+			return nil, nil
+		},
+	})
+
+	_, _, err := runIn(t, unboundCredentialManifest, Options{NonInteractive: true, DryRun: true})
+	require.NoError(t, err)
+}
+
+func TestRun_ResolvedCredentialDeploys(t *testing.T) {
+	install(t, fakes{
+		cred: func(id string) (*workload.Credential, error) {
+			return &workload.Credential{CredentialID: id, Name: "my-app/OPENAI_API_KEY"}, nil
+		},
+		create: func(any) (*workload.Workload, error) { return running("wl-1"), nil },
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return running("wl-1"), nil
+		},
+	})
+
+	result, _, err := runIn(t, unboundCredentialManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+	assert.Equal(t, "wl-1", result.WorkloadID)
 }


### PR DESCRIPTION
Fifth of the `dr workload up` stack, on top of #762. Review #759 → #760 → #761 → #762 first.

## What

A credential id is the one part of the manifest local validation cannot judge. The ledger checks that the `dr-credential:` shorthand parses; whether the id behind it names a real credential is a fact only the platform holds. Left unchecked, a typo survives every local check and surfaces as a container that will not start, minutes and one paid-for build later, with a runtime error that never mentions the manifest.

`Compile` has been handing back every reference for exactly this since the manifest package landed. This wires the GET that the note at the foot of `run.go` was waiting for, and removes the note.

## Decisions worth a look

- **Where it sits.** At the end of the apply gate, immediately before the first mutation, so a run that is going to be refused for some other reason does not spend the lookups first.
- **A dry run never reaches it.** It mutates nothing, and failing a `--dry-run` over a file it was asked only to describe would be the wrong contract.
- **Every problem at once**, matching what the validation ledger does with the rest of the file. These references come from something the user is about to edit; learning about the second bad id after fixing the first is two trips through a build pipeline for one edit.
- **Each line names the variable and the manifest line**, not only the id, because the id alone is a hex string the reader then has to hunt for.
- **One GET per credential, not per reference.** Several variables commonly read different keys of the same stored credential.
- **The wizard's placeholder is refused without asking the platform**, which is why the wizard writes it in full instead of commenting the entry out.
- **A transport failure is kept distinct from a missing credential.** Reporting "does not exist" because the platform was briefly unreachable would send someone editing a correct file.

The eleventh test seam pushed `install` past the cyclomatic limit, so it becomes a list of `swap` calls over a shared generic helper rather than a ladder of ifs and a parallel struct of saved values.

## Test plan

- [x] `task test` — no new failures (the `cmd/dotenv`, `cmd/plugin/*` and feature-gate failures pre-exist on the base branch)
- [x] `task lint` — clean on all three GOOS targets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the apply gate on the workload deploy path and adds network dependency right before mutation, though behavior is gated, well-tested, and fails closed without creating resources on bad refs.
> 
> **Overview**
> **`dr workload up` now validates every `dr-credential` reference against the platform immediately before the first create**, so bad ids or unfinished wizard placeholders fail in the CLI instead of after a build.
> 
> The new `verifyCredentials` step uses one GET per distinct credential id, aggregates every problem (missing id, placeholder, env var name, manifest line) in one error, and treats API outages as “cannot verify” rather than “does not exist.” **Dry runs still stop after planning and never perform these lookups.** The pending note in `run.go` is removed now that `Compiled.CredentialRefs` is wired through a `getCredentialFn` seam.
> 
> Test helpers in `run_test` were refactored to generic `swap`/`force` so the extra credential seam does not blow past cyclomatic limits; integration tests assert create is skipped on failure and that dry run does not hit the API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 109c5273e3675f61b7196bc5f54fedee20c47ee7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->