### PR TITLE
chore(codeowners): route cmd/artifact/ to workload-cli team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 * @datarobot-oss/cli-maintainers
 cmd/workload/ @datarobot-oss/workload-cli
+cmd/artifact/ @datarobot-oss/workload-cli
 internal/workload/ @datarobot-oss/workload-cli
 cmd/pipeline/ @datarobot-oss/compute-services
 internal/pipeline/ @datarobot-oss/compute-services


### PR DESCRIPTION
The cmd/artifact/ module was falling through to the wildcard `* @datarobot-oss/cli-maintainers` rule. Artifact commands are tightly coupled to internal/workload/ (already owned by @datarobot-oss/workload-cli), so route cmd/artifact/ to the same team for consistent review ownership.
<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787066291.129139 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process-only change to review ownership; no application code, security, or runtime behavior is affected.
> 
> **Overview**
> **CODEOWNERS** now assigns **`cmd/artifact/`** to **`@datarobot-oss/workload-cli`**, matching **`internal/workload/`** and **`cmd/workload/`**. Previously that path only matched the catch-all **`* @datarobot-oss/cli-maintainers`** rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d46fc984debdcf137bb44743a24a39c8f8be9b1c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->