### PR TITLE
test(cmd): migrate root_test.go to isolated RootFactory builds

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/tools"
@@ -25,6 +26,44 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// ---------------------------------------------------------------------------
+// Test isolation helper
+// ---------------------------------------------------------------------------
+
+// newIsolatedRootCmd returns a fresh *cli.CommandAdder built by a new
+// RootFactory with all side-effecting dependencies replaced by safe no-ops.
+// Each call returns an independent command tree so that:
+//   - viperx global state set by one test cannot bleed into the next
+//   - http.DefaultTransport is not mutated by TLS setup
+//   - Plugin discovery (filesystem + network) is skipped
+//   - The first-run animation is suppressed
+//
+// Use this helper for any test that calls Execute() on the root command.
+// Tests that only inspect the static command tree (flags, subcommands,
+// annotations) may continue to reference the package-level RootCmd singleton.
+func newIsolatedRootCmd() *cli.CommandAdder {
+	return NewRootFactory(
+		// Skip viperx initialization and drconfig.yaml reads so env vars set
+		// by one test cannot bleed into the next via shared viper state.
+		WithConfigInitializer(func(_ *cobra.Command, _ string) error { return nil }),
+		// Skip http.DefaultTransport mutation to avoid TLS state leaking across tests.
+		WithTLSSetup(func(_ *cobra.Command) error { return nil }),
+		// Return a minimal props struct instead of hitting the network or disk
+		// for device/user IDs, account info, etc.
+		WithTelemetryProps(func() *telemetry.CommonProperties {
+			return &telemetry.CommonProperties{}
+		}),
+		// Skip plugin discovery (filesystem walk + subprocess invocations).
+		WithPluginRegistrar(func(_ *cobra.Command) {}),
+		// Suppress the first-run animation; there is no TTY in test processes.
+		WithAnimation(func() {}),
+	).Build()
+}
+
+// ---------------------------------------------------------------------------
+// Tests that execute commands (use newIsolatedRootCmd for isolation)
+// ---------------------------------------------------------------------------
 
 func TestCaseInsensitiveCommands(t *testing.T) {
 	tests := []struct {
@@ -61,18 +100,15 @@ func TestCaseInsensitiveCommands(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a new root command for each test to ensure isolation
-			cmd := RootCmd
+			// Build a fresh, isolated command tree for each subtest so that
+			// PersistentPreRunE side effects (viperx, TLS) don't bleed.
+			cmd := newIsolatedRootCmd()
 
-			// Capture output
 			buf := new(bytes.Buffer)
 			cmd.SetOut(buf)
 			cmd.SetErr(buf)
-
-			// Set the args
 			cmd.SetArgs(tt.args)
 
-			// Execute the command
 			err := cmd.Execute()
 
 			if tt.shouldError {
@@ -95,14 +131,10 @@ func TestVersionFlag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// pflag does not reset flag values between Parse calls, so the
-			// version flag stays true after this test. Reset it so subsequent
-			// tests that execute the root command aren't affected.
-			t.Cleanup(func() {
-				_ = RootCmd.PersistentFlags().Set("version", "false")
-			})
+			// Fresh command tree per subtest: pflag flag values do not carry
+			// over between builds, so no manual cleanup of the version flag is needed.
+			cmd := newIsolatedRootCmd()
 
-			cmd := RootCmd
 			buf := new(bytes.Buffer)
 			cmd.SetOut(buf)
 			cmd.SetErr(buf)
@@ -129,17 +161,19 @@ func TestTelemetryPropExtractor_OnSuccessPath(t *testing.T) {
 		{Name: "echo-tool", Command: "echo 1.0.0", MinimumVersion: "1.0.0"},
 	}
 
-	cmd := RootCmd
-	cmd.SetArgs([]string{"dependency", "check"})
+	root := newIsolatedRootCmd()
+	root.SetArgs([]string{"dependency", "check"})
 
 	var outBuf bytes.Buffer
 
-	cmd.SetOut(&outBuf)
+	root.SetOut(&outBuf)
 
-	err := cmd.Execute()
+	err := root.Execute()
 	require.NoError(t, err)
 
-	checkCmd := findCommandByPath(RootCmd.Command, "dr dependency check")
+	// Locate the executed command in this build's command tree (not the
+	// production singleton) so annotations are read from the same instance.
+	checkCmd := findCommandByPath(root.Command, "dr dependency check")
 	require.NotNil(t, checkCmd)
 
 	event, ok := telemetry.EventFor(checkCmd, []string{})
@@ -161,16 +195,17 @@ func TestTelemetryPropExtractor_OnErrorPath(t *testing.T) {
 		{Name: "FakeTool", Command: "nonexistent_dr_fake_xyz", URL: "https://example.com"},
 	}
 
-	cmd := RootCmd
-	cmd.SetArgs([]string{"dependency", "check"})
+	root := newIsolatedRootCmd()
+	root.SetArgs([]string{"dependency", "check"})
 
 	var errBuf bytes.Buffer
 
-	cmd.SetErr(&errBuf)
+	root.SetErr(&errBuf)
 
-	_ = cmd.Execute() // returns error: missing dep
+	_ = root.Execute() // returns error: missing dep
 
-	checkCmd := findCommandByPath(RootCmd.Command, "dr dependency check")
+	// Find the command in this build's tree so annotations are authoritative.
+	checkCmd := findCommandByPath(root.Command, "dr dependency check")
 	require.NotNil(t, checkCmd)
 
 	event, ok := telemetry.EventFor(checkCmd, []string{})
@@ -215,7 +250,7 @@ func TestUnknownArgGuard(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := RootCmd
+			cmd := newIsolatedRootCmd()
 
 			var buf bytes.Buffer
 
@@ -234,6 +269,10 @@ func TestUnknownArgGuard(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// setUnknownArgGuards unit tests (pure cobra.Command, no RootCmd dependency)
+// ---------------------------------------------------------------------------
 
 func TestSetUnknownArgGuards_AppliesGuardToPureParent(t *testing.T) {
 	child := &cobra.Command{
@@ -277,7 +316,7 @@ func TestSetUnknownArgGuards_SkipsCommandWithRunE(t *testing.T) {
 // command (pure parent, no RunE) rejects an unrecognised first arg with the
 // expected "unknown command" message.
 //
-// Uses a fresh, isolated command tree rather than the global RootCmd to avoid
+// Uses a bare cobra.Command tree rather than the global RootCmd to avoid
 // state pollution from cobra's package-level finalizers slice, which accumulates
 // across Execute calls in other tests and can cause RootCmd to appear non-runnable
 // by the time this assertion runs in the full test suite.
@@ -320,14 +359,17 @@ func TestSetUnknownArgGuards_SkipsExplicitArgs(t *testing.T) {
 	assert.NotContains(t, err.Error(), "unknown command:", "explicit Args validator should not be overridden")
 }
 
-func TestWorkloadCommandNotPresentByDefault(t *testing.T) {
-	// Verify that workload command is not present by default (feature not enabled).
-	// The feature gating happens during init(), so this tests the actual state.
-	cmd := RootCmd
+// ---------------------------------------------------------------------------
+// Structural tests against the production singleton (read-only, no Execute)
+// ---------------------------------------------------------------------------
 
+// TestWorkloadCommandNotPresentByDefault verifies that workload is absent from
+// the default command tree. The feature gate is evaluated during init() so we
+// inspect the production singleton; no execution is required.
+func TestWorkloadCommandNotPresentByDefault(t *testing.T) {
 	var found bool
 
-	for _, subCmd := range cmd.Commands() {
+	for _, subCmd := range RootCmd.Commands() {
 		if subCmd.Name() == "workload" {
 			found = true
 			break
@@ -337,15 +379,14 @@ func TestWorkloadCommandNotPresentByDefault(t *testing.T) {
 	assert.False(t, found, "workload command should not be present when feature gate is not enabled")
 }
 
+// TestArtifactCommandNotPresentByDefault verifies that artifact is absent from
+// the default command tree. The artifact command shares the "workload" feature
+// gate, so it is filtered out by cli.CommandAdder during init() when the gate
+// is not enabled (the default).
 func TestArtifactCommandNotPresentByDefault(t *testing.T) {
-	// The artifact command shares the "workload" feature gate, so it is
-	// filtered out by cli.CommandAdder during init() when the gate is not
-	// enabled (the default).
-	cmd := RootCmd
-
 	var found bool
 
-	for _, subCmd := range cmd.Commands() {
+	for _, subCmd := range RootCmd.Commands() {
 		if subCmd.Name() == "artifact" {
 			found = true
 			break
@@ -355,10 +396,9 @@ func TestArtifactCommandNotPresentByDefault(t *testing.T) {
 	assert.False(t, found, "artifact command should not be present when feature gate is not enabled")
 }
 
-// TestPrivateCATLSFlagsAlwaysRegistered verifies that the private-ca
-// TLS flags are always registered on RootCmd (no longer feature-gated).
-// Flag registration happens during init(), so this tests the actual
-// registered state.
+// TestPrivateCATLSFlagsAlwaysRegistered verifies that the private-CA TLS flags
+// are always registered on RootCmd (no longer feature-gated). Flag registration
+// happens during init(); no execution is required.
 func TestPrivateCATLSFlagsAlwaysRegistered(t *testing.T) {
 	for _, name := range []string{"skip-certificate-check", "ca-cert"} {
 		assert.NotNil(t, RootCmd.PersistentFlags().Lookup(name),
@@ -376,12 +416,14 @@ func TestRootCmdTraverseChildrenEnabled(t *testing.T) {
 			"placed before a plugin name are consumed by core and not forwarded as raw args")
 }
 
-// TestUniversalFlagsParsedOnCoreSubcommand verifies that a universal flag such as
-// --debug is parsed correctly when it appears after a core subcommand and that
-// subcommand's own flags (e.g. "dr <cmd> --set-url http://x --debug").
-// This guards the TraverseChildren behaviour for core commands: unlike plugins,
-// core subcommands have no DisableFlagParsing so cobra continues to parse flags
-// after the command name, including persistent flags from root.
+// TestUniversalFlagsParsedOnCoreSubcommand verifies that a universal flag such
+// as --debug is parsed correctly when it appears after a core subcommand and
+// that subcommand's own flags (e.g. "dr <cmd> --set-url http://x --debug").
+// This guards the TraverseChildren behaviour for core commands.
+//
+// A fresh isolated command tree is used so the sentinel command does not
+// permanently mutate the production RootCmd and the --debug flag state is
+// automatically discarded after the test.
 func TestUniversalFlagsParsedOnCoreSubcommand(t *testing.T) {
 	var parsedDebug bool
 
@@ -398,22 +440,24 @@ func TestUniversalFlagsParsedOnCoreSubcommand(t *testing.T) {
 	}
 	sentinel.Flags().String("set-url", "", "test flag")
 
-	RootCmd.AddCommand(sentinel)
+	// Build a fresh isolated tree and add the sentinel to it. No cleanup of
+	// the command tree or the debug flag is needed — the tree is discarded when
+	// this test returns.
+	root := newIsolatedRootCmd()
+	root.AddCommand(sentinel)
 
-	defer func() {
-		RootCmd.RemoveCommand(sentinel)
-		// Reset the debug persistent flag so it does not bleed into other tests.
-		_ = RootCmd.PersistentFlags().Set("debug", "false")
-	}()
+	root.SetArgs([]string{"sentinel-universal-flags-test", "--set-url", "http://example.com", "--debug"})
 
-	RootCmd.SetArgs([]string{"sentinel-universal-flags-test", "--set-url", "http://example.com", "--debug"})
-
-	err := RootCmd.Execute()
+	err := root.Execute()
 	require.NoError(t, err)
 
 	assert.True(t, parsedDebug,
 		"--debug must be parsed by core when it appears after a core subcommand and its own flags")
 }
+
+// ---------------------------------------------------------------------------
+// showFirstRunAnimation isolation test
+// ---------------------------------------------------------------------------
 
 // TestShowFirstRunAnimationSkipsWhenNonInteractive guards against tools like
 // `expect` (used by the smoke test suite) attaching a real pty to dr's


### PR DESCRIPTION
## RATIONALE

Stacks on #799. That PR introduced `NewRootFactory` but left all existing tests
pointing at the production `RootCmd` singleton, which still shared viperx global
state across Execute calls. This PR makes the fix that the factory was built for.

## CHANGES

### `cmd/root_test.go`

**New helper: `newIsolatedRootCmd()`**

Calls `NewRootFactory` with five no-op overrides and returns a fresh
`*cli.CommandAdder`. Each call is independent — no shared mutable state.

| Injected override | What it prevents |
|---|---|
| `WithConfigInitializer` (no-op) | `viperx.SetEnvPrefix` / `AutomaticEnv` / config file reads — the primary source of env-var bleed between tests |
| `WithTLSSetup` (no-op) | Mutation of `http.DefaultTransport` across test cases |
| `WithTelemetryProps` (zero value) | Disk/network I/O for device IDs, user IDs, account info |
| `WithPluginRegistrar` (no-op) | Filesystem walk + subprocess invocations during test process |
| `WithAnimation` (no-op) | TTY animation that would hang in a headless test process |

**Migrated to `newIsolatedRootCmd()`:**
- `TestCaseInsensitiveCommands` — each subtest now builds its own tree
- `TestVersionFlag` — no more manual `t.Cleanup` to reset the version pflag
- `TestTelemetryPropExtractor_OnSuccessPath` / `OnErrorPath` — event lookup now uses the correct command instance from the isolated build
- `TestUnknownArgGuard` — each subtest gets a clean tree
- `TestUniversalFlagsParsedOnCoreSubcommand` — sentinel added to isolated tree; manual `RootCmd.RemoveCommand` + `--debug` reset in `t.Cleanup` removed

**Unchanged (structural read-only assertions):**
- `TestWorkloadCommandNotPresentByDefault`
- `TestArtifactCommandNotPresentByDefault`
- `TestPrivateCATLSFlagsAlwaysRegistered`
- `TestRootCmdTraverseChildrenEnabled`
- `TestTelemetryWiring_AllCoreCommandsTracked`
- All `setUnknownArgGuards` unit tests (already use bare `cobra.Command`)
- `TestShowFirstRunAnimationSkipsWhenNonInteractive` (calls function directly)

## TESTING

- `go test -race ./cmd/...` — all green
- `task lint` — 0 issues across linux, darwin, windows
- All pre-commit hooks pass
