### PR TITLE
feat: capture non-interactive telemetry, fix the yes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,11 +158,11 @@ For full details, see [docs/development/configuration.md](docs/development/confi
 - **Never bulk-bind subcommand flags to viper.** `viperx` does not expose
   `BindPFlags`. Bind only specific persistent flags explicitly via
   `viperx.BindPFlag` in `cmd/root.go::init()`.
-- **Read transient flags directly from cobra**: `cmd.Flags().GetBool("yes")`.
+- **Read transient flags directly from cobra**: e.g. `cmd.Flags().GetBool(cli.YesFlagName)`.
   Do not bind them with `viperx.BindPFlag`.
 - **Env-var override for a transient flag:** register only the env var via
-  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and OR the two sources at the call site:
-  `yesFlag, _ := cmd.Flags().GetBool("yes"); yes := yesFlag || viperx.GetBool("yes")`.
+  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and merge the sources with
+  `cli.IsNonInteractive(cmd)` rather than inlining the flag/env OR yourself.
 - **To make a key persistable**, add it to `config.PersistableKeys` and have the
   write site call `config.UpdateConfigFile("my-key")`.
 

--- a/cmd/artifact/code/checkout/cmd.go
+++ b/cmd/artifact/code/checkout/cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/datarobot/cli/cmd/artifact/code/internal/dirprompt"
 	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi/filesapi"
 	"github.com/datarobot/cli/internal/outputformat"
@@ -49,7 +50,7 @@ func defaultDeps() Deps {
 
 func init() {
 	// Per project rules: bind only the env var, read the flag directly from cobra.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 }
 
 func Cmd() *cobra.Command {
@@ -98,14 +99,13 @@ Example:
 
 	c.Flags().String("dir", "", "Project directory (default: current directory).")
 	c.Flags().Bool("clean", false, "Remove checkout directories instead of downloading.")
-	c.Flags().BoolP("yes", "y", false, "Skip interactive prompts.")
+	c.Flags().BoolP(cli.YesFlagName, "y", false, "Skip interactive prompts.")
 
 	return c
 }
 
 func runCheckout(cmd *cobra.Command, args []string, outputFormat outputformat.OutputFormat, deps Deps) error {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	yes := yesFlag || viperx.GetBool("yes")
+	yes := cli.IsNonInteractive(cmd)
 
 	dirFlag, _ := cmd.Flags().GetString("dir")
 	clean, _ := cmd.Flags().GetBool("clean")

--- a/cmd/artifact/code/codesync/cmd.go
+++ b/cmd/artifact/code/codesync/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/datarobot/cli/cmd/artifact/code/internal/dirprompt"
 	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/misc/reader"
@@ -91,7 +92,7 @@ func defaultDeps() Deps {
 
 func init() {
 	// --yes is read directly from cobra; only the env var binds to viper
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 }
 
 // Cmd returns the cobra.Command for `dr artifact code sync`.
@@ -140,7 +141,7 @@ Example:
 	c.Flags().String("dir", "", "Project directory (default: current directory).")
 	c.Flags().Bool("dry-run", false, "Show plan, no writes.")
 	c.Flags().Bool("diff", false, "Show plan + per-file unified diffs, no writes.")
-	c.Flags().BoolP("yes", "y", false, "Skip interactive prompts; auto-confirm.")
+	c.Flags().BoolP(cli.YesFlagName, "y", false, "Skip interactive prompts; auto-confirm.")
 	c.MarkFlagsMutuallyExclusive("dry-run", "diff")
 
 	telemetry.TrackWith(c, func(cmd *cobra.Command, _ []string) map[string]any {
@@ -200,14 +201,13 @@ func runSync(cmd *cobra.Command, outputFormat outputformat.OutputFormat, deps De
 // DATAROBOT_CLI_NON_INTERACTIVE env-var override into Yes, so the
 // downstream helpers see a single source of truth.
 func parseRunFlags(cmd *cobra.Command) runFlags {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	diff, _ := cmd.Flags().GetBool("diff")
 
 	return runFlags{
 		DryRun: dryRun,
 		Diff:   diff,
-		Yes:    yesFlag || viperx.GetBool("yes"),
+		Yes:    cli.IsNonInteractive(cmd),
 	}
 }
 

--- a/cmd/artifact/code/init/cmd.go
+++ b/cmd/artifact/code/init/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/datarobot/cli/cmd/artifact/code/internal/dirprompt"
 	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/outputformat"
@@ -72,16 +73,15 @@ Example:
 	outputformat.AddFlag(c, &outputFormat)
 
 	c.Flags().String("dir", "", "Project directory (default: current directory).")
-	c.Flags().BoolP("yes", "y", false, "Skip interactive prompts; use defaults.")
+	c.Flags().BoolP(cli.YesFlagName, "y", false, "Skip interactive prompts; use defaults.")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
 	// flag itself is read directly from cmd.Flags() in runInit so an explicit
 	// --yes does not leak into viper.AllSettings() and persist to drconfig.yaml.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(c, func(cmd *cobra.Command, args []string) map[string]any {
-		yesFlag, _ := cmd.Flags().GetBool("yes")
-		yes := yesFlag || viperx.GetBool("yes")
+		yes := cli.IsNonInteractive(cmd)
 
 		return map[string]any{
 			"artifact_id":   telemetry.FirstArg(args),
@@ -94,8 +94,7 @@ Example:
 }
 
 func runInit(cmd *cobra.Command, args []string, outputFormat outputformat.OutputFormat) error {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	yes := yesFlag || viperx.GetBool("yes")
+	yes := cli.IsNonInteractive(cmd)
 	dirFlag, _ := cmd.Flags().GetString("dir")
 
 	dir, err := dirprompt.ResolveDir(dirFlag, yes, dirprompt.AskWithDefault)

--- a/cmd/artifact/del/cmd.go
+++ b/cmd/artifact/del/cmd.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/helpers"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/misc/reader"
@@ -69,19 +70,17 @@ Example:
 		},
 	}
 
-	cmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt.")
+	cmd.Flags().BoolP(cli.YesFlagName, "y", false, "Skip the confirmation prompt.")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
 	// flag itself is read directly from cmd.Flags() so an explicit --yes does
 	// not leak into viper.AllSettings() and persist to drconfig.yaml.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(cmd *cobra.Command, args []string) map[string]any {
-		yesFlag, _ := cmd.Flags().GetBool("yes")
-
 		return map[string]any{
 			"artifact_id": telemetry.FirstArg(args),
-			"yes":         yesFlag || viperx.GetBool("yes"),
+			"yes":         cli.IsNonInteractive(cmd),
 		}
 	})
 
@@ -89,8 +88,7 @@ Example:
 }
 
 func confirmDelete(cmd *cobra.Command, artifactID string) (bool, error) {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	if yesFlag || viperx.GetBool("yes") {
+	if cli.IsNonInteractive(cmd) {
 		return true, nil
 	}
 

--- a/cmd/dependencies/install/cmd.go
+++ b/cmd/dependencies/install/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/cmd/helpers"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/dependencies"
 	"github.com/datarobot/cli/internal/log"
@@ -46,7 +47,7 @@ func Cmd() *cobra.Command {
 		Short: "📦 Install missing template dependencies",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			yesFlag = opts.Yes
-			nonInteractive = viperx.GetBool("yes")
+			nonInteractive = cli.IsNonInteractive(cmd)
 
 			log.Debug("deps: install start", "yes", yesFlag, "non_interactive", nonInteractive)
 
@@ -97,9 +98,9 @@ func Cmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, `Assume "yes" as answer to the install prompt.`)
+	cmd.Flags().BoolVarP(&opts.Yes, cli.YesFlagName, "y", false, `Assume "yes" as answer to the install prompt.`)
 
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/dependencies/install/cmd_test.go
+++ b/cmd/dependencies/install/cmd_test.go
@@ -69,7 +69,7 @@ func TestInstallCmd_PropExtractor_AllSatisfied(t *testing.T) {
 
 // TestInstallCmd_YesFlag_SkipsPromptAndInstalls verifies that --yes bypasses the
 // interactive prompt, that the install succeeds, and that the PropExtractor records
-// yes_flag=true / non_interactive=false.
+// yes_flag=true / non_interactive=true.
 func TestInstallCmd_YesFlag_SkipsPromptAndInstalls(t *testing.T) {
 	orig := tools.RequiredTools
 
@@ -94,7 +94,7 @@ func TestInstallCmd_YesFlag_SkipsPromptAndInstalls(t *testing.T) {
 	assert.Contains(t, installSuccess, "FakeTool")
 	assert.Empty(t, event.EventProperties["install_error"])
 	assert.Equal(t, true, event.EventProperties["yes_flag"])
-	assert.Equal(t, false, event.EventProperties["non_interactive"])
+	assert.Equal(t, true, event.EventProperties["non_interactive"])
 }
 
 // TestInstallCmd_NonInteractive_SkipsPromptAndInstalls verifies that

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -152,13 +152,9 @@ This wizard will help you:
 		}
 
 		showAllPrompts, _ := cmd.Flags().GetBool("all")
-		// Read --yes directly from flags rather than through viper to
-		// avoid the flag value leaking into viper.AllSettings() (and from
-		// there into drconfig.yaml on subsequent writes). The
-		// DATAROBOT_CLI_NON_INTERACTIVE environment variable still flows
-		// through viper via BindEnv below.
-		yesFlag, _ := cmd.Flags().GetBool("yes")
-		yes := yesFlag || viperx.GetBool("yes")
+		// Merge --yes and DATAROBOT_CLI_NON_INTERACTIVE via the shared helper so the
+		// transient flag never leaks into viper.AllSettings().
+		yes := cli.IsNonInteractive(cmd)
 
 		// When --yes is set, run fully non-interactive setup without TUI
 		if yes {
@@ -230,15 +226,15 @@ This wizard will help you:
 func init() {
 	SetupCmd.Flags().Bool("if-needed", false, "Only run setup if '.env' file doesn't exist or there are missing env vars.")
 	SetupCmd.Flags().BoolP("all", "a", false, "Show all prompts including those with default values already set.")
-	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for automation).")
+	SetupCmd.Flags().BoolP(cli.YesFlagName, "y", false, "Skip interactive prompts and use defaults (useful for automation).")
 	SetupCmd.Flags().StringP("output", "o", "", "Directory where the '.env' file should be written (defaults to repository root). This option skips the logic of finding the repository root.")
-	SetupCmd.MarkFlagsMutuallyExclusive("yes", "all")
+	SetupCmd.MarkFlagsMutuallyExclusive(cli.YesFlagName, "all")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper.
 	// The --yes flag itself is read directly from cmd.Flags() in RunE so
 	// that an explicit --yes does not leak into viper.AllSettings() and
 	// get persisted to drconfig.yaml on subsequent config writes.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.Track(SetupCmd)
 	telemetry.Track(UpdateCmd)

--- a/cmd/plugin/install/cmd.go
+++ b/cmd/plugin/install/cmd.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/datarobot/cli/cmd/plugin/shared"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/plugin"
@@ -71,14 +72,14 @@ Use --url to install directly from an HTTP/HTTPS URL instead of the registry.`,
 	cmd.Flags().BoolVar(&listPlugins, "list", false, "List available plugins from the registry")
 	cmd.Flags().StringVar(&filePath, "file", "", "Install from a local .tar.xz archive instead of the registry")
 	cmd.Flags().StringVar(&pluginURL, "url", "", "Install from an HTTP/HTTPS URL instead of the registry")
-	cmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, `Assume "yes" when prompted to install plugin dependencies.`)
+	cmd.Flags().BoolVarP(&yesFlag, cli.YesFlagName, "y", false, `Assume "yes" when prompted to install plugin dependencies.`)
 
 	// Mark mutually exclusive flags
 	cmd.MarkFlagsMutuallyExclusive("list", "versions", "version", "file", "url")
 	cmd.MarkFlagsMutuallyExclusive("file", "registry-url")
 	cmd.MarkFlagsMutuallyExclusive("url", "registry-url")
 
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(c *cobra.Command, args []string) map[string]any {
 		ver, _ := c.Flags().GetString("version")
@@ -272,7 +273,7 @@ func (h *headingWriter) Write(p []byte) (int, error) {
 // missing plugin dependencies. Consent is granted automatically when -y/--yes
 // is set; otherwise the user is prompted interactively.
 func confirmPluginDepsInstall() bool {
-	if yesFlag || viperx.GetBool("yes") {
+	if yesFlag || cli.IsNonInteractive(nil) {
 		return true
 	}
 

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -27,7 +27,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/dependencies"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/repo"
@@ -132,7 +132,7 @@ func NewStartModel(opts Options) Model {
 		repoRoot: repoRoot,
 		telemetry: telemetryCapture{
 			yesFlag:        opts.AnswerYes,
-			nonInteractive: viperx.GetBool("yes"),
+			nonInteractive: cli.IsNonInteractive(nil),
 		},
 	}
 }
@@ -346,7 +346,7 @@ func (m Model) handleDepsMissing(msg depsMissingMsg) (tea.Model, tea.Cmd) {
 	m.telemetry.missingMsgs = msg.checkResult.MissingMsgs
 	m.telemetry.wrongVersionMsgs = msg.checkResult.WrongVersionMsgs
 
-	autoInstall := m.opts.AnswerYes || viperx.GetBool("yes")
+	autoInstall := m.opts.AnswerYes || cli.IsNonInteractive(nil)
 
 	log.Debug("start: handling missing deps", "count", len(msg.prerequisites), "auto_install", autoInstall)
 
@@ -636,7 +636,7 @@ func findAndExecuteStart(m *Model) tea.Msg {
 		// Found a quickstart script
 		// Don't wait for confirmation if '--yes' flag is set or
 		// DATAROBOT_CLI_NON_INTERACTIVE env var is true
-		waitForConfirmation := !m.opts.AnswerYes && !viperx.GetBool("yes")
+		waitForConfirmation := !m.opts.AnswerYes && !cli.IsNonInteractive(nil)
 
 		return stepCompleteMsg{
 			message:              fmt.Sprintf("Found quickstart script at: %s\n", quickstartScript),

--- a/cmd/workload/config/cmd.go
+++ b/cmd/workload/config/cmd.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -117,11 +118,13 @@ Examples:
 
 	// Only the env var binds to viper; --yes is read from cobra so it never
 	// persists into drconfig.yaml.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWith(cmd, func(cmd *cobra.Command, _ []string) map[string]any {
+		nonInteractive := cli.IsNonInteractive(cmd)
+
 		return map[string]any{
-			"yes":           f.yes || viperx.GetBool("yes"),
+			"yes":           nonInteractive,
 			"type":          f.answers.Type,
 			"build_mode":    f.answers.BuildMode,
 			"bound":         f.answers.WorkloadID != "",
@@ -140,7 +143,7 @@ func addFlags(cmd *cobra.Command, f *flags) {
 	// only guessing is what the project directory can be read for, so the
 	// help text has to say that rather than leave "defaults" to be read as
 	// the other command's meaning.
-	cmd.Flags().BoolVarP(&f.yes, "yes", "y", false,
+	cmd.Flags().BoolVarP(&f.yes, cli.YesFlagName, "y", false,
 		"Do not prompt; answer every question from flags and what the project directory shows. "+
 			"A question neither of those answers is an error naming the flag that would settle it.")
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "Print the manifest and write nothing.")
@@ -188,7 +191,7 @@ func run(cmd *cobra.Command, f flags, format outputformat.OutputFormat) error {
 
 	// JSON output implies non-interactive: a wizard on stderr alongside a
 	// machine-readable stdout is a trap for whoever is parsing it.
-	yes := f.yes || viperx.GetBool("yes")
+	yes := cli.IsNonInteractive(cmd)
 
 	result, err := wizard.Run(wizard.Options{
 		Dir:            dir,

--- a/cmd/workload/del/cmd.go
+++ b/cmd/workload/del/cmd.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/helpers"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/misc/reader"
@@ -68,19 +69,17 @@ Example:
 		},
 	}
 
-	cmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt.")
+	cmd.Flags().BoolP(cli.YesFlagName, "y", false, "Skip the confirmation prompt.")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
 	// flag itself is read directly from cmd.Flags() so an explicit --yes does
 	// not leak into viper.AllSettings() and persist to drconfig.yaml.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(cmd *cobra.Command, args []string) map[string]any {
-		yesFlag, _ := cmd.Flags().GetBool("yes")
-
 		return map[string]any{
 			"workload_id": telemetry.FirstArg(args),
-			"yes":         yesFlag || viperx.GetBool("yes"),
+			"yes":         cli.IsNonInteractive(cmd),
 		}
 	})
 
@@ -92,8 +91,7 @@ Example:
 // interactively. A declined prompt is (false, nil) so the command exits 0
 // as a no-op.
 func confirmDelete(cmd *cobra.Command, workloadID string) (bool, error) {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	if yesFlag || viperx.GetBool("yes") {
+	if cli.IsNonInteractive(cmd) {
 		return true, nil
 	}
 

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/internal/pollflags"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/outputformat"
@@ -154,11 +155,13 @@ Examples:
 	outputformat.AddFlag(cmd, &outputFormat)
 	addFlags(cmd, &f, &poll)
 
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWith(cmd, func(cmd *cobra.Command, _ []string) map[string]any {
+		nonInteractive := cli.IsNonInteractive(cmd)
+
 		return map[string]any{
-			"yes":           f.yes || viperx.GetBool("yes"),
+			"yes":           nonInteractive,
 			"dry_run":       f.dryRun,
 			"detach":        f.detach,
 			"lock":          f.lock,
@@ -172,7 +175,7 @@ Examples:
 
 func addFlags(cmd *cobra.Command, f *flags, poll *pollflags.Set) {
 	cmd.Flags().StringVar(&f.dir, "dir", "", "Project directory; the manifest is searched upward from here.")
-	cmd.Flags().BoolVarP(&f.yes, "yes", "y", false,
+	cmd.Flags().BoolVarP(&f.yes, cli.YesFlagName, "y", false,
 		"Do not prompt. With no manifest this is an error rather than a wizard, "+
 			"and rolling a locked production version is not confirmed.")
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "Print the plan and change nothing.")
@@ -210,7 +213,7 @@ func run(cmd *cobra.Command, f flags, poll pollflags.Set, format outputformat.Ou
 
 	json := format == outputformat.OutputFormatJSON
 
-	yes := f.yes || viperx.GetBool("yes")
+	yes := cli.IsNonInteractive(cmd)
 
 	// JSON output implies non-interactive: a wizard drawn on stderr while
 	// stdout is being parsed is a trap for whoever is parsing it.

--- a/docs/development/flags.md
+++ b/docs/development/flags.md
@@ -350,14 +350,15 @@ Outside `internal/config/...`, all viper interaction goes through the
 Quick rules for new flags:
 
 - **Transient flags** (per-invocation): read directly via
-  `cmd.Flags().GetBool(...)`. Do not bind to viper.
+  `cmd.Flags().GetBool(...)` (for example `cli.YesFlagName`). Do not bind to viper.
 - **Env-var override needed?** Register only the env var with
-  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and OR the two sources in your
-  handler:
+  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and merge the sources with the shared
+  helper:
 
   ```go
-  yesFlag, _ := cmd.Flags().GetBool("yes")
-  yes := yesFlag || viperx.GetBool("yes")
+  _ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
+
+  nonInteractive := cli.IsNonInteractive(cmd)
   ```
 
 - **Sticky CLI preferences** (rare): bind via `viperx.BindPFlag` *and*

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -243,6 +243,8 @@ PersistentPreRunE (root.go)
     ├─ Initialize CommonProperties (session ID, user ID, env, ...)
     ├─ Stamp props.CommandKind = "core" or "plugin"
     │   based on telemetry.IsPluginCommand(cmd)
+    ├─ Stamp props.NonInteractive via telemetry.StampInteractionMode
+    │   so every event shares the same automation signal
     ├─ Build telemetry.Client
     └─ Register cobra.OnFinalize (closes over cmd, args, client)
     ↓
@@ -252,6 +254,23 @@ cobra.OnFinalize (via cobra's deferred postRun, fires on success and error paths
     ├─ telemetry.EventFor(cmd, args) → if tracked, client.Track(event)
     ├─ Flush telemetry (3-second timeout)
     └─ log.Stop()
+
+### Stamping universal interaction flags
+
+`telemetry.StampInteractionMode` centralizes everything that decides whether the
+current invocation is interactive. The helper runs exactly once in
+`root.PersistentPreRunE`, so every event in the session inherits the same
+`non_interactive` property without each command needing to parse flags on its own.
+
+- `DATAROBOT_CLI_NON_INTERACTIVE=true` forces `non_interactive=true`
+- Any parsed `--yes` flag (including short `-y`) flips the flag for that session
+- `--force-interactive` overrides both so wizards still render during automation
+- Commands can reuse the same logic directly via `cli.IsNonInteractive(cmd)`
+
+To expose another universal flag or environment override, extend
+`telemetry.StampInteractionMode` (and update its tests) rather than touching
+individual commands. **TODO:** when the next global automation flag is added,
+document its behavior here and wire it through the helper alongside `--yes`.
 ```
 
 ### Reading RunE results in a PropExtractor

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -1,0 +1,20 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+// YesFlagName is the canonical name used for non-interactive confirmation flags.
+// Commands that accept "--yes"/"-y" should derive their flag registration from
+// this constant so shared helpers (telemetry, env bindings, etc.) can consume it.
+const YesFlagName = "yes"

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -1,0 +1,47 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/spf13/cobra"
+)
+
+// IsNonInteractive reports whether the current command invocation should skip prompts.
+// It merges the non-interactive environment variable, any explicit --yes flag, and the
+// global --force-interactive override into a single truthy signal for automation.
+func IsNonInteractive(cmd *cobra.Command) bool {
+	if viperx.GetBool("force-interactive") {
+		return false
+	}
+
+	if reader.IsNonInteractive() {
+		return true
+	}
+
+	if cmd == nil {
+		return viperx.GetBool(YesFlagName)
+	}
+
+	flag := cmd.Flags().Lookup(YesFlagName)
+	if flag != nil {
+		if yes, err := cmd.Flags().GetBool(YesFlagName); err == nil && yes {
+			return true
+		}
+	}
+
+	return viperx.GetBool(YesFlagName)
+}

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNonInteractiveEnv(t *testing.T) {
+	t.Cleanup(viperx.Reset)
+	t.Setenv(reader.NonInteractiveEnv, "1")
+
+	assert.True(t, IsNonInteractive(nil))
+}
+
+func TestIsNonInteractiveFlag(t *testing.T) {
+	t.Cleanup(viperx.Reset)
+	t.Setenv(reader.NonInteractiveEnv, "")
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().BoolP(YesFlagName, "y", false, "skip prompts")
+	require.NoError(t, cmd.ParseFlags([]string{"--" + YesFlagName}))
+
+	assert.True(t, IsNonInteractive(cmd))
+}
+
+func TestIsNonInteractiveForceInteractiveOverrides(t *testing.T) {
+	t.Cleanup(viperx.Reset)
+	t.Setenv(reader.NonInteractiveEnv, "true")
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool(YesFlagName, false, "skip prompts")
+	require.NoError(t, cmd.ParseFlags([]string{"--" + YesFlagName}))
+
+	viperx.Set("force-interactive", true)
+
+	assert.False(t, IsNonInteractive(cmd))
+}

--- a/internal/telemetry/interaction.go
+++ b/internal/telemetry/interaction.go
@@ -12,74 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package telemetry provides Amplitude-based usage analytics for the DataRobot CLI.
-// This file handles detection and stamping of the interaction mode (interactive vs
-// non-interactive) so every event carries consistent metadata.
 package telemetry
 
 import (
-	"github.com/datarobot/cli/internal/config/viperx"
-	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/spf13/cobra"
 )
 
-// yesFlagName is the canonical name of the per-command flag that opts the
-// caller into skipping interactive prompts.
-const yesFlagName = "yes"
-
-// StampInteractionMode annotates props with whether the current invocation is
-// running in non-interactive mode. This is called once in the root command's
-// PersistentPreRunE so every downstream event shares the same metadata without
-// per-command duplication.
+// StampInteractionMode annotates props with whether the current invocation is running
+// in non-interactive mode. This happens once in root PersistentPreRunE so every event
+// shares the same interaction metadata without per-command duplication.
+//
+// TODO: fold additional universal automation flags (e.g. future --non-interactive variants)
+//
+//	into this helper instead of re-implementing the logic in individual commands.
 func StampInteractionMode(props *CommonProperties, cmd *cobra.Command) {
 	if props == nil {
 		return
 	}
 
-	props.NonInteractive = computeNonInteractive(cmd)
-}
-
-// computeNonInteractive evaluates the global sources that flip the CLI into
-// non-interactive behaviour: the force-interactive viper override, the
-// DATAROBOT_CLI_NON_INTERACTIVE env var, and any per-command --yes flag.
-func computeNonInteractive(cmd *cobra.Command) bool {
-	// force-interactive takes precedence even when automation flags are present,
-	// because the caller explicitly asked to surface wizards.
-	if viperx.GetBool("force-interactive") {
-		return false
-	}
-
-	// DATAROBOT_CLI_NON_INTERACTIVE=true is the canonical signal for automation.
-	if reader.IsNonInteractive() {
-		return true
-	}
-
-	// --yes is the per-command opt-in to skip prompts.
-	if hasYesFlag(cmd) {
-		return true
-	}
-
-	return false
-}
-
-// hasYesFlag reports whether cmd (or its inherited flag set) was invoked with
-// --yes. Returns false when cmd is nil, the flag is absent, or the flag is not
-// a bool.
-func hasYesFlag(cmd *cobra.Command) bool {
-	if cmd == nil {
-		return false
-	}
-
-	yesFlag := cmd.Flags().Lookup(yesFlagName)
-	if yesFlag == nil {
-		return false
-	}
-
-	yesValue, err := cmd.Flags().GetBool(yesFlagName)
-	if err != nil {
-		// A missing or non-bool flag should behave as "not set".
-		return false
-	}
-
-	return yesValue
+	props.NonInteractive = cli.IsNonInteractive(cmd)
 }

--- a/internal/telemetry/interaction_test.go
+++ b/internal/telemetry/interaction_test.go
@@ -17,6 +17,7 @@ package telemetry
 import (
 	"testing"
 
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/spf13/cobra"
@@ -26,6 +27,7 @@ import (
 
 func TestStampInteractionMode_NonInteractiveEnv(t *testing.T) {
 	t.Setenv(reader.NonInteractiveEnv, "1")
+	t.Cleanup(viperx.Reset)
 
 	props := &CommonProperties{}
 
@@ -37,7 +39,9 @@ func TestStampInteractionMode_NonInteractiveEnv(t *testing.T) {
 
 func TestStampInteractionMode_YesFlag(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
-	cmd.Flags().BoolP("yes", "y", false, "skip prompts")
+	cmd.Flags().BoolP(cli.YesFlagName, "y", false, "skip prompts")
+	t.Setenv(reader.NonInteractiveEnv, "")
+	t.Cleanup(viperx.Reset)
 
 	require.NoError(t, cmd.ParseFlags([]string{"--yes"}))
 
@@ -50,14 +54,14 @@ func TestStampInteractionMode_YesFlag(t *testing.T) {
 }
 
 func TestStampInteractionMode_ForceInteractiveOverrides(t *testing.T) {
-	defer viperx.Reset()
+	t.Cleanup(viperx.Reset)
 
 	// Simulate both automation signals; force-interactive should still win.
 	t.Setenv(reader.NonInteractiveEnv, "true")
 	viperx.Set("force-interactive", true)
 
 	cmd := &cobra.Command{Use: "test"}
-	cmd.Flags().Bool("yes", false, "skip prompts")
+	cmd.Flags().Bool(cli.YesFlagName, false, "skip prompts")
 	require.NoError(t, cmd.ParseFlags([]string{"--yes"}))
 
 	props := &CommonProperties{NonInteractive: true}

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/internal/shell"
 	"github.com/datarobot/cli/internal/state"
@@ -85,7 +86,10 @@ func CollectCommonProperties() *CommonProperties {
 		OSVersion:     detectOSVersion(),
 		Language:      detectLanguage(),
 		GoVersion:     runtime.Version(),
-		Shell:         DetectShell(),
+		// Seed the interaction mode with the environment variable so automation workflows
+		// are marked even if the command itself lacks a --yes flag.
+		NonInteractive: reader.IsNonInteractive(),
+		Shell:          DetectShell(),
 	}
 
 	// Get DataRobot instance info from config


### PR DESCRIPTION
# RATIONALE
We need to understand when the CLI is executing without human interaction—either through `--yes` or automation—so downstream analytics can measure scripted usage. Capturing that signal once per invocation keeps individual commands from having to wire their own telemetry.

## CHANGES
- add a `non_interactive` field to the shared telemetry payload and include it in every event
- introduce `telemetry.StampInteractionMode` to evaluate environment, `--yes`, and `--force-interactive`
- call the new helper from `root.PersistentPreRunE` so the flag is set once per process
- cover interaction-mode detection in unit tests and ensure the property defaults sensibly
- document the interaction-mode pipeline and note TODOs for wiring future universal flags through the same helper

- finally, finally take care of this code smell.

```go
# before
#	yesFlag, _ := cmd.Flags().GetBool("yes")
#	yes := yesFlag || viperx.GetBool("yes")
# after
	yes := cli.IsNonInteractive(cmd)
```

## TESTING
- `go test ./internal/telemetry ./cmd`

## FOLLOW-UP
- TODO: Extend `telemetry.StampInteractionMode` (and its tests/docs) whenever new automation-focused flags or env overrides are introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cross-cutting refactor of prompt-skipping and telemetry metadata with tests and docs; no auth, persistence, or deploy logic changes beyond consistent flag/env handling.
> 
> **Overview**
> **Centralizes how the CLI decides to skip prompts** and how analytics records scripted runs. New helpers `cli.YesFlagName`, `cli.IsNonInteractive(cmd)`, and `telemetry.StampInteractionMode` fold together `DATAROBOT_CLI_NON_INTERACTIVE`, per-command `--yes`/`-y`, and the root `--force-interactive` override.
> 
> `root.PersistentPreRunE` now stamps **`non_interactive`** on shared telemetry properties once per invocation; `CommonProperties` exposes it on every Amplitude event. Dozens of commands (artifact code flows, deletes, dotenv setup, deps/plugin install, workload config/up, `dr start`, etc.) register `--yes` via the constant and call `IsNonInteractive` instead of inlining `cmd.Flags().GetBool("yes") || viperx.GetBool("yes")`.
> 
> **Docs** (`AGENTS.md`, configuration/flags/telemetry guides) describe the pattern. Unit tests cover the helper and stamping, including force-interactive wins; `dependencies install` telemetry now treats an explicit `--yes` as `non_interactive=true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95c40036d51f3d5ae23e80dc6362e51d0640787e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->