### PR TITLE
[CFX-7576] chore: increase timeout on expect_templates_setup

### DIFF
--- a/smoke_test_scripts/expect_templates_setup.exp
+++ b/smoke_test_scripts/expect_templates_setup.exp
@@ -10,8 +10,13 @@ puts "DATAROBOT_CLI_CONFIG: $env(DATAROBOT_CLI_CONFIG)"
 
 spawn dr templates setup --config $env(DATAROBOT_CLI_CONFIG)
 
-# Handle potential authentication prompt with longer timeout
-set timeout 10
+# Handle potential authentication prompt with longer timeout.
+# dr templates setup makes two token-verification round-trips (EnsureAuthenticated
+# in PreRunE, then AuthorizeRequest when the TUI fetches templates) plus the
+# template list fetch before rendering. Each VerifyToken call has a 30s client
+# timeout, so under slow API conditions the combined startup can exceed 10s.
+# 30s gives ample headroom while still failing fast on a genuine hang.
+set timeout 30
 expect {
     "to connect your DataRobot credentials" {
         # Auth prompt appeared - this means token validation failed


### PR DESCRIPTION
Daily Regression Tests were failing.

increase timeout on expect_templates_setup from 10s to 30s.

eta: last couple of runs were averaging around 8s, so I can easily see this exceeding 10s.

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1786739469.438649 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to an expect script; no production code or security impact.
> 
> **Overview**
> Fixes **daily regression failures** where `expect_templates_setup.exp` timed out before `dr templates setup` finished authenticating and loading the template list.
> 
> The expect block that waits for either the auth prompt or the template list (`"more"`) now uses a **30s** timeout instead of **10s**, with comments noting multiple token-verification calls and a 30s client timeout per verify under slow API conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 851a69e1cb9725ab6ed86ce1bc54b3ac245b9ff3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->