### PR TITLE
[CFX-7669] fix(ci): pin arduino/setup-task Task version to 3.52.0

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -29,5 +29,5 @@ runs:
       if: inputs.install-task == 'true'
       uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
       with:
-        version: 3.x
+        version: 3.52.0
         repo-token: ${{ github.token }}

--- a/.github/workflows/_smoke-windows.yaml
+++ b/.github/workflows/_smoke-windows.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Taskfile
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
-          version: 3.x
+          version: 3.52.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Smoke Tests for Binary

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -332,7 +332,7 @@ jobs:
       - name: Install Taskfile
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:
-          version: 3.x
+          version: 3.52.0
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test completion generation


### PR DESCRIPTION
## RATIONALE

Daily smoke tests + `Build Windows` failed on `main` at commit `dcec55a`
(run [32154924572](https://github.com/datarobot-oss/cli/actions/runs/32154924572))
with:

```
Failed to download version v3.53.1: Error: Unexpected HTTP response: 404
in "Set up Go and Task"
```

Root cause: `arduino/setup-task`'s `version: 3.x` input floats to whatever
`go-task/task` release GitHub currently reports as latest. `go-task/task`
tagged `v3.53.1` at 15:23 UTC on 2026-08-18 but didn't finish publishing its
release assets until 15:41 UTC. Our `build-windows` and
`smoke-test (macos-latest)` jobs ran at 15:33 UTC — inside that ~18-minute
window — resolved the brand-new tag, and 404'd downloading its binary. The
automatic re-run passed once `v3.53.1` was fully published, confirming this
was a transient upstream race rather than a regression from `dcec55a`.

Full diagnosis posted to [CFX-7669](https://datarobot.atlassian.net/browse/CFX-7669).

**Credit:** @taras-pokornyy already landed this exact pin for the
`.github/actions/setup/action.yaml` call site as an incidental fix in
[#788](https://github.com/datarobot-oss/cli/pull/788) (`dr self update
--version`). This PR carries that fix forward — same version pin — and
extends it to the two call sites #788 doesn't touch, as a standalone
CI-only fix since #788 is a larger, separate feature PR. Commit is
co-authored accordingly.

## CHANGES

- Pin `arduino/setup-task`'s `version: 3.x` → `3.52.0` (exact, already
  published) in all three call sites, closing the race for good:
  - `.github/actions/setup/action.yaml`
  - `.github/workflows/_smoke-windows.yaml`
  - `.github/workflows/pr-checks.yaml`
- Matches the project's existing convention of pinning tool versions
  explicitly rather than floating (`GOLANGCI_LINT_VERSION`,
  `LEFTHOOK_VERSION`, `JSCPD_VERSION`, `GORELEASER_VERSION` in
  `Taskfile.yaml`).

CI-config only — no Go source changes, no tests affected.

Ref: CFX-7669

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow configuration only; no application code, auth, or runtime behavior changes.
> 
> **Overview**
> **Pins Task (go-task) to `3.52.0`** everywhere CI installs it via `arduino/setup-task`, replacing the floating **`3.x`** input that could resolve to a brand-new release before its binaries are published (causing transient **404** failures on Windows build and smoke jobs).
> 
> The same pin is applied in the shared **Setup Go and Task** composite action, the **Windows smoke** workflow, and the **PR completion-tests** job—aligned with how other CI tools are version-pinned in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61b8cc69e984db73c23e86bbb3acd8ee97e2268a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->