### PR TITLE
[RAPTOR-19326] feat(workload): store .env secrets as credentials

### DIFF
--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/datarobot/cli/internal/version"
@@ -133,7 +134,22 @@ func RedactedReqInfo(req *http.Request) string {
 		return ""
 	}
 
-	return string(requestDump)
+	return RedactSecretFields(string(requestDump))
+}
+
+// secretBodyFields matches a JSON field whose value is a secret. The dump
+// above includes the request body, and bodies carry secrets: POST
+// /credentials/ sends one by definition. Without this, `dr --debug` writes
+// the user's token into the debug log file, permanently and in the clear.
+var secretBodyFields = regexp.MustCompile(
+	`(?i)"(apiToken|password|passwd|secret|privateKey|clientSecret|refreshToken|accessToken|token)"\s*:\s*"[^"]*"`)
+
+// RedactSecretFields replaces the value of every known secret-bearing JSON
+// field in s. It is deliberately keyed on field names rather than on the value
+// looking secret: a redactor that has to recognise a secret will one day fail
+// to, and this one only has to recognise the handful of names the API uses.
+func RedactSecretFields(s string) string {
+	return secretBodyFields.ReplaceAllString(s, `"$1": "[REDACTED]"`)
 }
 
 // TODO: I believe we want to delete this function as there is SetURLToConfig function

--- a/internal/config/api_test.go
+++ b/internal/config/api_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/datarobot/cli/internal/testutil"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -227,5 +228,26 @@ func (suite *APITestSuite) TestCommandPathToTraceWithAliases() {
 			trace := CommandPathToTrace(cmd.CommandPath())
 			suite.Equal(tc.expectedTrace, trace)
 		})
+	}
+}
+
+// A credential POST sends a secret in its body, and the debug dump includes
+// bodies. Without redaction `dr --debug` writes the user's token into the log
+// file it leaves in their home directory.
+func TestRedactSecretFields(t *testing.T) {
+	const body = `{"name":"my-app/OPENAI_API_KEY","credentialType":"api_token","apiToken":"sk-live-abc123"}`
+
+	out := RedactSecretFields(body)
+
+	assert.NotContains(t, out, "sk-live-abc123")
+	assert.Contains(t, out, "[REDACTED]")
+	assert.Contains(t, out, "my-app/OPENAI_API_KEY", "the name is not a secret and is what makes a log useful")
+	assert.Contains(t, out, "api_token", "the type is not a secret either")
+}
+
+func TestRedactSecretFields_CoversTheOtherNames(t *testing.T) {
+	for _, field := range []string{"password", "secret", "privateKey", "clientSecret", "refreshToken", "token"} {
+		out := RedactSecretFields(`{"` + field + `":"hunter2"}`)
+		assert.NotContains(t, out, "hunter2", "field %q", field)
 	}
 }

--- a/internal/workload/credential.go
+++ b/internal/workload/credential.go
@@ -28,6 +28,45 @@ type Credential struct {
 	CredentialType string `json:"credentialType"`
 }
 
+// CredentialTypeAPIToken stores a single opaque token under the apiToken
+// field, which is the shape every secret imported from a .env takes: one name,
+// one value, and nothing about what the value is for.
+const CredentialTypeAPIToken = "api_token"
+
+// CreateCredential stores a secret and returns the credential holding it, so a
+// manifest can reference it by id instead of carrying the value.
+//
+// This is the one call in the CLI that sends a secret. The value goes from
+// wherever the caller read it straight to the platform and is never written to
+// disk, which is the whole point: the reference that ends up in the committed
+// manifest names a credential, and the credential is the only place the secret
+// lives.
+//
+// A name already in use comes back as a 409 wrapped in *drapi.HTTPError.
+// Callers decide what that means, because reusing a credential of the same
+// name would silently deploy whatever value it already holds, which may not be
+// the one the user just supplied.
+func CreateCredential(name, value string) (*Credential, error) {
+	url, err := config.GetEndpointURL("/api/v2/credentials/")
+	if err != nil {
+		return nil, err
+	}
+
+	body := map[string]string{
+		"name":           name,
+		"credentialType": CredentialTypeAPIToken,
+		"apiToken":       value,
+	}
+
+	var cred Credential
+
+	if err := drapi.PostJSON(url, "credential", body, &cred); err != nil {
+		return nil, err
+	}
+
+	return &cred, nil
+}
+
 // GetCredential fetches a stored credential by id. A missing id comes back as
 // a 404 wrapped in *drapi.HTTPError.
 //

--- a/internal/workload/credential.go
+++ b/internal/workload/credential.go
@@ -37,10 +37,15 @@ const CredentialTypeAPIToken = "api_token"
 // manifest can reference it by id instead of carrying the value.
 //
 // This is the one call in the CLI that sends a secret. The value goes from
-// wherever the caller read it straight to the platform and is never written to
-// disk, which is the whole point: the reference that ends up in the committed
-// manifest names a credential, and the credential is the only place the secret
-// lives.
+// wherever the caller read it straight to the platform and never reaches the
+// manifest, which is the whole point: the reference that ends up committed
+// names a credential, and the credential is the only place the secret lives.
+//
+// Not reaching the manifest is this function's own guarantee. Not reaching
+// disk at all takes one more thing, because the debug log dumps outgoing
+// request bodies and this body is a secret by definition; that is what the
+// redaction in config.RedactedReqInfo is for, and why it belongs in the same
+// change as this call rather than a later one.
 //
 // A name already in use comes back as a 409 wrapped in *drapi.HTTPError.
 // Callers decide what that means, because reusing a credential of the same

