### PR TITLE
[RAPTOR-18998] feat(workload): pin to an Enclave on create, list by Enclave

### DIFF
--- a/cmd/workload/create/cmd.go
+++ b/cmd/workload/create/cmd.go
@@ -55,8 +55,8 @@ named Enclave, which must be eligible and grant you deploy access. The
 flag refuses to override a spec that already sets either field, and using
 it means the spec is re-encoded rather than sent byte-for-byte. Without
 the flag (or with enclaveSelectionPolicy "availability"), DataRobot picks
-the placement. Where the workload actually runs is reported by the
-read-only placements field on the workload document.
+the placement. Confirm where the workload landed with
+'dr workload list --enclave <name>'.
 
 Three flows:
 

--- a/cmd/workload/create/cmd.go
+++ b/cmd/workload/create/cmd.go
@@ -25,7 +25,10 @@ import (
 func Cmd() *cobra.Command {
 	var outputFormat outputformat.OutputFormat
 
-	var specFile string
+	var (
+		specFile string
+		enclave  string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -45,6 +48,15 @@ using standard YAML typing rules before sending: quote values that must
 stay strings (for example "0644" or "1.10"), and unquoted dates are sent
 as RFC3339 timestamps. The server validates field-level shape and returns
 a 422 with a JSON-path detail on a mismatch.
+
+Use --enclave <name> to pin the workload to a specific Enclave: it sets
+runtime.enclaveSelectionPolicy to "manual" and runtime.enclaves to the
+named Enclave, which must be eligible and grant you deploy access. The
+flag refuses to override a spec that already sets either field, and using
+it means the spec is re-encoded rather than sent byte-for-byte. Without
+the flag (or with enclaveSelectionPolicy "availability"), DataRobot picks
+the placement. Where the workload actually runs is reported by the
+read-only placements field on the workload document.
 
 Three flows:
 
@@ -117,6 +129,7 @@ Three flows:
 Example:
   dr workload create --spec-file workload.json
   dr workload create --spec-file workload.yaml
+  dr workload create --spec-file workload.json --enclave prod-east
   dr workload create --spec-file workload.yaml --output-format json`,
 		Args:         cobra.NoArgs,
 		PreRunE:      auth.EnsureAuthenticatedE,
@@ -127,6 +140,15 @@ Example:
 			payload, err := workload.ReadSpecFile(specFile)
 			if err != nil {
 				return err
+			}
+
+			// Changed, not enclave != "": an explicit --enclave "" must be
+			// rejected by ApplyEnclavePin, not silently create unpinned.
+			if cmd.Flags().Changed("enclave") {
+				payload, err = workload.ApplyEnclavePin(payload, enclave)
+				if err != nil {
+					return err
+				}
 			}
 
 			if err := workload.ValidateWorkloadCreateRequest(payload); err != nil {
@@ -147,9 +169,13 @@ Example:
 	cmd.Flags().StringVar(&specFile, "spec-file", "", "Path to JSON or YAML spec file (required)")
 	_ = cmd.MarkFlagRequired("spec-file")
 
+	cmd.Flags().StringVar(&enclave, "enclave", "",
+		"Pin the workload to the named Enclave (sets runtime.enclaveSelectionPolicy=manual)")
+
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
 			"output_format": string(outputFormat),
+			"enclave":       enclave,
 		}
 	})
 

--- a/cmd/workload/create/cmd_test.go
+++ b/cmd/workload/create/cmd_test.go
@@ -75,3 +75,32 @@ func TestCmd_RejectsPositionalArgs(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 }
+
+func TestCmd_BlankEnclaveFailsBeforeNetwork(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spec.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"name": "wl", "artifactId": "art-1"}`), 0o600))
+
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--spec-file", path, "--enclave", ""})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --enclave")
+}
+
+func TestCmd_EnclaveConflictsWithSpecPin(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spec.json")
+	spec := `{"name": "wl", "artifactId": "art-1", "runtime": {"enclaves": ["prod-west"], "enclaveSelectionPolicy": "manual"}}`
+	require.NoError(t, os.WriteFile(path, []byte(spec), 0o600))
+
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--spec-file", path, "--enclave", "prod-east"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already sets")
+}

