### PR TITLE
Add opencode plugin v0.1.6

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -234,6 +234,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.6",
+          "url": "opencode/opencode-0.1.6.tar.xz",
+          "sha256": "4a6f84068ed850e57278e6a2f6f81ab7c733cacc10392dd37d21562f65432256",
+          "releaseDate": "2026-08-19"
+        },
+        {
           "version": "0.1.5",
           "url": "opencode/opencode-0.1.5.tar.xz",
           "sha256": "75b0eb84e4462d37c3ef5d0ee61bd7c11066da4c266fdd70b1be1af9b8ce9198",


### PR DESCRIPTION
## Summary

Publishes [opencode-cli-plugin v0.1.6](https://github.com/datarobot/opencode-cli-plugin/releases/tag/v0.1.6) to the CLI plugin index.

- Plugin: `opencode`
- Version: `0.1.6`
- SHA256: `4a6f84068ed850e57278e6a2f6f81ab7c733cacc10392dd37d21562f65432256`

The release carries the [CFX-7600](https://datarobot.atlassian.net/browse/CFX-7600) fix — `golang.org/x/mod v0.37.0` → `v0.40.0` and the Go toolchain `1.26.5` → `1.26.6`.

**Why this PR is on the critical path:** the notebook kernel images run `dr plugin install opencode` at build time, and the prebuilt binaries that ships were the source of the HIGH findings on `golang.org/x/mod` (CVE-2026-56864, CVE-2026-56865, GO-2026-6179/6180) and the companion `stdlib@go1.26.5` finding ([CFX-7662](https://datarobot.atlassian.net/browse/CFX-7662)). `dr plugin install` resolves `latest` from this index, so until this entry lands it keeps resolving to `0.1.5` and kernel rebuilds cannot pick the fix up.

## CHANGES

- `docs/plugins/opencode/opencode-0.1.6.tar.xz` — release artifact (43,055,720 bytes)
- `docs/plugins/index.json` — prepend the `0.1.6` entry to `plugins.opencode.versions`

## Verification

Checked before staging:

- `shasum -a 256 -c opencode-0.1.6.tar.xz.sha256` → **OK**
- The `sha256` in `index.json` matches `git cat-file -p :docs/plugins/opencode/opencode-0.1.6.tar.xz | shasum -a 256` — the committed blob, not just the local file
- `index.json` `sha256`/`url`/`releaseDate` copied from the release’s own `index-fragment.json`
- All 7 binaries in the tarball report the fixed versions:

```
opencode-darwin-amd64            go1.26.6 x/mod v0.40.0
opencode-darwin-arm64            go1.26.6 x/mod v0.40.0
opencode-linux-amd64             go1.26.6 x/mod v0.40.0
opencode-linux-arm64             go1.26.6 x/mod v0.40.0
opencode-linux-riscv64           go1.26.6 x/mod v0.40.0
opencode-windows-amd64.exe       go1.26.6 x/mod v0.40.0
opencode-windows-arm64.exe       go1.26.6 x/mod v0.40.0
```

- `manifest.json` in the tarball reads `0.1.6`, matching the tag
- Index diff is exactly 6 added lines; no reformatting elsewhere in the file

## Test Plan

- [ ] `dr plugin install opencode` installs 0.1.6
- [ ] `dr opencode --help` shows usage

## NOTES

Raised as a branch on this repo rather than via `task release:publish`, because that script runs `git push fork main --force`; with the fork remote pointed here that would force-push `main` upstream. The index and tarball changes are identical to what it produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787136392.861169 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Index-only publish with a pinned SHA256 and no runtime code changes; main risk is a mismatched hash or artifact, which the author verified before merge.
> 
> **Overview**
> Registers **opencode `0.1.6`** as the newest entry in `docs/plugins/index.json`, so `dr plugin install opencode` resolves **latest** to this release instead of `0.1.5`. The index row includes `opencode/opencode-0.1.6.tar.xz`, its SHA256, and release date `2026-08-19`.
> 
> This unblocks consumers (e.g. notebook kernel image builds) that install opencode at build time from the index, picking up the **CFX-7600** rebuild with **Go 1.26.6** and **`golang.org/x/mod` v0.40.0** to address the reported CVEs on the prior prebuilt binaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8126083a4285ea08ce867461bba8d60030b1a3b0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->