### PR TITLE
[RAPTOR-18959] feat(workload): remove the workload feature gate for WAPI GA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,7 +222,7 @@ Feature gates allow commands to be hidden until ready for release. For comprehen
 
 **Quick reference:**
 - Gate a command via `features.SetGate(cmd, "feature-name")` (sets the annotation on the command)
-- Enable via env var: `DATAROBOT_CLI_FEATURE_<NAME>=true` (e.g., `DATAROBOT_CLI_FEATURE_WORKLOAD=true`)
+- Enable via env var: `DATAROBOT_CLI_FEATURE_<NAME>=true` (e.g., `DATAROBOT_CLI_FEATURE_PIPELINE=true`)
 - Currently supported: environment variables only (config file support planned)
 - Filtering happens via `cli.CommandAdder.AddCommand` at registration time — `CommandAdder` is the only filtering mechanism
 - To gate a **nested** subcommand, wrap the parent with `&cli.CommandAdder{Command: parent}` and call `adder.AddCommand(...)` instead of `parent.AddCommand(...)`

--- a/cmd/artifact/cmd.go
+++ b/cmd/artifact/cmd.go
@@ -22,7 +22,6 @@ import (
 	"github.com/datarobot/cli/cmd/artifact/get"
 	"github.com/datarobot/cli/cmd/artifact/list"
 	"github.com/datarobot/cli/cmd/artifact/lock"
-	"github.com/datarobot/cli/internal/features"
 	"github.com/spf13/cobra"
 )
 
