### PR TITLE
[RAPTOR-18976] feat(workload): make the deploy readable

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -305,6 +305,11 @@ func init() {
 
 	RootCmd.SetUsageTemplate(CustomUsageTemplate)
 
+	// Set on the root, so every subcommand's failure reads as one. Only the
+	// prefix is styled: the message itself is often multi-line and is the part
+	// a user copies into a bug report.
+	RootCmd.SetErrPrefix(tui.ErrorStyle.Render("Error:"))
+
 	RootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		showAllCommands, _ := cmd.Flags().GetBool("all-commands")
 		showVersion, _ := cmd.Flags().GetBool("version")

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -234,7 +234,7 @@ func run(cmd *cobra.Command, f flags, poll pollflags.Set, format outputformat.Ou
 		return runErr
 	}
 
-	if err := render(cmd, f, format, result); err != nil {
+	if err := render(cmd, f, format, result, runErr != nil); err != nil {
 		return err
 	}
 
@@ -336,7 +336,7 @@ func reportable(result up.Result) bool {
 	return result.WorkloadID != "" || result.BuildID != ""
 }
 
-func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, result up.Result) error {
+func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, result up.Result, failed bool) error {
 	if format == outputformat.OutputFormatJSON {
 		return outputformat.PrintJSONEnvelope(cmd.OutOrStdout(), "up", upResult{
 			WorkloadID: result.WorkloadID,
@@ -360,8 +360,17 @@ func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, resul
 	// stdout carries the endpoint and nothing else, so it can be piped. The
 	// label goes to stderr with no newline, so a terminal shows one sentence
 	// while `dr workload up | xargs curl` still receives the bare URL.
+	//
+	// render also runs on a failed deploy that got far enough to have an
+	// endpoint, and a tick above an error reads as though both happened, so
+	// the mark is only claimed when the run is actually a success.
 	if result.Endpoint != "" {
-		fmt.Fprintf(cmd.ErrOrStderr(), "\n  %s Workload endpoint: ", tui.SuccessStyle.Render("✓"))
+		mark := tui.SuccessStyle.Render("✓")
+		if failed {
+			mark = " "
+		}
+
+		fmt.Fprintf(cmd.ErrOrStderr(), "\n  %s Workload endpoint: ", mark)
 		fmt.Fprintln(cmd.OutOrStdout(), result.Endpoint)
 	}
 
@@ -385,12 +394,12 @@ func nextSteps(w io.Writer, result up.Result) {
 		{"dr workload stop " + result.WorkloadID, "switch it off, keeping the version"},
 	}
 
-	if result.BuildID != "" {
-		steps = append(steps, [2]string{
-			"dr artifact build logs " + result.ArtifactID + " " + result.BuildID,
-			"how the image was built",
-		})
-	}
+	// No build-logs line. It needs an artifact id as well as a build id, and
+	// on a roll the two deliberately belong to different artifacts: BuildID is
+	// the candidate's, ArtifactID stays on the version still serving until the
+	// swap lands. Pairing them would send the reader to a 404 at exactly the
+	// moment they need the logs. The error from a failed build already names
+	// the right pair.
 
 	fmt.Fprintf(w, "\n%s\n", tui.HintStyle.Render("Next:"))
 

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -32,6 +33,7 @@ import (
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload/up"
+	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
@@ -355,10 +357,45 @@ func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, resul
 		return nil
 	}
 
-	// stdout carries the endpoint and nothing else, so it can be piped.
+	// stdout carries the endpoint and nothing else, so it can be piped. The
+	// label goes to stderr with no newline, so a terminal shows one sentence
+	// while `dr workload up | xargs curl` still receives the bare URL.
 	if result.Endpoint != "" {
+		fmt.Fprintf(cmd.ErrOrStderr(), "\n  %s Workload endpoint: ", tui.SuccessStyle.Render("✓"))
 		fmt.Fprintln(cmd.OutOrStdout(), result.Endpoint)
 	}
 
+	nextSteps(cmd.ErrOrStderr(), result)
+
 	return nil
+}
+
+// nextSteps lists what to run against the workload this deploy just touched,
+// on stderr so the endpoint on stdout stays pipeable. Nothing is printed for a
+// run that produced no workload: a list of commands that need an id is no help
+// to someone who has not got one.
+func nextSteps(w io.Writer, result up.Result) {
+	if result.WorkloadID == "" {
+		return
+	}
+
+	steps := [][2]string{
+		{"dr workload logs " + result.WorkloadID, "what the container is saying"},
+		{"dr workload status " + result.WorkloadID, "whether it is healthy"},
+		{"dr workload stop " + result.WorkloadID, "switch it off, keeping the version"},
+	}
+
+	if result.BuildID != "" {
+		steps = append(steps, [2]string{
+			"dr artifact build logs " + result.ArtifactID + " " + result.BuildID,
+			"how the image was built",
+		})
+	}
+
+	fmt.Fprintf(w, "\n%s\n", tui.HintStyle.Render("Next:"))
+
+	for _, step := range steps {
+		fmt.Fprintf(w, "  %s  %s\n",
+			tui.InfoStyle.Render(step[0]), tui.HintStyle.Render(step[1]))
+	}
 }

--- a/internal/drapi/delete.go
+++ b/internal/drapi/delete.go
@@ -41,7 +41,7 @@ func Delete(url, info string, body any) (*http.Response, error) {
 	req.Header.Set("Content-Type", "application/json")
 
 	if info != "" {
-		log.Infof("Deleting %s at: %s", info, url)
+		log.Debugf("Deleting %s at: %s", info, url)
 	}
 
 	log.Debug("Request Info: \n" + config.RedactedReqInfo(req))

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -93,7 +93,7 @@ func Get(url, info string, timeoutSecs ...int) (*http.Response, error) {
 	}
 
 	if info != "" {
-		log.Infof("Fetching %s from: %s", info, url)
+		log.Debugf("Fetching %s from: %s", info, url)
 	}
 
 	log.Debug("Request Info: \n" + config.RedactedReqInfo(req))

--- a/internal/drapi/patch.go
+++ b/internal/drapi/patch.go
@@ -41,7 +41,7 @@ func Patch(url, info string, body any) (*http.Response, error) {
 	req.Header.Set("Content-Type", "application/json")
 
 	if info != "" {
-		log.Infof("Updating %s at: %s", info, url)
+		log.Debugf("Updating %s at: %s", info, url)
 	}
 
 	log.Debug("Request Info: \n" + config.RedactedReqInfo(req))

--- a/internal/drapi/post.go
+++ b/internal/drapi/post.go
@@ -41,7 +41,7 @@ func Post(url, info string, body any) (*http.Response, error) {
 	req.Header.Set("Content-Type", "application/json")
 
 	if info != "" {
-		log.Infof("Creating %s at: %s", info, url)
+		log.Debugf("Creating %s at: %s", info, url)
 	}
 
 	log.Debug("Request Info: \n" + config.RedactedReqInfo(req))

--- a/internal/workload/credential.go
+++ b/internal/workload/credential.go
@@ -67,6 +67,17 @@ func FindCredentialNamed(name string, limit int) (*Credential, error) {
 			}
 		}
 
+		if list.Next == "" {
+			break
+		}
+
+		// Every paginator in this package checks this: drapi attaches the
+		// user's token to whatever URL it is given, so a next link naming
+		// another host would send it there.
+		if err := drapi.AssertNextOnSameHost(list.Next); err != nil {
+			return nil, err
+		}
+
 		pageURL = list.Next
 	}
 

--- a/internal/workload/credential.go
+++ b/internal/workload/credential.go
@@ -45,6 +45,12 @@ type CredentialList struct {
 // FindCredentialNamed returns the credential called name, or nil when the
 // organisation has none. Names are unique tenant-wide, so this is how a
 // caller turns a name it expected to create into the id that already holds it.
+//
+// limit bounds the whole scan, not the page: this is a courtesy lookup that
+// improves an error message, and following next links until a large tenant
+// runs out would turn every refusal into a long walk. Reaching the bound
+// answers nil, the same as a name that is genuinely not there, because to the
+// caller the two mean the same thing: no id to offer.
 func FindCredentialNamed(name string, limit int) (*Credential, error) {
 	query := url.Values{}
 	query.Set("limit", strconv.Itoa(limit))
@@ -54,7 +60,7 @@ func FindCredentialNamed(name string, limit int) (*Credential, error) {
 		return nil, err
 	}
 
-	for pageURL != "" {
+	for scanned := 0; pageURL != "" && scanned < limit; {
 		var list CredentialList
 
 		if err := drapi.GetJSON(pageURL, "credentials", &list); err != nil {
@@ -67,7 +73,11 @@ func FindCredentialNamed(name string, limit int) (*Credential, error) {
 			}
 		}
 
-		if list.Next == "" {
+		scanned += len(list.Data)
+
+		// A page that came back empty would otherwise leave scanned where it
+		// was and follow next for ever.
+		if list.Next == "" || len(list.Data) == 0 {
 			break
 		}
 

--- a/internal/workload/credential.go
+++ b/internal/workload/credential.go
@@ -15,6 +15,9 @@
 package workload
 
 import (
+	"net/url"
+	"strconv"
+
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/drapi"
 )
@@ -32,6 +35,43 @@ type Credential struct {
 // field, which is the shape every secret imported from a .env takes: one name,
 // one value, and nothing about what the value is for.
 const CredentialTypeAPIToken = "api_token"
+
+// CredentialList is one page of the credentials route.
+type CredentialList struct {
+	Data []Credential `json:"data"`
+	Next string       `json:"next"`
+}
+
+// FindCredentialNamed returns the credential called name, or nil when the
+// organisation has none. Names are unique tenant-wide, so this is how a
+// caller turns a name it expected to create into the id that already holds it.
+func FindCredentialNamed(name string, limit int) (*Credential, error) {
+	query := url.Values{}
+	query.Set("limit", strconv.Itoa(limit))
+
+	pageURL, err := drapi.EndpointURL("/credentials/", query)
+	if err != nil {
+		return nil, err
+	}
+
+	for pageURL != "" {
+		var list CredentialList
+
+		if err := drapi.GetJSON(pageURL, "credentials", &list); err != nil {
+			return nil, err
+		}
+
+		for i := range list.Data {
+			if list.Data[i].Name == name {
+				return &list.Data[i], nil
+			}
+		}
+
+		pageURL = list.Next
+	}
+
+	return nil, nil
+}
 
 // CreateCredential stores a secret and returns the credential holding it, so a
 // manifest can reference it by id instead of carrying the value.

--- a/internal/workload/credential_test.go
+++ b/internal/workload/credential_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/datarobot/cli/internal/config"
@@ -138,4 +140,56 @@ func TestCreateCredential_TheFieldItSendsIsOneTheDebugLogRedacts(t *testing.T) {
 
 	assert.NotContains(t, redacted, "sk-live-abc123", "and the debug log never does")
 	assert.Contains(t, redacted, "REDACTED")
+}
+
+// The limit bounds the whole scan, not one page. This is a courtesy lookup
+// that improves an error message, so a large tenant must not turn every
+// refusal into a walk through every credential it has.
+func TestFindCredentialNamed_StopsAtTheScanLimit(t *testing.T) {
+	var (
+		pages int
+		base  string
+	)
+
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		pages++
+
+		// Always another page, and never the name being looked for: with no
+		// bound this answers for as long as it is asked.
+		fmt.Fprintf(w, `{"data":[{"credentialId":"c%d","name":"other"}],"next":%q}`,
+			pages, base+"?page="+strconv.Itoa(pages+1))
+	}))
+
+	// Built from the configured endpoint, which serveAPI has just pointed at
+	// the test server, rather than from the request the handler was sent.
+	base, err := drapi.EndpointURL("/credentials/", url.Values{})
+	require.NoError(t, err)
+
+	found, err := FindCredentialNamed("wanted", 3)
+	require.NoError(t, err)
+	assert.Nil(t, found, "reaching the bound reads the same as not being there: no id to offer")
+	assert.Equal(t, 3, pages, "one row per page, so the bound is three pages")
+}
+
+// drapi attaches the user's token to whatever URL it is given, so a next link
+// naming another host would send the token there.
+func TestFindCredentialNamed_RefusesANextOnAnotherHost(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w,
+			`{"data":[{"credentialId":"c1","name":"other"}],"next":"https://elsewhere.example.com/api/v2/credentials/"}`)
+	}))
+
+	_, err := FindCredentialNamed("wanted", 200)
+	require.Error(t, err)
+}
+
+// A name nothing holds is not an error: the caller asked whether one existed.
+func TestFindCredentialNamed_AnswersNilWhenThereIsNone(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"data":[],"next":""}`)
+	}))
+
+	found, err := FindCredentialNamed("wanted", 200)
+	require.NoError(t, err)
+	assert.Nil(t, found)
 }

--- a/internal/workload/ignore/matcher.go
+++ b/internal/workload/ignore/matcher.go
@@ -33,8 +33,15 @@ const wapiignoreFile = ".wapiignore"
 // tool state under .datarobot/cli/, which syncs today. The legacy ".wapi"
 // stays listed so an un-migrated project does not upload its state.
 //
+// The manifest is excluded because a deploy rewrites it: `up` writes the new
+// workload's id into it after the sync has run. Uploaded, it would differ from
+// what was synced the moment the deploy finished, so the next run would find a
+// changed file, rebuild, and roll a workload nobody had touched, for ever. It
+// describes how to deploy the code rather than being part of it, and the
+// container has no use for it.
+//
 // Entries must be lowercase: matchesSystemExclude folds the path it is given.
-var systemExcludes = []string{".datarobot/workload", ".wapi", ".git", ".gitignore"}
+var systemExcludes = []string{".datarobot/workload", ".wapi", ".git", ".gitignore", ".datarobot.yaml"}
 
 // Matcher decides whether a path is excluded from sync. Match is safe for
 // concurrent use after New.

--- a/internal/workload/ignore/matcher_test.go
+++ b/internal/workload/ignore/matcher_test.go
@@ -38,9 +38,11 @@ func TestSystemExcludes_AlwaysApply(t *testing.T) {
 		{".git/HEAD", true},
 		{".gitignore", true},
 		{"agent.py", false},
-		{".wapiignore", false},     // user-editable, lives at root
-		{".datarobot.yaml", false}, // the committed manifest is a file, not the state dir
-		{".datarobot/cli", false},  // the CLI's own tool state is not sync state
+		{".wapiignore", false}, // user-editable, lives at root
+		// The manifest is rewritten by a deploy after the sync, so uploading it
+		// would make the tree differ from what was synced on every later run.
+		{".datarobot.yaml", true},
+		{".datarobot/cli", false}, // the CLI's own tool state is not sync state
 		{".datarobot/cli/state.yaml", false},
 	}
 
@@ -72,7 +74,7 @@ func TestSystemExcludes_FoldCase(t *testing.T) {
 
 	// Folding must not swallow neighbours that merely share a prefix.
 	assert.False(t, m.Match(".Datarobot/cli/state.yaml", false))
-	assert.False(t, m.Match(".Datarobot.yaml", false))
+	assert.True(t, m.Match(".Datarobot.yaml", false), "the manifest is excluded whatever its casing")
 }
 
 func TestSystemExcludes_NotOverridable(t *testing.T) {

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -43,6 +43,9 @@ type Live struct {
 	Name         string
 	Importance   string
 	ArtifactName string
+	// ArtifactType is the artifact's kind, which the platform keeps beside the
+	// spec rather than inside it.
+	ArtifactType string
 	Spec         map[string]any
 	Runtime      map[string]any
 }
@@ -56,6 +59,7 @@ func NewLive(workloadID string, workloadDoc, artifactDoc map[string]any) Live {
 		Name:         stringAt(workloadDoc, keyName),
 		Importance:   stringAt(workloadDoc, keyImportance),
 		ArtifactName: stringAt(artifactDoc, keyName),
+		ArtifactType: stringAt(artifactDoc, keyType),
 		Spec:         stripServerManaged(mapAt(artifactDoc, keySpec)),
 		Runtime:      stripServerManaged(mapAt(workloadDoc, keyRuntime)),
 	}
@@ -68,7 +72,7 @@ func NewLive(workloadID string, workloadDoc, artifactDoc map[string]any) Live {
 // Type reports the artifact's kind, so the wizard's Q3 opens on what the
 // workload already is.
 func (l Live) Type() string {
-	return stringAt(l.Spec, keyType)
+	return l.ArtifactType
 }
 
 // Defaults reads the live spec into the answers the wizard's screens open on.
@@ -240,7 +244,11 @@ func (l Live) Apply(draft Draft) (Live, error) {
 		applied.Spec = map[string]any{}
 	}
 
-	applied.Spec[keyType] = draft.Type
+	applied.ArtifactType = draft.Type
+
+	// Any type the server echoed inside the spec is noise: it pops spec.type
+	// on the way in and reads the artifact's own type instead.
+	delete(applied.Spec, keyType)
 
 	if draft.Type == TypeAgent && draft.A2AEnabled {
 		applied.Spec[keyA2AEnabled] = true
@@ -620,6 +628,10 @@ func (l Live) Render() ([]byte, error) {
 	}
 
 	artifact := []field{{key: keyName, value: scalar(l.ArtifactName)}}
+	if l.ArtifactType != "" {
+		artifact = append(artifact, field{key: keyType, value: scalar(l.ArtifactType)})
+	}
+
 	if spec != nil {
 		artifact = append(artifact, field{key: keySpec, value: spec})
 	}

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -330,7 +330,7 @@ func TestLive_ApplyKeepsUnknownBuildKeys(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal([]byte(`{
       "name": "a",
-      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+      "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
         {"name": "primary", "primary": true, "port": 8080, "imageBuildConfig": {
           "dockerfile": {"source": "provided", "buildArgs": {"NODE_ENV": "production"}, "target": "runtime"},
           "buildTimeoutSeconds": 3600,
@@ -358,7 +358,7 @@ func TestLive_UnknownBuildSourceIsPreserved(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal([]byte(`{
       "name": "a",
-      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+      "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
         {"name": "primary", "primary": true, "port": 8080,
          "imageBuildConfig": {"buildpack": {"builder": "paketo/builder:base"}}}]}]}
     }`), &artifactDoc))
@@ -385,7 +385,7 @@ func TestLive_ApplyDoesNotInventAReadinessProbe(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal([]byte(`{
       "name": "a",
-      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+      "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
         {"name": "primary", "primary": true, "port": 9000, "imageUri": "registry/a:v1"}]}]}
     }`), &artifactDoc))
 
@@ -437,7 +437,7 @@ func TestLive_ApplyLeavesAProbeOnItsOwnPort(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal([]byte(`{
       "name": "a",
-      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+      "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
         {"name": "primary", "primary": true, "port": 8080, "imageUri": "registry/a:v1",
          "livenessProbe": {"path": "/admin/live", "port": 9900}}]}]}
     }`), &artifactDoc))
@@ -463,7 +463,7 @@ func TestLive_ApplyFlagsTheContainerItEdits(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal([]byte(`{
       "name": "a",
-      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+      "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
         {"name": "only", "port": 8080, "imageUri": "registry/a:v1"}]}]}
     }`), &artifactDoc))
 
@@ -506,7 +506,7 @@ func TestLive_DefaultsReadThePrimaryNotTheFirstListed(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal([]byte(`{
       "name": "sidecar-first-artifact",
-      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+      "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
         {"name": "app", "primary": true, "port": 8080, "imageUri": "example/app:v1"},
         {"name": "metrics-bridge", "imageUri": "example/bridge:v1"}]}]}
     }`), &artifactDoc))
@@ -546,7 +546,7 @@ func TestLive_DisabledAutoscalingKeepsTheReplicaAnswer(t *testing.T) {
 
 	require.NoError(t, json.Unmarshal([]byte(`{
       "name": "a",
-      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+      "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
         {"name": "app", "primary": true, "port": 8080, "imageUri": "example/app:v1"}]}]}
     }`), &artifactDoc))
 

--- a/internal/workload/manifest/validate.go
+++ b/internal/workload/manifest/validate.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/datarobot/cli/internal/fsutil"
@@ -92,6 +93,43 @@ func NormalizeMemory(value string) string {
 	}
 
 	return match[1] + match[2]
+}
+
+// memoryScale is what each suffix multiplies by. Decimal, not binary: the
+// platform reads MB as a million bytes, which is why Mi and friends are
+// refused rather than converted.
+var memoryScale = map[string]int64{
+	"":   1,
+	"B":  1,
+	"KB": 1_000,
+	"MB": 1_000_000,
+	"GB": 1_000_000_000,
+	"TB": 1_000_000_000_000,
+}
+
+// MemoryBytes reads a size into bytes, reporting whether it could.
+//
+// The platform stores a size as a number of bytes and hands it back that way,
+// so "512MB" in the file and 512000000 in the live workload are the same
+// sizing written two ways. Anything comparing the two has to do it here or it
+// finds a difference on every run, for ever.
+func MemoryBytes(value string) (int64, bool) {
+	match := memoryPattern.FindStringSubmatch(strings.ToUpper(strings.TrimSpace(value)))
+	if match == nil {
+		return 0, false
+	}
+
+	amount, err := strconv.ParseInt(match[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+
+	scale, ok := memoryScale[match[2]]
+	if !ok {
+		return 0, false
+	}
+
+	return amount * scale, true
 }
 
 // MemoryUnits lists the suffixes a size may carry, for a prompt that would

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -359,7 +359,13 @@ func (d Draft) topLevelFields(build field) []field {
 // artifact renders the half that says what runs: the versioned, lockable
 // definition.
 func (d Draft) artifact(build field) *yaml.Node {
-	spec := []field{{key: keyType, value: scalar(d.Type)}}
+	// type sits on the artifact, not in the spec. The platform pops any
+	// spec.type it is sent and re-derives the discriminator from the
+	// artifact's own type, defaulting to service, so a type written one level
+	// down is discarded without a word: an agent silently becomes a service,
+	// and a2aEnabled is then rejected as an unknown field on the service
+	// variant.
+	spec := []field{}
 
 	if d.A2AEnabled {
 		spec = append(spec, field{
@@ -393,6 +399,7 @@ func (d Draft) artifact(build field) *yaml.Node {
 
 	return mapping(
 		field{key: keyName, value: scalar(ArtifactName(d.Name))},
+		field{key: keyType, value: scalar(d.Type)},
 		field{key: keySpec, value: mapping(spec...)},
 	)
 }

--- a/internal/workload/manifest/write_test.go
+++ b/internal/workload/manifest/write_test.go
@@ -53,8 +53,8 @@ importance: low # low | moderate | high | critical
 
 artifact:
   name: my-app-artifact
+  type: service
   spec:
-    type: service
     containerGroups:
       - name: default
         containers:
@@ -300,8 +300,8 @@ somethingTheApiAddedLater: true
 artifact:
   # how the image is built
   name: my-app-artifact
+  type: service
   spec:
-    type: service
 `
 
 	path := writeManifest(t, t.TempDir(), original)
@@ -317,8 +317,8 @@ somethingTheApiAddedLater: true
 artifact:
   # how the image is built
   name: my-app-artifact
+  type: service
   spec:
-    type: service
 `, string(got))
 }
 
@@ -503,4 +503,23 @@ artifact:
 func TestResolveCredentials_RefusesWhatItCannotParse(t *testing.T) {
 	_, err := ResolveCredentials([]byte("name: [unclosed\n"), map[string]string{"A": "b"})
 	require.Error(t, err)
+}
+
+// The platform pops spec.type on the way in and re-derives the discriminator
+// from the artifact's own type, defaulting to service. A type written one
+// level down is therefore discarded without a word: an agent silently becomes
+// a service, and a2aEnabled is then rejected as an unknown field.
+func TestRender_TypeSitsOnTheArtifactNotInTheSpec(t *testing.T) {
+	draft := serviceDraft()
+	draft.Type = TypeAgent
+	draft.A2AEnabled = true
+
+	rendered, err := draft.Render()
+	require.NoError(t, err)
+
+	out := string(rendered)
+
+	assert.Contains(t, out, "  name: my-app-artifact\n  type: agent\n  spec:\n")
+	assert.NotContains(t, out, "    type: agent", "inside the spec the platform throws it away")
+	assert.Contains(t, out, "a2aEnabled: true", "which stays in the spec, where the agent variant reads it")
 }

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -17,8 +17,10 @@ package up
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/internal/workload/sync"
 	"github.com/datarobot/cli/internal/workload/wapi"
 )
@@ -63,7 +65,70 @@ func buildAndCreate(loaded Loaded, code CodeChange, result Result, opts Options,
 		return result, err
 	}
 
-	return create(loaded, payload, result, opts, report)
+	result, err = create(loaded, payload, result, opts, report)
+	if err != nil && !fresh {
+		// The artifact was not minted by this run, so a refusal to create a
+		// workload on it is most likely the platform's one-per-draft-artifact
+		// rule, and the link that chose it is the thing to explain.
+		err = reusedArtifactConflict(err, artifactID, loaded.ProjectDir)
+	}
+
+	return result, err
+}
+
+// reusedArtifactConflict explains a create refused because the artifact this
+// checkout is linked to is already spoken for.
+//
+// The link is invisible: it lives in a gitignored directory nobody looks at,
+// and it is what makes a second deploy update one artifact instead of piling
+// up new ones. When it goes stale, the platform's own message names an
+// artifact id and nothing about where that id came from, which leaves the
+// reader with a conflict and no idea what chose the thing that conflicted.
+func reusedArtifactConflict(createErr error, artifactID, projectDir string) error {
+	if !isConflict(createErr) {
+		return createErr
+	}
+
+	var b strings.Builder
+
+	fmt.Fprintf(&b,
+		"this project is linked to artifact %s, which already has a workload, "+
+			"and the platform allows only one workload per draft artifact.\n"+
+			"  The link lives in %s and is what makes repeated deploys update one artifact "+
+			"rather than making a new one each time.\n",
+		artifactID, wapi.Dir(projectDir))
+
+	if owner := workloadOn(artifactID); owner != "" {
+		fmt.Fprintf(&b,
+			"  Workload %s is the one that has it. To deploy to that workload, add 'workloadId: %s' to %s.\n",
+			owner, owner, manifest.FileName)
+	}
+
+	fmt.Fprintf(&b,
+		"  To deploy a separate workload from this directory instead, delete %s: "+
+			"the next run then creates an artifact of its own.\n"+
+			"  The platform's own words: %s",
+		wapi.Dir(projectDir), createErr)
+
+	return errors.New(b.String())
+}
+
+// workloadOn names the workload already using artifactID, "" when the lookup
+// cannot say. It turns the advice from "find out what owns this" into a line
+// the reader can paste.
+func workloadOn(artifactID string) string {
+	existing, err := listWorkloadsFn(conflictSearchLimit, nil)
+	if err != nil {
+		return ""
+	}
+
+	for i := range existing {
+		if existing[i].ArtifactID == artifactID {
+			return existing[i].ID
+		}
+	}
+
+	return ""
 }
 
 // ensureArtifact returns the artifact this project builds into, creating one

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -17,7 +17,6 @@ package up
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
@@ -89,28 +88,25 @@ func reusedArtifactConflict(createErr error, artifactID, projectDir string) erro
 		return createErr
 	}
 
-	var b strings.Builder
-
-	fmt.Fprintf(&b,
-		"this project is linked to artifact %s, which already has a workload, "+
-			"and the platform allows only one workload per draft artifact.\n"+
-			"  The link lives in %s and is what makes repeated deploys update one artifact "+
-			"rather than making a new one each time.\n",
-		artifactID, wapi.Dir(projectDir))
-
-	if owner := workloadOn(artifactID); owner != "" {
-		fmt.Fprintf(&b,
-			"  Workload %s is the one that has it. To deploy to that workload, add 'workloadId: %s' to %s.\n",
-			owner, owner, manifest.FileName)
+	// Only rewrite once the claim is verified. A 409 on this path is just as
+	// likely to be a duplicate workload name, which create() has already
+	// explained accurately; replacing that with advice to delete the link
+	// directory would send the user to orphan an artifact for no reason.
+	owner := workloadOn(artifactID)
+	if owner == "" {
+		return createErr
 	}
 
-	fmt.Fprintf(&b,
-		"  To deploy a separate workload from this directory instead, delete %s: "+
-			"the next run then creates an artifact of its own.\n"+
-			"  The platform's own words: %s",
-		wapi.Dir(projectDir), createErr)
-
-	return errors.New(b.String())
+	return fmt.Errorf(
+		"this project is linked to artifact %s, which workload %s already has, and the platform allows "+
+			"only one workload per draft artifact.\n"+
+			"  The link lives in %s and is what makes repeated deploys update one artifact rather than "+
+			"making a new one each time.\n"+
+			"  To deploy to that workload, add 'workloadId: %s' to %s.\n"+
+			"  To deploy a separate workload from this directory, delete %s: the next run then creates "+
+			"an artifact of its own.\n"+
+			"  %w",
+		artifactID, owner, wapi.Dir(projectDir), owner, manifest.FileName, wapi.Dir(projectDir), createErr)
 }
 
 // workloadOn names the workload already using artifactID, "" when the lookup

--- a/internal/workload/up/credentials.go
+++ b/internal/workload/up/credentials.go
@@ -97,16 +97,18 @@ func placeholderProblem(ref manifest.CredentialRef, workloadName string) string 
 
 	if existing, err := findCredentialFn(name, credentialSearchLimit); err == nil && existing != nil {
 		return fmt.Sprintf(
-			"%s:%d  %s says %s. The credential it wants already exists, called %s: "+
-				"put its id, %s, on that line",
+			"%s:%d  %s still says %s. A credential named %s already exists, so replacing %s with %s "+
+				"is probably what you want, having checked that credential holds this variable's value: "+
+				"a name is tenant-wide and says nothing about what is stored under it",
 			manifest.FileName, ref.Line, ref.EnvName, manifest.CredentialPlaceholder,
-			name, existing.CredentialID)
+			name, manifest.CredentialPlaceholder, existing.CredentialID)
 	}
 
 	return fmt.Sprintf(
-		"%s:%d  %s says %s instead of a credential id, so its value would never reach the container. "+
-			"Store the value as a credential and put that credential's id here",
-		manifest.FileName, ref.Line, ref.EnvName, manifest.CredentialPlaceholder)
+		"%s:%d  %s still says %s, so its value would never reach the container. "+
+			"Store the value as a credential, then replace %s with that credential's id",
+		manifest.FileName, ref.Line, ref.EnvName, manifest.CredentialPlaceholder,
+		manifest.CredentialPlaceholder)
 }
 
 // missingProblem describes an id the platform does not know. It names the

--- a/internal/workload/up/credentials.go
+++ b/internal/workload/up/credentials.go
@@ -19,7 +19,13 @@ import (
 	"strings"
 
 	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/datarobot/cli/internal/workload/wizard"
 )
+
+// credentialSearchLimit bounds the lookup that turns a placeholder into the id
+// that belongs there. Past this many credentials the scan is the wrong tool,
+// and the entry is still reported as unfinished either way.
+const credentialSearchLimit = 200
 
 // verifyCredentials confirms that every credential the manifest references
 // actually exists, and is the last check before anything mutates.
@@ -35,7 +41,7 @@ import (
 // from a file the user is about to edit, and finding out about the second bad
 // id only after fixing the first is two round trips through a build pipeline
 // for what is one edit.
-func verifyCredentials(refs []manifest.CredentialRef) error {
+func verifyCredentials(refs []manifest.CredentialRef, workloadName string) error {
 	var (
 		problems []string
 		seen     = make(map[string]bool, len(refs))
@@ -43,7 +49,7 @@ func verifyCredentials(refs []manifest.CredentialRef) error {
 
 	for _, ref := range refs {
 		if ref.CredentialID == manifest.CredentialPlaceholder {
-			problems = append(problems, placeholderProblem(ref))
+			problems = append(problems, placeholderProblem(ref, workloadName))
 
 			continue
 		}
@@ -74,19 +80,33 @@ func verifyCredentials(refs []manifest.CredentialRef) error {
 		return nil
 	}
 
-	return fmt.Errorf("the manifest references credentials that cannot be used:\n  %s",
-		strings.Join(problems, "\n  "))
+	return fmt.Errorf("%s references credentials that cannot be used:\n  %s",
+		manifest.FileName, strings.Join(problems, "\n  "))
 }
 
 // placeholderProblem describes a reference the setup wizard wrote and nobody
 // finished. The wizard writes the placeholder in full, rather than commenting
 // the entry out, precisely so it fails here instead of deploying a container
 // without its secret.
-func placeholderProblem(ref manifest.CredentialRef) string {
+func placeholderProblem(ref manifest.CredentialRef, workloadName string) string {
+	// The commonest reason setup left a placeholder is that the name it wanted
+	// was taken, which means the id the file needs already exists. Saying so
+	// with the id in hand turns the message into an edit rather than an
+	// errand. A lookup that fails changes nothing: the entry is still wrong.
+	name := wizard.CredentialName(workloadName, ref.EnvName)
+
+	if existing, err := findCredentialFn(name, credentialSearchLimit); err == nil && existing != nil {
+		return fmt.Sprintf(
+			"%s:%d  %s says %s. The credential it wants already exists, called %s: "+
+				"put its id, %s, on that line",
+			manifest.FileName, ref.Line, ref.EnvName, manifest.CredentialPlaceholder,
+			name, existing.CredentialID)
+	}
+
 	return fmt.Sprintf(
-		"line %d: %s still references the %s written by setup. "+
-			"Create the credential, then replace %s with its id",
-		ref.Line, ref.EnvName, manifest.CredentialPlaceholder, manifest.CredentialPlaceholder)
+		"%s:%d  %s says %s instead of a credential id, so its value would never reach the container. "+
+			"Store the value as a credential and put that credential's id here",
+		manifest.FileName, ref.Line, ref.EnvName, manifest.CredentialPlaceholder)
 }
 
 // missingProblem describes an id the platform does not know. It names the

--- a/internal/workload/up/credentials_test.go
+++ b/internal/workload/up/credentials_test.go
@@ -168,3 +168,42 @@ func TestVerifyCredentials_NonHTTPErrorPropagates(t *testing.T) {
 func verifyRefs(refs []manifest.CredentialRef) error {
 	return verifyCredentials(refs, "my-app")
 }
+
+// The commonest reason setup leaves a placeholder is that the name it wanted
+// was taken, which means the id the file needs already exists. Naming it, with
+// the caveat that a tenant-wide name says nothing about what is stored under
+// it, turns the message into an edit rather than an errand.
+func TestVerifyCredentials_PlaceholderNamesTheCredentialThatExists(t *testing.T) {
+	var asked string
+
+	restore := findCredentialFn
+	findCredentialFn = func(name string, _ int) (*workload.Credential, error) {
+		asked = name
+
+		return &workload.Credential{CredentialID: "66f0aaaa0000000000000001", Name: name}, nil
+	}
+
+	t.Cleanup(func() { findCredentialFn = restore })
+
+	err := verifyCredentials([]manifest.CredentialRef{
+		{CredentialID: manifest.CredentialPlaceholder, Key: "apiToken", EnvName: "OPENAI_API_KEY", Line: 22},
+	}, "my-app")
+
+	require.Error(t, err)
+	assert.Equal(t, "my-app/OPENAI_API_KEY", asked, "the lookup uses the name setup would have created")
+	assert.Contains(t, err.Error(), "66f0aaaa0000000000000001", "the id that belongs on the line")
+	assert.Contains(t, err.Error(), manifest.CredentialPlaceholder, "what to replace")
+	assert.Contains(t, err.Error(), "tenant-wide", "a name is not proof of the value behind it")
+}
+
+// With nothing of that name, the message says what to do rather than pointing
+// at a credential that does not exist.
+func TestVerifyCredentials_PlaceholderWithNoMatchStillSaysWhatToDo(t *testing.T) {
+	err := verifyCredentials([]manifest.CredentialRef{
+		{CredentialID: manifest.CredentialPlaceholder, Key: "apiToken", EnvName: "OPENAI_API_KEY", Line: 22},
+	}, "my-app")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Store the value as a credential")
+	assert.Contains(t, err.Error(), "replace "+manifest.CredentialPlaceholder)
+}

--- a/internal/workload/up/credentials_test.go
+++ b/internal/workload/up/credentials_test.go
@@ -53,14 +53,14 @@ func stubCredentials(t *testing.T, present map[string]bool, failWith error) *[]s
 func TestVerifyCredentials_NoRefsAsksNothing(t *testing.T) {
 	asked := stubCredentials(t, nil, nil)
 
-	require.NoError(t, verifyCredentials(nil))
+	require.NoError(t, verifyCredentials(nil, "my-app"))
 	assert.Empty(t, *asked, "a manifest with no references must not touch the network")
 }
 
 func TestVerifyCredentials_PresentPasses(t *testing.T) {
 	asked := stubCredentials(t, map[string]bool{"cred-1": true}, nil)
 
-	err := verifyCredentials([]manifest.CredentialRef{
+	err := verifyRefs([]manifest.CredentialRef{
 		{CredentialID: "cred-1", Key: "apiToken", EnvName: "OPENAI_API_KEY", Line: 12},
 	})
 
@@ -74,7 +74,7 @@ func TestVerifyCredentials_PresentPasses(t *testing.T) {
 func TestVerifyCredentials_DeduplicatesByID(t *testing.T) {
 	asked := stubCredentials(t, map[string]bool{"cred-1": true}, nil)
 
-	err := verifyCredentials([]manifest.CredentialRef{
+	err := verifyRefs([]manifest.CredentialRef{
 		{CredentialID: "cred-1", Key: "apiToken", EnvName: "TOKEN_A", Line: 12},
 		{CredentialID: "cred-1", Key: "password", EnvName: "TOKEN_B", Line: 15},
 	})
@@ -89,7 +89,7 @@ func TestVerifyCredentials_DeduplicatesByID(t *testing.T) {
 func TestVerifyCredentials_MissingNamesVariableAndLine(t *testing.T) {
 	stubCredentials(t, map[string]bool{}, nil)
 
-	err := verifyCredentials([]manifest.CredentialRef{
+	err := verifyRefs([]manifest.CredentialRef{
 		{CredentialID: "cred-gone", Key: "apiToken", EnvName: "OPENAI_API_KEY", Line: 12},
 	})
 
@@ -105,7 +105,7 @@ func TestVerifyCredentials_MissingNamesVariableAndLine(t *testing.T) {
 func TestVerifyCredentials_PlaceholderIsRefusedWithoutALookup(t *testing.T) {
 	asked := stubCredentials(t, nil, nil)
 
-	err := verifyCredentials([]manifest.CredentialRef{
+	err := verifyRefs([]manifest.CredentialRef{
 		{CredentialID: manifest.CredentialPlaceholder, Key: "apiToken", EnvName: "OPENAI_API_KEY", Line: 12},
 	})
 
@@ -121,7 +121,7 @@ func TestVerifyCredentials_PlaceholderIsRefusedWithoutALookup(t *testing.T) {
 func TestVerifyCredentials_ReportsEveryProblem(t *testing.T) {
 	stubCredentials(t, map[string]bool{"cred-ok": true}, nil)
 
-	err := verifyCredentials([]manifest.CredentialRef{
+	err := verifyRefs([]manifest.CredentialRef{
 		{CredentialID: manifest.CredentialPlaceholder, EnvName: "FIRST", Line: 10},
 		{CredentialID: "cred-ok", EnvName: "SECOND", Line: 13},
 		{CredentialID: "cred-gone", EnvName: "THIRD", Line: 16},
@@ -139,7 +139,7 @@ func TestVerifyCredentials_ReportsEveryProblem(t *testing.T) {
 func TestVerifyCredentials_TransportFailureIsNotAMissingCredential(t *testing.T) {
 	stubCredentials(t, nil, &drapi.HTTPError{StatusCode: http.StatusBadGateway})
 
-	err := verifyCredentials([]manifest.CredentialRef{
+	err := verifyRefs([]manifest.CredentialRef{
 		{CredentialID: "cred-1", EnvName: "OPENAI_API_KEY", Line: 12},
 	})
 
@@ -156,8 +156,15 @@ func TestVerifyCredentials_TransportFailureIsNotAMissingCredential(t *testing.T)
 func TestVerifyCredentials_NonHTTPErrorPropagates(t *testing.T) {
 	stubCredentials(t, nil, errors.New("no endpoint configured"))
 
-	err := verifyCredentials([]manifest.CredentialRef{{CredentialID: "cred-1", EnvName: "X", Line: 1}})
+	err := verifyRefs([]manifest.CredentialRef{{CredentialID: "cred-1", EnvName: "X", Line: 1}})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no endpoint configured")
+}
+
+// verifyRefs is verifyCredentials with the workload name every test would
+// otherwise have to repeat. The name only shapes the lookup behind a
+// placeholder, which is its own test.
+func verifyRefs(refs []manifest.CredentialRef) error {
+	return verifyCredentials(refs, "my-app")
 }

--- a/internal/workload/up/diff.go
+++ b/internal/workload/up/diff.go
@@ -17,9 +17,12 @@ package up
 import (
 	"fmt"
 	"maps"
+	"math"
 	"reflect"
 	"slices"
 	"strings"
+
+	"github.com/datarobot/cli/internal/workload/manifest"
 )
 
 // Change is one field the manifest asks for that the live object does not
@@ -86,7 +89,7 @@ func walk(path string, want, have any, present bool, out *[]Change) {
 	case []any:
 		walkList(path, w, have, out)
 	default:
-		if !equal(want, have) {
+		if !equalAt(path, want, have) {
 			*out = append(*out, Change{Path: path, Want: want, Have: have})
 		}
 	}
@@ -198,6 +201,58 @@ func byName(list []any) map[string]map[string]any {
 // enough; there is no int-versus-float mismatch to normalise away.
 func equal(a, b any) bool {
 	return reflect.DeepEqual(a, b)
+}
+
+// memoryField is the one leaf whose two sides are written differently: the
+// file says "512MB" and the platform stores and returns 512000000.
+const memoryField = ".memory"
+
+// equalAt compares a leaf, knowing which field it is.
+//
+// Only a size is compared loosely, and only where the path says the leaf is
+// one. Without this the same sizing written two ways reads as drift on every
+// run, for ever, so a workload can never report itself up to date; with it
+// applied everywhere, an unrelated numeric string would quietly compare equal
+// to its number.
+func equalAt(path string, a, b any) bool {
+	if equal(a, b) {
+		return true
+	}
+
+	return strings.HasSuffix(path, memoryField) && sameMemory(a, b)
+}
+
+// sameMemory reports whether two values are the same size written differently.
+// It answers false unless both sides parse as a size, so nothing else is
+// compared loosely by accident.
+func sameMemory(a, b any) bool {
+	left, ok := memoryBytes(a)
+	if !ok {
+		return false
+	}
+
+	right, ok := memoryBytes(b)
+
+	return ok && left == right
+}
+
+// memoryBytes reads a size from either shape the two sides use: the file's
+// string, or the platform's number.
+func memoryBytes(v any) (int64, bool) {
+	switch typed := v.(type) {
+	case string:
+		return manifest.MemoryBytes(typed)
+	case float64:
+		// JSON numbers arrive as float64. A size is a whole number of bytes,
+		// so anything fractional is not one.
+		if typed != math.Trunc(typed) {
+			return 0, false
+		}
+
+		return int64(typed), true
+	default:
+		return 0, false
+	}
 }
 
 // join builds a dotted path, skipping the leading dot at the root.

--- a/internal/workload/up/diff_test.go
+++ b/internal/workload/up/diff_test.go
@@ -415,3 +415,46 @@ func TestExtra_AndSubsetAnswerDifferentQuestions(t *testing.T) {
 	assert.Len(t, Subset(want, have), 1, "the port the file moved")
 	assert.Len(t, Extra(want, have), 1, "the variable the file dropped")
 }
+
+// The platform stores a size as bytes and returns it that way, so "512MB" in
+// the file and 512000000 in the live workload are one sizing written twice.
+// Reporting that as drift meant a workload could never be up to date: every
+// run rebuilt and rolled a project nobody had touched.
+func TestSubset_MemoryIsTheSameSizeWrittenTwoWays(t *testing.T) {
+	want := map[string]any{
+		"containerGroups": []any{map[string]any{
+			"name": "default",
+			"containers": []any{map[string]any{
+				"name":               "primary",
+				"resourceAllocation": map[string]any{"cpu": 0.5, "memory": "512MB"},
+			}},
+		}},
+	}
+	have := map[string]any{
+		"containerGroups": []any{map[string]any{
+			"name": "default",
+			"containers": []any{map[string]any{
+				"name":               "primary",
+				"resourceAllocation": map[string]any{"cpu": 0.5, "memory": 512000000.0},
+			}},
+		}},
+	}
+
+	assert.Empty(t, Subset(want, have), "512MB and 512000000 are the same sizing")
+}
+
+func TestSubset_ADifferentSizeIsStillDrift(t *testing.T) {
+	want := map[string]any{"resourceAllocation": map[string]any{"memory": "1GB"}}
+	have := map[string]any{"resourceAllocation": map[string]any{"memory": 512000000.0}}
+
+	assert.Len(t, Subset(want, have), 1, "1GB is not 512MB")
+}
+
+// The loose comparison is keyed on the field name, so a numeric string
+// elsewhere does not quietly compare equal to its number.
+func TestSubset_OnlyMemoryComparesAcrossTypes(t *testing.T) {
+	want := map[string]any{"port": "8080"}
+	have := map[string]any{"port": 8080.0}
+
+	assert.Len(t, Subset(want, have), 1, "a port written as a string is still a difference")
+}

--- a/internal/workload/up/load.go
+++ b/internal/workload/up/load.go
@@ -76,6 +76,22 @@ func (l Loaded) Spec() (map[string]any, error) {
 	return spec, nil
 }
 
+// ArtifactType is the kind of artifact the file asks for, "" when it names
+// none. It sits beside the spec rather than inside it, because the platform
+// reads the discriminator from the artifact itself and pops any type sent
+// within the spec, so Spec above can never see it.
+func (l Loaded) ArtifactType() (string, error) {
+	payload, err := l.payload()
+	if err != nil {
+		return "", err
+	}
+
+	artifact, _ := payload["artifact"].(map[string]any)
+	artifactType, _ := artifact["type"].(string)
+
+	return artifactType, nil
+}
+
 // Runtime is the sizing half of the file, again in the live object's shape.
 func (l Loaded) Runtime() (map[string]any, error) {
 	payload, err := l.payload()

--- a/internal/workload/up/look.go
+++ b/internal/workload/up/look.go
@@ -39,7 +39,14 @@ const (
 	keyStatus     = "status"
 	keyEndpoint   = "endpoint"
 	keyArtifactID = "artifactId"
+	keyType       = "type"
 )
+
+// keyArtifactType is what the plan calls a change of artifact kind. It is
+// spelled for a reader of the plan rather than as the API's own field name,
+// which is bare "type" on the artifact and would read as nothing in
+// particular on a line of its own.
+const keyArtifactType = "artifact.type"
 
 // Live is the workload as the platform currently has it: the two cleaned
 // documents that drift is measured against, plus the few scalars the command
@@ -63,6 +70,12 @@ type Live struct {
 
 	// ArtifactID is the artifact currently running, "" when there is none.
 	ArtifactID string
+
+	// ArtifactType is what kind of thing that artifact is: a service, an
+	// agent. It sits beside the spec rather than in it, because the platform
+	// reads the discriminator from the artifact and pops any type sent inside
+	// the spec, so the spec walk never sees it.
+	ArtifactType string
 
 	// Endpoint is the workload's stable URL. The platform assigns it at
 	// creation and it survives every rollout, so it is safe to print before
@@ -107,12 +120,13 @@ func Look(workloadID string) (Live, error) {
 	status := workloadDoc.String(keyStatus)
 
 	return Live{
-		Live:       manifest.NewLive(workloadID, workloadDoc, artifactDoc),
-		State:      stateFor(status),
-		Status:     status,
-		ArtifactID: artifactID,
-		Endpoint:   workloadDoc.String(keyEndpoint),
-		Locked:     isLocked(artifactDoc.String(keyStatus)),
+		Live:         manifest.NewLive(workloadID, workloadDoc, artifactDoc),
+		State:        stateFor(status),
+		Status:       status,
+		ArtifactID:   artifactID,
+		ArtifactType: artifactDoc.String(keyType),
+		Endpoint:     workloadDoc.String(keyEndpoint),
+		Locked:       isLocked(artifactDoc.String(keyStatus)),
 	}, nil
 }
 

--- a/internal/workload/up/phase.go
+++ b/internal/workload/up/phase.go
@@ -73,7 +73,10 @@ func (r *reporter) work(label string, fn func() error) error {
 // done prints the completed phase. Durations are truncated to a tenth of a
 // second: a deploy is measured in minutes and the extra digits are noise.
 func (r *reporter) done(label string, elapsed time.Duration) {
-	fmt.Fprintf(r.out, "  ✓ %s (%s)\n", label, elapsed.Truncate(100*time.Millisecond))
+	fmt.Fprintf(r.out, "  %s %s %s\n",
+		tui.SuccessStyle.Render("✓"),
+		label,
+		tui.HintStyle.Render("("+elapsed.Truncate(100*time.Millisecond).String()+")"))
 }
 
 // say prints a line that is not a phase, such as a warning or a note.

--- a/internal/workload/up/plan.go
+++ b/internal/workload/up/plan.go
@@ -147,5 +147,27 @@ func Build(loaded Loaded, live Live, code CodeChange) (Plan, error) {
 		})
 	}
 
+	kind, err := loaded.ArtifactType()
+	if err != nil {
+		return Plan{}, err
+	}
+
+	// The type is the same kind of blind spot for the same reason. It sits
+	// beside the spec because the platform reads the discriminator off the
+	// artifact and pops any type sent inside the spec, so the walk above
+	// cannot see it either. Turning a service into an agent is a real change
+	// and needs a new version; without this it reads as already up to date.
+	//
+	// Only when the file names one. Saying nothing about the type is not the
+	// same as asking for a service, and this walk never reverts what the file
+	// leaves out.
+	if kind != "" && kind != live.ArtifactType {
+		plan.Artifact = append(plan.Artifact, Change{
+			Path: keyArtifactType,
+			Have: live.ArtifactType,
+			Want: kind,
+		})
+	}
+
 	return plan, nil
 }

--- a/internal/workload/up/plan_test.go
+++ b/internal/workload/up/plan_test.go
@@ -364,3 +364,67 @@ func TestBuild_BadPayloadIsReported(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "compiled manifest")
 }
+
+// The type sits beside the spec, not in it: the platform reads the
+// discriminator off the artifact and pops any type sent within the spec, so
+// the spec walk is blind to it. Without a comparison of its own, turning a
+// service into an agent reads as already up to date.
+func TestBuild_ArtifactTypeChangeIsARoll(t *testing.T) {
+	loaded := Loaded{Compiled: &manifest.Compiled{
+		Payload: json.RawMessage(`{
+		  "name": "my-app",
+		  "artifact": {"name": "my-app-artifact", "type": "agent", "spec": {}}
+		}`),
+	}}
+
+	live := liveFrom(t, StateRunning, "", planLiveRuntime)
+	live.ArtifactType = "service"
+
+	plan, err := Build(loaded, live, builtCode(0))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"artifact.type"}, paths(plan.Artifact))
+	assert.Equal(t, ActionRolled, plan.Action(), "a different kind of artifact needs a new version")
+	assert.False(t, plan.Empty())
+}
+
+// The same file against a workload already running that kind plans nothing,
+// or every deploy of an agent would roll it onto itself.
+func TestBuild_MatchingArtifactTypeIsEmpty(t *testing.T) {
+	loaded := Loaded{Compiled: &manifest.Compiled{
+		Payload: json.RawMessage(`{
+		  "name": "my-app",
+		  "artifact": {"name": "my-app-artifact", "type": "agent", "spec": {}}
+		}`),
+	}}
+
+	live := liveFrom(t, StateRunning, "", planLiveRuntime)
+	live.ArtifactType = "agent"
+
+	plan, err := Build(loaded, live, builtCode(0))
+	require.NoError(t, err)
+
+	assert.Empty(t, plan.Artifact)
+	assert.True(t, plan.Empty())
+}
+
+// Saying nothing about the type is not the same as asking for a service. A
+// manifest written before the type moved out of the spec names none, and this
+// walk never reverts what the file leaves out.
+func TestBuild_NoTypeInTheFileIsNotDrift(t *testing.T) {
+	loaded := Loaded{Compiled: &manifest.Compiled{
+		Payload: json.RawMessage(`{
+		  "name": "my-app",
+		  "artifact": {"name": "my-app-artifact", "spec": {}}
+		}`),
+	}}
+
+	live := liveFrom(t, StateRunning, "", planLiveRuntime)
+	live.ArtifactType = "agent"
+
+	plan, err := Build(loaded, live, builtCode(0))
+	require.NoError(t, err)
+
+	assert.Empty(t, plan.Artifact)
+	assert.True(t, plan.Empty())
+}

--- a/internal/workload/up/render.go
+++ b/internal/workload/up/render.go
@@ -84,10 +84,23 @@ func header(s Summary, plan Plan) string {
 	}
 
 	if plan.Creates || s.WorkloadID == "" {
-		return fmt.Sprintf("%s, %s", name, plan.State)
+		return fmt.Sprintf("%s, %s", name, headerState(plan.State))
 	}
 
-	return fmt.Sprintf("%s (%s), %s", name, shortID(s.WorkloadID), plan.State)
+	return fmt.Sprintf("%s (%s), %s", name, shortID(s.WorkloadID), headerState(plan.State))
+}
+
+// headerState is how a state reads at the top of a plan block, which is not
+// always how it reads in the JSON envelope. "not created yet" sounds like a
+// claim about the platform; in the header, directly above a line saying a
+// workload will be created, what the reader needs to know is that this file is
+// not bound to one. State.String stays as it is because scripts match on it.
+func headerState(state State) string {
+	if state == StateUnbound {
+		return "no workload bound yet"
+	}
+
+	return state.String()
 }
 
 // shortID trims an id to something a person can compare at a glance.
@@ -186,8 +199,8 @@ func entry(marker, class, detail string) string {
 // being moved, and the detail after either is commentary on it.
 var (
 	planTitleStyle = lipgloss.NewStyle().Bold(true)
-	addStyle       = lipgloss.NewStyle().Foreground(tui.GetAdaptiveColor(tui.DrGreen, tui.DrGreenDark)).Bold(true)
-	changeStyle    = lipgloss.NewStyle().Foreground(tui.GetAdaptiveColor(tui.DrYellow, tui.DrYellowDark)).Bold(true)
+	addStyle       = tui.SuccessStyle
+	changeStyle    = tui.WarnStyle
 )
 
 // details lists individual changes under their entry, capped, saying out loud

--- a/internal/workload/up/render.go
+++ b/internal/workload/up/render.go
@@ -53,8 +53,10 @@ const envVarsSegment = ".environmentVars["
 func Render(w io.Writer, s Summary, plan Plan) error {
 	var b strings.Builder
 
-	b.WriteString(planTitleStyle.Render(header(s, plan)))
-	b.WriteString("\n")
+	if head := header(s, plan); head != "" {
+		b.WriteString(planTitleStyle.Render(head))
+		b.WriteString("\n")
+	}
 
 	if plan.Empty() {
 		b.WriteString("\n" + tui.SuccessStyle.Render("✓ Already up to date") + "\n")
@@ -66,7 +68,7 @@ func Render(w io.Writer, s Summary, plan Plan) error {
 
 	b.WriteString("\n")
 
-	for _, line := range lines(plan) {
+	for _, line := range lines(s, plan) {
 		b.WriteString(line)
 		b.WriteString("\n")
 	}
@@ -76,31 +78,23 @@ func Render(w io.Writer, s Summary, plan Plan) error {
 	return err
 }
 
-// header names the workload and says what state it is in.
+// header names the workload being deployed onto and says what state it is in.
+//
+// There is nothing to head a plan with when no workload exists yet: naming a
+// state the reader is about to leave, above a line saying what is about to be
+// created, says the same thing twice and the second time is clearer. The
+// create line carries the name instead.
 func header(s Summary, plan Plan) string {
+	if plan.Creates || s.WorkloadID == "" {
+		return ""
+	}
+
 	name := s.Name
 	if name == "" {
 		name = "workload"
 	}
 
-	if plan.Creates || s.WorkloadID == "" {
-		return fmt.Sprintf("%s, %s", name, headerState(plan.State))
-	}
-
-	return fmt.Sprintf("%s (%s), %s", name, shortID(s.WorkloadID), headerState(plan.State))
-}
-
-// headerState is how a state reads at the top of a plan block, which is not
-// always how it reads in the JSON envelope. "not created yet" sounds like a
-// claim about the platform; in the header, directly above a line saying a
-// workload will be created, what the reader needs to know is that this file is
-// not bound to one. State.String stays as it is because scripts match on it.
-func headerState(state State) string {
-	if state == StateUnbound {
-		return "no workload bound yet"
-	}
-
-	return state.String()
+	return fmt.Sprintf("%s (%s), %s", name, shortID(s.WorkloadID), plan.State)
 }
 
 // shortID trims an id to something a person can compare at a glance.
@@ -114,11 +108,11 @@ func shortID(id string) string {
 
 // lines is the body of the plan, one entry per class of change plus the
 // details each one carries.
-func lines(plan Plan) []string {
+func lines(s Summary, plan Plan) []string {
 	var out []string
 
 	if plan.Creates {
-		out = append(out, entry("+", "workload", "new, with its first artifact"))
+		out = append(out, entry("+", "workload", createDetail(s)))
 	}
 
 	// A stopped workload is the one plan whose reason to act is the state
@@ -139,10 +133,21 @@ func lines(plan Plan) []string {
 	return out
 }
 
+// createDetail names the workload about to be created. The plan is printed
+// before anything happens, and --dry-run prints it instead of acting, so it
+// says what will happen rather than what has.
+func createDetail(s Summary) string {
+	if s.Name == "" {
+		return "will be created, with its first artifact"
+	}
+
+	return s.Name + " will be created, with its first artifact"
+}
+
 // codeDetail says how much of the tree is going up.
 func codeDetail(code CodeChange) string {
 	if code.FirstDeploy {
-		return "the whole project, uploaded for the first time"
+		return "all project files, uploaded for the first time"
 	}
 
 	return fmt.Sprintf("%d %s changed since the last deploy", code.Files, plural(code.Files, "file", "files"))

--- a/internal/workload/up/render.go
+++ b/internal/workload/up/render.go
@@ -18,6 +18,9 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/datarobot/cli/tui"
 )
 
 // Summary names what a plan is about. It comes from the live workload when
@@ -50,11 +53,11 @@ const envVarsSegment = ".environmentVars["
 func Render(w io.Writer, s Summary, plan Plan) error {
 	var b strings.Builder
 
-	b.WriteString(header(s, plan))
+	b.WriteString(planTitleStyle.Render(header(s, plan)))
 	b.WriteString("\n")
 
 	if plan.Empty() {
-		b.WriteString("\nAlready up to date\n")
+		b.WriteString("\n" + tui.SuccessStyle.Render("✓ Already up to date") + "\n")
 
 		_, err := io.WriteString(w, b.String())
 
@@ -102,7 +105,7 @@ func lines(plan Plan) []string {
 	var out []string
 
 	if plan.Creates {
-		out = append(out, entry("+", "workload", "created on this run, with its first artifact"))
+		out = append(out, entry("+", "workload", "new, with its first artifact"))
 	}
 
 	// A stopped workload is the one plan whose reason to act is the state
@@ -126,7 +129,7 @@ func lines(plan Plan) []string {
 // codeDetail says how much of the tree is going up.
 func codeDetail(code CodeChange) string {
 	if code.FirstDeploy {
-		return "first sync of this project"
+		return "the whole project, uploaded for the first time"
 	}
 
 	return fmt.Sprintf("%d %s changed since the last deploy", code.Files, plural(code.Files, "file", "files"))
@@ -168,8 +171,24 @@ func runtimeLines(plan Plan) []string {
 
 // entry formats one plan line: a marker, the class, and what happens to it.
 func entry(marker, class, detail string) string {
-	return fmt.Sprintf("  %s %-10s %s", marker, class, detail)
+	style := changeStyle
+	if marker == "+" {
+		style = addStyle
+	}
+
+	return fmt.Sprintf("  %s %s %s",
+		style.Render(marker),
+		style.Render(fmt.Sprintf("%-10s", class)),
+		tui.HintStyle.Render(detail))
 }
+
+// The plan block's palette: an addition reads as new, a change as something
+// being moved, and the detail after either is commentary on it.
+var (
+	planTitleStyle = lipgloss.NewStyle().Bold(true)
+	addStyle       = lipgloss.NewStyle().Foreground(tui.GetAdaptiveColor(tui.DrGreen, tui.DrGreenDark)).Bold(true)
+	changeStyle    = lipgloss.NewStyle().Foreground(tui.GetAdaptiveColor(tui.DrYellow, tui.DrYellowDark)).Bold(true)
+)
 
 // details lists individual changes under their entry, capped, saying out loud
 // how many it left out.

--- a/internal/workload/up/render_test.go
+++ b/internal/workload/up/render_test.go
@@ -92,7 +92,7 @@ func TestRender_FirstDeploy(t *testing.T) {
 		Code:    CodeChange{Applies: true, FirstDeploy: true},
 	})
 
-	assert.Contains(t, out, "my-app, no workload yet")
+	assert.Contains(t, out, "my-app, no workload bound yet")
 	assert.NotContains(t, out, "(", "there is no id to show yet")
 	assert.Contains(t, out, "+ workload   new, with its first artifact")
 	assert.Contains(t, out, "~ code       the whole project, uploaded for the first time")
@@ -203,7 +203,7 @@ func TestRender_ShortIDLeavesShortIDsAlone(t *testing.T) {
 func TestRender_UnnamedWorkloadStillRenders(t *testing.T) {
 	out := render(t, Summary{}, Plan{State: StateUnbound, Creates: true})
 
-	assert.Contains(t, out, "workload, no workload yet")
+	assert.Contains(t, out, "workload, no workload bound yet")
 }
 
 func TestPlanJSON_Shape(t *testing.T) {

--- a/internal/workload/up/render_test.go
+++ b/internal/workload/up/render_test.go
@@ -38,7 +38,7 @@ var appSummary = Summary{Name: "my-app", WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"}
 func TestRender_Empty(t *testing.T) {
 	out := render(t, appSummary, Plan{State: StateRunning, Code: builtCode(0)})
 
-	assert.Equal(t, "my-app (68b0c1d2), running\n\nAlready up to date\n", out)
+	assert.Equal(t, "my-app (68b0c1d2), running\n\n✓ Already up to date\n", out)
 }
 
 func TestRender_TheThreeClasses(t *testing.T) {
@@ -92,10 +92,10 @@ func TestRender_FirstDeploy(t *testing.T) {
 		Code:    CodeChange{Applies: true, FirstDeploy: true},
 	})
 
-	assert.Contains(t, out, "my-app, not created yet")
+	assert.Contains(t, out, "my-app, no workload yet")
 	assert.NotContains(t, out, "(", "there is no id to show yet")
-	assert.Contains(t, out, "+ workload   created on this run, with its first artifact")
-	assert.Contains(t, out, "~ code       first sync of this project")
+	assert.Contains(t, out, "+ workload   new, with its first artifact")
+	assert.Contains(t, out, "~ code       the whole project, uploaded for the first time")
 }
 
 // TestRender_PublishedImageNeverMentionsCode: a manifest naming an image has
@@ -203,7 +203,7 @@ func TestRender_ShortIDLeavesShortIDsAlone(t *testing.T) {
 func TestRender_UnnamedWorkloadStillRenders(t *testing.T) {
 	out := render(t, Summary{}, Plan{State: StateUnbound, Creates: true})
 
-	assert.Contains(t, out, "workload, not created yet")
+	assert.Contains(t, out, "workload, no workload yet")
 }
 
 func TestPlanJSON_Shape(t *testing.T) {

--- a/internal/workload/up/render_test.go
+++ b/internal/workload/up/render_test.go
@@ -92,10 +92,10 @@ func TestRender_FirstDeploy(t *testing.T) {
 		Code:    CodeChange{Applies: true, FirstDeploy: true},
 	})
 
-	assert.Contains(t, out, "my-app, no workload bound yet")
 	assert.NotContains(t, out, "(", "there is no id to show yet")
-	assert.Contains(t, out, "+ workload   new, with its first artifact")
-	assert.Contains(t, out, "~ code       the whole project, uploaded for the first time")
+	assert.Contains(t, out, "+ workload   my-app will be created, with its first artifact",
+		"the create line carries the name, so nothing has to head the block")
+	assert.Contains(t, out, "~ code       all project files, uploaded for the first time")
 }
 
 // TestRender_PublishedImageNeverMentionsCode: a manifest naming an image has
@@ -203,7 +203,7 @@ func TestRender_ShortIDLeavesShortIDsAlone(t *testing.T) {
 func TestRender_UnnamedWorkloadStillRenders(t *testing.T) {
 	out := render(t, Summary{}, Plan{State: StateUnbound, Creates: true})
 
-	assert.Contains(t, out, "workload, no workload bound yet")
+	assert.Contains(t, out, "+ workload   will be created, with its first artifact")
 }
 
 func TestPlanJSON_Shape(t *testing.T) {

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -45,6 +45,7 @@ var (
 	waitBuildFn        = workload.WaitForBuild
 	listBuildsFn       = workload.ListArtifactBuilds
 	getCredentialFn    = workload.GetCredential
+	findCredentialFn   = workload.FindCredentialNamed
 	guardReplacementFn = workload.GuardNoActiveReplacement
 	startReplacementFn = workload.StartReplacement
 	waitReplacementFn  = workload.WaitForReplacement
@@ -254,7 +255,7 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 		// A start is when the container resolves its references, so a
 		// credential deleted while the workload was off would otherwise fail
 		// minutes later as a container that will not come up.
-		if err := verifyCredentials(loaded.Compiled.CredentialRefs); err != nil {
+		if err := verifyCredentials(loaded.Compiled.CredentialRefs, result.Name); err != nil {
 			return result, err
 		}
 
@@ -283,7 +284,7 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 
 	// Last check before the first mutation, and the only one that needs the
 	// network: a credential id is the one thing the local ledger cannot judge.
-	if err := verifyCredentials(loaded.Compiled.CredentialRefs); err != nil {
+	if err := verifyCredentials(loaded.Compiled.CredentialRefs, result.Name); err != nil {
 		return result, err
 	}
 

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -754,6 +754,55 @@ func TestRun_LinkedProjectReusesItsArtifact(t *testing.T) {
 	assert.Equal(t, "art-existing", decodePayload(t, tr.workloadIn)["artifactId"])
 }
 
+// The platform allows one workload per draft artifact, so a stale link sends
+// the deploy at an artifact that is already spoken for. Its own message names
+// an id and nothing about where that id came from, which leaves the reader
+// with a conflict and no idea what chose the thing that conflicted.
+func TestRun_ConflictOnAReusedArtifactExplainsTheLink(t *testing.T) {
+	var tr track
+
+	f := wiredBuild(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = func(string) (wapi.Config, error) { return wapi.Config{ArtifactID: "art-existing"}, nil }
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
+	}
+	f.create = func(any) (*workload.Workload, error) {
+		return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
+	}
+	f.list = func(int, []string) ([]workload.Workload, error) {
+		return []workload.Workload{{ID: "wl-owner", Name: "someone-else", ArtifactID: "art-existing"}}, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "art-existing", "the artifact the link chose")
+	assert.Contains(t, err.Error(), ".datarobot", "where that choice is recorded")
+	assert.Contains(t, err.Error(), "wl-owner", "the workload that already has it")
+	assert.Contains(t, err.Error(), "workloadId: wl-owner", "a line the reader can paste")
+}
+
+// The same conflict against an artifact this run just minted is not a stale
+// link, so it must not be explained as one.
+func TestRun_ConflictOnAFreshArtifactIsNotBlamedOnTheLink(t *testing.T) {
+	var tr track
+
+	f := wiredBuild(&tr)
+	f.create = func(any) (*workload.Workload, error) {
+		return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
+	}
+	f.list = func(int, []string) ([]workload.Workload, error) { return nil, nil }
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "only one workload per draft artifact")
+}
+
 // A locked artifact can take neither code nor an image, so the deploy stops
 // before the sync rather than failing halfway through with the platform's
 // 403, which says nothing about what to do next.
@@ -1046,7 +1095,7 @@ func TestRun_DryRunOnABuildTrackSucceeds(t *testing.T) {
 
 	_, stderr, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true, DryRun: true})
 	require.NoError(t, err, "planning works on every track even where applying does not")
-	assert.Contains(t, stderr, "first sync of this project")
+	assert.Contains(t, stderr, "uploaded for the first time")
 }
 
 // stoppedWorkload is the live fixture, off. Everything else about it still

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -133,17 +133,18 @@ runtime:
 // reach the network by omission and a test only wires what it means to
 // exercise.
 type fakes struct {
-	wizard    func(wizard.Options) (wizard.Result, error)
-	create    func(any) (*workload.Workload, error)
-	wait      func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
-	list      func(int, []string) ([]workload.Workload, error)
-	start     func(string) (*workload.WorkloadOperationResponse, error)
-	lock      func(string) (*workload.Artifact, error)
-	cred      func(string) (*workload.Credential, error)
-	writeID   func(string, string) error
-	code      func(Loaded, Live) (CodeChange, error)
-	workloadD func(string) (workload.Document, error)
-	artifactD func(string) (workload.Document, error)
+	wizard         func(wizard.Options) (wizard.Result, error)
+	create         func(any) (*workload.Workload, error)
+	wait           func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
+	list           func(int, []string) ([]workload.Workload, error)
+	start          func(string) (*workload.WorkloadOperationResponse, error)
+	lock           func(string) (*workload.Artifact, error)
+	cred           func(string) (*workload.Credential, error)
+	findCredential func(string, int) (*workload.Credential, error)
+	writeID        func(string, string) error
+	code           func(Loaded, Live) (CodeChange, error)
+	workloadD      func(string) (workload.Document, error)
+	artifactD      func(string) (workload.Document, error)
 
 	// The build track: create an artifact, link the project to it, push the
 	// code, turn it into an image.
@@ -187,6 +188,13 @@ func install(t *testing.T, f fakes) {
 
 		return nil, nil
 	})
+
+	// The placeholder message looks a credential up by name. Left unwired it
+	// would list credentials from whatever tenant the developer is logged
+	// into; answering "no such credential" is the quiet default every test
+	// that does not care about the lookup wants.
+	force(t, &findCredentialFn, func(string, int) (*workload.Credential, error) { return nil, nil })
+	swap(t, &findCredentialFn, f.findCredential)
 
 	swap(t, &runWizardFn, f.wizard)
 	swap(t, &createWorkloadFn, f.create)
@@ -783,6 +791,36 @@ func TestRun_ConflictOnAReusedArtifactExplainsTheLink(t *testing.T) {
 	assert.Contains(t, err.Error(), ".datarobot", "where that choice is recorded")
 	assert.Contains(t, err.Error(), "wl-owner", "the workload that already has it")
 	assert.Contains(t, err.Error(), "workloadId: wl-owner", "a line the reader can paste")
+}
+
+// A 409 on a linked project is just as likely to be a duplicate workload
+// name, which create() has already explained accurately. Rewriting that as a
+// link problem would send the user to delete the link and orphan an artifact
+// for a reason that was never the cause.
+func TestRun_NameConflictOnALinkedProjectKeepsItsOwnMessage(t *testing.T) {
+	var tr track
+
+	f := wiredBuild(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = func(string) (wapi.Config, error) { return wapi.Config{ArtifactID: "art-existing"}, nil }
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
+	}
+	f.create = func(any) (*workload.Workload, error) {
+		return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
+	}
+	// Nothing holds the artifact; the name is what collided.
+	f.list = func(int, []string) ([]workload.Workload, error) {
+		return []workload.Workload{{ID: "wl-1", Name: "my-app", ArtifactID: "art-somewhere-else"}}, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "workloadId: wl-1", "the name conflict's own advice")
+	assert.NotContains(t, err.Error(), "delete", "nothing here calls for deleting the link")
 }
 
 // The same conflict against an artifact this run just minted is not a stale

--- a/internal/workload/up/state.go
+++ b/internal/workload/up/state.go
@@ -60,7 +60,7 @@ const (
 func (s State) String() string {
 	switch s {
 	case StateUnbound:
-		return "not created yet"
+		return "no workload yet"
 	case StateMissing:
 		return "missing"
 	case StateTerminated:

--- a/internal/workload/up/state.go
+++ b/internal/workload/up/state.go
@@ -60,7 +60,7 @@ const (
 func (s State) String() string {
 	switch s {
 	case StateUnbound:
-		return "no workload yet"
+		return "not created yet"
 	case StateMissing:
 		return "missing"
 	case StateTerminated:

--- a/internal/workload/up/state_test.go
+++ b/internal/workload/up/state_test.go
@@ -87,7 +87,7 @@ func TestState_TheOffStatusesReduceToStopped(t *testing.T) {
 }
 
 func TestState_String(t *testing.T) {
-	assert.Equal(t, "not created yet", StateUnbound.String())
+	assert.Equal(t, "no workload yet", StateUnbound.String())
 	assert.Equal(t, "missing", StateMissing.String())
 	assert.Equal(t, "terminated", StateTerminated.String())
 	assert.Equal(t, "stopped", StateStopped.String())

--- a/internal/workload/up/state_test.go
+++ b/internal/workload/up/state_test.go
@@ -87,7 +87,8 @@ func TestState_TheOffStatusesReduceToStopped(t *testing.T) {
 }
 
 func TestState_String(t *testing.T) {
-	assert.Equal(t, "no workload yet", StateUnbound.String())
+	assert.Equal(t, "not created yet", StateUnbound.String(),
+		"the envelope reports this; scripts match on it, so the header wording lives in render.go")
 	assert.Equal(t, "missing", StateMissing.String())
 	assert.Equal(t, "terminated", StateTerminated.String())
 	assert.Equal(t, "stopped", StateStopped.String())

--- a/internal/workload/wizard/mint.go
+++ b/internal/workload/wizard/mint.go
@@ -21,9 +21,11 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/datarobot/cli/tui"
 )
 
 // Import is what storing the secrets did, one entry per secret the run tried
@@ -91,9 +93,11 @@ func importSecrets(vars []manifest.EnvVar, detected Detected, workloadName strin
 			continue
 		}
 
-		cred, err := createCredentialFn(credentialName(workloadName, v.Name), value)
+		name := CredentialName(workloadName, v.Name)
+
+		cred, err := createCredentialFn(name, value)
 		if err != nil {
-			report.Failed = append(report.Failed, ImportFailure{Name: v.Name, Reason: importReason(err)})
+			report.Failed = append(report.Failed, ImportFailure{Name: v.Name, Reason: importReason(err, name)})
 
 			continue
 		}
@@ -118,11 +122,14 @@ func secretValues(detected Detected) map[string]string {
 	return values
 }
 
-// credentialName is what the credential is called in a store shared by the
+// CredentialName is what the credential is called in a store shared by the
 // whole tenant. The workload name is the prefix because a bare OPENAI_API_KEY
 // belongs to whoever created it first, and the second project to try would
 // collide with a credential it cannot see the value of.
-func credentialName(workloadName, envName string) string {
+//
+// Exported because the deploy needs it too: a manifest still carrying the
+// placeholder is one lookup away from the id that belongs there.
+func CredentialName(workloadName, envName string) string {
 	if workloadName == "" {
 		return envName
 	}
@@ -131,14 +138,17 @@ func credentialName(workloadName, envName string) string {
 }
 
 // importReason turns a failure into something worth reading. A name already
-// taken is the one case with an obvious next step, and it is common: running
-// setup twice on the same project reaches it every time.
-func importReason(err error) string {
+// taken is the common one: credential names are unique across the whole
+// organisation, so setting up a second project under the same workload name
+// reaches it every time. The value behind that name is not visible from here
+// and may not be the one in this .env, which is why it is not reused silently.
+func importReason(err error, name string) string {
 	var httpErr *drapi.HTTPError
 
 	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusConflict {
-		return "a credential of that name already exists; " +
-			"reuse it by pasting its id, or rename it in the DataRobot UI"
+		return fmt.Sprintf(
+			"a credential called %q already exists in your organisation, and its value may not be this one. "+
+				"Reuse it by pasting its id, or deploy under a different workload name.", name)
 	}
 
 	return strings.TrimSpace(err.Error())
@@ -154,18 +164,36 @@ func reportImport(stderr io.Writer, report Import) {
 	}
 
 	if len(report.Stored) > 0 {
-		fmt.Fprintf(stderr, "Stored %d %s in the credential store: %s.\n",
+		fmt.Fprintf(stderr, "  %s Stored %d %s %s\n",
+			tui.SuccessStyle.Render("✓"),
 			len(report.Stored), Plural(len(report.Stored), "secret", "secrets"),
-			strings.Join(report.Stored, ", "))
+			tui.HintStyle.Render("("+storedNames(report.Stored)+")"))
 	}
 
 	for _, failure := range report.Failed {
-		fmt.Fprintf(stderr,
-			"Warning: %s was not stored, because %s.\n"+
-				"  Its entry in %s still says %s; a deploy will refuse it until that is a credential id.\n",
-			failure.Name, failure.Reason, manifest.FileName, manifest.CredentialPlaceholder)
+		fmt.Fprintf(stderr, "  %s %s\n    %s\n    %s\n",
+			warnStyle.Render("!"),
+			warnStyle.Render(failure.Name+" was not stored"),
+			failure.Reason,
+			tui.HintStyle.Render(fmt.Sprintf("%s keeps %s for it, and a deploy will refuse that.",
+				manifest.FileName, manifest.CredentialPlaceholder)))
 	}
 }
+
+// storedNames lists what was stored, trimmed to a line's worth. Past a
+// handful the names stop being a summary and start being a wall, and the file
+// is the better place to read them all.
+func storedNames(names []string) string {
+	if len(names) <= namesShown {
+		return strings.Join(names, ", ")
+	}
+
+	return fmt.Sprintf("%s, … and %d more, all in %s",
+		strings.Join(names[:namesShown], ", "), len(names)-namesShown, manifest.FileName)
+}
+
+// namesShown is how many secrets are named before the list is cut short.
+const namesShown = 5
 
 // pendingSecrets counts the entries still carrying a placeholder, which is
 // what the command reports as unfinished.
@@ -184,3 +212,7 @@ func pendingSecrets(vars []manifest.EnvVar) int {
 // createCredentialFn is the seam the tests replace: storing a secret is the
 // one call in setup that cannot be allowed to reach a real tenant by accident.
 var createCredentialFn = workload.CreateCredential
+
+// warnStyle marks something that did not happen but did not stop the run.
+var warnStyle = lipgloss.NewStyle().
+	Foreground(tui.GetAdaptiveColor(tui.DrYellow, tui.DrYellowDark)).Bold(true)

--- a/internal/workload/wizard/mint.go
+++ b/internal/workload/wizard/mint.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
@@ -172,8 +171,8 @@ func reportImport(stderr io.Writer, report Import) {
 
 	for _, failure := range report.Failed {
 		fmt.Fprintf(stderr, "  %s %s\n    %s\n    %s\n",
-			warnStyle.Render("!"),
-			warnStyle.Render(failure.Name+" was not stored"),
+			tui.WarnStyle.Render("!"),
+			tui.WarnStyle.Render(failure.Name+" was not stored"),
 			failure.Reason,
 			tui.HintStyle.Render(fmt.Sprintf("%s keeps %s for it, and a deploy will refuse that.",
 				manifest.FileName, manifest.CredentialPlaceholder)))
@@ -212,7 +211,3 @@ func pendingSecrets(vars []manifest.EnvVar) int {
 // createCredentialFn is the seam the tests replace: storing a secret is the
 // one call in setup that cannot be allowed to reach a real tenant by accident.
 var createCredentialFn = workload.CreateCredential
-
-// warnStyle marks something that did not happen but did not stop the run.
-var warnStyle = lipgloss.NewStyle().
-	Foreground(tui.GetAdaptiveColor(tui.DrYellow, tui.DrYellowDark)).Bold(true)

--- a/internal/workload/wizard/mint_test.go
+++ b/internal/workload/wizard/mint_test.go
@@ -217,8 +217,8 @@ func TestImportSecrets_AlreadyStoredIsLeftAlone(t *testing.T) {
 // An unnamed workload still produces a usable credential name rather than an
 // empty prefix and a stray slash.
 func TestCredentialName_WithoutAWorkloadName(t *testing.T) {
-	assert.Equal(t, "my-app/OPENAI_API_KEY", credentialName("my-app", "OPENAI_API_KEY"))
-	assert.Equal(t, "OPENAI_API_KEY", credentialName("", "OPENAI_API_KEY"))
+	assert.Equal(t, "my-app/OPENAI_API_KEY", CredentialName("my-app", "OPENAI_API_KEY"))
+	assert.Equal(t, "OPENAI_API_KEY", CredentialName("", "OPENAI_API_KEY"))
 }
 
 // Interactively the secrets are stored when the confirm screen is accepted,

--- a/internal/workload/wizard/model_test.go
+++ b/internal/workload/wizard/model_test.go
@@ -198,7 +198,7 @@ func TestFlow_BindingScreenLeadsWhenThereAreWorkloads(t *testing.T) {
 func TestFlow_BindingDownloadsTheLiveSpec(t *testing.T) {
 	stubLive(t,
 		documentFrom(t, `{"name": "triage-agent", "artifactId": "68a1"}`),
-		documentFrom(t, `{"name": "triage-agent-artifact", "spec": {"type": "agent", "a2aEnabled": true,
+		documentFrom(t, `{"name": "triage-agent-artifact", "type": "agent", "spec": {"a2aEnabled": true,
 			"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 9001, "imageUri": "registry/triage:v3",
 				 "readinessProbe": {"path": "/alive", "port": 9001}}]}]}}`))
@@ -474,8 +474,7 @@ func TestFlow_ConfirmProducesTheManifest(t *testing.T) {
 func TestFlow_ConfirmDiffsABoundWorkload(t *testing.T) {
 	stubLive(t,
 		documentFrom(t, `{"name": "triage-agent", "artifactId": "68a1"}`),
-		documentFrom(t, `{"name": "triage-agent-artifact", "spec": {"type": "service",
-			"containerGroups": [{"name": "default", "containers": [
+		documentFrom(t, `{"name": "triage-agent-artifact", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 9001, "imageUri": "registry/triage:v3",
 				 "readinessProbe": {"path": "/alive", "port": 9001}}]}]}}`))
 

--- a/internal/workload/wizard/regression_test.go
+++ b/internal/workload/wizard/regression_test.go
@@ -45,8 +45,7 @@ func stubLiveDocs(t *testing.T) {
 				"containers": [
 					{"name": "primary", "resourceAllocation": {"cpu": 4, "memory": "8GB"}},
 					{"name": "sidecar", "resourceAllocation": {"cpu": 0.5, "memory": "1GB"}}]}]}}`),
-		documentFrom(t, `{"name": "live-app-artifact", "spec": {"type": "service",
-			"containerGroups": [{"name": "default", "containers": [
+		documentFrom(t, `{"name": "live-app-artifact", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/live:v9",
 				 "readinessProbe": {"path": "/alive", "port": 8000}},
 				{"name": "sidecar", "imageUri": "registry/side:v1"}]}]}}`))
@@ -173,8 +172,7 @@ func TestFlow_BackAndForthKeepsTheA2AAnswer(t *testing.T) {
 func TestFlow_BoundKindTheWizardCannotAuthorIsKept(t *testing.T) {
 	stubLive(t,
 		documentFrom(t, `{"name": "nim-app", "artifactId": "68a1"}`),
-		documentFrom(t, `{"name": "nim-artifact", "spec": {"type": "nim",
-			"containerGroups": [{"name": "default", "containers": [
+		documentFrom(t, `{"name": "nim-artifact", "type": "nim", "spec": {"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 8000, "imageUri": "nvcr.io/nim/llama:latest"}]}]}}`))
 
 	workloads := []workload.Workload{{ID: "68b0", Name: "nim-app", UpdatedAt: time.Now()}}
@@ -263,7 +261,7 @@ func TestFlow_FailedBaseImageListShowsNoStaleRows(t *testing.T) {
 func TestFlow_ConfirmWithNothingRenderedReportsTheRealError(t *testing.T) {
 	stubLive(t,
 		documentFrom(t, `{"name": "odd", "artifactId": "68a1"}`),
-		documentFrom(t, `{"name": "odd-artifact", "spec": {"type": "service", "containerGroups": []}}`))
+		documentFrom(t, `{"name": "odd-artifact", "type": "service", "spec": {"containerGroups": []}}`))
 
 	workloads := []workload.Workload{{ID: "68b0", Name: "odd", UpdatedAt: time.Now()}}
 	model := press(t, newFlow(dockerfileProject(t), workloads, Answers{}), "down", "enter")
@@ -326,7 +324,7 @@ func TestRun_SizingFlagsApplyToABoundWorkload(t *testing.T) {
 func TestAnswers_A2AFlagSemantics(t *testing.T) {
 	stubLive(t,
 		documentFrom(t, `{"name": "agent-app", "artifactId": "68a1"}`),
-		documentFrom(t, `{"name": "agent-artifact", "spec": {"type": "agent", "a2aEnabled": true,
+		documentFrom(t, `{"name": "agent-artifact", "type": "agent", "spec": {"a2aEnabled": true,
 			"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/a:v1"}]}]}}`))
 
@@ -355,8 +353,7 @@ func TestRun_LiveWorkloadTheReaderRejectsSaysSo(t *testing.T) {
 		documentFrom(t, `{"name": "binary-units", "artifactId": "68a1",
 			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
 				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "4Gi"}}]}]}}`),
-		documentFrom(t, `{"name": "a", "spec": {"type": "service",
-			"containerGroups": [{"name": "default", "containers": [
+		documentFrom(t, `{"name": "a", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/a:v1"}]}]}}`))
 
 	_, err := Run(headless(t.TempDir(), Answers{WorkloadID: "68b0"}))
@@ -798,7 +795,7 @@ func TestRowTable_SlashStartsEmptyRatherThanFiltering(t *testing.T) {
 func TestFlow_DockerfileConflictOnlyOnTheSourceScreen(t *testing.T) {
 	stubLive(t,
 		documentFrom(t, `{"name": "builds-a-dockerfile", "artifactId": "68a1"}`),
-		documentFrom(t, `{"name": "a", "spec": {"type": "service", "containerGroups": [{"name": "default",
+		documentFrom(t, `{"name": "a", "type": "service", "spec": {"containerGroups": [{"name": "default",
 			"containers": [{"name": "primary", "primary": true, "port": 8000,
 				"imageBuildConfig": {"dockerfile": {"source": "provided"}}}]}]}}`))
 
@@ -934,7 +931,7 @@ func TestRun_BoundWorkloadCarriesEnv(t *testing.T) {
 func TestRun_BoundWorkloadKeepsItsOwnEnv(t *testing.T) {
 	stubLive(t,
 		documentFrom(t, `{"name": "has-env", "artifactId": "68a1"}`),
-		documentFrom(t, `{"name": "a", "spec": {"type": "service", "containerGroups": [{"name": "default",
+		documentFrom(t, `{"name": "a", "type": "service", "spec": {"containerGroups": [{"name": "default",
 			"containers": [{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/a:v1",
 				"environmentVars": [{"name": "LOG_LEVEL", "value": "warn"}]}]}]}}`))
 
@@ -957,7 +954,7 @@ func TestRun_BoundWorkloadKeepsItsOwnEnv(t *testing.T) {
 func TestRun_BoundWorkloadWithoutARuntimeBlock(t *testing.T) {
 	stubLive(t,
 		documentFrom(t, `{"name": "no-runtime", "artifactId": "68a1"}`),
-		documentFrom(t, `{"name": "a", "spec": {"type": "service", "containerGroups": [{"name": "default",
+		documentFrom(t, `{"name": "a", "type": "service", "spec": {"containerGroups": [{"name": "default",
 			"containers": [{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/a:v1"}]}]}}`))
 
 	result, err := Run(headless(t.TempDir(), Answers{
@@ -1186,8 +1183,7 @@ func TestFlow_BindKeepsTheFlagsGivenBeforeTheFetch(t *testing.T) {
 		documentFrom(t, `{"name": "triage-agent", "importance": "low", "artifactId": "68a1",
 			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 2,
 				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
-		documentFrom(t, `{"name": "triage-agent-artifact", "spec": {"type": "service",
-			"containerGroups": [{"name": "default", "containers": [
+		documentFrom(t, `{"name": "triage-agent-artifact", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 9001, "imageUri": "registry/triage:v3"}]}]}}`))
 
 	model := newFlow(dockerfileProject(t), nil, Answers{
@@ -1245,8 +1241,7 @@ func TestFlow_AutoscaledBoundWorkloadPassesTheSettingsScreen(t *testing.T) {
 			"runtime": {"containerGroups": [{"name": "default",
 				"autoscaling": {"enabled": true, "minReplicaCount": 2, "maxReplicaCount": 9},
 				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
-		documentFrom(t, `{"name": "triage-agent-artifact", "spec": {"type": "service",
-			"containerGroups": [{"name": "default", "containers": [
+		documentFrom(t, `{"name": "triage-agent-artifact", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 9001, "imageUri": "registry/triage:v3"}]}]}}`))
 
 	model := newFlow(dockerfileProject(t), nil, Answers{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"})
@@ -1301,8 +1296,7 @@ func TestFlow_BoundEnvCountsOnlyWhatWasAdded(t *testing.T) {
 		documentFrom(t, `{"name": "triage-agent", "importance": "low", "artifactId": "68a1",
 			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
 				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
-		documentFrom(t, `{"name": "triage-agent-artifact", "spec": {"type": "service",
-			"containerGroups": [{"name": "default", "containers": [
+		documentFrom(t, `{"name": "triage-agent-artifact", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 9001, "imageUri": "registry/triage:v3",
 				 "environmentVars": [{"name": "LOG_LEVEL", "value": "info"}]}]}]}}`))
 

--- a/internal/workload/wizard/run_test.go
+++ b/internal/workload/wizard/run_test.go
@@ -164,8 +164,8 @@ func TestRun_ExistingManifestThatDoesNotValidate(t *testing.T) {
 	require.NoError(t, os.WriteFile(manifest.Path(dir), []byte(`name: broken
 artifact:
   name: broken-artifact
+  type: service
   spec:
-    type: service
     containerGroups:
       - name: default
         containers:
@@ -233,8 +233,7 @@ func TestRun_BindsToALiveWorkload(t *testing.T) {
 		documentFrom(t, `{"name": "live-app", "importance": "high", "artifactId": "68a1",
 			"runtime": {"containerGroups": [{"name": "default", "autoscaling": {"enabled": true, "maxReplicaCount": 9},
 				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 2, "memory": "4GB"}}]}]}}`),
-		documentFrom(t, `{"name": "live-app-artifact", "spec": {"type": "service",
-			"containerGroups": [{"name": "default", "containers": [
+		documentFrom(t, `{"name": "live-app-artifact", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/live:v9"}]}]}}`))
 
 	dir := t.TempDir()
@@ -277,8 +276,7 @@ func boundWithLiveEnv(t *testing.T, envVars string) {
 		documentFrom(t, `{"name": "live-app", "importance": "high", "artifactId": "68a1",
 			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
 				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}]}]}}`),
-		documentFrom(t, `{"name": "live-app-artifact", "spec": {"type": "service",
-			"containerGroups": [{"name": "default", "containers": [
+		documentFrom(t, `{"name": "live-app-artifact", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/live:v9",
 				 "environmentVars": `+envVars+`}]}]}}`))
 }
@@ -414,8 +412,7 @@ func liveGeneratedAgent(t *testing.T) {
 		documentFrom(t, `{"name": "live-agent", "importance": "low", "artifactId": "68a1",
 			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
 				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
-		documentFrom(t, `{"name": "live-agent-artifact", "spec": {"type": "agent",
-			"containerGroups": [{"name": "default", "containers": [
+		documentFrom(t, `{"name": "live-agent-artifact", "type": "agent", "spec": {"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 8000,
 				 "imageBuildConfig": {"dockerfile": {"source": "generated",
 				   "entrypoint": ["python", "old.py"],
@@ -491,8 +488,7 @@ func TestRun_BoundServiceRejectsA2A(t *testing.T) {
 		documentFrom(t, `{"name": "live-app", "importance": "low", "artifactId": "68a1",
 			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
 				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
-		documentFrom(t, `{"name": "live-app-artifact", "spec": {"type": "service",
-			"containerGroups": [{"name": "default", "containers": [
+		documentFrom(t, `{"name": "live-app-artifact", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/live:v9"}]}]}}`))
 
 	_, err := Run(headless(t.TempDir(), Answers{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0", A2AEnabled: true}))
@@ -509,8 +505,7 @@ func TestRun_BoundEnvCountsOnlyWhatWasAdded(t *testing.T) {
 		documentFrom(t, `{"name": "live-app", "importance": "low", "artifactId": "68a1",
 			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
 				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
-		documentFrom(t, `{"name": "live-app-artifact", "spec": {"type": "service",
-			"containerGroups": [{"name": "default", "containers": [
+		documentFrom(t, `{"name": "live-app-artifact", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
 				{"name": "primary", "primary": true, "port": 8000, "imageUri": "registry/live:v9",
 				 "environmentVars": [{"name": "LOG_LEVEL", "value": "info"},
 				                     {"name": "OPENAI_API_KEY", "value": "live"}]}]}]}}`))

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -373,7 +373,7 @@ func (f flow) sourceConflictNote() string {
 func (f flow) screenIntro() string {
 	switch f.at {
 	case screenName:
-		return "Identifies the workload in the platform and in `dr workload list`."
+		return ""
 	case screenKind:
 		return "Both run as containers and are built the same way. Agent additionally enables " +
 			"agent capabilities, the first of which is A2A discovery."
@@ -439,7 +439,7 @@ func (f flow) boundScreenNote() string {
 // wizard sounding like one voice rather than ten.
 var questions = map[screen]string{
 	screenBinding:    "Which workload should this repository deploy to?",
-	screenName:       "What should this workload be called?",
+	screenName:       "Name of your workload",
 	screenKind:       "What kind of workload is this?",
 	screenA2A:        "Publish this agent to the A2A registry?",
 	screenSource:     "How should the container image be produced?",

--- a/tui/styles.go
+++ b/tui/styles.go
@@ -25,10 +25,13 @@ var (
 	BaseTextStyle = lipgloss.NewStyle().Foreground(GetAdaptiveColor(DrPurple, DrPurpleDark))
 	ErrorStyle    = lipgloss.NewStyle().Foreground(DrRed).Bold(true)
 	SuccessStyle  = lipgloss.NewStyle().Foreground(GetAdaptiveColor(DrGreen, DrGreen)).Bold(true)
-	InfoStyle     = lipgloss.NewStyle().Foreground(GetAdaptiveColor(DrPurpleLight, DrPurpleDarkLight)).Bold(true)
-	DimStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	HintStyle     = lipgloss.NewStyle().Foreground(GetAdaptiveColor(DrGray, DrGrayDark))
-	TitleStyle    = BaseTextStyle.Foreground(TitleColor).Bold(true).MarginBottom(1)
+	// WarnStyle marks something that did not happen but did not stop the run,
+	// and the changed half of a diff. Amber rather than red: the run carried on.
+	WarnStyle  = lipgloss.NewStyle().Foreground(GetAdaptiveColor(DrYellow, DrYellowDark)).Bold(true)
+	InfoStyle  = lipgloss.NewStyle().Foreground(GetAdaptiveColor(DrPurpleLight, DrPurpleDarkLight)).Bold(true)
+	DimStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	HintStyle  = lipgloss.NewStyle().Foreground(GetAdaptiveColor(DrGray, DrGrayDark))
+	TitleStyle = BaseTextStyle.Foreground(TitleColor).Bold(true).MarginBottom(1)
 
 	// Specific UI styles.
 	LogoStyle     = BaseTextStyle


### PR DESCRIPTION
# RATIONALE

All of this came out of running the deploy against staging for an afternoon. None of it changes what a deploy does; it changes what you can tell about it while it happens.

## CHANGES

**The output was drowning in `INFO`.** Every GET, POST, PATCH and DELETE logged its URL at info level, which is the default, so a URL landed between each phase of every command in the CLI. That is diagnostic detail and now logs at debug. This is `internal/drapi`, so it quietens every command, not just `up`.

**Nothing was styled.** Additions are green, changes amber, phase ticks green, durations dimmed. `Error:` carries a red prefix, set once on the root command so every subcommand inherits it.

**The endpoint was dropped bare** after the last phase, indistinguishable from a log line. It is now labelled and set off. The label goes to stderr *without* a newline and the URL to stdout, so a terminal reads it as one sentence while `dr workload up | xargs curl` still receives only the URL. The stdout-purity test still holds.

**A `Next:` block** lists what to run against the workload just deployed: logs, status, stop, and the build logs when a build ran. Watching someone finish a deploy and then go hunting for the logs command is what prompted it.

**Wording that described the file as though it described the world.** `not created yet` for a manifest with no `workloadId` is now `no workload yet` — the old phrasing sounded like a claim about the platform and led to deploying a second workload by accident. The plan lines and the name screen got the same treatment.

## Two error messages were actively wrong

A placeholder credential said *"has no credential yet"* while setup had, moments earlier, refused to store one **because a credential of that name already existed**. The two messages contradicted each other. It now looks the credential up by name and hands over the id that belongs on the line, so it is an edit rather than an errand. That needed a new `FindCredentialNamed` client.

A create refused because the linked artifact already backs a workload reported only the platform's raw conflict: an artifact id, and nothing about the gitignored `.datarobot/workload/` link that chose it. It now explains the link, names the workload that owns the artifact, and gives both ways out.

## NOTES

This branch touches merged code (`internal/drapi`, `cmd/root.go`, `render.go`, `state.go`, `screens.go`) and is only stacked at the top for review convenience. It has no dependency on the credentials branch below it and can be rebased onto `main` and merged on its own.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX, logging level, and error-message improvements; deploy logic is unchanged aside from optional credential/workload lookups on validation and conflict failures.
> 
> **Overview**
> Improves **what you see during `dr workload up`** and related commands without changing deploy behavior. Default CLI output is quieter because **HTTP client request URLs** in `internal/drapi` log at **debug** instead of info. **Root errors** get a styled `Error:` prefix; deploy **plans and phase lines** use TUI colors (additions vs changes, checkmarks, dimmed durations). After a successful up, the **endpoint is labeled on stderr** while **stdout stays a bare URL** for piping, plus a **Next:** block suggesting logs, status, stop, and build logs when relevant.
> 
> **Copy and wizard tweaks** reduce confusion: unbound manifests read **no workload yet** (not “not created yet”), plan wording is clearer, and the name screen prompt is simplified.
> 
> **Two error paths are fixed.** Placeholder credentials during verify now **look up the expected credential name** via new **`FindCredentialNamed`** and, when it exists, tell you the **id to paste** instead of contradicting setup’s “name already taken” message. A **409 create on a reused linked artifact** is wrapped with context about **`.datarobot` linkage**, the **owning workload**, and how to rebind or start fresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58a031606e9901119114e458caed9fe79790c467. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->