--- a/cmd/workload/create/cmd_test.go
+++ b/cmd/workload/create/cmd_test.go
@@ -15,10 +15,17 @@
 package create
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -74,6 +81,47 @@ func TestCmd_RejectsPositionalArgs(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
+}
+
+// TestCmd_EnclavePinReachesTheWire asserts the pinned bytes are what gets
+// POSTed: dropping the ApplyEnclavePin result on the floor would create an
+// unpinned workload and exit 0, which no other test can catch.
+func TestCmd_EnclavePinReachesTheWire(t *testing.T) {
+	var posted []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		posted, _ = io.ReadAll(r.Body)
+
+		fmt.Fprint(w, `{"id":"wl-1","name":"my-app","status":"submitted"}`)
+	}))
+
+	defer srv.Close()
+
+	viperx.Set(config.DataRobotURL, srv.URL)
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+	viperx.Set(config.SkipAuthKey, true)
+
+	t.Cleanup(viperx.Reset)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "spec.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"name": "wl", "artifactId": "art-1"}`), 0o600))
+
+	cmd := Cmd()
+	cmd.PreRunE = nil
+	cmd.SetArgs([]string{"--spec-file", path, "--enclave", "prod-east"})
+
+	require.NoError(t, cmd.Execute())
+
+	var body map[string]any
+
+	require.NoError(t, json.Unmarshal(posted, &body), "the body must be JSON, not a base64-encoded string")
+
+	runtime, ok := body["runtime"].(map[string]any)
+
+	require.True(t, ok)
+	assert.Equal(t, "manual", runtime["enclaveSelectionPolicy"])
+	assert.Equal(t, []any{"prod-east"}, runtime["enclaves"])
 }
 
 func TestCmd_BlankEnclaveFailsBeforeNetwork(t *testing.T) {

--- a/cmd/workload/list/cmd.go
+++ b/cmd/workload/list/cmd.go
@@ -15,6 +15,7 @@
 package list
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -31,6 +32,7 @@ func Cmd() *cobra.Command {
 	var (
 		limit    int
 		statuses []string
+		enclave  string
 	)
 
 	cmd := &cobra.Command{
@@ -45,11 +47,17 @@ For each workload the listing shows:
 
 By default, output is a human-readable table. Use --output-format json for machine-parseable output.
 
+Use --enclave to only list workloads running on the named Enclave. The
+filter matches where each workload actually runs (its resolved placement),
+not the pin requested at create time; an unknown name simply matches
+nothing.
+
 Example:
   dr workload list
   dr workload list --limit 10
   dr workload list --status running
   dr workload list --status errored --status interrupted
+  dr workload list --enclave prod-east
   dr workload list --output-format json`,
 		Args:         cobra.NoArgs,
 		PreRunE:      auth.EnsureAuthenticatedE,
@@ -61,12 +69,18 @@ Example:
 				return fmt.Errorf("invalid --limit %d: must be positive", limit)
 			}
 
+			// A blank --enclave would silently drop the filter and list
+			// everything, the opposite of what the flag asked for.
+			if cmd.Flags().Changed("enclave") && strings.TrimSpace(enclave) == "" {
+				return errors.New("invalid --enclave: the Enclave name must be non-blank")
+			}
+
 			parsedStatuses, err := workload.ParseWorkloadStatuses(statuses)
 			if err != nil {
 				return err
 			}
 
-			workloads, err := workload.ListWorkloads(limit, parsedStatuses)
+			workloads, err := workload.ListWorkloads(limit, parsedStatuses, enclave)
 			if err != nil {
 				return err
 			}
@@ -80,6 +94,8 @@ Example:
 	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of workloads to return")
 	cmd.Flags().StringSliceVar(&statuses, "status", nil,
 		"Filter by status (repeatable, also accepts comma-separated values; e.g. running, errored)")
+	cmd.Flags().StringVar(&enclave, "enclave", "",
+		"Only list workloads running on the named Enclave")
 
 	telemetry.TrackWith(cmd, func(c *cobra.Command, _ []string) map[string]any {
 		limit, _ := c.Flags().GetInt("limit")
@@ -88,6 +104,7 @@ Example:
 			"limit":         limit,
 			"output_format": string(outputFormat),
 			"status":        strings.Join(statuses, ","),
+			"enclave":       enclave,
 		}
 	})
 

--- a/cmd/workload/list/cmd_test.go
+++ b/cmd/workload/list/cmd_test.go
@@ -59,3 +59,17 @@ func TestCmd_InvalidOutputFormat(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `invalid output format "yaml"`)
 }
+
+func TestCmd_BlankEnclave(t *testing.T) {
+	// An explicit empty --enclave must fail loudly rather than silently
+	// listing every workload with the filter dropped.
+	for _, value := range []string{"", "   "} {
+		cmd := Cmd()
+		cmd.PreRunE = nil
+		cmd.SetArgs([]string{"--enclave", value})
+
+		err := cmd.Execute()
+		require.Error(t, err, "enclave %q", value)
+		assert.Contains(t, err.Error(), "invalid --enclave")
+	}
+}

--- a/internal/workload/enclave.go
+++ b/internal/workload/enclave.go
@@ -30,20 +30,11 @@ const (
 	EnclaveSelectionPolicyManual       = "manual"
 )
 
-// ApplyEnclavePin pins a workload create spec to a single Enclave by name:
+// ApplyEnclavePin pins a JSON workload create spec to a single Enclave:
 // runtime.enclaveSelectionPolicy becomes "manual" and runtime.enclaves the
-// one-element list the server accepts today. spec must already be JSON
-// (ReadSpecFile converts YAML before this point).
-//
-// The pin refuses to fight the spec: when the spec already carries either
-// field the caller gets an error instead of a silent rewrite, because the
-// spec file is the reviewable artifact and a flag that quietly overrides it
-// would leave the file lying about where the workload runs.
-//
-// Applying the pin re-encodes the spec, so the byte-for-byte passthrough
-// promise of a plain create no longer holds; numbers survive verbatim via
-// json.Number, but key order does not. The server does not care about
-// either.
+// one-element list the server accepts today. It errors if the spec already
+// sets either field rather than silently rewriting it. Re-encodes the spec:
+// numbers survive via json.Number, key order does not.
 func ApplyEnclavePin(spec []byte, enclave string) ([]byte, error) {
 	name := strings.TrimSpace(enclave)
 	if name == "" {

--- a/internal/workload/enclave.go
+++ b/internal/workload/enclave.go
@@ -1,0 +1,89 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Enclave selection policies as serialized by the server. availability (the
+// default) lets DataRobot place the workload; manual pins it to the Enclaves
+// named in runtime.enclaves.
+const (
+	EnclaveSelectionPolicyAvailability = "availability"
+	EnclaveSelectionPolicyManual       = "manual"
+)
+
+// ApplyEnclavePin pins a workload create spec to a single Enclave by name:
+// runtime.enclaveSelectionPolicy becomes "manual" and runtime.enclaves the
+// one-element list the server accepts today. spec must already be JSON
+// (ReadSpecFile converts YAML before this point).
+//
+// The pin refuses to fight the spec: when the spec already carries either
+// field the caller gets an error instead of a silent rewrite, because the
+// spec file is the reviewable artifact and a flag that quietly overrides it
+// would leave the file lying about where the workload runs.
+//
+// Applying the pin re-encodes the spec, so the byte-for-byte passthrough
+// promise of a plain create no longer holds; numbers survive verbatim via
+// json.Number, but key order does not. The server does not care about
+// either.
+func ApplyEnclavePin(spec []byte, enclave string) ([]byte, error) {
+	name := strings.TrimSpace(enclave)
+	if name == "" {
+		return nil, errors.New("invalid --enclave: the Enclave name must be non-blank")
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(spec))
+	dec.UseNumber()
+
+	var doc map[string]any
+
+	if err := dec.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("invalid spec: %w", err)
+	}
+
+	runtime := map[string]any{}
+
+	if raw, ok := doc["runtime"]; ok && raw != nil {
+		runtime, ok = raw.(map[string]any)
+		if !ok {
+			return nil, errors.New("invalid spec: 'runtime' must be an object")
+		}
+	}
+
+	// Presence alone is the conflict, not a differing value: a spec that says
+	// enclaves: [] pinned nothing on purpose, and "the flag agrees with the
+	// file" is not worth a second code path.
+	if _, ok := runtime["enclaveSelectionPolicy"]; ok {
+		return nil, errors.New(
+			"spec already sets runtime.enclaveSelectionPolicy; remove it from the spec or drop --enclave")
+	}
+
+	if _, ok := runtime["enclaves"]; ok {
+		return nil, errors.New(
+			"spec already sets runtime.enclaves; remove it from the spec or drop --enclave")
+	}
+
+	runtime["enclaveSelectionPolicy"] = EnclaveSelectionPolicyManual
+	runtime["enclaves"] = []string{name}
+	doc["runtime"] = runtime
+
+	return json.Marshal(doc)
+}

--- a/internal/workload/enclave.go
+++ b/internal/workload/enclave.go
@@ -59,6 +59,13 @@ func ApplyEnclavePin(spec []byte, enclave string) ([]byte, error) {
 		return nil, fmt.Errorf("invalid spec: %w", err)
 	}
 
+	// A top-level null decodes successfully into a nil map, and assigning
+	// runtime into that would panic. Any other non-object (array, string)
+	// already fails Decode above.
+	if doc == nil {
+		return nil, errors.New("invalid spec: the spec must be a JSON object")
+	}
+
 	runtime := map[string]any{}
 
 	if raw, ok := doc["runtime"]; ok && raw != nil {

--- a/internal/workload/enclave.go
+++ b/internal/workload/enclave.go
@@ -50,9 +50,6 @@ func ApplyEnclavePin(spec []byte, enclave string) ([]byte, error) {
 		return nil, fmt.Errorf("invalid spec: %w", err)
 	}
 
-	// A top-level null decodes successfully into a nil map, and assigning
-	// runtime into that would panic. Any other non-object (array, string)
-	// already fails Decode above.
 	if doc == nil {
 		return nil, errors.New("invalid spec: the spec must be a JSON object")
 	}
@@ -66,9 +63,6 @@ func ApplyEnclavePin(spec []byte, enclave string) ([]byte, error) {
 		}
 	}
 
-	// Presence alone is the conflict, not a differing value: a spec that says
-	// enclaves: [] pinned nothing on purpose, and "the flag agrees with the
-	// file" is not worth a second code path.
 	if _, ok := runtime["enclaveSelectionPolicy"]; ok {
 		return nil, errors.New(
 			"spec already sets runtime.enclaveSelectionPolicy; remove it from the spec or drop --enclave")

--- a/internal/workload/enclave.go
+++ b/internal/workload/enclave.go
@@ -34,8 +34,10 @@ const (
 // runtime.enclaveSelectionPolicy becomes "manual" and runtime.enclaves the
 // one-element list the server accepts today. It errors if the spec already
 // sets either field rather than silently rewriting it. Re-encodes the spec:
-// numbers survive via json.Number, key order does not.
-func ApplyEnclavePin(spec []byte, enclave string) ([]byte, error) {
+// numbers survive via json.Number, key order does not. Returns
+// json.RawMessage, not []byte, so handing the result to a marshalling
+// client sends JSON rather than a base64 string.
+func ApplyEnclavePin(spec []byte, enclave string) (json.RawMessage, error) {
 	name := strings.TrimSpace(enclave)
 	if name == "" {
 		return nil, errors.New("invalid --enclave: the Enclave name must be non-blank")

--- a/internal/workload/enclave_test.go
+++ b/internal/workload/enclave_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyEnclavePin_AddsRuntimeWhenAbsent(t *testing.T) {
+	pinned, err := ApplyEnclavePin([]byte(`{"name":"my-app","artifactId":"art-1"}`), "prod-east")
+	require.NoError(t, err)
+
+	var doc map[string]any
+
+	require.NoError(t, json.Unmarshal(pinned, &doc))
+	assert.Equal(t, "my-app", doc["name"])
+
+	runtime, ok := doc["runtime"].(map[string]any)
+
+	require.True(t, ok)
+	assert.Equal(t, EnclaveSelectionPolicyManual, runtime["enclaveSelectionPolicy"])
+	assert.Equal(t, []any{"prod-east"}, runtime["enclaves"])
+}
+
+func TestApplyEnclavePin_PreservesExistingRuntimeFields(t *testing.T) {
+	spec := `{
+		"name": "my-app",
+		"artifactId": "art-1",
+		"runtime": {
+			"containerGroups": [{
+				"name": "default",
+				"replicaCount": 2,
+				"containers": [{"name": "app", "resourceAllocation": {"cpu": 1, "memory": 4294967296}}]
+			}]
+		}
+	}`
+
+	pinned, err := ApplyEnclavePin([]byte(spec), "prod-east")
+	require.NoError(t, err)
+
+	var doc map[string]any
+
+	require.NoError(t, json.Unmarshal(pinned, &doc))
+
+	runtime := doc["runtime"].(map[string]any)
+
+	assert.Equal(t, EnclaveSelectionPolicyManual, runtime["enclaveSelectionPolicy"])
+	assert.NotNil(t, runtime["containerGroups"], "existing runtime content must survive the pin")
+
+	// The large memory integer must survive re-encoding verbatim rather than
+	// decaying into scientific notation via float64.
+	assert.Contains(t, string(pinned), "4294967296")
+}
+
+func TestApplyEnclavePin_TrimsTheName(t *testing.T) {
+	pinned, err := ApplyEnclavePin([]byte(`{"name":"a"}`), "  prod-east  ")
+	require.NoError(t, err)
+	assert.Contains(t, string(pinned), `"enclaves":["prod-east"]`)
+}
+
+func TestApplyEnclavePin_RejectsBlankName(t *testing.T) {
+	for _, name := range []string{"", "   "} {
+		_, err := ApplyEnclavePin([]byte(`{"name":"a"}`), name)
+		require.Error(t, err, "name %q", name)
+		assert.Contains(t, err.Error(), "non-blank")
+	}
+}
+
+func TestApplyEnclavePin_RejectsSpecWithSelectionPolicy(t *testing.T) {
+	spec := `{"name":"a","runtime":{"enclaveSelectionPolicy":"availability"}}`
+
+	_, err := ApplyEnclavePin([]byte(spec), "prod-east")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "runtime.enclaveSelectionPolicy")
+}
+
+func TestApplyEnclavePin_RejectsSpecWithEnclaves(t *testing.T) {
+	// An empty list still counts: presence is the conflict, since the file
+	// said something about placement on purpose.
+	spec := `{"name":"a","runtime":{"enclaves":[]}}`
+
+	_, err := ApplyEnclavePin([]byte(spec), "prod-east")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "runtime.enclaves")
+}
+
+func TestApplyEnclavePin_RejectsNonObjectRuntime(t *testing.T) {
+	_, err := ApplyEnclavePin([]byte(`{"name":"a","runtime":[]}`), "prod-east")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'runtime' must be an object")
+}
+
+func TestApplyEnclavePin_NullRuntimeIsAbsent(t *testing.T) {
+	pinned, err := ApplyEnclavePin([]byte(`{"name":"a","runtime":null}`), "prod-east")
+	require.NoError(t, err)
+	assert.Contains(t, string(pinned), `"enclaves":["prod-east"]`)
+}
+
+func TestApplyEnclavePin_RejectsInvalidJSON(t *testing.T) {
+	_, err := ApplyEnclavePin([]byte(`{`), "prod-east")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid spec")
+}

--- a/internal/workload/enclave_test.go
+++ b/internal/workload/enclave_test.go
@@ -46,7 +46,7 @@ func TestApplyEnclavePin_PreservesExistingRuntimeFields(t *testing.T) {
 			"containerGroups": [{
 				"name": "default",
 				"replicaCount": 2,
-				"containers": [{"name": "app", "resourceAllocation": {"cpu": 1, "memory": 4294967296}}]
+				"containers": [{"name": "app", "resourceAllocation": {"cpu": 1, "memory": 9007199254740993}}]
 			}]
 		}
 	}`
@@ -63,9 +63,9 @@ func TestApplyEnclavePin_PreservesExistingRuntimeFields(t *testing.T) {
 	assert.Equal(t, EnclaveSelectionPolicyManual, runtime["enclaveSelectionPolicy"])
 	assert.NotNil(t, runtime["containerGroups"], "existing runtime content must survive the pin")
 
-	// The large memory integer must survive re-encoding verbatim rather than
-	// decaying into scientific notation via float64.
-	assert.Contains(t, string(pinned), "4294967296")
+	// 2^53+1 is not representable in a float64: without json.Number it
+	// re-encodes as 9007199254740992 and this fails.
+	assert.Contains(t, string(pinned), "9007199254740993")
 }
 
 func TestApplyEnclavePin_TrimsTheName(t *testing.T) {

--- a/internal/workload/enclave_test.go
+++ b/internal/workload/enclave_test.go
@@ -117,3 +117,11 @@ func TestApplyEnclavePin_RejectsInvalidJSON(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid spec")
 }
+
+func TestApplyEnclavePin_RejectsNullSpec(t *testing.T) {
+	// A top-level null decodes into a nil map without error; the pin must
+	// reject it rather than panic assigning runtime into a nil map.
+	_, err := ApplyEnclavePin([]byte(`null`), "prod-east")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a JSON object")
+}

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -113,7 +113,7 @@ func reusedArtifactConflict(createErr error, artifactID, projectDir string) erro
 // cannot say. It turns the advice from "find out what owns this" into a line
 // the reader can paste.
 func workloadOn(artifactID string) string {
-	existing, err := listWorkloadsFn(conflictSearchLimit, nil)
+	existing, err := listWorkloadsFn(conflictSearchLimit, nil, "")
 	if err != nil {
 		return ""
 	}

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -490,7 +490,7 @@ func nameTaken(createErr error, workloadName, path string) error {
 		return createErr
 	}
 
-	existing, err := listWorkloadsFn(conflictSearchLimit, nil)
+	existing, err := listWorkloadsFn(conflictSearchLimit, nil, "")
 	if err != nil {
 		// The conflict is the real story; a failure to look up what caused it
 		// is a footnote that should not replace it.

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -136,7 +136,7 @@ type fakes struct {
 	wizard         func(wizard.Options) (wizard.Result, error)
 	create         func(any) (*workload.Workload, error)
 	wait           func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
-	list           func(int, []string) ([]workload.Workload, error)
+	list           func(int, []string, string) ([]workload.Workload, error)
 	start          func(string) (*workload.WorkloadOperationResponse, error)
 	lock           func(string) (*workload.Artifact, error)
 	cred           func(string) (*workload.Credential, error)
@@ -470,7 +470,7 @@ func TestRun_ConflictNamesTheWorkloadThatOwnsTheName(t *testing.T) {
 		create: func(any) (*workload.Workload, error) {
 			return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
 		},
-		list: func(int, []string) ([]workload.Workload, error) {
+		list: func(int, []string, string) ([]workload.Workload, error) {
 			return []workload.Workload{{ID: "wl-other", Name: "someone-else"}, *running("wl-existing")}, nil
 		},
 		writeID: func(string, string) error {
@@ -504,7 +504,7 @@ func TestRun_ConflictWithNoMatchKeepsTheOriginalError(t *testing.T) {
 		create: func(any) (*workload.Workload, error) {
 			return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
 		},
-		list: func(int, []string) ([]workload.Workload, error) { return nil, errors.New("list unavailable") },
+		list: func(int, []string, string) ([]workload.Workload, error) { return nil, errors.New("list unavailable") },
 	})
 
 	_, _, err := runIn(t, unboundImageManifest, Options{NonInteractive: true})
@@ -778,7 +778,7 @@ func TestRun_ConflictOnAReusedArtifactExplainsTheLink(t *testing.T) {
 	f.create = func(any) (*workload.Workload, error) {
 		return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
 	}
-	f.list = func(int, []string) ([]workload.Workload, error) {
+	f.list = func(int, []string, string) ([]workload.Workload, error) {
 		return []workload.Workload{{ID: "wl-owner", Name: "someone-else", ArtifactID: "art-existing"}}, nil
 	}
 
@@ -810,7 +810,7 @@ func TestRun_NameConflictOnALinkedProjectKeepsItsOwnMessage(t *testing.T) {
 		return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
 	}
 	// Nothing holds the artifact; the name is what collided.
-	f.list = func(int, []string) ([]workload.Workload, error) {
+	f.list = func(int, []string, string) ([]workload.Workload, error) {
 		return []workload.Workload{{ID: "wl-1", Name: "my-app", ArtifactID: "art-somewhere-else"}}, nil
 	}
 
@@ -832,7 +832,7 @@ func TestRun_ConflictOnAFreshArtifactIsNotBlamedOnTheLink(t *testing.T) {
 	f.create = func(any) (*workload.Workload, error) {
 		return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
 	}
-	f.list = func(int, []string) ([]workload.Workload, error) { return nil, nil }
+	f.list = func(int, []string, string) ([]workload.Workload, error) { return nil, nil }
 
 	install(t, f)
 

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -63,7 +63,7 @@ func runInteractiveFlow(opts Options, detected Detected) ([]byte, manifest.Draft
 	var workloads []workload.Workload
 
 	if opts.Answers.WorkloadID == "" && opts.Answers.Name == "" {
-		fetched, err := listWorkloadsFn(workloadPickLimit, nil)
+		fetched, err := listWorkloadsFn(workloadPickLimit, nil, "")
 		if err != nil {
 			return nil, manifest.Draft{}, err
 		}

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -413,6 +413,9 @@ func ListWorkloads(limit int, statuses []string, enclave string) ([]Workload, er
 		return nil, fmt.Errorf("invalid limit %d: must be positive", limit)
 	}
 
+	// Trim so a copied name with stray spaces matches, same as the pin side.
+	enclave = strings.TrimSpace(enclave)
+
 	query := url.Values{}
 	query.Set("limit", strconv.Itoa(min(limit, maxWorkloadPageSize)))
 

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -406,7 +406,12 @@ type WorkloadList struct {
 // page size is clamped and larger totals are satisfied via next-links.
 const maxWorkloadPageSize = 100
 
-func ListWorkloads(limit int, statuses []string) ([]Workload, error) {
+// ListWorkloads fetches up to limit workloads, optionally filtered by status
+// and by the name of the Enclave they actually run on (the server's ?enclave=
+// param matches the resolved placement, not the requested pin). enclave is
+// passed verbatim when non-empty; the server answers an unknown name with an
+// empty list, not an error.
+func ListWorkloads(limit int, statuses []string, enclave string) ([]Workload, error) {
 	if limit <= 0 {
 		return nil, fmt.Errorf("invalid limit %d: must be positive", limit)
 	}
@@ -416,6 +421,10 @@ func ListWorkloads(limit int, statuses []string) ([]Workload, error) {
 
 	for _, s := range statuses {
 		query.Add("status", s)
+	}
+
+	if enclave != "" {
+		query.Set("enclave", enclave)
 	}
 
 	pageURL, err := drapi.EndpointURL("/workloads/", query)

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -407,10 +407,7 @@ type WorkloadList struct {
 const maxWorkloadPageSize = 100
 
 // ListWorkloads fetches up to limit workloads, optionally filtered by status
-// and by the name of the Enclave they actually run on (the server's ?enclave=
-// param matches the resolved placement, not the requested pin). enclave is
-// passed verbatim when non-empty; the server answers an unknown name with an
-// empty list, not an error.
+// and by the name of the Enclave they actually run on.
 func ListWorkloads(limit int, statuses []string, enclave string) ([]Workload, error) {
 	if limit <= 0 {
 		return nil, fmt.Errorf("invalid limit %d: must be positive", limit)

--- a/internal/workload/workload_test.go
+++ b/internal/workload/workload_test.go
@@ -369,6 +369,23 @@ func TestListWorkloads_EnclaveFilter(t *testing.T) {
 	require.Len(t, workloads, 1)
 }
 
+func TestListWorkloads_TrimsEnclave(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "prod-east", r.URL.Query().Get("enclave"),
+			"stray whitespace from a copied name must not reach the query")
+		fmt.Fprint(w, workloadListPage("", serverWorkloadDoc("wl-1", "a", "running")))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := ListWorkloads(25, nil, "  prod-east  ")
+	require.NoError(t, err)
+}
+
 func TestListWorkloads_NoEnclaveParamWhenUnfiltered(t *testing.T) {
 	installSkipAuth(t)
 

--- a/internal/workload/workload_test.go
+++ b/internal/workload/workload_test.go
@@ -346,10 +346,45 @@ func TestListWorkloads_SinglePageWithStatusFilter(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	workloads, err := ListWorkloads(25, []string{"running", "errored"})
+	workloads, err := ListWorkloads(25, []string{"running", "errored"}, "")
 	require.NoError(t, err)
 	require.Len(t, workloads, 1)
 	assert.Equal(t, "wl-1", workloads[0].ID)
+}
+
+func TestListWorkloads_EnclaveFilter(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "prod-east", r.URL.Query().Get("enclave"))
+		fmt.Fprint(w, workloadListPage("", serverWorkloadDoc("wl-1", "a", "running")))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	workloads, err := ListWorkloads(25, nil, "prod-east")
+	require.NoError(t, err)
+	require.Len(t, workloads, 1)
+}
+
+func TestListWorkloads_NoEnclaveParamWhenUnfiltered(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, present := r.URL.Query()["enclave"]
+
+		assert.False(t, present, "an empty filter must stay out of the query entirely")
+		fmt.Fprint(w, workloadListPage("", serverWorkloadDoc("wl-1", "a", "running")))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := ListWorkloads(25, nil, "")
+	require.NoError(t, err)
 }
 
 func TestListWorkloads_ClampsPageSizeToServerMax(t *testing.T) {
@@ -366,7 +401,7 @@ func TestListWorkloads_ClampsPageSizeToServerMax(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	_, err := ListWorkloads(250, nil)
+	_, err := ListWorkloads(250, nil, "")
 	require.NoError(t, err)
 }
 
@@ -401,7 +436,7 @@ func TestListWorkloads_FollowsNextAndTruncatesToLimit(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	workloads, err := ListWorkloads(3, nil)
+	workloads, err := ListWorkloads(3, nil, "")
 	require.NoError(t, err)
 	assert.Equal(t, 2, calls)
 	require.Len(t, workloads, 3)
@@ -410,7 +445,7 @@ func TestListWorkloads_FollowsNextAndTruncatesToLimit(t *testing.T) {
 
 func TestListWorkloads_RejectsNonPositiveLimit(t *testing.T) {
 	for _, limit := range []int{0, -1} {
-		_, err := ListWorkloads(limit, nil)
+		_, err := ListWorkloads(limit, nil, "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must be positive")
 	}


### PR DESCRIPTION
# RATIONALE

CLI half of the Enclave placement work ([RAPTOR-18998](https://datarobot.atlassian.net/browse/RAPTOR-18998)): let a developer pin a workload to a specific Enclave at create time, and find the workloads running on a given Enclave.

The Workload API expresses the pin in the create request as `runtime.enclaveSelectionPolicy: "manual"` plus `runtime.enclaves: ["<name>"]` (a list, one entry accepted today), and its list endpoint filters by resolved placement via `?enclave=<name>`. Pinning through the spec file already works with no CLI change, since the spec is sent verbatim; the flag exists so one committed spec can be deployed to different Enclaves without editing the file:

```shell
dr workload create --spec-file spec.json --enclave hadr-workload-01-rbac --output-format json
  {
    "id": "6a843ba51b848e217b9471ae",
    "name": "cli-enclave-test-pinned-140140",
    "status": "submitted",
    "type": "service",
    "importance": "low",
    "artifactId": "6a843ba51b848e217b9471ad",
    "endpoint": "https://internal-url.datarobot.com/workloads/6a843ba51b848e217b9471ae/",
    "createdAt": "2026-08-18T11:01:57Z",
    "updatedAt": "2026-08-18T11:01:57Z"
  }


dr workload list --enclave prod-east

╭──────────────────────────┬────────────────────────────────┬───────────┬─────────┬────────────┬──────────────────────╮
│ WORKLOAD ID              │ NAME                           │ STATUS    │ TYPE    │ IMPORTANCE │ UPDATED              │
├──────────────────────────┼────────────────────────────────┼───────────┼─────────┼────────────┼──────────────────────┤
│ 6a843ba51b848e217b9471ae │ cli-enclave-test-pinned-140140 │ launching │ service │ low        │ 2026-08-18 11:01 UTC │
│ 6a83cb911b848e217b947030 │ hello-whoami-charlie           │ running   │ service │ low        │ 2026-08-18 03:20 UTC │
│ 6a8309c70071967d89243203 │ okta-a2a-finance               │ stopped   │ agent   │ low        │ 2026-08-17 13:16 UTC │
│ ...                      │ ...                            │ ...       │ ...     │ ...        │ ...                  │
╰──────────────────────────┴────────────────────────────────┴───────────┴─────────┴────────────┴──────────────────────╯
```
Edge cases:
```
$ dr workload create --spec-file spec.json --enclave ""
Error: invalid --enclave: the Enclave name must be non-blank

$ dr workload create --spec-file spec-that-already-pins.json --enclave prod-east
Error: spec already sets runtime.enclaveSelectionPolicy; remove it from the spec or drop --enclave

$ dr workload list --enclave no-such-enclave-xyz
No workloads found.
```

## CHANGES

- `dr workload create --enclave <name>`: injects `runtime.enclaveSelectionPolicy: "manual"` and `runtime.enclaves: ["<name>"]` into the spec before POSTing (`internal/workload/enclave.go`, `ApplyEnclavePin`).
  - Refuses to override a spec that already sets either field: the spec file stays the source of truth, the flag never silently rewrites it.
  - An explicit blank `--enclave` is an error, not an unpinned create.
  - The re-encode preserves numbers via `json.Number` (e.g. byte-count memory values survive verbatim); key order is not preserved, and the help text documents that the byte-for-byte passthrough promise does not hold with the flag.
- `dr workload list --enclave <name>`: maps to the `?enclave=` query param, filtering by the name of the Enclave the workload actually runs on (resolved placement, not the requested pin). A blank value errors instead of silently listing everything.
- `ListWorkloads` gained the `enclave` parameter; the two other call sites (`up` conflict search, wizard picker) pass an empty filter.

Both flags ride the existing `workload` feature gate; no new gate.

## TESTING

- `task lint` clean on all three GOOS legs; `task test` passes.
- New tests: `ApplyEnclavePin` (runtime creation, field and numeric preservation, trim, blank/conflict/malformed/`runtime: null` handling), list query-param assertions (filter present when set, absent when not), command-level blank-flag and spec-conflict tests.

Verified end to end on 2026-08-14 and re-verified after the rebase on 2026-08-18 against a live dev environment with two registered Enclaves, running a Workload API build that includes the placement read-back, the `?enclave=` list filter, and the pluralized `runtime.enclaves[]` request schema:

- The pin caused the placement: the same spec (same resource bundle) created twice landed on the default Enclave without the flag and on the named Enclave with `--enclave <name>`; the stored runtime read back `enclaveSelectionPolicy: manual` and `enclaves: ["<name>"]`, and the workload's `placements[]` named the pinned Enclave.
- `dr workload list --enclave <name>` returned exactly the workloads whose resolved placement is that Enclave. The filter matches the recorded placement, which survives a stop; workloads that predate placement recording never match. An unknown name returns "No workloads found." with exit 0, and `--output-format json` emits a single valid JSON document with logs on stderr.
- Both guards fired before any network call: a blank `--enclave`, and `--enclave` combined with a spec that already sets either pin field.
