### PR TITLE
[CFX-7682] Follow-up code review validation

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -16,8 +16,11 @@ package cmd
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/features"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/tools"
@@ -235,6 +238,21 @@ func TestUnknownArgGuard(t *testing.T) {
 	}
 }
 
+// requireGateDisabled skips the calling test when the named feature gate is
+// enabled in the ambient environment. Gate filtering happens in init(), long
+// before a test can unset the variable, so the only sound option is to skip.
+func requireGateDisabled(t *testing.T, name string) {
+	t.Helper()
+
+	if !features.Enabled(name) {
+		return
+	}
+
+	t.Skipf("feature gate %q is enabled in the environment (%sFEATURE_%s); "+
+		"gating is applied at init() so this default-state test cannot run",
+		name, config.EnvPrefix, strings.ToUpper(strings.ReplaceAll(name, "-", "_")))
+}
+
 func TestSetUnknownArgGuards_AppliesGuardToPureParent(t *testing.T) {
 	child := &cobra.Command{
 		Use:  "child",
@@ -321,6 +339,8 @@ func TestSetUnknownArgGuards_SkipsExplicitArgs(t *testing.T) {
 }
 
 func TestWorkloadCommandNotPresentByDefault(t *testing.T) {
+	requireGateDisabled(t, "workload")
+
 	// Verify that workload command is not present by default (feature not enabled).
 	// The feature gating happens during init(), so this tests the actual state.
 	cmd := RootCmd
@@ -338,6 +358,8 @@ func TestWorkloadCommandNotPresentByDefault(t *testing.T) {
 }
 
 func TestArtifactCommandNotPresentByDefault(t *testing.T) {
+	requireGateDisabled(t, "workload")
+
 	// The artifact command shares the "workload" feature gate, so it is
 	// filtered out by cli.CommandAdder during init() when the gate is not
 	// enabled (the default).

--- a/cmd/task/list/cmd.go
+++ b/cmd/task/list/cmd.go
@@ -291,9 +291,9 @@ func Cmd() *cobra.Command {
 
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			binaryName := "task"
-			discovery := task.NewTaskDiscovery("Taskfile.gen.yaml")
 
-			rootTaskfile, err := discovery.Discover(dir, 2)
+			// Same resolution as `dr run`, so the list is the Taskfile that will actually execute.
+			rootTaskfile, _, err := task.ResolveTaskfile(dir)
 			if err != nil {
 				_, _ = fmt.Fprintln(os.Stderr, task.FormatDiscoveryError(err))
 

--- a/cmd/task/list/cmd.go
+++ b/cmd/task/list/cmd.go
@@ -292,7 +292,6 @@ func Cmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			binaryName := "task"
 
-			// Same resolution as `dr run`, so the list is the Taskfile that will actually execute.
 			rootTaskfile, _, err := task.ResolveTaskfile(dir)
 			if err != nil {
 				_, _ = fmt.Fprintln(os.Stderr, task.FormatDiscoveryError(err))

--- a/cmd/task/list/cmd_test.go
+++ b/cmd/task/list/cmd_test.go
@@ -15,6 +15,11 @@
 package list
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/datarobot/cli/internal/outputformat"
@@ -25,51 +30,79 @@ import (
 )
 
 func TestTaskListJSON(t *testing.T) {
-	t.Skip("Skipping task list test - requires a DataRobot project directory with Taskfile")
+	projectDir := t.TempDir()
+	writeProjectFixture(t, projectDir, true)
+	writeFakeTaskBinary(t, filepath.Join(t.TempDir(), "task.log"))
 
-	// Create a root command with persistent output-format flag
 	root := &cobra.Command{Use: "test"}
 
 	var rootOutputFormat outputformat.OutputFormat
 	outputformat.AddPersistentFlag(root, &rootOutputFormat)
 
-	// Create and add the list command
-	listCmd := Cmd()
-	root.AddCommand(listCmd)
+	root.AddCommand(Cmd())
+	root.SetArgs([]string{"list", "--dir", projectDir, "--output-format", "json"})
 
-	// Parse args to set JSON output format
-	root.SetArgs([]string{"list", "--output-format", "json"})
+	var err error
 
-	// Execute the command - should not error
-	err := root.Execute()
+	out := captureStdout(t, func() { err = root.Execute() })
 	require.NoError(t, err)
 
-	// Test passes if command executes successfully with JSON format flag
-	// (actual output is tested via manual smoke tests)
+	var envelope struct {
+		Tasks []TaskOutput `json:"tasks"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(out), &envelope))
+	require.Len(t, envelope.Tasks, 1)
+	assert.Equal(t, "dev", envelope.Tasks[0].Name)
 }
 
 func TestTaskListText(t *testing.T) {
-	t.Skip("Skipping task list test - requires a DataRobot project directory with Taskfile")
+	projectDir := t.TempDir()
+	writeProjectFixture(t, projectDir, true)
+	writeFakeTaskBinary(t, filepath.Join(t.TempDir(), "task.log"))
 
-	// Create a root command with persistent output-format flag
 	root := &cobra.Command{Use: "test"}
 
 	var rootOutputFormat outputformat.OutputFormat
 	outputformat.AddPersistentFlag(root, &rootOutputFormat)
 
-	// Create and add the list command
-	listCmd := Cmd()
-	root.AddCommand(listCmd)
+	root.AddCommand(Cmd())
+	root.SetArgs([]string{"list", "--dir", projectDir})
 
-	// Execute with default text format
-	root.SetArgs([]string{"list"})
+	var err error
 
-	// Execute the command - should not error
-	err := root.Execute()
+	out := captureStdout(t, func() { err = root.Execute() })
 	require.NoError(t, err)
 
-	// Test passes if command executes successfully with default (text) format
-	// (actual output is tested via manual smoke tests)
+	assert.Contains(t, out, "Available Tasks")
+	assert.Contains(t, out, "dev")
+	assert.NotContains(t, out, `"tasks"`)
+}
+
+// captureStdout is local because the shared helper lives under
+// cmd/pipeline/internal, which this package cannot import.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = w
+
+	fn()
+
+	require.NoError(t, w.Close())
+
+	os.Stdout = old
+
+	var buf bytes.Buffer
+
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+
+	return buf.String()
 }
 
 func TestToTaskOutputs(t *testing.T) {

--- a/cmd/task/list/resolve_test.go
+++ b/cmd/task/list/resolve_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package list
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	rootTaskfileYAML     = "Taskfile.yaml"
+	rootTaskfileYML      = "Taskfile.yml"
+	generatedTaskfileYML = "Taskfile.gen.yaml"
+
+	// projectTemplateMarker only ever reaches a generated Taskfile via the
+	// project's own .Taskfile.template, so finding it proves the embedded
+	// default was not used.
+	projectTemplateMarker = "from-project-template"
+)
+
+// `dr task list` has to read the same Taskfile `dr run` executes. Resolving it
+// separately made list regenerate Taskfile.gen.yaml over the file run had just
+// chosen, and list a different set of tasks than the next run would execute.
+func TestCmdListsRootTaskfileWithoutRegenerating(t *testing.T) {
+	projectDir := t.TempDir()
+	writeProjectFixture(t, projectDir, true)
+
+	logFile := filepath.Join(t.TempDir(), "task.log")
+	writeFakeTaskBinary(t, logFile)
+
+	cmd := Cmd()
+	cmd.SetArgs([]string{"--dir", projectDir})
+
+	require.NoError(t, cmd.Execute())
+
+	require.Contains(t, readTextFile(t, logFile), "-t "+filepath.Join(projectDir, rootTaskfileYML))
+
+	_, err := os.Stat(filepath.Join(projectDir, generatedTaskfileYML))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestCmdListsTaskfileGeneratedFromProjectTemplate(t *testing.T) {
+	projectDir := t.TempDir()
+	writeProjectFixture(t, projectDir, false)
+
+	logFile := filepath.Join(t.TempDir(), "task.log")
+	writeFakeTaskBinary(t, logFile)
+
+	cmd := Cmd()
+	cmd.SetArgs([]string{"--dir", projectDir})
+
+	require.NoError(t, cmd.Execute())
+
+	require.Contains(t, readTextFile(t, logFile), "-t "+filepath.Join(projectDir, generatedTaskfileYML))
+
+	generated := readTextFile(t, filepath.Join(projectDir, generatedTaskfileYML))
+	require.Contains(t, generated, projectTemplateMarker)
+}
+
+func writeProjectFixture(t *testing.T, projectDir string, includeRootTaskfile bool) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(projectDir, ".datarobot", "answers"), 0o755))
+
+	template := strings.Join([]string{
+		"version: '3'",
+		"includes:",
+		"  {{- range .Includes }}",
+		"  {{ .Name }}:",
+		"    taskfile: {{ .Taskfile }}",
+		"    dir: {{ .Dir }}",
+		"  {{- end }}",
+		"tasks:",
+		"  " + projectTemplateMarker + ":",
+		"    desc: Marker task",
+		"    cmds:",
+		"      - echo marker",
+		"",
+	}, "\n")
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projectDir, ".Taskfile.template"), []byte(template), 0o644))
+
+	if includeRootTaskfile {
+		root := "version: '3'\ntasks:\n  committed:\n    desc: Committed task\n    cmds:\n      - echo committed\n"
+		require.NoError(t, os.WriteFile(filepath.Join(projectDir, rootTaskfileYML), []byte(root), 0o644))
+	}
+
+	writeComponentTaskfile(t, filepath.Join(projectDir, "agent"), rootTaskfileYML)
+	writeComponentTaskfile(t, filepath.Join(projectDir, "fastapi_server"), rootTaskfileYAML)
+}
+
+func writeComponentTaskfile(t *testing.T, componentDir string, filename string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(componentDir, 0o755))
+
+	contents := strings.Join([]string{
+		"version: '3'",
+		"tasks:",
+		"  dev:",
+		"    desc: Dev component",
+		"    cmds:",
+		"      - echo dev",
+		"",
+	}, "\n")
+
+	require.NoError(t, os.WriteFile(filepath.Join(componentDir, filename), []byte(contents), 0o644))
+}
+
+func writeFakeTaskBinary(t *testing.T, logFile string) {
+	t.Helper()
+
+	binDir := t.TempDir()
+	t.Setenv("TASK_LOG", logFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if runtime.GOOS == "windows" {
+		writeFakeWindowsTaskBinary(t, binDir)
+
+		return
+	}
+
+	writeFakeUnixTaskBinary(t, binDir)
+}
+
+func writeFakeUnixTaskBinary(t *testing.T, binDir string) {
+	t.Helper()
+
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$TASK_LOG"
+if [ "$1" = "--list" ]; then
+  cat <<'JSON'
+{"tasks":[{"name":"dev","desc":"Dev component"}]}
+JSON
+fi
+exit 0
+`
+
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "task"), []byte(script), 0o755))
+}
+
+func writeFakeWindowsTaskBinary(t *testing.T, binDir string) {
+	t.Helper()
+
+	script := `@echo off
+echo %*>>"%TASK_LOG%"
+if "%1"=="--list" (
+  echo {"tasks":[{"name":"dev","desc":"Dev component"}]}
+)
+exit /b 0
+`
+
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "task.bat"), []byte(script), 0o755))
+}
+
+func readTextFile(t *testing.T, path string) string {
+	t.Helper()
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return string(contents)
+}

--- a/cmd/task/run/cmd.go
+++ b/cmd/task/run/cmd.go
@@ -34,7 +34,7 @@ type taskRunOptions struct {
 	taskOpts task.RunOpts
 }
 
-const taskRunFromRootEnv = "DATAROBOT_CLI_TASK_RUN_FROM_ROOT"
+const taskRunFromRootEnv = task.RunFromRootEnv
 
 // splitTaskArgs separates task names from additional arguments.
 // Supports: dr run task1 task2 -- -flag1 -flag2
@@ -71,32 +71,6 @@ func splitTaskArgs(args []string) (taskNames []string, taskArgs []string) {
 	return taskNames, taskArgs
 }
 
-func taskfileForRun(dir string) (string, bool, error) {
-	if os.Getenv(taskRunFromRootEnv) != "" {
-		discovery := task.NewTaskDiscovery("Taskfile.gen.yaml")
-
-		rootTaskfile, err := discovery.Discover(dir, 2)
-
-		return rootTaskfile, false, err
-	}
-
-	discovery, err := task.NewDiscovery("Taskfile.gen.yaml", "")
-	if err != nil {
-		return "", false, err
-	}
-
-	discovery.PreferRootTaskfile = true
-
-	rootTaskfile, err := discovery.Discover(dir, 2)
-	if err != nil {
-		return "", false, err
-	}
-
-	usingRootTaskfile := filepath.Base(rootTaskfile) != "Taskfile.gen.yaml"
-
-	return rootTaskfile, usingRootTaskfile, nil
-}
-
 func Cmd() *cobra.Command {
 	var opts taskRunOptions
 
@@ -128,9 +102,16 @@ Examples:
 			binaryName := "task"
 			taskNames, taskArgs := splitTaskArgs(args)
 
-			rootTaskfile, usingRootTaskfile, err := taskfileForRun(opts.Dir)
+			rootTaskfile, usingRootTaskfile, err := task.ResolveTaskfile(opts.Dir)
 			if err != nil {
 				_, _ = fmt.Fprintln(os.Stderr, task.FormatDiscoveryError(err))
+
+				return cli.ErrSilent
+			}
+
+			runStackEnv, err := task.GuardRunStack(rootTaskfile, taskNames)
+			if err != nil {
+				_, _ = fmt.Fprintln(os.Stderr, "❌ "+err.Error())
 
 				return cli.ErrSilent
 			}
@@ -163,6 +144,8 @@ Examples:
 			}
 
 			opts.taskOpts.TaskArgs = taskArgs
+			opts.taskOpts.Env = append(opts.taskOpts.Env, runStackEnv)
+
 			if usingRootTaskfile {
 				opts.taskOpts.Env = append(opts.taskOpts.Env, taskRunFromRootEnv+"=1")
 			}
@@ -236,10 +219,7 @@ func completeTaskNames(opts *taskRunOptions) ([]string, cobra.ShellCompDirective
 	if _, err := os.Stat(standardTaskfile); err == nil {
 		taskfilePath = standardTaskfile
 	} else {
-		// Try template discovery with Taskfile.gen.yaml
-		discovery := task.NewTaskDiscovery("Taskfile.gen.yaml")
-
-		discoveredTaskfile, err := discovery.Discover(opts.Dir, 2)
+		discoveredTaskfile, _, err := task.ResolveTaskfile(opts.Dir)
 		if err != nil {
 			// No Taskfile found - return no completions
 			return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/task/run/cmd_test.go
+++ b/cmd/task/run/cmd_test.go
@@ -15,11 +15,15 @@
 package run
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/datarobot/cli/internal/cli"
 	"github.com/stretchr/testify/require"
@@ -31,12 +35,52 @@ const (
 	generatedTaskfileYML = "Taskfile.gen.yaml"
 )
 
+// helperDirEnv makes the test binary behave as `dr task run --dir <value>` so a
+// task can re-invoke the command in a real child process.
+const helperDirEnv = "DR_TEST_RUN_HELPER_DIR"
+
+// helperBinEnv is the path the fake task binary re-invokes as `dr`.
+const helperBinEnv = "DR_TEST_HELPER_BIN"
+
+// recurseTaskEnv is the task name the fake task binary re-invokes `dr` with,
+// emulating a generated task whose only command is `dr task run <itself>`.
+const recurseTaskEnv = "DR_TEST_RECURSE_TASK"
+
+// fakeTaskMaxDepth bounds the fake task binary's own recursion so a regression
+// fails the assertions instead of fork bombing the machine.
+const fakeTaskMaxDepth = "5"
+
+type fakeTaskBehaviour int
+
+const (
+	terminatingTaskBinary fakeTaskBehaviour = iota
+	recursingTaskBinary
+)
+
+func TestMain(m *testing.M) {
+	dir := os.Getenv(helperDirEnv)
+	if dir == "" {
+		os.Exit(m.Run())
+	}
+
+	cmd := Cmd()
+	cmd.SetArgs(append([]string{"--dir", dir}, os.Args[1:]...))
+
+	if err := cmd.Execute(); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
 func TestCmdPrefersRecipeRootTaskfileWhenPresent(t *testing.T) {
 	recipeDir := t.TempDir()
 	writeRecipeFixture(t, recipeDir, true)
 
 	logFile := filepath.Join(t.TempDir(), "task.log")
-	writeFakeTaskBinary(t, logFile)
+	writeFakeTaskBinary(t, logFile, terminatingTaskBinary)
 
 	cmd := Cmd()
 	cmd.SetArgs([]string{"--dir", recipeDir, "start"})
@@ -57,7 +101,7 @@ func TestCmdUsesEmbeddedGeneratedTaskfileWhenCalledFromRootTaskfile(t *testing.T
 	t.Setenv(taskRunFromRootEnv, "1")
 
 	logFile := filepath.Join(t.TempDir(), "task.log")
-	writeFakeTaskBinary(t, logFile)
+	writeFakeTaskBinary(t, logFile, terminatingTaskBinary)
 
 	cmd := Cmd()
 	cmd.SetArgs([]string{"--dir", recipeDir, "start"})
@@ -79,7 +123,7 @@ func TestCmdUsesRecipeTemplateWhenRootTaskfileIsMissing(t *testing.T) {
 	writeRecipeFixture(t, recipeDir, false)
 
 	logFile := filepath.Join(t.TempDir(), "task.log")
-	writeFakeTaskBinary(t, logFile)
+	writeFakeTaskBinary(t, logFile, terminatingTaskBinary)
 
 	cmd := Cmd()
 	cmd.SetArgs([]string{"--dir", recipeDir, "dev"})
@@ -107,6 +151,42 @@ func TestCmdReturnsErrNotInTemplateWhenDatarobotMissing(t *testing.T) {
 
 	// Command prints the message to stderr and returns ErrSilent (already printed)
 	require.ErrorIs(t, err, cli.ErrSilent)
+}
+
+// TestCmdStopsGeneratedTaskThatInvokesItself covers the recipe template's
+// `lint: [dr task run lint]` against a project with no committed root Taskfile.
+// Nothing sets DATAROBOT_CLI_TASK_RUN_FROM_ROOT on that path, so every
+// generation regenerated the same Taskfile.gen.yaml and forked again forever.
+func TestCmdStopsGeneratedTaskThatInvokesItself(t *testing.T) {
+	recipeDir := t.TempDir()
+	writeRecipeFixture(t, recipeDir, false)
+
+	logFile := filepath.Join(t.TempDir(), "task.log")
+	writeFakeTaskBinary(t, logFile, recursingTaskBinary)
+
+	self, err := os.Executable()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// The command must run out of process: it propagates the task exit code via
+	// os.Exit, which would take the test binary down with it.
+	cmd := exec.CommandContext(ctx, self, "lint")
+	cmd.Env = append(os.Environ(),
+		helperDirEnv+"="+recipeDir,
+		helperBinEnv+"="+self,
+		recurseTaskEnv+"=lint",
+	)
+
+	out, err := cmd.CombinedOutput()
+
+	require.NotErrorIs(t, ctx.Err(), context.DeadlineExceeded, "`dr run lint` never terminated:\n%s", out)
+	require.Error(t, err, "expected a non-zero exit:\n%s", out)
+	require.Contains(t, string(out), "task recursion detected", "output:\n%s", out)
+
+	// The re-entry is refused before it spawns anything, so `task` runs once.
+	require.Equal(t, 1, strings.Count(readTaskLog(t, logFile), "\n"), "task invocations:\n%s", readTaskLog(t, logFile))
 }
 
 func writeRecipeFixture(t *testing.T, recipeDir string, includeRootTaskfile bool) {
@@ -170,7 +250,7 @@ func writeComponentTaskfile(t *testing.T, componentDir string, filename string) 
 	require.NoError(t, os.WriteFile(filepath.Join(componentDir, filename), []byte(contents), 0o644))
 }
 
-func writeFakeTaskBinary(t *testing.T, logFile string) {
+func writeFakeTaskBinary(t *testing.T, logFile string, behaviour fakeTaskBehaviour) {
 	t.Helper()
 
 	binDir := t.TempDir()
@@ -178,15 +258,15 @@ func writeFakeTaskBinary(t *testing.T, logFile string) {
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	if runtime.GOOS == "windows" {
-		writeFakeWindowsTaskBinary(t, binDir)
+		writeFakeWindowsTaskBinary(t, binDir, behaviour)
 
 		return
 	}
 
-	writeFakeUnixTaskBinary(t, binDir)
+	writeFakeUnixTaskBinary(t, binDir, behaviour)
 }
 
-func writeFakeUnixTaskBinary(t *testing.T, binDir string) {
+func writeFakeUnixTaskBinary(t *testing.T, binDir string, behaviour fakeTaskBehaviour) {
 	t.Helper()
 
 	script := `#!/bin/sh
@@ -200,10 +280,22 @@ fi
 printf '%s|%s|%s\n' "$PWD" "$DATAROBOT_CLI_TASK_RUN_FROM_ROOT" "$*" >> "$TASK_LOG"
 `
 
+	if behaviour == recursingTaskBinary {
+		script += `
+DR_TEST_DEPTH=$((${DR_TEST_DEPTH:-0} + 1))
+if [ "$DR_TEST_DEPTH" -gt ` + fakeTaskMaxDepth + ` ]; then
+  echo "fake task: runaway recursion" >&2
+  exit 9
+fi
+export DR_TEST_DEPTH
+exec "$` + helperBinEnv + `" "$` + recurseTaskEnv + `"
+`
+	}
+
 	require.NoError(t, os.WriteFile(filepath.Join(binDir, "task"), []byte(script), 0o755))
 }
 
-func writeFakeWindowsTaskBinary(t *testing.T, binDir string) {
+func writeFakeWindowsTaskBinary(t *testing.T, binDir string, behaviour fakeTaskBehaviour) {
 	t.Helper()
 
 	script := `@echo off
@@ -212,8 +304,21 @@ if "%1"=="--list" (
   exit /b 0
 )
 echo %CD%^|%DATAROBOT_CLI_TASK_RUN_FROM_ROOT%^|%*>>"%TASK_LOG%"
-exit /b 0
 `
+
+	if behaviour == recursingTaskBinary {
+		script += `if "%DR_TEST_DEPTH%"=="" set DR_TEST_DEPTH=0
+set /a DR_TEST_DEPTH=%DR_TEST_DEPTH%+1
+if %DR_TEST_DEPTH% GTR ` + fakeTaskMaxDepth + ` (
+  echo fake task: runaway recursion 1>&2
+  exit /b 9
+)
+"%` + helperBinEnv + `%" "%` + recurseTaskEnv + `%"
+exit /b %ERRORLEVEL%
+`
+	} else {
+		script += "exit /b 0\n"
+	}
 
 	require.NoError(t, os.WriteFile(filepath.Join(binDir, "task.bat"), []byte(script), 0o755))
 }

--- a/internal/task/discovery.go
+++ b/internal/task/discovery.go
@@ -26,6 +26,7 @@ import (
 	"text/template"
 
 	"github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/tui"
 	"gopkg.in/yaml.v3"
 )
@@ -136,14 +137,6 @@ func NewDiscovery(taskfileName, templatePath string) (*Discovery, error) {
 	return NewComposeDiscovery(taskfileName, absPath), nil
 }
 
-// IsTemplateDir reports whether dir is a DataRobot template directory
-// (i.e. it contains a ".datarobot" folder).
-func IsTemplateDir(dir string) bool {
-	_, err := os.Stat(filepath.Join(dir, ".datarobot"))
-
-	return err == nil
-}
-
 func (d *Discovery) existingRootTaskfile(root string) string {
 	for _, name := range []string{"Taskfile.yaml", "Taskfile.yml"} {
 		path := filepath.Join(root, name)
@@ -178,7 +171,7 @@ func (d *Discovery) generateTaskfile(root string, includes []componentInclude) (
 }
 
 func (d *Discovery) Discover(root string, maxDepth int) (string, error) {
-	if !IsTemplateDir(root) {
+	if !repo.IsTemplateDir(root) {
 		return "", ErrNotInTemplate
 	}
 

--- a/internal/task/resolve.go
+++ b/internal/task/resolve.go
@@ -1,0 +1,115 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// GeneratedTaskfileName is the Taskfile composed from the components found
+// under the project root.
+const GeneratedTaskfileName = "Taskfile.gen.yaml"
+
+// RunFromRootEnv is set on a task spawned by a committed root Taskfile. That
+// task calling `dr run` again must compose from components rather than resolve
+// back to the file it is already running inside.
+const RunFromRootEnv = "DATAROBOT_CLI_TASK_RUN_FROM_ROOT"
+
+// RunStackEnv carries the Taskfile/task pairs of the ancestor `dr task run`
+// invocations. RunFromRootEnv only breaks the one specific loop where a
+// committed root Taskfile shells back into `dr run`; a project whose tasks come
+// from a generated Taskfile has no such handoff, so a task there that calls
+// `dr run <itself>` would otherwise fork forever.
+const RunStackEnv = "DATAROBOT_CLI_TASK_STACK"
+
+const (
+	runStackEntrySep = "\n"
+	runStackFieldSep = "\x1f"
+)
+
+var ErrTaskRecursion = errors.New("task recursion detected")
+
+// componentSearchDepth is how far below the project root a component Taskfile
+// may sit.
+const componentSearchDepth = 2
+
+// ResolveTaskfile returns the Taskfile a project's tasks actually come from,
+// and whether that is a committed root Taskfile rather than the generated one.
+//
+// Every command that reads or runs a project's tasks has to agree on this.
+// Resolving it differently per command means `dr task list` regenerates and
+// overwrites the file `dr run` just chose, then lists tasks that are not the
+// ones the next run will execute.
+func ResolveTaskfile(dir string) (path string, fromRootTaskfile bool, err error) {
+	if os.Getenv(RunFromRootEnv) != "" {
+		path, err = NewTaskDiscovery(GeneratedTaskfileName).Discover(dir, componentSearchDepth)
+
+		return path, false, err
+	}
+
+	discovery, err := NewDiscovery(GeneratedTaskfileName, "")
+	if err != nil {
+		return "", false, err
+	}
+
+	discovery.PreferRootTaskfile = true
+
+	path, err = discovery.Discover(dir, componentSearchDepth)
+	if err != nil {
+		return "", false, err
+	}
+
+	return path, filepath.Base(path) != GeneratedTaskfileName, nil
+}
+
+// GuardRunStack rejects a `dr task run` that would re-enter a Taskfile/task
+// pair already running above it, and returns the RunStackEnv assignment to hand
+// to the task process so its own children stay guarded.
+func GuardRunStack(taskfile string, tasks []string) (string, error) {
+	abs, err := filepath.Abs(taskfile)
+	if err != nil {
+		return "", fmt.Errorf("resolving Taskfile path %q: %w", taskfile, err)
+	}
+
+	names := tasks
+	if len(names) == 0 {
+		// No task name means the Taskfile's default task.
+		names = []string{""}
+	}
+
+	stack := os.Getenv(RunStackEnv)
+	active := strings.Split(stack, runStackEntrySep)
+	entries := make([]string, 0, len(names))
+
+	for _, name := range names {
+		entry := abs + runStackFieldSep + name
+		if stack != "" && slices.Contains(active, entry) {
+			return "", fmt.Errorf("%w: task %q in %s invokes itself; a task must not call `dr run` for a task in the same Taskfile", ErrTaskRecursion, name, abs)
+		}
+
+		entries = append(entries, entry)
+	}
+
+	if stack != "" {
+		entries = append([]string{stack}, entries...)
+	}
+
+	return RunStackEnv + "=" + strings.Join(entries, runStackEntrySep), nil
+}

--- a/internal/task/resolve_test.go
+++ b/internal/task/resolve_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func setRunStack(t *testing.T, assignment string) {
+	t.Helper()
+
+	key, value, _ := strings.Cut(assignment, "=")
+	t.Setenv(key, value)
+}
+
+func TestGuardRunStackAllowsFirstInvocation(t *testing.T) {
+	taskfile := filepath.Join(t.TempDir(), GeneratedTaskfileName)
+
+	assignment, err := GuardRunStack(taskfile, []string{"lint"})
+	require.NoError(t, err)
+	require.Equal(t, RunStackEnv+"="+taskfile+"\x1flint", assignment)
+}
+
+func TestGuardRunStackRejectsSelfReentry(t *testing.T) {
+	taskfile := filepath.Join(t.TempDir(), GeneratedTaskfileName)
+
+	assignment, err := GuardRunStack(taskfile, []string{"lint"})
+	require.NoError(t, err)
+	setRunStack(t, assignment)
+
+	_, err = GuardRunStack(taskfile, []string{"lint"})
+	require.ErrorIs(t, err, ErrTaskRecursion)
+}
+
+func TestGuardRunStackRejectsIndirectReentry(t *testing.T) {
+	taskfile := filepath.Join(t.TempDir(), GeneratedTaskfileName)
+
+	assignment, err := GuardRunStack(taskfile, []string{"lint"})
+	require.NoError(t, err)
+	setRunStack(t, assignment)
+
+	assignment, err = GuardRunStack(taskfile, []string{"install"})
+	require.NoError(t, err)
+	setRunStack(t, assignment)
+
+	_, err = GuardRunStack(taskfile, []string{"lint"})
+	require.ErrorIs(t, err, ErrTaskRecursion)
+}
+
+func TestGuardRunStackAllowsRootTaskfileHandoff(t *testing.T) {
+	dir := t.TempDir()
+
+	assignment, err := GuardRunStack(filepath.Join(dir, "Taskfile.yaml"), []string{"start"})
+	require.NoError(t, err)
+	setRunStack(t, assignment)
+
+	// The committed root Taskfile's `start` shells back into `dr run start`,
+	// which resolves to the generated Taskfile: a different file, not a loop.
+	_, err = GuardRunStack(filepath.Join(dir, GeneratedTaskfileName), []string{"start"})
+	require.NoError(t, err)
+}
+
+func TestGuardRunStackTreatsDefaultTaskAsAnEntry(t *testing.T) {
+	taskfile := filepath.Join(t.TempDir(), GeneratedTaskfileName)
+
+	assignment, err := GuardRunStack(taskfile, nil)
+	require.NoError(t, err)
+	setRunStack(t, assignment)
+
+	_, err = GuardRunStack(taskfile, nil)
+	require.ErrorIs(t, err, ErrTaskRecursion)
+}
+
+func TestGuardRunStackIsolatesDifferentProjects(t *testing.T) {
+	assignment, err := GuardRunStack(filepath.Join(t.TempDir(), GeneratedTaskfileName), []string{"lint"})
+	require.NoError(t, err)
+	setRunStack(t, assignment)
+
+	_, err = GuardRunStack(filepath.Join(t.TempDir(), GeneratedTaskfileName), []string{"lint"})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
# RATIONALE

Create more consistent behavior, cover more recursive infinite loop conditions, clean up tests from this review: https://github.com/datarobot-oss/cli/pull/538#pullrequestreview-4967186304

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787112110.084279 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared task discovery/run path used by `dr run` and `dr task list`, including new env-based recursion guards; behavior is heavily covered by new tests but mistakes could still affect everyday task execution in template projects.
> 
> **Overview**
> **Unifies Taskfile resolution** so `dr task list`, `dr run`, and shell completion all use shared `task.ResolveTaskfile`, matching what `dr run` executes and avoiding extra `Taskfile.gen.yaml` regeneration when listing tasks.
> 
> **Adds recursion protection** for generated tasks that call `dr run` on themselves (e.g. `lint: dr task run lint`): `GuardRunStack` tracks `DATAROBOT_CLI_TASK_RUN_FROM_ROOT` / `DATAROBOT_CLI_TASK_STACK` and fails with *task recursion detected* instead of fork-bombing. Run path injects the stack env into the task runner.
> 
> **Test and hygiene updates**: feature-gated root command tests skip when gates are on; list JSON/text tests run against temp fixtures; new resolve/guard unit tests and an out-of-process recursion test; template detection uses `repo.IsTemplateDir` instead of a local helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6862650b4232c0132a5e4f347ddc4945efd5af61. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->