### PR TITLE
[RAPTOR-19406] fix(workload): roll into the existing artifact repository

### DIFF
--- a/docs/commands/artifact.md
+++ b/docs/commands/artifact.md
@@ -107,11 +107,13 @@ spec:
 
 ### `get`
 
-Show a single artifact: its name, status, code reference, and timestamps.
+Show a single artifact: its name, status, repository and version, code reference, and timestamps.
 
 ```bash
 dr artifact get <artifact-id> [--output-format text|json]
 ```
+
+The repository is the lineage the artifact belongs to. Successive versions of one workload share it, which is what tells them apart from unrelated artifacts that happen to carry the same name. The version numbers the artifact within that repository and is assigned only on locking, so a draft shows none.
 
 ### `list`
 

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -47,9 +47,21 @@ func ParseArtifactStatus(s string) (string, error) {
 }
 
 type Artifact struct {
-	ID        string    `json:"id"`
-	Name      string    `json:"name"`
-	Status    string    `json:"status"`
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+
+	// ArtifactRepositoryID is the lineage this artifact belongs to. Successive
+	// versions of one thing share it, which is the only way to tell them from
+	// unrelated artifacts that happen to carry the same name.
+	ArtifactRepositoryID string `json:"artifactRepositoryId"`
+
+	// Version numbers this artifact within its repository. A pointer because
+	// the platform sends null for a draft and assigns a number only on
+	// locking, and an unnumbered draft is a different thing from a version 0
+	// that no repository ever issues.
+	Version *int `json:"version"`
+
 	Spec      Spec      `json:"spec"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
@@ -129,9 +141,18 @@ type DatarobotCodeRef struct {
 }
 
 type ArtifactOutput struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Status    string `json:"status"`
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+
+	// ArtifactRepositoryID and Version place the artifact in its lineage.
+	// Neither is omitempty: the text and JSON forms of a command have to carry
+	// the same fields, and a key that comes and goes with the artifact's status
+	// is one a script cannot rely on. A draft's version is null rather than 0,
+	// which says unnumbered instead of naming a version no repository issues.
+	ArtifactRepositoryID string `json:"artifactRepositoryId"`
+	Version              *int   `json:"version"`
+
 	CatalogID string `json:"catalogId"`
 	VersionID string `json:"versionId"`
 	CreatedAt string `json:"createdAt"`
@@ -140,11 +161,13 @@ type ArtifactOutput struct {
 
 func NewArtifactOutput(a Artifact) ArtifactOutput {
 	out := ArtifactOutput{
-		ID:        a.ID,
-		Name:      a.Name,
-		Status:    a.Status,
-		CreatedAt: a.CreatedAt.Format(time.RFC3339),
-		UpdatedAt: a.UpdatedAt.Format(time.RFC3339),
+		ID:                   a.ID,
+		Name:                 a.Name,
+		Status:               a.Status,
+		ArtifactRepositoryID: a.ArtifactRepositoryID,
+		Version:              a.Version,
+		CreatedAt:            a.CreatedAt.Format(time.RFC3339),
+		UpdatedAt:            a.UpdatedAt.Format(time.RFC3339),
 	}
 
 	if codeRef := ExtractCodeRef(a); codeRef != nil {

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -84,7 +84,7 @@ func (l Live) Defaults() Draft {
 		WorkloadID: l.WorkloadID,
 		Name:       l.Name,
 		Importance: orDefaultString(l.Importance, DefaultImportance),
-		Type:       orDefaultString(l.Type(), TypeService),
+		Type:       ArtifactTypeOrDefault(l.Type()),
 		A2AEnabled: boolAt(l.Spec, keyA2AEnabled),
 		Port:       DefaultPort,
 		HealthPath: DefaultHealthPath,

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -37,6 +37,25 @@ const (
 	TypeAgent   = "agent"
 )
 
+// ArtifactTypeOrDefault applies the platform's default for an artifact block
+// that names no type: it is created as a service. Every reader that has to
+// predict what kind of thing the platform is about to make has to say so the
+// same way, or two of them answer differently about one file.
+func ArtifactTypeOrDefault(artifactType string) string {
+	return orDefaultString(artifactType, TypeService)
+}
+
+// SameArtifactType reports whether two artifact types name the same kind.
+//
+// Folded because the platform's own documents disagree about the casing of
+// their enums. Comparing them exactly is what turns a hand-written "Service"
+// into drift that can never be satisfied: nothing about the file changes it,
+// so every run mints a version and rolls it, for ever, against a workload
+// nobody touched.
+func SameArtifactType(a, b string) bool {
+	return strings.EqualFold(a, b)
+}
+
 // Build modes, named the way the user chooses them rather than the way the
 // spec spells them: BuildModeDockerfile writes source: provided.
 const (

--- a/internal/workload/manifest/write_test.go
+++ b/internal/workload/manifest/write_test.go
@@ -523,3 +523,19 @@ func TestRender_TypeSitsOnTheArtifactNotInTheSpec(t *testing.T) {
 	assert.NotContains(t, out, "    type: agent", "inside the spec the platform throws it away")
 	assert.Contains(t, out, "a2aEnabled: true", "which stays in the spec, where the agent variant reads it")
 }
+
+// The type is compared, not just defaulted, and folding is the whole point:
+// the platform's own documents disagree about the casing of their enums, so an
+// exact comparison turns a spelling into drift nothing can satisfy.
+func TestSameArtifactType(t *testing.T) {
+	assert.True(t, SameArtifactType("service", "service"))
+	assert.True(t, SameArtifactType("Service", "service"), "casing is not a change")
+	assert.True(t, SameArtifactType("AGENT", "agent"))
+	assert.False(t, SameArtifactType("agent", "service"), "a different kind still is")
+}
+
+func TestArtifactTypeOrDefault(t *testing.T) {
+	assert.Equal(t, TypeService, ArtifactTypeOrDefault(""),
+		"the platform creates a block that names no type as a service")
+	assert.Equal(t, TypeAgent, ArtifactTypeOrDefault(TypeAgent))
+}

--- a/internal/workload/output.go
+++ b/internal/workload/output.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -75,24 +76,55 @@ func printArtifactsJSON(artifacts []Artifact) error {
 }
 
 func printArtifactDetails(artifact Artifact) {
-	catalogID, versionID := emptyValuePlaceholder, emptyValuePlaceholder
-
-	if codeRef := ExtractCodeRef(artifact); codeRef != nil {
-		catalogID = codeRef.CatalogID
-		versionID = codeRef.CatalogVersionID
-	}
+	catalogID, versionID := codeRefDisplay(artifact)
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
 	fmt.Fprintf(w, "ID:\t%s\n", artifact.ID)
 	fmt.Fprintf(w, "Name:\t%s\n", artifact.Name)
 	fmt.Fprintf(w, "Status:\t%s\n", artifact.Status)
+	// Spelled "Repository version" rather than "Version", which would sit two
+	// lines from the catalog's "Version ID" and read as the same thing.
+	fmt.Fprintf(w, "Repository:\t%s\n", orPlaceholder(artifact.ArtifactRepositoryID))
+	fmt.Fprintf(w, "Repository version:\t%s\n", artifactVersion(artifact))
 	fmt.Fprintf(w, "Catalog ID:\t%s\n", catalogID)
 	fmt.Fprintf(w, "Version ID:\t%s\n", versionID)
 	fmt.Fprintf(w, "Created:\t%s\n", artifact.CreatedAt.UTC().Format(timestampFormat))
 	fmt.Fprintf(w, "Updated:\t%s\n", artifact.UpdatedAt.UTC().Format(timestampFormat))
 
 	w.Flush()
+}
+
+// artifactVersion is the artifact's number within its repository. The platform
+// assigns one only on locking, so a draft genuinely has none and says so
+// rather than reporting 0, which would name a version no repository issues.
+func artifactVersion(artifact Artifact) string {
+	if artifact.Version == nil {
+		return emptyValuePlaceholder
+	}
+
+	return strconv.Itoa(*artifact.Version)
+}
+
+// codeRefDisplay is the artifact's catalog pair as the table and the detail
+// block both print it, with the placeholder wherever there is nothing to name.
+func codeRefDisplay(artifact Artifact) (catalogID, versionID string) {
+	codeRef := ExtractCodeRef(artifact)
+	if codeRef == nil {
+		return emptyValuePlaceholder, emptyValuePlaceholder
+	}
+
+	return orPlaceholder(codeRef.CatalogID), orPlaceholder(codeRef.CatalogVersionID)
+}
+
+// orPlaceholder is the single spelling of "nothing to show here", so a value
+// that renders as a dash in one command does not render as a blank in another.
+func orPlaceholder(value string) string {
+	if value == "" {
+		return emptyValuePlaceholder
+	}
+
+	return value
 }
 
 // Build log levels in ascending severity. Used by FilterLogsByLevel to drop
@@ -292,10 +324,7 @@ func printBuildsTable(builds []Build) {
 		Headers(headers...)
 
 	for _, b := range builds {
-		name := b.Name
-		if name == "" {
-			name = emptyValuePlaceholder
-		}
+		name := orPlaceholder(b.Name)
 
 		t.Row(
 			b.ID,
@@ -370,10 +399,7 @@ func printWorkloadsJSON(workloads []Workload) error {
 }
 
 func printWorkloadDetails(workload Workload) {
-	endpoint := workload.Endpoint
-	if endpoint == "" {
-		endpoint = emptyValuePlaceholder
-	}
+	endpoint := orPlaceholder(workload.Endpoint)
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
@@ -462,12 +488,7 @@ func printArtifactsTable(artifacts []Artifact) {
 		Headers(headers...)
 
 	for _, a := range artifacts {
-		catalogID, versionID := emptyValuePlaceholder, emptyValuePlaceholder
-
-		if codeRef := ExtractCodeRef(a); codeRef != nil {
-			catalogID = codeRef.CatalogID
-			versionID = codeRef.CatalogVersionID
-		}
+		catalogID, versionID := codeRefDisplay(a)
 
 		updated := a.UpdatedAt.UTC().Format(timestampFormat)
 

--- a/internal/workload/output_test.go
+++ b/internal/workload/output_test.go
@@ -181,8 +181,86 @@ func TestPrintArtifactDetails_WithoutCodeRef(t *testing.T) {
 		printArtifactDetails(artifact)
 	})
 
-	assert.Contains(t, output, "Catalog ID:  —")
-	assert.Contains(t, output, "Version ID:  —")
+	// Matched loosely because the gap is tabwriter's, sized by the longest
+	// label on the block. Pinning it turns adding a field into a failure about
+	// a field nobody changed.
+	assert.Regexp(t, `Catalog ID:\s+—`, output)
+	assert.Regexp(t, `Version ID:\s+—`, output)
+}
+
+// A draft has no number of its own, and the repository is the platform's to
+// assign, so an artifact read before either exists shows both as absent rather
+// than as a version 0 that does not exist.
+func TestPrintArtifactDetails_DraftHasNoRepositoryVersion(t *testing.T) {
+	artifact := makeTestArtifact("art-abc-123", "my-agent", "DRAFT", "", "")
+
+	output := captureStdout(t, func() {
+		printArtifactDetails(artifact)
+	})
+
+	assert.Regexp(t, `Repository:\s+—`, output)
+	assert.Regexp(t, `Repository version:\s+—`, output)
+}
+
+func TestPrintArtifactDetails_LockedShowsItsRepositoryAndVersion(t *testing.T) {
+	artifact := makeTestArtifact("art-abc-123", "my-agent", "LOCKED", "", "")
+	artifact.ArtifactRepositoryID = "repo-555"
+	artifact.Version = intPtr(2)
+
+	output := captureStdout(t, func() {
+		printArtifactDetails(artifact)
+	})
+
+	assert.Regexp(t, `Repository:\s+repo-555`, output)
+	assert.Regexp(t, `Repository version:\s+2`, output)
+}
+
+// The two fields ride the JSON envelope as well, which is how a deploy is
+// checked without opening the Registry.
+func TestNewArtifactOutput_CarriesRepositoryAndVersion(t *testing.T) {
+	locked := makeTestArtifact("art-1", "my-agent", "LOCKED", "", "")
+	locked.ArtifactRepositoryID = "repo-555"
+	locked.Version = intPtr(3)
+
+	out := NewArtifactOutput(locked)
+	assert.Equal(t, "repo-555", out.ArtifactRepositoryID)
+	require.NotNil(t, out.Version)
+	assert.Equal(t, 3, *out.Version)
+}
+
+// Text and JSON have to carry the same fields, so a draft emits both keys
+// rather than dropping the ones it has no value for: a script cannot branch on
+// a key that comes and goes with the artifact's status. The version is null,
+// which says unnumbered, where 0 would name a version no repository issues.
+func TestNewArtifactOutput_DraftStillCarriesBothKeys(t *testing.T) {
+	encoded, err := json.Marshal(NewArtifactOutput(makeTestArtifact("art-2", "my-agent", "DRAFT", "", "")))
+	require.NoError(t, err)
+
+	var decoded map[string]any
+
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	assert.Contains(t, decoded, "artifactRepositoryId")
+	assert.Contains(t, decoded, "version")
+	assert.Nil(t, decoded["version"])
+	assert.Empty(t, decoded["artifactRepositoryId"])
+}
+
+func intPtr(v int) *int { return &v }
+
+// A container can carry a codeRef whose catalog pair is half filled in: the
+// sync creates the reference and the version id arrives when the upload lands,
+// so the window between them is real. Both halves read as absent rather than
+// as a blank column, which is the same answer an artifact with no codeRef at
+// all gets, because to a reader they are the same thing.
+func TestPrintArtifactDetails_PartialCodeRefReadsAsAbsent(t *testing.T) {
+	artifact := makeTestArtifact("art-abc-123", "my-agent", "DRAFT", "cat-xyz-789", "")
+
+	output := captureStdout(t, func() {
+		printArtifactDetails(artifact)
+	})
+
+	assert.Regexp(t, `Catalog ID:\s+cat-xyz-789`, output)
+	assert.Regexp(t, `Version ID:\s+—`, output)
 }
 
 func TestPrintArtifactsTable_WithCodeRef(t *testing.T) {

--- a/internal/workload/up/look.go
+++ b/internal/workload/up/look.go
@@ -40,6 +40,12 @@ const (
 	keyEndpoint   = "endpoint"
 	keyArtifactID = "artifactId"
 	keyType       = "type"
+
+	// keyArtifactRepositoryID is the repository an artifact belongs to. The
+	// platform assigns it, so it is read here and never written to the file;
+	// a create that sends it back is what makes successive versions land in
+	// one repository instead of each opening its own.
+	keyArtifactRepositoryID = "artifactRepositoryId"
 )
 
 // keyArtifactType is what the plan calls a change of artifact kind. It is
@@ -76,6 +82,12 @@ type Live struct {
 	// reads the discriminator from the artifact and pops any type sent inside
 	// the spec, so the spec walk never sees it.
 	ArtifactType string
+
+	// ArtifactRepositoryID is the lineage the running version belongs to, ""
+	// when there is no artifact to read it from. A roll hands it to the
+	// version it mints, which is what makes the two successive versions of one
+	// thing rather than two unrelated artifacts sharing a name.
+	ArtifactRepositoryID string
 
 	// Endpoint is the workload's stable URL. The platform assigns it at
 	// creation and it survives every rollout, so it is safe to print before
@@ -120,13 +132,14 @@ func Look(workloadID string) (Live, error) {
 	status := workloadDoc.String(keyStatus)
 
 	return Live{
-		Live:         manifest.NewLive(workloadID, workloadDoc, artifactDoc),
-		State:        stateFor(status),
-		Status:       status,
-		ArtifactID:   artifactID,
-		ArtifactType: artifactDoc.String(keyType),
-		Endpoint:     workloadDoc.String(keyEndpoint),
-		Locked:       isLocked(artifactDoc.String(keyStatus)),
+		Live:                 manifest.NewLive(workloadID, workloadDoc, artifactDoc),
+		State:                stateFor(status),
+		Status:               status,
+		ArtifactID:           artifactID,
+		ArtifactType:         artifactDoc.String(keyType),
+		ArtifactRepositoryID: artifactDoc.String(keyArtifactRepositoryID),
+		Endpoint:             workloadDoc.String(keyEndpoint),
+		Locked:               isLocked(artifactDoc.String(keyStatus)),
 	}, nil
 }
 

--- a/internal/workload/up/plan.go
+++ b/internal/workload/up/plan.go
@@ -14,6 +14,8 @@
 
 package up
 
+import "github.com/datarobot/cli/internal/workload/manifest"
+
 // Actions are what a run will do, and what the JSON envelope reports. A run
 // does exactly one of them, so when several could apply the most significant
 // wins: creating beats rolling, rolling beats retuning, retuning beats
@@ -161,7 +163,12 @@ func Build(loaded Loaded, live Live, code CodeChange) (Plan, error) {
 	// Only when the file names one. Saying nothing about the type is not the
 	// same as asking for a service, and this walk never reverts what the file
 	// leaves out.
-	if kind != "" && kind != live.ArtifactType {
+	//
+	// The comparison folds case, which is not cosmetic: nothing in the file can
+	// resolve a difference the platform does not consider one, so a spelling
+	// the ledger accepts and the platform normalises would be drift that every
+	// run mints a version for and never clears.
+	if kind != "" && !manifest.SameArtifactType(kind, live.ArtifactType) {
 		plan.Artifact = append(plan.Artifact, Change{
 			Path: keyArtifactType,
 			Have: live.ArtifactType,

--- a/internal/workload/up/plan_test.go
+++ b/internal/workload/up/plan_test.go
@@ -408,6 +408,29 @@ func TestBuild_MatchingArtifactTypeIsEmpty(t *testing.T) {
 	assert.True(t, plan.Empty())
 }
 
+// A spelling difference is not a change. Nothing in the file can resolve one,
+// because the platform normalises the value and hands the same thing back, so
+// a case-sensitive comparison here is drift that never clears: every run mints
+// a version and rolls a workload nobody touched, for ever. The ledger does not
+// enforce an enum on the type, so a hand-written "Service" reaches this.
+func TestBuild_ArtifactTypeSpellingIsNotAChange(t *testing.T) {
+	loaded := Loaded{Compiled: &manifest.Compiled{
+		Payload: json.RawMessage(`{
+		  "name": "my-app",
+		  "artifact": {"name": "my-app-artifact", "type": "Service", "spec": {}}
+		}`),
+	}}
+
+	live := liveFrom(t, StateRunning, "", planLiveRuntime)
+	live.ArtifactType = "service"
+
+	plan, err := Build(loaded, live, builtCode(0))
+	require.NoError(t, err)
+
+	assert.Empty(t, plan.Artifact)
+	assert.True(t, plan.Empty(), "a workload nobody changed is already up to date")
+}
+
 // Saying nothing about the type is not the same as asking for a service. A
 // manifest written before the type moved out of the spec names none, and this
 // walk never reverts what the file leaves out.

--- a/internal/workload/up/repository_test.go
+++ b/internal/workload/up/repository_test.go
@@ -169,12 +169,14 @@ func TestRun_RepositoryRefusedRollsIntoANewOneInstead(t *testing.T) {
 
 	install(t, f)
 
-	result, _, err := runIn(t, newImage(), Options{NonInteractive: true})
+	result, stderr, err := runIn(t, newImage(), Options{NonInteractive: true})
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{liveRepositoryID, ""}, sent, "the retry drops the repository and keeps everything else")
 	assert.Equal(t, ActionRolled, result.Action, "a refused repository still leaves a deploy to finish")
 	assert.Equal(t, "art-2", result.ArtifactID)
+	assert.Contains(t, stderr, "starts one of its own",
+		"the lineage forks here, and a run that said nothing would leave nobody to explain the second Registry row")
 }
 
 // One retry, not a loop. A 404 with nothing to drop is the artifact itself
@@ -378,4 +380,127 @@ func TestRun_RepositoryOnTheLiveArtifactIsNotDrift(t *testing.T) {
 
 	assert.Equal(t, ActionUnchanged, result.Action)
 	assert.Contains(t, stderr, "Already up to date")
+}
+
+// pinned is a file with a repository id hand-written into the artifact block.
+// The key is the platform's own and nothing documents it as an input, but the
+// compiler passes through what it does not recognize, so it reaches the create
+// unless something takes it off.
+func pinned(content, repositoryID string) string {
+	return strings.Replace(content, "  name: my-app-artifact\n",
+		"  name: my-app-artifact\n  artifactRepositoryId: "+repositoryID+"\n", 1)
+}
+
+// The repository a version joins is the workload's own or none, and a line in
+// the file does not get a say. Honouring one would join a lineage on the
+// strength of a stale checkout, and would defeat the one case that has to
+// start fresh: a file that changed the artifact's kind.
+func TestRun_RepositoryWrittenIntoTheFileIsNotSent(t *testing.T) {
+	var tr track
+
+	install(t, wiredRoll(&tr))
+
+	_, _, err := runIn(t, pinned(newImage(), "68c0000000000000000000ee"), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Empty(t, sentRepository(t, tr.artifactIn),
+		"the base fixture's live artifact has no repository, and the file's is not one")
+}
+
+// The fallback is a create carrying no repository at all, rather than one
+// carrying whatever the file said. A retry that asked for a second repository
+// would be answered the same way as the first and the deploy would fail on a
+// field the run itself put there.
+func TestRun_RepositoryFallbackDropsTheFilesRepositoryToo(t *testing.T) {
+	var tr track
+
+	f := inRepository(wiredRoll(&tr))
+
+	var sent []string
+
+	f.newArtifact = func(payload any) (*workload.Artifact, error) {
+		sent = append(sent, sentRepository(t, payload))
+
+		if len(sent) == 1 {
+			return nil, notFound()
+		}
+
+		return &workload.Artifact{ID: "art-2", Status: workload.ArtifactStatusDraft}, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, pinned(newImage(), "68c0000000000000000000ee"), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{liveRepositoryID, ""}, sent)
+}
+
+// agentBuiltDrift is the built project's file with the artifact relabelled,
+// which is the change that leaves the running version's lineage behind.
+func agentBuiltDrift() string {
+	return strings.Replace(builtDrift(), "  name: gpt-oss-20b-vllm-artifact\n",
+		"  name: gpt-oss-20b-vllm-artifact\n  type: agent\n", 1)
+}
+
+// builtRollLeavingTheLineage is that roll with the draft an earlier attempt
+// left behind sitting in the repository the platform opened for it, which is
+// where an artifact of the new kind can only be.
+func builtRollLeavingTheLineage(tr *track) fakes {
+	const agentRepositoryID = "68c0000000000000000000f2"
+
+	f := builtRoll(tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("art-abandoned")
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{
+			ID:                   id,
+			Status:               workload.ArtifactStatusDraft,
+			ArtifactRepositoryID: agentRepositoryID,
+		}, nil
+	}
+
+	docs := artifactDocs("art-abandoned", 9000)
+	f.artifactD = func(id string) (workload.Document, error) {
+		d, err := docs(id)
+		if err != nil {
+			return nil, err
+		}
+
+		if id == "art-abandoned" {
+			d[keyType], d[keyArtifactRepositoryID] = "agent", agentRepositoryID
+
+			return d, nil
+		}
+
+		d[keyType], d[keyArtifactRepositoryID] = "service", liveRepositoryID
+
+		return d, nil
+	}
+
+	return f
+}
+
+// A roll that changed the artifact's kind is starting a lineage of its own, so
+// the draft its own last attempt minted is still the version to fill. Measured
+// against the live artifact's repository it would be refused instead, and a
+// build that fails after the create would leave a draft and a Registry row per
+// attempt: the pile reuse exists to prevent.
+func TestRun_LeftoverDraftIsReusedWhenTheRollStartsItsOwnRepository(t *testing.T) {
+	var tr track
+
+	f := builtRollLeavingTheLineage(&tr)
+	f.newArtifact = func(any) (*workload.Artifact, error) {
+		t.Error("the draft the last attempt left behind is the version to roll onto")
+
+		return nil, errors.New("nothing should be created")
+	}
+
+	install(t, f)
+
+	_, stderr, err := runIn(t, agentBuiltDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "earlier attempt")
+	assert.NotContains(t, tr.steps, "create-artifact")
 }

--- a/internal/workload/up/repository_test.go
+++ b/internal/workload/up/repository_test.go
@@ -1,0 +1,381 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// liveRepositoryID is the repository the running version in the roll fixtures
+// belongs to. Anything a roll mints should join it.
+const liveRepositoryID = "68c0000000000000000000f1"
+
+// inRepository puts the running version in liveRepositoryID, which is what
+// every artifact the platform has actually created looks like. The base
+// fixture leaves it out so the older shape stays covered too.
+func inRepository(f fakes) fakes {
+	return liveArtifact(f, func(d workload.Document) {
+		d[keyArtifactRepositoryID] = liveRepositoryID
+	})
+}
+
+// asType is inRepository with the running version relabelled, so a file asking
+// for another kind has something to disagree with.
+func asType(f fakes, artifactType string) fakes {
+	return liveArtifact(inRepository(f), func(d workload.Document) {
+		d[keyType] = artifactType
+	})
+}
+
+// liveArtifact rebuilds the artifact seam with edit applied, so each helper
+// above says only what it changes.
+func liveArtifact(f fakes, edit func(workload.Document)) fakes {
+	previous := f.artifactD
+
+	f.artifactD = func(id string) (workload.Document, error) {
+		d := docOf(liveImageArtifactJSON)
+
+		if previous != nil {
+			var err error
+			if d, err = previous(id); err != nil {
+				return nil, err
+			}
+		}
+
+		edit(d)
+
+		return d, nil
+	}
+
+	return f
+}
+
+// agentManifest is newImage with the artifact relabelled an agent, which is
+// the change that has to start a lineage of its own. The type goes at the
+// artifact's top level because that is where the platform reads it.
+func agentManifest() string {
+	return strings.Replace(newImage(), "  name: my-app-artifact\n", "  name: my-app-artifact\n  type: agent\n", 1)
+}
+
+// sentRepository is the repository id on the create the run actually sent, ""
+// when it sent none.
+func sentRepository(t *testing.T, payload any) string {
+	t.Helper()
+
+	raw, ok := payload.(json.RawMessage)
+	require.True(t, ok, "the create payload is the artifact block as raw JSON")
+
+	var block map[string]any
+
+	require.NoError(t, json.Unmarshal(raw, &block))
+
+	id, _ := block[keyArtifactRepositoryID].(string)
+
+	return id
+}
+
+// notFound is the answer the platform gives for a repository it will not let
+// this caller write to, whether because it is gone or because it was never
+// shared with them.
+func notFound() error {
+	return &drapi.HTTPError{StatusCode: http.StatusNotFound, Detail: "Artifact repository not found."}
+}
+
+// The point of the whole change: the version a roll mints joins the one the
+// running version is already in, so the Registry shows one lineage rather than
+// a new row per deploy.
+func TestRun_RollJoinsTheRunningVersionsRepository(t *testing.T) {
+	var tr track
+
+	install(t, inRepository(wiredRoll(&tr)))
+
+	_, _, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, liveRepositoryID, sentRepository(t, tr.artifactIn))
+}
+
+// Nothing to join means nothing to send, and the platform opens one. This is
+// also the shape of a live artifact from before repositories existed.
+func TestRun_RollWithNoRepositoryToJoinSendsNone(t *testing.T) {
+	var tr track
+
+	install(t, wiredRoll(&tr))
+
+	_, _, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Empty(t, sentRepository(t, tr.artifactIn),
+		"the base fixture has no repository, so there is nothing to ask for")
+}
+
+// A repository carries the type of the artifact that opened it and the
+// platform refuses one that disagrees, so a service that became an agent is a
+// new lineage rather than the next version of the old one.
+func TestRun_RollOfADifferentArtifactTypeStartsItsOwnRepository(t *testing.T) {
+	var tr track
+
+	install(t, asType(wiredRoll(&tr), "service"))
+
+	_, _, err := runIn(t, agentManifest(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Empty(t, sentRepository(t, tr.artifactIn),
+		"asking a service's repository to hold an agent only earns a 422")
+}
+
+// The repository id is read off the live artifact, so a user cannot correct a
+// refusal of it. Falling back to a repository of its own keeps the deploy
+// working; refusing would strand it on a detail nobody can see.
+func TestRun_RepositoryRefusedRollsIntoANewOneInstead(t *testing.T) {
+	var tr track
+
+	f := inRepository(wiredRoll(&tr))
+
+	var sent []string
+
+	f.newArtifact = func(payload any) (*workload.Artifact, error) {
+		sent = append(sent, sentRepository(t, payload))
+
+		if len(sent) == 1 {
+			return nil, notFound()
+		}
+
+		tr.steps = append(tr.steps, "create-artifact")
+
+		return &workload.Artifact{ID: "art-2", Status: workload.ArtifactStatusDraft}, nil
+	}
+
+	install(t, f)
+
+	result, _, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{liveRepositoryID, ""}, sent, "the retry drops the repository and keeps everything else")
+	assert.Equal(t, ActionRolled, result.Action, "a refused repository still leaves a deploy to finish")
+	assert.Equal(t, "art-2", result.ArtifactID)
+}
+
+// One retry, not a loop. A 404 with nothing to drop is the artifact itself
+// being refused, and asking twice would earn the same answer twice.
+func TestRun_NotFoundWithNoRepositorySentIsNotRetried(t *testing.T) {
+	var tr track
+
+	f := wiredRoll(&tr)
+
+	calls := 0
+	f.newArtifact = func(any) (*workload.Artifact, error) {
+		calls++
+
+		return nil, notFound()
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+// The type check before the create is a prediction, and it reads the live
+// artifact's type rather than the repository's own, so it can be wrong. When
+// it is, the platform answers 422 and the retry has to cover it, or a guess
+// this code made turns a deploy that worked into one that fails.
+func TestRun_RepositoryTypeRefusedRollsIntoANewOneInstead(t *testing.T) {
+	var tr track
+
+	f := inRepository(wiredRoll(&tr))
+
+	var sent []string
+
+	f.newArtifact = func(payload any) (*workload.Artifact, error) {
+		sent = append(sent, sentRepository(t, payload))
+
+		if len(sent) == 1 {
+			return nil, &drapi.HTTPError{
+				StatusCode: http.StatusUnprocessableEntity,
+				Detail:     "Artifact repository type 'agent' does not match artifact type 'service'",
+			}
+		}
+
+		return &workload.Artifact{ID: "art-2", Status: workload.ArtifactStatusDraft}, nil
+	}
+
+	install(t, f)
+
+	result, _, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{liveRepositoryID, ""}, sent)
+	assert.Equal(t, ActionRolled, result.Action, "a mispredicted type still leaves a deploy to finish")
+}
+
+// Dropping the repository cannot make a refused artifact acceptable, so a 422
+// the repository had nothing to do with fails again and that answer is the one
+// reported. One wasted request on a deploy that was going to fail anyway is
+// the price of not having to read the platform's wording to tell them apart.
+func TestRun_RepositoryFallbackDoesNotSwallowOtherFailures(t *testing.T) {
+	var tr track
+
+	f := inRepository(wiredRoll(&tr))
+
+	calls := 0
+	f.newArtifact = func(any) (*workload.Artifact, error) {
+		calls++
+
+		return nil, &drapi.HTTPError{StatusCode: http.StatusUnprocessableEntity, Detail: "spec is incomplete"}
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Equal(t, 2, calls, "tried without the repository, then reported the answer that came back")
+	assert.Contains(t, err.Error(), "spec is incomplete", "the artifact's own refusal is what the user sees")
+}
+
+// A failure the API layer never turned into an HTTPError says nothing about
+// the repository, so it is reported rather than retried.
+func TestRun_RepositoryFallbackLeavesPlainErrorsAlone(t *testing.T) {
+	var tr track
+
+	f := inRepository(wiredRoll(&tr))
+
+	calls := 0
+	f.newArtifact = func(any) (*workload.Artifact, error) {
+		calls++
+
+		return nil, errors.New("connection reset")
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+// The id rides the create and nothing else.
+//
+// Asserted on withRepository directly, because a single run cannot show it:
+// the plan is computed before anything is created, so a run-level check passes
+// whether or not the compiled payload was tagged. The damage would land on the
+// NEXT run, as drift the file can never satisfy. What actually prevents it is
+// that withRepository leaves its input alone, so every later read of
+// ArtifactPayload() is still the file's own block.
+func TestWithRepository_LeavesTheCompiledBlockAlone(t *testing.T) {
+	payload := json.RawMessage(`{"name":"my-app-artifact","spec":{"containerGroups":[]}}`)
+	before := string(payload)
+
+	joined, err := withRepository(payload, liveRepositoryID)
+	require.NoError(t, err)
+
+	assert.Equal(t, before, string(payload), "the block the plan reads is not the block the create sends")
+	assert.Equal(t, liveRepositoryID, sentRepository(t, joined))
+	assert.Empty(t, sentRepository(t, payload))
+}
+
+// builtRollInRepository is the built-project roll with the running version in
+// a repository, which is the only path that reaches the leftover-draft check.
+func builtRollInRepository(tr *track, draftRepositoryID string) fakes {
+	f := builtRoll(tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("art-abandoned")
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{
+			ID:                   id,
+			Status:               workload.ArtifactStatusDraft,
+			ArtifactRepositoryID: draftRepositoryID,
+		}, nil
+	}
+
+	// The leftover says what the file says, so only the repository is left to
+	// decide whether it can be reused.
+	docs := artifactDocs("art-abandoned", 9000)
+	f.artifactD = func(id string) (workload.Document, error) {
+		d, err := docs(id)
+		if err != nil {
+			return nil, err
+		}
+
+		d[keyArtifactRepositoryID] = liveRepositoryID
+
+		return d, nil
+	}
+
+	return f
+}
+
+// A draft an earlier attempt left in another lineage is not promoted into this
+// one. Artifacts cannot move between repositories, so reusing it would not
+// merge the two: it would swap the workload onto the draft's, silently and for
+// good. The drafts this happens with are the ones released before the id was
+// sent at all.
+func TestRun_LeftoverDraftFromAnotherRepositoryIsNotReused(t *testing.T) {
+	var tr track
+
+	install(t, builtRollInRepository(&tr, "68c0000000000000000000ff"))
+
+	_, stderr, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, tr.steps, "create-artifact", "a fresh version is minted rather than the stray promoted")
+	assert.NotContains(t, stderr, "earlier attempt")
+	assert.Equal(t, liveRepositoryID, sentRepository(t, tr.artifactIn),
+		"and it is minted into the workload's own lineage")
+}
+
+// The same leftover, already in the workload's lineage, is still the version
+// to roll onto. Refusing it would put back the pile of drafts per attempt that
+// reuse exists to prevent.
+func TestRun_LeftoverDraftInTheSameRepositoryIsStillReused(t *testing.T) {
+	var tr track
+
+	f := builtRollInRepository(&tr, liveRepositoryID)
+	f.newArtifact = func(any) (*workload.Artifact, error) {
+		t.Fatal("a draft in the right lineage is already the version to roll onto")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	_, stderr, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "earlier attempt")
+}
+
+// The same file against the same live pair still plans nothing. A repository
+// on the live artifact is not drift, and a run that reported it as such would
+// roll a new version on every deploy of something nobody changed.
+func TestRun_RepositoryOnTheLiveArtifactIsNotDrift(t *testing.T) {
+	install(t, inRepository(liveImage(fakes{})))
+
+	result, stderr, err := runIn(t, boundImageManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, ActionUnchanged, result.Action)
+	assert.Contains(t, stderr, "Already up to date")
+}

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -86,6 +86,10 @@ func roll(loaded Loaded, live Live, plan Plan, result Result, opts Options, repo
 // every deploy. A file the platform builds from needs the working tree and an
 // image before it is worth promoting. A published image needs neither, and is
 // one call.
+//
+// Whatever is minted joins the repository the running version belongs to, so a
+// workload deployed ten times reads as ten versions of one thing rather than
+// ten artifacts that happen to share a name.
 func candidateArtifact(
 	loaded Loaded,
 	live Live,
@@ -97,11 +101,57 @@ func candidateArtifact(
 		return version{ID: id}, nil
 	}
 
+	repository := sameRepository(loaded, live)
+
 	if mode := loaded.Manifest.BuildMode(); mode == manifest.BuildModeDockerfile || mode == manifest.BuildModeGenerated {
-		return buildVersion(loaded, live, code, opts, report)
+		return buildVersion(loaded, live, code, repository, opts, report)
 	}
 
-	return createVersion(loaded, report)
+	return createVersion(loaded, repository, report)
+}
+
+// sameRepository is the repository the new version joins, "" when it should
+// start one of its own.
+//
+// The one case that has to start fresh is a file that changed the artifact's
+// kind. A repository carries a type, taken from the artifact that opened it,
+// and the platform refuses an artifact whose own type disagrees. A service
+// that became an agent is a new lineage rather than the next version of the
+// old one, so asking for the old repository would earn a 422 saying exactly
+// that. Cheaper and clearer to notice it here, where both types are already in
+// hand.
+func sameRepository(loaded Loaded, live Live) string {
+	if live.ArtifactRepositoryID == "" || !sameArtifactType(loaded, live) {
+		return ""
+	}
+
+	return live.ArtifactRepositoryID
+}
+
+// sameArtifactType reports whether the file still asks for the kind of thing
+// the workload is running.
+//
+// Both sides are defaulted, which is deliberately not what the plan does with
+// the same two values. The plan treats an unstated type as the file having no
+// opinion, because it never reverts what the file leaves out. The question
+// here is a different one: what kind of thing is the artifact about to be
+// created. The platform answers service for a block that names none, so that
+// is what the repository will be compared against, whatever the file meant by
+// saying nothing. The comparison itself is shared with the plan's, so the two
+// cannot come to disagree about what a type change is.
+//
+// A file that cannot be read answers no, which starts a new repository. That
+// costs a row in the Registry; joining the wrong one costs a round trip.
+func sameArtifactType(loaded Loaded, live Live) bool {
+	wanted, err := loaded.ArtifactType()
+	if err != nil {
+		return false
+	}
+
+	return manifest.SameArtifactType(
+		manifest.ArtifactTypeOrDefault(wanted),
+		manifest.ArtifactTypeOrDefault(live.ArtifactType),
+	)
 }
 
 // confirmLock asks whether to roll a locked version, and reports whether the

--- a/internal/workload/up/version.go
+++ b/internal/workload/up/version.go
@@ -16,8 +16,12 @@ package up
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/sync"
 	"github.com/datarobot/cli/internal/workload/wapi"
@@ -55,8 +59,15 @@ type version struct {
 //
 // Every step here is recoverable except by leaving a draft artifact behind,
 // which is why the next run looks for one before making another.
-func buildVersion(loaded Loaded, live Live, code CodeChange, opts Options, report *reporter) (version, error) {
-	made, err := versionArtifact(loaded, live, report)
+func buildVersion(
+	loaded Loaded,
+	live Live,
+	code CodeChange,
+	repositoryID string,
+	opts Options,
+	report *reporter,
+) (version, error) {
+	made, err := versionArtifact(loaded, live, repositoryID, report)
 	if err != nil {
 		return made, err
 	}
@@ -86,18 +97,21 @@ func buildVersion(loaded Loaded, live Live, code CodeChange, opts Options, repor
 
 // versionArtifact returns the artifact to fill and build, reusing the one an
 // earlier attempt left behind rather than adding to a pile of drafts.
-func versionArtifact(loaded Loaded, live Live, report *reporter) (version, error) {
+func versionArtifact(loaded Loaded, live Live, repositoryID string, report *reporter) (version, error) {
 	if id, ok := abandoned(loaded, live); ok {
 		report.say("  Continuing with artifact %s from an earlier attempt.\n", id)
 
 		return version{ID: id}, nil
 	}
 
-	return createVersion(loaded, report)
+	return createVersion(loaded, repositoryID, report)
 }
 
-// createVersion mints an artifact from the file's artifact block.
-func createVersion(loaded Loaded, report *reporter) (version, error) {
+// createVersion mints an artifact from the file's artifact block, into
+// repositoryID when the run has a lineage for it to join. An empty
+// repositoryID leaves the platform to open one, which is what the first deploy
+// of anything wants.
+func createVersion(loaded Loaded, repositoryID string, report *reporter) (version, error) {
 	var created *workload.Artifact
 
 	err := report.run("Creating the new version", func() error {
@@ -106,7 +120,7 @@ func createVersion(loaded Loaded, report *reporter) (version, error) {
 			return payloadErr
 		}
 
-		artifact, createErr := createArtifactFn(payload)
+		artifact, createErr := createInRepository(payload, repositoryID)
 		created = artifact
 
 		return createErr
@@ -116,6 +130,91 @@ func createVersion(loaded Loaded, report *reporter) (version, error) {
 	}
 
 	return version{ID: created.ID, Fresh: true}, nil
+}
+
+// createInRepository mints the artifact inside repositoryID, and falls back to
+// letting the platform open one when it will not take that repository.
+//
+// The fallback is what keeps this from turning deploys that worked into
+// failures. The id is read off the live artifact rather than typed by anyone,
+// so a refusal names something the user cannot correct: a repository deleted
+// from the UI and one belonging to whoever created the workload and never
+// shared both answer 404, and neither is a reason to leave a workload on the
+// version it was. Landing in a repository of its own is precisely the
+// behaviour this change exists to stop being the default, which is what makes
+// it the right thing to fall back to.
+//
+// The retry covers both answers the repository can produce, and only when one
+// was actually asked for. A repository that is gone or was never shared comes
+// back 404; one whose type disagrees with the artifact comes back 422, which
+// sameRepository tries to predict but cannot promise, since the prediction
+// reads the live artifact's type rather than the repository's own. Retrying
+// both is what keeps a wrong guess from failing a deploy instead of costing a
+// round trip.
+//
+// Dropping the id cannot make a refused artifact acceptable, so a 422 the
+// repository had nothing to do with fails again, identically, and that second
+// answer is the one reported. The cost of covering the case is one wasted
+// request on a deploy that was going to fail anyway. Reading the message to
+// tell the two apart would be exact until the day the API rewords it.
+func createInRepository(payload json.RawMessage, repositoryID string) (*workload.Artifact, error) {
+	if repositoryID == "" {
+		return createArtifactFn(payload)
+	}
+
+	joined, err := withRepository(payload, repositoryID)
+	if err != nil {
+		return nil, err
+	}
+
+	artifact, err := createArtifactFn(joined)
+	if err == nil || !repositoryRefused(err) {
+		return artifact, err
+	}
+
+	log.Debug("artifact repository refused; creating the version in a new one",
+		"artifact_repository_id", repositoryID, "err", err)
+
+	return createArtifactFn(payload)
+}
+
+// repositoryRefused reports whether err is an answer a repository can cause.
+func repositoryRefused(err error) bool {
+	var httpErr *drapi.HTTPError
+
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+
+	return httpErr.StatusCode == http.StatusNotFound ||
+		httpErr.StatusCode == http.StatusUnprocessableEntity
+}
+
+// withRepository is the artifact block with the repository it should join
+// added to it.
+//
+// The id goes on the payload and never on the compiled manifest, and that
+// placement is load-bearing twice. The plan measures the file against the live
+// spec, so a server-owned id on the file's side of that comparison would read
+// as drift on every run, for ever. And a leftover draft is reused only when the
+// file still describes it, a check that compares this same block against the
+// artifact: an id in the block would fail every draft minted before this
+// change and quietly mint a replacement each time.
+func withRepository(payload json.RawMessage, repositoryID string) (json.RawMessage, error) {
+	var block map[string]any
+
+	if err := json.Unmarshal(payload, &block); err != nil {
+		return nil, fmt.Errorf("cannot read the artifact block: %w", err)
+	}
+
+	block[keyArtifactRepositoryID] = repositoryID
+
+	raw, err := json.Marshal(block)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert the artifact block to JSON: %w", err)
+	}
+
+	return raw, nil
 }
 
 // abandoned reports an artifact a previous roll made and never promoted, and
@@ -136,6 +235,16 @@ func createVersion(loaded Loaded, report *reporter) (version, error) {
 // again next run. A draft that no longer matches is left where it is and a
 // new one minted, which is what happens anyway when there is nothing to
 // reuse.
+//
+// The repository is checked for the same reason as the spec, and the one the
+// running version is in decides. An artifact cannot be moved between
+// repositories once it exists, so promoting a draft from elsewhere does not
+// merge two lineages: it abandons the workload's own and adopts the draft's,
+// from that run onwards and with nothing said. The drafts this can happen with
+// are the ones a release before this one left behind and the ones
+// `dr artifact create` makes, both of which sit in a repository of their own.
+// Minting a fresh version costs the stray draft that reuse exists to avoid;
+// reusing costs the lineage, permanently.
 func abandoned(loaded Loaded, live Live) (string, bool) {
 	if !projectLinkedFn(loaded.ProjectDir) {
 		return "", false
@@ -151,11 +260,26 @@ func abandoned(loaded Loaded, live Live) (string, bool) {
 		return "", false
 	}
 
+	if !joinable(artifact, live) {
+		return "", false
+	}
+
 	if !describes(loaded, cfg.ArtifactID) {
 		return "", false
 	}
 
 	return cfg.ArtifactID, true
+}
+
+// joinable reports whether promoting this draft would leave the workload in
+// the repository it is already in. A workload in none has nothing to lose,
+// which is every workload created before repositories were sent at all.
+func joinable(draft *workload.Artifact, live Live) bool {
+	if live.ArtifactRepositoryID == "" {
+		return true
+	}
+
+	return draft.ArtifactRepositoryID == live.ArtifactRepositoryID
 }
 
 // describes reports whether the draft still says what the file's artifact

--- a/internal/workload/up/version.go
+++ b/internal/workload/up/version.go
@@ -98,7 +98,7 @@ func buildVersion(
 // versionArtifact returns the artifact to fill and build, reusing the one an
 // earlier attempt left behind rather than adding to a pile of drafts.
 func versionArtifact(loaded Loaded, live Live, repositoryID string, report *reporter) (version, error) {
-	if id, ok := abandoned(loaded, live); ok {
+	if id, ok := abandoned(loaded, live, repositoryID); ok {
 		report.say("  Continuing with artifact %s from an earlier attempt.\n", id)
 
 		return version{ID: id}, nil
@@ -112,7 +112,10 @@ func versionArtifact(loaded Loaded, live Live, repositoryID string, report *repo
 // repositoryID leaves the platform to open one, which is what the first deploy
 // of anything wants.
 func createVersion(loaded Loaded, repositoryID string, report *reporter) (version, error) {
-	var created *workload.Artifact
+	var (
+		created  *workload.Artifact
+		fellBack bool
+	)
 
 	err := report.run("Creating the new version", func() error {
 		payload, payloadErr := loaded.Compiled.ArtifactPayload()
@@ -120,8 +123,8 @@ func createVersion(loaded Loaded, repositoryID string, report *reporter) (versio
 			return payloadErr
 		}
 
-		artifact, createErr := createInRepository(payload, repositoryID)
-		created = artifact
+		artifact, forked, createErr := createInRepository(payload, repositoryID)
+		created, fellBack = artifact, forked
 
 		return createErr
 	})
@@ -129,11 +132,23 @@ func createVersion(loaded Loaded, repositoryID string, report *reporter) (versio
 		return version{}, err
 	}
 
+	// Said out loud rather than only to the debug log. The deploy itself is
+	// fine and there is nothing to do about it, but from here the workload's
+	// versions are two lineages and the Registry carries a second entry under
+	// the same name. Nobody goes looking for the cause of that after a run
+	// that printed nothing but check marks.
+	if fellBack {
+		report.say("  Artifact repository %s would not take the new version, so it starts one of its own.\n",
+			repositoryID)
+	}
+
 	return version{ID: created.ID, Fresh: true}, nil
 }
 
 // createInRepository mints the artifact inside repositoryID, and falls back to
-// letting the platform open one when it will not take that repository.
+// letting the platform open one when it will not take that repository. It
+// reports whether that fallback fired, which is the one thing that happens
+// here the caller has to say out loud.
 //
 // The fallback is what keeps this from turning deploys that worked into
 // failures. The id is read off the live artifact rather than typed by anyone,
@@ -157,25 +172,42 @@ func createVersion(loaded Loaded, repositoryID string, report *reporter) (versio
 // answer is the one reported. The cost of covering the case is one wasted
 // request on a deploy that was going to fail anyway. Reading the message to
 // tell the two apart would be exact until the day the API rewords it.
-func createInRepository(payload json.RawMessage, repositoryID string) (*workload.Artifact, error) {
-	if repositoryID == "" {
-		return createArtifactFn(payload)
+func createInRepository(payload json.RawMessage, repositoryID string) (*workload.Artifact, bool, error) {
+	// Every request below starts from a block with no repository on it. The
+	// field is the platform's own and the file has no business carrying one,
+	// but the compiler passes keys it does not recognize through untouched, so
+	// a hand-written id would otherwise join a lineage this run may have just
+	// decided to leave, and would turn the fallback below into a second
+	// request for a repository rather than a request for none.
+	free, err := withoutRepository(payload)
+	if err != nil {
+		return nil, false, err
 	}
 
-	joined, err := withRepository(payload, repositoryID)
+	if repositoryID == "" {
+		artifact, createErr := createArtifactFn(free)
+
+		return artifact, false, createErr
+	}
+
+	joined, err := withRepository(free, repositoryID)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	artifact, err := createArtifactFn(joined)
 	if err == nil || !repositoryRefused(err) {
-		return artifact, err
+		return artifact, false, err
 	}
 
 	log.Debug("artifact repository refused; creating the version in a new one",
 		"artifact_repository_id", repositoryID, "err", err)
 
-	return createArtifactFn(payload)
+	artifact, err = createArtifactFn(free)
+
+	// A retry that failed too forked nothing, so there is nothing to announce
+	// and the error it came back with is the whole story.
+	return artifact, err == nil, err
 }
 
 // repositoryRefused reports whether err is an answer a repository can cause.
@@ -191,7 +223,8 @@ func repositoryRefused(err error) bool {
 }
 
 // withRepository is the artifact block with the repository it should join
-// added to it.
+// added to it, and with anything the file said about one taken off first: the
+// id is the platform's own field, and this is the only place that decides it.
 //
 // The id goes on the payload and never on the compiled manifest, and that
 // placement is load-bearing twice. The plan measures the file against the live
@@ -207,7 +240,11 @@ func withRepository(payload json.RawMessage, repositoryID string) (json.RawMessa
 		return nil, fmt.Errorf("cannot read the artifact block: %w", err)
 	}
 
-	block[keyArtifactRepositoryID] = repositoryID
+	delete(block, keyArtifactRepositoryID)
+
+	if repositoryID != "" {
+		block[keyArtifactRepositoryID] = repositoryID
+	}
 
 	raw, err := json.Marshal(block)
 	if err != nil {
@@ -215,6 +252,12 @@ func withRepository(payload json.RawMessage, repositoryID string) (json.RawMessa
 	}
 
 	return raw, nil
+}
+
+// withoutRepository is the artifact block with no repository on it at all,
+// which is the create that asks the platform to open one.
+func withoutRepository(payload json.RawMessage) (json.RawMessage, error) {
+	return withRepository(payload, "")
 }
 
 // abandoned reports an artifact a previous roll made and never promoted, and
@@ -236,16 +279,16 @@ func withRepository(payload json.RawMessage, repositoryID string) (json.RawMessa
 // new one minted, which is what happens anyway when there is nothing to
 // reuse.
 //
-// The repository is checked for the same reason as the spec, and the one the
-// running version is in decides. An artifact cannot be moved between
+// The repository is checked for the same reason as the spec, and the one this
+// roll set out to land in decides. An artifact cannot be moved between
 // repositories once it exists, so promoting a draft from elsewhere does not
-// merge two lineages: it abandons the workload's own and adopts the draft's,
-// from that run onwards and with nothing said. The drafts this can happen with
-// are the ones a release before this one left behind and the ones
+// merge two lineages: it abandons the one the roll was joining and adopts the
+// draft's, from that run onwards and with nothing said. The drafts this can
+// happen with are the ones a release before this one left behind and the ones
 // `dr artifact create` makes, both of which sit in a repository of their own.
 // Minting a fresh version costs the stray draft that reuse exists to avoid;
 // reusing costs the lineage, permanently.
-func abandoned(loaded Loaded, live Live) (string, bool) {
+func abandoned(loaded Loaded, live Live, repositoryID string) (string, bool) {
 	if !projectLinkedFn(loaded.ProjectDir) {
 		return "", false
 	}
@@ -260,7 +303,7 @@ func abandoned(loaded Loaded, live Live) (string, bool) {
 		return "", false
 	}
 
-	if !joinable(artifact, live) {
+	if !joinable(artifact, repositoryID) {
 		return "", false
 	}
 
@@ -272,14 +315,23 @@ func abandoned(loaded Loaded, live Live) (string, bool) {
 }
 
 // joinable reports whether promoting this draft would leave the workload in
-// the repository it is already in. A workload in none has nothing to lose,
+// the repository the roll is heading for.
+//
+// It is the roll's intended repository that decides, not the live artifact's.
+// The two differ exactly when the file changed the artifact's kind: the roll
+// is then starting a lineage of its own by design, so there is nothing left to
+// protect, and measuring against the lineage being left would refuse the very
+// draft the previous attempt minted and mint another one per attempt, which is
+// the pile reuse exists to prevent.
+//
+// An empty repository is that case, and also a workload that has none to lose,
 // which is every workload created before repositories were sent at all.
-func joinable(draft *workload.Artifact, live Live) bool {
-	if live.ArtifactRepositoryID == "" {
+func joinable(draft *workload.Artifact, repositoryID string) bool {
+	if repositoryID == "" {
 		return true
 	}
 
-	return draft.ArtifactRepositoryID == live.ArtifactRepositoryID
+	return draft.ArtifactRepositoryID == repositoryID
 }
 
 // describes reports whether the draft still says what the file's artifact
@@ -312,6 +364,13 @@ func describes(loaded Loaded, artifactID string) bool {
 	// the version runs, and an artifact renamed in the UI is not a reason to
 	// mint another.
 	delete(want, keyArtifactName)
+
+	// The repository is not the file's to state either, and createInRepository
+	// takes it off every request, so a draft can never carry the one written
+	// there. Comparing it would make a hand-written id refuse every leftover
+	// for good: a fresh draft per attempt, and the same id refusing that one
+	// too.
+	delete(want, keyArtifactRepositoryID)
 
 	// Both directions, which is the difference between this and measuring
 	// drift. Subset catches a value the file changed or added; Extra catches

--- a/internal/workload/wizard/answers.go
+++ b/internal/workload/wizard/answers.go
@@ -200,7 +200,7 @@ func (a Answers) draft(detected Detected) (manifest.Draft, error) {
 		WorkloadID: a.WorkloadID,
 		Name:       name,
 		Importance: manifest.DefaultImportance,
-		Type:       orDefault(a.Type, manifest.TypeService),
+		Type:       manifest.ArtifactTypeOrDefault(a.Type),
 		A2AEnabled: a.A2AEnabled,
 		Port:       a.Port,
 		HealthPath: orDefault(a.HealthPath, manifest.DefaultHealthPath),

--- a/internal/workload/wizard/interactive.go
+++ b/internal/workload/wizard/interactive.go
@@ -43,7 +43,7 @@ const execEnvPickLimit = 200
 // about (the runtime sizing) and the binding, which would otherwise be lost
 // and turn a bind into a create.
 func (a Answers) partialDraft(detected Detected) manifest.Draft {
-	kind := orDefault(a.Type, manifest.TypeService)
+	kind := manifest.ArtifactTypeOrDefault(a.Type)
 
 	draft := manifest.Draft{
 		WorkloadID: a.WorkloadID,


### PR DESCRIPTION
# RATIONALE

Every roll minted an artifact with no `artifactRepositoryId`, so the platform opened a new repository each time instead of adding a version to the existing one. Deploying a workload twice left two Registry rows with the same name, and `--lock` could never produce a numbered sequence, since numbering is per repository.

## CHANGES

`Look` reads the repository off the live artifact, and the roll sends it back on create. Three calls worth arguing about:

**Read live, never stored.** The ticket proposes recording the id in `.datarobot/workload/config.json`. Reading it off the live artifact costs no extra call and keeps this independent of RAPTOR-19516: the repository follows the workload rather than the checkout, so under `--env` each manifest's own `workloadId` already gives it its own lineage. Storing it would add a fifth row to 19516's single-slot table and a field to migrate later.

**The id goes on the create payload and never into the compiled manifest.** There it would be a field the plan measures, so it would read as drift the file can never satisfy, and it would break `describes()` so every draft left by an older release gets replaced instead of reused.

**Both 404 and 422 retry once without it.** A repository you cannot write to answers 404; one whose type disagrees answers 422. The check before the create predicts the second from the live artifact rather than from the repository itself, so it can be wrong, and a wrong guess would otherwise turn a deploy that worked into one that fails. Dropping the id cannot make a refused artifact acceptable, so an unrelated failure fails again and that answer is the one reported.

One unrelated-looking change, found while doing the above: the plan compared artifact types case-sensitively and the manifest ledger enforces no enum on the field, so a hand-written `type: Service` was drift nothing could resolve, and every run would mint a version and roll a workload nobody had touched. Both comparisons now go through one helper that folds case.

Step 4 of the ticket, grouping in `dr artifact list`, is deliberately not here. It is a gated surface change, and the table already has a `VERSION ID` column holding the catalog version, so putting an artifact `VERSION` beside it needs a naming decision this PR should not make.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core `dr workload up` roll/create path and artifact API payloads; behavior is heavily covered by new integration tests but mistaken repository handling could still affect production deploy lineage.
> 
> **Overview**
> **Workload rolls** now read `artifactRepositoryId` from the live artifact and attach it only to the **create** payload (not the compiled manifest), so each roll adds a version in the same repository instead of opening a new one. If the platform refuses that repository (**404** or **422**, e.g. type mismatch), the CLI retries once **without** the id so deploys still complete. Leftover drafts are reused only when they belong to the **same** repository as the running version.
> 
> **Drift planning** compares artifact types with **case folding** (`Service` vs `service` is no longer perpetual drift). Wizard/live defaults share **`ArtifactTypeOrDefault`** for missing types.
> 
> **`dr artifact get`** (text and JSON) exposes **Repository** and **Repository version** (`version` is null for drafts). Docs for `artifact get` are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4d2cc1d67938ed752ab079773937a3e91bba3b5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->