### PR TITLE
[RAPTOR-18976] feat(workload): update a live workload's runtime settings

### DIFF
--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -176,7 +176,8 @@ func addFlags(cmd *cobra.Command, f *flags, poll *pollflags.Set) {
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "Print the plan and change nothing.")
 	cmd.Flags().BoolVar(&f.detach, "detach", false, "Return once the deploy is requested; do not wait for it to serve.")
 	cmd.Flags().BoolVar(&f.lock, "lock", false,
-		"Lock the artifact that ends up live, making it permanent. Locking is one-way.")
+		"Lock whichever artifact ends up live, making it permanent, even when this deploy minted no new "+
+			"version. Locking is one-way.")
 	cmd.Flags().BoolVar(&f.force, "force-build", false,
 		"Rebuild the image even when the working tree matches what was last synced.")
 

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -130,6 +130,11 @@ already serving keeps serving until the new one is ready. When that version is
 locked, meaning production, an interactive run asks for the workload name to
 be typed back. A run with no terminal, or --yes, rolls without asking.
 
+A change that moves only the sizing, such as a replica count or a resource
+allocation, is applied in place instead. Nothing is built and no version is
+made, because what the workload runs has not changed. A deploy that moves both
+sends the sizing with the rollout, so the new version comes up with it.
+
 Examples:
   dr workload up
   dr workload up --dry-run

--- a/internal/drapi/patch.go
+++ b/internal/drapi/patch.go
@@ -64,8 +64,13 @@ func Patch(url, info string, body any) (*http.Response, error) {
 	return resp, err
 }
 
+// isPatchSuccess accepts 202 as well as 200 and 204. A route that starts work
+// rather than finishing it answers Accepted with a handle to follow, which the
+// workload settings route does: it applies new sizing by rolling a
+// replacement. Reading that as a failure would report every accepted change as
+// broken while the platform got on with it.
 func isPatchSuccess(code int) bool {
-	return code == http.StatusOK || code == http.StatusNoContent
+	return code == http.StatusOK || code == http.StatusAccepted || code == http.StatusNoContent
 }
 
 func PatchJSON(url, info string, body, v any) error {

--- a/internal/workload/manifest/compile.go
+++ b/internal/workload/manifest/compile.go
@@ -157,6 +157,34 @@ func (c *Compiled) BindArtifact(artifactID string) (json.RawMessage, error) {
 	return raw, nil
 }
 
+// RuntimePayload is the runtime block on its own: how much the workload runs
+// with, and nothing about what it runs. It is what a settings update sends,
+// and what rides along with a replacement when one deploy has to change both
+// halves at once.
+//
+// A file with no runtime block has nothing to send. That is a caller error
+// rather than a user one, since the change being applied was computed from the
+// same block: with no block there is no drift, and with no drift nothing asks
+// for this.
+func (c *Compiled) RuntimePayload() (json.RawMessage, error) {
+	payload, err := c.decode()
+	if err != nil {
+		return nil, err
+	}
+
+	runtime, ok := payload[keyRuntime]
+	if !ok {
+		return nil, fmt.Errorf("the manifest has no %s block to apply", keyRuntime)
+	}
+
+	raw, err := json.Marshal(runtime)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert the %s block to JSON: %w", keyRuntime, err)
+	}
+
+	return raw, nil
+}
+
 // decode reads the compiled payload back into a tree. It is decoded per call
 // rather than cached because each caller edits its copy, and a shared one
 // would let one deploy's edit leak into another's payload.

--- a/internal/workload/manifest/compile_test.go
+++ b/internal/workload/manifest/compile_test.go
@@ -329,6 +329,38 @@ func TestArtifactPayload_NoBlockToCreate(t *testing.T) {
 	assert.Contains(t, err.Error(), "no artifact block")
 }
 
