### PR TITLE
Update Docker base image to latest version

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,5 @@
 # Wolfi-based, minimal, nonroot equivalent of distroless/static. Digest captured 2026-07-22.
-FROM cgr.dev/chainguard/static:latest@sha256:60582b2ae6074f641094af0f370d4ab241aab271858a66223dcde7eee9f51638
+FROM cgr.dev/chainguard/static:latest
 
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/dr /dr

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,5 @@
 # Wolfi-based, minimal, nonroot equivalent of distroless/static. Digest captured 2026-07-22.
+# Do not pin chainguard/static via sha; these eventually disappear
 FROM cgr.dev/chainguard/static:latest
 
 ARG TARGETPLATFORM

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-# Wolfi-based, minimal, nonroot equivalent of distroless/static. Digest captured 2026-07-22.
+# Wolfi-based, minimal, nonroot equivalent of distroless/static.
 # Do not pin chainguard/static via sha; these eventually disappear
 FROM cgr.dev/chainguard/static:latest
 


### PR DESCRIPTION

# RATIONALE

unpin wolfi images since they disappear

## CHANGES

Drop the sha to keep the image up to date

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787113313.783839 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Dockerfile tag change for the release image base; no application code or runtime logic changes, with only the usual supply-chain variability from using an unpinned `latest` tag.
> 
> **Overview**
> **Unpins the Wolfi/Chainguard static base image** in `Dockerfile.goreleaser` by removing the `@sha256:…` digest and using `cgr.dev/chainguard/static:latest` only.
> 
> This keeps release builds from breaking when the previously pinned digest is no longer available, at the cost of **non-reproducible** base image resolution on each build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fa9496372fce1959f05621812fec747cb8f799e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->