### PR TITLE
chore(go): upgrade go.mod to 1.26.6

### DIFF
--- a/.github/documentation-style-spec.md
+++ b/.github/documentation-style-spec.md
@@ -262,7 +262,7 @@ Add periods to descriptions
 
 **Format**
 ```markdown
-✅ **Note:** The CLI requires Go 1.26.5 or later.
+✅ **Note:** The CLI requires Go 1.26.6 or later.
 
 ✅ **Important:** Never commit `.env` files to version control.
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: 1.26.5
+  go: 1.26.6
 linters:
   enable:
     - asasalint

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ If you would like to build and install from source, you can do so by following t
 
 #### Prerequisites
 
-- Go 1.26.5 or later (for building from source)
+- Go 1.26.6 or later (for building from source)
 - Git
 - [Task](https://taskfile.dev/) (for development and task running)
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -73,7 +73,7 @@ See [Building](building.md) for detailed workflow documentation.
 
 Before you begin development:
 
-- **Go 1.26.5 or later**&mdash;required for building the CLI.
+- **Go 1.26.6 or later**&mdash;required for building the CLI.
 - **Git**&mdash;version control.
 - **Task**&mdash;task runner for development commands.
 - **golangci-lint**&mdash;installed automatically via `task dev-init`.

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -18,7 +18,7 @@ This guide outlines how to build, test, and develop with the DataRobot CLI.
 
 ### Prerequisites
 
-- [Go 1.26.5+](https://golang.org/dl/)
+- [Go 1.26.6+](https://golang.org/dl/)
 - Git version control
 - [Task](https://taskfile.dev/installation/) (The task runner)
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -6,7 +6,7 @@ This page outlines how to set up your development environment to build and devel
 
 ## Prerequisites
 
-- [Go 1.26.5](https://golang.org/dl/)
+- [Go 1.26.6](https://golang.org/dl/)
 - Git for version control
 - [Task](https://taskfile.dev/installation/) (A task runner)
 
@@ -60,7 +60,7 @@ The devcontainer's `postCreateCommand` runs `task bootstrap`, which verifies the
 
 #### Option B: Local setup (no container)
 
-If you prefer not to use a devcontainer, install the [prerequisites](#prerequisites) listed above (Go 1.26.5, Git, Task), then run:
+If you prefer not to use a devcontainer, install the [prerequisites](#prerequisites) listed above (Go 1.26.6, Git, Task), then run:
 
 ```bash
 task bootstrap

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datarobot/cli
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
# RATIONALE

New Go version, new CVEs to deal with.

Other PRs are as of today failing govulncheck CI.

## CHANGES

- go.mod
- lots of little references

## TESTING

- `go mod tidy`
- `go mod verify`
- `go fix`
- `go vet`
- `task uninstall-tools install-tools` to ensure that my toolset is still working
- `task bootstrap` to ensure everything still works

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1786666101.086059 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Toolchain and documentation-only bump with no runtime or application logic changes.
> 
> **Overview**
> Bumps the project’s required Go toolchain from **1.26.5** to **1.26.6** so builds and CI (including govulncheck) align with the patched release.
> 
> The `go` directive in `go.mod` and golangci-lint’s `run.go` in `.golangci.yaml` are updated together, and README plus development docs (setup, building, style spec) now state **Go 1.26.6** as the minimum for building from source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3844443ce116b4c25ff4fc3d18b88935485eda0f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->