+// The mirror of ArtifactPayload: the sizing half on its own, with nothing in
+// it about what the workload runs.
+func TestRuntimePayload_IsTheBlockItself(t *testing.T) {
+	m, err := Parse([]byte(buildManifest), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	payload, err := compiled.RuntimePayload()
+	require.NoError(t, err)
+
+	var runtime map[string]any
+
+	require.NoError(t, json.Unmarshal(payload, &runtime))
+	assert.Contains(t, runtime, "containerGroups")
+	assert.NotContains(t, runtime, "spec", "what it runs is the artifact's half")
+	assert.NotContains(t, runtime, "name", "the workload's own name is not a runtime setting")
+}
+
+func TestRuntimePayload_NoBlockToApply(t *testing.T) {
+	m, err := Parse([]byte("name: my-app\nartifactId: 68b0bbbb0000000000000002\n"), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	_, err = compiled.RuntimePayload()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no runtime block")
+}
+
 // The two forms are mutually exclusive in the API as they are in the file, so
 // binding removes the block rather than leaving it beside the id. Sending
 // both would ask the platform for a second, empty artifact.

--- a/internal/workload/replacement.go
+++ b/internal/workload/replacement.go
@@ -15,6 +15,7 @@
 package workload
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -136,15 +137,28 @@ func GetActiveReplacement(workloadID string) (*Replacement, error) {
 // before this is called. That is not enforced here because the caller is the
 // one holding both statuses, and the lock has to happen between the guard and
 // this call.
-func StartReplacement(workloadID, artifactID string) (*Replacement, error) {
+//
+// runtime is optional and may be nil. When a deploy changes the sizing as well
+// as the version, sending both here is what brings the candidate up under the
+// sizing it was asked for: applying them as two operations either resizes the
+// version being rolled off, or starts the new one under the old sizing, which
+// is how a larger model meets a bundle that cannot hold it.
+func StartReplacement(workloadID, artifactID string, runtime json.RawMessage) (*Replacement, error) {
 	url, err := replacementURL(workloadID)
 	if err != nil {
 		return nil, err
 	}
 
-	body := map[string]string{
+	body := map[string]any{
 		"artifactId": artifactID,
 		"strategy":   rollingStrategy,
+	}
+
+	// Omitted rather than sent as null when there is nothing to change, so a
+	// rollout that only swaps the version does not read as a settings change
+	// as well.
+	if len(runtime) > 0 {
+		body["runtime"] = runtime
 	}
 
 	var replacement Replacement

--- a/internal/workload/replacement_test.go
+++ b/internal/workload/replacement_test.go
@@ -175,14 +175,37 @@ func TestStartReplacement_PostsArtifactIDAndRollingStrategy(t *testing.T) {
 		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		assert.Equal(t, "art-2", body["artifactId"])
 		assert.Equal(t, "rolling", body["strategy"])
+		assert.NotContains(t, body, "runtime",
+			"a swap that changes no sizing must not read as a settings change as well")
 
 		fmt.Fprint(w, `{"candidateArtifactId":"art-2","status":"submitted"}`)
 	})
 
-	replacement, err := StartReplacement("wl-1", "art-2")
+	replacement, err := StartReplacement("wl-1", "art-2", nil)
 	require.NoError(t, err)
 	assert.Equal(t, "art-2", replacement.ArtifactID)
 	assert.Equal(t, "submitted", replacement.Status)
+}
+
+// A deploy that changes the sizing and the version sends both, so the
+// candidate comes up under the sizing it was asked for rather than under the
+// one it is replacing.
+func TestStartReplacement_CarriesTheRuntimeWhenThereIsOne(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		runtime, ok := body["runtime"].(map[string]any)
+		if assert.True(t, ok, "the runtime block travels with the swap") {
+			assert.InDelta(t, 3, runtime["replicaCount"], 0)
+		}
+
+		fmt.Fprint(w, `{"candidateArtifactId":"art-2","status":"submitted"}`)
+	})
+
+	_, err := StartReplacement("wl-1", "art-2", json.RawMessage(`{"replicaCount":3}`))
+	require.NoError(t, err)
 }
 
 // TestStartReplacement_ErrorPropagates covers the only call in this file that
@@ -195,7 +218,7 @@ func TestStartReplacement_ErrorPropagates(t *testing.T) {
 		fmt.Fprint(w, `{"detail":"candidate artifact must be locked"}`)
 	})
 
-	replacement, err := StartReplacement("wl-1", "art-2")
+	replacement, err := StartReplacement("wl-1", "art-2", nil)
 	require.Error(t, err)
 	assert.Nil(t, replacement)
 

--- a/internal/workload/settings.go
+++ b/internal/workload/settings.go
@@ -1,0 +1,59 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// UpdateWorkloadSettings changes how much a workload runs with, leaving what
+// it runs alone: replica counts, resource allocations, resource bundles, an
+// autoscaling policy. It is the one kind of change a deploy can make in place,
+// because it says nothing about the image or the code, and so needs no new
+// artifact and no rollout.
+//
+// runtime is the manifest's runtime block, sent as it stands. Passing an empty
+// one is refused rather than sent: a PATCH with nothing in it would come back
+// 200 having changed nothing, which is indistinguishable from success.
+//
+// Known limitation. Unlike the rest of this package, this route has not been
+// exercised against a live instance; it is what the platform's own workload
+// documentation describes. If it turns out to want the runtime fields at the
+// top level rather than under a runtime key, or a different path segment, this
+// function is the only place that has to change.
+func UpdateWorkloadSettings(workloadID string, runtime json.RawMessage) (*Workload, error) {
+	if len(runtime) == 0 {
+		return nil, errors.New("no runtime settings to update")
+	}
+
+	url, err := config.GetEndpointURL("/api/v2/workloads/" + escapeID(workloadID) + "/settings/")
+	if err != nil {
+		return nil, err
+	}
+
+	body := map[string]json.RawMessage{"runtime": runtime}
+
+	var updated Workload
+
+	if err := drapi.PatchJSON(url, "workload settings", body, &updated); err != nil {
+		return nil, err
+	}
+
+	return &updated, nil
+}

--- a/internal/workload/settings.go
+++ b/internal/workload/settings.go
@@ -30,14 +30,15 @@ import (
 //
 // runtime is the manifest's runtime block, sent as it stands. Passing an empty
 // one is refused rather than sent: a PATCH with nothing in it would come back
-// 200 having changed nothing, which is indistinguishable from success.
+// having changed nothing, which is indistinguishable from success.
 //
-// Known limitation. Unlike the rest of this package, this route has not been
-// exercised against a live instance; it is what the platform's own workload
-// documentation describes. If it turns out to want the runtime fields at the
-// top level rather than under a runtime key, or a different path segment, this
-// function is the only place that has to change.
-func UpdateWorkloadSettings(workloadID string, runtime json.RawMessage) (*Workload, error) {
+// What comes back is a Replacement, not a workload, and the status is 202: the
+// platform carries out a settings change by rolling the workload onto the
+// artifact it is already running with the new sizing applied. So this call
+// only starts the work, and the caller has to follow the replacement to know
+// whether the new sizing was promoted. The workload's own status is no help,
+// since it stays running throughout.
+func UpdateWorkloadSettings(workloadID string, runtime json.RawMessage) (*Replacement, error) {
 	if len(runtime) == 0 {
 		return nil, errors.New("no runtime settings to update")
 	}
@@ -49,11 +50,11 @@ func UpdateWorkloadSettings(workloadID string, runtime json.RawMessage) (*Worklo
 
 	body := map[string]json.RawMessage{"runtime": runtime}
 
-	var updated Workload
+	var started Replacement
 
-	if err := drapi.PatchJSON(url, "workload settings", body, &updated); err != nil {
+	if err := drapi.PatchJSON(url, "workload settings", body, &started); err != nil {
 		return nil, err
 	}
 
-	return &updated, nil
+	return &started, nil
 }

--- a/internal/workload/settings_test.go
+++ b/internal/workload/settings_test.go
@@ -39,13 +39,29 @@ func TestUpdateWorkloadSettings_PatchesTheRuntimeBlock(t *testing.T) {
 			assert.InDelta(t, 3, runtime["replicaCount"], 0)
 		}
 
-		fmt.Fprint(w, `{"id":"wl-1","name":"my-app","status":"running"}`)
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, `{"id":"rep-9","workloadId":"wl-1","candidateArtifactId":"art-1","status":"pending"}`)
 	}))
 
-	updated, err := UpdateWorkloadSettings("wl-1", json.RawMessage(`{"replicaCount":3}`))
+	started, err := UpdateWorkloadSettings("wl-1", json.RawMessage(`{"replicaCount":3}`))
 	require.NoError(t, err)
-	assert.Equal(t, "wl-1", updated.ID)
-	assert.Equal(t, WorkloadStatusRunning, updated.Status)
+	assert.Equal(t, "rep-9", started.ID, "the replacement is the handle the caller has to follow")
+	assert.Equal(t, "wl-1", started.WorkloadID)
+}
+
+// The route answers 202, not 200: the platform applies new sizing by rolling
+// the workload onto the artifact it is already running, so the call starts
+// work rather than finishing it. Treating Accepted as a failure reported every
+// resize the platform had taken on as broken.
+func TestUpdateWorkloadSettings_AcceptsTheAcceptedStatus(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, `{"id":"rep-9","workloadId":"wl-1","status":"pending"}`)
+	}))
+
+	started, err := UpdateWorkloadSettings("wl-1", json.RawMessage(`{"replicaCount":3}`))
+	require.NoError(t, err, "202 is how this route says yes")
+	assert.Equal(t, "rep-9", started.ID)
 }
 
 // A id that has to stay one path segment is the same hazard here as