@@ -36,8 +35,6 @@ func Cmd() *cobra.Command {
 Create and inspect artifacts, build their container images, and
 synchronize local code with a remote artifact.`,
 	}
-
-	features.SetGate(cmd, "workload")
 
 	cmd.AddCommand(
 		// The artifact is the primary resource: direct verbs, like

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/datarobot/cli/internal/features"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/tools"
@@ -320,39 +321,30 @@ func TestSetUnknownArgGuards_SkipsExplicitArgs(t *testing.T) {
 	assert.NotContains(t, err.Error(), "unknown command:", "explicit Args validator should not be overridden")
 }
 
-func TestWorkloadCommandNotPresentByDefault(t *testing.T) {
-	// Verify that workload command is not present by default (feature not enabled).
-	// The feature gating happens during init(), so this tests the actual state.
-	cmd := RootCmd
-
-	var found bool
-
-	for _, subCmd := range cmd.Commands() {
-		if subCmd.Name() == "workload" {
-			found = true
-			break
-		}
+// TestWorkloadAndArtifactCommandsAlwaysRegistered verifies that both command
+// trees reach RootCmd with no environment set up (no longer feature-gated).
+// Registration happens during init(), so this tests the actual state.
+func TestWorkloadAndArtifactCommandsAlwaysRegistered(t *testing.T) {
+	for _, name := range []string{"workload", "artifact"} {
+		assert.NotNilf(t, childByName(RootCmd.Command, name),
+			"%s command should always be registered (no longer feature-gated)", name)
 	}
-
-	assert.False(t, found, "workload command should not be present when feature gate is not enabled")
 }
 
-func TestArtifactCommandNotPresentByDefault(t *testing.T) {
-	// The artifact command shares the "workload" feature gate, so it is
-	// filtered out by cli.CommandAdder during init() when the gate is not
-	// enabled (the default).
-	cmd := RootCmd
-
-	var found bool
-
-	for _, subCmd := range cmd.Commands() {
-		if subCmd.Name() == "artifact" {
-			found = true
-			break
-		}
+// TestGatedCommandFilteredFromRootCmd is the counterpart: it pins that
+// cli.CommandAdder really does keep a disabled command out of the live tree.
+// Removing the workload gate took away the only test of that, and without one
+// a change that stopped the filtering would ship an unreleased command into
+// `dr --help` and shell completions with every test still green. Gates are
+// read during init(), so this reflects the environment the binary started in
+// rather than anything the test can set.
+func TestGatedCommandFilteredFromRootCmd(t *testing.T) {
+	if features.Enabled("pipeline") {
+		t.Skip("pipeline gate is enabled in this environment, so absence cannot be asserted")
 	}
 
-	assert.False(t, found, "artifact command should not be present when feature gate is not enabled")
+	assert.Nil(t, childByName(RootCmd.Command, "pipeline"),
+		"a command whose feature gate is off must not reach RootCmd")
 }
 
 // TestPrivateCATLSFlagsAlwaysRegistered verifies that the private-ca

--- a/cmd/telemetry_wiring_test.go
+++ b/cmd/telemetry_wiring_test.go
@@ -18,8 +18,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/datarobot/cli/cmd/artifact"
-	"github.com/datarobot/cli/cmd/workload"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,6 +45,29 @@ var expectedTrackedCommands = []string{
 	"dr plugin install",
 	"dr plugin uninstall",
 	"dr plugin update",
+	"dr artifact create",
+	"dr artifact get",
+	"dr artifact list",
+	"dr artifact delete",
+	"dr artifact lock",
+	"dr artifact build create",
+	"dr artifact build get",
+	"dr artifact build list",
+	"dr artifact build logs",
+	"dr artifact code init",
+	"dr artifact code sync",
+	"dr artifact code versions",
+	"dr workload config",
+	"dr workload up",
+	"dr workload create",
+	"dr workload get",
+	"dr workload list",
+	"dr workload delete",
+	"dr workload start",
+	"dr workload stop",
+	"dr workload status",
+	"dr workload endpoint",
+	"dr workload logs",
 }
 
 // TestTelemetryWiring_AllCoreCommandsTracked walks the static command tree
@@ -57,91 +78,6 @@ func TestTelemetryWiring_AllCoreCommandsTracked(t *testing.T) {
 		t.Run(path, func(t *testing.T) {
 			cmd := findCommandByPath(RootCmd.Command, path)
 			require.NotNilf(t, cmd, "command %q not found in static command tree", path)
-
-			assert.Containsf(t, cmd.Annotations, "telemetry",
-				"command %q must be wired to telemetry via telemetry.Track / TrackWith", path)
-		})
-	}
-}
-
-// expectedWorkloadTrackedCommands enumerates leaf commands under
-// `dr workload` that must be wired to fire a telemetry event. The
-// `dr workload` subtree is hidden from the live RootCmd by
-// cli.CommandAdder when DATAROBOT_CLI_FEATURE_WORKLOAD is unset
-// (the default in CI), so this test walks a freshly-built subtree
-// produced by workload.Cmd() instead of the global RootCmd.
-//
-// Paths are relative to workload.Cmd() (no "dr" prefix) because
-// findCommandByPath matches against the root's Name(), which is
-// "workload" for the standalone subtree.
-var expectedWorkloadTrackedCommands = []string{
-	"workload config",
-	"workload up",
-	"workload create",
-	"workload get",
-	"workload list",
-	"workload delete",
-	"workload start",
-	"workload stop",
-	"workload status",
-	"workload endpoint",
-	"workload logs",
-}
-
-// TestTelemetryWiring_AllWorkloadCommandsTracked walks the workload
-// subtree (built via workload.Cmd() to bypass the feature-gate filter
-// in cli.CommandAdder) and asserts each entry has the "telemetry"
-// annotation set by telemetry.Track / TrackWith.
-func TestTelemetryWiring_AllWorkloadCommandsTracked(t *testing.T) {
-	workloadRoot := workload.Cmd()
-
-	for _, path := range expectedWorkloadTrackedCommands {
-		t.Run("dr "+path, func(t *testing.T) {
-			cmd := findCommandByPath(workloadRoot, path)
-			require.NotNilf(t, cmd, "command %q not found in workload subtree", path)
-
-			assert.Containsf(t, cmd.Annotations, "telemetry",
-				"command %q must be wired to telemetry via telemetry.Track / TrackWith", path)
-		})
-	}
-}
-
-// expectedArtifactTrackedCommands enumerates leaf commands under
-// `dr artifact` that must be wired to fire a telemetry event. Like the
-// workload subtree, `dr artifact` is hidden from the live RootCmd by
-// cli.CommandAdder when DATAROBOT_CLI_FEATURE_WORKLOAD is unset (the
-// default in CI), so this test walks a freshly-built subtree produced by
-// artifact.Cmd() instead of the global RootCmd.
-//
-// Paths are relative to artifact.Cmd() (no "dr" prefix) because
-// findCommandByPath matches against the root's Name(), which is
-// "artifact" for the standalone subtree.
-var expectedArtifactTrackedCommands = []string{
-	"artifact create",
-	"artifact get",
-	"artifact list",
-	"artifact delete",
-	"artifact lock",
-	"artifact build create",
-	"artifact build get",
-	"artifact build list",
-	"artifact build logs",
-	"artifact code init",
-	"artifact code sync",
-	"artifact code versions",
-}
-
-// TestTelemetryWiring_AllArtifactCommandsTracked walks the artifact
-// subtree (built via artifact.Cmd() to bypass the feature-gate filter
-// in cli.CommandAdder) and asserts each entry has the "telemetry"
-// annotation set by telemetry.Track / TrackWith.
-func TestTelemetryWiring_AllArtifactCommandsTracked(t *testing.T) {
-	artifactRoot := artifact.Cmd()
-
-	for _, path := range expectedArtifactTrackedCommands {
-		t.Run("dr "+path, func(t *testing.T) {
-			cmd := findCommandByPath(artifactRoot, path)
-			require.NotNilf(t, cmd, "command %q not found in artifact subtree", path)
 
 			assert.Containsf(t, cmd.Annotations, "telemetry",
 				"command %q must be wired to telemetry via telemetry.Track / TrackWith", path)

--- a/cmd/workload/cmd.go
+++ b/cmd/workload/cmd.go
@@ -26,7 +26,6 @@ import (
 	"github.com/datarobot/cli/cmd/workload/status"
 	"github.com/datarobot/cli/cmd/workload/stop"
 	"github.com/datarobot/cli/cmd/workload/up"
-	"github.com/datarobot/cli/internal/features"
 	"github.com/spf13/cobra"
 )
 
@@ -40,8 +39,6 @@ func Cmd() *cobra.Command {
 
 Manage and monitor workloads in your deployment infrastructure.`,
 	}
