### PR TITLE
[RAPTOR-18976] feat(workload): sync and build on the first deploy

### DIFF
--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -60,12 +60,23 @@ type upResult struct {
 	Plan       up.PlanJSON `json:"plan"`
 }
 
+// buildID is the envelope's build reference: the id when a build ran, null
+// when none did. An empty string would read as a build that produced nothing.
+func buildID(id string) *string {
+	if id == "" {
+		return nil
+	}
+
+	return &id
+}
+
 type flags struct {
 	dir    string
 	yes    bool
 	dryRun bool
 	detach bool
 	lock   bool
+	force  bool
 
 	// bindingFlags exist only to be refused. Cobra's own "unknown flag"
 	// message would leave the user guessing where binding lives, and these
@@ -100,6 +111,12 @@ With no manifest, a terminal opens the same setup wizard 'dr workload config'
 runs and continues straight into the deploy. Without a terminal it is an
 error: this command never deploys by guessing.
 
+A manifest that names a published image deploys in one call. One that asks the
+platform to build creates an artifact, pushes the working tree to it and waits
+for an image first, so the first deploy of such a project takes as long as the
+build does. A build the deploy believes would produce the image already on the
+artifact is skipped; --force-build says otherwise.
+
 Examples:
   dr workload up
   dr workload up --dry-run
@@ -125,6 +142,7 @@ Examples:
 			"dry_run":       f.dryRun,
 			"detach":        f.detach,
 			"lock":          f.lock,
+			"force_build":   f.force,
 			"output_format": string(outputFormat),
 		}
 	})
@@ -139,6 +157,8 @@ func addFlags(cmd *cobra.Command, f *flags, poll *pollflags.Set) {
 	cmd.Flags().BoolVar(&f.detach, "detach", false, "Return once the deploy is requested; do not wait for it to serve.")
 	cmd.Flags().BoolVar(&f.lock, "lock", false,
 		"Lock the artifact that ends up live, making it permanent. Locking is one-way.")
+	cmd.Flags().BoolVar(&f.force, "force-build", false,
+		"Rebuild the image even when the working tree matches what was last synced.")
 
 	cmd.Flags().StringVar(&f.workloadID, "workload-id", "", "")
 	cmd.Flags().StringVar(&f.name, "name", "", "")
@@ -177,6 +197,7 @@ func run(cmd *cobra.Command, f flags, poll pollflags.Set, format outputformat.Ou
 		DryRun:         f.dryRun,
 		Detach:         f.detach,
 		Lock:           f.lock,
+		ForceBuild:     f.force,
 		PollInterval:   poll.Interval,
 		PollTimeout:    poll.Timeout,
 		Stderr:         cmd.ErrOrStderr(),
@@ -237,10 +258,12 @@ func checkFlags(cmd *cobra.Command, f flags) error {
 
 // reportable says whether a failed run left behind anything worth printing.
 // A failure after the workload exists still reports it: losing the id because
-// the wait timed out is how a deploy becomes unfindable. With no id at all an
-// envelope of empty strings would be noise.
+// the wait timed out is how a deploy becomes unfindable. A build that failed
+// before any workload existed is the same problem, since the build id is the
+// only way back to the logs that say why. With no id at all an envelope of
+// empty strings would be noise.
 func reportable(result up.Result) bool {
-	return result.WorkloadID != ""
+	return result.WorkloadID != "" || result.BuildID != ""
 }
 
 func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, result up.Result) error {
@@ -251,7 +274,7 @@ func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, resul
 			Status:     result.Status,
 			Endpoint:   result.Endpoint,
 			ArtifactID: result.ArtifactID,
-			BuildID:    nil,
+			BuildID:    buildID(result.BuildID),
 			Action:     result.Action,
 			Locked:     result.Locked,
 			Plan:       result.Plan.JSON(),

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -128,6 +128,25 @@ func TestCmd_BuildIDIsNullNotEmpty(t *testing.T) {
 	assert.Nil(t, value, "no build happened, which is not the same as a build that produced nothing")
 }
 
+// The other half of the same promise: a deploy that did build says which one,
+// so a pipeline can fetch the logs without going looking for it.
+func TestCmd_BuildIDIsCarriedWhenABuildRan(t *testing.T) {
+	result := deployed()
+	result.BuildID = "68c0000000000000000000b2"
+
+	stubRun(t, result, nil)
+
+	stdout, _, err := runCmd(t, "--output-format", "json")
+	require.NoError(t, err)
+
+	var envelope map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(stdout), &envelope))
+
+	body, _ := envelope["up"].(map[string]any)
+	assert.Equal(t, "68c0000000000000000000b2", body["buildId"])
+}
+
 // TestCmd_JSONImpliesNonInteractive stops a wizard being drawn on stderr
 // while stdout is being parsed.
 func TestCmd_JSONImpliesNonInteractive(t *testing.T) {
@@ -236,6 +255,26 @@ func TestCmd_FailureAfterTheWorkloadExistsStillEmitsTheEnvelope(t *testing.T) {
 
 	body, _ := envelope["up"].(map[string]any)
 	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", body["workloadId"])
+}
+
+// A build that fails never creates a workload, so gating the envelope on the
+// workload id alone would drop the one id the failure produced and leave a
+// pipeline with nothing to fetch the logs with.
+func TestCmd_FailedBuildStillEmitsTheEnvelope(t *testing.T) {
+	stubRun(t, up.Result{BuildID: "68c0000000000000000000b2", Action: "created"},
+		errors.New("build 68c0000000000000000000b2 finished as FAILED"))
+
+	stdout, _, err := runCmd(t, "--output-format", "json")
+	require.Error(t, err)
+
+	var envelope map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(stdout), &envelope),
+		"a failed build is still a build someone has to go and read")
+
+	body, _ := envelope["up"].(map[string]any)
+	assert.Equal(t, "68c0000000000000000000b2", body["buildId"])
+	assert.Empty(t, body["workloadId"])
 }
 
 // TestCmd_FailureBeforeAnythingExistsJustFails: there is no id to report, so

--- a/internal/workload/manifest/compile.go
+++ b/internal/workload/manifest/compile.go
@@ -93,6 +93,71 @@ func (m *Manifest) Compile() (*Compiled, error) {
 	return &Compiled{Payload: payload, WorkloadID: workloadID, CredentialRefs: refs}, nil
 }
 
