### PR TITLE
[CFX-4450] dr self update --version

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -29,5 +29,5 @@ runs:
       if: inputs.install-task == 'true'
       uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
       with:
-        version: 3.53.0
+        version: 3.52.0
         repo-token: ${{ github.token }}

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -29,5 +29,5 @@ runs:
       if: inputs.install-task == 'true'
       uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
       with:
-        version: 3.x
+        version: 3.53.0
         repo-token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ To install a specific released version instead of the latest, pass `--version`:
 dr self update --version v0.12.3
 ```
 
-`--version` accepts `vX.Y.Z` or `X.Y.Z` and refuses to install a version older than the one currently running. It is not supported when `dr` was installed via the Homebrew cask; Homebrew always installs the latest release and cannot pin versions&mdash;uninstall the cask and use the manual install script instead.
+`--version` accepts `vX.Y.Z` or `X.Y.Z` and refuses to install a version older than the one currently running, unless `--force`/`-f` is also passed. It is not supported when `dr` was installed via the Homebrew cask; Homebrew always installs the latest release and cannot pin versions&mdash;uninstall the cask and use the manual install script instead.
 
 After updating, verify the new version:
 

--- a/README.md
+++ b/README.md
@@ -221,9 +221,17 @@ This command will automatically:
 
 The update process supports:
 
-- **Homebrew (macOS)**&mdash;automatically upgrades via `brew upgrade --cask dr-cli`
+- **Homebrew (macOS/Linux)**&mdash;automatically upgrades via `brew upgrade --cask dr-cli`
 - **Windows**&mdash;runs the latest PowerShell installation script
 - **macOS/Linux**&mdash;runs the latest shell installation script
+
+To install a specific released version instead of the latest, pass `--version`:
+
+```bash
+dr self update --version v0.12.3
+```
+
+`--version` accepts `vX.Y.Z` or `X.Y.Z` and refuses to install a version older than the one currently running. It is not supported when `dr` was installed via the Homebrew cask; Homebrew always installs the latest release and cannot pin versions&mdash;uninstall the cask and use the manual install script instead.
 
 After updating, verify the new version:
 

--- a/cmd/self/update/cmd.go
+++ b/cmd/self/update/cmd.go
@@ -89,7 +89,7 @@ with your default shell.
 
 			switch runtime.GOOS {
 			case "windows":
-				command = "irm https://raw.githubusercontent.com/datarobot-oss/cli/main/install.ps1 | iex"
+				command = "irm https://cli.datarobot.com/winstall | iex"
 				if targetVersion != "" {
 					command = fmt.Sprintf("$env:VERSION='%s'; %s", targetVersion, command)
 				}
@@ -117,7 +117,7 @@ with your default shell.
 					return fmt.Errorf("detect shell: %w", err)
 				}
 
-				command = "curl -fsSL https://raw.githubusercontent.com/datarobot-oss/cli/main/install.sh | sh"
+				command = "curl -fsSL https://cli.datarobot.com/install | sh"
 				if targetVersion != "" {
 					command += " -s -- " + targetVersion
 				}
@@ -215,8 +215,9 @@ func isBrewCaskInstalled(brewPath string) bool {
 func brewCaskVersionError(targetVersion string) error {
 	return fmt.Errorf(
 		"dr was installed via Homebrew (dr-cli cask). Homebrew always installs the latest release and cannot pin versions.\n\n"+
-			"To install %s manually, uninstall the cask and run:\n\n"+
-			"  curl -fsSL https://raw.githubusercontent.com/datarobot-oss/cli/main/install.sh | sh -s -- %s\n",
+			"To install %s manually, uninstall the cask and install with the installation script:\n\n"+
+			"  brew uninstall --cask dr-cli\n"+
+			"  curl -fsSL https://cli.datarobot.com/install | sh -s -- %s\n",
 		targetVersion, targetVersion)
 }
 

--- a/cmd/self/update/cmd.go
+++ b/cmd/self/update/cmd.go
@@ -19,9 +19,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/datarobot/cli/internal/fsutil"
 	"github.com/datarobot/cli/internal/log"
 	internalShell "github.com/datarobot/cli/internal/shell"
@@ -30,8 +32,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// versionPattern requires a strict MAJOR.MINOR.PATCH numeric triplet, with an
+// optional leading "v" and optional -prerelease / +build suffixes.
+var versionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+(-[0-9A-Za-z-.]+)?(\+[0-9A-Za-z-.]+)?$`)
+
 func Cmd() *cobra.Command { //nolint:cyclop
-	var force bool
+	var (
+		force         bool
+		targetVersion string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "update",
@@ -42,12 +51,25 @@ with your default shell.
 `,
 
 		RunE: func(_ *cobra.Command, _ []string) error {
+			if targetVersion != "" {
+				normalized, err := normalizeAndValidateVersion(targetVersion)
+				if err != nil {
+					return err
+				}
+
+				targetVersion = normalized
+
+				if err := refuseDowngrade(targetVersion); err != nil {
+					return err
+				}
+			}
+
 			requirement, err := tools.GetSelfRequirement()
 			if err != nil {
 				return fmt.Errorf("get self requirement: %w", err)
 			}
 
-			if tools.SufficientSelfVersion(requirement.MinimumVersion) && !force {
+			if tools.SufficientSelfVersion(requirement.MinimumVersion) && !force && targetVersion == "" {
 				if requirement.MinimumVersion != "" {
 					fmt.Fprintf(os.Stderr, "Required version: %s. ", requirement.MinimumVersion)
 				}
@@ -56,46 +78,6 @@ with your default shell.
 				fmt.Fprintln(os.Stderr, "Skipping update. To force update to latest version, add -f flag.")
 
 				return nil
-			}
-
-			// Account for when dr-cli cask has been installed - via `brew install datarobot-oss/taps/dr-cli`
-			if runtime.GOOS == "darwin" { //nolint:nestif
-				// Try to find brew and check if datarobot-oss is installed
-				brewPath, err := exec.LookPath("brew")
-				if err == nil {
-					brewCheckCmd := exec.Command(brewPath, "list", "--cask", "dr-cli")
-
-					// If we have dr-cli cask installed then attempt upgrade (err above indicates dr-cli wasn't found)
-					if err := brewCheckCmd.Run(); err == nil {
-						// Update brew first
-						brewUpdateCmd := exec.Command(brewPath, "update")
-						brewUpdateCmd.Stdout = os.Stdout
-						brewUpdateCmd.Stderr = os.Stderr
-
-						if err := brewUpdateCmd.Run(); err != nil {
-							fmt.Fprintln(os.Stderr, "Error: ", err)
-							return fmt.Errorf("brew update: %w", err)
-						}
-
-						brewReinstallCmd := exec.Command(brewPath, "reinstall", "--cask", "dr-cli", "--force")
-						brewReinstallCmd.Stdout = os.Stdout
-						brewReinstallCmd.Stderr = os.Stderr
-
-						if err := brewReinstallCmd.Run(); err != nil {
-							fmt.Fprintln(os.Stderr, "Error: ", err)
-							return fmt.Errorf("brew reinstall: %w", err)
-						}
-
-						return nil
-					}
-				}
-			}
-
-			// Now, assuming we haven't upgraded via brew handle with OS specific command
-			shell, err := internalShell.DetectShell()
-			if err != nil {
-				fmt.Fprintln(os.Stderr, "Error while determining shell: ", err)
-				return fmt.Errorf("detect shell: %w", err)
 			}
 
 			var (
@@ -108,6 +90,9 @@ with your default shell.
 			switch runtime.GOOS {
 			case "windows":
 				command = "irm https://raw.githubusercontent.com/datarobot-oss/cli/main/install.ps1 | iex"
+				if targetVersion != "" {
+					command = fmt.Sprintf("$env:VERSION='%s'; %s", targetVersion, command)
+				}
 
 				var err error
 
@@ -121,7 +106,22 @@ with your default shell.
 				// which uses /C and cannot run `irm ... | iex`).
 				execCmd = exec.Command("powershell", "-NoProfile", "-Command", command)
 			case "darwin", "linux":
+				if handled, err := tryBrewUpdate(targetVersion); handled {
+					return err
+				}
+
+				// Now, assuming we haven't upgraded via brew handle with OS specific command
+				shell, err := internalShell.DetectShell()
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "Error while determining shell: ", err)
+					return fmt.Errorf("detect shell: %w", err)
+				}
+
 				command = "curl -fsSL https://raw.githubusercontent.com/datarobot-oss/cli/main/install.sh | sh"
+				if targetVersion != "" {
+					command += " -s -- " + targetVersion
+				}
+
 				execCmd = exec.Command(shell, "-c", command)
 			default:
 				return fmt.Errorf("could not determine OS: %s", runtime.GOOS)
@@ -158,8 +158,107 @@ with your default shell.
 	}
 
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "Force update to latest version")
+	cmd.Flags().StringVar(&targetVersion, "version", "", "Install a specific released version instead of latest (e.g. v0.12.3)")
 
 	return cmd
+}
+
+// normalizeAndValidateVersion validates s as a strict semantic version
+// (vMAJOR.MINOR.PATCH, optionally without the leading "v", optionally with a
+// -prerelease and/or +build suffix) and returns it normalized to "vX.Y.Z...".
+func normalizeAndValidateVersion(s string) (string, error) {
+	trimmed := strings.TrimSpace(s)
+	if !versionPattern.MatchString(trimmed) {
+		return "", fmt.Errorf("invalid version %q: expected vMAJOR.MINOR.PATCH (e.g. v0.12.3)", s)
+	}
+
+	if strings.HasPrefix(trimmed, "v") {
+		return trimmed, nil
+	}
+
+	return "v" + trimmed, nil
+}
+
+// refuseDowngrade errors if requestedVersion is older than the currently
+// running dr version (version.Version). Skipped entirely for non-release
+// ("dev") builds.
+func refuseDowngrade(requestedVersion string) error {
+	if version.Version == "dev" {
+		return nil
+	}
+
+	installed, err := semver.NewVersion(version.Version)
+	if err != nil {
+		return nil
+	}
+
+	requested, err := semver.NewVersion(requestedVersion)
+	if err != nil {
+		return fmt.Errorf("invalid version %q: expected vMAJOR.MINOR.PATCH (e.g. v0.12.3)", requestedVersion)
+	}
+
+	if requested.LessThan(installed) {
+		return fmt.Errorf("refusing to install older version (installed: %s, requested: %s)", version.Version, requestedVersion)
+	}
+
+	return nil
+}
+
+// isBrewCaskInstalled reports whether the dr-cli Homebrew cask is installed,
+// given a resolved brew path.
+func isBrewCaskInstalled(brewPath string) bool {
+	return exec.Command(brewPath, "list", "--cask", "dr-cli").Run() == nil
+}
+
+// brewCaskVersionError is returned when --version is requested but dr was
+// installed via the Homebrew cask, which cannot pin specific versions.
+func brewCaskVersionError(targetVersion string) error {
+	return fmt.Errorf(
+		"dr was installed via Homebrew (dr-cli cask). Homebrew always installs the latest release and cannot pin versions.\n\n"+
+			"To install %s manually, uninstall the cask and run:\n\n"+
+			"  curl -fsSL https://raw.githubusercontent.com/datarobot-oss/cli/main/install.sh | sh -s -- %s\n",
+		targetVersion, targetVersion)
+}
+
+// tryBrewUpdate checks whether dr was installed via the Homebrew cask and,
+// if so, either hard-errors (targetVersion set — Homebrew can't pin
+// versions) or updates via brew directly. handled is true whenever the
+// brew-managed path was taken (regardless of success), signaling the caller
+// should return err immediately rather than falling through to the generic
+// install-script path.
+func tryBrewUpdate(targetVersion string) (handled bool, err error) {
+	brewPath, err := exec.LookPath("brew")
+	if err != nil {
+		return false, nil
+	}
+
+	if !isBrewCaskInstalled(brewPath) {
+		return false, nil
+	}
+
+	if targetVersion != "" {
+		return true, brewCaskVersionError(targetVersion)
+	}
+
+	brewUpdateCmd := exec.Command(brewPath, "update")
+	brewUpdateCmd.Stdout = os.Stdout
+	brewUpdateCmd.Stderr = os.Stderr
+
+	if err := brewUpdateCmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "Error: ", err)
+		return true, fmt.Errorf("brew update: %w", err)
+	}
+
+	brewReinstallCmd := exec.Command(brewPath, "reinstall", "--cask", "dr-cli", "--force")
+	brewReinstallCmd.Stdout = os.Stdout
+	brewReinstallCmd.Stderr = os.Stderr
+
+	if err := brewReinstallCmd.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "Error: ", err)
+		return true, fmt.Errorf("brew reinstall: %w", err)
+	}
+
+	return true, nil
 }
 
 // resolveInstallDir returns the directory of the currently running executable,

--- a/cmd/self/update/cmd.go
+++ b/cmd/self/update/cmd.go
@@ -59,7 +59,7 @@ with your default shell.
 
 				targetVersion = normalized
 
-				if err := refuseDowngrade(targetVersion); err != nil {
+				if err := refuseDowngrade(targetVersion, force); err != nil {
 					return err
 				}
 			}
@@ -181,9 +181,10 @@ func normalizeAndValidateVersion(s string) (string, error) {
 
 // refuseDowngrade errors if requestedVersion is older than the currently
 // running dr version (version.Version). Skipped entirely for non-release
-// ("dev") builds.
-func refuseDowngrade(requestedVersion string) error {
-	if version.Version == "dev" {
+// ("dev") builds, or when force is set (an explicit --force overrides the
+// refusal, allowing an intentional downgrade).
+func refuseDowngrade(requestedVersion string, force bool) error {
+	if version.Version == "dev" || force {
 		return nil
 	}
 

--- a/cmd/self/update/cmd_test.go
+++ b/cmd/self/update/cmd_test.go
@@ -144,5 +144,6 @@ func TestBrewCaskVersionError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Homebrew (dr-cli cask)")
 	assert.Contains(t, err.Error(), "cannot pin versions")
-	assert.Contains(t, err.Error(), "install.sh | sh -s -- v0.12.3")
+	assert.Contains(t, err.Error(), "brew uninstall --cask dr-cli")
+	assert.Contains(t, err.Error(), "cli.datarobot.com/install | sh -s -- v0.12.3")
 }

--- a/cmd/self/update/cmd_test.go
+++ b/cmd/self/update/cmd_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -64,4 +65,84 @@ func TestResolveInstallDirFollowsSymlink(t *testing.T) {
 	// not the directory containing the symlink itself.
 	assert.Equal(t, filepath.Dir(realExe), filepath.Dir(resolved))
 	assert.NotEqual(t, linkDir, filepath.Dir(resolved))
+}
+
+func TestNormalizeAndValidateVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr string // "" means no error expected
+	}{
+		{"bare v-prefixed", "v1.2.3", "v1.2.3", ""},
+		{"bare no prefix", "1.2.3", "v1.2.3", ""},
+		{"prerelease suffix", "v0.12.3-rc.1", "v0.12.3-rc.1", ""},
+		{"build suffix no v", "0.12.3+build.5", "v0.12.3+build.5", ""},
+		{"prerelease and build", "v1.2.3-rc.1+build.5", "v1.2.3-rc.1+build.5", ""},
+		{"missing patch", "1.2", "", `invalid version "1.2": expected vMAJOR.MINOR.PATCH (e.g. v0.12.3)`},
+		{"non-numeric", "abc", "", `invalid version "abc": expected vMAJOR.MINOR.PATCH (e.g. v0.12.3)`},
+		{"too many components", "v1.2.3.4", "", `invalid version "v1.2.3.4": expected vMAJOR.MINOR.PATCH (e.g. v0.12.3)`},
+		{"empty", "", "", `invalid version "": expected vMAJOR.MINOR.PATCH (e.g. v0.12.3)`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeAndValidateVersion(tt.input)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+
+				return
+			}
+
+			require.Error(t, err)
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestRefuseDowngrade(t *testing.T) {
+	originalVersion := version.Version
+
+	defer func() { version.Version = originalVersion }()
+
+	tests := []struct {
+		name      string
+		installed string
+		requested string
+		wantErr   string // "" means no error expected
+	}{
+		{
+			"older requested is refused", "v0.12.3", "v0.11.0",
+			"refusing to install older version (installed: v0.12.3, requested: v0.11.0)",
+		},
+		{"same version is allowed", "v0.12.3", "v0.12.3", ""},
+		{"newer version is allowed", "v0.12.3", "v0.13.0", ""},
+		{"dev bypasses the check entirely", "dev", "v0.0.1", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version.Version = tt.installed
+
+			err := refuseDowngrade(tt.requested)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestBrewCaskVersionError(t *testing.T) {
+	err := brewCaskVersionError("v0.12.3")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Homebrew (dr-cli cask)")
+	assert.Contains(t, err.Error(), "cannot pin versions")
+	assert.Contains(t, err.Error(), "install.sh | sh -s -- v0.12.3")
 }

--- a/cmd/self/update/cmd_test.go
+++ b/cmd/self/update/cmd_test.go
@@ -110,22 +110,25 @@ func TestRefuseDowngrade(t *testing.T) {
 		name      string
 		installed string
 		requested string
+		force     bool
 		wantErr   string // "" means no error expected
 	}{
 		{
-			"older requested is refused", "v0.12.3", "v0.11.0",
+			"older requested is refused", "v0.12.3", "v0.11.0", false,
 			"refusing to install older version (installed: v0.12.3, requested: v0.11.0)",
 		},
-		{"same version is allowed", "v0.12.3", "v0.12.3", ""},
-		{"newer version is allowed", "v0.12.3", "v0.13.0", ""},
-		{"dev bypasses the check entirely", "dev", "v0.0.1", ""},
+		{"same version is allowed", "v0.12.3", "v0.12.3", false, ""},
+		{"newer version is allowed", "v0.12.3", "v0.13.0", false, ""},
+		{"dev bypasses the check entirely", "dev", "v0.0.1", false, ""},
+		{"force allows downgrade", "v0.12.3", "v0.11.0", true, ""},
+		{"force with dev still allowed", "dev", "v0.0.1", true, ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			version.Version = tt.installed
 
-			err := refuseDowngrade(tt.requested)
+			err := refuseDowngrade(tt.requested, tt.force)
 			if tt.wantErr == "" {
 				assert.NoError(t, err)
 

--- a/docs/commands/self.md
+++ b/docs/commands/self.md
@@ -121,17 +121,25 @@ dr self update
 
 This command automatically detects your installation method and uses the appropriate update mechanism:
 
-- **Homebrew (macOS)**&mdash;uses `brew update && upgrade dr-cli` if installed via Homebrew
+- **Homebrew (macOS/Linux)**&mdash;uses `brew update && upgrade dr-cli` if installed via Homebrew
 - **Windows**&mdash;runs the PowerShell installation script
 - **macOS/Linux**&mdash;runs the shell installation script
 
 The update process will download and install the latest version while preserving your configuration and credentials.
+
+**Options:**
+
+- `--version <version>`&mdash;install a specific released version instead of the latest. Accepts `vX.Y.Z` or `X.Y.Z`, optionally with a `-prerelease` and/or `+build` suffix. Refuses to install a version older than the one currently running. Not available when `dr` was installed via the Homebrew cask&mdash;Homebrew always installs the latest release and cannot pin versions, so the command exits with an error showing the manual `install.sh` command to run instead.
 
 **Examples:**
 
 ```bash
 # Update to latest version
 dr self update
+
+# Install a specific version
+dr self update --version v0.12.3
+dr self update --version 0.12.3
 ```
 
 > [!NOTE]

--- a/docs/commands/self.md
+++ b/docs/commands/self.md
@@ -129,7 +129,8 @@ The update process will download and install the latest version while preserving
 
 **Options:**
 
-- `--version <version>`&mdash;install a specific released version instead of the latest. Accepts `vX.Y.Z` or `X.Y.Z`, optionally with a `-prerelease` and/or `+build` suffix. Refuses to install a version older than the one currently running. Not available when `dr` was installed via the Homebrew cask&mdash;Homebrew always installs the latest release and cannot pin versions, so the command exits with an error showing the manual `install.sh` command to run instead.
+- `--version <version>`&mdash;install a specific released version instead of the latest. Accepts `vX.Y.Z` or `X.Y.Z`, optionally with a `-prerelease` and/or `+build` suffix. Refuses to install a version older than the one currently running unless `--force`/`-f` is also set. Not available when `dr` was installed via the Homebrew cask&mdash;Homebrew always installs the latest release and cannot pin versions, so the command exits with an error showing the manual install command to run instead.
+- `--force`/`-f`&mdash;force the update even if the installed version already satisfies requirements, and (combined with `--version`) allow installing an older version than the one currently running.
 
 **Examples:**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ Detailed documentation for each command:
 - [task](commands/task.md)&mdash;Taskfile composition and management, including task listing and execution.
 - [dotenv](commands/dotenv.md)&mdash;environment variable management with interactive wizard and validation.
 - [completion](commands/completion.md)&mdash;shell completion setup (install/uninstall or generate for bash, zsh, fish, PowerShell).
-- [self](commands/self.md)&mdash;CLI utility commands (version, update, config, completion, and plugin authoring: add, publish, package).
+- [self](commands/self.md)&mdash;CLI utility commands (version, update &mdash; including installing a specific released version, config, completion, and plugin authoring: add, publish, package).
 - [plugins](commands/plugins.md)&mdash;plugin system documentation.
 - [component](commands/component-managed-updates.md)&mdash;component management and updates.
 - [Command reference index](commands/README.md)&mdash;full command tree including `dependencies check` and global flags.

--- a/docs/user-guide/quick-reference.md
+++ b/docs/user-guide/quick-reference.md
@@ -143,6 +143,9 @@ dr self version
 # Update CLI
 dr self update
 
+# Install a specific version
+dr self update --version v0.12.3
+
 # Enable shell completions
 dr self completion install [bash|zsh|fish|powershell]
 


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->
`dr self update` could only ever install the *latest* release — there was no way to pin a specific version. This blocks reproducible environments, rollback-for-testing, and matching a specific `dr` version to a teammate's or CI's. This change adds a `--version` flag with strict validation, refuses downgrades, and hard-errors under Homebrew (which can't pin versions at all).

While implementing this, the existing Homebrew-cask detection was found to be macOS-only (`if runtime.GOOS == "darwin"`), even though Homebrew ("Linuxbrew") is a documented, supported install method on Linux too (`README.md`'s own "Install via Homebrew / Linuxbrew" section). A Linux user on a brew-managed install would previously fall straight through to the raw `curl | sh` path, bypassing brew entirely and getting no protection from the new `--version`-under-Homebrew guard. This is fixed alongside the main feature.


## CHANGES
- Added `--version <version>` flag to `dr self update` (no shorthand, not settable via any env var).
  - `normalizeAndValidateVersion`: strict `vMAJOR.MINOR.PATCH` validation (optional leading `v`, optional `-prerelease`/`+build` suffix), normalized to a `v`-prefixed form. Uses a regex rather than the semver library's lenient parser, since the ticket's own example (`"1.2"` → error) would otherwise silently pass.
  - `refuseDowngrade`: uses `github.com/Masterminds/semver/v3` to block installing a version older than the one currently running; skipped entirely for non-release (`"dev"`) builds.
  - The existing "already sufficient, skip update" short-circuit no longer swallows an explicit `--version` request.
- Extracted the Homebrew-cask update logic into `tryBrewUpdate`, and extended it to run on **both** `darwin` and `linux` (previously darwin-only), consolidated into the single `switch runtime.GOOS { case "darwin", "linux": ... }` dispatch instead of a separate standalone `if` block. Shell detection now only runs when actually needed (previously called unconditionally, even for the brew-handled path and for Windows where it's unused).
  - `brewCaskVersionError`: hard error returned when `--version` is passed but `dr` is installed via the Homebrew cask, with the manual `install.sh` command to run instead.
- Threaded `targetVersion` into the non-brew install paths: appended to the `curl | sh` invocation (`sh -s -- <version>`) and set via `$env:VERSION='<version>';` before the PowerShell one-liner on Windows — both install scripts already supported pinned versions, this just wires the flag through.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the CLI replaces itself (brew reinstall and remote install scripts) on user machines; behavior is well-tested but mistakes could break updates or pin the wrong release.
> 
> **Overview**
> Adds **`--version`** to **`dr self update`** so users can install a specific release (`vX.Y.Z` or `X.Y.Z`) instead of always taking latest. Versions are validated with a strict MAJOR.MINOR.PATCH regex, normalized to a `v` prefix, and **downgrades are refused** against the running binary (skipped for `dev` builds). An explicit `--version` request is no longer blocked by the “already sufficient, skip update” shortcut.
> 
> Pinned installs are wired into the existing install scripts on **Windows** (`$env:VERSION`) and **Unix shell** (`install.sh -s -- <version>`). **Homebrew cask** installs cannot pin versions; `--version` now returns a guided error with the manual `install.sh` command.
> 
> Homebrew self-update logic is refactored into **`tryBrewUpdate`** and extended from **macOS-only to macOS and Linux**, so Linuxbrew-managed `dr-cli` cask installs use `brew update` / `reinstall` instead of falling through to `curl | sh`. Shell detection runs only when the generic install path is needed.
> 
> User docs (README, `self`, quick reference) and unit tests for validation, downgrade refusal, and the Homebrew pin error are updated. CI pins Taskfile to **3.52.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b841ea44b00d84d6c72a52b9be61846584963ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->