--- a/internal/workload/credential_test.go
+++ b/internal/workload/credential_test.go
@@ -15,6 +15,7 @@
 package workload
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -66,4 +67,44 @@ func TestGetCredential_EscapesID(t *testing.T) {
 
 	_, err := GetCredential("a/b")
 	require.NoError(t, err)
+}
+
+func TestCreateCredential_PostsTheValueAndReturnsTheID(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v2/credentials/", r.URL.Path)
+
+		var body map[string]string
+
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "my-app/OPENAI_API_KEY", body["name"])
+		assert.Equal(t, CredentialTypeAPIToken, body["credentialType"])
+		assert.Equal(t, "sk-live-abc123", body["apiToken"])
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"credentialId":"66f1a2b3c4d5e6f7a8b9c0d1","name":"my-app/OPENAI_API_KEY"}`)
+	}))
+
+	cred, err := CreateCredential("my-app/OPENAI_API_KEY", "sk-live-abc123")
+	require.NoError(t, err)
+	assert.Equal(t, "66f1a2b3c4d5e6f7a8b9c0d1", cred.CredentialID)
+}
+
+// A name already in use is the caller's decision, not this function's:
+// reusing whatever credential holds that name would deploy a value the user
+// never supplied.
+func TestCreateCredential_ConflictSurvivesAsAnHTTPError(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprint(w, `{"detail":"credential name already exists"}`)
+	}))
+
+	_, err := CreateCredential("my-app/OPENAI_API_KEY", "sk-live-abc123")
+	require.Error(t, err)
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "already exists")
 }

--- a/internal/workload/credential_test.go
+++ b/internal/workload/credential_test.go
@@ -17,9 +17,11 @@ package workload
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 
+	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -107,4 +109,33 @@ func TestCreateCredential_ConflictSurvivesAsAnHTTPError(t *testing.T) {
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
 	assert.Contains(t, err.Error(), "already exists")
+}
+
+// The debug log dumps outgoing request bodies, and this body is a secret by
+// definition. Redaction is keyed on field names, so the guarantee only holds
+// while the name this call sends is one of the names the redactor knows: a
+// release carrying the POST but not that pairing writes the user's token, in
+// the clear, into a log file in their home directory.
+func TestCreateCredential_TheFieldItSendsIsOneTheDebugLogRedacts(t *testing.T) {
+	var (
+		sent   []byte
+		readEr error
+	)
+
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sent, readEr = io.ReadAll(r.Body)
+
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"credentialId":"c1","name":"my-app/OPENAI_API_KEY"}`)
+	}))
+
+	_, err := CreateCredential("my-app/OPENAI_API_KEY", "sk-live-abc123")
+	require.NoError(t, err)
+	require.NoError(t, readEr)
+	require.Contains(t, string(sent), "sk-live-abc123", "the platform still gets the real value")
+
+	redacted := config.RedactSecretFields(string(sent))
+
+	assert.NotContains(t, redacted, "sk-live-abc123", "and the debug log never does")
+	assert.Contains(t, redacted, "REDACTED")
 }

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -283,7 +283,7 @@ func applyEnvVars(container map[string]any, vars []EnvVar) {
 
 		value := v.Value
 		if v.Secret {
-			value = CredentialShorthandPrefix + CredentialPlaceholder + "/" + credentialKey
+			value = CredentialShorthandPrefix + v.credentialID() + "/" + credentialKey
 		}
 
 		existing = append(existing, map[string]any{keyName: v.Name, keyValue: value})

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -125,9 +125,23 @@ type EnvVar struct {
 	// value belongs in the credential store and never in this file.
 	Value string
 	// Secret means the value belongs in the credential store, so the entry is
-	// written as a reference carrying CredentialPlaceholder in place of an id
-	// that does not exist yet.
+	// written as a reference rather than as a literal.
 	Secret bool
+	// CredentialID is the credential holding the secret, when one was stored
+	// for it. Empty means none was, and the reference is written carrying
+	// CredentialPlaceholder instead: an entry that is visibly unfinished, which
+	// a deploy refuses by name.
+	CredentialID string
+}
+
+// credentialID is the id to write for a secret, and the placeholder when the
+// secret never reached the credential store.
+func (v EnvVar) credentialID() string {
+	if v.CredentialID == "" {
+		return CredentialPlaceholder
+	}
+
+	return v.CredentialID
 }
 
 // CredentialPlaceholder stands in for a credential id until one is created.
@@ -402,7 +416,8 @@ func (d Draft) runtime() *yaml.Node {
 }
 
 // environmentVars renders the .env variables the manifest carries. Ordinary
-// settings become literals. Secrets become credential references carrying
+// settings become literals. A secret becomes a credential reference: to the
+// credential that was stored for it, or, when none was, to
 // CredentialPlaceholder, so the entry is present and obviously unfinished
 // rather than absent and easy to miss.
 func (d Draft) environmentVars() *yaml.Node {
@@ -412,14 +427,20 @@ func (d Draft) environmentVars() *yaml.Node {
 		value := scalar(v.Value)
 		entry := []field{{key: keyName, value: scalar(v.Name)}}
 
-		if v.Secret {
+		switch {
+		case v.Secret && v.CredentialID == "":
 			value = scalar(CredentialShorthandPrefix + CredentialPlaceholder + "/" + credentialKey)
 			entry = append(entry, field{
 				key:     keyValue,
 				value:   value,
 				comment: "replace " + CredentialPlaceholder + " with the credential id",
 			})
-		} else {
+
+		case v.Secret:
+			value = scalar(CredentialShorthandPrefix + v.credentialID() + "/" + credentialKey)
+			entry = append(entry, field{key: keyValue, value: value})
+
+		default:
 			entry = append(entry, field{key: keyValue, value: value})
 		}
 

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -611,3 +611,115 @@ func opensBlock(line string) bool {
 
 	return false
 }
+
+// ResolveCredentials rewrites every credential reference still carrying
+// CredentialPlaceholder to the id stored for that variable, keyed by ids on
+// the environment variable's name.
+//
+// This exists for one case: the setup wizard's confirm screen lets the file be
+// edited by hand before it is written, and the credentials are stored after
+// that, deliberately, so walking to the end and cancelling leaves nothing
+// behind. Re-rendering from the draft at that point would produce a file
+// carrying the new ids and none of the user's edit. Editing their own bytes
+// keeps both.
+//
+// Matching is by variable name because the placeholder text is identical for
+// every secret in the file: two of them differ only in which entry they sit
+// in, so a textual substitution could not tell them apart. A name the map does
+// not mention is left alone, placeholder and all, which is what an entry no
+// credential was stored for should look like.
+func ResolveCredentials(content []byte, ids map[string]string) ([]byte, error) {
+	if len(ids) == 0 {
+		return content, nil
+	}
+
+	var doc yaml.Node
+
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		return nil, fmt.Errorf("cannot parse the manifest to record the credential ids: %w", err)
+	}
+
+	if len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
+		return nil, errors.New("cannot record the credential ids: root must be a YAML mapping")
+	}
+
+	if err := checkAliases(doc.Content[0]); err != nil {
+		return nil, fmt.Errorf("cannot record the credential ids: %w", err)
+	}
+
+	setCredentialIDs(doc.Content[0], ids)
+
+	var buf bytes.Buffer
+
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+
+	if err := enc.Encode(&doc); err != nil {
+		return nil, fmt.Errorf("cannot render the manifest: %w", err)
+	}
+
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("cannot render the manifest: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// setCredentialIDs walks every environmentVars sequence in the tree, wherever
+// the spec puts it, and fills in the placeholders it finds.
+func setCredentialIDs(node *yaml.Node, ids map[string]string) {
+	node = resolveAlias(node)
+	if node == nil {
+		return
+	}
+
+	switch node.Kind {
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if node.Content[i].Value == keyEnvironmentVars {
+				fillPlaceholders(node.Content[i+1], ids)
+			}
+
+			setCredentialIDs(node.Content[i+1], ids)
+		}
+	case yaml.SequenceNode:
+		for _, item := range node.Content {
+			setCredentialIDs(item, ids)
+		}
+	case yaml.DocumentNode, yaml.ScalarNode, yaml.AliasNode:
+		// Leaves. AliasNode is unreachable: resolveAlias replaced it above.
+	}
+}
+
+// fillPlaceholders rewrites one environmentVars sequence.
+func fillPlaceholders(vars *yaml.Node, ids map[string]string) {
+	placeholder := CredentialShorthandPrefix + CredentialPlaceholder + "/"
+
+	for _, entry := range seqItems(vars) {
+		name, ok := scalarString(mapValue(entry, keyName))
+		if !ok {
+			continue
+		}
+
+		id, ok := ids[name]
+		if !ok || id == "" {
+			continue
+		}
+
+		value := mapValue(entry, keyValue)
+		if value == nil {
+			continue
+		}
+
+		current, ok := scalarString(value)
+		if !ok || !strings.HasPrefix(current, placeholder) {
+			continue
+		}
+
+		value.SetString(CredentialShorthandPrefix + id + "/" + strings.TrimPrefix(current, placeholder))
+
+		// The comment told the reader to replace the placeholder, which has
+		// now happened.
+		value.LineComment = ""
+	}
+}

--- a/internal/workload/manifest/write_test.go
+++ b/internal/workload/manifest/write_test.go
@@ -434,3 +434,73 @@ func TestRender_NoEnvKeysWritesNoBlock(t *testing.T) {
 	assert.NotContains(t, string(out), "environmentVars")
 	assert.NotContains(t, string(out), ".env")
 }
+
+// Two secrets render the same placeholder text, differing only in which entry
+// they sit in, so the id has to be matched to the variable by name. A textual
+// substitution could not tell them apart and would give both the same
+// credential.
+func TestResolveCredentials_MatchesEachSecretByName(t *testing.T) {
+	content := []byte(`name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            environmentVars:
+              - name: OPENAI_API_KEY
+                value: dr-credential:PLACEHOLDER/apiToken # replace PLACEHOLDER with the credential id
+              - name: DATABASE_URL
+                value: dr-credential:PLACEHOLDER/apiToken # replace PLACEHOLDER with the credential id
+              - name: LOG_LEVEL
+                value: debug
+`)
+
+	out, err := ResolveCredentials(content, map[string]string{
+		"OPENAI_API_KEY": "66f000000000000000000001",
+		"DATABASE_URL":   "66f000000000000000000002",
+	})
+	require.NoError(t, err)
+
+	got := string(out)
+
+	assert.Contains(t, got, "dr-credential:66f000000000000000000001/apiToken")
+	assert.Contains(t, got, "dr-credential:66f000000000000000000002/apiToken")
+	assert.NotContains(t, got, CredentialPlaceholder, "no entry keeps a placeholder, and none is told to replace one")
+	assert.Contains(t, got, "value: debug", "a variable that is not a secret is untouched")
+}
+
+// An entry no credential was stored for keeps its placeholder: it is the file
+// saying, visibly, that it is not finished.
+func TestResolveCredentials_LeavesUnstoredEntriesAlone(t *testing.T) {
+	content := []byte(`name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            environmentVars:
+              - name: OPENAI_API_KEY
+                value: dr-credential:PLACEHOLDER/apiToken
+              - name: DATABASE_URL
+                value: dr-credential:PLACEHOLDER/apiToken
+`)
+
+	out, err := ResolveCredentials(content, map[string]string{"OPENAI_API_KEY": "66f000000000000000000001"})
+	require.NoError(t, err)
+
+	got := string(out)
+
+	assert.Contains(t, got, "dr-credential:66f000000000000000000001/apiToken")
+	assert.Contains(t, got, "dr-credential:PLACEHOLDER/apiToken", "the one nothing was stored for stays unfinished")
+}
+
+// A hand-edited file can be anything, including unparseable. Failing loudly
+// beats writing a file the ids never reached.
+func TestResolveCredentials_RefusesWhatItCannotParse(t *testing.T) {
+	_, err := ResolveCredentials([]byte("name: [unclosed\n"), map[string]string{"A": "b"})
+	require.Error(t, err)
+}

--- a/internal/workload/wizard/mint.go
+++ b/internal/workload/wizard/mint.go
@@ -1,0 +1,186 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+)
+
+// Import is what storing the secrets did, one entry per secret the run tried
+// to store. It exists so the caller can report the outcome per variable: a
+// partial import is the normal failure here, not an exceptional one, and
+// "3 of 5 stored" is the only honest way to say it.
+type Import struct {
+	// Stored are the variables now carrying a credential id.
+	Stored []string
+	// Failed are the variables still carrying the placeholder, each with the
+	// reason, ready to be printed.
+	Failed []ImportFailure
+}
+
+// ImportFailure is one secret that did not reach the credential store.
+type ImportFailure struct {
+	// Name is the environment variable, which is what the user recognises;
+	// the credential name is derived from it and is noise by comparison.
+	Name string
+	// Reason is why, phrased for someone who now has to finish the job by
+	// hand. It never carries the value.
+	Reason string
+}
+
+// Any reports whether anything was tried at all.
+func (i Import) Any() bool {
+	return len(i.Stored) > 0 || len(i.Failed) > 0
+}
+
+// importSecrets stores each secret and writes the credential id back into the
+// variable, so the manifest can reference it instead of carrying a
+// placeholder. It is the half of the .env import that needs the network, and
+// the only place in setup that sends a secret anywhere.
+//
+// Values come from detected rather than from vars: a manifest.EnvVar has no
+// value for a secret by construction, which is what keeps a secret out of the
+// file even when a render goes wrong. The value is read here, sent, and
+// dropped.
+//
+// One secret failing does not fail the run. The variable keeps its
+// placeholder, which is an entry a deploy refuses by name, so the worst case
+// is the state this whole feature started from rather than a wizard that
+// leaves nothing on disk after asking eight questions.
+func importSecrets(vars []manifest.EnvVar, detected Detected, workloadName string) ([]manifest.EnvVar, Import) {
+	values := secretValues(detected)
+	out := make([]manifest.EnvVar, len(vars))
+	copy(out, vars)
+
+	var report Import
+
+	for i, v := range out {
+		if !v.Secret || v.CredentialID != "" {
+			continue
+		}
+
+		value, ok := values[v.Name]
+		if !ok || value == "" {
+			// Classified as a secret with nothing to store: an empty
+			// assignment in the .env, or a name the table added by hand.
+			report.Failed = append(report.Failed, ImportFailure{
+				Name:   v.Name,
+				Reason: "it has no value in " + EnvFileName,
+			})
+
+			continue
+		}
+
+		cred, err := createCredentialFn(credentialName(workloadName, v.Name), value)
+		if err != nil {
+			report.Failed = append(report.Failed, ImportFailure{Name: v.Name, Reason: importReason(err)})
+
+			continue
+		}
+
+		out[i].CredentialID = cred.CredentialID
+
+		report.Stored = append(report.Stored, v.Name)
+	}
+
+	return out, report
+}
+
+// secretValues indexes the detected values by name. The map is built once
+// rather than searched per variable, and holds only what is about to be sent.
+func secretValues(detected Detected) map[string]string {
+	values := make(map[string]string, len(detected.EnvVars))
+
+	for _, v := range detected.EnvVars {
+		values[v.Name] = v.Value
+	}
+
+	return values
+}
+
+// credentialName is what the credential is called in a store shared by the
+// whole tenant. The workload name is the prefix because a bare OPENAI_API_KEY
+// belongs to whoever created it first, and the second project to try would
+// collide with a credential it cannot see the value of.
+func credentialName(workloadName, envName string) string {
+	if workloadName == "" {
+		return envName
+	}
+
+	return workloadName + "/" + envName
+}
+
+// importReason turns a failure into something worth reading. A name already
+// taken is the one case with an obvious next step, and it is common: running
+// setup twice on the same project reaches it every time.
+func importReason(err error) string {
+	var httpErr *drapi.HTTPError
+
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusConflict {
+		return "a credential of that name already exists; " +
+			"reuse it by pasting its id, or rename it in the DataRobot UI"
+	}
+
+	return strings.TrimSpace(err.Error())
+}
+
+// reportImport says what reached the credential store. Silence would be the
+// wrong answer either way: a secret that was stored is a thing that now exists
+// outside this repository, and one that was not is an entry the next deploy
+// will refuse.
+func reportImport(stderr io.Writer, report Import) {
+	if stderr == nil || !report.Any() {
+		return
+	}
+
+	if len(report.Stored) > 0 {
+		fmt.Fprintf(stderr, "Stored %d %s in the credential store: %s.\n",
+			len(report.Stored), Plural(len(report.Stored), "secret", "secrets"),
+			strings.Join(report.Stored, ", "))
+	}
+
+	for _, failure := range report.Failed {
+		fmt.Fprintf(stderr,
+			"Warning: %s was not stored, because %s.\n"+
+				"  Its entry in %s still says %s; a deploy will refuse it until that is a credential id.\n",
+			failure.Name, failure.Reason, manifest.FileName, manifest.CredentialPlaceholder)
+	}
+}
+
+// pendingSecrets counts the entries still carrying a placeholder, which is
+// what the command reports as unfinished.
+func pendingSecrets(vars []manifest.EnvVar) int {
+	pending := 0
+
+	for _, v := range vars {
+		if v.Secret && v.CredentialID == "" {
+			pending++
+		}
+	}
+
+	return pending
+}
+
+// createCredentialFn is the seam the tests replace: storing a secret is the
+// one call in setup that cannot be allowed to reach a real tenant by accident.
+var createCredentialFn = workload.CreateCredential

--- a/internal/workload/wizard/mint_test.go
+++ b/internal/workload/wizard/mint_test.go
@@ -261,3 +261,58 @@ func TestFlow_CancelStoresNothing(t *testing.T) {
 	require.Error(t, err)
 	assert.Empty(t, *stored)
 }
+
+// --dry-run promises to change nothing, and a credential is a change that
+// outlives the run. The interactive path has to mean by it what the headless
+// one does.
+func TestFlow_DryRunStoresNothing(t *testing.T) {
+	stored := credentialStore(t)
+
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\nEXPOSE 3000\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz01\n"), 0o600))
+
+	start := newFlow(Detect(dir), nil, Answers{})
+	start.dryRun = true
+
+	model := press(t, pastName(t, start), "enter", "enter", "enter", "enter")
+	require.Equal(t, screenConfirm, model.at)
+
+	accepted := press(t, model, "enter")
+
+	assert.Empty(t, *stored, "a run that writes no file must create no credential")
+	assert.True(t, accepted.done)
+	assert.Contains(t, string(accepted.content), "PLACEHOLDER",
+		"with nothing stored there is no id to write, and the entry stays visibly unfinished")
+}
+
+// The confirm screen's [e] is the last chance to change the file, and the
+// secrets are stored after it. Re-rendering from the draft at that point threw
+// the edit away, silently, in the one step between agreeing and the write.
+func TestFlow_ConfirmKeepsAHandEditWhenSecretsAreStored(t *testing.T) {
+	stored := credentialStore(t)
+
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\nEXPOSE 3000\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz01\n"), 0o600))
+
+	model := press(t, pastName(t, newFlow(Detect(dir), nil, Answers{})), "enter", "enter", "enter", "enter")
+	require.Equal(t, screenConfirm, model.at)
+
+	// What the editor left: the rendered file with one line the wizard would
+	// never produce.
+	edit := strings.Replace(string(model.content), "importance: low", "importance: high", 1)
+	require.NotEqual(t, string(model.content), edit, "the fixture has to actually change something")
+
+	edited, _ := model.edited(editedMsg{content: []byte(edit)})
+	model, ok := edited.(flow)
+	require.True(t, ok)
+
+	accepted := press(t, model, "enter")
+	require.Len(t, *stored, 1)
+
+	assert.Contains(t, string(accepted.content), "importance: high", "the hand edit survives to the file")
+	assert.Contains(t, string(accepted.content), "dr-credential:66f000000000000000000001/apiToken",
+		"and the credential the run stored is still the one referenced")
+	assert.NotContains(t, string(accepted.content), "PLACEHOLDER")
+}

--- a/internal/workload/wizard/mint_test.go
+++ b/internal/workload/wizard/mint_test.go
@@ -1,0 +1,263 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// storedCredential is one call to the credential store, kept so a test can
+// assert what was sent without the store existing.
+type storedCredential struct {
+	Name  string
+	Value string
+}
+
+// credentialStore makes storing succeed, and records what was stored. Every
+// test that imports a .env carrying a secret has to say which store it runs
+// against, because the difference is whether the manifest ends up with an id
+// or with a placeholder.
+func credentialStore(t *testing.T) *[]storedCredential {
+	t.Helper()
+
+	stored := make([]storedCredential, 0)
+
+	original := createCredentialFn
+	createCredentialFn = func(name, value string) (*workload.Credential, error) {
+		stored = append(stored, storedCredential{Name: name, Value: value})
+
+		return &workload.Credential{CredentialID: "66f0000000000000000000" + itoa(len(stored)), Name: name}, nil
+	}
+
+	t.Cleanup(func() { createCredentialFn = original })
+
+	return &stored
+}
+
+// noCredentialStore makes storing fail the way an unreachable platform does.
+func noCredentialStore(t *testing.T, err error) {
+	t.Helper()
+
+	original := createCredentialFn
+	createCredentialFn = func(string, string) (*workload.Credential, error) { return nil, err }
+
+	t.Cleanup(func() { createCredentialFn = original })
+}
+
+// itoa is strconv.Itoa padded to two digits, so the ids the fake store hands
+// out are the same length as real ones.
+func itoa(n int) string {
+	return fmt.Sprintf("%02d", n)
+}
+
+// envProject is a project with a Dockerfile and a .env holding one ordinary
+// setting and one secret.
+func envProject(t *testing.T) string {
+	t.Helper()
+
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("LOG_LEVEL=debug\nOPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz01\n"), 0o600))
+
+	return dir
+}
+
+// The point of the whole import: the value goes from .env to the credential
+// store, and what lands in the committed file is an id.
+func TestRun_SecretsBecomeCredentials(t *testing.T) {
+	stored := credentialStore(t)
+	dir := envProject(t)
+
+	result, err := Run(headless(dir, Answers{Name: "my-app"}))
+	require.NoError(t, err)
+
+	require.Len(t, *stored, 1, "only the secret is stored; an ordinary setting is a literal")
+	assert.Equal(t, "my-app/OPENAI_API_KEY", (*stored)[0].Name,
+		"the store is tenant-wide, so a bare variable name would collide with every other project")
+	assert.Equal(t, "sk-abcdefghijklmnopqrstuvwxyz01", (*stored)[0].Value)
+
+	written := string(result.Content)
+
+	assert.Contains(t, written, "dr-credential:66f000000000000000000001/apiToken")
+	assert.NotContains(t, written, "PLACEHOLDER")
+	assert.NotContains(t, written, "sk-abcdefghijklmnopqrstuvwxyz01", "the value never reaches the file")
+	assert.Equal(t, 0, result.EnvSecretsPending, "nothing is left for the user to finish")
+}
+
+// A store that cannot be reached leaves the entry as it was before this
+// existed: present, obviously unfinished, and refused by name at deploy.
+func TestRun_UnreachableStoreLeavesThePlaceholder(t *testing.T) {
+	noCredentialStore(t, errors.New("dial tcp: connection refused"))
+
+	dir := envProject(t)
+
+	var stderr strings.Builder
+
+	opts := headless(dir, Answers{Name: "my-app"})
+	opts.Stderr = &stderr
+
+	result, err := Run(opts)
+	require.NoError(t, err, "one secret failing must not throw away eight answered questions")
+
+	assert.Contains(t, string(result.Content), "dr-credential:PLACEHOLDER/apiToken")
+	assert.Equal(t, 1, result.EnvSecretsPending)
+	assert.Contains(t, stderr.String(), "OPENAI_API_KEY was not stored")
+	assert.Contains(t, stderr.String(), "connection refused")
+	assert.NotContains(t, stderr.String(), "sk-abcdefghijklmnopqrstuvwxyz01",
+		"a message about a secret must not carry it")
+}
+
+// Running setup twice on the same project is the common way to meet a name
+// that is taken, and reusing whatever holds it would deploy a value the user
+// never supplied.
+func TestRun_TakenCredentialNameSaysHowToFinish(t *testing.T) {
+	noCredentialStore(t, &drapi.HTTPError{StatusCode: http.StatusConflict})
+
+	dir := envProject(t)
+
+	var stderr strings.Builder
+
+	opts := headless(dir, Answers{Name: "my-app"})
+	opts.Stderr = &stderr
+
+	_, err := Run(opts)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr.String(), "already exists")
+	assert.Contains(t, stderr.String(), "pasting its id")
+}
+
+// A dry run promises to change nothing, and a credential is the one thing
+// this command creates that outlives the file it was about to write.
+func TestRun_DryRunStoresNothing(t *testing.T) {
+	stored := credentialStore(t)
+	dir := envProject(t)
+
+	opts := headless(dir, Answers{Name: "my-app"})
+	opts.DryRun = true
+
+	result, err := Run(opts)
+	require.NoError(t, err)
+
+	assert.Empty(t, *stored, "a dry run must not leave a credential behind")
+	assert.Contains(t, string(result.Content), "PLACEHOLDER")
+}
+
+// --skip-env means the file carries nothing from .env, so there is nothing to
+// store either.
+func TestRun_SkipEnvStoresNothing(t *testing.T) {
+	stored := credentialStore(t)
+	dir := envProject(t)
+
+	_, err := Run(headless(dir, Answers{Name: "my-app", SkipEnv: true}))
+	require.NoError(t, err)
+
+	assert.Empty(t, *stored)
+}
+
+// A secret classified from a name with an empty assignment has nothing to
+// store. Sending an empty value would create a credential that resolves to
+// nothing, which fails at the container rather than here.
+func TestImportSecrets_NoValueIsReportedNotSent(t *testing.T) {
+	stored := credentialStore(t)
+
+	vars, report := importSecrets(
+		[]manifest.EnvVar{{Name: "API_TOKEN", Secret: true}},
+		Detected{EnvVars: []EnvVar{{Name: "API_TOKEN", Kind: EnvSecret, Value: ""}}},
+		"my-app",
+	)
+
+	assert.Empty(t, *stored)
+	assert.Empty(t, vars[0].CredentialID)
+	require.Len(t, report.Failed, 1)
+	assert.Contains(t, report.Failed[0].Reason, "no value")
+}
+
+// A variable that already names a credential is left alone: it was stored by
+// an earlier run, or written by hand, and storing it again would leave the
+// first one orphaned.
+func TestImportSecrets_AlreadyStoredIsLeftAlone(t *testing.T) {
+	stored := credentialStore(t)
+
+	vars, report := importSecrets(
+		[]manifest.EnvVar{{Name: "API_TOKEN", Secret: true, CredentialID: "66f0aaaa0000000000000001"}},
+		Detected{EnvVars: []EnvVar{{Name: "API_TOKEN", Kind: EnvSecret, Value: "shhh"}}},
+		"my-app",
+	)
+
+	assert.Empty(t, *stored)
+	assert.Equal(t, "66f0aaaa0000000000000001", vars[0].CredentialID)
+	assert.False(t, report.Any())
+}
+
+// An unnamed workload still produces a usable credential name rather than an
+// empty prefix and a stray slash.
+func TestCredentialName_WithoutAWorkloadName(t *testing.T) {
+	assert.Equal(t, "my-app/OPENAI_API_KEY", credentialName("my-app", "OPENAI_API_KEY"))
+	assert.Equal(t, "OPENAI_API_KEY", credentialName("", "OPENAI_API_KEY"))
+}
+
+// Interactively the secrets are stored when the confirm screen is accepted,
+// and the file that gets written is the one that was on screen with the
+// placeholders resolved.
+func TestFlow_ConfirmStoresTheSecrets(t *testing.T) {
+	stored := credentialStore(t)
+
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\nEXPOSE 3000\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz01\n"), 0o600))
+
+	// Name, kind, source, readiness, env: the confirm screen is next.
+	model := press(t, pastName(t, newFlow(Detect(dir), nil, Answers{})), "enter", "enter", "enter", "enter")
+	require.Equal(t, screenConfirm, model.at)
+	assert.Contains(t, string(model.content), "PLACEHOLDER", "nothing has been stored while it can still be cancelled")
+
+	accepted := press(t, model, "enter")
+
+	require.Len(t, *stored, 1)
+	assert.Equal(t, "test-app/OPENAI_API_KEY", (*stored)[0].Name)
+	assert.True(t, accepted.done)
+	assert.Contains(t, string(accepted.content), "dr-credential:66f000000000000000000001/apiToken")
+	assert.NotContains(t, string(accepted.content), "PLACEHOLDER")
+}
+
+// Cancelling after walking the whole wizard must leave nothing behind: a
+// credential outlives the run that created it.
+func TestFlow_CancelStoresNothing(t *testing.T) {
+	stored := credentialStore(t)
+
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\nEXPOSE 3000\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
+		[]byte("OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz01\n"), 0o600))
+
+	model := press(t, pastName(t, newFlow(Detect(dir), nil, Answers{})), "enter", "enter", "enter", "enter")
+	require.Equal(t, screenConfirm, model.at)
+
+	_, _, err := press(t, model, "esc").result()
+	require.Error(t, err)
+	assert.Empty(t, *stored)
+}