+// ArtifactPayload is the inline artifact block on its own, which is exactly
+// what POST /artifacts/ accepts: the manifest carries the create request
+// verbatim, so there is nothing to translate.
+//
+// A deploy needs this whenever the platform builds the image, because the
+// artifact has to exist before there is anywhere to sync code to, and it has
+// to be built before there is an image for a workload to run. A manifest that
+// binds an existing artifact by id has no block to hand over and says so.
+func (c *Compiled) ArtifactPayload() (json.RawMessage, error) {
+	payload, err := c.decode()
+	if err != nil {
+		return nil, err
+	}
+
+	artifact, ok := payload[keyArtifact]
+	if !ok {
+		return nil, fmt.Errorf("the manifest has no %s block to create", keyArtifact)
+	}
+
+	raw, err := json.Marshal(artifact)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert the %s block to JSON: %w", keyArtifact, err)
+	}
+
+	return raw, nil
+}
+
+// BindArtifact is the create payload with the inline artifact swapped for a
+// reference to one that already exists. The two forms are mutually exclusive
+// in the API as they are in the manifest, so the block is removed rather than
+// left alongside the id.
+//
+// This is what a built deploy sends. The artifact was created from the block,
+// then filled with code and an image; sending the block again would ask the
+// platform for a second, empty artifact.
+func (c *Compiled) BindArtifact(artifactID string) (json.RawMessage, error) {
+	payload, err := c.decode()
+	if err != nil {
+		return nil, err
+	}
+
+	delete(payload, keyArtifact)
+	payload[keyArtifactID] = artifactID
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert the manifest to JSON: %w", err)
+	}
+
+	return raw, nil
+}
+
+// decode reads the compiled payload back into a tree. It is decoded per call
+// rather than cached because each caller edits its copy, and a shared one
+// would let one deploy's edit leak into another's payload.
+func (c *Compiled) decode() (map[string]any, error) {
+	var payload map[string]any
+
+	if err := json.Unmarshal(c.Payload, &payload); err != nil {
+		return nil, fmt.Errorf("cannot read the compiled manifest: %w", err)
+	}
+
+	return payload, nil
+}
+
 // expandCredentialShorthand rewrites every environmentVars entry carrying
 // the shorthand into the API object form. The walk is shape-agnostic so
 // environmentVars is found wherever the spec puts it: containerGroups,

--- a/internal/workload/manifest/compile_test.go
+++ b/internal/workload/manifest/compile_test.go
@@ -245,3 +245,125 @@ func TestCompile_PayloadIsValidCreateSpec(t *testing.T) {
 
 	assert.NoError(t, workload.ValidateWorkloadCreateRequest(compiled.Payload))
 }