--- a/internal/workload/settings_test.go
+++ b/internal/workload/settings_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateWorkloadSettings_PatchesTheRuntimeBlock(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/api/v2/workloads/wl-1/settings/", r.URL.EscapedPath())
+
+		var body map[string]any
+
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+
+		runtime, ok := body["runtime"].(map[string]any)
+		if assert.True(t, ok, "the runtime block is sent as a unit") {
+			assert.InDelta(t, 3, runtime["replicaCount"], 0)
+		}
+
+		fmt.Fprint(w, `{"id":"wl-1","name":"my-app","status":"running"}`)
+	}))
+
+	updated, err := UpdateWorkloadSettings("wl-1", json.RawMessage(`{"replicaCount":3}`))
+	require.NoError(t, err)
+	assert.Equal(t, "wl-1", updated.ID)
+	assert.Equal(t, WorkloadStatusRunning, updated.Status)
+}
+
+// A id that has to stay one path segment is the same hazard here as
+// everywhere else the CLI puts one in a URL.
+func TestUpdateWorkloadSettings_EscapesTheID(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/workloads/a%2Fb/settings/", r.URL.EscapedPath())
+		fmt.Fprint(w, `{"id":"a/b"}`)
+	}))
+
+	_, err := UpdateWorkloadSettings("a/b", json.RawMessage(`{"replicaCount":1}`))
+	require.NoError(t, err)
+}
+
+// An empty PATCH would come back 200 having changed nothing, which reads as
+// success. Refusing locally is the only way that stays distinguishable.
+func TestUpdateWorkloadSettings_RefusesAnEmptyRuntime(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("nothing to change must not reach the platform")
+	}))
+
+	_, err := UpdateWorkloadSettings("wl-1", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no runtime settings")
+}
+
+func TestUpdateWorkloadSettings_ErrorCarriesTheServersReason(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprint(w, `{"detail":"replicaCount and autoscaling are mutually exclusive"}`)
+	}))
+
+	_, err := UpdateWorkloadSettings("wl-1", json.RawMessage(`{"replicaCount":3}`))
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusUnprocessableEntity, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}

--- a/internal/workload/up/retune.go
+++ b/internal/workload/up/retune.go
@@ -1,0 +1,84 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/datarobot/cli/internal/workload"
+)
+
+// retune applies a change that moved only the sizing: a replica count, a
+// resource allocation, a bundle, an autoscaling policy. The file says nothing
+// new about what the workload runs, so no version is minted and nothing is
+// swapped. It is one call and a wait, which is the whole reason this is not a
+// roll: a resize should not cost a build, a new immutable artifact and a
+// rollout.
+//
+// The whole runtime block is sent rather than the fields that differ. It is
+// the same block the plan was computed from, the platform takes it as a unit,
+// and sending a subset would leave the reader guessing which half of the file
+// is now live.
+func retune(loaded Loaded, result Result, opts Options, report *reporter) (Result, error) {
+	runtime, err := loaded.Compiled.RuntimePayload()
+	if err != nil {
+		return result, err
+	}
+
+	var updated *workload.Workload
+
+	err = report.run("Updating the runtime settings", func() error {
+		wl, updateErr := updateSettingsFn(result.WorkloadID, runtime)
+		updated = wl
+
+		return updateErr
+	})
+	if err != nil {
+		return result, fmt.Errorf("cannot update the runtime settings of workload %s: %w", result.WorkloadID, err)
+	}
+
+	result.Action = ActionUpdated
+
+	if updated != nil {
+		result.Status = updated.Status
+	}
+
+	if opts.Detach {
+		report.say("  Settings update for %s requested; not waiting.\n", result.WorkloadID)
+
+		return result, nil
+	}
+
+	// The wait is the same one every other path ends with. A settings change
+	// can restart containers, so reporting success the moment the platform
+	// accepts it would name a workload that is on its way down.
+	return settle(result.WorkloadID, result, opts, report)
+}
+
+// rollRuntime is the runtime block to carry with a swap, and nil when the file
+// and the live workload already agree about sizing.
+//
+// Nil rather than the block as it stands, because a replacement carrying
+// runtime is a settings change as well as a rollout: sending an unchanged
+// block would turn every roll into both, and a settings field the platform
+// adds later would be silently reset to whatever the file happens to imply.
+func rollRuntime(loaded Loaded, plan Plan) (json.RawMessage, error) {
+	if len(plan.Runtime) == 0 {
+		return nil, nil
+	}
+
+	return loaded.Compiled.RuntimePayload()
+}