-
-	features.SetGate(cmd, "workload")
 
 	cmd.AddCommand(
 		// Setup, and the one subcommand here that never calls the API: it

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -58,8 +58,8 @@ These flags are available for all commands:
 | [`plugin`](plugins.md)            | Inspect and manage CLI plugins.                             |
 | [`llm-gateway`](llm-gateway.md)   | List and select the default LLM (gateway + deployed models). |
 | [`pipeline`](pipeline.md)         | Manage pipelines via the pipelines API (feature-gated).     |
-| [`artifact`](artifact.md)         | Build and manage workload artifacts (feature-gated).        |
-| [`workload`](workload.md)         | Deploy and manage workloads from artifacts (feature-gated). |
+| [`artifact`](artifact.md)         | Build and manage workload artifacts.                        |
+| [`workload`](workload.md)         | Deploy and manage workloads from artifacts.                 |
 | [`dependencies`](dependencies.md) | Check and install template dependencies (advanced).         |
 
 ### Command tree
@@ -134,7 +134,7 @@ dr
 │   │       └── delete Delete a specific version
 │   └── task           Inspect individual pipeline tasks (source + signature)
 │       └── get        Display task source, parameters, and input payload
-├── artifact           Artifact management (feature-gated)
+├── artifact           Artifact management
 │   ├── create         Create an artifact
 │   ├── get            Display details of an artifact
 │   ├── list           List artifacts
@@ -150,7 +150,9 @@ dr
 │       ├── sync       Push and pull code changes
 │       ├── versions   List catalog versions
 │       └── checkout   Download a version snapshot
-├── workload           Workload management (alias: wl, feature-gated)
+├── workload           Workload management (alias: wl)
+│   ├── config         Write the .datarobot.yaml that `up` deploys from
+│   ├── up             Deploy the project, applying what changed
 │   ├── create         Create (deploy) a workload
 │   ├── get            Display details of a workload
 │   ├── list           List workloads
@@ -371,12 +373,14 @@ For detailed documentation on each command, see:
   - `environment`&mdash;`create`/`list`/`update`/`delete` named pip-package environments; `version delete` removes a specific version.
   - `task`&mdash;`get` to inspect a task's source code, function signature parameters, and (for locked versions) the latest pipeline input payload.
 
-- **[artifact](artifact.md)**&mdash;build and manage the container artifacts that back workloads (feature-gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`).
+- **[artifact](artifact.md)**&mdash;build and manage the container artifacts that back workloads.
   - `create` / `get` / `list` / `lock` / `delete`&mdash;the draft-to-locked artifact lifecycle.
   - `build`&mdash;`create` / `get` / `list` / `logs` for container image builds.
   - `code`&mdash;`init` / `sync` / `versions` / `checkout` to sync local code with an artifact via a `.datarobot/workload/` state directory.
 
-- **[workload](workload.md)**&mdash;deploy and operate workloads created from artifacts (alias `wl`; feature-gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`).
+- **[workload](workload.md)**&mdash;deploy and operate workloads created from artifacts (alias `wl`).
+  - `config`&mdash;write the committed `.datarobot.yaml` that `up` deploys from, via a wizard or from flags.
+  - `up`&mdash;read that manifest, diff it and the working tree against what is running, and apply only what changed.
   - `create` / `get` / `list` / `delete`&mdash;the workload lifecycle.
   - `start` / `stop` / `status`&mdash;run-state control and status polling.
   - `endpoint` / `logs`&mdash;print the endpoint URL and stream container logs.

--- a/docs/commands/artifact.md
+++ b/docs/commands/artifact.md
@@ -21,13 +21,11 @@ Each container in the spec is one of two kinds:
 - **Prebuilt**: set `imageUri` to an existing image. There is nothing to build.
 - **Built from source**: set `imageBuildConfig`, push your code with `dr artifact code sync`, and produce an image with `dr artifact build create`. The Dockerfile is either one you provide (`./Dockerfile`) or one the server generates from a base environment.
 
-The `code` subcommands keep a local directory in sync with an artifact's source. They store a `.datarobot/workload/` state directory at the project root, much like `.git/`: local work happens in the project root while `.datarobot/workload/` records the remote binding and last-synced state. Once a directory is linked with `dr artifact code init`, the `build` and `code` subcommands read the artifact id from `.datarobot/workload/config.json`, so you can leave it off. A project linked by an older CLI keeps its state in a root `.wapi/`; the next command that touches state relocates it and prints one line saying so.
+The `code` subcommands keep a local directory in sync with an artifact's source. They store a `.datarobot/workload/` state directory at the project root, much like `.git/`: local work happens in the project root while `.datarobot/workload/` records the remote binding and last-synced state. Once a directory is linked with `dr artifact code init`, the `build` and `code` subcommands read the artifact id from `.datarobot/workload/config.json`, so you can leave it off.
 
 A locked, fully built artifact is what you hand to `dr workload create` to deploy. See [`dr workload`](workload.md).
 
 > [!NOTE]
-> The `artifact` command is currently behind a feature gate. Enable it by exporting `DATAROBOT_CLI_FEATURE_WORKLOAD=true` before running any `dr artifact` subcommand. See [Feature gates](../development/feature-gates.md) for details.
->
 > **First time?** If you're new to the CLI, start with the [Quick start](../../README.md#quick-start) for step-by-step setup instructions.
 
 ## Quick start
@@ -224,4 +222,3 @@ dr artifact build logs <artifact-id> <build-id> --level debug
 - [`dr workload`](workload.md): deploy a locked artifact as a running workload.
 - [Authentication](auth.md): how `dr auth login` and `--skip-auth` interact.
 - [Configuration](../user-guide/configuration.md): config file and environment-variable precedence.
-- [Feature gates](../development/feature-gates.md): turning `DATAROBOT_CLI_FEATURE_WORKLOAD` on and off.

--- a/docs/commands/workload.md
+++ b/docs/commands/workload.md
@@ -18,8 +18,6 @@ Startup is asynchronous. A workload moves through `submitted â†’ provisioning â†
 `start` and `stop` are asynchronous and idempotent too: stopping keeps the workload so it can be started again later, and the artifact it was created from is never removed along with it.
 
 > [!NOTE]
-> The `workload` command is currently behind a feature gate. Enable it by exporting `DATAROBOT_CLI_FEATURE_WORKLOAD=true` before running any `dr workload` subcommand. See [Feature gates](../development/feature-gates.md) for details.
->
 > **First time?** If you're new to the CLI, start with the [Quick start](../../README.md#quick-start) for step-by-step setup instructions.
 
 ## Quick start
@@ -42,6 +40,8 @@ dr workload logs <workload-id> --follow
 
 | Command                | Endpoint                                  | Purpose                                        |
 | ---------------------- | ----------------------------------------- | ---------------------------------------------- |
+| `dr workload config`   | none, writes .datarobot.yaml              | Write the manifest `up` deploys from.          |
+| `dr workload up`       | several, orchestrates the deploy          | Deploy the project, applying what changed.     |
 | `dr workload create`   | `POST   /api/v2/workloads/`               | Deploy a workload from a spec.                 |
 | `dr workload get`      | `GET    /api/v2/workloads/{id}/`          | Show a single workload.                        |
 | `dr workload list`     | `GET    /api/v2/workloads/`               | List workloads, optionally filtered by status. |
@@ -53,6 +53,26 @@ dr workload logs <workload-id> --follow
 | `dr workload logs`     | `GET    /api/v2/otel/workload/{id}/logs/` | Show a workload's container logs.              |
 
 ## Subcommands
+
+### `config`
+
+Answer a handful of questions and write the committed `.datarobot.yaml` that `dr workload up` deploys from. The file is the platform's own workload-create spec plus the `workloadId` binding the CLI manages for you. Setup is a one-time act: with a manifest already present this command prints its path and exits, because editing twelve lines of YAML beats re-answering eight questions. Delete the file to start over.
+
+The wizard is interactive by default. Every answer also has a flag (`--name`, `--type`, `--build-mode`, `--image`, `--dockerfile`, `--execution-environment`, `--port`, `--health`, `--cpu`, `--memory`, `--replicas`, `--entrypoint`), so a scripted or non-interactive run can supply them up front. Run `dr workload config --help` for the full set.
+
+```bash
+dr workload config [--dir <path>] [--name <name>] [--dry-run]
+```
+
+### `up`
+
+Read the committed `.datarobot.yaml`, compare it and the working tree against what is running, and apply the difference. The plan is printed, then carried out; nothing to do prints "Already up to date" and exits 0. `--dry-run` prints the plan and stops, which is also the answer to "what would this deploy" in CI.
+
+Only fields the manifest mentions are managed. A setting the file never names survives every deploy, and deleting a line stops managing that field rather than reverting it.
+
+```bash
+dr workload up [--dir <path>] [--dry-run] [--detach] [--force-build] [--lock]
+```
 
 ### `create`
 
@@ -243,4 +263,3 @@ dr workload delete <workload-id>
 - [`dr artifact`](artifact.md): build and lock the artifact a workload runs.
 - [Authentication](auth.md): how `dr auth login` and `--skip-auth` interact.
 - [Configuration](../user-guide/configuration.md): config file and environment-variable precedence.
-- [Feature gates](../development/feature-gates.md): turning `DATAROBOT_CLI_FEATURE_WORKLOAD` on and off.

--- a/docs/development/feature-gates.md
+++ b/docs/development/feature-gates.md
@@ -14,18 +14,22 @@ Feature flags in this CLI serve to:
 
 ## How It Works
 
-Commands can declare a feature gate using Cobra's built-in `Annotations` map. During CLI initialization, any command with a disabled feature annotation is removed from the command tree.
+A command declares a feature gate by calling `features.SetGate`, which records the gate name in the command's Cobra `Annotations` map under `features.AnnotationKey`. During CLI initialization, any command whose gate is not enabled is filtered out before it is ever registered in the command tree.
 
 ```go
-Annotations: map[string]string{
-    features.AnnotationKey: "feature-name",
-}
+cmd := &cobra.Command{Use: "pipeline"}
+
+features.SetGate(cmd, "pipeline")
 ```
 
-When a command is removed, it:
+Call `SetGate` rather than assigning `Annotations` yourself: it allocates the map when needed and preserves annotations written by other subsystems, such as the `telemetry` annotation set by `telemetry.Track`.
+
+When a command is filtered out, it:
 - Does not appear in `dr --help`
 - Returns "unknown command" error if invoked directly
 - Is implicitly unavailable for subcommands if its parent is removed
+
+To list every gate currently live in the tree, run `grep -rn 'features.SetGate' cmd/`.
 
 ## Enabling a Feature
 
@@ -34,11 +38,11 @@ When a command is removed, it:
 Set the env var `DATAROBOT_CLI_FEATURE_<FEATURE_NAME>=true` or `=1`:
 
 ```bash
-DATAROBOT_CLI_FEATURE_WORKLOAD=true dr workload --help
+DATAROBOT_CLI_FEATURE_PIPELINE=true dr pipeline --help
 ```
 
 Feature names are converted from lowercase with hyphens to uppercase with underscores:
-- `workload` → `DATAROBOT_CLI_FEATURE_WORKLOAD`
+- `pipeline` → `DATAROBOT_CLI_FEATURE_PIPELINE`
 - `my-feature` → `DATAROBOT_CLI_FEATURE_MY_FEATURE`
 
 ### Config File (Future)
@@ -47,10 +51,10 @@ Config file support (e.g., `drconfig.yaml`) is not yet implemented. See the TODO
 
 ## Adding a Feature-Gated Command
 
-1. **Create the command package** (e.g., `cmd/workload/cmd.go`):
+1. **Create the command package** (e.g., `cmd/pipeline/cmd.go`):
 
 ```go
-package workload
+package pipeline
 
 import (
     "github.com/datarobot/cli/internal/features"
@@ -58,14 +62,19 @@ import (
 )
 
 func Cmd() *cobra.Command {
-    return &cobra.Command{
-        Use:     "workload",
+    cmd := &cobra.Command{
+        Use:     "pipeline",
         GroupID: "core",
-        Short:   "Workload management commands",
-        Annotations: map[string]string{
-            features.AnnotationKey: "workload",
-        },
+        Short:   "Pipelines API management commands",
     }
+
+    features.SetGate(cmd, "pipeline")
+
+    cmd.AddCommand(
+        // ... subcommands ...
+    )
+
+    return cmd
 }
 ```
 
@@ -74,10 +83,12 @@ func Cmd() *cobra.Command {
 ```go
 RootCmd.AddCommand(
     // ... existing commands ...
-    workload.Cmd(),
+    pipeline.Cmd(),
     // ...
 )
 ```
+
+3. **Assert the gate in the package's own test**, as `TestCmd_FeatureGate` does in `cmd/pipeline/cmd_test.go`. Dropping the gate later should then be a deliberate, reviewed change rather than an accident.
 
 That's it. `RootCmd` is a `cli.CommandAdder`, so `AddCommand` automatically filters any gated command whose feature is disabled.
 
@@ -88,6 +99,8 @@ To gate a subcommand, the **parent** command must also use `cli.CommandAdder` so
 ```go
 func Cmd() *cobra.Command {
     parent := &cobra.Command{Use: "parent"}
+
+    features.SetGate(gatedSubCmd, "my-feature")
 
     adder := &cli.CommandAdder{Command: parent}
     adder.AddCommand(
@@ -105,22 +118,52 @@ When the parent command itself is gated and disabled, child commands are implici
 
 When a feature is ready for general availability:
 
-1. Delete the `Annotations` map from the command
-2. No other changes needed; feature is now permanently available
+1. Delete the `features.SetGate` call from every command carrying the gate. One gate name can cover several command trees, so run `grep -rn 'features.SetGate' cmd/` and confirm you have found them all before you stop.
+2. Delete the now-unused `github.com/datarobot/cli/internal/features` import from each file you touched. Go does not compile with an unused import, so this is not optional cleanup.
+3. Update the tests that encoded the gate: drop the package's gate assertion, and invert any root-level test asserting the command is absent by default so that it asserts presence instead.
+4. Update the docs that tell people to export the env var: the note at the top of `docs/commands/<command>.md`, and the feature-gated entries in `docs/commands/README.md`.
+5. Leave `internal/features` and `cli.CommandAdder` alone. They stay live for the remaining gates, and `DATAROBOT_CLI_FEATURE_<NAME>` simply becomes a no-op for the released feature, so scripts that still set it keep working.
 
 ```go
 // Before (gated)
-&cobra.Command{
-    Use:     "workload",
-    Annotations: map[string]string{
-        features.AnnotationKey: "workload",
-    },
-}
+import (
+    "github.com/datarobot/cli/cmd/pipeline/create"
+    "github.com/datarobot/cli/internal/features"
+    "github.com/spf13/cobra"
+)
 
+func Cmd() *cobra.Command {
+    cmd := &cobra.Command{
+        Use:     "pipeline",
+        GroupID: "core",
+        Short:   "Pipelines API management commands",
+    }
+
+    features.SetGate(cmd, "pipeline")
+
+    cmd.AddCommand(create.Cmd())
+
+    return cmd
+}
+```
+
+```go
 // After (GA)
-&cobra.Command{
-    Use:     "workload",
-    // No annotations
+import (
+    "github.com/datarobot/cli/cmd/pipeline/create"
+    "github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+    cmd := &cobra.Command{
+        Use:     "pipeline",
+        GroupID: "core",
+        Short:   "Pipelines API management commands",
+    }
+
+    cmd.AddCommand(create.Cmd())
+
+    return cmd
 }
 ```
 
@@ -128,14 +171,14 @@ When a feature is ready for general availability:
 
 Feature flags are tested via:
 
-- Unit tests in `internal/features/features_test.go` covering `Enabled()`
-- Unit tests in `internal/cli/command_test.go` covering `CommandAdder`
-- Integration tests in `cmd/root_test.go` verifying runtime behavior
+- Unit tests in `internal/features/features_test.go` covering `Enabled`, `SetProvider`, and `SetGate`
+- Unit tests in `internal/cli/command_test.go` covering `CommandAdder` filtering, including nested gated subcommands
+- A per-command gate assertion in the gated package's own test, as `TestCmd_FeatureGate` does in `cmd/pipeline/cmd_test.go`
 - Manual testing with env vars: `DATAROBOT_CLI_FEATURE_<NAME>=true dr <command>`
 
 ## Limitations
 
-- **Config file support not yet implemented** — only env vars work (TODO in code)
+- **Config file support not yet implemented**: only env vars work (TODO in code)
 - Feature flags are evaluated at CLI startup, not at runtime
 - Enabling a feature via env var affects the entire CLI session
 - Disabling a feature is not supported (only enabled or absent)

--- a/docs/development/structure.md
+++ b/docs/development/structure.md
@@ -117,7 +117,7 @@ Feature flag system:
 - `SetGate`: Marks a command with a feature gate annotation
 - `Enabled`: Checks if a feature is enabled via environment variables
 - `AnnotationKey`: The key used for feature gate annotations
-- Environment variable format: `DATAROBOT_CLI_FEATURE_<NAME>` (e.g., `DATAROBOT_CLI_FEATURE_WORKLOAD=true`)
+- Environment variable format: `DATAROBOT_CLI_FEATURE_<NAME>` (e.g., `DATAROBOT_CLI_FEATURE_PIPELINE=true`)
 
 #### task/
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -71,6 +71,8 @@ nav:
       - self: commands/self.md
       - plugins: commands/plugins.md
       - component: commands/component-managed-updates.md
+      - artifact: commands/artifact.md
+      - workload: commands/workload.md
   - Development:
       - development/README.md
       - Setup: development/setup.md

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -37,7 +37,7 @@ type envVarProvider struct{}
 
 // IsEnabled checks if a feature is enabled via environment variable.
 // Feature names are converted to uppercase with underscores replacing hyphens.
-// Format: DATAROBOT_CLI_FEATURE_<NAME> (e.g., DATAROBOT_CLI_FEATURE_WORKLOAD).
+// Format: DATAROBOT_CLI_FEATURE_<NAME> (e.g., DATAROBOT_CLI_FEATURE_PIPELINE).
 func (p *envVarProvider) IsEnabled(name string) bool {
 	envKey := config.EnvPrefix + "FEATURE_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
 	if v := os.Getenv(envKey); v != "" {


### PR DESCRIPTION
# RATIONALE

`dr workload` and `dr artifact` have been hidden behind `DATAROBOT_CLI_FEATURE_WORKLOAD` since v0.2.63. Workload API is GA, so the gate is now pure friction: every user and every doc has to export the variable first, and until they do neither tree appears in `dr --help` or in shell completions.

Both trees share the single gate name `workload`, so they can only be ungated together. `pipeline` stays gated and becomes the only live gate, so `internal/features` and `cli.CommandAdder` stay put.

## CHANGES

Dropped the two `features.SetGate` calls and everything that referenced the variable.

`docs/development/feature-gates.md` needed more than a find-and-replace. It used `workload` as its worked example throughout, and it taught a raw `Annotations` literal that no call site has ever used, so it is now written around `pipeline` and `features.SetGate`. Its "Removing a Feature Gate" procedure was also wrong: it said to delete the `Annotations` map and stop, which does not compile, because it leaves an unused import behind.

`docs/commands/workload.md` and `artifact.md` join the mkdocs nav, where neither had ever appeared. Adding `workload.md` turned up that it documented 9 of the 11 subcommands, missing `config` and `up`, so those are filled in rather than published incomplete.

## Breaking change: legacy `.wapi/` state is no longer read

GA is also the cutoff for the pre-GA state layout, so `EnsureMigrated` and the `Dir()` fallback are gone. **A project still holding a root `.wapi/` now reads as unlinked.**

That directory shipped from v0.2.63 through v0.2.81. The auto-migration that would have relocated it existed only in v0.2.82 and v0.2.83, so anyone who skipped those two releases gets no migration at all. The affected population is gate-opting early adopters by definition, since exporting the variable was the only way to create the directory in the first place.

One path degraded badly without a guard. Every command reports a visible "not linked" error except `dr workload up`, which read the project as a first deploy, minted a **second artifact server-side** and orphaned the one the project had been pushing to, along with its builds and locked versions, silently. So `wapi.LegacyState` now recognises the old layout and every affected command explains itself:

```
Error: not linked: .wapi/ holds state written by an older CLI, which is no longer read.
Run 'dr artifact code init art-abc-123' to link this project again, then delete .wapi/
```

`up` refuses before it touches the server. `dr artifact code init` still succeeds, because re-linking is the recovery, but it now prints a note that the old directory is orphaned. Naming the artifact id is the point: `.wapi/` carries a `.gitignore` of `*`, so nothing else would ever surface it, and that id is the only way back.

A project that was genuinely never linked still gets the plain hint, with no mention of a directory it does not have.

### Residual cost, not fixed

A `.wapi/.rollback` tree left by a sync that crashed on v0.2.81 or earlier is no longer swept, and those backups are the only copy of the files that sync overwrote. Keeping that working would mean keeping half the legacy machinery alive. Flagging it here rather than burying it; the guard at least makes the surrounding situation visible.

## NOTES

Reviewers running the suite locally: `Taskfile.yaml` loads `.env`, and a typical dev `.env` sets `DATAROBOT_CLI_FEATURE_WORKLOAD=true`, so `task test` exercises the gate-on path. For the clean signal use `DATAROBOT_CLI_FEATURE_WORKLOAD= go test ./...`.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Always-on exposure of workload and artifact commands changes the default CLI surface for all users (help, completions, and discoverability). Remaining risk is mostly operational—`pipeline` is still gated and tests/env quirks around `DATAROBOT_CLI_FEATURE_WORKLOAD` in dev `.env` are called out in the PR notes.
> 
> **Overview**
> **`dr artifact` and `dr workload` are no longer hidden behind `DATAROBOT_CLI_FEATURE_WORKLOAD`.** The `features.SetGate` calls are removed from `cmd/artifact/cmd.go` and `cmd/workload/cmd.go`, so both trees always appear in `dr --help`, completions, and the live `RootCmd` tree. `pipeline` remains the only gated command.
> 
> Tests are flipped to match: `TestWorkloadAndArtifactCommandsAlwaysRegistered` asserts both commands are present by default, and `TestGatedCommandFilteredFromRootCmd` keeps coverage that `pipeline` stays out of `RootCmd` when its gate is off. Telemetry wiring tests no longer build separate gated subtrees—artifact and workload paths are checked on `RootCmd` via an expanded `expectedTrackedCommands` list.
> 
> Documentation drops the env-var requirement for artifact/workload, adds **`config` and `up`** to the workload reference and command tree, publishes **artifact** and **workload** in `docs/mkdocs.yml`, and rewrites **feature-gates** docs to use `pipeline` and `features.SetGate` (including a corrected GA checklist). `AGENTS.md` and comment examples now cite `DATAROBOT_CLI_FEATURE_PIPELINE` instead of `WORKLOAD`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fc85bc70de9c663404d63b81fdd551442bfc46f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->