+
+// buildManifest asks the platform to build, which is the only case where the
+// artifact has to be created on its own before a workload can reference it.
+const buildManifest = `name: my-app
+importance: low
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageBuildConfig:
+              dockerfile:
+                source: provided
+runtime:
+  containerGroups:
+    - name: default
+      replicaCount: 1
+`
+
+// The manifest carries the artifact-create request verbatim, so lifting the
+// block out is the whole of the translation.
+func TestArtifactPayload_IsTheBlockItself(t *testing.T) {
+	m, err := Parse([]byte(buildManifest), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	payload, err := compiled.ArtifactPayload()
+	require.NoError(t, err)
+
+	var artifact map[string]any
+
+	require.NoError(t, json.Unmarshal(payload, &artifact))
+	assert.Equal(t, "my-app-artifact", artifact["name"])
+	assert.Contains(t, artifact, "spec")
+	assert.NotContains(t, artifact, "runtime", "the sizing half is the workload's, not the artifact's")
+}
+
+// Credential shorthand is expanded on the way out here as it is everywhere
+// else, because this payload reaches the API without passing through the
+// workload create.
+func TestArtifactPayload_CarriesExpandedCredentials(t *testing.T) {
+	m, err := Parse([]byte(`name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    containerGroups:
+      - containers:
+          - name: primary
+            imageUri: a:1
+            environmentVars:
+              - name: OPENAI_API_KEY
+                value: dr-credential:68f0cccc0000000000000003/apiToken
+`), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	payload, err := compiled.ArtifactPayload()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(payload), "drCredentialId")
+	assert.NotContains(t, string(payload), CredentialShorthandPrefix)
+}
+
+func TestArtifactPayload_NoBlockToCreate(t *testing.T) {
+	m, err := Parse([]byte("name: my-app\nartifactId: 68b0bbbb0000000000000002\n"), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	_, err = compiled.ArtifactPayload()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no artifact block")
+}
+
+// The two forms are mutually exclusive in the API as they are in the file, so
+// binding removes the block rather than leaving it beside the id. Sending
+// both would ask the platform for a second, empty artifact.
+func TestBindArtifact_ReplacesTheInlineBlock(t *testing.T) {
+	m, err := Parse([]byte(buildManifest), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	payload, err := compiled.BindArtifact("68a0000000000000000000a1")
+	require.NoError(t, err)
+
+	var bound map[string]any
+
+	require.NoError(t, json.Unmarshal(payload, &bound))
+	assert.Equal(t, "68a0000000000000000000a1", bound["artifactId"])
+	assert.NotContains(t, bound, "artifact")
+	assert.Equal(t, "my-app", bound["name"])
+	assert.Contains(t, bound, "runtime")
+	assert.Contains(t, bound, "importance", "everything the file said about the workload still travels")
+}
+
+// Each call edits its own copy, so one deploy's binding cannot leak into
+// another's payload.
+func TestBindArtifact_LeavesTheCompiledPayloadAlone(t *testing.T) {
+	m, err := Parse([]byte(buildManifest), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	_, err = compiled.BindArtifact("68a0000000000000000000a1")
+	require.NoError(t, err)
+
+	assert.Contains(t, string(compiled.Payload), `"artifact"`)
+	assert.NotContains(t, string(compiled.Payload), "artifactId")
+}

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -1,0 +1,314 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/datarobot/cli/internal/workload/wapi"
+)
+
+// buildAndCreate is the first deploy of a project whose image the platform
+// builds. It is four acts where a published image is one: the artifact has to
+// exist before there is anywhere to put code, the code has to be there before
+// there is anything to build, and the image has to exist before a workload
+// can run it.
+//
+// Each act is separately resumable, which is the point of doing them in this
+// order rather than creating the workload first. A run that dies after the
+// sync leaves an artifact holding the code; the next one picks it up instead
+// of starting again. A workload created up front would instead sit there
+// pointing at an image that does not exist yet, visible in the UI and unable
+// to start, for as long as the build took.
+func buildAndCreate(loaded Loaded, code CodeChange, result Result, opts Options, report *reporter) (Result, error) {
+	artifactID, fresh, err := ensureArtifact(loaded, report)
+	if err != nil {
+		return result, err
+	}
+
+	result.ArtifactID = artifactID
+
+	synced, err := syncCode(loaded.ProjectDir, report)
+	if err != nil {
+		return result, err
+	}
+
+	buildID, err := maybeBuild(artifactID, fresh, code, synced, opts, report)
+
+	// Recorded before the error check: a failed build is still a build, and
+	// the caller's envelope should be able to name the one to go and read.
+	result.BuildID = buildID
+
+	if err != nil {
+		return result, err
+	}
+
+	payload, err := loaded.Compiled.BindArtifact(artifactID)
+	if err != nil {
+		return result, err
+	}
+
+	return create(loaded, payload, result, opts, report)
+}
+
+// ensureArtifact returns the artifact this project builds into, creating one
+// and linking the directory to it the first time. fresh reports which of the
+// two happened, because an artifact that was just created has no image and
+// therefore always needs a build.
+//
+// The link lives in the project's own state directory rather than in the
+// manifest. The manifest describes what to deploy and is committed; which
+// artifact a particular checkout has been pushing to is local, and writing it
+// into a shared file would have two developers fighting over one draft.
+func ensureArtifact(loaded Loaded, report *reporter) (string, bool, error) {
+	if projectLinkedFn(loaded.ProjectDir) {
+		cfg, err := loadProjectFn(loaded.ProjectDir)
+		if err != nil {
+			return "", false, fmt.Errorf("cannot read which artifact %s is linked to: %w", loaded.ProjectDir, err)
+		}
+
+		if err := usableArtifact(loaded.ProjectDir, cfg.ArtifactID); err != nil {
+			return "", false, err
+		}
+
+		return cfg.ArtifactID, false, nil
+	}
+
+	var created *workload.Artifact
+
+	err := report.run("Creating the artifact", func() error {
+		payload, payloadErr := loaded.Compiled.ArtifactPayload()
+		if payloadErr != nil {
+			return payloadErr
+		}
+
+		artifact, createErr := createArtifactFn(payload)
+		created = artifact
+
+		return createErr
+	})
+	if err != nil {
+		return "", false, err
+	}
+
+	// The artifact exists and nothing records that fact yet, so a failure
+	// here strands it: the next run would create a second one. Saying which
+	// id was lost is the difference between a re-run and a support ticket.
+	if err := initProjectFn(loaded.ProjectDir, wapi.InitOptions{ArtifactID: created.ID}); err != nil {
+		return "", false, fmt.Errorf(
+			"artifact %s was created but %s could not be linked to it, so the next deploy would create another. "+
+				"Run 'dr artifact code init %s' here, then deploy again: %w",
+			created.ID, loaded.ProjectDir, created.ID, err)
+	}
+
+	return created.ID, true, nil
+}
+
+// usableArtifact refuses a locked artifact before the sync finds out the hard
+// way. Locking is one-way and makes the artifact immutable, so neither the
+// code push nor the build that follows can land; the platform would refuse
+// the PATCH halfway through with a 403 that says nothing about what to do.
+func usableArtifact(projectDir, artifactID string) error {
+	artifact, err := getArtifactFn(artifactID)
+	if err != nil {
+		return fmt.Errorf("cannot read artifact %s, which this project is linked to: %w", artifactID, err)
+	}
+
+	if artifact.IsLocked() {
+		return fmt.Errorf(
+			"artifact %s is locked, so it can take neither new code nor a new image. "+
+				"Locking is permanent, so deploying a change means a new artifact: "+
+				"delete %s and run up again to make one",
+			artifactID, wapi.Dir(projectDir))
+	}
+
+	return nil
+}
+
+// syncCode uploads the working tree to the artifact's code store. The engine
+// does the whole of it: lock the project, diff against what was last synced,
+// upload, and patch the artifact's codeRef to the version it minted, which is
+// what points the next build at this code.
+func syncCode(projectDir string, report *reporter) (*sync.Result, error) {
+	var result *sync.Result
+
+	err := report.run("Syncing code", func() error {
+		r, syncErr := syncProjectFn(projectDir)
+		result = r
+
+		return syncErr
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot sync the project's code: %w", err)
+	}
+
+	// A conflict is not a failure: the engine keeps the local file and parks
+	// a copy of the remote one beside it. It still has to be said out loud,
+	// because what was just uploaded is not what the user last saw.
+	if result != nil && result.ConflictCount > 0 {
+		report.say("  %d file(s) differed from the last sync; local copies kept as %v.\n",
+			result.ConflictCount, result.ConflictCopies)
+	}
+
+	return result, nil
+}
+
+// maybeBuild spends a build only when there is a reason to, and names the
+// build it ran so the caller can report it. An empty id means no build
+// happened, which is not the same as a build that produced nothing.
+//
+// A build is minutes, so skipping one that would produce the image already
+// sitting on the artifact is worth the two conditions it takes to be sure.
+// The reasons to build are: the artifact is new, so no image exists; the sync
+// moved something, so any image is now stale; or the user said to.
+//
+// Otherwise the tree matches what was synced and the only open question is
+// whether the previous run got as far as an image. That question is asked of
+// the platform rather than assumed, because the common way to arrive here is
+// a first deploy that failed after the sync.
+func maybeBuild(
+	artifactID string,
+	fresh bool,
+	code CodeChange,
+	synced *sync.Result,
+	opts Options,
+	report *reporter,
+) (string, error) {
+	if !fresh && !opts.ForceBuild && !changed(code, synced) {
+		built, err := hasImage(artifactID)
+		if err != nil {
+			return "", err
+		}
+
+		if built {
+			report.say("  Image is up to date; no rebuild needed.\n")
+
+			return "", nil
+		}
+	}
+
+	return buildImage(artifactID, opts, report)
+}
+
+// changed reports whether anything moved. The sync's own count is preferred
+// over the plan's: the plan was computed before the upload and is a
+// prediction, while the result is what happened.
+func changed(code CodeChange, synced *sync.Result) bool {
+	if synced == nil {
+		return code.Changed()
+	}
+
+	return synced.UploadedCount > 0 || synced.DeletedCount > 0
+}
+
+// hasImage reports whether the artifact has ever built successfully. Any
+// completed build answers it, without regard to which is newest: this is only
+// asked when the working tree matches what was last synced, so a build that
+// completed at all built the code about to be deployed.
+//
+// The exception is code pushed by `dr artifact code sync` between deploys,
+// which leaves a completed build of the previous version and a tree that
+// looks unchanged to `up`. That is what --force-build is for.
+func hasImage(artifactID string) (bool, error) {
+	builds, err := listBuildsFn(artifactID, buildHistoryLimit)
+	if err != nil {
+		return false, fmt.Errorf("cannot tell whether artifact %s has been built: %w", artifactID, err)
+	}
+
+	for _, build := range builds {
+		if build.Status == workload.BuildStatusCompleted {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// buildHistoryLimit bounds the look back for a completed build. A handful of
+// attempts is all a deploy can have made; past that the answer is no.
+const buildHistoryLimit = 20
+
+// buildImage builds the artifact's image and waits for it. The wait is not
+// optional even under --detach: a workload created against an artifact with
+// no image would come up unable to start, and --detach promises not to wait
+// for the workload, not to deploy something that cannot run.
+func buildImage(artifactID string, opts Options, report *reporter) (string, error) {
+	var built *workload.Build
+
+	err := report.run("Building the image", func() error {
+		buildID, triggerErr := triggerBuild(artifactID)
+		if triggerErr != nil {
+			return triggerErr
+		}
+
+		// WaitForBuild hands the build back alongside its error when the
+		// build ends badly or the wait runs out, so the id is taken from it
+		// before the error is looked at: it is the only way to the logs.
+		b, waitErr := waitBuildFn(artifactID, buildID, opts.PollInterval, opts.PollTimeout, nil)
+		built = b
+
+		return waitErr
+	})
+
+	if built == nil {
+		// The build was never triggered, or the very first poll failed.
+		return "", err
+	}
+
+	if workload.IsBuildErrorStatus(built.Status) {
+		// Said here rather than left to the wait's own wording, because this
+		// is the only place that knows which artifact the build belongs to.
+		return built.ID, fmt.Errorf("build %s finished as %s; see 'dr artifact build logs %s %s'",
+			built.ID, built.Status, artifactID, built.ID)
+	}
+
+	// A build still running when the wait expires keeps its id too: it is
+	// what the user needs to follow it to the end.
+	return built.ID, err
+}
+
+// triggerBuild starts one build and names it. The endpoint answers with a
+// list because an artifact can have several containers to build; the deploy
+// follows the first, since the CLI only ever describes one.
+func triggerBuild(artifactID string) (string, error) {
+	triggered, err := triggerBuildFn(artifactID)
+	if err != nil {
+		return "", err
+	}
+
+	if len(triggered.BuildIDs) == 0 {
+		return "", errors.New("the platform accepted the build but named no build to follow")
+	}
+
+	return triggered.BuildIDs[0], nil
+}
+
+// defaultSync runs the sync engine over the project. Yes is set because `up`
+// has already printed its plan and been confirmed, if confirmation was ever
+// going to happen; a second prompt from inside a phase would be a surprise,
+// and in CI it would be a hang.
+func defaultSync(projectDir string) (*sync.Result, error) {
+	engine, err := sync.New(projectDir, sync.Options{Yes: true})
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() { _ = engine.Close() }()
+
+	return engine.Run()
+}

--- a/internal/workload/up/doc.go
+++ b/internal/workload/up/doc.go
@@ -46,6 +46,16 @@
 // because a typed round trip silently drops every field this release has not
 // heard of, and half the point is that those survive.
 //
+// A deploy comes in two shapes, decided by whether the manifest names a
+// published image or asks the platform to build one. The first is a single
+// create. The second has to make an artifact, push the working tree to it and
+// wait for an image before there is anything for a workload to run, and it
+// does them in that order so a run that dies partway leaves something the
+// next one picks up rather than a workload pointing at an image that does not
+// exist. Which artifact a checkout pushes to is local state, kept beside the
+// code rather than in the committed manifest, because it is a property of the
+// clone and not of the project.
+//
 // Non-scope: no terminal output and no cobra. Rendering a plan and running
 // the phases belong to the command; this package hands back values.
 package up

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -160,9 +160,9 @@ func Run(opts Options) (Result, error) {
 		return result, err
 	}
 
-	if opts.DryRun || plan.Empty() {
-		noteUnusedForce(plan, opts)
+	noteUnusedForce(plan, opts)
 
+	if opts.DryRun || plan.Empty() {
 		return result, nil
 	}
 
@@ -173,12 +173,25 @@ func Run(opts Options) (Result, error) {
 // because a run which stops without saying so reads as a rebuild that quietly
 // happened. A dry run is excluded: it changes nothing by definition, and the
 // flag not having been used is the least of what it did not do.
+//
+// There are two ways for the flag to be idle. A run that deploys nothing is
+// the loud one. The quiet one is a manifest naming a published image: the
+// deploy goes ahead and succeeds, so nothing invites a second look at the
+// image it is actually serving, and the flag asked for a rebuild of something
+// this project never builds.
 func noteUnusedForce(plan Plan, opts Options) {
-	if !opts.ForceBuild || opts.DryRun || !plan.Empty() {
+	if !opts.ForceBuild || opts.DryRun {
 		return
 	}
 
-	fmt.Fprintf(opts.Stderr, "  --force-build had no effect: nothing is being deployed.\n")
+	switch {
+	case plan.Empty():
+		fmt.Fprintf(opts.Stderr, "  --force-build had no effect: nothing is being deployed.\n")
+
+	case !plan.Code.Applies:
+		fmt.Fprintf(opts.Stderr,
+			"  --force-build had no effect: this manifest names an image the platform does not build.\n")
+	}
 }
 
 // load finds the manifest, running the setup wizard when there is none and a

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -15,6 +15,7 @@
 package up
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -37,10 +38,19 @@ var (
 	waitWorkloadFn    = workload.WaitForWorkload
 	listWorkloadsFn   = workload.ListWorkloads
 	startWorkloadFn   = workload.StartWorkload
+	createArtifactFn  = workload.CreateArtifact
+	getArtifactFn     = workload.GetArtifact
 	lockArtifactFn    = workload.LockArtifact
+	triggerBuildFn    = workload.TriggerArtifactBuild
+	waitBuildFn       = workload.WaitForBuild
+	listBuildsFn      = workload.ListArtifactBuilds
 	getCredentialFn   = workload.GetCredential
 	writeWorkloadIDFn = manifest.WriteWorkloadID
 	codeChangeFn      = defaultCodeChange
+	projectLinkedFn   = wapi.Exists
+	loadProjectFn     = wapi.LoadConfig
+	initProjectFn     = wapi.Initialize
+	syncProjectFn     = defaultSync
 )
 
 // ErrNotWired reports a path the plan understands but the apply cannot take
@@ -63,6 +73,13 @@ type Options struct {
 
 	// Detach returns once the apply is requested, skipping the waits.
 	Detach bool
+
+	// ForceBuild rebuilds the image even when the working tree matches what
+	// was last synced. The deploy skips a build it believes would produce the
+	// image already on the artifact; this is the way to say it is wrong,
+	// which it can be when code reached the artifact through
+	// `dr artifact code sync` rather than through a deploy.
+	ForceBuild bool
 
 	// Lock makes the artifact that ends up live immutable and permanent.
 	// Locking is one-way, so it happens last, only after the workload is
@@ -93,6 +110,12 @@ type Result struct {
 	ArtifactID string
 	Action     string
 	Locked     bool
+
+	// BuildID names the image build this run ran, empty when it ran none:
+	// either the manifest points at a published image, or the one already on
+	// the artifact was still current. A build that failed still sets it, so
+	// the caller can say which logs to read.
+	BuildID string
 }
 
 // Run reads, plans, and applies as much of the plan as this release can.
@@ -138,10 +161,24 @@ func Run(opts Options) (Result, error) {
 	}
 
 	if opts.DryRun || plan.Empty() {
+		noteUnusedForce(plan, opts)
+
 		return result, nil
 	}
 
 	return apply(loaded, live, plan, result, opts)
+}
+
+// noteUnusedForce reports a --force-build that is about to do nothing,
+// because a run which stops without saying so reads as a rebuild that quietly
+// happened. A dry run is excluded: it changes nothing by definition, and the
+// flag not having been used is the least of what it did not do.
+func noteUnusedForce(plan Plan, opts Options) {
+	if !opts.ForceBuild || opts.DryRun || !plan.Empty() {
+		return
+	}
+
+	fmt.Fprintf(opts.Stderr, "  --force-build had no effect: nothing is being deployed.\n")
 }
 
 // load finds the manifest, running the setup wizard when there is none and a
@@ -206,17 +243,16 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 			ErrNotWired, unwired(plan))
 	}
 
-	// Only an image the platform builds needs a version, a sync and a build
-	// before the create. A published imageUri and a file bound to an existing
-	// artifact id are the same single POST, so neither is refused here.
-	if mode := loaded.Manifest.BuildMode(); mode == manifest.BuildModeDockerfile || mode == manifest.BuildModeGenerated {
-		return result, fmt.Errorf(
-			"%w: creating a workload whose image the platform builds (%s mode). "+
-				"Publishing the image yourself and switching the manifest to an imageUri works today",
-			ErrNotWired, mode)
+	report := newReporter(opts.Stderr, opts.Spinner)
+
+	// A published image is one POST. Anything the platform builds has to be
+	// given somewhere to put the code and time to turn it into an image
+	// first, which is a different shape of deploy rather than a longer one.
+	if plan.Code.Applies {
+		return buildAndCreate(loaded, plan.Code, result, opts, report)
 	}
 
-	return create(loaded, result, opts)
+	return create(loaded, loaded.Compiled.Payload, result, opts, report)
 }
 
 // unwired names the change the plan asks for. Calling every live workload a
@@ -290,17 +326,25 @@ func startable(live Live, workloadName string) error {
 		workloadName)
 }
 
-// create makes the workload from the compiled manifest and waits for it to
-// serve. The binding is written back the moment the workload exists, before
-// anything else can fail, so a run that dies during the wait still leaves the
-// next one able to find what it made.
-func create(loaded Loaded, result Result, opts Options) (Result, error) {
-	report := newReporter(opts.Stderr, opts.Spinner)
-
+// create makes the workload and waits for it to serve. payload is the create
+// request: the compiled manifest as it stands for a published image, or the
+// same thing with the inline artifact swapped for the id of the one that was
+// just built.
+//
+// The binding is written back the moment the workload exists, before anything
+// else can fail, so a run that dies during the wait still leaves the next one
+// able to find what it made.
+func create(
+	loaded Loaded,
+	payload json.RawMessage,
+	result Result,
+	opts Options,
+	report *reporter,
+) (Result, error) {
 	var created *workload.Workload
 
 	err := report.run("Creating workload", func() error {
-		wl, createErr := createWorkloadFn(loaded.Compiled.Payload)
+		wl, createErr := createWorkloadFn(payload)
 		if createErr != nil {
 			return nameTaken(createErr, result.Name, loaded.Path)
 		}

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -16,7 +16,9 @@ package up
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -27,6 +29,8 @@ import (
 
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/datarobot/cli/internal/workload/wizard"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -140,6 +144,18 @@ type fakes struct {
 	code      func(Loaded, Live) (CodeChange, error)
 	workloadD func(string) (workload.Document, error)
 	artifactD func(string) (workload.Document, error)
+
+	// The build track: create an artifact, link the project to it, push the
+	// code, turn it into an image.
+	newArtifact func(any) (*workload.Artifact, error)
+	getArtifact func(string) (*workload.Artifact, error)
+	linked      func(string) bool
+	project     func(string) (wapi.Config, error)
+	link        func(string, wapi.InitOptions) error
+	sync        func(string) (*sync.Result, error)
+	build       func(string) (*workload.BuildTriggerResponse, error)
+	waitBuild   func(string, string, time.Duration, time.Duration, func(*workload.Build)) (*workload.Build, error)
+	builds      func(string, int) ([]workload.Build, error)
 }
 
 // install swaps in the seams the test supplied and restores them afterwards.
@@ -172,6 +188,20 @@ func install(t *testing.T, f fakes) {
 	swap(t, &codeChangeFn, f.code)
 	swap(t, &getWorkloadDocFn, f.workloadD)
 	swap(t, &getArtifactDocFn, f.artifactD)
+
+	// A test that does not wire the build track must not be able to reach it
+	// by accident, and an unlinked project is the state a first deploy starts
+	// from.
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	swap(t, &createArtifactFn, f.newArtifact)
+	swap(t, &getArtifactFn, f.getArtifact)
+	swap(t, &projectLinkedFn, f.linked)
+	swap(t, &loadProjectFn, f.project)
+	swap(t, &initProjectFn, f.link)
+	swap(t, &syncProjectFn, f.sync)
+	swap(t, &triggerBuildFn, f.build)
+	swap(t, &waitBuildFn, f.waitBuild)
+	swap(t, &listBuildsFn, f.builds)
 }
 
 // swap installs fake over the seam at target, and does nothing when the test
@@ -560,25 +590,347 @@ func TestRun_MissingWorkloadNamesTheRebind(t *testing.T) {
 	assert.Contains(t, err.Error(), "remove workloadId")
 }
 
-// TestRun_BuildTracksPlanButDoNotApplyYet: the plan is correct and printed,
-// and the refusal says which half is missing rather than failing obscurely.
-func TestRun_BuildTracksPlanButDoNotApplyYet(t *testing.T) {
-	install(t, fakes{
+// track records what the build path did, in order, so a test can pin the
+// sequence as well as the outcome. The order is the whole design: an artifact
+// to hold the code, then the code, then an image, then a workload to run it.
+type track struct {
+	steps      []string
+	artifactIn any
+	linkedTo   wapi.InitOptions
+	workloadIn any
+}
+
+// wiredBuild is a build path where every step works, over the track that
+// records it. Individual tests override one seam to break one step.
+func wiredBuild(tr *track) fakes {
+	return fakes{
 		code: func(Loaded, Live) (CodeChange, error) {
 			return CodeChange{Applies: true, FirstDeploy: true}, nil
 		},
-		create: func(any) (*workload.Workload, error) {
-			t.Fatal("the build tracks are not wired")
+		newArtifact: func(payload any) (*workload.Artifact, error) {
+			tr.steps = append(tr.steps, "create-artifact")
+			tr.artifactIn = payload
 
-			return nil, nil
+			return &workload.Artifact{ID: "art-1", Status: workload.ArtifactStatusDraft}, nil
 		},
-	})
+		link: func(dir string, opts wapi.InitOptions) error {
+			tr.steps = append(tr.steps, "link")
+			tr.linkedTo = opts
+
+			return nil
+		},
+		sync: func(string) (*sync.Result, error) {
+			tr.steps = append(tr.steps, "sync")
+
+			return &sync.Result{UploadedCount: 3, NewVersion: "ver-1"}, nil
+		},
+		build: func(string) (*workload.BuildTriggerResponse, error) {
+			tr.steps = append(tr.steps, "build")
+
+			return &workload.BuildTriggerResponse{BuildIDs: []string{"bld-1"}}, nil
+		},
+		waitBuild: func(_, id string, _, _ time.Duration, _ func(*workload.Build)) (*workload.Build, error) {
+			return &workload.Build{ID: id, Status: workload.BuildStatusCompleted}, nil
+		},
+		create: func(payload any) (*workload.Workload, error) {
+			tr.steps = append(tr.steps, "create-workload")
+			tr.workloadIn = payload
+
+			return running("wl-1"), nil
+		},
+		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			return running(id), nil
+		},
+	}
+}
+
+// decodePayload reads back what was sent to a create endpoint.
+func decodePayload(t *testing.T, payload any) map[string]any {
+	t.Helper()
+
+	raw, ok := payload.(json.RawMessage)
+	require.True(t, ok, "the create clients are handed raw JSON")
+
+	var decoded map[string]any
+
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	return decoded
+}
+
+// TestRun_FirstDeployBuildsThenCreates is the shape of a deploy the platform
+// builds: four acts in an order chosen so that a run which dies partway
+// leaves something the next run can pick up, rather than a workload pointing
+// at an image that does not exist.
+func TestRun_FirstDeployBuildsThenCreates(t *testing.T) {
+	var tr track
+
+	install(t, wiredBuild(&tr))
+
+	result, stderr, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"create-artifact", "link", "sync", "build", "create-workload"}, tr.steps)
+	assert.Equal(t, "art-1", tr.linkedTo.ArtifactID)
+	assert.Equal(t, "wl-1", result.WorkloadID)
+	assert.Equal(t, "bld-1", result.BuildID, "the caller's envelope has to be able to name the build")
+	assert.Contains(t, stderr, "Building the image")
+
+	// The artifact is created from the manifest's own artifact block, which
+	// is the create request already: nothing is translated on the way.
+	assert.Equal(t, "my-app-artifact", decodePayload(t, tr.artifactIn)["name"])
+
+	// The workload is then created against that artifact rather than with a
+	// second copy of the block, which would ask for a second, empty artifact.
+	sent := decodePayload(t, tr.workloadIn)
+	assert.Equal(t, "art-1", sent["artifactId"])
+	assert.NotContains(t, sent, "artifact")
+	assert.Contains(t, sent, "runtime", "the sizing half still travels with the create")
+}
+
+// A project that is already linked keeps its artifact. Creating a second one
+// would orphan the code that was pushed to the first.
+func TestRun_LinkedProjectReusesItsArtifact(t *testing.T) {
+	var tr track
+
+	f := wiredBuild(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = func(string) (wapi.Config, error) { return wapi.Config{ArtifactID: "art-existing"}, nil }
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
+	}
+	f.newArtifact = func(any) (*workload.Artifact, error) {
+		t.Fatal("the project is already linked; a second artifact would orphan the first")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"sync", "build", "create-workload"}, tr.steps)
+	assert.Equal(t, "art-existing", decodePayload(t, tr.workloadIn)["artifactId"])
+}
+
+// A locked artifact can take neither code nor an image, so the deploy stops
+// before the sync rather than failing halfway through with the platform's
+// 403, which says nothing about what to do next.
+func TestRun_LockedArtifactStopsBeforeThePush(t *testing.T) {
+	var tr track
+
+	f := wiredBuild(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = func(string) (wapi.Config, error) { return wapi.Config{ArtifactID: "art-locked"}, nil }
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusLocked}, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "art-locked")
+	assert.Contains(t, err.Error(), "locked")
+	assert.Empty(t, tr.steps, "nothing may be pushed at an artifact that cannot accept it")
+}
+
+// The artifact exists and only the local record of it failed to write, which
+// is the one failure that strands something. The error has to carry the id,
+// or the next run creates a second artifact and the first is unreachable.
+func TestRun_LinkFailureNamesTheStrandedArtifact(t *testing.T) {
+	var tr track
+
+	f := wiredBuild(&tr)
+	f.link = func(string, wapi.InitOptions) error { return errors.New("permission denied") }
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "art-1")
+	assert.Contains(t, err.Error(), "dr artifact code init art-1")
+	assert.NotContains(t, tr.steps, "sync")
+}
+
+// A build that fails is the end of the deploy. Creating the workload anyway
+// would produce something that cannot start, and the message points at the
+// logs that say why rather than repeating that it failed.
+func TestRun_FailedBuildStopsAndNamesTheLogs(t *testing.T) {
+	var tr track
+
+	f := wiredBuild(&tr)
+	// WaitForBuild's own contract: on a terminal error status it returns the
+	// build and an error together. Stubbing a nil error here would test a
+	// wait that does not exist and hide the id being dropped.
+	f.waitBuild = func(_, id string, _, _ time.Duration, _ func(*workload.Build)) (*workload.Build, error) {
+		return &workload.Build{ID: id, Status: workload.BuildStatusFailed},
+			fmt.Errorf("build %s ended with status %s", id, workload.BuildStatusFailed)
+	}
+
+	install(t, f)
+
+	result, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dr artifact build logs art-1 bld-1")
+	assert.NotContains(t, tr.steps, "create-workload")
+	assert.Equal(t, "bld-1", result.BuildID, "a failed build is still the build to go and read")
+}
+
+// A wait that runs out returns the build it was still watching, and that id
+// is the only way to follow the build to the end.
+func TestRun_TimedOutBuildKeepsItsID(t *testing.T) {
+	var tr track
+
+	f := wiredBuild(&tr)
+	f.waitBuild = func(_, id string, _, _ time.Duration, _ func(*workload.Build)) (*workload.Build, error) {
+		return &workload.Build{ID: id, Status: workload.BuildStatusInProgress},
+			fmt.Errorf("timeout waiting for build %s", id)
+	}
+
+	install(t, f)
+
+	result, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+	assert.NotContains(t, tr.steps, "create-workload")
+	assert.Equal(t, "bld-1", result.BuildID)
+}
+
+// The build is waited for even under --detach. --detach promises not to wait
+// for the workload to serve, not to hand back a workload that cannot start.
+func TestRun_DetachStillWaitsForTheImage(t *testing.T) {
+	var tr track
+
+	f := wiredBuild(&tr)
+	f.wait = func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		t.Fatal("--detach does not wait for the workload")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true, Detach: true})
+	require.NoError(t, err)
+	assert.Contains(t, tr.steps, "build")
+}
+
+// An artifact that has already built the code in the tree is not rebuilt.
+// This is the second run after a first deploy that failed at the workload,
+// and a rebuild there is minutes spent to produce the image already sitting
+// on the artifact.
+func TestRun_UnchangedTreeWithAnImageSkipsTheBuild(t *testing.T) {
+	var tr track
+
+	f := linkedAndSynced(&tr)
+	f.builds = func(string, int) ([]workload.Build, error) {
+		return []workload.Build{{ID: "bld-0", Status: workload.BuildStatusCompleted}}, nil
+	}
+
+	install(t, f)
 
 	_, stderr, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
-	require.Error(t, err)
-	require.ErrorIs(t, err, ErrNotWired)
-	assert.Contains(t, err.Error(), "dockerfile")
-	assert.Contains(t, stderr, "+ workload", "the plan is still printed before the refusal")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"sync", "create-workload"}, tr.steps)
+	assert.Contains(t, stderr, "Image is up to date")
+}
+
+// The same run where the previous attempt never got as far as an image. The
+// question is asked of the platform rather than assumed, because assuming
+// either way is wrong half the time.
+func TestRun_UnchangedTreeWithNoImageStillBuilds(t *testing.T) {
+	var tr track
+
+	f := linkedAndSynced(&tr)
+	f.builds = func(string, int) ([]workload.Build, error) {
+		return []workload.Build{{ID: "bld-0", Status: workload.BuildStatusFailed}}, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"sync", "build", "create-workload"}, tr.steps)
+}
+
+// --force-build is the answer to code that reached the artifact by some route
+// the deploy cannot see, which leaves a completed build of the wrong version
+// and a tree that looks unchanged.
+func TestRun_ForceBuildRebuildsAnUnchangedTree(t *testing.T) {
+	var tr track
+
+	f := linkedAndSynced(&tr)
+	f.builds = func(string, int) ([]workload.Build, error) {
+		t.Fatal("--force-build has already answered the question")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true, ForceBuild: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"sync", "build", "create-workload"}, tr.steps)
+}
+
+// linkedAndSynced is a project that has deployed before and whose working
+// tree has not moved since, which is the state where the build becomes a
+// question rather than a certainty.
+func linkedAndSynced(tr *track) fakes {
+	f := wiredBuild(tr)
+
+	f.code = func(Loaded, Live) (CodeChange, error) { return CodeChange{Applies: true}, nil }
+	f.linked = func(string) bool { return true }
+	f.project = func(string) (wapi.Config, error) { return wapi.Config{ArtifactID: "art-1"}, nil }
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
+	}
+	f.sync = func(string) (*sync.Result, error) {
+		tr.steps = append(tr.steps, "sync")
+
+		return &sync.Result{NewVersion: "ver-1"}, nil
+	}
+
+	return f
+}
+
+// A conflict is not a failure, and it cannot be silent either: what was just
+// uploaded is not what the user last looked at.
+func TestRun_SyncConflictsAreReported(t *testing.T) {
+	var tr track
+
+	f := wiredBuild(&tr)
+	f.sync = func(string) (*sync.Result, error) {
+		tr.steps = append(tr.steps, "sync")
+
+		return &sync.Result{UploadedCount: 1, ConflictCount: 1, ConflictCopies: []string{"app.py.LOCAL.170"}}, nil
+	}
+
+	install(t, f)
+
+	_, stderr, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "app.py.LOCAL.170")
+}
+
+// A flag that was asked for and did nothing has to say so, or it reads as a
+// rebuild that quietly happened.
+func TestRun_ForceBuildWithNothingToDoSaysSo(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return doc(t, liveWorkloadJSON), nil },
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	_, stderr, err := runIn(t, bound, Options{NonInteractive: true, ForceBuild: true})
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "--force-build had no effect")
 }
 
 // A file bound to an existing artifact has no build mode to read, and gating

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -933,6 +933,44 @@ func TestRun_ForceBuildWithNothingToDoSaysSo(t *testing.T) {
 	assert.Contains(t, stderr, "--force-build had no effect")
 }
 
