### PR TITLE
[RAPTOR-18976] feat(workload): roll a built project onto a new version

### DIFF
--- a/internal/workload/up/diff.go
+++ b/internal/workload/up/diff.go
@@ -226,3 +226,86 @@ func format(v any) string {
 		return fmt.Sprintf("%v", value)
 	}
 }
+
+// Extra reports every element of a name-keyed list that have carries and want
+// does not name, as paths.
+//
+// It is the question Subset deliberately does not ask. Measuring drift against
+// a running workload is one-directional on purpose: a field the file leaves
+// out is left alone rather than reverted. But "could this document have been
+// produced by this file?" is a different question, and there a name the file
+// never mentions is proof that it could not, because creating it fresh would
+// not have put that name there.
+//
+// Only names are compared, never the keys inside an element. The platform
+// fills in its own defaults and server-owned fields, so an element the file
+// does name always carries more than the file said and none of that is
+// evidence of anything. The name-keyed lists are different: containerGroups,
+// containers and environmentVars are the file's own, and the platform adds no
+// entries to them.
+func Extra(want, have map[string]any) []string {
+	var out []string
+
+	extra("", want, have, &out)
+
+	return out
+}
+
+// extra walks have alongside want. It iterates have's keys rather than want's,
+// because the case worth catching is a list the file no longer mentions at
+// all: deleting the last environment variable drops the whole block from the
+// file, and a walk driven by want would never look at it.
+func extra(path string, want map[string]any, have map[string]any, out *[]string) {
+	for _, key := range slices.Sorted(maps.Keys(have)) {
+		at := join(path, key)
+
+		if list, ok := have[key].([]any); ok && nameKeyed(list) {
+			extraInList(at, want[key], list, out)
+
+			continue
+		}
+
+		child, ok := have[key].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		wanted, ok := want[key].(map[string]any)
+		if !ok {
+			// The file says nothing about this object, so nothing inside it
+			// can be something the file removed.
+			continue
+		}
+
+		extra(at, wanted, child, out)
+	}
+}
+
+// extraInList compares one name-keyed list. A want side that is missing or is
+// not a list reads as empty, which is exactly what deleting the block means.
+func extraInList(path string, want any, have []any, out *[]string) {
+	named := map[string]map[string]any{}
+
+	if list, ok := want.([]any); ok {
+		named = byName(list)
+	}
+
+	for _, item := range have {
+		element, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		name, _ := element["name"].(string)
+		at := fmt.Sprintf("%s[%s]", path, name)
+
+		counterpart, found := named[name]
+		if !found {
+			*out = append(*out, at)
+
+			continue
+		}
+
+		extra(at, counterpart, element, out)
+	}
+}

--- a/internal/workload/up/diff_test.go
+++ b/internal/workload/up/diff_test.go
@@ -342,3 +342,76 @@ func TestChange_String(t *testing.T) {
 	assert.Equal(t, "entrypoint: [1 item(s)] -> [2 item(s)]",
 		Change{Path: "entrypoint", Have: []any{"a"}, Want: []any{"a", "b"}}.String())
 }
+
+// Extra is the half Subset deliberately leaves out: what the live side
+// carries that the file no longer names.
+func TestExtra_FindsWhatTheFileNoLongerNames(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+		have string
+		out  []string
+	}{
+		{
+			name: "an env var the file dropped",
+			want: `{"spec":{"containerGroups":[{"name":"default","containers":[{"name":"primary"}]}]}}`,
+			have: `{"spec":{"containerGroups":[{"name":"default","containers":[
+			        {"name":"primary","environmentVars":[{"name":"FOO","value":"1"}]}]}]}}`,
+			out: []string{"spec.containerGroups[default].containers[primary].environmentVars[FOO]"},
+		},
+		{
+			name: "the last env var, so the file has no block at all",
+			want: `{"spec":{"containerGroups":[{"name":"default","containers":[{"name":"primary","port":8080}]}]}}`,
+			have: `{"spec":{"containerGroups":[{"name":"default","containers":[
+			        {"name":"primary","port":8080,"environmentVars":[{"name":"FOO","value":"1"}]}]}]}}`,
+			out: []string{"spec.containerGroups[default].containers[primary].environmentVars[FOO]"},
+		},
+		{
+			name: "a sidecar the file dropped",
+			want: `{"spec":{"containerGroups":[{"name":"default","containers":[{"name":"primary"}]}]}}`,
+			have: `{"spec":{"containerGroups":[{"name":"default","containers":[
+			        {"name":"primary"},{"name":"metrics"}]}]}}`,
+			out: []string{"spec.containerGroups[default].containers[metrics]"},
+		},
+		{
+			name: "nothing removed, so nothing to report",
+			want: `{"spec":{"containerGroups":[{"name":"default","containers":[{"name":"primary","port":8080}]}]}}`,
+			have: `{"spec":{"containerGroups":[{"name":"default","containers":[{"name":"primary","port":8080}]}]}}`,
+			out:  nil,
+		},
+		{
+			name: "server-owned fields are not removals",
+			want: `{"spec":{"containerGroups":[{"name":"default","containers":[{"name":"primary"}]}]}}`,
+			have: `{"id":"art-1","status":"draft","spec":{"containerGroups":[{"name":"default","containers":[
+			        {"name":"primary","imageUri":"registry/built:sha","readinessProbe":{"path":"/health"}}]}]}}`,
+			out: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var want, have map[string]any
+
+			require.NoError(t, json.Unmarshal([]byte(tc.want), &want))
+			require.NoError(t, json.Unmarshal([]byte(tc.have), &have))
+
+			assert.Equal(t, tc.out, Extra(want, have))
+		})
+	}
+}
+
+// The two questions are not the same one asked twice: a file that adds
+// something is Subset's business and a file that removes something is Extra's,
+// and each is silent about the other.
+func TestExtra_AndSubsetAnswerDifferentQuestions(t *testing.T) {
+	var want, have map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"spec":{"containerGroups":[{"name":"default","containers":[{"name":"primary","port":9000}]}]}}`), &want))
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"spec":{"containerGroups":[{"name":"default","containers":[
+		  {"name":"primary","port":8080,"environmentVars":[{"name":"FOO","value":"1"}]}]}]}}`), &have))
+
+	assert.Len(t, Subset(want, have), 1, "the port the file moved")
+	assert.Len(t, Extra(want, have), 1, "the variable the file dropped")
+}

