### PR TITLE
[RAPTOR-18976] feat(workload): start a stopped workload

### DIFF
--- a/internal/workload/up/look.go
+++ b/internal/workload/up/look.go
@@ -57,6 +57,10 @@ type Live struct {
 	// change the deploy.
 	State State
 
+	// Status is the platform's own word. Three statuses reduce to
+	// StateStopped and only some of them can be started.
+	Status string
+
 	// ArtifactID is the artifact currently running, "" when there is none.
 	ArtifactID string
 
@@ -100,9 +104,12 @@ func Look(workloadID string) (Live, error) {
 		return Live{}, err
 	}
 
+	status := workloadDoc.String(keyStatus)
+
 	return Live{
 		Live:       manifest.NewLive(workloadID, workloadDoc, artifactDoc),
-		State:      stateFor(workloadDoc.String(keyStatus)),
+		State:      stateFor(status),
+		Status:     status,
 		ArtifactID: artifactID,
 		Endpoint:   workloadDoc.String(keyEndpoint),
 		Locked:     isLocked(artifactDoc.String(keyStatus)),

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -182,9 +182,12 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 		return result, err
 	}
 
-	// Starting counts: it is when the container resolves its references, so a
-	// credential deleted while the workload was off fails minutes later as a
-	// container that will not come up.
+	// Checked before every path below, which either mutates or refuses. A
+	// start counts as a mutation: it is when the container resolves its
+	// references, so a credential deleted while the workload was off would
+	// surface minutes later as a container that will not come up. On a path
+	// about to be refused it shadows ErrNotWired, deliberately: one run to
+	// learn about both beats two.
 	if err := verifyCredentials(loaded.Compiled.CredentialRefs); err != nil {
 		return result, err
 	}
@@ -272,7 +275,7 @@ func deployable(live Live, workloadName string) error {
 	}
 }
 
-// startable refuses the one off status that cannot be started. The platform
+// startable refuses the one status that cannot be started. The platform
 // no-ops a start of a suspended workload, so accepting it would poll until
 // the timeout for a transition that is never coming. Interrupted can be
 // started.

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -182,13 +182,20 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 		return result, err
 	}
 
+	// Starting counts: it is when the container resolves its references, so a
+	// credential deleted while the workload was off fails minutes later as a
+	// container that will not come up.
+	if err := verifyCredentials(loaded.Compiled.CredentialRefs); err != nil {
+		return result, err
+	}
+
 	// Starting is checked before the roll refusal so that a stopped workload
 	// the file already agrees with gets deployed rather than turned away.
 	// When the file asks for more than a start, the refusal wins: bringing the
 	// workload up on the version it was stopped on would report a failure
 	// having already changed something, which is the worst of both.
 	if plan.Action() == ActionStarted {
-		return start(result, opts)
+		return start(live, result, opts)
 	}
 
 	if !plan.Creates {
@@ -206,12 +213,6 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 			ErrNotWired, mode)
 	}
 
-	// Last check before the first mutation, and the only one that needs the
-	// network: a credential id is the one thing the local ledger cannot judge.
-	if err := verifyCredentials(loaded.Compiled.CredentialRefs); err != nil {
-		return result, err
-	}
-
 	return create(loaded, result, opts)
 }
 
@@ -219,11 +220,18 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 // roll is wrong for a runtime-only plan, which mints no artifact: the printed
 // plan and the refusal underneath it then disagree about what is missing.
 func unwired(plan Plan) string {
-	if plan.Action() == ActionUpdated {
-		return "changing the runtime settings of a live workload"
+	// Calling a stopped workload "live" contradicts the plan block above,
+	// whose first line says it is to be started.
+	subject := "a live workload"
+	if plan.State == StateStopped {
+		subject = "a stopped workload, which is also not being started"
 	}
 
-	return "rolling a live workload onto a new version"
+	if plan.Action() == ActionUpdated {
+		return "changing the runtime settings of " + subject
+	}
+
+	return "rolling " + subject + " onto a new version"
 }
 
 // deployable refuses the live states that cannot take a deploy, one message
@@ -253,12 +261,30 @@ func deployable(live Live, workloadName string) error {
 			"workload %s is still settling. Wait for it to finish, then deploy",
 			workloadName)
 
-	case StateUnbound, StateRunning, StateStopped:
+	case StateUnbound, StateRunning:
 		return nil
+
+	case StateStopped:
+		return startable(live, workloadName)
 
 	default:
 		return nil
 	}