--- a/internal/workload/wizard/model.go
+++ b/internal/workload/wizard/model.go
@@ -108,6 +108,17 @@ type flow struct {
 	imports  Import
 	imported bool
 
+	// dryRun stops the confirm screen storing anything. A run that promises
+	// to write no file must not leave a credential behind either, and a
+	// credential outlives the run that made it.
+	dryRun bool
+
+	// handEdited records that the confirm screen's [e] was used, so the file
+	// about to be written is the user's bytes rather than a render of the
+	// draft. It decides how the credential ids get in: re-rendering would
+	// throw the edit away.
+	handEdited bool
+
 	// nameGiven distinguishes a name the user chose from the one the
 	// directory suggested, so returning to the screen shows the answer that
 	// was given there and never re-offers a suggestion as a typed value.
@@ -510,7 +521,10 @@ var accepting = map[screen]func(*flow) (tea.Cmd, error){
 // screen is where a secret's value could leak, and no value is on it either
 // way.
 func (f *flow) acceptConfirm() (tea.Cmd, error) {
-	if f.imported || pendingSecrets(f.draft.EnvVars) == 0 {
+	// A dry run stores nothing, the same as the headless path. The references
+	// keep their placeholders, which is what a file nobody created a
+	// credential for should say.
+	if f.imported || f.dryRun || pendingSecrets(f.draft.EnvVars) == 0 {
 		return nil, nil
 	}
 
@@ -525,9 +539,9 @@ func (f *flow) acceptConfirm() (tea.Cmd, error) {
 	}, nil
 }
 
-// secretsStored records the ids and re-renders, so what is written is what was
-// on screen with the placeholders resolved. A render that fails now is fatal:
-// the credentials exist, and ending as a cancellation would say nothing
+// secretsStored records the ids and puts them in the file, so what is written
+// is what was on screen with the placeholders resolved. A failure now is
+// fatal: the credentials exist, and ending as a cancellation would say nothing
 // happened.
 func (f flow) secretsStored(msg secretsStoredMsg) (tea.Model, tea.Cmd) {
 	f.loading = ""
@@ -535,7 +549,7 @@ func (f flow) secretsStored(msg secretsStoredMsg) (tea.Model, tea.Cmd) {
 	f.imports = msg.report
 	f.draft.EnvVars = msg.vars
 
-	if err := f.render(); err != nil {
+	if err := f.resolveContent(); err != nil {
 		f.fatal = err
 
 		return f, tea.Quit
@@ -544,6 +558,41 @@ func (f flow) secretsStored(msg secretsStoredMsg) (tea.Model, tea.Cmd) {
 	f.done = true
 
 	return f, tea.Quit
+}
+
+// resolveContent puts the new credential ids into what is about to be written.
+//
+// A file nobody touched is re-rendered from the draft, which now carries them.
+// One edited by hand on the confirm screen is not: re-rendering would throw
+// that edit away silently, at the last moment before the write, including any
+// credential id the user pasted in themselves. The placeholders in their own
+// bytes are rewritten instead.
+func (f *flow) resolveContent() error {
+	if !f.handEdited {
+		return f.render()
+	}
+
+	resolved, err := manifest.ResolveCredentials(f.content, credentialIDs(f.draft.EnvVars))
+	if err != nil {
+		return err
+	}
+
+	f.content = resolved
+
+	return f.rediff()
+}
+
+// credentialIDs is the id stored for each variable, by variable name.
+func credentialIDs(vars []manifest.EnvVar) map[string]string {
+	ids := make(map[string]string, len(vars))
+
+	for _, v := range vars {
+		if v.Secret && v.CredentialID != "" {
+			ids[v.Name] = v.CredentialID
+		}
+	}
+
+	return ids
 }
 
 // accept validates and records the current screen's answer. A non-nil command
@@ -936,16 +985,27 @@ func (f flow) edited(msg editedMsg) (tea.Model, tea.Cmd) {
 	}
 
 	f.content = msg.content
+	f.handEdited = true
 
 	// The diff has to be recomputed against what the editor left, not
 	// cleared: an empty diff is how the screen says "nothing changes for the
 	// running workload", which an edited file has no business claiming.
+	if err := f.rediff(); err != nil {
+		f.failed = err
+
+		return f, nil
+	}
+
+	return f, nil
+}
+
+// rediff recomputes what the confirm screen shows against the current bytes,
+// which is only meaningful when a live workload is being changed.
+func (f *flow) rediff() error {
 	if f.live != nil {
 		before, err := f.live.Render()
 		if err != nil {
-			f.failed = err
-
-			return f, nil
+			return err
 		}
 
 		f.diff = unifiedDiff(f.live.Name, string(before), string(f.content))
@@ -953,7 +1013,7 @@ func (f flow) edited(msg editedMsg) (tea.Model, tea.Cmd) {
 
 	f.buildPreview()
 
-	return f, nil
+	return nil
 }
 
 func (f flow) result() ([]byte, manifest.Draft, error) {

--- a/internal/workload/wizard/model.go
+++ b/internal/workload/wizard/model.go
@@ -101,6 +101,13 @@ type flow struct {
 	// failures no screen can recover from.
 	fatal error
 
+	// imports is what storing the secrets did, read once the flow has ended
+	// and the terminal is back. imported stops a second attempt: the confirm
+	// screen can be reached twice, and a credential already stored must not be
+	// stored again under a second name.
+	imports  Import
+	imported bool
+
 	// nameGiven distinguishes a name the user chose from the one the
 	// directory suggested, so returning to the screen shows the answer that
 	// was given there and never re-offers a suggestion as a typed value.
@@ -128,6 +135,13 @@ type execEnvsLoadedMsg struct {
 type editedMsg struct {
 	content []byte
 	err     error
+}
+
+// secretsStoredMsg carries the variables with their credential ids filled in,
+// and the record of which of them made it.
+type secretsStoredMsg struct {
+	vars   []manifest.EnvVar
+	report Import
 }
 
 func newFlow(detected Detected, workloads []workload.Workload, answers Answers) flow {
@@ -233,6 +247,9 @@ func (f flow) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case editedMsg:
 		return f.edited(msg)
+
+	case secretsStoredMsg:
+		return f.secretsStored(msg)
 
 	case tea.KeyMsg:
 		return f.key(msg)
@@ -479,6 +496,54 @@ var accepting = map[screen]func(*flow) (tea.Cmd, error){
 	screenImage:      (*flow).acceptImage,
 	screenSettings:   (*flow).acceptSettings,
 	screenEnv:        (*flow).acceptEnv,
+	screenConfirm:    (*flow).acceptConfirm,
+}
+
+// acceptConfirm stores the secrets, and is the last thing that happens before
+// the file is written.
+//
+// Here rather than when the env table is left, because a credential outlives
+// the run that created it: someone who walks the wizard to the end and then
+// cancels should not have left a secret on the platform. The cost is that the
+// confirm screen shows the reference carrying the placeholder while the file
+// written a moment later carries the id. That is the right way round; the
+// screen is where a secret's value could leak, and no value is on it either
+// way.
+func (f *flow) acceptConfirm() (tea.Cmd, error) {
+	if f.imported || pendingSecrets(f.draft.EnvVars) == 0 {
+		return nil, nil
+	}
+
+	f.loading = "Storing secrets…"
+
+	vars, detected, name := f.draft.EnvVars, f.detected, f.draft.Name
+
+	return func() tea.Msg {
+		stored, report := importSecrets(vars, detected, name)
+
+		return secretsStoredMsg{vars: stored, report: report}
+	}, nil
+}
+
+// secretsStored records the ids and re-renders, so what is written is what was
+// on screen with the placeholders resolved. A render that fails now is fatal:
+// the credentials exist, and ending as a cancellation would say nothing
+// happened.
+func (f flow) secretsStored(msg secretsStoredMsg) (tea.Model, tea.Cmd) {
+	f.loading = ""
+	f.imported = true
+	f.imports = msg.report
+	f.draft.EnvVars = msg.vars
+
+	if err := f.render(); err != nil {
+		f.fatal = err
+
+		return f, tea.Quit
+	}
+
+	f.done = true
+
+	return f, tea.Quit
 }
 
 // accept validates and records the current screen's answer. A non-nil command

--- a/internal/workload/wizard/regression_test.go
+++ b/internal/workload/wizard/regression_test.go
@@ -421,10 +421,12 @@ func TestInteractiveOutput_NeverStdout(t *testing.T) {
 	assert.Same(t, os.Stderr, interactiveOutput(&bytes.Buffer{}))
 }
 
-// The .env keys reach the file as commented placeholders by default, because
-// a deploy that silently drops the app's configuration is the worse default.
-// Values never do.
+// The .env keys reach the file by default, because a deploy that silently
+// drops the app's configuration is the worse default. Values never do: an
+// ordinary setting is a literal, a secret is a reference.
 func TestRun_EnvKeysAreListedByDefault(t *testing.T) {
+	noCredentialStore(t, errors.New("no store in this test"))
+
 	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
 	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
 		[]byte("LOG_LEVEL=debug\nOPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz01\n"), 0o600))
@@ -440,8 +442,8 @@ func TestRun_EnvKeysAreListedByDefault(t *testing.T) {
 	assert.Contains(t, written, "- name: LOG_LEVEL")
 	assert.Contains(t, written, "value: debug")
 
-	// The secret is a reference carrying the placeholder, and its value never
-	// leaves .env.
+	// With no store to send it to, the secret is a reference carrying the
+	// placeholder. Its value never leaves .env either way.
 	assert.Contains(t, written, "- name: OPENAI_API_KEY")
 	assert.Contains(t, written, "dr-credential:PLACEHOLDER/apiToken")
 	assert.NotContains(t, written, "sk-abcdefghijklmnopqrstuvwxyz01")
@@ -494,7 +496,10 @@ func TestFlow_EnvTableIsPerRowAndOverridable(t *testing.T) {
 	assert.Contains(t, view, "←/→", "the legend names the keys that change a row")
 
 	// Accepting the classifier's proposal lists the two deployable keys and
-	// drops the local-only one.
+	// drops the local-only one. The preview shows the placeholder because
+	// nothing has been stored yet: the secrets are sent when the confirm
+	// screen is accepted, so a wizard that is cancelled leaves no credential
+	// behind.
 	accepted := press(t, model, "enter")
 	require.Equal(t, screenConfirm, accepted.at)
 	assert.Contains(t, string(accepted.content), "- name: LOG_LEVEL")
@@ -901,6 +906,7 @@ func TestFlow_BindingSelectionSurvivesBackNavigation(t *testing.T) {
 // entirely while the command still reported them as written.
 func TestRun_BoundWorkloadCarriesEnv(t *testing.T) {
 	stubLiveDocs(t)
+	credentialStore(t)
 
 	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
 	require.NoError(t, os.WriteFile(filepath.Join(dir, EnvFileName),
@@ -914,7 +920,8 @@ func TestRun_BoundWorkloadCarriesEnv(t *testing.T) {
 	assert.Equal(t, 2, result.EnvKeysListed)
 	assert.Contains(t, written, "LOG_LEVEL")
 	assert.Contains(t, written, "debug")
-	assert.Contains(t, written, "dr-credential:PLACEHOLDER/apiToken")
+	assert.Contains(t, written, "dr-credential:66f000000000000000000001/apiToken",
+		"binding stores its secrets like any other run")
 	assert.NotContains(t, written, "Xk9mPq2vLw8nRt5yBc3z", "a secret's value stays in .env")
 
 	parsed, err := manifest.Load(result.Path)

--- a/internal/workload/wizard/run.go
+++ b/internal/workload/wizard/run.go
@@ -157,7 +157,7 @@ func Run(opts Options) (Result, error) {
 		Content:           content,
 		Draft:             draft,
 		EnvKeysListed:     len(draft.EnvVars),
-		EnvSecretsPending: countSecrets(draft.EnvVars),
+		EnvSecretsPending: pendingSecrets(draft.EnvVars),
 	}
 
 	if opts.DryRun {
@@ -169,19 +169,6 @@ func Run(opts Options) (Result, error) {
 	}
 
 	return result, nil
-}
-
-// countSecrets is how many entries are waiting on a credential.
-func countSecrets(vars []manifest.EnvVar) int {
-	pending := 0
-
-	for _, v := range vars {
-		if v.Secret {
-			pending++
-		}
-	}
-
-	return pending
 }
 
 // existing reports the manifest that is already there, and reads it rather
@@ -231,12 +218,34 @@ func (o Options) resolveHeadless(detected Detected) ([]byte, manifest.Draft, err
 		return nil, manifest.Draft{}, err
 	}
 
+	draft.EnvVars = o.storeSecrets(draft.EnvVars, detected, draft.Name)
+
 	content, err := draft.Render()
 	if err != nil {
 		return nil, manifest.Draft{}, err
 	}
 
 	return content, draft, nil
+}
+
+// storeSecrets sends each secret to the credential store and reports what
+// happened, so the render that follows writes credential ids rather than
+// placeholders.
+//
+// It runs after the answers are settled and before anything is written, which
+// is the only moment both facts are available: which variables the user calls
+// secret, and what they are worth. Nothing is stored under --dry-run, because
+// a run that promises to change nothing must not leave a credential behind.
+func (o Options) storeSecrets(vars []manifest.EnvVar, detected Detected, workloadName string) []manifest.EnvVar {
+	if o.DryRun {
+		return vars
+	}
+
+	stored, report := importSecrets(vars, detected, workloadName)
+
+	reportImport(o.Stderr, report)
+
+	return stored
 }
 
 // resolveHeadlessBound binds to a live workload without prompting: the live
@@ -256,8 +265,10 @@ func (o Options) resolveHeadlessBound(detected Detected) ([]byte, manifest.Draft
 	// A name the workload already declares keeps its running value, so it is
 	// not something this run added. Narrowing the draft here rather than
 	// leaving it to Apply's own skip is what keeps the reported counts equal
-	// to what reached the file.
+	// to what reached the file, and keeps a credential from being stored for a
+	// variable the workload is already serving.
 	draft.EnvVars = live.NewEnvVars(draft.EnvVars)
+	draft.EnvVars = o.storeSecrets(draft.EnvVars, detected, draft.Name)
 
 	applied, err := live.Apply(draft)
 	if err != nil {

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -88,6 +88,11 @@ func runInteractiveFlow(opts Options, detected Detected) ([]byte, manifest.Draft
 		return nil, manifest.Draft{}, ErrCancelled
 	}
 
+	// Printed here rather than from inside the flow: until tui.Run returns,
+	// the alt screen owns the terminal and anything written to stderr lands
+	// underneath a full-screen redraw.
+	reportImport(opts.Stderr, finished.imports)
+
 	return finished.result()
 }
 

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -76,8 +76,14 @@ func runInteractiveFlow(opts Options, detected Detected) ([]byte, manifest.Draft
 	// screen and every redraw there, so `dr workload config` inside a command
 	// substitution would capture escape sequences ahead of the path.
 	//
+	started := newFlow(detected, workloads, opts.Answers)
+	// Carried into the flow because the confirm screen is where secrets would
+	// be stored, and --dry-run has to mean the same thing on a terminal as it
+	// does headless: nothing created, here or on the platform.
+	started.dryRun = opts.DryRun
+
 	// tui.Run already wraps the model for Ctrl-C, so it is not wrapped here.
-	final, err := tui.Run(newFlow(detected, workloads, opts.Answers),
+	final, err := tui.Run(started,
 		tea.WithAltScreen(), tea.WithOutput(interactiveOutput(opts.Stderr)))
 	if err != nil {
 		return nil, manifest.Draft{}, err


### PR DESCRIPTION
# RATIONALE

The wizard classified a `.env`, wrote every secret as a `dr-credential:PLACEHOLDER/apiToken` reference, and left the user to create the credential by hand and paste the id back. That is the one manual step between a fresh checkout and a working deploy, and it is the step a workshop cannot afford.

This is the missing half: one POST per secret, the value going straight from `.env` to the credential store and touching no file, and the id it returns written into the manifest.

## CHANGES

- `workload.CreateCredential` stores a secret as an `api_token` credential. It is the only call in the CLI that sends one.
- Credentials are named `<workload>/<VAR>`. The store is tenant-wide, so a bare `OPENAI_API_KEY` belongs to whoever created it first.
- `manifest.EnvVar` carries a `CredentialID`. With one the reference names it; without one the placeholder is written exactly as before, comment and all.
- One secret failing does not fail the run. That variable keeps its placeholder, which a deploy refuses by name, so the worst case is the state this started from rather than a wizard that leaves nothing on disk after eight answered questions. A name already taken is reported rather than reused: reusing it would deploy a value the user never supplied.
- Interactively the secrets are sent when the **confirm screen is accepted**, not when the env table is left, so a wizard that is cancelled leaves no credential behind. The cost is that the preview shows the placeholder and the file written a moment later carries the id.
- A dry run stores nothing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds the CLI’s only outbound secret upload and tenant-wide credential creation, but failures are partial, dry-run/cancel avoid side effects, and manifest files still omit raw values.
> 
> **Overview**
> Setup wizard and headless runs now **POST each classified `.env` secret** to the tenant credential store and write **`dr-credential:<id>/apiToken`** into the manifest instead of leaving **`PLACEHOLDER`** for manual fix-up.
> 
> **`workload.CreateCredential`** is the single CLI path that transmits secret values (as `api_token` credentials named **`workload/VAR`**). **`manifest.EnvVar`** gains **`CredentialID`**; draft/live rendering and bound-workload env merge use real ids when present and placeholders when import failed or was skipped.
> 
> **`importSecrets`** in the wizard handles per-variable outcomes: empty values and **409 name conflicts** are reported without aborting the run (conflicts are not silently reused). **`--dry-run`** and **`--skip-env`** skip storage; **`EnvSecretsPending`** counts secrets still on placeholders.
> 
> **Interactive flow** stores secrets only when the **confirm screen** is accepted (preview may still show placeholders); cancelling leaves no credentials. Headless/bound paths call **`storeSecrets`** before render and print **`reportImport`** on stderr after the TUI exits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21efc9220232dcc0ae99634b864ecc3354a5d4ed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->