--- a/internal/workload/up/doc.go
+++ b/internal/workload/up/doc.go
@@ -56,6 +56,16 @@
 // code rather than in the committed manifest, because it is a property of the
 // clone and not of the project.
 //
+// A workload that already exists is rolled rather than created again: a new
+// version is minted, the platform swaps onto it, and the endpoint survives.
+// The version a file names by id is promoted as it stands, and one the
+// platform builds is filled first, by the same three acts as a first deploy.
+// The order there is what keeps it safe to run against something in use: the
+// project is pointed at the new version before the code is pushed, so an
+// upload can never rewrite what is currently serving. A run that dies between
+// minting a version and promoting it leaves a draft nothing points at, and
+// the next run continues with it rather than adding another to the pile.
+//
 // Non-scope: no terminal output and no cobra. Rendering a plan and running
 // the phases belong to the command; this package hands back values.
 package up

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -49,24 +49,16 @@ func roll(loaded Loaded, live Live, plan Plan, result Result, opts Options, repo
 			result.Name, live.WorkloadID)
 	}
 
-	// A new version of a built project is born with neither code nor an
-	// image, so rolling onto it would promote something that cannot start.
-	// Giving it both is the next change, and it is more than a longer wait:
-	// the code has to reach the new version before the old one is touched.
-	// The test is the file's build mode rather than whether code changed,
-	// because a spec-only edit to a built project has the same problem.
-	if mode := loaded.Manifest.BuildMode(); mode == manifest.BuildModeDockerfile || mode == manifest.BuildModeGenerated {
-		return result, fmt.Errorf(
-			"%w: rolling a workload whose image the platform builds (%s mode). The plan above is correct, "+
-				"and a new version of a published image rolls today",
-			ErrNotWired, mode)
-	}
-
 	if err := guardReplacementFn(live.WorkloadID); err != nil {
 		return result, err
 	}
 
-	candidate, fresh, err := candidateArtifact(loaded, report)
+	made, err := candidateArtifact(loaded, live, plan.Code, opts, report)
+
+	// Recorded before the error check: a failed build is still a build, and
+	// the caller's envelope should be able to name the one to go and read.
+	result.BuildID = made.BuildID
+
 	if err != nil {
 		return result, err
 	}
@@ -83,36 +75,32 @@ func roll(loaded Loaded, live Live, plan Plan, result Result, opts Options, repo
 		return result, err
 	}
 
-	return replace(live.WorkloadID, candidate, lock, fresh, result, opts, report)
+	return replace(live.WorkloadID, made, lock, result, opts, report)
 }
 
