### PR TITLE
[CFX-7585] Stop reporting server errors and bad endpoint schemes as credential problems

### DIFF
--- a/cmd/auth/check/cmd.go
+++ b/cmd/auth/check/cmd.go
@@ -159,6 +159,8 @@ func verifyDotenvToken(dotenvEndpoint, dotenvToken string) bool {
 			fmt.Print(tui.InfoStyle.Render(dotenvBaseURL))
 			fmt.Println(tui.BaseTextStyle.Render(" timed out. Check your network and try again."))
 		} else {
+			// Blames the token for any non-200, unlike the env-var leg.
+			// Splitting on the status here is a planned follow-up.
 			fmt.Println(tui.BaseTextStyle.Render("❌ DATAROBOT_API_TOKEN in '.env' is invalid or expired."))
 			fmt.Print(tui.BaseTextStyle.Render("Run "))
 			fmt.Print(tui.InfoStyle.Render("dr dotenv update"))

--- a/cmd/auth/check/cmd_test.go
+++ b/cmd/auth/check/cmd_test.go
@@ -52,6 +52,9 @@ func TestVerifyDotenvToken_StatusErrorKeepsMessage(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	orig := os.Stdout
+
+	t.Cleanup(func() { os.Stdout = orig })
+
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 

--- a/cmd/auth/check/cmd_test.go
+++ b/cmd/auth/check/cmd_test.go
@@ -16,6 +16,10 @@ package check
 
 import (
 	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,4 +41,31 @@ func TestCheckCLICredentials_QuotedEndpointNamesEndpointNotToken(t *testing.T) {
 	require.False(t, valid)
 	assert.Contains(t, buf.String(), "DATAROBOT_ENDPOINT environment variable is invalid")
 	assert.NotContains(t, buf.String(), "DATAROBOT_API_TOKEN environment variable is invalid or expired")
+}
+
+// The '.env' leg consumes VerifyToken's error as an opaque non-nil; the typed
+// *config.HTTPStatusError must leave its message and verdict unchanged.
+func TestVerifyDotenvToken_StatusErrorKeepsMessage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = w
+
+	valid := verifyDotenvToken(server.URL+"/api/v2", "expired-token")
+
+	os.Stdout = orig
+
+	require.NoError(t, w.Close())
+
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	require.False(t, valid)
+	assert.Contains(t, string(out), "DATAROBOT_API_TOKEN in '.env' is invalid or expired")
 }

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -175,6 +175,16 @@ Unset it and try again:
 $ dr auth check
 ❌ Could not connect to https://app.example.com: dial tcp: lookup app.example.com: no such host
 Check DATAROBOT_ENDPOINT and your network, then try again.
+
+# The instance answered, but not with a credential verdict (only 401/403 blame the token)
+$ dr auth check
+❌ https://app.example.com answered HTTP 503, so the CLI could not verify your credentials.
+Check DATAROBOT_ENDPOINT, and the instance's status if it persists.
+
+# Endpoint scheme the CLI cannot use
+$ dr auth check
+❌ DATAROBOT_ENDPOINT environment variable is invalid: unsupported URL scheme "ftp", use https://
+Set it to a valid DataRobot URL and try again.
 ```
 
 > [!TIP]

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -29,7 +29,7 @@ var MyCmd = &cobra.Command{
 
 The hook functions are outlined below.
 
-1. **Checks environment credentials first**: A complete `DATAROBOT_ENDPOINT` (or `DATAROBOT_API_ENDPOINT`) and `DATAROBOT_API_TOKEN` pair takes precedence over the config file. If the pair fails verification, the command fails with the reason (timeout, malformed endpoint, unreachable endpoint, or invalid token). It never falls back to the stored profile and never starts the login flow, because that would silently run the command against a different DataRobot instance than the one requested.
+1. **Checks environment credentials first**: A complete `DATAROBOT_ENDPOINT` (or `DATAROBOT_API_ENDPOINT`) and `DATAROBOT_API_TOKEN` pair takes precedence over the config file. If the pair fails verification, the command fails with the reason (timeout, malformed endpoint, unreachable endpoint, a non-2xx status from the instance, or an invalid token; only a 401 or 403 blames the token). It never falls back to the stored profile and never starts the login flow, because that would silently run the command against a different DataRobot instance than the one requested.
 2. **Checks for valid credentials**: With no complete environment pair, checks if a valid API key already exists in the config file.
 3. **Auto-configures URL if missing**: If no DataRobot URL is configured, prompts you to set it up.
 4. **Retrieves new credentials**: If config-file credentials are missing or expired, the hook automatically triggers the browser-based login flow.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -357,7 +357,8 @@ func EnsureAuthenticated(ctx context.Context) bool { //nolint: cyclop
 		return false
 	}
 
-	// No valid token, attempt to get one
+	// Reached for any non-timeout failure, including a 5xx from the instance.
+	// Restricting the login flow to rejected credentials is a planned follow-up.
 	log.Warn("No valid API key found. Starting authentication flow...")
 
 	// Auto-retrieve new credentials without prompting

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -117,20 +118,24 @@ func GetEnvCredentials() EnvCredentials {
 	}
 }
 
-// ValidateEndpoint returns a non-nil error when endpoint is not a usable
-// DataRobot URL (for example, it is wrapped in literal surrounding quotes that
-// make url.Parse fail). It lets callers distinguish a malformed
-// DATAROBOT_ENDPOINT from an expired/invalid token when reporting why
-// environment credentials failed verification. An empty endpoint returns nil
-// (that case is ErrEnvCredentialsNotSet, handled by the caller).
+// ValidateEndpoint rejects an endpoint the CLI cannot use: one that will not
+// parse (surrounding quotes) or a scheme other than http/https. Empty is nil.
 func ValidateEndpoint(endpoint string) error {
 	if endpoint == "" {
 		return nil
 	}
 
-	_, err := config.SchemeHostOnly(endpoint)
+	baseURL, err := config.SchemeHostOnly(endpoint)
+	if err != nil {
+		return err
+	}
 
-	return err
+	// Checked here, not in SchemeHostOnly, which set-url and export share.
+	if scheme, _, _ := strings.Cut(baseURL, "://"); scheme != "http" && scheme != "https" {
+		return fmt.Errorf("unsupported URL scheme %q, use https://", scheme)
+	}
+
+	return nil
 }
 
 // ReportEnvCredentialsError writes a classified explanation of why an
@@ -198,6 +203,23 @@ func ReportEnvCredentialsError(w io.Writer, creds *EnvCredentials, err error) {
 		fmt.Fprint(w, info.Render(envDatarobotHost))
 		fmt.Fprintln(w, base.Render(": "+urlErr.Err.Error()))
 		fmt.Fprintln(w, base.Render("Check "+creds.endpointVarName()+" and your network, then try again."))
+
+		return
+	}
+
+	// Only 401 and 403 mean the token was judged and rejected. Blaming it for
+	// a 404, 429, or 5xx would tell the user to unset working credentials.
+	var statusErr *config.HTTPStatusError
+	if errors.As(err, &statusErr) &&
+		statusErr.StatusCode != http.StatusUnauthorized &&
+		statusErr.StatusCode != http.StatusForbidden {
+		envDatarobotHost, _ := config.SchemeHostOnly(creds.Endpoint)
+
+		fmt.Fprint(w, base.Render("❌ "))
+		fmt.Fprint(w, info.Render(envDatarobotHost))
+		fmt.Fprintln(w, base.Render(fmt.Sprintf(" answered HTTP %d, so the CLI could not verify your credentials.",
+			statusErr.StatusCode)))
+		fmt.Fprintln(w, base.Render("Check "+creds.endpointVarName()+", and the instance's status if it persists."))
 
 		return
 	}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -295,6 +296,50 @@ func TestReportEnvCredentialsError(t *testing.T) {
 		assert.Contains(t, buf.String(), "DATAROBOT_API_ENDPOINT environment variable is invalid")
 		assert.NotContains(t, buf.String(), "DATAROBOT_ENDPOINT environment variable is invalid")
 	})
+
+	t.Run("unsupported scheme is an endpoint problem, not transport", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		creds := &EnvCredentials{Endpoint: "ftp://app.example.com/api/v2", Token: "some-token"}
+		dialErr := &url.Error{
+			Op:  "Get",
+			URL: creds.Endpoint + "/version/",
+			Err: errors.New(`unsupported protocol scheme "ftp"`),
+		}
+		ReportEnvCredentialsError(&buf, creds, dialErr)
+
+		assert.Contains(t, buf.String(), `unsupported URL scheme "ftp"`)
+		assert.NotContains(t, buf.String(), "Could not connect")
+	})
+
+	// Only 401 and 403 may blame the token; every other status is the server
+	// failing to answer the version check.
+	creds := &EnvCredentials{Endpoint: "https://app.example.com/api/v2", Token: "some-token"}
+
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(fmt.Sprintf("%d blames the token", status), func(t *testing.T) {
+			var buf bytes.Buffer
+
+			ReportEnvCredentialsError(&buf, creds, &config.HTTPStatusError{StatusCode: status})
+
+			assert.Contains(t, buf.String(), "DATAROBOT_API_TOKEN environment variable is invalid or expired")
+			assert.Contains(t, buf.String(), "unset DATAROBOT_API_TOKEN")
+		})
+	}
+
+	for _, status := range []int{
+		http.StatusNotFound, http.StatusTooManyRequests, http.StatusInternalServerError,
+	} {
+		t.Run(fmt.Sprintf("%d blames the instance", status), func(t *testing.T) {
+			var buf bytes.Buffer
+
+			ReportEnvCredentialsError(&buf, creds, &config.HTTPStatusError{StatusCode: status})
+
+			assert.Contains(t, buf.String(), fmt.Sprintf("answered HTTP %d", status))
+			assert.Contains(t, buf.String(), "https://app.example.com")
+			assert.NotContains(t, buf.String(), "unset DATAROBOT_API_TOKEN")
+		})
+	}
 }
 
 // TestEnsureAuthenticated_EnvUnreachableStoredValid proves VerifyToken's
@@ -531,6 +576,9 @@ func TestValidateEndpoint(t *testing.T) {
 		{"single quoted", "'https://staging.datarobot.com/api/v2'", true},
 		{"double quoted", `"https://staging.datarobot.com/api/v2"`, true},
 		{"mismatched quotes", `'https://staging.datarobot.com/api/v2"`, true},
+		{"plain http", "http://localhost:8080/api/v2", false},
+		{"uppercase scheme", "HTTPS://app.datarobot.com/api/v2", false},
+		{"ftp scheme", "ftp://app.datarobot.com/api/v2", true},
 	}
 
 	for _, c := range cases {

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -17,6 +17,7 @@ package config
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -42,7 +43,18 @@ func getUserAgent(ctx context.Context) string {
 	return GetUserAgentHeader()
 }
 
+// HTTPStatusError is a non-200 answer to the version check, so callers can tell
+// a rejected token (401/403) from a server or endpoint problem.
+type HTTPStatusError struct {
+	StatusCode int
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("token verification returned HTTP %d", e.StatusCode)
+}
+
 // VerifyToken verifies if the datarobot endpoint + api key pair correspond to a valid pair.
+// A non-200 response is returned as *HTTPStatusError.
 func VerifyToken(ctx context.Context, datarobotEndpoint, token string) error {
 	_, err := url.Parse(datarobotEndpoint)
 	if err != nil {
@@ -80,7 +92,7 @@ func VerifyToken(ctx context.Context, datarobotEndpoint, token string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.New("invalid token")
+		return &HTTPStatusError{StatusCode: resp.StatusCode}
 	}
 
 	return nil

--- a/internal/config/auth_test.go
+++ b/internal/config/auth_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// statusServer answers every request with status.
+func statusServer(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(server.Close)
+
+	return server
+}
+
+// Callers classify on the status, so collapsing every non-200 into one error
+// would leave them unable to tell a rejected token from a failing instance.
+func TestVerifyTokenPreservesStatus(t *testing.T) {
+	for _, status := range []int{
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusTooManyRequests,
+		http.StatusServiceUnavailable,
+	} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			server := statusServer(t, status)
+
+			err := VerifyToken(context.Background(), server.URL+"/api/v2", "some-token")
+
+			var statusErr *HTTPStatusError
+
+			require.ErrorAs(t, err, &statusErr)
+			assert.Equal(t, status, statusErr.StatusCode)
+		})
+	}
+}
+
+func TestVerifyTokenOKReturnsNil(t *testing.T) {
+	server := statusServer(t, http.StatusOK)
+
+	require.NoError(t, VerifyToken(context.Background(), server.URL+"/api/v2", "some-token"))
+}
+
+// GetAPIKey wraps VerifyToken for `dr auth check` and the request-time token
+// cache; the typed error must reach them intact.
+func TestGetAPIKeyPropagatesStatus(t *testing.T) {
+	server := statusServer(t, http.StatusServiceUnavailable)
+
+	viper.Set(DataRobotURL, server.URL+"/api/v2")
+	viper.Set(DataRobotAPIKey, "some-token")
+
+	t.Cleanup(viper.Reset)
+
+	key, err := GetAPIKey(context.Background())
+	assert.Empty(t, key)
+
+	var statusErr *HTTPStatusError
+
+	require.ErrorAs(t, err, &statusErr)
+	assert.Equal(t, http.StatusServiceUnavailable, statusErr.StatusCode)
+}


### PR DESCRIPTION
## Summary

`dr` told users to throw away a working API token whenever the version check came back as anything other than 200. A 404 from a mistyped endpoint, a 429, or a 503 all printed "DATAROBOT_API_TOKEN is invalid or expired, unset it". Only 401 and 403 still say that; any other status now names what the instance answered. And an endpoint scheme the CLI cannot use (`ftp://host`) reads as a bad endpoint instead of a network failure. Both were suppressed review findings on #751, which made them visible on every command.

## Notes for review

The scheme check went into `ValidateEndpoint`, not into the `SchemeHostOnly` helper that `set-url` and `export` share, so those keep accepting what they always did.

Deliberately out of scope, same defect family, follow-up material: `dr auth check`'s `.env` and stored-profile legs still call every failure a stale token or missing key, `EnsureAuthenticated` still starts the login flow when the stored profile's instance answers 5xx, and `dr auth set-url ftp://host` still writes the endpoint unvalidated.

## Output

```
$ DATAROBOT_ENDPOINT=http://127.0.0.1:51801/api/v2 dr auth check   # instance returning 503
- ❌ DATAROBOT_API_TOKEN environment variable is invalid or expired.
- Unset it and try again:
-   unset DATAROBOT_API_TOKEN (or Remove-Item Env:\DATAROBOT_API_TOKEN on Windows)
+ ❌ http://127.0.0.1:51801 answered HTTP 503, so the CLI could not verify your credentials.
+ Check DATAROBOT_ENDPOINT, and the instance's status if it persists.

$ DATAROBOT_ENDPOINT=ftp://example.com/api/v2 dr auth check
- ❌ Could not connect to ftp://example.com: unsupported protocol scheme "ftp"
- Check DATAROBOT_ENDPOINT and your network, then try again.
+ ❌ DATAROBOT_ENDPOINT environment variable is invalid: unsupported URL scheme "ftp", use https://
+ Set it to a valid DataRobot URL and try again.
```

## Technical Changes

- `internal/config/auth.go`: `VerifyToken` returns `*HTTPStatusError{StatusCode}` instead of a flat `invalid token`.
- `internal/auth/auth.go`: `ValidateEndpoint` requires http or https; the classifier's fallthrough splits on the status.
- Tests pin the status preservation, its consumers (`GetAPIKey`, the `.env` leg of `dr auth check`), and 401/403 keeping the exact #751 wording.
- `docs/`: the two new messages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared auth verification and error reporting used on every authenticated command; behavior is narrower (better classification) but mistakes could mis-route users on edge HTTP statuses.
> 
> **Overview**
> Fixes misleading **“invalid or expired API token”** messages when environment credentials fail for reasons other than rejected auth.
> 
> **`VerifyToken`** now returns **`*HTTPStatusError`** with the real status instead of a generic invalid-token error. **`ReportEnvCredentialsError`** (used by **`EnsureAuthenticated`** and **`dr auth check`** for env vars) only tells users to unset **`DATAROBOT_API_TOKEN`** on **401** or **403**; for other non-2xx responses it reports that the instance **answered HTTP *n*** and points at endpoint/instance health. **`ValidateEndpoint`** additionally rejects schemes other than **http/https** (e.g. **`ftp://`**) as a bad endpoint, not a connection failure.
> 
> Docs and tests cover status preservation, **`GetAPIKey`**, scheme validation, and the new user-facing copy. The **`.env`** path in **`dr auth check`** and stored-profile login behavior are **unchanged** for non-401 failures (called out in code as follow-up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b5b4a64ecee28d55f77bcdf846847b61d6b3ee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->