+// The quieter half of the same problem: a manifest naming a published image
+// deploys and succeeds, so a --force-build that was never going to build
+// anything leaves nothing to suggest the image is not what the flag implied.
+func TestRun_ForceBuildOnAPublishedImageSaysSo(t *testing.T) {
+	install(t, fakes{
+		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return running("wl-new"), nil
+		},
+		build: func(string) (*workload.BuildTriggerResponse, error) {
+			t.Fatal("a published image is not built by the platform")
+
+			return nil, nil
+		},
+	})
+
+	result, stderr, err := runIn(t, unboundImageManifest, Options{NonInteractive: true, ForceBuild: true})
+	require.NoError(t, err, "the deploy still goes ahead; only the flag was idle")
+
+	assert.Equal(t, ActionCreated, result.Action)
+	assert.Contains(t, stderr, "--force-build had no effect")
+	assert.Contains(t, stderr, "does not build")
+}
+
+// The flag is not idle on a build track, so saying it was would be a lie in
+// the one case it actually did something.
+func TestRun_ForceBuildOnABuildTrackSaysNothing(t *testing.T) {
+	var tr track
+
+	install(t, linkedAndSynced(&tr))
+
+	_, stderr, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true, ForceBuild: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, tr.steps, "build", "the flag did something here")
+	assert.NotContains(t, stderr, "--force-build had no effect")
+}
+
 // A file bound to an existing artifact has no build mode to read, and gating
 // the create on the image mode refused it with a message about the platform
 // building an image it was never asked to build.