-// candidateArtifact is the version to roll onto, and whether this run made
-// it. A file bound to an artifact by id is asking for something that already
-// exists, so there is nothing to create; minting one anyway would leave a
-// stray artifact behind on every deploy.
-func candidateArtifact(loaded Loaded, report *reporter) (string, bool, error) {
+// candidateArtifact is the version to roll onto.
+//
+// A file bound to an artifact by id is asking for one that already exists, so
+// there is nothing to make; minting one anyway would leave a stray behind on
+// every deploy. A file the platform builds from needs the working tree and an
+// image before it is worth promoting. A published image needs neither, and is
+// one call.
+func candidateArtifact(
+	loaded Loaded,
+	live Live,
+	code CodeChange,
+	opts Options,
+	report *reporter,
+) (version, error) {
 	if id := loaded.Compiled.ArtifactID; id != "" {
-		return id, false, nil
+		return version{ID: id}, nil
 	}
 
-	var created *workload.Artifact
-
-	err := report.run("Creating the new version", func() error {
-		payload, payloadErr := loaded.Compiled.ArtifactPayload()
-		if payloadErr != nil {
-			return payloadErr
-		}
-
-		artifact, createErr := createArtifactFn(payload)
-		created = artifact
-
-		return createErr
-	})
-	if err != nil {
-		return "", false, err
+	if mode := loaded.Manifest.BuildMode(); mode == manifest.BuildModeDockerfile || mode == manifest.BuildModeGenerated {
+		return buildVersion(loaded, live, code, opts, report)
 	}
 
-	return created.ID, true, nil
+	return createVersion(loaded, report)
 }
 
 // confirmLock asks whether to roll a locked version, and reports whether the
@@ -145,11 +133,12 @@ func confirmLock(live Live, workloadName string, opts Options) (bool, error) {
 // whole point: the platform wants the lock in place before the replacement is
 // POSTed, and by then everything that could still refuse the rollout has had
 // its say, so a lock taken here is one the run is committed to using.
-func matchLock(candidate string, fresh bool, report *reporter) (bool, error) {
-	// A candidate the file named may already be locked, and locking twice is
-	// not a no-op at the platform. One created here is always a draft.
-	if !fresh {
-		already, lockedErr := lockedAlready(candidate)
+func matchLock(made version, report *reporter) (bool, error) {
+	// A candidate the file named, or one left by an earlier attempt, may
+	// already be locked, and locking twice is not a no-op at the platform.
+	// One created by this run is always a draft.
+	if !made.Fresh {
+		already, lockedErr := lockedAlready(made.ID)
 		if lockedErr != nil {
 			return false, lockedErr
 		}
@@ -160,14 +149,14 @@ func matchLock(candidate string, fresh bool, report *reporter) (bool, error) {
 	}
 
 	err := report.run("Locking the new version", func() error {
-		_, lockErr := lockArtifactFn(candidate)
+		_, lockErr := lockArtifactFn(made.ID)
 
 		return lockErr
 	})
 	if err != nil {
 		return false, fmt.Errorf(
 			"artifact %s could not be locked, and a locked workload only accepts a locked version, "+
-				"so nothing was rolled: %w", candidate, err)
+				"so nothing was rolled: %w", made.ID, err)
 	}
 
 	return true, nil
@@ -215,8 +204,9 @@ func confirmRoll(workloadName string, opts Options) (bool, error) {
 
 // replace starts the rollout and follows it to the end.
 func replace(
-	workloadID, artifactID string,
-	lock, fresh bool,
+	workloadID string,
+	made version,
+	lock bool,
 	result Result,
 	opts Options,
 	report *reporter,
@@ -229,7 +219,7 @@ func replace(
 	}
 
 	if lock {
-		locked, err := matchLock(artifactID, fresh, report)
+		locked, err := matchLock(made, report)
 		if err != nil {
 			return result, err
 		}
@@ -240,19 +230,19 @@ func replace(
 	var started *workload.Replacement
 
 	err := report.run("Rolling out the new version", func() error {
-		replacement, startErr := startReplacementFn(workloadID, artifactID)
+		replacement, startErr := startReplacementFn(workloadID, made.ID)
 		started = replacement
 
 		return startErr
 	})
 	if err != nil {
-		return result, fmt.Errorf("cannot roll workload %s onto artifact %s: %w", workloadID, artifactID, err)
+		return result, fmt.Errorf("cannot roll workload %s onto artifact %s: %w", workloadID, made.ID, err)
 	}
 
 	result.Action = ActionRolled
 
 	if opts.Detach {
-		report.say("  Rollout of %s onto artifact %s requested; not waiting.\n", workloadID, artifactID)
+		report.say("  Rollout of %s onto artifact %s requested; not waiting.\n", workloadID, made.ID)
 
 		return result, nil
 	}

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -642,6 +642,9 @@ func TestRun_RollReusesTheVersionAnEarlierAttemptLeft(t *testing.T) {
 	f.getArtifact = func(id string) (*workload.Artifact, error) {
 		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
 	}
+	// The leftover was made from the file this run is reading, so it says
+	// what the file says. That is what makes it the version to roll onto.
+	f.artifactD = artifactDocs("art-abandoned", 9000)
 	f.newArtifact = func(any) (*workload.Artifact, error) {
 		t.Fatal("an unpromoted draft is already the version to roll onto")
 
@@ -658,6 +661,52 @@ func TestRun_RollReusesTheVersionAnEarlierAttemptLeft(t *testing.T) {
 		tr.steps)
 	assert.Equal(t, ActionRolled, result.Action)
 	assert.Contains(t, stderr, "earlier attempt")
+}
+
+// An artifact's spec is fixed when it is created, so a draft left by an
+// attempt that read an older file describes that older file. Promoting it
+// would roll out a version the yaml no longer asks for and report the deploy
+// as done, leaving the same drift to be found again next run.
+func TestRun_RollDoesNotReuseADraftTheFileHasMovedPast(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("art-abandoned")
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
+	}
+	// The leftover still carries the port the file had when it was made; the
+	// file has since asked for another.
+	f.artifactD = artifactDocs("art-abandoned", 8500)
+
+	install(t, f)
+
+	_, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, tr.steps, "create-artifact",
+		"a draft describing an older file is not the version to roll onto")
+	assert.NotContains(t, tr.steps, "replace:art-abandoned")
+}
+
+// artifactDocs answers the document read: the leftover draft at the port it
+// was created with, and the live artifact for everything else.
+func artifactDocs(abandonedID string, port int) func(string) (workload.Document, error) {
+	return func(id string) (workload.Document, error) {
+		d := docOf(liveArtifactJSON)
+		d["status"] = workload.ArtifactStatusDraft
+
+		if id != abandonedID {
+			return d, nil
+		}
+
+		groups, _ := d["spec"].(map[string]any)["containerGroups"].([]any)
+		container, _ := groups[0].(map[string]any)["containers"].([]any)[0].(map[string]any)
+		container["port"] = float64(port)
+
+		return d, nil
+	}
 }
 
 // A locked draft can take neither code nor an image, which is what a roll

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -690,8 +690,61 @@ func TestRun_RollDoesNotReuseADraftTheFileHasMovedPast(t *testing.T) {
 	assert.NotContains(t, tr.steps, "replace:art-abandoned")
 }
 
+// Deleting a line is a change like any other, and the leftover was made
+// before it. Reuse driven only by what the file still mentions would find
+// everything matching, promote the draft, and leave the deleted variable
+// running; minting a fresh version drops it. The same file has to produce the
+// same running spec whether or not an earlier attempt left something behind.
+func TestRun_RollDoesNotReuseADraftCarryingWhatTheFileDeleted(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("art-abandoned")
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
+	}
+
+	// The leftover agrees with the file about everything the file still says,
+	// and carries one variable the file no longer does.
+	f.artifactD = func(id string) (workload.Document, error) {
+		d := docOf(liveArtifactJSON)
+		d["status"] = workload.ArtifactStatusDraft
+
+		if id != "art-abandoned" {
+			return d, nil
+		}
+
+		container := primaryOf(d)
+		container["port"] = float64(9000)
+		container["environmentVars"] = []any{
+			map[string]any{"name": "FOO", "value": "1"},
+		}
+
+		group, _ := d["spec"].(map[string]any)["containerGroups"].([]any)[0].(map[string]any)
+		group["containers"] = []any{container}
+
+		return d, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, tr.steps, "create-artifact",
+		"a draft carrying a variable the file deleted is not the version to roll onto")
+	assert.NotContains(t, tr.steps, "replace:art-abandoned")
+}
+
 // artifactDocs answers the document read: the leftover draft at the port it
 // was created with, and the live artifact for everything else.
+//
+// The leftover is built to look like what createVersion makes, which is the
+// file's artifact block and nothing else. The live artifact carries a sidecar
+// the file has never heard of, and that is right for the live one: an
+// unmentioned sidecar is not drift. A leftover cannot have one, because the
+// only thing that could have made it is this file.
 func artifactDocs(abandonedID string, port int) func(string) (workload.Document, error) {
 	return func(id string) (workload.Document, error) {
 		d := docOf(liveArtifactJSON)
@@ -701,12 +754,22 @@ func artifactDocs(abandonedID string, port int) func(string) (workload.Document,
 			return d, nil
 		}
 
-		groups, _ := d["spec"].(map[string]any)["containerGroups"].([]any)
-		container, _ := groups[0].(map[string]any)["containers"].([]any)[0].(map[string]any)
+		container := primaryOf(d)
 		container["port"] = float64(port)
+
+		group, _ := d["spec"].(map[string]any)["containerGroups"].([]any)[0].(map[string]any)
+		group["containers"] = []any{container}
 
 		return d, nil
 	}
+}
+
+// primaryOf reaches the first container of the first group.
+func primaryOf(d workload.Document) map[string]any {
+	groups, _ := d["spec"].(map[string]any)["containerGroups"].([]any)
+	container, _ := groups[0].(map[string]any)["containers"].([]any)[0].(map[string]any)
+
+	return container
 }
 
 // A locked draft can take neither code nor an image, which is what a roll

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -17,11 +17,14 @@ package up
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -511,23 +514,271 @@ func TestRun_StoppedWorkloadWithANewVersionSaysStartItFirst(t *testing.T) {
 	assert.Empty(t, tr.steps)
 }
 
-// A new version of a built project is born with no code and no image, so it
-// needs the sync and the build before anything is promoted onto it.
-func TestRun_RollingABuiltProjectIsNotWiredYet(t *testing.T) {
+// builtRoll is a roll of a project whose image the platform builds, with
+// every step wired to succeed. The live artifact is made a draft: the lock
+// ceremony has its own tests above, and leaving it locked would put a
+// confirmation in the middle of every assertion about the build.
+func builtRoll(tr *track) fakes {
+	f := wiredRoll(tr)
+
+	f.workloadD = func(string) (workload.Document, error) { return docOf(liveWorkloadJSON), nil }
+	f.artifactD = func(string) (workload.Document, error) {
+		d := docOf(liveArtifactJSON)
+		d["status"] = workload.ArtifactStatusDraft
+
+		return d, nil
+	}
+
+	f.link = func(_ string, opts wapi.InitOptions) error {
+		tr.steps = append(tr.steps, "link")
+		tr.linkedTo = opts
+
+		return nil
+	}
+	f.save = func(_ string, cfg wapi.Config) error {
+		tr.steps = append(tr.steps, "relink")
+		tr.savedCfg = cfg
+
+		return nil
+	}
+	f.codeRef = func(artifactID, catalogID, versionID string) error {
+		tr.steps = append(tr.steps, "carry-code")
+		tr.carried = []string{artifactID, catalogID, versionID}
+
+		return nil
+	}
+	f.sync = func(string) (*sync.Result, error) {
+		tr.steps = append(tr.steps, "sync")
+
+		return &sync.Result{UploadedCount: 2, NewVersion: "ver-2"}, nil
+	}
+	f.build = func(string) (*workload.BuildTriggerResponse, error) {
+		tr.steps = append(tr.steps, "build")
+
+		return &workload.BuildTriggerResponse{BuildIDs: []string{"bld-2"}}, nil
+	}
+	f.waitBuild = func(_, id string, _, _ time.Duration, _ func(*workload.Build)) (*workload.Build, error) {
+		return &workload.Build{ID: id, Status: workload.BuildStatusCompleted}, nil
+	}
+
+	return f
+}
+
+// builtDrift is the built project's file asking for one thing the live spec
+// does not say, which is the smallest change that mints a version.
+func builtDrift() string {
+	return "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" +
+		strings.Replace(boundLiveManifest, "port: 8000", "port: 9000", 1)
+}
+
+// syncedProject is a project that has pushed code before, linked to the
+// artifact named. It is what every roll of a built project starts from,
+// because the version now serving got its code the same way.
+func syncedProject(artifactID string) func(string) (wapi.Config, error) {
+	catalog, version := "cat1", "ver1"
+
+	return func(string) (wapi.Config, error) {
+		return wapi.Config{
+			ArtifactID:          artifactID,
+			CatalogID:           &catalog,
+			LastSyncedVersionID: &version,
+		}, nil
+	}
+}
+
+// A new version of a built project is born with neither code nor an image, so
+// the roll has to fill it before anything is promoted onto it. The order is
+// the whole point: the project is pointed at the new version before the sync,
+// or the upload would rewrite the code of the version currently serving.
+func TestRun_RollsABuiltProjectOntoAFreshlyBuiltVersion(t *testing.T) {
 	var tr track
 
-	f := wiredRoll(&tr)
-	f.workloadD = func(string) (workload.Document, error) { return docOf(liveWorkloadJSON), nil }
-	f.artifactD = func(string) (workload.Document, error) { return docOf(liveArtifactJSON), nil }
+	f := builtRoll(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("68a0000000000000000000a1")
 
 	install(t, f)
 
-	drifted := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" +
-		strings.Replace(boundLiveManifest, "port: 8000", "port: 9000", 1)
+	result, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
 
-	_, stderr, err := runIn(t, drifted, Options{NonInteractive: true})
-	require.ErrorIs(t, err, ErrNotWired)
-	assert.Contains(t, err.Error(), "dockerfile")
-	assert.Empty(t, tr.steps, "a refusal must not have created a version first")
-	assert.Contains(t, stderr, "+ artifact", "the plan is still printed")
+	assert.Equal(t,
+		[]string{"guard", "create-artifact", "relink", "sync", "build", "guard", "replace:art-2", "await-rollout", "settle"},
+		tr.steps)
+	assert.Equal(t, "art-2", tr.savedCfg.ArtifactID, "the sync has to land in the new version, not the live one")
+	assert.Equal(t, ActionRolled, result.Action)
+	assert.Equal(t, "bld-2", result.BuildID, "the envelope has to be able to name the build")
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", result.WorkloadID)
+}
+
+// The project is linked to the version that is serving, which is the state a
+// finished roll leaves behind. Pushing into it would rewrite production's
+// code in place.
+func TestRun_RollNeverPushesIntoTheVersionThatIsServing(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("68a0000000000000000000a1")
+
+	install(t, f)
+
+	_, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, tr.steps, "create-artifact", "the live version is not a candidate to push into")
+	assert.NotEqual(t, "68a0000000000000000000a1", tr.savedCfg.ArtifactID)
+}
+
+// A run that died between creating a version and promoting it left a draft
+// with the code already in it. Making another would pile up an artifact per
+// attempt, and the one left behind is exactly what this run wants.
+func TestRun_RollReusesTheVersionAnEarlierAttemptLeft(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("art-abandoned")
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
+	}
+	f.newArtifact = func(any) (*workload.Artifact, error) {
+		t.Fatal("an unpromoted draft is already the version to roll onto")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	result, stderr, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]string{"guard", "sync", "build", "guard", "replace:art-abandoned", "await-rollout", "settle"},
+		tr.steps)
+	assert.Equal(t, ActionRolled, result.Action)
+	assert.Contains(t, stderr, "earlier attempt")
+}
+
+// A locked draft can take neither code nor an image, which is what a roll
+// onto production leaves behind when it dies between the lock and the swap.
+// Reusing it would fail at the push with the platform's own 403.
+func TestRun_RollDoesNotReuseALockedLeftover(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("art-abandoned")
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusLocked}, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, tr.steps, "create-artifact", "nothing more can be pushed into a locked draft")
+	assert.Contains(t, tr.steps, "replace:art-2")
+}
+
+// A spec-only roll moves a port or a probe and leaves the working tree alone,
+// so the sync mints no version and patches nothing. Without this the new
+// artifact would go to the builder with no code reference at all.
+func TestRun_SpecOnlyRollCarriesTheCodeOver(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("68a0000000000000000000a1")
+	f.sync = func(string) (*sync.Result, error) {
+		tr.steps = append(tr.steps, "sync")
+
+		return &sync.Result{}, nil
+	}
+
+	install(t, f)
+
+	result, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"art-2", "cat1", "ver1"}, tr.carried,
+		"a new version of the same code has to point at that code")
+	assert.Equal(t,
+		[]string{"guard", "create-artifact", "relink", "sync", "carry-code", "build", "guard", "replace:art-2", "await-rollout", "settle"},
+		tr.steps)
+	assert.Equal(t, "bld-2", result.BuildID, "a version born without an image still needs one")
+}
+
+// Nothing to upload and nothing recorded to inherit means there would be
+// nothing to build, which is worth saying before a builder is asked to
+// produce an image from an empty artifact.
+func TestRun_SpecOnlyRollWithNoCodeToCarryStopsBeforeTheBuild(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = func(string) (wapi.Config, error) {
+		return wapi.Config{ArtifactID: "68a0000000000000000000a1"}, nil
+	}
+	f.sync = func(string) (*sync.Result, error) {
+		tr.steps = append(tr.steps, "sync")
+
+		return &sync.Result{}, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "art-2")
+	assert.Contains(t, err.Error(), "nothing to build")
+	assert.NotContains(t, tr.steps, "build")
+	assert.NotContains(t, tr.steps, "replace:art-2", "a version with no code must not be promoted")
+}
+
+// The version exists and only the local record of it failed to write. The
+// next run would create another and this one would be unreachable, so the
+// error has to carry the id.
+func TestRun_RollLinkFailureNamesTheStrandedVersion(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("68a0000000000000000000a1")
+	f.save = func(string, wapi.Config) error { return errors.New("permission denied") }
+
+	install(t, f)
+
+	_, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "art-2")
+	assert.Contains(t, err.Error(), "dr artifact code init art-2")
+	assert.NotContains(t, tr.steps, "sync", "nothing may be pushed at a version nothing points to")
+}
+
+// A build that fails ends the roll with the old version still serving, and
+// the id of the build is the only way to the logs that say why.
+func TestRun_FailedBuildOnARollLeavesTheOldVersionServing(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("68a0000000000000000000a1")
+	// WaitForBuild's own contract: a terminal failure comes back as the build
+	// and an error together.
+	f.waitBuild = func(_, id string, _, _ time.Duration, _ func(*workload.Build)) (*workload.Build, error) {
+		return &workload.Build{ID: id, Status: workload.BuildStatusFailed},
+			fmt.Errorf("build %s ended with status %s", id, workload.BuildStatusFailed)
+	}
+
+	install(t, f)
+
+	result, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dr artifact build logs")
+	assert.Equal(t, "bld-2", result.BuildID, "a failed build is still the build to go and read")
+	assert.NotContains(t, tr.steps, "replace:art-2")
+	assert.Equal(t, "68a0000000000000000000a1", result.ArtifactID,
+		"the envelope names what is serving, which is still the old version")
 }

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -53,6 +53,8 @@ var (
 	projectLinkedFn    = wapi.Exists
 	loadProjectFn      = wapi.LoadConfig
 	initProjectFn      = wapi.Initialize
+	saveProjectFn      = wapi.SaveConfig
+	patchCodeRefFn     = workload.PatchArtifactCodeRef
 	syncProjectFn      = defaultSync
 )
 

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -152,6 +152,8 @@ type fakes struct {
 	linked      func(string) bool
 	project     func(string) (wapi.Config, error)
 	link        func(string, wapi.InitOptions) error
+	save        func(string, wapi.Config) error
+	codeRef     func(string, string, string) error
 	sync        func(string) (*sync.Result, error)
 	build       func(string) (*workload.BuildTriggerResponse, error)
 	waitBuild   func(string, string, time.Duration, time.Duration, func(*workload.Build)) (*workload.Build, error)
@@ -214,6 +216,8 @@ func install(t *testing.T, f fakes) {
 	swap(t, &projectLinkedFn, f.linked)
 	swap(t, &loadProjectFn, f.project)
 	swap(t, &initProjectFn, f.link)
+	swap(t, &saveProjectFn, f.save)
+	swap(t, &patchCodeRefFn, f.codeRef)
 	swap(t, &syncProjectFn, f.sync)
 	swap(t, &triggerBuildFn, f.build)
 	swap(t, &waitBuildFn, f.waitBuild)
@@ -621,6 +625,11 @@ type track struct {
 	artifactIn any
 	linkedTo   wapi.InitOptions
 	workloadIn any
+
+	// savedCfg is the project state after a roll re-pointed it, and carried
+	// is the (artifact, catalog, version) a spec-only roll inherited.
+	savedCfg wapi.Config
+	carried  []string
 }
 
 // wiredBuild is a build path where every step works, over the track that

--- a/internal/workload/up/version.go
+++ b/internal/workload/up/version.go
@@ -15,12 +15,17 @@
 package up
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/sync"
 	"github.com/datarobot/cli/internal/workload/wapi"
 )
+
+// keyArtifactName is the artifact block's own name field, dropped before the
+// spec comparison below.
+const keyArtifactName = "name"
 
 // version is the artifact a roll promotes, and what making it cost.
 type version struct {
@@ -82,7 +87,7 @@ func buildVersion(loaded Loaded, live Live, code CodeChange, opts Options, repor
 // versionArtifact returns the artifact to fill and build, reusing the one an
 // earlier attempt left behind rather than adding to a pile of drafts.
 func versionArtifact(loaded Loaded, live Live, report *reporter) (version, error) {
-	if id, ok := abandoned(loaded.ProjectDir, live); ok {
+	if id, ok := abandoned(loaded, live); ok {
 		report.say("  Continuing with artifact %s from an earlier attempt.\n", id)
 
 		return version{ID: id}, nil
@@ -113,7 +118,8 @@ func createVersion(loaded Loaded, report *reporter) (version, error) {
 	return version{ID: created.ID, Fresh: true}, nil
 }
 
-// abandoned reports an artifact a previous roll made and never promoted.
+// abandoned reports an artifact a previous roll made and never promoted, and
+// which still describes what the file asks for.
 //
 // The project's link is the only record of it, and it is only a candidate
 // when it is not the version currently serving: linked to the live one means
@@ -121,12 +127,21 @@ func createVersion(loaded Loaded, report *reporter) (version, error) {
 // A locked one is no use either, since nothing more can be pushed into it,
 // which is the state a roll onto production leaves behind when it dies
 // between the lock and the swap.
-func abandoned(projectDir string, live Live) (string, bool) {
-	if !projectLinkedFn(projectDir) {
+//
+// The spec is checked as well, because an artifact's is fixed when it is
+// created. Between the attempt that left this one behind and now, the file
+// may have moved a port, a probe or an environment variable; the draft still
+// carries the old answer, and promoting it would roll out a version the file
+// no longer describes, report success, and leave the same drift to be found
+// again next run. A draft that no longer matches is left where it is and a
+// new one minted, which is what happens anyway when there is nothing to
+// reuse.
+func abandoned(loaded Loaded, live Live) (string, bool) {
+	if !projectLinkedFn(loaded.ProjectDir) {
 		return "", false
 	}
 
-	cfg, err := loadProjectFn(projectDir)
+	cfg, err := loadProjectFn(loaded.ProjectDir)
 	if err != nil || cfg.ArtifactID == "" || cfg.ArtifactID == live.ArtifactID {
 		return "", false
 	}
@@ -136,7 +151,45 @@ func abandoned(projectDir string, live Live) (string, bool) {
 		return "", false
 	}
 
+	if !describes(loaded, cfg.ArtifactID) {
+		return "", false
+	}
+
 	return cfg.ArtifactID, true
+}
+
+// describes reports whether the draft still says what the file's artifact
+// block says. The comparison is the plan's own, one-directional: a field the
+// file does not mention is not a difference, so a draft carrying something
+// the platform filled in for itself is still a match.
+//
+// A read that fails answers no. Minting a second draft costs an artifact
+// nobody promotes; promoting one whose spec was never confirmed costs a
+// rollout of the wrong thing.
+func describes(loaded Loaded, artifactID string) bool {
+	payload, err := loaded.Compiled.ArtifactPayload()
+	if err != nil {
+		return false
+	}
+
+	var want map[string]any
+
+	if err := json.Unmarshal(payload, &want); err != nil {
+		return false
+	}
+
+	doc, err := getArtifactDocFn(artifactID)
+	if err != nil {
+		return false
+	}
+
+	// The name is the CLI's own, derived from the workload's, and the block
+	// carries it only so a create has one to send. It says nothing about what
+	// the version runs, and an artifact renamed in the UI is not a reason to
+	// mint another.
+	delete(want, keyArtifactName)
+
+	return len(Subset(want, doc)) == 0
 }
 
 // linkProject points the project at the new version, so the sync uploads into

--- a/internal/workload/up/version.go
+++ b/internal/workload/up/version.go
@@ -189,7 +189,13 @@ func describes(loaded Loaded, artifactID string) bool {
 	// mint another.
 	delete(want, keyArtifactName)
 
-	return len(Subset(want, doc)) == 0
+	// Both directions, which is the difference between this and measuring
+	// drift. Subset catches a value the file changed or added; Extra catches
+	// one it removed. Without the second, deleting an environment variable
+	// leaves everything the file still mentions matching, the leftover is
+	// reused, and it is rolled out still carrying the variable that was
+	// deleted, which minting a fresh artifact would have dropped.
+	return len(Subset(want, doc)) == 0 && len(Extra(want, doc)) == 0
 }
 
 // linkProject points the project at the new version, so the sync uploads into

--- a/internal/workload/up/version.go
+++ b/internal/workload/up/version.go
@@ -1,0 +1,233 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"fmt"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/datarobot/cli/internal/workload/wapi"
+)
+
+// version is the artifact a roll promotes, and what making it cost.
+type version struct {
+	// ID is the artifact. It is set as soon as one exists, including when
+	// what came back alongside it was an error, so the caller can say what
+	// was left behind.
+	ID string
+
+	// Fresh reports that this run created it, which means it is certainly a
+	// draft and certainly has no image yet.
+	Fresh bool
+
+	// BuildID names the image build this run ran, "" when it ran none. A
+	// failed build sets it: it is the way to the logs.
+	BuildID string
+}
+
+// buildVersion produces the version a built project rolls onto: a new
+// artifact carrying the working tree, with an image made from it.
+//
+// The artifact is created and the project pointed at it before the sync, not
+// after. The sync engine patches the code reference of whichever artifact the
+// project is linked to, and until this runs that is the version currently
+// serving: syncing first would rewrite what production points at while
+// production is running it, and would fail outright once that version is
+// locked, halfway through, with the upload already done.
+//
+// Every step here is recoverable except by leaving a draft artifact behind,
+// which is why the next run looks for one before making another.
+func buildVersion(loaded Loaded, live Live, code CodeChange, opts Options, report *reporter) (version, error) {
+	made, err := versionArtifact(loaded, live, report)
+	if err != nil {
+		return made, err
+	}
+
+	if err := linkProject(loaded.ProjectDir, made, report); err != nil {
+		return made, err
+	}
+
+	synced, err := syncCode(loaded.ProjectDir, report)
+	if err != nil {
+		return made, err
+	}
+
+	if err := inheritCode(loaded.ProjectDir, made.ID, synced, report); err != nil {
+		return made, err
+	}
+
+	// A version minted here has no image whatever the working tree says, so
+	// Fresh is what stops maybeBuild from skipping the build and promoting an
+	// artifact with nothing to run. One picked up from an earlier attempt may
+	// already have its image, and that is the skip worth having.
+	buildID, err := maybeBuild(made.ID, made.Fresh, code, synced, opts, report)
+	made.BuildID = buildID
+
+	return made, err
+}
+
+// versionArtifact returns the artifact to fill and build, reusing the one an
+// earlier attempt left behind rather than adding to a pile of drafts.
+func versionArtifact(loaded Loaded, live Live, report *reporter) (version, error) {
+	if id, ok := abandoned(loaded.ProjectDir, live); ok {
+		report.say("  Continuing with artifact %s from an earlier attempt.\n", id)
+
+		return version{ID: id}, nil
+	}
+
+	return createVersion(loaded, report)
+}
+
+// createVersion mints an artifact from the file's artifact block.
+func createVersion(loaded Loaded, report *reporter) (version, error) {
+	var created *workload.Artifact
+
+	err := report.run("Creating the new version", func() error {
+		payload, payloadErr := loaded.Compiled.ArtifactPayload()
+		if payloadErr != nil {
+			return payloadErr
+		}
+
+		artifact, createErr := createArtifactFn(payload)
+		created = artifact
+
+		return createErr
+	})
+	if err != nil {
+		return version{}, err
+	}
+
+	return version{ID: created.ID, Fresh: true}, nil
+}
+
+// abandoned reports an artifact a previous roll made and never promoted.
+//
+// The project's link is the only record of it, and it is only a candidate
+// when it is not the version currently serving: linked to the live one means
+// the last roll finished, and the next change needs an artifact of its own.
+// A locked one is no use either, since nothing more can be pushed into it,
+// which is the state a roll onto production leaves behind when it dies
+// between the lock and the swap.
+func abandoned(projectDir string, live Live) (string, bool) {
+	if !projectLinkedFn(projectDir) {
+		return "", false
+	}
+
+	cfg, err := loadProjectFn(projectDir)
+	if err != nil || cfg.ArtifactID == "" || cfg.ArtifactID == live.ArtifactID {
+		return "", false
+	}
+
+	artifact, err := getArtifactFn(cfg.ArtifactID)
+	if err != nil || artifact.IsLocked() {
+		return "", false
+	}
+
+	return cfg.ArtifactID, true
+}
+
+// linkProject points the project at the new version, so the sync uploads into
+// it and the next run can find it. The catalog holding the code and the
+// version last pushed to it are carried across untouched: they describe the
+// code store, which is shared, and clearing them would make the next sync
+// treat every file as new.
+func linkProject(projectDir string, made version, report *reporter) error {
+	// An artifact picked up from an earlier attempt is the one the project is
+	// already pointed at, which is how it was found.
+	if !made.Fresh {
+		return nil
+	}
+
+	if !projectLinkedFn(projectDir) {
+		if err := initProjectFn(projectDir, wapi.InitOptions{ArtifactID: made.ID}); err != nil {
+			return linkFailure(made.ID, projectDir, err)
+		}
+
+		return nil
+	}
+
+	cfg, err := loadProjectFn(projectDir)
+	if err != nil {
+		return fmt.Errorf("cannot read which artifact %s is linked to: %w", projectDir, err)
+	}
+
+	cfg.ArtifactID = made.ID
+
+	if err := saveProjectFn(projectDir, cfg); err != nil {
+		return linkFailure(made.ID, projectDir, err)
+	}
+
+	report.say("  Project now pushes to artifact %s.\n", made.ID)
+
+	return nil
+}
+
+// linkFailure says which artifact was stranded. The artifact exists and
+// nothing records that fact, so the next run would make another; naming the
+// id is the difference between a re-run and a support ticket.
+func linkFailure(artifactID, projectDir string, err error) error {
+	return fmt.Errorf(
+		"artifact %s was created but %s could not be pointed at it, so the next deploy would create another. "+
+			"Run 'dr artifact code init %s' here, then deploy again: %w",
+		artifactID, projectDir, artifactID, err)
+}
+
+// inheritCode gives the new version the code the old one was running, when
+// the sync had nothing to upload.
+//
+// A spec-only roll is the case: the file changed a port or a probe, the
+// working tree did not, and the engine returns without minting a version or
+// patching anything. The new artifact would then go to the builder with no
+// code reference at all, and the roll would promote something that cannot
+// start. Pointing it at the version last synced is what makes "a new version
+// of the same code" true.
+func inheritCode(projectDir, artifactID string, synced *sync.Result, report *reporter) error {
+	if synced != nil && synced.NewVersion != "" {
+		return nil
+	}
+
+	cfg, err := loadProjectFn(projectDir)
+	if err != nil {
+		return fmt.Errorf("cannot read the code this project last pushed: %w", err)
+	}
+
+	catalog, lastVersion := deref(cfg.CatalogID), deref(cfg.LastSyncedVersionID)
+	if catalog == "" || lastVersion == "" {
+		return fmt.Errorf(
+			"artifact %s has no code and the working tree had nothing to upload, so there would be "+
+				"nothing to build. Check that %s holds the project's source",
+			artifactID, projectDir)
+	}
+
+	err = report.run("Carrying the code over", func() error {
+		return patchCodeRefFn(artifactID, catalog, lastVersion)
+	})
+	if err != nil {
+		return fmt.Errorf("cannot point artifact %s at the code it should build (%s): %w",
+			artifactID, lastVersion, err)
+	}
+
+	return nil
+}
+
+// deref reads an optional recorded id.
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+
+	return *s
+}


### PR DESCRIPTION
# RATIONALE

The previous PR rolls a workload whose image is published. This one rolls the case people actually hit: change some code, run `up` again, on a project the platform builds.

A new version of such a project is born with neither code nor an image, so it cannot simply be promoted. It has to be filled first, by the same three acts as a first deploy, and the order is what makes it safe against something in use.

## CHANGES

- The artifact is created and the project pointed at it **before** the sync. The sync engine patches the code reference of whichever artifact the project is linked to, and until this runs that is the version currently serving: syncing first would rewrite production's code while production runs it, and would fail outright once that version is locked, halfway through, with the upload already done.
- A spec-only roll (a port, a probe) leaves the working tree alone, so the sync mints nothing and the new artifact would reach the builder with no code at all. It inherits the version last pushed instead.
- A run that dies between minting a version and promoting it leaves a draft nothing points at. The next run continues with it rather than adding another. A locked leftover is not reused: nothing more can be pushed into it.
- A failed build ends the roll with the old version still serving, and keeps the build id, which is the way to the logs.
- Removes the last refusal on the roll path. What remains refused after this is a runtime-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the live deploy roll path for platform-built images with ordering that affects production safety (relink-before-sync), but behavior is heavily specified in tests and mirrors the existing first-deploy build track.
> 
> **Overview**
> **Rolling platform-built workloads is implemented** — the `ErrNotWired` guard for dockerfile/generated roll paths is removed, and `candidateArtifact` now runs the same fill-then-promote flow as first deploy via new `version.go` (`buildVersion`).
> 
> The **project is relinked to the new artifact before sync**, so uploads never patch the version currently serving. **Draft artifacts from a failed prior roll are reused**; locked leftovers are not. **Spec-only rolls** with no tree changes **inherit the last synced code reference** (`inheritCode` / `patchCodeRef`) so the builder still has something to build. **Failed builds** set `result.BuildID` and leave the old version serving without calling replace.
> 
> Package docs in `doc.go` describe roll behavior for built projects; roll tests cover ordering, reuse, carry-code, link failures, and failed builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f5cb968d558aa5016404273f6d9fb7017044be7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->