### PR TITLE
[RAPTOR-18976] feat(workload): roll a live workload onto a new version

### DIFF
--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -18,9 +18,11 @@
 package up
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/datarobot/cli/cmd/internal/pollflags"
@@ -117,6 +119,12 @@ for an image first, so the first deploy of such a project takes as long as the
 build does. A build the deploy believes would produce the image already on the
 artifact is skipped; --force-build says otherwise.
 
+Deploying onto a workload that already exists rolls it: a new version is made
+from the file and swapped in, the endpoint does not change, and the version
+already serving keeps serving until the new one is ready. When that version is
+locked, meaning production, an interactive run asks for the workload name to
+be typed back. A run with no terminal, or --yes, rolls without asking.
+
 Examples:
   dr workload up
   dr workload up --dry-run
@@ -152,7 +160,9 @@ Examples:
 
 func addFlags(cmd *cobra.Command, f *flags, poll *pollflags.Set) {
 	cmd.Flags().StringVar(&f.dir, "dir", "", "Project directory; the manifest is searched upward from here.")
-	cmd.Flags().BoolVarP(&f.yes, "yes", "y", false, "Do not prompt. With no manifest this is an error rather than a wizard.")
+	cmd.Flags().BoolVarP(&f.yes, "yes", "y", false,
+		"Do not prompt. With no manifest this is an error rather than a wizard, "+
+			"and rolling a locked production version is not confirmed.")
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "Print the plan and change nothing.")
 	cmd.Flags().BoolVar(&f.detach, "detach", false, "Return once the deploy is requested; do not wait for it to serve.")
 	cmd.Flags().BoolVar(&f.lock, "lock", false,
@@ -197,6 +207,7 @@ func run(cmd *cobra.Command, f flags, poll pollflags.Set, format outputformat.Ou
 		DryRun:         f.dryRun,
 		Detach:         f.detach,
 		Lock:           f.lock,
+		Confirm:        typedConfirm(cmd),
 		ForceBuild:     f.force,
 		PollInterval:   poll.Interval,
 		PollTimeout:    poll.Timeout,
@@ -254,6 +265,33 @@ func checkFlags(cmd *cobra.Command, f flags) error {
 	}
 
 	return nil
+}
+
+// typedConfirm asks a question that only the exact expected word answers.
+//
+// It goes to stderr and reads a single line, like everything else the deploy
+// says: stdout is the endpoint, or one JSON document, and a question printed
+// into it would break whatever is parsing it. A y/n would not do here, since
+// the one thing this is asked about is rolling production.
+//
+// The deploy calls it only on an interactive run, so it never has to decide
+// whether prompting is allowed. An answer that cannot be read at all is a no,
+// which leaves the workload running what it was running.
+func typedConfirm(cmd *cobra.Command) func(question, want string) (bool, error) {
+	return func(question, want string) (bool, error) {
+		fmt.Fprint(cmd.ErrOrStderr(), question)
+
+		scanner := bufio.NewScanner(cmd.InOrStdin())
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				return false, fmt.Errorf("cannot read the answer: %w", err)
+			}
+
+			return false, nil
+		}
+
+		return strings.TrimSpace(scanner.Text()) == want, nil
+	}
 }
 
 // reportable says whether a failed run left behind anything worth printing.

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -47,6 +47,11 @@ const (
 // without a network.
 var runFn = up.Run
 
+// isStdinTerminalFn answers whether a person is there to be asked. A test
+// harness always pipes stdin, so the tests that are about what happens on a
+// terminal replace it.
+var isStdinTerminalFn = reader.IsStdinTerminal
+
 // upResult is the stable JSON shape emitted by --output-format json. BuildID
 // is a pointer so it is null rather than empty when no build happened, which
 // is the difference between "skipped" and "produced nothing".
@@ -197,9 +202,11 @@ func run(cmd *cobra.Command, f flags, poll pollflags.Set, format outputformat.Ou
 
 	json := format == outputformat.OutputFormatJSON
 
+	yes := f.yes || viperx.GetBool("yes")
+
 	// JSON output implies non-interactive: a wizard drawn on stderr while
 	// stdout is being parsed is a trap for whoever is parsing it.
-	nonInteractive := f.yes || viperx.GetBool("yes") || json || !reader.IsStdinTerminal()
+	nonInteractive := yes || json || !isStdinTerminalFn()
 
 	result, runErr := runFn(up.Options{
 		Dir:            dir,
@@ -207,7 +214,7 @@ func run(cmd *cobra.Command, f flags, poll pollflags.Set, format outputformat.Ou
 		DryRun:         f.dryRun,
 		Detach:         f.detach,
 		Lock:           f.lock,
-		Confirm:        typedConfirm(cmd),
+		Confirm:        rollConfirm(cmd, yes),
 		ForceBuild:     f.force,
 		PollInterval:   poll.Interval,
 		PollTimeout:    poll.Timeout,
@@ -265,6 +272,23 @@ func checkFlags(cmd *cobra.Command, f flags) error {
 	}
 
 	return nil
+}
+
+// rollConfirm is how a locked production roll gets its answer, and nil when
+// there is nobody to ask or the answer is already in. --yes is that answer,
+// and a run with no terminal has nobody to give one.
+//
+// Deliberately not keyed on --output json. That flag says how to format
+// stdout; it is not consent, and folding it in here would mean
+// `dr workload up --output json` on a terminal rolls production without a
+// word. The question and its answer never touch stdout, so a run that asks
+// still emits exactly one document.
+func rollConfirm(cmd *cobra.Command, yes bool) func(question, want string) (bool, error) {
+	if yes || !isStdinTerminalFn() {
+		return nil
+	}
+
+	return typedConfirm(cmd)
 }
 
 // typedConfirm asks a question that only the exact expected word answers.

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/datarobot/cli/internal/workload/up"
@@ -49,12 +50,21 @@ func stubRun(t *testing.T, result up.Result, err error) *up.Options {
 func runCmd(t *testing.T, args ...string) (stdout, stderr string, err error) {
 	t.Helper()
 
+	return runCmdWithInput(t, "", args...)
+}
+
+// runCmdWithInput is runCmd with something waiting on stdin, for the one
+// question the deploy asks.
+func runCmdWithInput(t *testing.T, input string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+
 	cmd := Cmd()
 
 	var out, errOut bytes.Buffer
 
 	cmd.SetOut(&out)
 	cmd.SetErr(&errOut)
+	cmd.SetIn(strings.NewReader(input))
 	cmd.SetArgs(args)
 
 	// The command's own PreRunE authenticates, which a unit test must not do.
@@ -286,6 +296,53 @@ func TestCmd_FailureBeforeAnythingExistsJustFails(t *testing.T) {
 	require.Error(t, err)
 	assert.Empty(t, stdout)
 	assert.Contains(t, err.Error(), "manifest")
+}
+
+// The deploy asks one question, and only the exact name answers it. The
+// question goes to stderr because stdout carries the endpoint.
+func TestCmd_TypedConfirmAcceptsOnlyTheName(t *testing.T) {
+	cases := []struct {
+		typed string
+		want  bool
+	}{
+		{"my-app\n", true},
+		{"  my-app  \n", true},
+		{"y\n", false},
+		{"My-App\n", false},
+		{"\n", false},
+		{"", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.typed, func(t *testing.T) {
+			cmd := Cmd()
+
+			var errOut bytes.Buffer
+
+			cmd.SetErr(&errOut)
+			cmd.SetIn(strings.NewReader(c.typed))
+
+			agreed, err := typedConfirm(cmd)("Type the workload name: ", "my-app")
+			require.NoError(t, err)
+
+			assert.Equal(t, c.want, agreed)
+			assert.Contains(t, errOut.String(), "Type the workload name: ")
+		})
+	}
+}
+
+// The question reaches the deploy wired up, so a locked production roll can
+// actually be answered from a terminal.
+func TestCmd_ConfirmIsHandedToTheDeploy(t *testing.T) {
+	seen := stubRun(t, deployed(), nil)
+
+	_, _, err := runCmdWithInput(t, "my-app\n")
+	require.NoError(t, err)
+	require.NotNil(t, seen.Confirm)
+
+	agreed, err := seen.Confirm("anything? ", "my-app")
+	require.NoError(t, err)
+	assert.True(t, agreed)
 }
 
 func TestCmd_IsRegisteredUnderWorkload(t *testing.T) {

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -334,6 +334,8 @@ func TestCmd_TypedConfirmAcceptsOnlyTheName(t *testing.T) {
 // The question reaches the deploy wired up, so a locked production roll can
 // actually be answered from a terminal.
 func TestCmd_ConfirmIsHandedToTheDeploy(t *testing.T) {
+	onATerminal(t)
+
 	seen := stubRun(t, deployed(), nil)
 
 	_, _, err := runCmdWithInput(t, "my-app\n")
@@ -343,6 +345,58 @@ func TestCmd_ConfirmIsHandedToTheDeploy(t *testing.T) {
 	agreed, err := seen.Confirm("anything? ", "my-app")
 	require.NoError(t, err)
 	assert.True(t, agreed)
+}
+
+// onATerminal makes the run look like one a person is watching. A test
+// harness always pipes stdin, so without this every test is the CI case.
+func onATerminal(t *testing.T) {
+	t.Helper()
+
+	prev := isStdinTerminalFn
+	isStdinTerminalFn = func() bool { return true }
+
+	t.Cleanup(func() { isStdinTerminalFn = prev })
+}
+
+// --yes is the answer, so there is nothing left to ask and the deploy is
+// handed no way to ask it.
+func TestCmd_YesHandsTheDeployNoQuestion(t *testing.T) {
+	onATerminal(t)
+
+	seen := stubRun(t, deployed(), nil)
+
+	_, _, err := runCmd(t, "--yes")
+	require.NoError(t, err)
+
+	assert.True(t, seen.NonInteractive)
+	assert.Nil(t, seen.Confirm, "--yes already said yes")
+}
+
+// --output-format json keeps the wizard off the terminal, but it says how to
+// format stdout rather than that production may be rolled without a word.
+// Somebody is still there, so the question still reaches the deploy.
+func TestCmd_JSONOutputStillHandsOverTheQuestion(t *testing.T) {
+	onATerminal(t)
+
+	seen := stubRun(t, deployed(), nil)
+
+	_, _, err := runCmd(t, "--output-format", "json")
+	require.NoError(t, err)
+
+	assert.True(t, seen.NonInteractive, "no wizard may be drawn into the document")
+	assert.NotNil(t, seen.Confirm, "but there is still someone to ask about production")
+}
+
+// With no terminal there is nobody to ask, which is the CI case: the deploy
+// gets no question and rolls on the review the pipeline already had.
+func TestCmd_NoTerminalHandsTheDeployNoQuestion(t *testing.T) {
+	seen := stubRun(t, deployed(), nil)
+
+	_, _, err := runCmd(t)
+	require.NoError(t, err)
+
+	assert.True(t, seen.NonInteractive)
+	assert.Nil(t, seen.Confirm)
 }
 
 func TestCmd_IsRegisteredUnderWorkload(t *testing.T) {

--- a/internal/workload/manifest/compile.go
+++ b/internal/workload/manifest/compile.go
@@ -60,6 +60,12 @@ type Compiled struct {
 	Payload json.RawMessage
 	// WorkloadID is the stripped binding, "" when the manifest is unbound.
 	WorkloadID string
+	// ArtifactID is the artifact the file binds to by id, "" when the file
+	// describes one inline instead. Unlike WorkloadID it stays in Payload,
+	// because it is the platform's own field rather than a CLI convenience.
+	// A deploy reads it to know there is nothing to create: the version being
+	// rolled onto already exists.
+	ArtifactID string
 	// CredentialRefs lists every credential the payload references.
 	CredentialRefs []CredentialRef
 }
@@ -81,6 +87,7 @@ func (m *Manifest) Compile() (*Compiled, error) {
 	}
 
 	workloadID := m.WorkloadID()
+	artifactID, _ := scalarString(mapValue(m.root, keyArtifactID))
 
 	delete(doc, keyWorkloadID)
 	expandCredentialShorthand(doc)
@@ -90,7 +97,12 @@ func (m *Manifest) Compile() (*Compiled, error) {
 		return nil, fmt.Errorf("cannot convert manifest to JSON: %w", err)
 	}
 
-	return &Compiled{Payload: payload, WorkloadID: workloadID, CredentialRefs: refs}, nil
+	return &Compiled{
+		Payload:        payload,
+		WorkloadID:     workloadID,
+		ArtifactID:     artifactID,
+		CredentialRefs: refs,
+	}, nil
 }
 
 // ArtifactPayload is the inline artifact block on its own, which is exactly

--- a/internal/workload/manifest/compile.go
+++ b/internal/workload/manifest/compile.go
@@ -87,7 +87,7 @@ func (m *Manifest) Compile() (*Compiled, error) {
 	}
 
 	workloadID := m.WorkloadID()
-	artifactID, _ := scalarString(mapValue(m.root, keyArtifactID))
+	artifactID := topLevelString(m.root, keyArtifactID)
 
 	delete(doc, keyWorkloadID)
 	expandCredentialShorthand(doc)

--- a/internal/workload/up/plan.go
+++ b/internal/workload/up/plan.go
@@ -134,5 +134,18 @@ func Build(loaded Loaded, live Live, code CodeChange) (Plan, error) {
 	plan.Artifact = Subset(spec, live.Spec)
 	plan.Runtime = Subset(runtime, live.Runtime)
 
+	// A file that names an artifact by id describes no spec to compare, so
+	// the walk above has nothing to say about it. Pointing at a different
+	// version than the one running is still the whole plan: it is a roll, and
+	// without this the run reports "already up to date" while the file and
+	// the workload disagree about what should be serving.
+	if bound := loaded.Compiled.ArtifactID; bound != "" && bound != live.ArtifactID {
+		plan.Artifact = append(plan.Artifact, Change{
+			Path: keyArtifactID,
+			Have: live.ArtifactID,
+			Want: bound,
+		})
+	}
+
 	return plan, nil
 }

--- a/internal/workload/up/plan_test.go
+++ b/internal/workload/up/plan_test.go
@@ -245,6 +245,45 @@ func TestBuild_SplitsDriftIntoItsTwoHalves(t *testing.T) {
 	assert.Equal(t, ActionRolled, plan.Action(), "a spec change mints a version even with sizing alongside")
 }
 
+// A file bound to an artifact by id describes no spec, so the field walk has
+// nothing to compare. Pointing at a version other than the one running is
+// still the entire plan, and reporting "already up to date" while the file
+// and the workload disagree would be the worst kind of wrong.
+func TestBuild_BoundToAnotherArtifactIsARoll(t *testing.T) {
+	loaded := Loaded{Compiled: &manifest.Compiled{
+		Payload:    json.RawMessage(`{"name": "my-app", "artifactId": "68b0bbbb0000000000000002"}`),
+		ArtifactID: "68b0bbbb0000000000000002",
+	}}
+
+	live := liveFrom(t, StateRunning, "", planLiveRuntime)
+	live.ArtifactID = "68a0000000000000000000a1"
+
+	plan, err := Build(loaded, live, builtCode(0))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"artifactId"}, paths(plan.Artifact))
+	assert.Equal(t, ActionRolled, plan.Action())
+	assert.False(t, plan.Empty())
+}
+
+// The same file against the workload already running that artifact plans
+// nothing, or every deploy would roll a version onto itself.
+func TestBuild_BoundToTheRunningArtifactIsEmpty(t *testing.T) {
+	loaded := Loaded{Compiled: &manifest.Compiled{
+		Payload:    json.RawMessage(`{"name": "my-app", "artifactId": "68a0000000000000000000a1"}`),
+		ArtifactID: "68a0000000000000000000a1",
+	}}
+
+	live := liveFrom(t, StateRunning, "", planLiveRuntime)
+	live.ArtifactID = "68a0000000000000000000a1"
+
+	plan, err := Build(loaded, live, builtCode(0))
+	require.NoError(t, err)
+
+	assert.Empty(t, plan.Artifact)
+	assert.True(t, plan.Empty())
+}
+
 func TestBuild_RuntimeOnlyDriftDoesNotRoll(t *testing.T) {
 	resized := `{
 	  "name": "my-app",

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -1,0 +1,257 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+)
+
+// roll moves a live workload onto a new version of what the file describes.
+// The endpoint never changes and the version already serving keeps serving
+// until the new one is ready, which is what makes this safe to run against
+// something in use.
+//
+// The order is not a preference. The guard comes first because a second
+// replacement POSTed while one is in flight queues another swap rather than
+// being refused, so the check that matters is the one immediately before the
+// call, and an early one saves a doomed run from creating anything. The
+// candidate is minted next, and locked before the rollout when production is
+// locked, because the platform will not replace a locked artifact with a
+// draft and locking is one-way: it has to happen to the new version, after
+// the user has agreed, and before the swap.
+func roll(loaded Loaded, live Live, plan Plan, result Result, opts Options, report *reporter) (Result, error) {
+	if live.State == StateStopped {
+		return result, fmt.Errorf(
+			"workload %s is stopped and the file asks for more than starting it. "+
+				"Start it with 'dr workload start %s' and deploy again, so the new version rolls out onto "+
+				"something that is running",
+			result.Name, live.WorkloadID)
+	}
+
+	// A new version of a built project is born with neither code nor an
+	// image, so rolling onto it would promote something that cannot start.
+	// Giving it both is the next change, and it is more than a longer wait:
+	// the code has to reach the new version before the old one is touched.
+	// The test is the file's build mode rather than whether code changed,
+	// because a spec-only edit to a built project has the same problem.
+	if mode := loaded.Manifest.BuildMode(); mode == manifest.BuildModeDockerfile || mode == manifest.BuildModeGenerated {
+		return result, fmt.Errorf(
+			"%w: rolling a workload whose image the platform builds (%s mode). The plan above is correct, "+
+				"and a new version of a published image rolls today",
+			ErrNotWired, mode)
+	}
+
+	if err := guardReplacementFn(live.WorkloadID); err != nil {
+		return result, err
+	}
+
+	candidate, fresh, err := candidateArtifact(loaded, report)
+	if err != nil {
+		return result, err
+	}
+
+	// result.ArtifactID stays on the version that is serving, and settle
+	// moves it when the rollout has actually promoted the new one. A failed
+	// swap leaves the old version running, so an envelope naming the
+	// candidate would send someone to read the wrong artifact.
+
+	locked, err := matchLock(live, candidate, fresh, result.Name, opts, report)
+	if err != nil {
+		return result, err
+	}
+
+	result.Locked = locked
+
+	return replace(live.WorkloadID, candidate, result, opts, report)
+}
+
+// candidateArtifact is the version to roll onto, and whether this run made
+// it. A file bound to an artifact by id is asking for something that already
+// exists, so there is nothing to create; minting one anyway would leave a
+// stray artifact behind on every deploy.
+func candidateArtifact(loaded Loaded, report *reporter) (string, bool, error) {
+	if id := loaded.Compiled.ArtifactID; id != "" {
+		return id, false, nil
+	}
+
+	var created *workload.Artifact
+
+	err := report.run("Creating the new version", func() error {
+		payload, payloadErr := loaded.Compiled.ArtifactPayload()
+		if payloadErr != nil {
+			return payloadErr
+		}
+
+		artifact, createErr := createArtifactFn(payload)
+		created = artifact
+
+		return createErr
+	})
+	if err != nil {
+		return "", false, err
+	}
+
+	return created.ID, true, nil
+}
+
+// matchLock makes the candidate immutable when the version it replaces is,
+// and reports whether it did. Draft replaces draft and locked replaces
+// locked; the platform rejects a mismatch.
+//
+// This is the point of no return, which is why the question is asked here
+// rather than earlier: everything before it can be abandoned, and a locked
+// artifact cannot be unlocked or deleted.
+func matchLock(live Live, candidate string, fresh bool, workloadName string, opts Options, report *reporter) (bool, error) {
+	if !live.Locked {
+		return false, nil
+	}
+
+	agreed, err := confirmRoll(workloadName, opts)
+	if err != nil {
+		return false, err
+	}
+
+	if !agreed {
+		return false, fmt.Errorf("cancelled: workload %s is still running the version it was", workloadName)
+	}
+
+	// A candidate the file named may already be locked, and locking twice is
+	// not a no-op at the platform. One created here is always a draft.
+	if !fresh {
+		already, lockedErr := lockedAlready(candidate)
+		if lockedErr != nil {
+			return false, lockedErr
+		}
+
+		if already {
+			return true, nil
+		}
+	}
+
+	err = report.run("Locking the new version", func() error {
+		_, lockErr := lockArtifactFn(candidate)
+
+		return lockErr
+	})
+	if err != nil {
+		return false, fmt.Errorf(
+			"artifact %s could not be locked, and a locked workload only accepts a locked version, "+
+				"so nothing was rolled: %w", candidate, err)
+	}
+
+	return true, nil
+}
+
+// lockedAlready reports whether the candidate is already immutable.
+func lockedAlready(artifactID string) (bool, error) {
+	artifact, err := getArtifactFn(artifactID)
+	if err != nil {
+		return false, fmt.Errorf("cannot read artifact %s to see whether it is already locked: %w", artifactID, err)
+	}
+
+	return artifact.IsLocked(), nil
+}
+
+// confirmRoll is decision 1 of the design, settled: `up` rolls production the
+// same as any other run, and the whole ceremony is typing the name back on an
+// interactive terminal. CI passes no flag, because a pipeline someone already
+// reviewed should not have to say so twice.
+//
+// A run that cannot ask is refused rather than waved through. Being unable to
+// prompt is not the same as having been told to go ahead, and the difference
+// matters exactly once.
+func confirmRoll(workloadName string, opts Options) (bool, error) {
+	if opts.NonInteractive {
+		return true, nil
+	}
+
+	if opts.Confirm == nil {
+		return false, errors.New(
+			"this rolls a locked, production version and there is no terminal to confirm on. " +
+				"Re-run with --yes to say so explicitly")
+	}
+
+	return opts.Confirm(fmt.Sprintf(
+		"Workload %s is running a locked version, which means production.\n"+
+			"The new version will be locked too, and locking cannot be undone.\n"+
+			"Type the workload name to roll it, anything else to stop: ", workloadName), workloadName)
+}
+
+// replace starts the rollout and follows it to the end.
+func replace(workloadID, artifactID string, result Result, opts Options, report *reporter) (Result, error) {
+	// The guard that actually holds. The live state can have changed since
+	// the one at the top, and this is the last moment before a swap that
+	// cannot be taken back by refusing it.
+	if err := guardReplacementFn(workloadID); err != nil {
+		return result, err
+	}
+
+	var started *workload.Replacement
+
+	err := report.run("Rolling out the new version", func() error {
+		replacement, startErr := startReplacementFn(workloadID, artifactID)
+		started = replacement
+
+		return startErr
+	})
+	if err != nil {
+		return result, fmt.Errorf("cannot roll workload %s onto artifact %s: %w", workloadID, artifactID, err)
+	}
+
+	result.Action = ActionRolled
+
+	if opts.Detach {
+		report.say("  Rollout of %s onto artifact %s requested; not waiting.\n", workloadID, artifactID)
+
+		return result, nil
+	}
+
+	if err := awaitRollout(workloadID, started, opts, report); err != nil {
+		return result, err
+	}
+
+	return settle(workloadID, result, opts, report)
+}
+
+// awaitRollout waits for the swap itself, before the wait for the workload.
+// They are two questions: the rollout says whether the new version was
+// promoted, and a failed one leaves the old version serving, so reporting the
+// workload as healthy afterwards would be true and completely misleading.
+func awaitRollout(workloadID string, started *workload.Replacement, opts Options, report *reporter) error {
+	var settled *workload.Replacement
+
+	err := report.run("Waiting for the rollout", func() error {
+		replacement, waitErr := waitReplacementFn(workloadID, started, opts.PollInterval, opts.PollTimeout, nil)
+		settled = replacement
+
+		return waitErr
+	})
+	if err == nil {
+		return nil
+	}
+
+	if settled != nil && workload.IsFailedReplacementStatus(settled.Status) {
+		return fmt.Errorf(
+			"the rollout of workload %s ended as %s, so it is still running the version it was; "+
+				"check 'dr workload logs %s': %w",
+			workloadID, settled.Status, workloadID, err)
+	}
+
+	return err
+}

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -31,10 +31,15 @@ import (
 // replacement POSTed while one is in flight queues another swap rather than
 // being refused, so the check that matters is the one immediately before the
 // call, and an early one saves a doomed run from creating anything. The
-// candidate is minted next, and locked before the rollout when production is
-// locked, because the platform will not replace a locked artifact with a
-// draft and locking is one-way: it has to happen to the new version, after
-// the user has agreed, and before the swap.
+// candidate is minted next, and the question of locking is put then, while
+// the answer still costs nothing.
+//
+// The lock itself is last, inside replace, between the final guard and the
+// POST. The platform will not replace a locked artifact with a draft, so the
+// candidate has to be locked to go; but locking is one-way, and an artifact
+// locked for a rollout that is then refused can be neither unlocked nor
+// deleted. Taking the lock only once nothing is left that can say no is what
+// keeps a lost race from leaving one behind.
 func roll(loaded Loaded, live Live, plan Plan, result Result, opts Options, report *reporter) (Result, error) {
 	if live.State == StateStopped {
 		return result, fmt.Errorf(
@@ -71,14 +76,14 @@ func roll(loaded Loaded, live Live, plan Plan, result Result, opts Options, repo
 	// swap leaves the old version running, so an envelope naming the
 	// candidate would send someone to read the wrong artifact.
 
-	locked, err := matchLock(live, candidate, fresh, result.Name, opts, report)
+	// Asked now, locked later. Agreeing costs nothing that cannot be undone;
+	// the lock is taken inside replace, once the last guard has passed.
+	lock, err := confirmLock(live, result.Name, opts)
 	if err != nil {
 		return result, err
 	}
 
-	result.Locked = locked
-
-	return replace(live.WorkloadID, candidate, result, opts, report)
+	return replace(live.WorkloadID, candidate, lock, fresh, result, opts, report)
 }
 
 // candidateArtifact is the version to roll onto, and whether this run made
@@ -110,14 +115,14 @@ func candidateArtifact(loaded Loaded, report *reporter) (string, bool, error) {
 	return created.ID, true, nil
 }
 
-// matchLock makes the candidate immutable when the version it replaces is,
-// and reports whether it did. Draft replaces draft and locked replaces
-// locked; the platform rejects a mismatch.
+// confirmLock asks whether to roll a locked version, and reports whether the
+// candidate has to be locked to match. Draft replaces draft and locked
+// replaces locked; the platform rejects a mismatch.
 //
-// This is the point of no return, which is why the question is asked here
-// rather than earlier: everything before it can be abandoned, and a locked
-// artifact cannot be unlocked or deleted.
-func matchLock(live Live, candidate string, fresh bool, workloadName string, opts Options, report *reporter) (bool, error) {
+// Only the question is asked here. The lock itself waits until immediately
+// before the swap, because locking is one-way and an artifact locked for a
+// rollout that never starts can be neither unlocked nor deleted.
+func confirmLock(live Live, workloadName string, opts Options) (bool, error) {
 	if !live.Locked {
 		return false, nil
 	}
@@ -131,6 +136,16 @@ func matchLock(live Live, candidate string, fresh bool, workloadName string, opt
 		return false, fmt.Errorf("cancelled: workload %s is still running the version it was", workloadName)
 	}
 
+	return true, nil
+}
+
+// matchLock makes the candidate immutable, and reports whether it is.
+//
+// It runs between the final in-flight guard and the swap. That window is the
+// whole point: the platform wants the lock in place before the replacement is
+// POSTed, and by then everything that could still refuse the rollout has had
+// its say, so a lock taken here is one the run is committed to using.
+func matchLock(candidate string, fresh bool, report *reporter) (bool, error) {
 	// A candidate the file named may already be locked, and locking twice is
 	// not a no-op at the platform. One created here is always a draft.
 	if !fresh {
@@ -144,7 +159,7 @@ func matchLock(live Live, candidate string, fresh bool, workloadName string, opt
 		}
 	}
 
-	err = report.run("Locking the new version", func() error {
+	err := report.run("Locking the new version", func() error {
 		_, lockErr := lockArtifactFn(candidate)
 
 		return lockErr
@@ -194,12 +209,27 @@ func confirmRoll(workloadName string, opts Options) (bool, error) {
 }
 
 // replace starts the rollout and follows it to the end.
-func replace(workloadID, artifactID string, result Result, opts Options, report *reporter) (Result, error) {
+func replace(
+	workloadID, artifactID string,
+	lock, fresh bool,
+	result Result,
+	opts Options,
+	report *reporter,
+) (Result, error) {
 	// The guard that actually holds. The live state can have changed since
 	// the one at the top, and this is the last moment before a swap that
 	// cannot be taken back by refusing it.
 	if err := guardReplacementFn(workloadID); err != nil {
 		return result, err
+	}
+
+	if lock {
+		locked, err := matchLock(artifactID, fresh, report)
+		if err != nil {
+			return result, err
+		}
+
+		result.Locked = locked
 	}
 
 	var started *workload.Replacement

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -192,20 +192,25 @@ func lockedAlready(artifactID string) (bool, error) {
 // prompt is not the same as having been told to go ahead, and the difference
 // matters exactly once.
 func confirmRoll(workloadName string, opts Options) (bool, error) {
+	// Being able to ask settles it, ahead of any inference about whether
+	// anyone is there. NonInteractive is also true for --output json, which
+	// says how to format stdout rather than that production may be rolled
+	// without a word, and the caller passes no Confirm when the answer is
+	// already in.
+	if opts.Confirm != nil {
+		return opts.Confirm(fmt.Sprintf(
+			"Workload %s is running a locked version, which means production.\n"+
+				"The new version will be locked too, and locking cannot be undone.\n"+
+				"Type the workload name to roll it, anything else to stop: ", workloadName), workloadName)
+	}
+
 	if opts.NonInteractive {
 		return true, nil
 	}
 
-	if opts.Confirm == nil {
-		return false, errors.New(
-			"this rolls a locked, production version and there is no terminal to confirm on. " +
-				"Re-run with --yes to say so explicitly")
-	}
-
-	return opts.Confirm(fmt.Sprintf(
-		"Workload %s is running a locked version, which means production.\n"+
-			"The new version will be locked too, and locking cannot be undone.\n"+
-			"Type the workload name to roll it, anything else to stop: ", workloadName), workloadName)
+	return false, errors.New(
+		"this rolls a locked, production version and there is no terminal to confirm on. " +
+			"Re-run with --yes to say so explicitly")
 }
 
 // replace starts the rollout and follows it to the end.

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -249,6 +249,70 @@ func TestRun_LockedProductionRollsAfterTheNameIsTyped(t *testing.T) {
 	assert.True(t, result.Locked)
 }
 
+// A file naming an artifact by id is the one way to reach matchLock with a
+// candidate this run did not create, so it is the only path that asks the
+// platform whether the successor is locked already. Locking twice is not a
+// no-op there, which is what the question is for.
+func TestRun_LockedRollDoesNotRelockAnArtifactTheFileNamed(t *testing.T) {
+	var tr track
+
+	f := lockedLive(wiredRoll(&tr))
+	f.newArtifact = func(any) (*workload.Artifact, error) {
+		t.Fatal("the file named the version to roll onto")
+
+		return nil, nil
+	}
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		tr.steps = append(tr.steps, "read:"+id)
+
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusLocked}, nil
+	}
+
+	install(t, f)
+
+	named := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundArtifactManifest
+
+	result, _, err := runIn(t, named, Options{
+		Confirm: func(string, string) (bool, error) { return true, nil },
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"guard", "guard", "read:68b0bbbb0000000000000002",
+		"replace:68b0bbbb0000000000000002", "await-rollout", "settle",
+	}, tr.steps, "an artifact already locked is read, not locked again")
+	assert.True(t, result.Locked)
+}
+
+// The other half: a named artifact that is still a draft has to be locked to
+// match the production version it is replacing, because the platform refuses
+// to put a draft where a locked one was.
+func TestRun_LockedRollLocksANamedDraft(t *testing.T) {
+	var tr track
+
+	f := lockedLive(wiredRoll(&tr))
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		tr.steps = append(tr.steps, "read:"+id)
+
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
+	}
+
+	install(t, f)
+
+	named := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundArtifactManifest
+
+	result, _, err := runIn(t, named, Options{
+		Confirm: func(string, string) (bool, error) { return true, nil },
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"guard", "guard", "read:68b0bbbb0000000000000002", "lock:68b0bbbb0000000000000002",
+		"replace:68b0bbbb0000000000000002", "await-rollout", "settle",
+	}, tr.steps)
+	assert.True(t, result.Locked)
+}
+
 // A plan with both halves is refused rather than half-applied. Rolling and
 // leaving the sizing behind would carry out part of the plan just printed and
 // report the whole of it as done, which is worse than not starting.
@@ -327,7 +391,7 @@ func TestRun_LockedProductionWithNoWayToAskRefuses(t *testing.T) {
 }
 
 // CI passes no flag: a pipeline that was already reviewed should not have to
-// say so twice.
+// say so twice. There is nobody to ask, so the command passes no Confirm.
 func TestRun_LockedProductionRollsInCIWithoutAsking(t *testing.T) {
 	var tr track
 
@@ -335,18 +399,38 @@ func TestRun_LockedProductionRollsInCIWithoutAsking(t *testing.T) {
 
 	install(t, f)
 
-	result, _, err := runIn(t, newImage(), Options{
-		NonInteractive: true,
-		Confirm: func(string, string) (bool, error) {
-			t.Fatal("nothing may prompt without a terminal")
-
-			return false, nil
-		},
-	})
+	result, _, err := runIn(t, newImage(), Options{NonInteractive: true})
 	require.NoError(t, err)
 
 	assert.Contains(t, tr.steps, "lock:art-2")
 	assert.True(t, result.Locked)
+}
+
+// --output json makes the run non-interactive so no wizard is drawn into the
+// document, but it is a statement about stdout, not consent. Somebody is
+// still sitting there, so production still gets to be asked about; the
+// question and its answer never touch stdout.
+func TestRun_JSONOutputStillAsksBeforeRollingProduction(t *testing.T) {
+	var (
+		tr    track
+		asked string
+	)
+
+	install(t, lockedLive(wiredRoll(&tr)))
+
+	_, _, err := runIn(t, newImage(), Options{
+		NonInteractive: true,
+		Confirm: func(question, _ string) (bool, error) {
+			asked = question
+
+			return false, nil
+		},
+	})
+	require.Error(t, err, "the answer was no, so nothing may roll")
+
+	assert.Contains(t, asked, "production", "being unable to draw a wizard is not consent")
+	assert.NotContains(t, tr.steps, "lock:art-2")
+	assert.NotContains(t, tr.steps, "replace:art-2")
 }
 
 // --lock and a locked predecessor both lock, and locking twice is not a

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -242,11 +242,62 @@ func TestRun_LockedProductionRollsAfterTheNameIsTyped(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]string{"guard", "create-artifact", "lock:art-2", "guard", "replace:art-2", "await-rollout", "settle"},
-		tr.steps, "the successor is locked before the swap, not after")
+		[]string{"guard", "create-artifact", "guard", "lock:art-2", "replace:art-2", "await-rollout", "settle"},
+		tr.steps, "the successor is locked after the last guard and before the swap")
 	assert.Contains(t, asked, "production")
 	assert.Equal(t, "my-app", expect, "the name is what has to be typed")
 	assert.True(t, result.Locked)
+}
+
+// A plan with both halves is refused rather than half-applied. Rolling and
+// leaving the sizing behind would carry out part of the plan just printed and
+// report the whole of it as done, which is worse than not starting.
+func TestRun_RollThatAlsoResizesIsRefusedWholesale(t *testing.T) {
+	var tr track
+
+	install(t, wiredRoll(&tr))
+
+	both := strings.Replace(newImage(), "cpu: 0.5", "cpu: 2", 1)
+
+	_, _, err := runIn(t, both, Options{NonInteractive: true})
+	require.ErrorIs(t, err, ErrNotWired)
+	assert.Contains(t, err.Error(), "runtime settings")
+	assert.Empty(t, tr.steps, "nothing may be rolled while half the plan cannot be applied")
+}
+
+// Locking cannot be undone and a locked artifact cannot be deleted, so a lock
+// taken before the final guard is stranded when that guard refuses. The guard
+// has to lose the race first.
+func TestRun_LockIsNotTakenWhenTheFinalGuardRefuses(t *testing.T) {
+	var (
+		tr    track
+		calls int
+	)
+
+	f := lockedLive(wiredRoll(&tr))
+
+	// The first guard passes and the second finds a rollout someone else
+	// started meanwhile, which is the race this ordering exists for.
+	f.guard = func(string) error {
+		tr.steps = append(tr.steps, "guard")
+		calls++
+
+		if calls == 1 {
+			return nil
+		}
+
+		return errors.New("workload wl-1 already has a replacement in progress")
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, newImage(), Options{
+		Confirm: func(string, string) (bool, error) { return true, nil },
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already has a replacement in progress")
+	assert.NotContains(t, tr.steps, "lock:art-2",
+		"a refused rollout must not leave an artifact locked for a swap that never happened")
 }
 
 func TestRun_LockedProductionLeftAloneWhenTheAnswerIsNo(t *testing.T) {

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -1,0 +1,398 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The live pair below says exactly what boundImageManifest says, so a run
+// against it plans nothing. Every roll test moves one field and no more, and
+// the field it moves is in the artifact, because that is what mints a
+// version.
+const (
+	liveImageWorkloadJSON = `{
+  "id": "68b0c1d2e3f4a5b6c7d8e9f0",
+  "name": "my-app",
+  "status": "running",
+  "importance": "low",
+  "artifactId": "68a0000000000000000000a1",
+  "endpoint": "https://app.datarobot.com/workloads/68b0/",
+  "runtime": {
+    "containerGroups": [
+      {
+        "name": "default",
+        "replicaCount": 1,
+        "containers": [
+          {"name": "primary", "resourceAllocation": {"cpu": 0.5, "memory": "512MB"}}
+        ]
+      }
+    ]
+  }
+}`
+
+	liveImageArtifactJSON = `{
+  "id": "68a0000000000000000000a1",
+  "name": "my-app-artifact",
+  "status": "draft",
+  "spec": {
+    "type": "service",
+    "containerGroups": [
+      {
+        "name": "default",
+        "containers": [
+          {"name": "primary", "primary": true, "port": 8080, "imageUri": "registry/team/app:v1"}
+        ]
+      }
+    ]
+  }
+}`
+)
+
+// boundImageManifest is unboundImageManifest tied to the live workload above.
+const boundImageManifest = "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + unboundImageManifest
+
+// newImage is the same file asking for a different image, which is the
+// smallest change that needs a new version rolled in.
+func newImage() string {
+	return strings.Replace(boundImageManifest, "app:v1", "app:v2", 1)
+}
+
+// liveImage points the two reads at the running pair.
+func liveImage(f fakes) fakes {
+	f.workloadD = func(string) (workload.Document, error) { return docOf(liveImageWorkloadJSON), nil }
+	f.artifactD = func(string) (workload.Document, error) { return docOf(liveImageArtifactJSON), nil }
+
+	return f
+}
+
+// docOf is doc without a *testing.T, so the fixtures above can be built
+// inside the seams themselves, which take no test to call.
+func docOf(raw string) workload.Document {
+	var d workload.Document
+
+	if err := json.Unmarshal([]byte(raw), &d); err != nil {
+		panic(err)
+	}
+
+	return d
+}
+
+// wiredRoll is a roll where every step succeeds, recording the order they
+// happened in. Order is most of what this path has to get right.
+func wiredRoll(tr *track) fakes {
+	return liveImage(fakes{
+		guard: func(string) error {
+			tr.steps = append(tr.steps, "guard")
+
+			return nil
+		},
+		newArtifact: func(payload any) (*workload.Artifact, error) {
+			tr.steps = append(tr.steps, "create-artifact")
+			tr.artifactIn = payload
+
+			return &workload.Artifact{ID: "art-2", Status: workload.ArtifactStatusDraft}, nil
+		},
+		lock: func(id string) (*workload.Artifact, error) {
+			tr.steps = append(tr.steps, "lock:"+id)
+
+			return &workload.Artifact{ID: id, Status: workload.ArtifactStatusLocked}, nil
+		},
+		replace: func(workloadID, artifactID string) (*workload.Replacement, error) {
+			tr.steps = append(tr.steps, "replace:"+artifactID)
+
+			return &workload.Replacement{ID: "rep-1", WorkloadID: workloadID, ArtifactID: artifactID}, nil
+		},
+		waitReplace: func(_ string, started *workload.Replacement, _, _ time.Duration,
+			_ func(*workload.Replacement),
+		) (*workload.Replacement, error) {
+			tr.steps = append(tr.steps, "await-rollout")
+			started.Status = workload.ReplacementStatusCompleted
+
+			return started, nil
+		},
+		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			tr.steps = append(tr.steps, "settle")
+
+			return &workload.Workload{
+				ID: id, Name: "my-app", Status: workload.WorkloadStatusRunning,
+				ArtifactID: "art-2", Endpoint: "https://app.datarobot.com/workloads/68b0/",
+			}, nil
+		},
+	})
+}
+
+// locked makes the running version production.
+func lockedLive(f fakes) fakes {
+	f.artifactD = func(string) (workload.Document, error) {
+		d := docOf(liveImageArtifactJSON)
+		d["status"] = workload.ArtifactStatusLocked
+
+		return d, nil
+	}
+
+	return f
+}
+
+func TestRun_LivePairWithNoDriftPlansNothing(t *testing.T) {
+	install(t, liveImage(fakes{}))
+
+	result, stderr, err := runIn(t, boundImageManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionUnchanged, result.Action, "the fixtures have to agree or every roll test is testing noise")
+	assert.Contains(t, stderr, "Already up to date")
+}
+
+func TestRun_RollsALiveWorkloadOntoANewVersion(t *testing.T) {
+	var tr track
+
+	install(t, wiredRoll(&tr))
+
+	result, stderr, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"guard", "create-artifact", "guard", "replace:art-2", "await-rollout", "settle"}, tr.steps)
+	assert.Equal(t, ActionRolled, result.Action)
+	assert.Equal(t, "art-2", result.ArtifactID)
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", result.WorkloadID, "a roll never makes a second workload")
+	assert.Equal(t, "https://app.datarobot.com/workloads/68b0/", result.Endpoint, "the endpoint survives a rollout")
+	assert.False(t, result.Locked, "a draft rolls onto a draft")
+	assert.Contains(t, stderr, "+ artifact")
+}
+
+// A file that names an artifact is deploying one that already exists, so
+// creating another would leave a stray behind on every run.
+func TestRun_RollUsesTheArtifactTheFileNames(t *testing.T) {
+	var tr track
+
+	f := wiredRoll(&tr)
+	f.newArtifact = func(any) (*workload.Artifact, error) {
+		t.Fatal("the file named the version to roll onto")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	named := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundArtifactManifest
+
+	result, _, err := runIn(t, named, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"guard", "guard", "replace:68b0bbbb0000000000000002", "await-rollout", "settle"}, tr.steps)
+	assert.Equal(t, ActionRolled, result.Action)
+}
+
+// The up-front guard exists so a doomed run fails before it creates a version
+// nobody will ever roll.
+func TestRun_ReplacementInFlightStopsBeforeAnythingIsMade(t *testing.T) {
+	var tr track
+
+	f := wiredRoll(&tr)
+	f.guard = func(string) error { return errors.New("workload wl-1 already has a replacement in progress") }
+
+	install(t, f)
+
+	_, _, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already has a replacement in progress")
+	assert.Empty(t, tr.steps, "nothing may be created while a rollout is running")
+}
+
+// Decision 1: rolling production is allowed, and typing the name is the whole
+// ceremony. The new version is locked before the swap, because the platform
+// will not replace a locked version with a draft.
+func TestRun_LockedProductionRollsAfterTheNameIsTyped(t *testing.T) {
+	var (
+		tr     track
+		asked  string
+		expect string
+	)
+
+	install(t, lockedLive(wiredRoll(&tr)))
+
+	result, _, err := runIn(t, newImage(), Options{
+		Confirm: func(question, want string) (bool, error) {
+			asked, expect = question, want
+
+			return true, nil
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]string{"guard", "create-artifact", "lock:art-2", "guard", "replace:art-2", "await-rollout", "settle"},
+		tr.steps, "the successor is locked before the swap, not after")
+	assert.Contains(t, asked, "production")
+	assert.Equal(t, "my-app", expect, "the name is what has to be typed")
+	assert.True(t, result.Locked)
+}
+
+func TestRun_LockedProductionLeftAloneWhenTheAnswerIsNo(t *testing.T) {
+	var tr track
+
+	install(t, lockedLive(wiredRoll(&tr)))
+
+	_, _, err := runIn(t, newImage(), Options{
+		Confirm: func(string, string) (bool, error) { return false, nil },
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still running the version it was")
+	assert.NotContains(t, tr.steps, "lock:art-2", "locking cannot be undone, so it must not happen on a no")
+	assert.NotContains(t, tr.steps, "replace:art-2")
+}
+
+// Being unable to ask is not the same as having been told to go ahead.
+func TestRun_LockedProductionWithNoWayToAskRefuses(t *testing.T) {
+	var tr track
+
+	install(t, lockedLive(wiredRoll(&tr)))
+
+	_, _, err := runIn(t, newImage(), Options{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--yes")
+	assert.NotContains(t, tr.steps, "replace:art-2")
+}
+
+// CI passes no flag: a pipeline that was already reviewed should not have to
+// say so twice.
+func TestRun_LockedProductionRollsInCIWithoutAsking(t *testing.T) {
+	var tr track
+
+	f := lockedLive(wiredRoll(&tr))
+
+	install(t, f)
+
+	result, _, err := runIn(t, newImage(), Options{
+		NonInteractive: true,
+		Confirm: func(string, string) (bool, error) {
+			t.Fatal("nothing may prompt without a terminal")
+
+			return false, nil
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, tr.steps, "lock:art-2")
+	assert.True(t, result.Locked)
+}
+
+// --lock and a locked predecessor both lock, and locking twice is not a
+// no-op at the platform.
+func TestRun_LockFlagDoesNotLockTheVersionTwice(t *testing.T) {
+	var tr track
+
+	install(t, lockedLive(wiredRoll(&tr)))
+
+	result, _, err := runIn(t, newImage(), Options{NonInteractive: true, Lock: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, strings.Count(strings.Join(tr.steps, " "), "lock:art-2"))
+	assert.True(t, result.Locked)
+}
+
+// A failed rollout leaves the old version serving, so reporting the workload
+// as healthy afterwards would be true and entirely misleading.
+func TestRun_FailedRolloutSaysTheOldVersionIsStillServing(t *testing.T) {
+	var tr track
+
+	f := wiredRoll(&tr)
+	f.waitReplace = func(_ string, started *workload.Replacement, _, _ time.Duration,
+		_ func(*workload.Replacement),
+	) (*workload.Replacement, error) {
+		started.Status = workload.ReplacementStatusFailed
+
+		return started, errors.New("replacement rep-1 ended with status failed")
+	}
+	f.wait = func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		t.Fatal("a failed rollout has nothing to settle")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	result, _, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still running the version it was")
+	assert.Contains(t, err.Error(), "dr workload logs")
+	assert.Equal(t, "68a0000000000000000000a1", result.ArtifactID,
+		"the envelope names what is serving, which after a failed swap is the old version")
+}
+
+func TestRun_DetachedRollDoesNotWait(t *testing.T) {
+	var tr track
+
+	install(t, wiredRoll(&tr))
+
+	result, stderr, err := runIn(t, newImage(), Options{NonInteractive: true, Detach: true})
+	require.NoError(t, err)
+
+	assert.NotContains(t, tr.steps, "await-rollout")
+	assert.NotContains(t, tr.steps, "settle")
+	assert.Equal(t, ActionRolled, result.Action)
+	assert.Contains(t, stderr, "not waiting")
+}
+
+// Rolling onto something that is not running is a different operation, and
+// guessing which half the user meant is worse than asking.
+func TestRun_StoppedWorkloadWithANewVersionSaysStartItFirst(t *testing.T) {
+	var tr track
+
+	f := wiredRoll(&tr)
+	f.workloadD = func(string) (workload.Document, error) {
+		d := docOf(liveImageWorkloadJSON)
+		d["status"] = workload.WorkloadStatusStopped
+
+		return d, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dr workload start")
+	assert.Empty(t, tr.steps)
+}
+
+// A new version of a built project is born with no code and no image, so it
+// needs the sync and the build before anything is promoted onto it.
+func TestRun_RollingABuiltProjectIsNotWiredYet(t *testing.T) {
+	var tr track
+
+	f := wiredRoll(&tr)
+	f.workloadD = func(string) (workload.Document, error) { return docOf(liveWorkloadJSON), nil }
+	f.artifactD = func(string) (workload.Document, error) { return docOf(liveArtifactJSON), nil }
+
+	install(t, f)
+
+	drifted := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" +
+		strings.Replace(boundLiveManifest, "port: 8000", "port: 9000", 1)
+
+	_, stderr, err := runIn(t, drifted, Options{NonInteractive: true})
+	require.ErrorIs(t, err, ErrNotWired)
+	assert.Contains(t, err.Error(), "dockerfile")
+	assert.Empty(t, tr.steps, "a refusal must not have created a version first")
+	assert.Contains(t, stderr, "+ artifact", "the plan is still printed")
+}

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -260,10 +260,11 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 		return start(live, result, opts)
 	}
 
-	// What is left is a runtime-only change: no new version is minted, so
-	// none of the machinery below applies and a settings update is its own
-	// call, which the platform has not given the CLI yet.
-	if !plan.Creates && !plan.RollsArtifact() {
+	// A runtime change is its own call, which the CLI has not been given yet.
+	// Refused whether or not a version is also being rolled: rolling and
+	// leaving the sizing behind would carry out half the plan that was just
+	// printed and report the whole of it as done.
+	if !plan.Creates && (len(plan.Runtime) > 0 || !plan.RollsArtifact()) {
 		return result, fmt.Errorf("%w: %s. The plan above is correct; applying it is the next change",
 			ErrNotWired, unwired(plan))
 	}
@@ -286,13 +287,20 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 	return create(loaded, loaded.Compiled.Payload, result, opts, report)
 }
 
-// unwired names the change the plan asks for. Now that the roll is wired that
-// is only ever a runtime-only one, and calling a stopped workload "live"
-// contradicts the plan block above, whose first line says it is to be started.
+// unwired names the change the plan asks for. Now that the roll is wired the
+// runtime block is the only thing left that cannot be applied, on its own or
+// alongside a roll. Calling a stopped workload "live" contradicts the plan
+// block above, whose first line says it is to be started.
 func unwired(plan Plan) string {
 	subject := "a live workload"
 	if plan.State == StateStopped {
 		subject = "a stopped workload, which is also not being started"
+	}
+
+	// Naming only the roll would read as though the rollout were the missing
+	// piece, when the rollout is the half that works.
+	if plan.RollsArtifact() {
+		return "changing the runtime settings of " + subject + " in the same deploy as a new version"
 	}
 
 	return "changing the runtime settings of " + subject

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -33,24 +33,27 @@ import (
 
 // Test seams. The deploy is mostly network, and the tests are not.
 var (
-	runWizardFn       = wizard.Run
-	createWorkloadFn  = workload.CreateWorkload
-	waitWorkloadFn    = workload.WaitForWorkload
-	listWorkloadsFn   = workload.ListWorkloads
-	startWorkloadFn   = workload.StartWorkload
-	createArtifactFn  = workload.CreateArtifact
-	getArtifactFn     = workload.GetArtifact
-	lockArtifactFn    = workload.LockArtifact
-	triggerBuildFn    = workload.TriggerArtifactBuild
-	waitBuildFn       = workload.WaitForBuild
-	listBuildsFn      = workload.ListArtifactBuilds
-	getCredentialFn   = workload.GetCredential
-	writeWorkloadIDFn = manifest.WriteWorkloadID
-	codeChangeFn      = defaultCodeChange
-	projectLinkedFn   = wapi.Exists
-	loadProjectFn     = wapi.LoadConfig
-	initProjectFn     = wapi.Initialize
-	syncProjectFn     = defaultSync
+	runWizardFn        = wizard.Run
+	createWorkloadFn   = workload.CreateWorkload
+	waitWorkloadFn     = workload.WaitForWorkload
+	listWorkloadsFn    = workload.ListWorkloads
+	startWorkloadFn    = workload.StartWorkload
+	createArtifactFn   = workload.CreateArtifact
+	getArtifactFn      = workload.GetArtifact
+	lockArtifactFn     = workload.LockArtifact
+	triggerBuildFn     = workload.TriggerArtifactBuild
+	waitBuildFn        = workload.WaitForBuild
+	listBuildsFn       = workload.ListArtifactBuilds
+	getCredentialFn    = workload.GetCredential
+	guardReplacementFn = workload.GuardNoActiveReplacement
+	startReplacementFn = workload.StartReplacement
+	waitReplacementFn  = workload.WaitForReplacement
+	writeWorkloadIDFn  = manifest.WriteWorkloadID
+	codeChangeFn       = defaultCodeChange
+	projectLinkedFn    = wapi.Exists
+	loadProjectFn      = wapi.LoadConfig
+	initProjectFn      = wapi.Initialize
+	syncProjectFn      = defaultSync
 )
 
 // ErrNotWired reports a path the plan understands but the apply cannot take
@@ -80,6 +83,12 @@ type Options struct {
 	// which it can be when code reached the artifact through
 	// `dr artifact code sync` rather than through a deploy.
 	ForceBuild bool
+
+	// Confirm asks the user a question that only typing want exactly may
+	// answer. It is used once, before rolling a locked production version,
+	// and nil when there is no terminal to ask on. Reading the answer is the
+	// caller's job because only it knows where the user's input comes from.
+	Confirm func(question, want string) (bool, error)
 
 	// Lock makes the artifact that ends up live immutable and permanent.
 	// Locking is one-way, so it happens last, only after the workload is
@@ -251,12 +260,21 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 		return start(live, result, opts)
 	}
 
-	if !plan.Creates {
+	// What is left is a runtime-only change: no new version is minted, so
+	// none of the machinery below applies and a settings update is its own
+	// call, which the platform has not given the CLI yet.
+	if !plan.Creates && !plan.RollsArtifact() {
 		return result, fmt.Errorf("%w: %s. The plan above is correct; applying it is the next change",
 			ErrNotWired, unwired(plan))
 	}
 
 	report := newReporter(opts.Stderr, opts.Spinner)
+
+	// A workload that already exists is replaced rather than created: the
+	// endpoint has to survive, and something is serving on it meanwhile.
+	if plan.RollsArtifact() {
+		return roll(loaded, live, plan, result, opts, report)
+	}
 
 	// A published image is one POST. Anything the platform builds has to be
 	// given somewhere to put the code and time to turn it into an image
@@ -268,22 +286,16 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 	return create(loaded, loaded.Compiled.Payload, result, opts, report)
 }
 
-// unwired names the change the plan asks for. Calling every live workload a
-// roll is wrong for a runtime-only plan, which mints no artifact: the printed
-// plan and the refusal underneath it then disagree about what is missing.
+// unwired names the change the plan asks for. Now that the roll is wired that
+// is only ever a runtime-only one, and calling a stopped workload "live"
+// contradicts the plan block above, whose first line says it is to be started.
 func unwired(plan Plan) string {
-	// Calling a stopped workload "live" contradicts the plan block above,
-	// whose first line says it is to be started.
 	subject := "a live workload"
 	if plan.State == StateStopped {
 		subject = "a stopped workload, which is also not being started"
 	}
 
-	if plan.Action() == ActionUpdated {
-		return "changing the runtime settings of " + subject
-	}
-
-	return "rolling " + subject + " onto a new version"
+	return "changing the runtime settings of " + subject
 }
 
 // deployable refuses the live states that cannot take a deploy, one message
@@ -542,7 +554,8 @@ func settle(workloadID string, result Result, opts Options, report *reporter) (R
 // would leave something undeletable behind and a workload that cannot be
 // rolled off it.
 func lock(result Result, report *reporter) (Result, error) {
-	// Already locked, and locking twice is not a no-op at the platform.
+	// Already locked, either by a roll onto locked production or before the
+	// workload was stopped. Locking twice is not a no-op at the platform.
 	if result.Locked {
 		return result, nil
 	}

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -156,6 +156,12 @@ type fakes struct {
 	build       func(string) (*workload.BuildTriggerResponse, error)
 	waitBuild   func(string, string, time.Duration, time.Duration, func(*workload.Build)) (*workload.Build, error)
 	builds      func(string, int) ([]workload.Build, error)
+
+	// The roll track: refuse to queue a second swap, start one, follow it.
+	guard       func(string) error
+	replace     func(string, string) (*workload.Replacement, error)
+	waitReplace func(string, *workload.Replacement, time.Duration, time.Duration,
+		func(*workload.Replacement)) (*workload.Replacement, error)
 }
 
 // install swaps in the seams the test supplied and restores them afterwards.
@@ -202,6 +208,13 @@ func install(t *testing.T, f fakes) {
 	swap(t, &triggerBuildFn, f.build)
 	swap(t, &waitBuildFn, f.waitBuild)
 	swap(t, &listBuildsFn, f.builds)
+
+	// Nothing stands in the way of a rollout unless a test says so, because
+	// the quiet answer is the one every other roll test wants.
+	force(t, &guardReplacementFn, func(string) error { return nil })
+	swap(t, &guardReplacementFn, f.guard)
+	swap(t, &startReplacementFn, f.replace)
+	swap(t, &waitReplacementFn, f.waitReplace)
 }
 
 // swap installs fake over the seam at target, and does nothing when the test

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -199,6 +199,16 @@ func install(t *testing.T, f fakes) {
 	// by accident, and an unlinked project is the state a first deploy starts
 	// from.
 	force(t, &projectLinkedFn, func(string) bool { return false })
+
+	// Unlike the seams below it, this one is reached by the lock path as well
+	// as the build track, so leaving it unset would send a test that gets
+	// there to whatever tenant the developer is logged into.
+	force(t, &getArtifactFn, func(id string) (*workload.Artifact, error) {
+		t.Fatalf("the run read artifact %s, which this test did not wire", id)
+
+		return nil, nil
+	})
+
 	swap(t, &createArtifactFn, f.newArtifact)
 	swap(t, &getArtifactFn, f.getArtifact)
 	swap(t, &projectLinkedFn, f.linked)


### PR DESCRIPTION
# RATIONALE

Deploying to a workload that already exists was the biggest hole left in `up`: the plan was correct and applying it was refused. This rolls it, for a manifest that names a published image or binds an artifact by id. Building projects are the next PR.

The endpoint survives and the version already serving keeps serving until the new one is ready, which is what makes this safe to run against something in use.

## CHANGES

- A new artifact is minted from the file, the platform swaps onto it, and the run follows the rollout to the end. A file that names an artifact by id promotes that one instead of creating a stray on every deploy.
- The in-flight guard runs twice: once up front so a doomed run creates nothing, once immediately before the swap, which is the check that actually holds.
- Rolling a locked artifact means rolling production. Decision 1 of the design, settled: `up` rolls it, and the ceremony is typing the workload name back on an interactive terminal. CI passes no flag. A run that cannot ask is refused rather than waved through.
- The successor is locked before the swap, because the platform will not replace a locked artifact with a draft, and locking cannot be undone.
- A failed rollout says the old version is still serving. Reporting the workload as healthy afterwards would be true and completely misleading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production deploy behavior (artifact replacement, pre-swap locking, and locked-version confirmation), but guards, explicit production typing, and broad tests limit mistaken rollouts.
> 
> **Overview**
> **`dr workload up` can roll an existing workload** instead of stopping with “not wired.” When the plan calls for a new artifact version, deploy creates or reuses a candidate artifact, starts a platform replacement (endpoint unchanged), waits on the rollout, then settles—same workload ID throughout.
> 
> **Planning fixes for `artifactId`-bound manifests:** compile exposes bound `ArtifactID`, and the planner treats a different bound id than what is running as an artifact roll so the command does not report “already up to date” while the file points at another version. Manifests that name an existing artifact roll onto that id without creating a spare artifact each run.
> 
> **Production safety:** rolling when the live artifact is locked prompts on stderr to re-type the workload name (`typedConfirm` wired from the command); `--yes`/non-interactive CI proceeds without prompting, and interactive runs without a confirm hook are refused. The successor is locked before swap when production is locked; replacement-in-flight is guarded up front and again immediately before start. Failed rollouts error with the old version still serving and keep the result envelope on the prior artifact id.
> 
> **Still out of scope:** rolls for workloads whose images are platform-built (dockerfile/generated) return `ErrNotWired`; runtime-only changes remain unwired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66d42128784824bef4f871e09054b28908236b52. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->