### PR DESCRIPTION
Seventh and last of the `dr workload up` stack, on top of #765. This is the one that makes the command useful for the projects `dr workload config` actually writes.

## What

Until now only a manifest naming a published image could be applied. A manifest asking the platform to build one planned correctly and then refused with `ErrNotWired` — which is every project the setup wizard writes with a Dockerfile.

A built deploy is four acts where a published image is one:

1. create the artifact from the manifest's `artifact` block
2. link the project directory to it
3. push the working tree (the sync engine, which also patches the artifact's `codeRef`)
4. build the image and wait for it

then create the workload against that artifact.

## Decisions worth a look

- **The order is chosen for resumability.** A run that dies partway leaves something the next one picks up. Creating the workload first would instead leave it in the UI pointing at an image that does not exist, unable to start, for as long as the build took.
- **The payload transforms live in the `manifest` package**, which owns the payload shape, so the deploy holds no opinions about key names. The manifest's `artifact` block already *is* the artifact-create request; `BindArtifact` then swaps it for the id. The two forms are mutually exclusive in the API as they are in the file, so binding removes the block rather than sending both, which would ask for a second, empty artifact.
- **The artifact link stays in the project's local state directory, not the manifest.** The manifest is committed and says what to deploy; the artifact a particular clone has been pushing to is a property of the clone, and putting it in a shared file would have two developers fighting over one draft.
- **The link write is the one failure that strands something**, because the artifact exists by then and nothing records it. That error carries the id and the command to recover with.
- **Builds are skipped when they would produce the image already on the artifact.** The way people arrive at a second deploy is a first one that failed after the sync, and a rebuild there is minutes for nothing. A build runs when the artifact is new, when the sync moved something, or when asked; otherwise the tree matches what was synced and the only open question — did the last attempt get as far as an image — is asked of the platform rather than assumed.
- **`--force-build` is the answer to the case the deploy cannot see:** code pushed by `dr artifact code sync` between deploys, which leaves a completed build of the previous version behind a tree that looks unchanged. Asked for on a run that is not going to deploy anything, it says so rather than staying silent, which would read as a rebuild that happened.
- **A locked artifact is refused before the push**, not during it. It can take neither code nor an image, and the platform's 403 arrives halfway through saying nothing about what to do instead.
- **The image is waited for even under `--detach`.** That flag promises not to wait for the workload to serve, not to hand back one that cannot start.
- **`buildId` in the JSON envelope is now populated** rather than always null, including when the build failed, so a pipeline can point its reader at the logs.

Rolling a new version onto a running workload is still not wired; this is the first deploy only.

## Worth a second opinion

The artifact create sends the manifest's `artifact` block verbatim, which for a build mode carries `imageBuildConfig` and no `imageUri`. The hackathon prototype sent `imageUri: placeholder:latest` alongside it. If the API requires a placeholder image on create, this needs one line; I would rather find that out from a real call than guess. Worth confirming against a live stack before this merges.

## Test plan

- [x] `task test` — no new failures
- [x] `task lint` — clean on all three GOOS targets
- [x] end-to-end against a live stack: `dr workload up` in a generated Dockerfile project

Made with [Cursor](https://cursor.com)