### PR TITLE
feat(cmd): introduce RootFactory pattern for isolated command assembly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,11 +158,11 @@ For full details, see [docs/development/configuration.md](docs/development/confi
 - **Never bulk-bind subcommand flags to viper.** `viperx` does not expose
   `BindPFlags`. Bind only specific persistent flags explicitly via
   `viperx.BindPFlag` in `cmd/root.go::init()`.
-- **Read transient flags directly from cobra**: `cmd.Flags().GetBool("yes")`.
+- **Read transient flags directly from cobra**: e.g. `cmd.Flags().GetBool(cli.YesFlagName)`.
   Do not bind them with `viperx.BindPFlag`.
 - **Env-var override for a transient flag:** register only the env var via
-  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and OR the two sources at the call site:
-  `yesFlag, _ := cmd.Flags().GetBool("yes"); yes := yesFlag || viperx.GetBool("yes")`.
+  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and merge the sources with
+  `cli.IsNonInteractive(cmd)` rather than inlining the flag/env OR yourself.
 - **To make a key persistable**, add it to `config.PersistableKeys` and have the
   write site call `config.UpdateConfigFile("my-key")`.
 

--- a/cmd/artifact/code/checkout/cmd.go
+++ b/cmd/artifact/code/checkout/cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/datarobot/cli/cmd/artifact/code/internal/dirprompt"
 	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi/filesapi"
 	"github.com/datarobot/cli/internal/outputformat"
@@ -49,7 +50,7 @@ func defaultDeps() Deps {
 
 func init() {
 	// Per project rules: bind only the env var, read the flag directly from cobra.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 }
 
 func Cmd() *cobra.Command {
@@ -98,14 +99,13 @@ Example:
 
 	c.Flags().String("dir", "", "Project directory (default: current directory).")
 	c.Flags().Bool("clean", false, "Remove checkout directories instead of downloading.")
-	c.Flags().BoolP("yes", "y", false, "Skip interactive prompts.")
+	c.Flags().BoolP(cli.YesFlagName, "y", false, "Skip interactive prompts.")
 
 	return c
 }
 
 func runCheckout(cmd *cobra.Command, args []string, outputFormat outputformat.OutputFormat, deps Deps) error {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	yes := yesFlag || viperx.GetBool("yes")
+	yes := cli.IsNonInteractive(cmd)
 
 	dirFlag, _ := cmd.Flags().GetString("dir")
 	clean, _ := cmd.Flags().GetBool("clean")

--- a/cmd/artifact/code/codesync/cmd.go
+++ b/cmd/artifact/code/codesync/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/datarobot/cli/cmd/artifact/code/internal/dirprompt"
 	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/misc/reader"
@@ -91,7 +92,7 @@ func defaultDeps() Deps {
 
 func init() {
 	// --yes is read directly from cobra; only the env var binds to viper
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 }
 
 // Cmd returns the cobra.Command for `dr artifact code sync`.
@@ -140,7 +141,7 @@ Example:
 	c.Flags().String("dir", "", "Project directory (default: current directory).")
 	c.Flags().Bool("dry-run", false, "Show plan, no writes.")
 	c.Flags().Bool("diff", false, "Show plan + per-file unified diffs, no writes.")
-	c.Flags().BoolP("yes", "y", false, "Skip interactive prompts; auto-confirm.")
+	c.Flags().BoolP(cli.YesFlagName, "y", false, "Skip interactive prompts; auto-confirm.")
 	c.MarkFlagsMutuallyExclusive("dry-run", "diff")
 
 	telemetry.TrackWith(c, func(cmd *cobra.Command, _ []string) map[string]any {
@@ -200,14 +201,13 @@ func runSync(cmd *cobra.Command, outputFormat outputformat.OutputFormat, deps De
 // DATAROBOT_CLI_NON_INTERACTIVE env-var override into Yes, so the
 // downstream helpers see a single source of truth.
 func parseRunFlags(cmd *cobra.Command) runFlags {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	diff, _ := cmd.Flags().GetBool("diff")
 
 	return runFlags{
 		DryRun: dryRun,
 		Diff:   diff,
-		Yes:    yesFlag || viperx.GetBool("yes"),
+		Yes:    cli.IsNonInteractive(cmd),
 	}
 }
 

--- a/cmd/artifact/code/init/cmd.go
+++ b/cmd/artifact/code/init/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/datarobot/cli/cmd/artifact/code/internal/dirprompt"
 	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/outputformat"
@@ -72,16 +73,15 @@ Example:
 	outputformat.AddFlag(c, &outputFormat)
 
 	c.Flags().String("dir", "", "Project directory (default: current directory).")
-	c.Flags().BoolP("yes", "y", false, "Skip interactive prompts; use defaults.")
+	c.Flags().BoolP(cli.YesFlagName, "y", false, "Skip interactive prompts; use defaults.")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
 	// flag itself is read directly from cmd.Flags() in runInit so an explicit
 	// --yes does not leak into viper.AllSettings() and persist to drconfig.yaml.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(c, func(cmd *cobra.Command, args []string) map[string]any {
-		yesFlag, _ := cmd.Flags().GetBool("yes")
-		yes := yesFlag || viperx.GetBool("yes")
+		yes := cli.IsNonInteractive(cmd)
 
 		return map[string]any{
 			"artifact_id":   telemetry.FirstArg(args),
@@ -94,8 +94,7 @@ Example:
 }
 
 func runInit(cmd *cobra.Command, args []string, outputFormat outputformat.OutputFormat) error {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	yes := yesFlag || viperx.GetBool("yes")
+	yes := cli.IsNonInteractive(cmd)
 	dirFlag, _ := cmd.Flags().GetString("dir")
 
 	dir, err := dirprompt.ResolveDir(dirFlag, yes, dirprompt.AskWithDefault)

--- a/cmd/artifact/del/cmd.go
+++ b/cmd/artifact/del/cmd.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/helpers"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/misc/reader"
@@ -69,19 +70,17 @@ Example:
 		},
 	}
 
-	cmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt.")
+	cmd.Flags().BoolP(cli.YesFlagName, "y", false, "Skip the confirmation prompt.")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
 	// flag itself is read directly from cmd.Flags() so an explicit --yes does
 	// not leak into viper.AllSettings() and persist to drconfig.yaml.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(cmd *cobra.Command, args []string) map[string]any {
-		yesFlag, _ := cmd.Flags().GetBool("yes")
-
 		return map[string]any{
 			"artifact_id": telemetry.FirstArg(args),
-			"yes":         yesFlag || viperx.GetBool("yes"),
+			"yes":         cli.IsNonInteractive(cmd),
 		}
 	})
 
@@ -89,8 +88,7 @@ Example:
 }
 
 func confirmDelete(cmd *cobra.Command, artifactID string) (bool, error) {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	if yesFlag || viperx.GetBool("yes") {
+	if cli.IsNonInteractive(cmd) {
 		return true, nil
 	}
 

--- a/cmd/dependencies/install/cmd.go
+++ b/cmd/dependencies/install/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/cmd/helpers"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/dependencies"
 	"github.com/datarobot/cli/internal/log"
@@ -46,7 +47,7 @@ func Cmd() *cobra.Command {
 		Short: "📦 Install missing template dependencies",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			yesFlag = opts.Yes
-			nonInteractive = viperx.GetBool("yes")
+			nonInteractive = cli.IsNonInteractive(cmd)
 
 			log.Debug("deps: install start", "yes", yesFlag, "non_interactive", nonInteractive)
 
@@ -97,9 +98,9 @@ func Cmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, `Assume "yes" as answer to the install prompt.`)
+	cmd.Flags().BoolVarP(&opts.Yes, cli.YesFlagName, "y", false, `Assume "yes" as answer to the install prompt.`)
 
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/dependencies/install/cmd_test.go
+++ b/cmd/dependencies/install/cmd_test.go
@@ -69,7 +69,7 @@ func TestInstallCmd_PropExtractor_AllSatisfied(t *testing.T) {
 
 // TestInstallCmd_YesFlag_SkipsPromptAndInstalls verifies that --yes bypasses the
 // interactive prompt, that the install succeeds, and that the PropExtractor records
-// yes_flag=true / non_interactive=false.
+// yes_flag=true / non_interactive=true.
 func TestInstallCmd_YesFlag_SkipsPromptAndInstalls(t *testing.T) {
 	orig := tools.RequiredTools
 
@@ -94,7 +94,7 @@ func TestInstallCmd_YesFlag_SkipsPromptAndInstalls(t *testing.T) {
 	assert.Contains(t, installSuccess, "FakeTool")
 	assert.Empty(t, event.EventProperties["install_error"])
 	assert.Equal(t, true, event.EventProperties["yes_flag"])
-	assert.Equal(t, false, event.EventProperties["non_interactive"])
+	assert.Equal(t, true, event.EventProperties["non_interactive"])
 }
 
 // TestInstallCmd_NonInteractive_SkipsPromptAndInstalls verifies that

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -152,13 +152,9 @@ This wizard will help you:
 		}
 
 		showAllPrompts, _ := cmd.Flags().GetBool("all")
-		// Read --yes directly from flags rather than through viper to
-		// avoid the flag value leaking into viper.AllSettings() (and from
-		// there into drconfig.yaml on subsequent writes). The
-		// DATAROBOT_CLI_NON_INTERACTIVE environment variable still flows
-		// through viper via BindEnv below.
-		yesFlag, _ := cmd.Flags().GetBool("yes")
-		yes := yesFlag || viperx.GetBool("yes")
+		// Merge --yes and DATAROBOT_CLI_NON_INTERACTIVE via the shared helper so the
+		// transient flag never leaks into viper.AllSettings().
+		yes := cli.IsNonInteractive(cmd)
 
 		// When --yes is set, run fully non-interactive setup without TUI
 		if yes {
@@ -230,15 +226,15 @@ This wizard will help you:
 func init() {
 	SetupCmd.Flags().Bool("if-needed", false, "Only run setup if '.env' file doesn't exist or there are missing env vars.")
 	SetupCmd.Flags().BoolP("all", "a", false, "Show all prompts including those with default values already set.")
-	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for automation).")
+	SetupCmd.Flags().BoolP(cli.YesFlagName, "y", false, "Skip interactive prompts and use defaults (useful for automation).")
 	SetupCmd.Flags().StringP("output", "o", "", "Directory where the '.env' file should be written (defaults to repository root). This option skips the logic of finding the repository root.")
-	SetupCmd.MarkFlagsMutuallyExclusive("yes", "all")
+	SetupCmd.MarkFlagsMutuallyExclusive(cli.YesFlagName, "all")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper.
 	// The --yes flag itself is read directly from cmd.Flags() in RunE so
 	// that an explicit --yes does not leak into viper.AllSettings() and
 	// get persisted to drconfig.yaml on subsequent config writes.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.Track(SetupCmd)
 	telemetry.Track(UpdateCmd)

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -24,14 +24,15 @@ import (
 // an error, so that Amplitude events are delivered even though
 // PersistentPostRunE is bypassed on the error path.
 //
-// telemetryClient is set in PersistentPreRunE (root.go); it will be nil only
-// if the process exits before any command runs (e.g. flag parse failure), in
-// which case there are no queued events to flush anyway.
+// The telemetry client is retrieved from productionFactory (set in
+// PersistentPreRunE) at flush time. It will be nil only if the process exits
+// before any command runs (e.g. a flag-parse failure), in which case there
+// are no queued events to flush.
 func Exit(code int) {
-	if telemetryClient != nil {
-		telemetryClient.Flush(3 * time.Second)
+	if c := productionFactory.TelemetryClient(); c != nil {
+		c.Flush(3 * time.Second)
 	}
 
-	// This is the only place in the codebase that should call os.Exit
+	// This is the only place in the codebase that should call os.Exit.
 	os.Exit(code) //nolint:forbidigo
 }

--- a/cmd/plugin/install/cmd.go
+++ b/cmd/plugin/install/cmd.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/datarobot/cli/cmd/plugin/shared"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/plugin"
@@ -71,14 +72,14 @@ Use --url to install directly from an HTTP/HTTPS URL instead of the registry.`,
 	cmd.Flags().BoolVar(&listPlugins, "list", false, "List available plugins from the registry")
 	cmd.Flags().StringVar(&filePath, "file", "", "Install from a local .tar.xz archive instead of the registry")
 	cmd.Flags().StringVar(&pluginURL, "url", "", "Install from an HTTP/HTTPS URL instead of the registry")
-	cmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, `Assume "yes" when prompted to install plugin dependencies.`)
+	cmd.Flags().BoolVarP(&yesFlag, cli.YesFlagName, "y", false, `Assume "yes" when prompted to install plugin dependencies.`)
 
 	// Mark mutually exclusive flags
 	cmd.MarkFlagsMutuallyExclusive("list", "versions", "version", "file", "url")
 	cmd.MarkFlagsMutuallyExclusive("file", "registry-url")
 	cmd.MarkFlagsMutuallyExclusive("url", "registry-url")
 
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(c *cobra.Command, args []string) map[string]any {
 		ver, _ := c.Flags().GetString("version")
@@ -272,7 +273,7 @@ func (h *headingWriter) Write(p []byte) (int, error) {
 // missing plugin dependencies. Consent is granted automatically when -y/--yes
 // is set; otherwise the user is prompted interactively.
 func confirmPluginDepsInstall() bool {
-	if yesFlag || viperx.GetBool("yes") {
+	if yesFlag || cli.IsNonInteractive(nil) {
 		return true
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,437 +12,79 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package cmd is the top-level cobra command package for the DataRobot CLI.
+//
+// Production entry-point: main.go calls ExecuteContext, which delegates to the
+// package-level productionFactory singleton built by init(). Sub-commands and
+// tests can call NewRootFactory (with functional options to override
+// dependencies) to obtain a fully-isolated command tree without touching any
+// package-level state.
 package cmd
 
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
-	"time"
 
 	"github.com/datarobot/cli/cmd/allcommands"
-	"github.com/datarobot/cli/cmd/artifact"
-	"github.com/datarobot/cli/cmd/auth"
-	"github.com/datarobot/cli/cmd/component"
-	"github.com/datarobot/cli/cmd/dependencies"
-	"github.com/datarobot/cli/cmd/dotenv"
-	llmgateway "github.com/datarobot/cli/cmd/llm-gateway"
-	"github.com/datarobot/cli/cmd/pipeline"
-	"github.com/datarobot/cli/cmd/plugin"
-	"github.com/datarobot/cli/cmd/self"
 	selfversion "github.com/datarobot/cli/cmd/self/version"
-	"github.com/datarobot/cli/cmd/start"
-	"github.com/datarobot/cli/cmd/task"
-	"github.com/datarobot/cli/cmd/task/run"
-	"github.com/datarobot/cli/cmd/templates"
-	"github.com/datarobot/cli/cmd/workload"
 	"github.com/datarobot/cli/internal/cli"
-	"github.com/datarobot/cli/internal/config"
-	"github.com/datarobot/cli/internal/config/viperx"
-	"github.com/datarobot/cli/internal/log"
-	"github.com/datarobot/cli/internal/misc/reader"
-	"github.com/datarobot/cli/internal/outputformat"
-	internalPlugin "github.com/datarobot/cli/internal/plugin"
-	"github.com/datarobot/cli/internal/state"
-	"github.com/datarobot/cli/internal/telemetry"
-	internalVersion "github.com/datarobot/cli/internal/version"
-	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
-var (
-	configFilePath   string
-	rootOutputFormat outputformat.OutputFormat
-)
+// productionFactory is the singleton RootFactory used by the running binary.
+// It is initialised in init() so that tests importing this package still get
+// a fully-wired command tree through the RootCmd convenience variable.
+var productionFactory *RootFactory
 
-// telemetryClient holds the active client for the current process. It is set
-// in PersistentPreRunE so that cmd.Exit can flush events when main's error
-// path fires (where only the signal context, not the cobra context, is available).
-var telemetryClient *telemetry.Client
+// RootCmd is the built root command from the production factory. It exists as
+// a package-level variable so existing tests and callers that reference
+// cmd.RootCmd continue to work without modification.
+//
+// For test isolation, prefer creating a dedicated factory with NewRootFactory
+// and calling Build() on it rather than sharing this singleton.
+var RootCmd *cli.CommandAdder
 
-// RootCmd represents the base command when called without any subcommands.
-// It uses CommandAdder to intelligently filter child commands based on feature gates.
-var RootCmd = &cli.CommandAdder{
-	Command: &cobra.Command{
-		Use:     internalVersion.CliName,
-		Version: internalVersion.Version,
-		Short:   "Build AI Applications Faster",
-		// TraverseChildren causes cobra to parse persistent flags left-to-right
-		// before descending into each subcommand. This lets universal flags such
-		// as --debug be placed before a plugin name (e.g. "dr --debug myplugin")
-		// and still be consumed by core. Plugin commands set DisableFlagParsing:true
-		// so args appearing AFTER the plugin name are never seen by core —
-		// preserving the kubectl/helm "core stays blind to plugin args" model.
-		TraverseChildren: true,
-		Long: `
-The DataRobot CLI helps you quickly set up, configure, and deploy AI applications
-using pre-built templates. Get from idea to production in minutes, not hours.
+// init wires up the package-level variables and registers the allcommands /
+// version helper functions that the factory's help override needs.
+//
+// These helpers cannot live inside root_factory.go itself because they import
+// packages that would create an import cycle (allcommands imports cmd
+// sub-packages; selfversion imports internal packages that indirectly
+// reference cmd). Registering function values here breaks the cycle while
+// keeping the factory import-light.
+func init() {
+	allCommandsOutputFn = func(root *cobra.Command) string {
+		return allcommands.GenerateCommandTree(root)
+	}
 
-✨ ` + tui.BaseTextStyle.Render("What you can do:") + `
-  • Choose from ready-made AI application templates
-  • Set up your development environment quickly
-  • Deploy to DataRobot with a single command
-  • Manage environment variables and configurations
+	runVersionCommandFn = func(cmd *cobra.Command) {
+		versionCmd := selfversion.Cmd()
 
-🎯 ` + tui.BaseTextStyle.Render("Quick Start:") + `
-  dr start             # Create your first AI app (start here!)
-  dr self update       # Update DataRobot CLI to latest version
-  dr --help            # Show all available commands
+		// Suppress cobra's automatic error/usage output to prevent double-printing.
+		versionCmd.SilenceErrors = true
+		versionCmd.SilenceUsage = true
+		versionCmd.SetArgs([]string{"--output-format", "text"})
+		versionCmd.SetOut(cmd.OutOrStdout())
+		versionCmd.SetErr(cmd.ErrOrStderr())
 
-💡 ` + tui.BaseTextStyle.Render("New to AI development?") + ` Perfect! Run 'dr start' and we'll guide you through everything.`,
-		// Show help by default when no subcommands match
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// PersistentPreRunE is a hook called after flags are parsed
-			// but before the command is run. Any logic that needs to happen
-			// before ANY command execution should go here.
-			log.Start()
+		if err := versionCmd.Execute(); err != nil {
+			fmt.Fprintln(cmd.ErrOrStderr(), err)
+		} else {
+			// Only print the update hint on success.
+			fmt.Fprintln(cmd.OutOrStdout(), "\nTo update: dr self update")
+		}
+	}
 
-			cmd.SilenceUsage = true // don’t spam usage for runtime errors
-
-			err := initializeConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			if err := setupTLS(cmd); err != nil {
-				return err
-			}
-
-			// Initialize telemetry client
-			// Always collect common properties for logging (even in dry-run mode),
-			// but only send to Amplitude if enabled.
-			props := telemetry.CollectCommonProperties()
-
-			// Stamp the command_kind common property based on whether
-			// the dispatched command was registered via TrackPlugin.
-			// CommonProperties is held by pointer inside Client, so this
-			// late-bound update is visible at Track time.
-			if props != nil {
-				if telemetry.IsPluginCommand(cmd) {
-					props.CommandKind = "plugin"
-				} else {
-					props.CommandKind = "core"
-				}
-			}
-			// Log the detected shell only when debug is active. Reuse Shell from
-			// telemetry props (already collected above) when available to avoid
-			// spawning a redundant ps(1) subprocess on macOS.
-			if log.GetLevel() <= log.DebugLevel {
-				var shell string
-
-				if props != nil {
-					shell = props.Shell
-				} else {
-					shell = telemetry.DetectShell()
-				}
-
-				log.Debug("Shell", "name", shell)
-			}
-
-			client := telemetry.NewClient(props)
-
-			// Store as process-level client so cmd.Exit can flush on the main error path.
-			telemetryClient = client
-
-			// Store telemetry client in context for use by commands
-			cmd.SetContext(context.WithValue(cmd.Context(), telemetry.ClientContextKey{}, client))
-
-			cobra.OnFinalize(func() {
-				if event, ok := telemetry.EventFor(cmd, args); ok {
-					client.Track(event)
-				}
-
-				client.Flush(3 * time.Second)
-
-				log.Stop()
-			})
-
-			config.SetAPIConsumerTrace(config.CommandPathToTrace(cmd.CommandPath()))
-
-			showFirstRunAnimation()
-
-			return nil
-		},
-		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
-			// Flush telemetry events before exit
-			if client, ok := cmd.Context().Value(telemetry.ClientContextKey{}).(*telemetry.Client); ok {
-				client.Flush(3 * time.Second)
-			}
-
-			log.Stop()
-
-			return nil
-		},
-		// RootCmd needs its own RunE (to show help on a bare "dr" invocation, after
-		// the first-run animation), which disqualifies it from setUnknownArgGuards'
-		// generic walk (that skips any command with a pre-existing RunE). So it gets
-		// the same "unknown command" Args validator explicitly here.
-		Args: func(_ *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return nil
-			}
-
-			return fmt.Errorf("unknown command: %s", args[0])
-		},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	},
+	productionFactory = NewRootFactory()
+	RootCmd = productionFactory.Build()
 }
 
 // ExecuteContext executes the root command with the given context.
-// It adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
+// This is called by main.main(). It only needs to happen once per process.
 func ExecuteContext(ctx context.Context) error {
 	if err := RootCmd.ExecuteContext(ctx); err != nil {
 		return fmt.Errorf("execute root command: %w", err)
 	}
 
 	return nil
-}
-
-// bindUniversal binds name to viper and annotates the flag for forwarding to
-// plugin subprocesses as DATAROBOT_CLI_<NAME>. The suffix is derived from the
-// flag name (uppercased, hyphens → underscores). This is the single
-// registration point — adding a new universal flag only requires one call here.
-func bindUniversal(name string) {
-	flag := RootCmd.PersistentFlags().Lookup(name)
-	_ = viperx.BindPFlag(name, flag)
-
-	if flag.Annotations == nil {
-		flag.Annotations = map[string][]string{}
-	}
-
-	flag.Annotations[config.UniversalAnnotationKey] = []string{strings.ToUpper(strings.ReplaceAll(name, "-", "_"))}
-}
-
-func init() {
-	// Allow invoking commands in a case-insensitive manner
-	cobra.EnableCaseInsensitive = true
-
-	// Disable Cobra's default completion command since we have our own under 'self'
-	RootCmd.CompletionOptions.DisableDefaultCmd = true
-
-	// Set custom version template to match our unified format
-	RootCmd.SetVersionTemplate(internalVersion.GetAppNameVersionText() + "\n\nTo update: dr self update\n")
-
-	// Configure persistent flags
-	RootCmd.PersistentFlags().StringVar(&configFilePath, "config", "",
-		"path to config file (default location: $HOME/.config/datarobot/drconfig.yaml)")
-	RootCmd.PersistentFlags().BoolP("version", "V", false, "display the version")
-	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
-	RootCmd.PersistentFlags().Bool("debug", false, "debug output")
-	RootCmd.PersistentFlags().Bool("all-commands", false, "display all available commands and their flags in tree format")
-	RootCmd.PersistentFlags().Bool(config.SkipAuthKey, false, "skip authentication checks (for advanced users)")
-	RootCmd.PersistentFlags().Bool("force-interactive", false, "force setup wizards to run even if already completed")
-	RootCmd.PersistentFlags().Duration("plugin-discovery-timeout", 2*time.Second, "timeout for plugin discovery (0s disables)")
-	RootCmd.PersistentFlags().Duration("plugin-update-check-interval", internalPlugin.DefaultUpdateCheckInterval, "cooldown between plugin update checks (0s disables)")
-	RootCmd.PersistentFlags().Bool("skip-plugin-update-check", false, "skip plugin update checks before running plugins")
-	RootCmd.PersistentFlags().Bool("disable-telemetry", false, "disable usage telemetry")
-
-	// Private CA / TLS flags
-	RootCmd.PersistentFlags().BoolP("skip-certificate-check", "k", false, "skip TLS certificate verification (insecure)")
-	RootCmd.PersistentFlags().String("ca-cert", "", "path to a PEM-encoded CA certificate bundle")
-	registerExportWindowsCertsFlag(RootCmd.Command)
-
-	outputformat.AddPersistentFlag(RootCmd.Command, &rootOutputFormat)
-
-	// Universal flags: bound to viper AND forwarded to plugin subprocesses as DATAROBOT_CLI_* env vars.
-	// To add a new universal flag, call bindUniversal here next to its registration above.
-	bindUniversal("debug")
-	bindUniversal("disable-telemetry")
-	bindUniversal("verbose")
-	bindUniversal("skip-certificate-check")
-	bindUniversal("ca-cert")
-
-	// Non-universal flags: bound to viper only.
-	_ = viperx.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config"))
-	_ = viperx.BindPFlag(config.SkipAuthKey, RootCmd.PersistentFlags().Lookup(config.SkipAuthKey))
-	_ = viperx.BindPFlag("force-interactive", RootCmd.PersistentFlags().Lookup("force-interactive"))
-	_ = viperx.BindPFlag("plugin-discovery-timeout", RootCmd.PersistentFlags().Lookup("plugin-discovery-timeout"))
-	_ = viperx.BindPFlag("plugin-update-check-interval", RootCmd.PersistentFlags().Lookup("plugin-update-check-interval"))
-	_ = viperx.BindPFlag("skip-plugin-update-check", RootCmd.PersistentFlags().Lookup("skip-plugin-update-check"))
-	_ = viperx.BindPFlag("output-format", RootCmd.PersistentFlags().Lookup("output-format"))
-
-	// Add command groups (plugin group added conditionally by registerPluginCommands)
-	RootCmd.AddGroup(
-		&cobra.Group{ID: "core", Title: tui.BaseTextStyle.Render("Core Commands:")},
-		&cobra.Group{ID: "self", Title: tui.BaseTextStyle.Render("Self Commands:")},
-		&cobra.Group{ID: "advanced", Title: tui.BaseTextStyle.Render("Advanced Commands:")},
-	)
-
-	// Add commands here to ensure that they are available to users.
-	// Be sure to set the command's GroupID field appropriately;
-	// otherwise the command will be added under 'Additional Commands'.
-	// Commands with disabled feature gates are automatically filtered by cli.CommandAdder.
-	RootCmd.AddCommand(
-		artifact.Cmd(),
-		auth.Cmd(),
-		component.Cmd(),
-		dependencies.Cmd(),
-		dotenv.Cmd(),
-		llmgateway.Cmd(),
-		run.Cmd(),
-		self.Cmd(),
-		start.Cmd(),
-		task.Cmd(),
-		templates.Cmd(),
-		workload.Cmd(),
-		plugin.Cmd(),
-		pipeline.Cmd(),
-	)
-
-	// Discover and register plugin commands
-	plugin.RegisterPluginCommands(RootCmd.Command)
-
-	// Guard parent commands against unrecognised positional args.
-	// Must run after all commands (including plugins) are registered.
-	setUnknownArgGuards(RootCmd.Command)
-
-	// Override the default help command to add --all-commands flag
-	defaultHelpFunc := RootCmd.HelpFunc()
-
-	RootCmd.SetUsageTemplate(CustomUsageTemplate)
-
-	// Set on the root, so every subcommand's failure reads as one. Only the
-	// prefix is styled: the message itself is often multi-line and is the part
-	// a user copies into a bug report.
-	RootCmd.SetErrPrefix(tui.ErrorStyle.Render("Error:"))
-
-	RootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		showAllCommands, _ := cmd.Flags().GetBool("all-commands")
-		showVersion, _ := cmd.Flags().GetBool("version")
-
-		if showAllCommands {
-			output := allcommands.GenerateCommandTree(cmd.Root())
-
-			_, _ = fmt.Fprint(cmd.OutOrStdout(), output)
-		} else if showVersion {
-			// Route through self version with explicit --output-format text
-			versionCmd := selfversion.Cmd()
-			// Suppress automatic error/usage output from cobra to prevent double-printing.
-			// Error handling is done explicitly below.
-			versionCmd.SilenceErrors = true
-			versionCmd.SilenceUsage = true
-			versionCmd.SetArgs([]string{"--output-format", "text"})
-			versionCmd.SetOut(cmd.OutOrStdout())
-			versionCmd.SetErr(cmd.ErrOrStderr())
-
-			if err := versionCmd.Execute(); err != nil {
-				fmt.Fprintln(cmd.ErrOrStderr(), err)
-			} else {
-				// Only print the update hint on success
-				fmt.Fprintln(cmd.OutOrStdout(), "\nTo update: dr self update")
-			}
-		} else {
-			// Use default help behavior but with customized template
-			RootCmd.SetHelpTemplate(CustomHelpTemplate)
-			defaultHelpFunc(cmd, args)
-		}
-	})
-}
-
-// setUnknownArgGuards walks the command tree and installs a RunE + Args validator
-// on every pure-parent command (has subcommands, no Run/RunE, no explicit Args set).
-//
-// Cobra checks !Runnable() before ValidateArgs, so a non-runnable parent silently
-// shows help for any arg. Making the command runnable lets Args fire first and
-// return a clear error; the RunE fallback shows help when no args are given.
-func setUnknownArgGuards(root *cobra.Command) {
-	for _, cmd := range root.Commands() {
-		setUnknownArgGuards(cmd)
-	}
-
-	if !root.HasSubCommands() {
-		return
-	}
-
-	if root.Args != nil || root.RunE != nil || root.Run != nil {
-		return
-	}
-
-	root.Args = func(_ *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return nil
-		}
-
-		return fmt.Errorf("unknown command: %s", args[0])
-	}
-
-	root.RunE = func(cmd *cobra.Command, _ []string) error {
-		return cmd.Help()
-	}
-}
-
-// initializeConfig initializes the configuration by reading from
-// various sources such as environment variables and config files.
-func initializeConfig(_ *cobra.Command) error {
-	var err error
-
-	// Set up Viper to process environment variables
-	// First automatically map any environment variables
-	// that are prefixed with DATAROBOT_CLI_ to config keys
-	viperx.SetEnvPrefix("DATAROBOT_CLI")
-	viperx.AutomaticEnv()
-	viperx.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-
-	// map VISUAL and EDITOR to external-editor config key,
-	// but set a default value
-	viperx.SetDefault("external-editor", "vi")
-
-	_ = viperx.BindEnv("external-editor", "VISUAL", "EDITOR")
-
-	// API consumer tracking is enabled by default.
-	// Set DATAROBOT_API_CONSUMER_TRACKING_ENABLED=false to opt out,
-	// matching the Python SDK convention.
-	viperx.SetDefault(config.APIConsumerTrackingEnabled, true)
-
-	_ = viperx.BindEnv(config.APIConsumerTrackingEnabled, "DATAROBOT_API_CONSUMER_TRACKING_ENABLED")
-
-	// If DATAROBOT_CLI_CONFIG is set and no explicit --config flag was provided,
-	// use the environment variable value
-	if configFilePath == "" {
-		if envConfigPath := viperx.GetString("config"); envConfigPath != "" {
-			configFilePath = envConfigPath
-		}
-	}
-
-	// Now read the config file
-	err = config.ReadConfigFile(configFilePath)
-	if err != nil {
-		return fmt.Errorf("Failed to read config file: %w", err)
-	}
-
-	return nil
-}
-
-// showFirstRunAnimation displays the animated DataRobot logo inline (no alt-screen)
-// on the very first CLI invocation, so the final settled frame remains in normal
-// terminal scrollback and whatever runs next (help text, or dr start's own inline
-// wizard) continues directly below it instead of hard-cutting from a full-screen
-// takeover. It checks global state to avoid showing it more than once, only runs
-// in interactive terminals, and is skipped entirely under automation (e.g. tools
-// like expect that attach a real pty and would otherwise see animation frames
-// mixed into output they're pattern-matching).
-func showFirstRunAnimation() {
-	if reader.IsNonInteractive() {
-		return
-	}
-
-	if !state.IsFirstRun() {
-		return
-	}
-
-	// Only show animation when stdout is a terminal (not piped or redirected)
-	fi, err := os.Stdout.Stat()
-	if err != nil || (fi.Mode()&os.ModeCharDevice) == 0 {
-		return
-	}
-
-	m := tui.NewLogoAnimationModel()
-
-	_, _ = tui.Run(m)
-
-	state.MarkAnimationShown()
 }

--- a/cmd/root_factory.go
+++ b/cmd/root_factory.go
@@ -1,0 +1,593 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/datarobot/cli/cmd/artifact"
+	"github.com/datarobot/cli/cmd/auth"
+	"github.com/datarobot/cli/cmd/component"
+	"github.com/datarobot/cli/cmd/dependencies"
+	"github.com/datarobot/cli/cmd/dotenv"
+	llmgateway "github.com/datarobot/cli/cmd/llm-gateway"
+	"github.com/datarobot/cli/cmd/pipeline"
+	"github.com/datarobot/cli/cmd/plugin"
+	"github.com/datarobot/cli/cmd/self"
+	"github.com/datarobot/cli/cmd/start"
+	"github.com/datarobot/cli/cmd/task"
+	"github.com/datarobot/cli/cmd/task/run"
+	"github.com/datarobot/cli/cmd/templates"
+	"github.com/datarobot/cli/cmd/workload"
+	"github.com/datarobot/cli/internal/cli"
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/outputformat"
+	internalPlugin "github.com/datarobot/cli/internal/plugin"
+	"github.com/datarobot/cli/internal/telemetry"
+	internalVersion "github.com/datarobot/cli/internal/version"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+// ---------------------------------------------------------------------------
+// Dependencies
+// ---------------------------------------------------------------------------
+
+// ConfigInitializerFunc initializes viperx and reads the config file. It
+// receives the cobra command being executed so flag values are accessible.
+// Replace this in tests to skip disk I/O and prevent env-var bleed.
+type ConfigInitializerFunc func(cmd *cobra.Command, configFilePath string) error
+
+// TLSSetupFunc configures http.DefaultTransport based on TLS-related flags
+// and the persisted ca-cert config value. Replace in tests to be a no-op.
+type TLSSetupFunc func(cmd *cobra.Command) error
+
+// TelemetryPropsFunc collects the common telemetry properties for an
+// invocation. Replace in tests to return nil (disables telemetry).
+type TelemetryPropsFunc func() *telemetry.CommonProperties
+
+// TelemetryClientFunc builds a telemetry client from the collected properties.
+// Replace in tests to return a no-op client.
+type TelemetryClientFunc func(props *telemetry.CommonProperties) *telemetry.Client
+
+// AnimationFunc is called once during the first CLI invocation to display the
+// DataRobot logo animation. Replace in tests with a no-op.
+type AnimationFunc func()
+
+// PluginRegistrarFunc discovers and registers plugin subcommands on cmd.
+// Replace in tests with a no-op.
+type PluginRegistrarFunc func(cmd *cobra.Command)
+
+// Dependencies bundles every injectable collaborator for the root command.
+// The zero-value is not useful; use DefaultDependencies() or NewRootFactory()
+// to get a properly populated instance.
+type Dependencies struct {
+	// ConfigInitializer initializes viperx and reads drconfig.yaml.
+	ConfigInitializer ConfigInitializerFunc
+
+	// TLSSetup configures the default HTTP transport for TLS.
+	TLSSetup TLSSetupFunc
+
+	// TelemetryProps collects common Amplitude properties once per invocation.
+	TelemetryProps TelemetryPropsFunc
+
+	// TelemetryClient builds the Amplitude client from collected properties.
+	TelemetryClient TelemetryClientFunc
+
+	// Animation runs the first-run logo animation.
+	Animation AnimationFunc
+
+	// PluginRegistrar discovers and wires plugin subcommands.
+	PluginRegistrar PluginRegistrarFunc
+}
+
+// DefaultDependencies returns the production-ready set of dependencies
+// wired to the real implementations used by the CLI binary.
+func DefaultDependencies() Dependencies {
+	return Dependencies{
+		ConfigInitializer: defaultConfigInitializer,
+		TLSSetup:          setupTLS,
+		TelemetryProps:    telemetry.CollectCommonProperties,
+		TelemetryClient:   telemetry.NewClient,
+		Animation:         showFirstRunAnimation,
+		PluginRegistrar:   plugin.RegisterPluginCommands,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Option helpers
+// ---------------------------------------------------------------------------
+
+// Option is a functional option applied to a RootFactory.
+type Option func(*RootFactory)
+
+// WithConfigInitializer overrides the config-initialization step. Useful in
+// tests that need to skip disk reads or inject fixed viper state.
+func WithConfigInitializer(fn ConfigInitializerFunc) Option {
+	return func(f *RootFactory) {
+		f.deps.ConfigInitializer = fn
+	}
+}
+
+// WithTLSSetup overrides the TLS-setup step. Useful in tests that do not
+// have a valid TLS environment.
+func WithTLSSetup(fn TLSSetupFunc) Option {
+	return func(f *RootFactory) {
+		f.deps.TLSSetup = fn
+	}
+}
+
+// WithTelemetryProps overrides the telemetry-properties collector. Pass a
+// function that returns nil to disable all telemetry in a test.
+func WithTelemetryProps(fn TelemetryPropsFunc) Option {
+	return func(f *RootFactory) {
+		f.deps.TelemetryProps = fn
+	}
+}
+
+// WithTelemetryClient overrides the telemetry-client constructor. Useful in
+// tests that want to capture or suppress telemetry events.
+func WithTelemetryClient(fn TelemetryClientFunc) Option {
+	return func(f *RootFactory) {
+		f.deps.TelemetryClient = fn
+	}
+}
+
+// WithAnimation overrides the first-run animation hook. Pass a no-op in tests.
+func WithAnimation(fn AnimationFunc) Option {
+	return func(f *RootFactory) {
+		f.deps.Animation = fn
+	}
+}
+
+// WithPluginRegistrar overrides the plugin-discovery hook. Pass a no-op in tests.
+func WithPluginRegistrar(fn PluginRegistrarFunc) Option {
+	return func(f *RootFactory) {
+		f.deps.PluginRegistrar = fn
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RootFactory
+// ---------------------------------------------------------------------------
+
+// RootFactory assembles the root cobra command from a set of injectable
+// Dependencies. Each call to Build() produces a fresh, fully-wired
+// *cli.CommandAdder, so multiple builds (e.g. in parallel tests) are
+// independent of each other and of any package-level state.
+//
+// Use NewRootFactory(opts...) to construct one, or rely on the
+// package-level RootCmd variable for the production singleton.
+type RootFactory struct {
+	// deps holds the injectable collaborators for this factory.
+	deps Dependencies
+
+	// configFilePath is the per-build config file override, populated from
+	// the --config flag or DATAROBOT_CLI_CONFIG env var during Build().
+	configFilePath string
+
+	// telemetryClient holds the active client for the current process-level
+	// build. It is also stored in the cobra context, but we keep a reference
+	// here so Exit() can flush events when main's error path fires.
+	telemetryClient *telemetry.Client
+}
+
+// NewRootFactory creates a RootFactory with the given functional options
+// applied on top of DefaultDependencies(). This is the primary constructor
+// for both production (zero options) and tests (injected overrides).
+func NewRootFactory(opts ...Option) *RootFactory {
+	f := &RootFactory{
+		deps: DefaultDependencies(),
+	}
+
+	for _, o := range opts {
+		o(f)
+	}
+
+	return f
+}
+
+// TelemetryClient returns the telemetry client that was wired during the
+// most recent Build() call. cmd.Exit uses this to flush events on error
+// paths where only the signal context, not a cobra context, is available.
+func (f *RootFactory) TelemetryClient() *telemetry.Client {
+	return f.telemetryClient
+}
+
+// Build constructs and returns a fully-wired *cli.CommandAdder. The returned
+// command includes all registered sub-commands, persistent flags, help
+// overrides, plugin discovery, and unknown-arg guards. Each call is
+// self-contained: it does not mutate any package-level state.
+func (f *RootFactory) Build() *cli.CommandAdder {
+	// outputFormat is captured per-build (not package-level) so parallel
+	// builds in tests cannot race on a shared variable.
+	var outputFormat outputformat.OutputFormat
+
+	cmd := f.buildRootCommand(&outputFormat)
+	adder := &cli.CommandAdder{Command: cmd}
+
+	f.registerFlags(adder, &outputFormat)
+	f.bindViperFlags(adder)
+	f.addGroups(adder)
+	f.addSubcommands(adder)
+	f.deps.PluginRegistrar(adder.Command)
+
+	// Guard every pure-parent command against unrecognised positional args.
+	// Must run after all sub-commands (including plugins) are registered.
+	setUnknownArgGuards(adder.Command)
+
+	f.configureHelp(adder)
+
+	return adder
+}
+
+// buildRootCommand constructs the bare cobra.Command with its Use, Long, and
+// PersistentPreRunE / PersistentPostRunE hooks wired to the factory's deps.
+func (f *RootFactory) buildRootCommand(outputFormat *outputformat.OutputFormat) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     internalVersion.CliName,
+		Version: internalVersion.Version,
+		Short:   "Build AI Applications Faster",
+
+		// TraverseChildren causes cobra to parse persistent flags left-to-right
+		// before descending into each subcommand. This lets universal flags such
+		// as --debug be placed before a plugin name (e.g. "dr --debug myplugin")
+		// and still be consumed by core. Plugin commands set DisableFlagParsing:true
+		// so args appearing AFTER the plugin name are never seen by core —
+		// preserving the kubectl/helm "core stays blind to plugin args" model.
+		TraverseChildren: true,
+
+		Long: `
+The DataRobot CLI helps you quickly set up, configure, and deploy AI applications
+using pre-built templates. Get from idea to production in minutes, not hours.
+
+✨ ` + tui.BaseTextStyle.Render("What you can do:") + `
+  • Choose from ready-made AI application templates
+  • Set up your development environment quickly
+  • Deploy to DataRobot with a single command
+  • Manage environment variables and configurations
+
+🎯 ` + tui.BaseTextStyle.Render("Quick Start:") + `
+  dr start             # Create your first AI app (start here!)
+  dr self update       # Update DataRobot CLI to latest version
+  dr --help            # Show all available commands
+
+💡 ` + tui.BaseTextStyle.Render("New to AI development?") + ` Perfect! Run 'dr start' and we'll guide you through everything.`,
+
+		// PersistentPreRunE is called after flags are parsed but before the
+		// command runs. All global initialization (logging, config, TLS,
+		// telemetry) lives here so every sub-command inherits it automatically.
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return f.persistentPreRun(cmd, args)
+		},
+
+		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
+			return f.persistentPostRun(cmd)
+		},
+
+		// RootCmd needs its own RunE (to show help on a bare "dr" invocation,
+		// after the first-run animation), which disqualifies it from
+		// setUnknownArgGuards' generic walk (that skips any command with a
+		// pre-existing RunE). So it gets the same "unknown command" Args
+		// validator explicitly here.
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return nil
+			}
+
+			return fmt.Errorf("unknown command: %s", args[0])
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+
+	// Allow invoking commands in a case-insensitive manner.
+	cobra.EnableCaseInsensitive = true
+
+	// Disable Cobra's default completion command since we have our own under 'self'.
+	cmd.CompletionOptions.DisableDefaultCmd = true
+
+	// Set custom version template to match our unified format.
+	cmd.SetVersionTemplate(internalVersion.GetAppNameVersionText() + "\n\nTo update: dr self update\n")
+
+	// Only the prefix is styled; the message itself is often multi-line and is
+	// the part a user copies into a bug report.
+	cmd.SetErrPrefix(tui.ErrorStyle.Render("Error:"))
+
+	return cmd
+}
+
+// persistentPreRun runs all global initialization in the correct order:
+// logging, config, TLS, telemetry collection, and the first-run animation.
+func (f *RootFactory) persistentPreRun(cmd *cobra.Command, args []string) error {
+	log.Start()
+
+	// Suppress cobra's usage printout for runtime errors — only show it for
+	// flag-parsing failures, which happen before this hook runs.
+	cmd.SilenceUsage = true
+
+	// Read drconfig.yaml and bind env vars into viper.
+	if err := f.deps.ConfigInitializer(cmd, f.configFilePath); err != nil {
+		return err
+	}
+
+	// Configure the default HTTP transport (ca-cert, skip-verify).
+	if err := f.deps.TLSSetup(cmd); err != nil {
+		return err
+	}
+
+	// Collect common properties for telemetry (and optional debug logging).
+	// Always collect even in dry-run mode; transmission is gated inside Client.
+	props := f.deps.TelemetryProps()
+
+	if props != nil {
+		// Stamp command_kind so every event knows whether it came from a core
+		// command or a plugin.
+		if telemetry.IsPluginCommand(cmd) {
+			props.CommandKind = "plugin"
+		} else {
+			props.CommandKind = "core"
+		}
+
+		// Stamp the interaction mode (non-interactive flag) once per invocation
+		// so every event shares consistent metadata without per-command duplication.
+		telemetry.StampInteractionMode(props, cmd)
+	}
+
+	// Log the detected shell only when debug is active. Reuse Shell from
+	// telemetry props (already collected above) when available to avoid
+	// spawning a redundant ps(1) subprocess on macOS.
+	if log.GetLevel() <= log.DebugLevel {
+		var shell string
+
+		if props != nil {
+			shell = props.Shell
+		} else {
+			shell = telemetry.DetectShell()
+		}
+
+		log.Debug("Shell", "name", shell)
+	}
+
+	client := f.deps.TelemetryClient(props)
+
+	// Store as factory-level client so cmd.Exit can flush on the main error path.
+	f.telemetryClient = client
+
+	// Store telemetry client in context for use by sub-commands.
+	cmd.SetContext(context.WithValue(cmd.Context(), telemetry.ClientContextKey{}, client))
+
+	cobra.OnFinalize(func() {
+		if event, ok := telemetry.EventFor(cmd, args); ok {
+			client.Track(event)
+		}
+
+		client.Flush(3 * time.Second)
+
+		log.Stop()
+	})
+
+	config.SetAPIConsumerTrace(config.CommandPathToTrace(cmd.CommandPath()))
+
+	f.deps.Animation()
+
+	return nil
+}
+
+// persistentPostRun flushes telemetry and stops the logger after a command
+// completes successfully.
+func (f *RootFactory) persistentPostRun(cmd *cobra.Command) error {
+	if client, ok := cmd.Context().Value(telemetry.ClientContextKey{}).(*telemetry.Client); ok {
+		client.Flush(3 * time.Second)
+	}
+
+	log.Stop()
+
+	return nil
+}
+
+// registerFlags attaches all persistent flags to the command adder.
+func (f *RootFactory) registerFlags(adder *cli.CommandAdder, outputFormat *outputformat.OutputFormat) {
+	flags := adder.PersistentFlags()
+
+	flags.String("config", "",
+		"path to config file (default location: $HOME/.config/datarobot/drconfig.yaml)")
+	flags.BoolP("version", "V", false, "display the version")
+	flags.BoolP("verbose", "v", false, "verbose output")
+	flags.Bool("debug", false, "debug output")
+	flags.Bool("all-commands", false, "display all available commands and their flags in tree format")
+	flags.Bool(config.SkipAuthKey, false, "skip authentication checks (for advanced users)")
+	flags.Bool("force-interactive", false, "force setup wizards to run even if already completed")
+	flags.Duration("plugin-discovery-timeout", 2*time.Second, "timeout for plugin discovery (0s disables)")
+	flags.Duration("plugin-update-check-interval", internalPlugin.DefaultUpdateCheckInterval, "cooldown between plugin update checks (0s disables)")
+	flags.Bool("skip-plugin-update-check", false, "skip plugin update checks before running plugins")
+	flags.Bool("disable-telemetry", false, "disable usage telemetry")
+
+	// Private CA / TLS flags.
+	flags.BoolP("skip-certificate-check", "k", false, "skip TLS certificate verification (insecure)")
+	flags.String("ca-cert", "", "path to a PEM-encoded CA certificate bundle")
+	registerExportWindowsCertsFlag(adder.Command)
+
+	outputformat.AddPersistentFlag(adder.Command, outputFormat)
+}
+
+// bindViperFlags wires persistent flags to viper and annotates the universal
+// ones for forwarding to plugin subprocesses as DATAROBOT_CLI_* env vars.
+func (f *RootFactory) bindViperFlags(adder *cli.CommandAdder) {
+	// bindUniversal binds name to viper AND annotates it for plugin forwarding.
+	bindUniversalOn := func(name string) {
+		flag := adder.PersistentFlags().Lookup(name)
+		_ = viperx.BindPFlag(name, flag)
+
+		if flag.Annotations == nil {
+			flag.Annotations = map[string][]string{}
+		}
+
+		flag.Annotations[config.UniversalAnnotationKey] = []string{
+			strings.ToUpper(strings.ReplaceAll(name, "-", "_")),
+		}
+	}
+
+	// Universal flags: bound to viper AND forwarded to plugin subprocesses as
+	// DATAROBOT_CLI_* env vars. To add a new universal flag, call bindUniversalOn
+	// next to its registration in registerFlags.
+	bindUniversalOn("debug")
+	bindUniversalOn("disable-telemetry")
+	bindUniversalOn("verbose")
+	bindUniversalOn("skip-certificate-check")
+	bindUniversalOn("ca-cert")
+
+	// Non-universal flags: bound to viper only (not forwarded to plugins).
+	pflags := adder.PersistentFlags()
+
+	_ = viperx.BindPFlag("config", pflags.Lookup("config"))
+	_ = viperx.BindPFlag(config.SkipAuthKey, pflags.Lookup(config.SkipAuthKey))
+	_ = viperx.BindPFlag("force-interactive", pflags.Lookup("force-interactive"))
+	_ = viperx.BindPFlag("plugin-discovery-timeout", pflags.Lookup("plugin-discovery-timeout"))
+	_ = viperx.BindPFlag("plugin-update-check-interval", pflags.Lookup("plugin-update-check-interval"))
+	_ = viperx.BindPFlag("skip-plugin-update-check", pflags.Lookup("skip-plugin-update-check"))
+	_ = viperx.BindPFlag("output-format", pflags.Lookup("output-format"))
+}
+
+// addGroups registers the named command groups used by the help template.
+func (f *RootFactory) addGroups(adder *cli.CommandAdder) {
+	adder.AddGroup(
+		&cobra.Group{ID: "core", Title: tui.BaseTextStyle.Render("Core Commands:")},
+		&cobra.Group{ID: "self", Title: tui.BaseTextStyle.Render("Self Commands:")},
+		&cobra.Group{ID: "advanced", Title: tui.BaseTextStyle.Render("Advanced Commands:")},
+	)
+}
+
+// addSubcommands registers all first-party sub-commands on the adder.
+// Commands whose feature gates are disabled are silently dropped by
+// cli.CommandAdder.AddCommand.
+func (f *RootFactory) addSubcommands(adder *cli.CommandAdder) {
+	adder.AddCommand(
+		artifact.Cmd(),
+		auth.Cmd(),
+		component.Cmd(),
+		dependencies.Cmd(),
+		dotenv.Cmd(),
+		llmgateway.Cmd(),
+		run.Cmd(),
+		self.Cmd(),
+		start.Cmd(),
+		task.Cmd(),
+		templates.Cmd(),
+		workload.Cmd(),
+		plugin.Cmd(),
+		pipeline.Cmd(),
+	)
+}
+
+// configureHelp installs custom usage/help templates and the --all-commands /
+// --version help-func overrides on the adder's root command.
+func (f *RootFactory) configureHelp(adder *cli.CommandAdder) {
+	adder.SetUsageTemplate(CustomUsageTemplate)
+
+	defaultHelpFunc := adder.HelpFunc()
+
+	adder.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		showAllCommands, _ := cmd.Flags().GetBool("all-commands")
+		showVersion, _ := cmd.Flags().GetBool("version")
+
+		switch {
+		case showAllCommands:
+			output := allCommandsOutput(cmd.Root())
+			_, _ = fmt.Fprint(cmd.OutOrStdout(), output)
+
+		case showVersion:
+			runVersionCommand(cmd)
+
+		default:
+			adder.SetHelpTemplate(CustomHelpTemplate)
+			defaultHelpFunc(cmd, args)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// defaultConfigInitializer — production implementation of ConfigInitializerFunc
+// ---------------------------------------------------------------------------
+
+// defaultConfigInitializer is the production ConfigInitializerFunc. It sets up
+// viper's env-var prefix, binds standard overrides, and reads drconfig.yaml from
+// disk. Tests can replace this with a no-op to skip disk I/O and isolate env state.
+func defaultConfigInitializer(cmd *cobra.Command, configFilePath string) error {
+	// Map any environment variables prefixed with DATAROBOT_CLI_ to config keys.
+	viperx.SetEnvPrefix("DATAROBOT_CLI")
+	viperx.AutomaticEnv()
+	viperx.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
+	// Map VISUAL and EDITOR to external-editor, with a safe default.
+	viperx.SetDefault("external-editor", "vi")
+
+	_ = viperx.BindEnv("external-editor", "VISUAL", "EDITOR")
+
+	// API consumer tracking is enabled by default; operators can opt out with
+	// DATAROBOT_API_CONSUMER_TRACKING_ENABLED=false (matches the Python SDK).
+	viperx.SetDefault(config.APIConsumerTrackingEnabled, true)
+	_ = viperx.BindEnv(config.APIConsumerTrackingEnabled, "DATAROBOT_API_CONSUMER_TRACKING_ENABLED")
+
+	// Resolve the config file path: flag > env var > default.
+	resolved := configFilePath
+	if resolved == "" {
+		if envPath := viperx.GetString("config"); envPath != "" {
+			resolved = envPath
+		}
+	}
+
+	if err := config.ReadConfigFile(resolved); err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers delegated to from configureHelp
+// ---------------------------------------------------------------------------
+
+// allCommandsOutput renders the full command tree and is the implementation
+// delegated to when --all-commands is set. Exists as a named helper so the
+// import of allcommands can live in root.go (the production side) while the
+// factory stays import-light. Overridden in root.go via allCommandsOutputFn.
+var allCommandsOutputFn func(root *cobra.Command) string
+
+// allCommandsOutput calls the registered output function (set by root.go).
+func allCommandsOutput(root *cobra.Command) string {
+	if allCommandsOutputFn != nil {
+		return allCommandsOutputFn(root)
+	}
+
+	return ""
+}
+
+// runVersionCommandFn is the implementation delegated to when --version is set
+// in a help context. Set by root.go so the factory avoids importing cmd/self/version.
+var runVersionCommandFn func(cmd *cobra.Command)
+
+// runVersionCommand calls the registered version runner.
+func runVersionCommand(cmd *cobra.Command) {
+	if runVersionCommandFn != nil {
+		runVersionCommandFn(cmd)
+	}
+}

--- a/cmd/root_helpers.go
+++ b/cmd/root_helpers.go
@@ -1,0 +1,90 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/state"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+// showFirstRunAnimation displays the animated DataRobot logo inline (no
+// alt-screen) on the very first CLI invocation, so the final settled frame
+// remains in normal terminal scrollback and whatever runs next continues
+// directly below it instead of hard-cutting from a full-screen takeover.
+//
+// It checks global state to avoid showing the animation more than once, only
+// runs in interactive terminals, and is skipped entirely under automation
+// (e.g. tools like expect that attach a real pty and would otherwise see
+// animation frames mixed into output they are pattern-matching).
+func showFirstRunAnimation() {
+	if reader.IsNonInteractive() {
+		return
+	}
+
+	if !state.IsFirstRun() {
+		return
+	}
+
+	// Only show the animation when stdout is a terminal (not piped or redirected).
+	fi, err := os.Stdout.Stat()
+	if err != nil || (fi.Mode()&os.ModeCharDevice) == 0 {
+		return
+	}
+
+	m := tui.NewLogoAnimationModel()
+
+	_, _ = tui.Run(m)
+
+	state.MarkAnimationShown()
+}
+
+// setUnknownArgGuards walks the command tree and installs a RunE + Args
+// validator on every pure-parent command (has subcommands, no Run/RunE, no
+// explicit Args set).
+//
+// Cobra checks !Runnable() before ValidateArgs, so a non-runnable parent
+// silently shows help for any arg. Making the command runnable lets Args fire
+// first and return a clear error; the RunE fallback shows help when no args
+// are given.
+func setUnknownArgGuards(root *cobra.Command) {
+	for _, cmd := range root.Commands() {
+		setUnknownArgGuards(cmd)
+	}
+
+	if !root.HasSubCommands() {
+		return
+	}
+
+	if root.Args != nil || root.RunE != nil || root.Run != nil {
+		return
+	}
+
+	root.Args = func(_ *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return nil
+		}
+
+		return fmt.Errorf("unknown command: %s", args[0])
+	}
+
+	root.RunE = func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	}
+}

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -27,7 +27,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/dependencies"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/repo"
@@ -132,7 +132,7 @@ func NewStartModel(opts Options) Model {
 		repoRoot: repoRoot,
 		telemetry: telemetryCapture{
 			yesFlag:        opts.AnswerYes,
-			nonInteractive: viperx.GetBool("yes"),
+			nonInteractive: cli.IsNonInteractive(nil),
 		},
 	}
 }
@@ -346,7 +346,7 @@ func (m Model) handleDepsMissing(msg depsMissingMsg) (tea.Model, tea.Cmd) {
 	m.telemetry.missingMsgs = msg.checkResult.MissingMsgs
 	m.telemetry.wrongVersionMsgs = msg.checkResult.WrongVersionMsgs
 
-	autoInstall := m.opts.AnswerYes || viperx.GetBool("yes")
+	autoInstall := m.opts.AnswerYes || cli.IsNonInteractive(nil)
 
 	log.Debug("start: handling missing deps", "count", len(msg.prerequisites), "auto_install", autoInstall)
 
@@ -636,7 +636,7 @@ func findAndExecuteStart(m *Model) tea.Msg {
 		// Found a quickstart script
 		// Don't wait for confirmation if '--yes' flag is set or
 		// DATAROBOT_CLI_NON_INTERACTIVE env var is true
-		waitForConfirmation := !m.opts.AnswerYes && !viperx.GetBool("yes")
+		waitForConfirmation := !m.opts.AnswerYes && !cli.IsNonInteractive(nil)
 
 		return stepCompleteMsg{
 			message:              fmt.Sprintf("Found quickstart script at: %s\n", quickstartScript),

--- a/cmd/workload/config/cmd.go
+++ b/cmd/workload/config/cmd.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -117,11 +118,13 @@ Examples:
 
 	// Only the env var binds to viper; --yes is read from cobra so it never
 	// persists into drconfig.yaml.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWith(cmd, func(cmd *cobra.Command, _ []string) map[string]any {
+		nonInteractive := cli.IsNonInteractive(cmd)
+
 		return map[string]any{
-			"yes":           f.yes || viperx.GetBool("yes"),
+			"yes":           nonInteractive,
 			"type":          f.answers.Type,
 			"build_mode":    f.answers.BuildMode,
 			"bound":         f.answers.WorkloadID != "",
@@ -140,7 +143,7 @@ func addFlags(cmd *cobra.Command, f *flags) {
 	// only guessing is what the project directory can be read for, so the
 	// help text has to say that rather than leave "defaults" to be read as
 	// the other command's meaning.
-	cmd.Flags().BoolVarP(&f.yes, "yes", "y", false,
+	cmd.Flags().BoolVarP(&f.yes, cli.YesFlagName, "y", false,
 		"Do not prompt; answer every question from flags and what the project directory shows. "+
 			"A question neither of those answers is an error naming the flag that would settle it.")
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "Print the manifest and write nothing.")
@@ -188,7 +191,7 @@ func run(cmd *cobra.Command, f flags, format outputformat.OutputFormat) error {
 
 	// JSON output implies non-interactive: a wizard on stderr alongside a
 	// machine-readable stdout is a trap for whoever is parsing it.
-	yes := f.yes || viperx.GetBool("yes")
+	yes := cli.IsNonInteractive(cmd)
 
 	result, err := wizard.Run(wizard.Options{
 		Dir:            dir,

--- a/cmd/workload/del/cmd.go
+++ b/cmd/workload/del/cmd.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/helpers"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/misc/reader"
@@ -68,19 +69,17 @@ Example:
 		},
 	}
 
-	cmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt.")
+	cmd.Flags().BoolP(cli.YesFlagName, "y", false, "Skip the confirmation prompt.")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
 	// flag itself is read directly from cmd.Flags() so an explicit --yes does
 	// not leak into viper.AllSettings() and persist to drconfig.yaml.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(cmd *cobra.Command, args []string) map[string]any {
-		yesFlag, _ := cmd.Flags().GetBool("yes")
-
 		return map[string]any{
 			"workload_id": telemetry.FirstArg(args),
-			"yes":         yesFlag || viperx.GetBool("yes"),
+			"yes":         cli.IsNonInteractive(cmd),
 		}
 	})
 
@@ -92,8 +91,7 @@ Example:
 // interactively. A declined prompt is (false, nil) so the command exits 0
 // as a no-op.
 func confirmDelete(cmd *cobra.Command, workloadID string) (bool, error) {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	if yesFlag || viperx.GetBool("yes") {
+	if cli.IsNonInteractive(cmd) {
 		return true, nil
 	}
 

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/internal/pollflags"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/outputformat"
@@ -154,11 +155,13 @@ Examples:
 	outputformat.AddFlag(cmd, &outputFormat)
 	addFlags(cmd, &f, &poll)
 
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWith(cmd, func(cmd *cobra.Command, _ []string) map[string]any {
+		nonInteractive := cli.IsNonInteractive(cmd)
+
 		return map[string]any{
-			"yes":           f.yes || viperx.GetBool("yes"),
+			"yes":           nonInteractive,
 			"dry_run":       f.dryRun,
 			"detach":        f.detach,
 			"lock":          f.lock,
@@ -172,7 +175,7 @@ Examples:
 
 func addFlags(cmd *cobra.Command, f *flags, poll *pollflags.Set) {
 	cmd.Flags().StringVar(&f.dir, "dir", "", "Project directory; the manifest is searched upward from here.")
-	cmd.Flags().BoolVarP(&f.yes, "yes", "y", false,
+	cmd.Flags().BoolVarP(&f.yes, cli.YesFlagName, "y", false,
 		"Do not prompt. With no manifest this is an error rather than a wizard, "+
 			"and rolling a locked production version is not confirmed.")
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "Print the plan and change nothing.")
@@ -210,7 +213,7 @@ func run(cmd *cobra.Command, f flags, poll pollflags.Set, format outputformat.Ou
 
 	json := format == outputformat.OutputFormatJSON
 
-	yes := f.yes || viperx.GetBool("yes")
+	yes := cli.IsNonInteractive(cmd)
 
 	// JSON output implies non-interactive: a wizard drawn on stderr while
 	// stdout is being parsed is a trap for whoever is parsing it.

--- a/docs/development/flags.md
+++ b/docs/development/flags.md
@@ -350,14 +350,15 @@ Outside `internal/config/...`, all viper interaction goes through the
 Quick rules for new flags:
 
 - **Transient flags** (per-invocation): read directly via
-  `cmd.Flags().GetBool(...)`. Do not bind to viper.
+  `cmd.Flags().GetBool(...)` (for example `cli.YesFlagName`). Do not bind to viper.
 - **Env-var override needed?** Register only the env var with
-  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and OR the two sources in your
-  handler:
+  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and merge the sources with the shared
+  helper:
 
   ```go
-  yesFlag, _ := cmd.Flags().GetBool("yes")
-  yes := yesFlag || viperx.GetBool("yes")
+  _ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
+
+  nonInteractive := cli.IsNonInteractive(cmd)
   ```
 
 - **Sticky CLI preferences** (rare): bind via `viperx.BindPFlag` *and*

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -243,6 +243,8 @@ PersistentPreRunE (root.go)
     ├─ Initialize CommonProperties (session ID, user ID, env, ...)
     ├─ Stamp props.CommandKind = "core" or "plugin"
     │   based on telemetry.IsPluginCommand(cmd)
+    ├─ Stamp props.NonInteractive via telemetry.StampInteractionMode
+    │   so every event shares the same automation signal
     ├─ Build telemetry.Client
     └─ Register cobra.OnFinalize (closes over cmd, args, client)
     ↓
@@ -252,6 +254,23 @@ cobra.OnFinalize (via cobra's deferred postRun, fires on success and error paths
     ├─ telemetry.EventFor(cmd, args) → if tracked, client.Track(event)
     ├─ Flush telemetry (3-second timeout)
     └─ log.Stop()
+
+### Stamping universal interaction flags
+
+`telemetry.StampInteractionMode` centralizes everything that decides whether the
+current invocation is interactive. The helper runs exactly once in
+`root.PersistentPreRunE`, so every event in the session inherits the same
+`non_interactive` property without each command needing to parse flags on its own.
+
+- `DATAROBOT_CLI_NON_INTERACTIVE=true` forces `non_interactive=true`
+- Any parsed `--yes` flag (including short `-y`) flips the flag for that session
+- `--force-interactive` overrides both so wizards still render during automation
+- Commands can reuse the same logic directly via `cli.IsNonInteractive(cmd)`
+
+To expose another universal flag or environment override, extend
+`telemetry.StampInteractionMode` (and update its tests) rather than touching
+individual commands. **TODO:** when the next global automation flag is added,
+document its behavior here and wire it through the helper alongside `--yes`.
 ```
 
 ### Reading RunE results in a PropExtractor

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -1,0 +1,20 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+// YesFlagName is the canonical name used for non-interactive confirmation flags.
+// Commands that accept "--yes"/"-y" should derive their flag registration from
+// this constant so shared helpers (telemetry, env bindings, etc.) can consume it.
+const YesFlagName = "yes"

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -1,0 +1,47 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/spf13/cobra"
+)
+
+// IsNonInteractive reports whether the current command invocation should skip prompts.
+// It merges the non-interactive environment variable, any explicit --yes flag, and the
+// global --force-interactive override into a single truthy signal for automation.
+func IsNonInteractive(cmd *cobra.Command) bool {
+	if viperx.GetBool("force-interactive") {
+		return false
+	}
+
+	if reader.IsNonInteractive() {
+		return true
+	}
+
+	if cmd == nil {
+		return viperx.GetBool(YesFlagName)
+	}
+
+	flag := cmd.Flags().Lookup(YesFlagName)
+	if flag != nil {
+		if yes, err := cmd.Flags().GetBool(YesFlagName); err == nil && yes {
+			return true
+		}
+	}
+
+	return viperx.GetBool(YesFlagName)
+}

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNonInteractiveEnv(t *testing.T) {
+	t.Cleanup(viperx.Reset)
+	t.Setenv(reader.NonInteractiveEnv, "1")
+
+	assert.True(t, IsNonInteractive(nil))
+}
+
+func TestIsNonInteractiveFlag(t *testing.T) {
+	t.Cleanup(viperx.Reset)
+	t.Setenv(reader.NonInteractiveEnv, "")
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().BoolP(YesFlagName, "y", false, "skip prompts")
+	require.NoError(t, cmd.ParseFlags([]string{"--" + YesFlagName}))
+
+	assert.True(t, IsNonInteractive(cmd))
+}
+
+func TestIsNonInteractiveForceInteractiveOverrides(t *testing.T) {
+	t.Cleanup(viperx.Reset)
+	t.Setenv(reader.NonInteractiveEnv, "true")
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool(YesFlagName, false, "skip prompts")
+	require.NoError(t, cmd.ParseFlags([]string{"--" + YesFlagName}))
+
+	viperx.Set("force-interactive", true)
+
+	assert.False(t, IsNonInteractive(cmd))
+}

--- a/internal/telemetry/interaction.go
+++ b/internal/telemetry/interaction.go
@@ -12,74 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package telemetry provides Amplitude-based usage analytics for the DataRobot CLI.
-// This file handles detection and stamping of the interaction mode (interactive vs
-// non-interactive) so every event carries consistent metadata.
 package telemetry
 
 import (
-	"github.com/datarobot/cli/internal/config/viperx"
-	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/spf13/cobra"
 )
 
-// yesFlagName is the canonical name of the per-command flag that opts the
-// caller into skipping interactive prompts.
-const yesFlagName = "yes"
-
-// StampInteractionMode annotates props with whether the current invocation is
-// running in non-interactive mode. This is called once in the root command's
-// PersistentPreRunE so every downstream event shares the same metadata without
-// per-command duplication.
+// StampInteractionMode annotates props with whether the current invocation is running
+// in non-interactive mode. This happens once in root PersistentPreRunE so every event
+// shares the same interaction metadata without per-command duplication.
+//
+// TODO: fold additional universal automation flags (e.g. future --non-interactive variants)
+//
+//	into this helper instead of re-implementing the logic in individual commands.
 func StampInteractionMode(props *CommonProperties, cmd *cobra.Command) {
 	if props == nil {
 		return
 	}
 
-	props.NonInteractive = computeNonInteractive(cmd)
-}
-
-// computeNonInteractive evaluates the global sources that flip the CLI into
-// non-interactive behaviour: the force-interactive viper override, the
-// DATAROBOT_CLI_NON_INTERACTIVE env var, and any per-command --yes flag.
-func computeNonInteractive(cmd *cobra.Command) bool {
-	// force-interactive takes precedence even when automation flags are present,
-	// because the caller explicitly asked to surface wizards.
-	if viperx.GetBool("force-interactive") {
-		return false
-	}
-
-	// DATAROBOT_CLI_NON_INTERACTIVE=true is the canonical signal for automation.
-	if reader.IsNonInteractive() {
-		return true
-	}
-
-	// --yes is the per-command opt-in to skip prompts.
-	if hasYesFlag(cmd) {
-		return true
-	}
-
-	return false
-}
-
-// hasYesFlag reports whether cmd (or its inherited flag set) was invoked with
-// --yes. Returns false when cmd is nil, the flag is absent, or the flag is not
-// a bool.
-func hasYesFlag(cmd *cobra.Command) bool {
-	if cmd == nil {
-		return false
-	}
-
-	yesFlag := cmd.Flags().Lookup(yesFlagName)
-	if yesFlag == nil {
-		return false
-	}
-
-	yesValue, err := cmd.Flags().GetBool(yesFlagName)
-	if err != nil {
-		// A missing or non-bool flag should behave as "not set".
-		return false
-	}
-
-	return yesValue
+	props.NonInteractive = cli.IsNonInteractive(cmd)
 }

--- a/internal/telemetry/interaction.go
+++ b/internal/telemetry/interaction.go
@@ -1,0 +1,85 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package telemetry provides Amplitude-based usage analytics for the DataRobot CLI.
+// This file handles detection and stamping of the interaction mode (interactive vs
+// non-interactive) so every event carries consistent metadata.
+package telemetry
+
+import (
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/spf13/cobra"
+)
+
+// yesFlagName is the canonical name of the per-command flag that opts the
+// caller into skipping interactive prompts.
+const yesFlagName = "yes"
+
+// StampInteractionMode annotates props with whether the current invocation is
+// running in non-interactive mode. This is called once in the root command's
+// PersistentPreRunE so every downstream event shares the same metadata without
+// per-command duplication.
+func StampInteractionMode(props *CommonProperties, cmd *cobra.Command) {
+	if props == nil {
+		return
+	}
+
+	props.NonInteractive = computeNonInteractive(cmd)
+}
+
+// computeNonInteractive evaluates the global sources that flip the CLI into
+// non-interactive behaviour: the force-interactive viper override, the
+// DATAROBOT_CLI_NON_INTERACTIVE env var, and any per-command --yes flag.
+func computeNonInteractive(cmd *cobra.Command) bool {
+	// force-interactive takes precedence even when automation flags are present,
+	// because the caller explicitly asked to surface wizards.
+	if viperx.GetBool("force-interactive") {
+		return false
+	}
+
+	// DATAROBOT_CLI_NON_INTERACTIVE=true is the canonical signal for automation.
+	if reader.IsNonInteractive() {
+		return true
+	}
+
+	// --yes is the per-command opt-in to skip prompts.
+	if hasYesFlag(cmd) {
+		return true
+	}
+
+	return false
+}
+
+// hasYesFlag reports whether cmd (or its inherited flag set) was invoked with
+// --yes. Returns false when cmd is nil, the flag is absent, or the flag is not
+// a bool.
+func hasYesFlag(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+
+	yesFlag := cmd.Flags().Lookup(yesFlagName)
+	if yesFlag == nil {
+		return false
+	}
+
+	yesValue, err := cmd.Flags().GetBool(yesFlagName)
+	if err != nil {
+		// A missing or non-bool flag should behave as "not set".
+		return false
+	}
+
+	return yesValue
+}

--- a/internal/telemetry/interaction_test.go
+++ b/internal/telemetry/interaction_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStampInteractionMode_NonInteractiveEnv(t *testing.T) {
+	t.Setenv(reader.NonInteractiveEnv, "1")
+
+	props := &CommonProperties{}
+
+	StampInteractionMode(props, nil)
+
+	// The environment variable alone should flip the telemetry flag.
+	assert.True(t, props.NonInteractive)
+}
+
+func TestStampInteractionMode_YesFlag(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().BoolP("yes", "y", false, "skip prompts")
+
+	require.NoError(t, cmd.ParseFlags([]string{"--yes"}))
+
+	props := &CommonProperties{}
+
+	StampInteractionMode(props, cmd)
+
+	// Any explicit --yes invocation is tracked as non-interactive.
+	assert.True(t, props.NonInteractive)
+}
+
+func TestStampInteractionMode_ForceInteractiveOverrides(t *testing.T) {
+	defer viperx.Reset()
+
+	// Simulate both automation signals; force-interactive should still win.
+	t.Setenv(reader.NonInteractiveEnv, "true")
+	viperx.Set("force-interactive", true)
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool("yes", false, "skip prompts")
+	require.NoError(t, cmd.ParseFlags([]string{"--yes"}))
+
+	props := &CommonProperties{NonInteractive: true}
+
+	StampInteractionMode(props, cmd)
+
+	assert.False(t, props.NonInteractive)
+}

--- a/internal/telemetry/interaction_test.go
+++ b/internal/telemetry/interaction_test.go
@@ -17,6 +17,7 @@ package telemetry
 import (
 	"testing"
 
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/spf13/cobra"
@@ -26,6 +27,7 @@ import (
 
 func TestStampInteractionMode_NonInteractiveEnv(t *testing.T) {
 	t.Setenv(reader.NonInteractiveEnv, "1")
+	t.Cleanup(viperx.Reset)
 
 	props := &CommonProperties{}
 
@@ -37,7 +39,9 @@ func TestStampInteractionMode_NonInteractiveEnv(t *testing.T) {
 
 func TestStampInteractionMode_YesFlag(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
-	cmd.Flags().BoolP("yes", "y", false, "skip prompts")
+	cmd.Flags().BoolP(cli.YesFlagName, "y", false, "skip prompts")
+	t.Setenv(reader.NonInteractiveEnv, "")
+	t.Cleanup(viperx.Reset)
 
 	require.NoError(t, cmd.ParseFlags([]string{"--yes"}))
 
@@ -50,14 +54,14 @@ func TestStampInteractionMode_YesFlag(t *testing.T) {
 }
 
 func TestStampInteractionMode_ForceInteractiveOverrides(t *testing.T) {
-	defer viperx.Reset()
+	t.Cleanup(viperx.Reset)
 
 	// Simulate both automation signals; force-interactive should still win.
 	t.Setenv(reader.NonInteractiveEnv, "true")
 	viperx.Set("force-interactive", true)
 
 	cmd := &cobra.Command{Use: "test"}
-	cmd.Flags().Bool("yes", false, "skip prompts")
+	cmd.Flags().Bool(cli.YesFlagName, false, "skip prompts")
 	require.NoError(t, cmd.ParseFlags([]string{"--yes"}))
 
 	props := &CommonProperties{NonInteractive: true}

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/internal/shell"
 	"github.com/datarobot/cli/internal/state"
@@ -85,7 +86,10 @@ func CollectCommonProperties() *CommonProperties {
 		OSVersion:     detectOSVersion(),
 		Language:      detectLanguage(),
 		GoVersion:     runtime.Version(),
-		Shell:         DetectShell(),
+		// Seed the interaction mode with the environment variable so automation workflows
+		// are marked even if the command itself lacks a --yes flag.
+		NonInteractive: reader.IsNonInteractive(),
+		Shell:          DetectShell(),
 	}
 
 	// Get DataRobot instance info from config

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -52,6 +52,7 @@ type CommonProperties struct {
 	Shell             string  // Name of the user's shell (e.g. "zsh", "bash", "powershell")
 	DataRobotInstance string  // Base URL of configured DataRobot instance
 	CommandKind       string  // "core" or "plugin", set by the root command after dispatch
+	NonInteractive    bool    // True when the invocation runs in non-interactive mode (env var, --yes flag, or automation)
 	OrganizationID    *string // DataRobot org ID from GET /api/v2/account/info/, cached to disk; nil on network failure or auth issues
 	TenantID          *string // DataRobot tenant ID from GET /api/v2/account/info/, cached to disk; nil if unavailable (legit absent for legacy/system accounts)
 	TemplateName      *string // Name of the DataRobot template used to create this project; nil when not inside a template project
@@ -134,6 +135,8 @@ func (p *CommonProperties) AsMap() map[string]any {
 		"shell":              p.Shell,
 		"datarobot_instance": p.DataRobotInstance,
 		"command_kind":       p.CommandKind,
+		// non_interactive tells analytics when commands ran without human input.
+		"non_interactive": p.NonInteractive,
 	}
 
 	if p.OrganizationID != nil {

--- a/internal/telemetry/properties_test.go
+++ b/internal/telemetry/properties_test.go
@@ -65,6 +65,7 @@ func TestCommonPropertiesAsMap(t *testing.T) {
 		Shell:             "zsh",
 		DataRobotInstance: "https://app.datarobot.com",
 		CommandKind:       "core",
+		NonInteractive:    true,
 		OrganizationID:    ptrString("parakeet"),
 		TenantID:          ptrString("parakeet-jones"),
 	}
@@ -75,6 +76,7 @@ func TestCommonPropertiesAsMap(t *testing.T) {
 	assert.Equal(t, "zsh", m["shell"])
 	assert.Equal(t, "https://app.datarobot.com", m["datarobot_instance"])
 	assert.Equal(t, "core", m["command_kind"])
+	assert.Equal(t, true, m["non_interactive"])
 	assert.Equal(t, "parakeet", m["organization_id"])
 	assert.Equal(t, "parakeet-jones", m["tenant_id"])
 	// Verify CWD is not included
@@ -285,6 +287,11 @@ func TestCommonPropertiesAsMap_DefaultCommandKindIsEmpty(t *testing.T) {
 	// collected properties default to an empty string.
 	assert.Empty(t, m["command_kind"])
 	assert.Contains(t, m, "command_kind")
+
+	// NonInteractive defaults to false until root stamps the actual interaction mode.
+	nonInteractive, ok := m["non_interactive"].(bool)
+	require.True(t, ok, "non_interactive property must always be present")
+	assert.False(t, nonInteractive)
 }
 
 func TestCollectCommonProperties_GeneratesSessionID(t *testing.T) {


### PR DESCRIPTION
## RATIONALE

As Carson noted, the CLI's root command setup uses package-level globals and `init()` side effects inherited from a basic cobra template. This creates two concrete problems:

1. **Env-var leakage in tests** — viperx state set by one test bleeds into the next because the production `RootCmd` singleton (built at `init()` time) reads live env vars on every Execute call.
2. **Inconsistent telemetry context** — properties like `command_kind` and `non_interactive` have to be stamped ad-hoc inside `PersistentPreRunE` against a shared global, making it easy to miss them in new commands or test scenarios.

GitHub CLI (`pkg/cmdutil.Factory`) and kubectl (`pkg/cmd/util.Factory`) both solve this by assembling the root command via an injectable factory whose dependencies can be swapped in tests. This PR brings the same pattern to the DataRobot CLI.

This PR also absorbs the `non_interactive` telemetry work that was in PR #797 (now merged here) — centralizing prompt-skip detection and Amplitude metadata in one place so individual commands never re-implement the `--yes || viperx` pattern themselves.

This PR **does not** fix env-var leakage in existing tests that use `RootCmd()` directly — that's #800.

## CHANGES

### New: `cmd/root_factory.go`

- Defines `RootFactory`, a `Dependencies` struct, and six `With*` functional option helpers (`WithConfigInitializer`, `WithTLSSetup`, `WithTelemetryProps`, `WithTelemetryClient`, `WithAnimation`, `WithPluginRegistrar`).
- `Build()` returns a fresh, fully-wired `*cli.CommandAdder` per call — no shared mutable state between calls.
- All wiring that was in `init()` (flag registration, viper binding, group/subcommand registration, help overrides, plugin discovery, unknown-arg guards) now runs per-build inside factory methods.

### New: `cmd/root_helpers.go`

Extracts `showFirstRunAnimation` and `setUnknownArgGuards` from the old `root.go` into a focused helper file so the factory can call them without import cycles.

### Refactored: `cmd/root.go`

Reduced to ~90 lines. Its only jobs now are:

1. Register import-cycle-breaking function values (`allCommandsOutputFn`, `runVersionCommandFn`).
2. Build the production singleton via `NewRootFactory()`.
3. Expose the backward-compatible `RootCmd` package-level var so existing tests need no changes.

### Updated: `cmd/exit.go`

Reads the telemetry client from `productionFactory.TelemetryClient()` at flush time rather than a bare package-level pointer.

### New: `internal/cli/flags.go`

Defines `YesFlagName = "yes"` as the single canonical constant for `--yes`/`-y` flag registration so shared helpers can consume it without magic strings.

### New: `internal/cli/runtime.go` + `runtime_test.go`

`IsNonInteractive(cmd)` centralizes the three-source check — `force-interactive` viper key, `DATAROBOT_CLI_NON_INTERACTIVE` env var, `--yes` flag — so individual commands call one function instead of inlining the two-line OR pattern. Three unit tests cover all paths.

### New: `internal/telemetry/interaction.go` + `interaction_test.go`

`StampInteractionMode` is called once in the factory's `persistentPreRun`. It now delegates to `cli.IsNonInteractive` — no local `yesFlagName`/`hasYesFlag` helpers needed. Three unit tests: env-var path, `--yes` flag path, `force-interactive` override.

### Updated: `internal/telemetry/properties.go` + `properties_test.go`

- Adds `NonInteractive bool` to `CommonProperties`, seeded from `reader.IsNonInteractive()` at collection time.
- Adds `"non_interactive"` to `AsMap()` so it appears on every Amplitude event.

### Command migrations (from #797)

All replace the two-line `yesFlag, _ := cmd.Flags().GetBool("yes"); yes := yesFlag || viperx.GetBool("yes")` pattern with `cli.IsNonInteractive(cmd)`:

- `cmd/artifact/code/checkout`, `codesync`, `init`
- `cmd/artifact/del`
- `cmd/dependencies/install` (+ test)
- `cmd/dotenv`
- `cmd/plugin/install`
- `cmd/start`
- `cmd/workload/config`, `del`, `up`

### Docs

`AGENTS.md`, `docs/development/flags.md`, `docs/development/telemetry.md` describe `IsNonInteractive` and `YesFlagName` as the canonical patterns going forward.

## TESTING

- `go build ./...` — clean
- `go test -race ./cmd/... ./internal/cli/... ./internal/telemetry/...` — all green
- `task lint` — 0 issues across linux, darwin, and windows
- All pre-commit hooks pass

## RELATED

- #800 — test isolation follow-up (migrates `root_test.go` to use `NewRootFactory` with stubbed deps)

## FOLLOW-UP

- TODO: Extend `telemetry.StampInteractionMode` (and its tests/docs) whenever new automation-focused flags or env overrides are introduced

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787169315.318989 -->
<!-- rr:slack:end -->