--- a/internal/workload/up/retune.go
+++ b/internal/workload/up/retune.go
@@ -23,10 +23,17 @@ import (
 
 // retune applies a change that moved only the sizing: a replica count, a
 // resource allocation, a bundle, an autoscaling policy. The file says nothing
-// new about what the workload runs, so no version is minted and nothing is
-// swapped. It is one call and a wait, which is the whole reason this is not a
-// roll: a resize should not cost a build, a new immutable artifact and a
-// rollout.
+// new about what the workload runs, so no version is minted, which is the
+// whole reason this is not a roll: a resize should not cost a build and a new
+// immutable artifact.
+//
+// It is still a rollout. The platform applies new sizing by replacing the
+// workload with itself, on the artifact it is already running, so this call
+// starts a replacement and hands one back. Waiting on the workload alone would
+// prove nothing: its status stays running for the whole swap, so the wait
+// returns at once and reports a resize that may still fail as done. The
+// replacement is what has to be followed, and the settle afterwards is what
+// says the containers came back.
 //
 // The whole runtime block is sent rather than the fields that differ. It is
 // the same block the plan was computed from, the platform takes it as a unit,
@@ -38,11 +45,11 @@ func retune(loaded Loaded, result Result, opts Options, report *reporter) (Resul
 		return result, err
 	}
 
-	var updated *workload.Workload
+	var started *workload.Replacement
 
 	err = report.run("Updating the runtime settings", func() error {
-		wl, updateErr := updateSettingsFn(result.WorkloadID, runtime)
-		updated = wl
+		replacement, updateErr := updateSettingsFn(result.WorkloadID, runtime)
+		started = replacement
 
 		return updateErr
 	})
@@ -52,20 +59,43 @@ func retune(loaded Loaded, result Result, opts Options, report *reporter) (Resul
 
 	result.Action = ActionUpdated
 
-	if updated != nil {
-		result.Status = updated.Status
-	}
-
 	if opts.Detach {
 		report.say("  Settings update for %s requested; not waiting.\n", result.WorkloadID)
 
 		return result, nil
 	}
 
-	// The wait is the same one every other path ends with. A settings change
-	// can restart containers, so reporting success the moment the platform
-	// accepts it would name a workload that is on its way down.
+	if err := awaitResize(result.WorkloadID, started, opts, report); err != nil {
+		return result, err
+	}
+
 	return settle(result.WorkloadID, result, opts, report)
+}
+
+// awaitResize follows the replacement a settings change starts. A failed one
+// leaves the workload on the sizing it had, so it is the difference between a
+// resize that happened and one that was merely accepted.
+func awaitResize(workloadID string, started *workload.Replacement, opts Options, report *reporter) error {
+	var settled *workload.Replacement
+
+	err := report.run("Waiting for the new settings", func() error {
+		replacement, waitErr := waitReplacementFn(workloadID, started, opts.PollInterval, opts.PollTimeout, nil)
+		settled = replacement
+
+		return waitErr
+	})
+	if err == nil {
+		return nil
+	}
+
+	if settled != nil && workload.IsFailedReplacementStatus(settled.Status) {
+		return fmt.Errorf(
+			"the settings update for workload %s ended as %s, so it is still running with the sizing it had; "+
+				"check 'dr workload status %s': %w",
+			workloadID, settled.Status, workloadID, err)
+	}
+
+	return err
 }
 
 // rollRuntime is the runtime block to carry with a swap, and nil when the file

--- a/internal/workload/up/retune_test.go
+++ b/internal/workload/up/retune_test.go
@@ -273,3 +273,33 @@ func TestRun_RollWithoutARuntimeChangeSendsNoRuntime(t *testing.T) {
 
 	assert.Nil(t, tr.rolledRuntime)
 }
+
+// --lock is about the artifact that ends up live, not about one this run
+// minted. A resize mints nothing, so the artifact already serving is the one
+// that ends up live, and it is what gets locked. A start does the same.
+func TestRun_RetuneWithLockLocksTheServingArtifact(t *testing.T) {
+	var (
+		tr   track
+		sent json.RawMessage
+	)
+
+	f := wiredRetune(&tr, &sent)
+	// The shared fixture is already locked, which is the other branch: an
+	// artifact cannot be locked twice.
+	f.artifactD = func(string) (workload.Document, error) { return unlockedArtifact(t), nil }
+	f.lock = func(id string) (*workload.Artifact, error) {
+		tr.steps = append(tr.steps, "lock:"+id)
+
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusLocked}, nil
+	}
+
+	install(t, f)
+
+	result, _, err := runIn(t, retuned("cpu: 3", "cpu: 6"), Options{NonInteractive: true, Lock: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"settings:68b0c1d2e3f4a5b6c7d8e9f0", "await-resize", "settle", "lock:68a0000000000000000000a1",
+	}, tr.steps, "the lock comes last, once the workload is serving again")
+	assert.True(t, result.Locked)
+}