+}
+
+// startable refuses the one off status that cannot be started. The platform
+// no-ops a start of a suspended workload, so accepting it would poll until
+// the timeout for a transition that is never coming. Interrupted can be
+// started.
+func startable(live Live, workloadName string) error {
+	if live.Status != workload.WorkloadStatusSuspended {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"workload %s is suspended, which a deploy cannot undo: the platform ignores a start while it is "+
+			"in that state. Find out why it was suspended before deploying again",
+		workloadName)
 }
 
 // create makes the workload from the compiled manifest and waits for it to
@@ -314,11 +340,14 @@ func create(loaded Loaded, result Result, opts Options) (Result, error) {
 // Nothing is written back and nothing is compiled here, because nothing is
 // being changed. The workload keeps the artifact it was stopped on, which is
 // the version this run just confirmed the file still describes.
-func start(result Result, opts Options) (Result, error) {
+func start(live Live, result Result, opts Options) (Result, error) {
 	report := newReporter(opts.Stderr, opts.Spinner)
 
+	var ack *workload.WorkloadOperationResponse
+
 	err := report.run("Starting workload", func() error {
-		_, startErr := startWorkloadFn(result.WorkloadID)
+		response, startErr := startWorkloadFn(result.WorkloadID)
+		ack = response
 
 		return startErr
 	})
@@ -326,15 +355,39 @@ func start(result Result, opts Options) (Result, error) {
 		return result, fmt.Errorf("cannot start workload %s: %w", result.WorkloadID, err)
 	}
 
+	// The only place the platform says it did nothing: a start it no-ops comes
+	// back 200 with a message saying so.
+	if ack != nil && ack.Status != "" {
+		report.say("  %s\n", ack.Status)
+	}
+
 	result.Action = ActionStarted
 
 	if opts.Detach {
+		// Without this the envelope reports "stopped" beside an action of
+		// "started", which reads as a run that did nothing.
+		result.Status = startingStatus(live.Status)
+
 		report.say("  Workload %s start requested; not waiting.\n", result.WorkloadID)
 
 		return result, nil
 	}
 
 	return settle(result.WorkloadID, result, opts, report)
+}
+
+// startingStatus is what to report for a start nobody waited for. An
+// unrecognised status is passed through rather than overwritten.
+func startingStatus(was string) string {
+	switch was {
+	case workload.WorkloadStatusStopped,
+		workload.WorkloadStatusSuspended,
+		workload.WorkloadStatusInterrupted:
+		return workload.WorkloadStatusSubmitted
+
+	default:
+		return was
+	}
 }
 
 // nameTaken turns a create conflict into an error naming what owns the name.
@@ -429,6 +482,11 @@ func settle(workloadID string, result Result, opts Options, report *reporter) (R
 // would leave something undeletable behind and a workload that cannot be
 // rolled off it.
 func lock(result Result, report *reporter) (Result, error) {
+	// Already locked, and locking twice is not a no-op at the platform.
+	if result.Locked {
+		return result, nil
+	}
+
 	if result.ArtifactID == "" {
 		return result, errors.New("cannot lock: the platform did not report which artifact is running")
 	}

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -36,6 +36,7 @@ var (
 	createWorkloadFn  = workload.CreateWorkload
 	waitWorkloadFn    = workload.WaitForWorkload
 	listWorkloadsFn   = workload.ListWorkloads
+	startWorkloadFn   = workload.StartWorkload
 	lockArtifactFn    = workload.LockArtifact
 	getCredentialFn   = workload.GetCredential
 	writeWorkloadIDFn = manifest.WriteWorkloadID
@@ -181,6 +182,15 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 		return result, err
 	}
 
+	// Starting is checked before the roll refusal so that a stopped workload
+	// the file already agrees with gets deployed rather than turned away.
+	// When the file asks for more than a start, the refusal wins: bringing the
+	// workload up on the version it was stopped on would report a failure
+	// having already changed something, which is the worst of both.
+	if plan.Action() == ActionStarted {
+		return start(result, opts)
+	}
+
 	if !plan.Creates {
 		return result, fmt.Errorf("%w: %s. The plan above is correct; applying it is the next change",
 			ErrNotWired, unwired(plan))
@@ -219,6 +229,10 @@ func unwired(plan Plan) string {
 // deployable refuses the live states that cannot take a deploy, one message
 // each. None of them are guesses: a workload that is gone stays gone, and one
 // that is unsettled may still be on its way somewhere.
+//
+// Stopped is not among them. A stopped workload is one POST away from being
+// deployable, and `up` means "make the file true", which for something that
+// is not running means starting it.
 func deployable(live Live, workloadName string) error {
 	switch live.State {
 	case StateMissing, StateTerminated:
@@ -239,11 +253,7 @@ func deployable(live Live, workloadName string) error {
 			"workload %s is still settling. Wait for it to finish, then deploy",
 			workloadName)
 
-	case StateStopped:
-		return fmt.Errorf(
-			"%w: starting a stopped workload before deploying onto it", ErrNotWired)
-
-	case StateUnbound, StateRunning:
+	case StateUnbound, StateRunning, StateStopped:
 		return nil
 
 	default:
@@ -294,6 +304,37 @@ func create(loaded Loaded, result Result, opts Options) (Result, error) {
 	}
 
 	return settle(created.ID, result, opts, report)
+}
+
+// start brings a stopped workload back up. It is the whole apply for a plan
+// that found nothing else to change: the file and the live spec already
+// agree, and the only thing standing between them and a served request is
+// that the workload is off.
+//
+// Nothing is written back and nothing is compiled here, because nothing is
+// being changed. The workload keeps the artifact it was stopped on, which is
+// the version this run just confirmed the file still describes.
+func start(result Result, opts Options) (Result, error) {
+	report := newReporter(opts.Stderr, opts.Spinner)
+
+	err := report.run("Starting workload", func() error {
+		_, startErr := startWorkloadFn(result.WorkloadID)
+
+		return startErr
+	})
+	if err != nil {
+		return result, fmt.Errorf("cannot start workload %s: %w", result.WorkloadID, err)
+	}
+
+	result.Action = ActionStarted
+
+	if opts.Detach {
+		report.say("  Workload %s start requested; not waiting.\n", result.WorkloadID)
+
+		return result, nil
+	}
+
+	return settle(result.WorkloadID, result, opts, report)
 }
 
 // nameTaken turns a create conflict into an error naming what owns the name.

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -124,8 +124,10 @@ runtime:
           resourceAllocation: {cpu: 0.5, memory: 512MB}
 `
 
-// fakes collects the seams a run touches. A zero value is a run where every
-// call fails loudly, so a test only wires what it means to exercise.
+// fakes collects the seams a run touches. A seam a test does not wire is
+// replaced by one that fails the test if it is reached, so a run can never
+// reach the network by omission and a test only wires what it means to
+// exercise.
 type fakes struct {
 	wizard    func(wizard.Options) (wizard.Result, error)
 	create    func(any) (*workload.Workload, error)
@@ -149,6 +151,15 @@ func install(t *testing.T, f fakes) {
 	// should not have to say so, and neither may touch a real project.
 	force(t, &writeWorkloadIDFn, func(string, string) error { return nil })
 	force(t, &codeChangeFn, func(Loaded, Live) (CodeChange, error) { return CodeChange{}, nil })
+
+	// swap leaves a seam alone when the test supplied nothing, so without this
+	// a stopped fixture with no start fake POSTs to whatever tenant the
+	// developer is logged into.
+	force(t, &startWorkloadFn, func(id string) (*workload.WorkloadOperationResponse, error) {
+		t.Fatalf("the run started workload %s, which this test did not wire", id)
+
+		return nil, nil
+	})
 
 	swap(t, &runWizardFn, f.wizard)
 	swap(t, &createWorkloadFn, f.create)
@@ -745,6 +756,179 @@ func TestRun_DetachedStartDoesNotWait(t *testing.T) {
 
 	assert.Equal(t, ActionStarted, result.Action)
 	assert.Contains(t, stderr, "start requested")
+	assert.Equal(t, workload.WorkloadStatusSubmitted, result.Status,
+		"reporting the status it was asked to leave reads as a run that did nothing")
+}
+
+// The platform no-ops a start of a suspended workload, so accepting one would
+// poll for a transition that is never coming.
+func TestRun_SuspendedIsRefusedRatherThanPolled(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			d := doc(t, liveWorkloadJSON)
+			d["status"] = workload.WorkloadStatusSuspended
+
+			return d, nil
+		},
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	_, _, err := runIn(t, bound, Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "suspended")
+}
+
+// An interrupted workload is one the platform took down and will start again.
+func TestRun_InterruptedStartsLikeAnyStoppedWorkload(t *testing.T) {
+	var started string
+
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			d := doc(t, liveWorkloadJSON)
+			d["status"] = workload.WorkloadStatusInterrupted
+
+			return d, nil
+		},
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		start: func(id string) (*workload.WorkloadOperationResponse, error) {
+			started = id
+
+			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
+		},
+		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			return running(id), nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	result, _, err := runIn(t, bound, Options{NonInteractive: true})
+	require.NoError(t, err)
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", started)
+	assert.Equal(t, ActionStarted, result.Action)
+}
+
+// A start the platform ignored comes back 200 with a message saying so, and a
+// green checkmark alone would be the whole account of it.
+func TestRun_StartAcknowledgementIsPrinted(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return stoppedWorkload(t), nil },
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		start: func(id string) (*workload.WorkloadOperationResponse, error) {
+			return &workload.WorkloadOperationResponse{WorkloadID: id, Status: "Proton is already running"}, nil
+		},
+		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			return running(id), nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	_, stderr, err := runIn(t, bound, Options{NonInteractive: true})
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "already running")
+}
+
+// --lock on a workload already running a locked artifact has nothing to do,
+// and locking twice is not a no-op at the platform.
+func TestRun_StartDoesNotRelockALockedArtifact(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return stoppedWorkload(t), nil },
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		start: func(id string) (*workload.WorkloadOperationResponse, error) {
+			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
+		},
+		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			return running(id), nil
+		},
+		lock: func(string) (*workload.Artifact, error) {
+			t.Fatal("the artifact this workload runs is already locked")
+
+			return nil, nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	result, _, err := runIn(t, bound, Options{NonInteractive: true, Lock: true})
+	require.NoError(t, err)
+	assert.True(t, result.Locked)
+}
+
+// The live pair for unboundCredentialManifest, stopped. It agrees with the
+// file in every respect, so the only thing the plan can find is that the
+// workload is off, which is what makes this a start rather than a roll.
+const (
+	stoppedCredWorkloadJSON = `{
+  "id": "68b0c1d2e3f4a5b6c7d8e9f0",
+  "name": "my-app",
+  "status": "stopped",
+  "importance": "low",
+  "artifactId": "68a0000000000000000000a1",
+  "runtime": {
+    "containerGroups": [
+      {
+        "name": "default",
+        "replicaCount": 1,
+        "containers": [
+          {"name": "primary", "resourceAllocation": {"cpu": 0.5, "memory": "512MB"}}
+        ]
+      }
+    ]
+  }
+}`
+
+	credArtifactJSON = `{
+  "id": "68a0000000000000000000a1",
+  "name": "my-app-artifact",
+  "status": "draft",
+  "spec": {
+    "type": "service",
+    "containerGroups": [
+      {
+        "name": "default",
+        "containers": [
+          {
+            "name": "primary", "primary": true, "port": 8080,
+            "imageUri": "registry/team/app:v1",
+            "environmentVars": [
+              {"source": "dr-credential", "name": "OPENAI_API_KEY",
+               "drCredentialId": "68b0cccc0000000000000003", "key": "apiToken"}
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}`
+)
+
+// A credential deleted while the workload was off would otherwise surface as
+// a container that will not come up, minutes later, saying nothing about the
+// manifest.
+func TestRun_StartVerifiesCredentialsFirst(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return doc(t, stoppedCredWorkloadJSON), nil },
+		artifactD: func(string) (workload.Document, error) { return doc(t, credArtifactJSON), nil },
+		cred: func(string) (*workload.Credential, error) {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
+		},
+		start: func(string) (*workload.WorkloadOperationResponse, error) {
+			t.Fatal("nothing may start before the credentials are known to resolve")
+
+			return nil, nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + unboundCredentialManifest
+
+	result, _, err := runIn(t, bound, Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Equal(t, ActionStarted, result.Plan.Action(),
+		"the fixtures have to agree, or this is testing the roll path instead")
+	assert.Contains(t, err.Error(), "OPENAI_API_KEY")
 }
 
 // TestRun_BadCredentialStopsBeforeTheCreate is the whole point of the check:

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -857,6 +857,55 @@ func TestRun_StartDoesNotRelockALockedArtifact(t *testing.T) {
 	assert.True(t, result.Locked)
 }
 
+// unlockedArtifact is the live artifact as a draft. liveArtifactJSON is
+// locked, which is the right shape for most of these tests and the wrong one
+// for asking whether --lock still does anything.
+func unlockedArtifact(t *testing.T) workload.Document {
+	t.Helper()
+
+	d := doc(t, liveArtifactJSON)
+	d["status"] = workload.ArtifactStatusDraft
+
+	return d
+}
+
+// The other half of --lock on the start path. The test above starts from an
+// artifact that is already locked, so it only reaches the skip branch; this
+// one has to actually lock, and not until the workload is serving.
+func TestRun_StartLocksAnUnlockedArtifactOnceItServes(t *testing.T) {
+	var order []string
+
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return stoppedWorkload(t), nil },
+		artifactD: func(string) (workload.Document, error) { return unlockedArtifact(t), nil },
+		start: func(id string) (*workload.WorkloadOperationResponse, error) {
+			order = append(order, "start")
+
+			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
+		},
+		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			order = append(order, "wait")
+
+			return running(id), nil
+		},
+		lock: func(id string) (*workload.Artifact, error) {
+			order = append(order, "lock:"+id)
+
+			return &workload.Artifact{ID: id, Status: workload.ArtifactStatusLocked}, nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	result, _, err := runIn(t, bound, Options{NonInteractive: true, Lock: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionStarted, result.Action, "a start, not a create: --lock has to work on this path too")
+	assert.Equal(t, []string{"start", "wait", "lock:art-1"}, order,
+		"locking is one-way, so it waits until the workload is actually serving")
+	assert.True(t, result.Locked)
+}
+
 // The live pair for unboundCredentialManifest, stopped. It agrees with the
 // file in every respect, so the only thing the plan can find is that the
 // workload is off, which is what makes this a start rather than a roll.

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -131,6 +131,7 @@ type fakes struct {
 	create    func(any) (*workload.Workload, error)
 	wait      func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
 	list      func(int, []string) ([]workload.Workload, error)
+	start     func(string) (*workload.WorkloadOperationResponse, error)
 	lock      func(string) (*workload.Artifact, error)
 	cred      func(string) (*workload.Credential, error)
 	writeID   func(string, string) error
@@ -153,6 +154,7 @@ func install(t *testing.T, f fakes) {
 	swap(t, &createWorkloadFn, f.create)
 	swap(t, &waitWorkloadFn, f.wait)
 	swap(t, &listWorkloadsFn, f.list)
+	swap(t, &startWorkloadFn, f.start)
 	swap(t, &lockArtifactFn, f.lock)
 	swap(t, &getCredentialFn, f.cred)
 	swap(t, &writeWorkloadIDFn, f.writeID)
@@ -507,7 +509,6 @@ func TestRun_RefusesTheStatesThatCannotTakeADeploy(t *testing.T) {
 		{workload.WorkloadStatusTerminated, "remove workloadId"},
 		{workload.WorkloadStatusErrored, "dr workload logs"},
 		{workload.WorkloadStatusProvisioning, "still settling"},
-		{workload.WorkloadStatusStopped, "starting a stopped workload"},
 	}
 
 	for _, c := range cases {
@@ -629,6 +630,121 @@ func TestRun_DryRunOnABuildTrackSucceeds(t *testing.T) {
 	_, stderr, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true, DryRun: true})
 	require.NoError(t, err, "planning works on every track even where applying does not")
 	assert.Contains(t, stderr, "first sync of this project")
+}
+
+// stoppedWorkload is the live fixture, off. Everything else about it still
+// matches boundLiveManifest, so the only thing a plan can find is that it is
+// not running.
+func stoppedWorkload(t *testing.T) workload.Document {
+	t.Helper()
+
+	d := doc(t, liveWorkloadJSON)
+	d["status"] = workload.WorkloadStatusStopped
+
+	return d
+}
+
+// TestRun_StartsAStoppedWorkload: `up` means make the file true, and a
+// workload the file describes exactly but which is switched off is not true
+// yet. Nothing is created and nothing is rolled; it is one POST.
+func TestRun_StartsAStoppedWorkload(t *testing.T) {
+	var started string
+
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return stoppedWorkload(t), nil },
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		start: func(id string) (*workload.WorkloadOperationResponse, error) {
+			started = id
+
+			return &workload.WorkloadOperationResponse{WorkloadID: id, Status: "queued"}, nil
+		},
+		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			return running(id), nil
+		},
+		create: func(any) (*workload.Workload, error) {
+			t.Fatal("the workload exists; starting it is not creating a second one")
+
+			return nil, nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	result, stderr, err := runIn(t, bound, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", started)
+	assert.Equal(t, ActionStarted, result.Action)
+	assert.Equal(t, workload.WorkloadStatusRunning, result.Status)
+	assert.Contains(t, stderr, "Starting workload")
+}
+
+// A plan that asks for more than a start is refused whole. Starting the
+// workload first would bring it up on the version it was stopped on and then
+// report a failure, which leaves the user worse off than refusing did.
+func TestRun_StoppedWithDriftIsRefusedWithoutStarting(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return stoppedWorkload(t), nil },
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		start: func(string) (*workload.WorkloadOperationResponse, error) {
+			t.Fatal("a refused plan must not have started anything")
+
+			return nil, nil
+		},
+	})
+
+	// One resource figure differs, which makes the run a retune as well as a
+	// start, and retuning is not wired.
+	drifted := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" +
+		strings.Replace(boundLiveManifest, "cpu: 3", "cpu: 4", 1)
+
+	_, _, err := runIn(t, drifted, Options{NonInteractive: true})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNotWired)
+}
+
+func TestRun_StartFailureNamesTheWorkload(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return stoppedWorkload(t), nil },
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		start: func(string) (*workload.WorkloadOperationResponse, error) {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
+		},
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			t.Fatal("there is nothing to wait for when the start was refused")
+
+			return nil, nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	_, _, err := runIn(t, bound, Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot start workload 68b0c1d2e3f4a5b6c7d8e9f0")
+}
+
+func TestRun_DetachedStartDoesNotWait(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return stoppedWorkload(t), nil },
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		start: func(id string) (*workload.WorkloadOperationResponse, error) {
+			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
+		},
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			t.Fatal("--detach returns as soon as the start is requested")
+
+			return nil, nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	result, stderr, err := runIn(t, bound, Options{NonInteractive: true, Detach: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionStarted, result.Action)
+	assert.Contains(t, stderr, "start requested")
 }
 
 // TestRun_BadCredentialStopsBeforeTheCreate is the whole point of the check:

--- a/internal/workload/up/state.go
+++ b/internal/workload/up/state.go
@@ -78,13 +78,6 @@ func (s State) String() string {
 	}
 }
 
-// Deployable reports whether `up` can apply a plan against this state
-// directly. StateStopped is deployable only after a start, which is why it is
-// excluded here rather than folded into StateRunning.
-func (s State) Deployable() bool {
-	return s == StateRunning
-}
-
 // stateFor maps a platform status onto the branch `up` takes.
 //
 // Two of these are judgement calls rather than transcription. "unknown" is

--- a/internal/workload/up/state_test.go
+++ b/internal/workload/up/state_test.go
@@ -72,17 +72,17 @@ func TestStateFor_EveryPlatformStatusIsMapped(t *testing.T) {
 	}
 }
 
-// TestState_OnlyRunningIsDeployable pins the distinction that matters most:
-// a stopped workload has to be started first, so folding it into running
-// would apply a plan against something that is not there.
-func TestState_OnlyRunningIsDeployable(t *testing.T) {
-	all := []State{
-		StateUnbound, StateMissing, StateTerminated,
-		StateStopped, StateSettling, StateRunning, StateErrored,
-	}
-
-	for _, s := range all {
-		assert.Equal(t, s == StateRunning, s.Deployable(), "state %s", s)
+// The statuses that mean "off" reduce to one state, because the plan is the
+// same for all three: the workload is not serving and `up` has to say so.
+// Which of them can actually be started is a question for the apply, and is
+// answered there rather than by the reduction.
+func TestState_TheOffStatusesReduceToStopped(t *testing.T) {
+	for _, status := range []string{
+		workload.WorkloadStatusStopped,
+		workload.WorkloadStatusSuspended,
+		workload.WorkloadStatusInterrupted,
+	} {
+		assert.Equal(t, StateStopped, stateFor(status), "status %q", status)
 	}
 }
 


### PR DESCRIPTION
Sixth of the `dr workload up` stack, on top of #764.

## What

`up` means make the file true, and a workload the file describes exactly but which is switched off is not true yet. It was refused with `ErrNotWired`; it is now one POST and a wait.

The plan already understood this case — it reports the run as `started` and refuses to call a stopped workload up to date — so this is the apply catching up with what was already being printed.

## Decisions worth a look

- **Stopped leaves the list of undeployable states**, which is now only the states that genuinely are not a starting point: gone, terminated, errored, still settling. Stopped never belonged with them; it is one call away from running.
- **The start branch is checked before the roll refusal**, so a workload the file agrees with gets deployed rather than turned away.
- **When the file asks for more than a start, the refusal wins and nothing is started.** Bringing the workload up on the version it was stopped on and then reporting a failure leaves the user worse off than refusing did: a running workload they did not ask for, on code they did not deploy.
- **Nothing is written back and nothing is compiled on this path**, because nothing is being changed. The workload keeps the artifact it was stopped on, which is the version this run just confirmed the file still describes.
- `--detach` and `--lock` behave as they do on a create, since both are about what happens after the workload is asked to run, not about how it was asked.

## Test plan

- [x] `task test` — no new failures
- [x] `task lint` — clean on all three GOOS targets

Made with [Cursor](https://cursor.com)