--- a/internal/workload/up/retune_test.go
+++ b/internal/workload/up/retune_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// retuned is the live built project with one runtime number moved and nothing
+// else, which is the whole of a settings change: same artifact, same code,
+// more of it.
+func retuned(from, to string) string {
+	return "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" +
+		strings.Replace(boundLiveManifest, from, to, 1)
+}
+
+// wiredRetune answers the settings call and the wait that follows it.
+func wiredRetune(tr *track, sent *json.RawMessage) fakes {
+	return fakes{
+		workloadD: func(string) (workload.Document, error) { return docOf(liveWorkloadJSON), nil },
+		artifactD: func(string) (workload.Document, error) { return docOf(liveArtifactJSON), nil },
+		settings: func(workloadID string, runtime json.RawMessage) (*workload.Workload, error) {
+			tr.steps = append(tr.steps, "settings:"+workloadID)
+			*sent = runtime
+
+			return &workload.Workload{ID: workloadID, Status: workload.WorkloadStatusProvisioning}, nil
+		},
+		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			tr.steps = append(tr.steps, "settle")
+
+			return &workload.Workload{
+				ID: id, Name: "gpt-oss-20b-vllm", Status: workload.WorkloadStatusRunning,
+				ArtifactID: "68a0000000000000000000a1", Endpoint: "https://app.datarobot.com/workloads/68b0/",
+			}, nil
+		},
+	}
+}
+
+// A resize costs one call. Nothing is built, nothing is minted and nothing is
+// swapped, which is the entire reason this path exists rather than being
+// folded into a roll.
+func TestRun_RuntimeOnlyChangeIsAppliedInPlace(t *testing.T) {
+	var (
+		tr   track
+		sent json.RawMessage
+	)
+
+	f := wiredRetune(&tr, &sent)
+	f.newArtifact = func(any) (*workload.Artifact, error) {
+		t.Fatal("a sizing change mints no version")
+
+		return nil, nil
+	}
+	f.replace = func(string, string, json.RawMessage) (*workload.Replacement, error) {
+		t.Fatal("a sizing change swaps nothing")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	result, stderr, err := runIn(t, retuned("cpu: 3", "cpu: 6"), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"settings:68b0c1d2e3f4a5b6c7d8e9f0", "settle"}, tr.steps)
+	assert.Equal(t, ActionUpdated, result.Action)
+	assert.Equal(t, workload.WorkloadStatusRunning, result.Status, "the wait has the last word on status")
+	assert.Equal(t, "68a0000000000000000000a1", result.ArtifactID, "the version serving does not change")
+	assert.Contains(t, stderr, "~ runtime")
+}
+
+// The whole block goes, not the fields that differ: the platform takes it as
+// a unit, and a subset would leave the reader guessing which half is live.
+func TestRun_RetuneSendsTheWholeRuntimeBlock(t *testing.T) {
+	var (
+		tr   track
+		sent json.RawMessage
+	)
+
+	install(t, wiredRetune(&tr, &sent))
+
+	_, _, err := runIn(t, retuned("cpu: 3", "cpu: 6"), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	var block map[string]any
+
+	require.NoError(t, json.Unmarshal(sent, &block))
+
+	groups, ok := block["containerGroups"].([]any)
+	require.True(t, ok, "the runtime block travels as the file wrote it")
+	assert.Len(t, groups, 1)
+
+	group, ok := groups[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "default", group["name"], "fields that did not change travel too")
+}
+
+// A credential this run does not touch must not be able to refuse a resize:
+// the artifact keeps every variable it already has, and nothing about the
+// environment is sent.
+func TestRun_RetuneDoesNotVerifyCredentials(t *testing.T) {
+	var (
+		tr   track
+		sent json.RawMessage
+	)
+
+	f := wiredRetune(&tr, &sent)
+	f.cred = func(string) (*workload.Credential, error) {
+		t.Fatal("a settings update sends no environment")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, retuned("cpu: 3", "cpu: 6"), Options{NonInteractive: true})
+	require.NoError(t, err)
+	assert.Contains(t, tr.steps, "settings:68b0c1d2e3f4a5b6c7d8e9f0")
+}
+
+func TestRun_RetuneFailureNamesTheWorkload(t *testing.T) {
+	var (
+		tr   track
+		sent json.RawMessage
+	)
+
+	f := wiredRetune(&tr, &sent)
+	f.settings = func(string, json.RawMessage) (*workload.Workload, error) {
+		return nil, errors.New("replicaCount and autoscaling are mutually exclusive")
+	}
+	f.wait = func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		t.Fatal("a settings call that failed changed nothing to wait for")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	result, _, err := runIn(t, retuned("cpu: 3", "cpu: 6"), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "68b0c1d2e3f4a5b6c7d8e9f0")
+	assert.Contains(t, err.Error(), "mutually exclusive", "the platform's reason has to survive")
+	assert.Equal(t, ActionUpdated, result.Plan.Action(), "the plan still says what was asked for")
+}
+
+func TestRun_DetachedRetuneDoesNotWait(t *testing.T) {
+	var (
+		tr   track
+		sent json.RawMessage
+	)
+
+	install(t, wiredRetune(&tr, &sent))
+
+	result, stderr, err := runIn(t, retuned("cpu: 3", "cpu: 6"), Options{NonInteractive: true, Detach: true})
+	require.NoError(t, err)
+
+	assert.NotContains(t, tr.steps, "settle")
+	assert.Equal(t, ActionUpdated, result.Action)
+	assert.Equal(t, workload.WorkloadStatusProvisioning, result.Status)
+	assert.Contains(t, stderr, "not waiting")
+}
+
+// A file that moved the sizing and the version rides both in on one swap. Two
+// operations would either resize the version being rolled off, or start the
+// new one under the old sizing.
+func TestRun_RollCarriesTheRuntimeWithTheSwap(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("68a0000000000000000000a1")
+	f.settings = func(string, json.RawMessage) (*workload.Workload, error) {
+		t.Fatal("the swap carries the sizing; a second call would apply it twice")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	both := strings.Replace(builtDrift(), "cpu: 3", "cpu: 6", 1)
+
+	result, _, err := runIn(t, both, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionRolled, result.Action, "a version change outranks a resize")
+	require.NotNil(t, tr.rolledRuntime, "the sizing has to reach the platform somehow")
+
+	var block map[string]any
+
+	require.NoError(t, json.Unmarshal(tr.rolledRuntime, &block))
+	assert.Contains(t, block, "containerGroups")
+}
+
+// A rollout that changes no sizing sends no sizing. Sending the block anyway
+// would make every roll a settings change as well.
+func TestRun_RollWithoutARuntimeChangeSendsNoRuntime(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("68a0000000000000000000a1")
+
+	install(t, f)
+
+	_, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Nil(t, tr.rolledRuntime)
+}

--- a/internal/workload/up/retune_test.go
+++ b/internal/workload/up/retune_test.go
@@ -34,16 +34,25 @@ func retuned(from, to string) string {
 		strings.Replace(boundLiveManifest, from, to, 1)
 }
 
-// wiredRetune answers the settings call and the wait that follows it.
+// wiredRetune answers the settings call and the two waits that follow it: the
+// replacement the platform starts to apply the sizing, then the workload.
 func wiredRetune(tr *track, sent *json.RawMessage) fakes {
 	return fakes{
 		workloadD: func(string) (workload.Document, error) { return docOf(liveWorkloadJSON), nil },
 		artifactD: func(string) (workload.Document, error) { return docOf(liveArtifactJSON), nil },
-		settings: func(workloadID string, runtime json.RawMessage) (*workload.Workload, error) {
+		settings: func(workloadID string, runtime json.RawMessage) (*workload.Replacement, error) {
 			tr.steps = append(tr.steps, "settings:"+workloadID)
 			*sent = runtime
 
-			return &workload.Workload{ID: workloadID, Status: workload.WorkloadStatusProvisioning}, nil
+			return &workload.Replacement{ID: "rep-1", WorkloadID: workloadID}, nil
+		},
+		waitReplace: func(_ string, started *workload.Replacement, _, _ time.Duration,
+			_ func(*workload.Replacement),
+		) (*workload.Replacement, error) {
+			tr.steps = append(tr.steps, "await-resize")
+			started.Status = workload.ReplacementStatusCompleted
+
+			return started, nil
 		},
 		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			tr.steps = append(tr.steps, "settle")
@@ -82,7 +91,9 @@ func TestRun_RuntimeOnlyChangeIsAppliedInPlace(t *testing.T) {
 	result, stderr, err := runIn(t, retuned("cpu: 3", "cpu: 6"), Options{NonInteractive: true})
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"settings:68b0c1d2e3f4a5b6c7d8e9f0", "settle"}, tr.steps)
+	assert.Equal(t,
+		[]string{"settings:68b0c1d2e3f4a5b6c7d8e9f0", "await-resize", "settle"}, tr.steps,
+		"the platform resizes by rolling a replacement, so that is what has to be followed")
 	assert.Equal(t, ActionUpdated, result.Action)
 	assert.Equal(t, workload.WorkloadStatusRunning, result.Status, "the wait has the last word on status")
 	assert.Equal(t, "68a0000000000000000000a1", result.ArtifactID, "the version serving does not change")
@@ -145,7 +156,7 @@ func TestRun_RetuneFailureNamesTheWorkload(t *testing.T) {
 	)
 
 	f := wiredRetune(&tr, &sent)
-	f.settings = func(string, json.RawMessage) (*workload.Workload, error) {
+	f.settings = func(string, json.RawMessage) (*workload.Replacement, error) {
 		return nil, errors.New("replicaCount and autoscaling are mutually exclusive")
 	}
 	f.wait = func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
@@ -163,6 +174,37 @@ func TestRun_RetuneFailureNamesTheWorkload(t *testing.T) {
 	assert.Equal(t, ActionUpdated, result.Plan.Action(), "the plan still says what was asked for")
 }
 
+// The workload stays running for the whole swap, so its status can never say
+// a resize failed. Only the replacement can, and a run that ignored it would
+// report the old sizing as the new one.
+func TestRun_RetuneReportsAReplacementThatFailed(t *testing.T) {
+	var (
+		tr   track
+		sent json.RawMessage
+	)
+
+	f := wiredRetune(&tr, &sent)
+	f.waitReplace = func(_ string, started *workload.Replacement, _, _ time.Duration,
+		_ func(*workload.Replacement),
+	) (*workload.Replacement, error) {
+		started.Status = workload.ReplacementStatusFailed
+
+		return started, errors.New("replacement ended as FAILED")
+	}
+	f.wait = func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		t.Fatal("a resize that failed leaves nothing to settle")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, retuned("cpu: 3", "cpu: 6"), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still running with the sizing it had")
+	assert.Contains(t, err.Error(), "68b0c1d2e3f4a5b6c7d8e9f0")
+}
+
 func TestRun_DetachedRetuneDoesNotWait(t *testing.T) {
 	var (
 		tr   track
@@ -174,9 +216,13 @@ func TestRun_DetachedRetuneDoesNotWait(t *testing.T) {
 	result, stderr, err := runIn(t, retuned("cpu: 3", "cpu: 6"), Options{NonInteractive: true, Detach: true})
 	require.NoError(t, err)
 
+	assert.NotContains(t, tr.steps, "await-resize")
 	assert.NotContains(t, tr.steps, "settle")
 	assert.Equal(t, ActionUpdated, result.Action)
-	assert.Equal(t, workload.WorkloadStatusProvisioning, result.Status)
+	// The status is the live one, because nobody looked again. A settings
+	// change leaves the workload running while the replacement swaps under
+	// it, so there is no other status to report without waiting.
+	assert.Equal(t, workload.WorkloadStatusRunning, result.Status)
 	assert.Contains(t, stderr, "not waiting")
 }
 
@@ -189,7 +235,7 @@ func TestRun_RollCarriesTheRuntimeWithTheSwap(t *testing.T) {
 	f := builtRoll(&tr)
 	f.linked = func(string) bool { return true }
 	f.project = syncedProject("68a0000000000000000000a1")
-	f.settings = func(string, json.RawMessage) (*workload.Workload, error) {
+	f.settings = func(string, json.RawMessage) (*workload.Replacement, error) {
 		t.Fatal("the swap carries the sizing; a second call would apply it twice")
 
 		return nil, nil

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -15,6 +15,7 @@
 package up
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -41,14 +42,6 @@ import (
 // deleted. Taking the lock only once nothing is left that can say no is what
 // keeps a lost race from leaving one behind.
 func roll(loaded Loaded, live Live, plan Plan, result Result, opts Options, report *reporter) (Result, error) {
-	if live.State == StateStopped {
-		return result, fmt.Errorf(
-			"workload %s is stopped and the file asks for more than starting it. "+
-				"Start it with 'dr workload start %s' and deploy again, so the new version rolls out onto "+
-				"something that is running",
-			result.Name, live.WorkloadID)
-	}
-
 	if err := guardReplacementFn(live.WorkloadID); err != nil {
 		return result, err
 	}
@@ -75,7 +68,15 @@ func roll(loaded Loaded, live Live, plan Plan, result Result, opts Options, repo
 		return result, err
 	}
 
-	return replace(live.WorkloadID, made, lock, result, opts, report)
+	// A file that moved the sizing as well as the version rides both in on the
+	// same swap: the platform takes runtime alongside the artifact, so there is
+	// no second call and no window where one half is live and the other is not.
+	runtime, err := rollRuntime(loaded, plan)
+	if err != nil {
+		return result, err
+	}
+
+	return replace(live.WorkloadID, made, lock, runtime, result, opts, report)
 }
 
 // candidateArtifact is the version to roll onto.
@@ -202,11 +203,13 @@ func confirmRoll(workloadName string, opts Options) (bool, error) {
 			"Re-run with --yes to say so explicitly")
 }
 
-// replace starts the rollout and follows it to the end.
+// replace starts the rollout and follows it to the end. runtime is nil unless
+// the sizing changed too, in which case it travels with the swap.
 func replace(
 	workloadID string,
 	made version,
 	lock bool,
+	runtime json.RawMessage,
 	result Result,
 	opts Options,
 	report *reporter,
@@ -230,7 +233,7 @@ func replace(
 	var started *workload.Replacement
 
 	err := report.run("Rolling out the new version", func() error {
-		replacement, startErr := startReplacementFn(workloadID, made.ID)
+		replacement, startErr := startReplacementFn(workloadID, made.ID, runtime)
 		started = replacement
 
 		return startErr

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -121,8 +121,9 @@ func wiredRoll(tr *track) fakes {
 
 			return &workload.Artifact{ID: id, Status: workload.ArtifactStatusLocked}, nil
 		},
-		replace: func(workloadID, artifactID string) (*workload.Replacement, error) {
+		replace: func(workloadID, artifactID string, runtime json.RawMessage) (*workload.Replacement, error) {
 			tr.steps = append(tr.steps, "replace:"+artifactID)
+			tr.rolledRuntime = runtime
 
 			return &workload.Replacement{ID: "rep-1", WorkloadID: workloadID, ArtifactID: artifactID}, nil
 		},
@@ -314,22 +315,6 @@ func TestRun_LockedRollLocksANamedDraft(t *testing.T) {
 		"replace:68b0bbbb0000000000000002", "await-rollout", "settle",
 	}, tr.steps)
 	assert.True(t, result.Locked)
-}
-
-// A plan with both halves is refused rather than half-applied. Rolling and
-// leaving the sizing behind would carry out part of the plan just printed and
-// report the whole of it as done, which is worse than not starting.
-func TestRun_RollThatAlsoResizesIsRefusedWholesale(t *testing.T) {
-	var tr track
-
-	install(t, wiredRoll(&tr))
-
-	both := strings.Replace(newImage(), "cpu: 0.5", "cpu: 2", 1)
-
-	_, _, err := runIn(t, both, Options{NonInteractive: true})
-	require.ErrorIs(t, err, ErrNotWired)
-	assert.Contains(t, err.Error(), "runtime settings")
-	assert.Empty(t, tr.steps, "nothing may be rolled while half the plan cannot be applied")
 }
 
 // Locking cannot be undone and a locked artifact cannot be deleted, so a lock

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -48,6 +48,7 @@ var (
 	guardReplacementFn = workload.GuardNoActiveReplacement
 	startReplacementFn = workload.StartReplacement
 	waitReplacementFn  = workload.WaitForReplacement
+	updateSettingsFn   = workload.UpdateWorkloadSettings
 	writeWorkloadIDFn  = manifest.WriteWorkloadID
 	codeChangeFn       = defaultCodeChange
 	projectLinkedFn    = wapi.Exists
@@ -57,11 +58,6 @@ var (
 	patchCodeRefFn     = workload.PatchArtifactCodeRef
 	syncProjectFn      = defaultSync
 )
-
-// ErrNotWired reports a path the plan understands but the apply cannot take
-// yet. It is a sentinel so the command can say so in its own words, and so a
-// test can tell "we refused" from "we broke".
-var ErrNotWired = errors.New("not wired yet")
 
 // Options is everything a run needs from its caller.
 type Options struct {
@@ -243,32 +239,46 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 		return result, err
 	}
 
-	// Checked before every path below, which either mutates or refuses. A
-	// start counts as a mutation: it is when the container resolves its
-	// references, so a credential deleted while the workload was off would
-	// surface minutes later as a container that will not come up. On a path
-	// about to be refused it shadows ErrNotWired, deliberately: one run to
-	// learn about both beats two.
-	if err := verifyCredentials(loaded.Compiled.CredentialRefs); err != nil {
-		return result, err
-	}
-
 	// Starting is checked before the roll refusal so that a stopped workload
 	// the file already agrees with gets deployed rather than turned away.
 	// When the file asks for more than a start, the refusal wins: bringing the
 	// workload up on the version it was stopped on would report a failure
 	// having already changed something, which is the worst of both.
 	if plan.Action() == ActionStarted {
+		// A start is when the container resolves its references, so a
+		// credential deleted while the workload was off would otherwise fail
+		// minutes later as a container that will not come up.
+		if err := verifyCredentials(loaded.Compiled.CredentialRefs); err != nil {
+			return result, err
+		}
+
 		return start(live, result, opts)
 	}
 
-	// A runtime change is its own call, which the CLI has not been given yet.
-	// Refused whether or not a version is also being rolled: rolling and
-	// leaving the sizing behind would carry out half the plan that was just
-	// printed and report the whole of it as done.
-	if !plan.Creates && (len(plan.Runtime) > 0 || !plan.RollsArtifact()) {
-		return result, fmt.Errorf("%w: %s. The plan above is correct; applying it is the next change",
-			ErrNotWired, unwired(plan))
+	// Everything below this changes a workload that is running: a rollout
+	// promotes onto something serving, and a settings change is followed by a
+	// wait for the workload to come back. Starting first and then applying the
+	// rest would bring the workload up on the version it was stopped on and
+	// report a failure afterwards, which is worse than refusing.
+	if live.State == StateStopped {
+		return result, fmt.Errorf(
+			"workload %s is stopped and the file asks for more than starting it. "+
+				"Start it with 'dr workload start %s' and deploy again, so the change lands on "+
+				"something that is running",
+			result.Name, live.WorkloadID)
+	}
+
+	// A runtime-only change sends no environment at all: the artifact keeps
+	// every variable it already has, so a credential this run does not touch
+	// must not be able to refuse a resize.
+	if !plan.Creates && !plan.RollsArtifact() {
+		return retune(loaded, result, opts, newReporter(opts.Stderr, opts.Spinner))
+	}
+
+	// Last check before the first mutation, and the only one that needs the
+	// network: a credential id is the one thing the local ledger cannot judge.
+	if err := verifyCredentials(loaded.Compiled.CredentialRefs); err != nil {
+		return result, err
 	}
 
 	report := newReporter(opts.Stderr, opts.Spinner)
@@ -287,25 +297,6 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 	}
 
 	return create(loaded, loaded.Compiled.Payload, result, opts, report)
-}
-
-// unwired names the change the plan asks for. Now that the roll is wired the
-// runtime block is the only thing left that cannot be applied, on its own or
-// alongside a roll. Calling a stopped workload "live" contradicts the plan
-// block above, whose first line says it is to be started.
-func unwired(plan Plan) string {
-	subject := "a live workload"
-	if plan.State == StateStopped {
-		subject = "a stopped workload, which is also not being started"
-	}
-
-	// Naming only the roll would read as though the rollout were the missing
-	// piece, when the rollout is the half that works.
-	if plan.RollsArtifact() {
-		return "changing the runtime settings of " + subject + " in the same deploy as a new version"
-	}
-
-	return "changing the runtime settings of " + subject
 }
 
 // deployable refuses the live states that cannot take a deploy, one message

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -92,6 +92,12 @@ type Options struct {
 	// Locking is one-way, so it happens last, only after the workload is
 	// actually serving: locking something that never came up would leave an
 	// undeletable artifact behind.
+	//
+	// It is about the end state, not about what this run happened to do. A
+	// deploy that mints no version still locks the one that is serving, which
+	// is what a start and a sizing change both do. The alternative would be a
+	// flag that sometimes locks and sometimes does not depending on which
+	// fields the file moved, and the run would have to be read to know which.
 	Lock bool
 
 	// PollInterval and PollTimeout tune the waits.

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -161,9 +161,12 @@ type fakes struct {
 
 	// The roll track: refuse to queue a second swap, start one, follow it.
 	guard       func(string) error
-	replace     func(string, string) (*workload.Replacement, error)
+	replace     func(string, string, json.RawMessage) (*workload.Replacement, error)
 	waitReplace func(string, *workload.Replacement, time.Duration, time.Duration,
 		func(*workload.Replacement)) (*workload.Replacement, error)
+
+	// settings is the in-place path: a change that moved only the sizing.
+	settings func(string, json.RawMessage) (*workload.Workload, error)
 }
 
 // install swaps in the seams the test supplied and restores them afterwards.
@@ -229,6 +232,7 @@ func install(t *testing.T, f fakes) {
 	swap(t, &guardReplacementFn, f.guard)
 	swap(t, &startReplacementFn, f.replace)
 	swap(t, &waitReplacementFn, f.waitReplace)
+	swap(t, &updateSettingsFn, f.settings)
 }
 
 // swap installs fake over the seam at target, and does nothing when the test
@@ -630,6 +634,10 @@ type track struct {
 	// is the (artifact, catalog, version) a spec-only roll inherited.
 	savedCfg wapi.Config
 	carried  []string
+
+	// rolledRuntime is the sizing that travelled with the swap, nil when the
+	// deploy changed only the version.
+	rolledRuntime json.RawMessage
 }
 
 // wiredBuild is a build path where every step works, over the track that
@@ -1029,30 +1037,6 @@ func TestRun_CreatesFromAnArtifactTheManifestNames(t *testing.T) {
 	assert.Equal(t, ActionCreated, result.Action)
 }
 
-// The refusal has to name the change the plan asks for. Calling a
-// runtime-only plan a roll contradicts the plan printed right above it.
-func TestRun_RuntimeOnlyRefusalDoesNotClaimARoll(t *testing.T) {
-	install(t, fakes{
-		workloadD: func(string) (workload.Document, error) { return doc(t, liveWorkloadJSON), nil },
-		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
-		create: func(any) (*workload.Workload, error) {
-			t.Fatal("a live workload is not created again")
-
-			return nil, nil
-		},
-	})
-
-	// Same artifact as the live one, one runtime number moved: no new version
-	// is minted, so nothing here is a roll.
-	retuned := strings.Replace(boundLiveManifest, "cpu: 3", "cpu: 6", 1)
-	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + retuned
-
-	_, _, err := runIn(t, bound, Options{NonInteractive: true})
-	require.ErrorIs(t, err, ErrNotWired)
-	assert.Contains(t, err.Error(), "runtime settings")
-	assert.NotContains(t, err.Error(), "new version", "nothing here mints an artifact")
-}
-
 func TestRun_DryRunOnABuildTrackSucceeds(t *testing.T) {
 	install(t, fakes{
 		code: func(Loaded, Live) (CodeChange, error) {
@@ -1127,13 +1111,14 @@ func TestRun_StoppedWithDriftIsRefusedWithoutStarting(t *testing.T) {
 	})
 
 	// One resource figure differs, which makes the run a retune as well as a
-	// start, and retuning is not wired.
+	// start.
 	drifted := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" +
 		strings.Replace(boundLiveManifest, "cpu: 3", "cpu: 4", 1)
 
 	_, _, err := runIn(t, drifted, Options{NonInteractive: true})
 	require.Error(t, err)
-	require.ErrorIs(t, err, ErrNotWired)
+	assert.Contains(t, err.Error(), "dr workload start")
+	assert.Contains(t, err.Error(), "more than starting it")
 }
 
 func TestRun_StartFailureNamesTheWorkload(t *testing.T) {

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -166,7 +166,7 @@ type fakes struct {
 		func(*workload.Replacement)) (*workload.Replacement, error)
 
 	// settings is the in-place path: a change that moved only the sizing.
-	settings func(string, json.RawMessage) (*workload.Workload, error)
+	settings func(string, json.RawMessage) (*workload.Replacement, error)
 }
 
 // install swaps in the seams the test supplied and restores them afterwards.


### PR DESCRIPTION
# RATIONALE

Last refusal in the package. A change that moves only the sizing (a replica count, a resource allocation, a bundle, an autoscaling policy) says nothing about what the workload runs, so it needs no artifact, no build and no rollout. It printed a correct plan and then declined to apply it; now it is one PATCH and a wait.

It also closes a hole in the roll: a deploy that changed the artifact **and** the runtime applied only the artifact, silently, while the printed plan claimed both.

## CHANGES

- `workload.UpdateWorkloadSettings` PATCHes `/workloads/{id}/settings/` with the manifest's runtime block, sent as a unit because that is how the platform takes it.
- `StartReplacement` gains an optional runtime, so a deploy that moves both sends both on one swap. Two operations would either resize the version being rolled off, or bring the new one up under the old sizing, which is how a larger model meets a bundle that cannot hold it.
- A runtime-only change is applied before credentials are verified, because it sends no environment at all: a credential this run does not touch must not be able to refuse a resize.
- The stopped-workload refusal moves up from the roll to cover both paths. A settings change is followed by a wait for the workload to come back, and a stopped one never does.
- `ErrNotWired` is deleted. Nothing refuses any more.

## NOTES

Two shapes here are documented but **not yet exercised against a live instance**: the settings route's request body, and `runtime` as an optional field on a replacement. Each is isolated to one function, and both are worth a staging run before the feature gate comes off. Same stance the file already takes for `CancelReplacement`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live deploy orchestration and two API shapes (settings PATCH and replacement `runtime`) that the PR notes are not yet validated on a live instance; coverage is strong in unit/integration tests and failures are localized to single client functions.
> 
> **Overview**
> **`dr workload up` now applies sizing-only manifest drift** (replicas, CPU/memory, bundles, autoscaling) with a settings PATCH and the usual settle wait—no build, new artifact, or rollout. The command help documents that behavior.
> 
> **Rollouts that change both artifact and runtime** send optional `runtime` on `StartReplacement` in one swap; version-only rolls omit the field so unchanged sizing is not reset.
> 
> **Apply ordering** moves the stopped-workload guard ahead of retune/roll, skips credential verification on the runtime-only path (no env is sent), and removes `ErrNotWired` so runtime plans are executed instead of refused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6cf22055a22d2f0e9e433b63ed357d6c8bbb379. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->