### PR TITLE
feat(cmd): introduce RootFactory pattern for isolated command assembly

### DIFF
--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -24,14 +24,15 @@ import (
 // an error, so that Amplitude events are delivered even though
 // PersistentPostRunE is bypassed on the error path.
 //
-// telemetryClient is set in PersistentPreRunE (root.go); it will be nil only
-// if the process exits before any command runs (e.g. flag parse failure), in
-// which case there are no queued events to flush anyway.
+// The telemetry client is retrieved from productionFactory (set in
+// PersistentPreRunE) at flush time. It will be nil only if the process exits
+// before any command runs (e.g. a flag-parse failure), in which case there
+// are no queued events to flush.
 func Exit(code int) {
-	if telemetryClient != nil {
-		telemetryClient.Flush(3 * time.Second)
+	if c := productionFactory.TelemetryClient(); c != nil {
+		c.Flush(3 * time.Second)
 	}
 
-	// This is the only place in the codebase that should call os.Exit
+	// This is the only place in the codebase that should call os.Exit.
 	os.Exit(code) //nolint:forbidigo
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,437 +12,79 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package cmd is the top-level cobra command package for the DataRobot CLI.
+//
+// Production entry-point: main.go calls ExecuteContext, which delegates to the
+// package-level productionFactory singleton built by init(). Sub-commands and
+// tests can call NewRootFactory (with functional options to override
+// dependencies) to obtain a fully-isolated command tree without touching any
+// package-level state.
 package cmd
 
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
-	"time"
 
 	"github.com/datarobot/cli/cmd/allcommands"
-	"github.com/datarobot/cli/cmd/artifact"
-	"github.com/datarobot/cli/cmd/auth"
-	"github.com/datarobot/cli/cmd/component"
-	"github.com/datarobot/cli/cmd/dependencies"
-	"github.com/datarobot/cli/cmd/dotenv"
-	llmgateway "github.com/datarobot/cli/cmd/llm-gateway"
-	"github.com/datarobot/cli/cmd/pipeline"
-	"github.com/datarobot/cli/cmd/plugin"
-	"github.com/datarobot/cli/cmd/self"
 	selfversion "github.com/datarobot/cli/cmd/self/version"
-	"github.com/datarobot/cli/cmd/start"
-	"github.com/datarobot/cli/cmd/task"
-	"github.com/datarobot/cli/cmd/task/run"
-	"github.com/datarobot/cli/cmd/templates"
-	"github.com/datarobot/cli/cmd/workload"
 	"github.com/datarobot/cli/internal/cli"
-	"github.com/datarobot/cli/internal/config"
-	"github.com/datarobot/cli/internal/config/viperx"
-	"github.com/datarobot/cli/internal/log"
-	"github.com/datarobot/cli/internal/misc/reader"
-	"github.com/datarobot/cli/internal/outputformat"
-	internalPlugin "github.com/datarobot/cli/internal/plugin"
-	"github.com/datarobot/cli/internal/state"
-	"github.com/datarobot/cli/internal/telemetry"
-	internalVersion "github.com/datarobot/cli/internal/version"
-	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
 
-var (
-	configFilePath   string
-	rootOutputFormat outputformat.OutputFormat
-)
+// productionFactory is the singleton RootFactory used by the running binary.
+// It is initialised in init() so that tests importing this package still get
+// a fully-wired command tree through the RootCmd convenience variable.
+var productionFactory *RootFactory
 
-// telemetryClient holds the active client for the current process. It is set
-// in PersistentPreRunE so that cmd.Exit can flush events when main's error
-// path fires (where only the signal context, not the cobra context, is available).
-var telemetryClient *telemetry.Client
+// RootCmd is the built root command from the production factory. It exists as
+// a package-level variable so existing tests and callers that reference
+// cmd.RootCmd continue to work without modification.
+//
+// For test isolation, prefer creating a dedicated factory with NewRootFactory
+// and calling Build() on it rather than sharing this singleton.
+var RootCmd *cli.CommandAdder
 
-// RootCmd represents the base command when called without any subcommands.
-// It uses CommandAdder to intelligently filter child commands based on feature gates.
-var RootCmd = &cli.CommandAdder{
-	Command: &cobra.Command{
-		Use:     internalVersion.CliName,
-		Version: internalVersion.Version,
-		Short:   "Build AI Applications Faster",
-		// TraverseChildren causes cobra to parse persistent flags left-to-right
-		// before descending into each subcommand. This lets universal flags such
-		// as --debug be placed before a plugin name (e.g. "dr --debug myplugin")
-		// and still be consumed by core. Plugin commands set DisableFlagParsing:true
-		// so args appearing AFTER the plugin name are never seen by core —
-		// preserving the kubectl/helm "core stays blind to plugin args" model.
-		TraverseChildren: true,
-		Long: `
-The DataRobot CLI helps you quickly set up, configure, and deploy AI applications
-using pre-built templates. Get from idea to production in minutes, not hours.
+// init wires up the package-level variables and registers the allcommands /
+// version helper functions that the factory's help override needs.
+//
+// These helpers cannot live inside root_factory.go itself because they import
+// packages that would create an import cycle (allcommands imports cmd
+// sub-packages; selfversion imports internal packages that indirectly
+// reference cmd). Registering function values here breaks the cycle while
+// keeping the factory import-light.
+func init() {
+	allCommandsOutputFn = func(root *cobra.Command) string {
+		return allcommands.GenerateCommandTree(root)
+	}
 
-✨ ` + tui.BaseTextStyle.Render("What you can do:") + `
-  • Choose from ready-made AI application templates
-  • Set up your development environment quickly
-  • Deploy to DataRobot with a single command
-  • Manage environment variables and configurations
+	runVersionCommandFn = func(cmd *cobra.Command) {
+		versionCmd := selfversion.Cmd()
 
-🎯 ` + tui.BaseTextStyle.Render("Quick Start:") + `
-  dr start             # Create your first AI app (start here!)
-  dr self update       # Update DataRobot CLI to latest version
-  dr --help            # Show all available commands
+		// Suppress cobra's automatic error/usage output to prevent double-printing.
+		versionCmd.SilenceErrors = true
+		versionCmd.SilenceUsage = true
+		versionCmd.SetArgs([]string{"--output-format", "text"})
+		versionCmd.SetOut(cmd.OutOrStdout())
+		versionCmd.SetErr(cmd.ErrOrStderr())
 
-💡 ` + tui.BaseTextStyle.Render("New to AI development?") + ` Perfect! Run 'dr start' and we'll guide you through everything.`,
-		// Show help by default when no subcommands match
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// PersistentPreRunE is a hook called after flags are parsed
-			// but before the command is run. Any logic that needs to happen
-			// before ANY command execution should go here.
-			log.Start()
+		if err := versionCmd.Execute(); err != nil {
+			fmt.Fprintln(cmd.ErrOrStderr(), err)
+		} else {
+			// Only print the update hint on success.
+			fmt.Fprintln(cmd.OutOrStdout(), "\nTo update: dr self update")
+		}
+	}
 
-			cmd.SilenceUsage = true // don’t spam usage for runtime errors
-
-			err := initializeConfig(cmd)
-			if err != nil {
-				return err
-			}
-
-			if err := setupTLS(cmd); err != nil {
-				return err
-			}
-
-			// Initialize telemetry client
-			// Always collect common properties for logging (even in dry-run mode),
-			// but only send to Amplitude if enabled.
-			props := telemetry.CollectCommonProperties()
-
-			// Stamp the command_kind common property based on whether
-			// the dispatched command was registered via TrackPlugin.
-			// CommonProperties is held by pointer inside Client, so this
-			// late-bound update is visible at Track time.
-			if props != nil {
-				if telemetry.IsPluginCommand(cmd) {
-					props.CommandKind = "plugin"
-				} else {
-					props.CommandKind = "core"
-				}
-			}
-			// Log the detected shell only when debug is active. Reuse Shell from
-			// telemetry props (already collected above) when available to avoid
-			// spawning a redundant ps(1) subprocess on macOS.
-			if log.GetLevel() <= log.DebugLevel {
-				var shell string
-
-				if props != nil {
-					shell = props.Shell
-				} else {
-					shell = telemetry.DetectShell()
-				}
-
-				log.Debug("Shell", "name", shell)
-			}
-
-			client := telemetry.NewClient(props)
-
-			// Store as process-level client so cmd.Exit can flush on the main error path.
-			telemetryClient = client
-
-			// Store telemetry client in context for use by commands
-			cmd.SetContext(context.WithValue(cmd.Context(), telemetry.ClientContextKey{}, client))
-
-			cobra.OnFinalize(func() {
-				if event, ok := telemetry.EventFor(cmd, args); ok {
-					client.Track(event)
-				}
-
-				client.Flush(3 * time.Second)
-
-				log.Stop()
-			})
-
-			config.SetAPIConsumerTrace(config.CommandPathToTrace(cmd.CommandPath()))
-
-			showFirstRunAnimation()
-
-			return nil
-		},
-		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
-			// Flush telemetry events before exit
-			if client, ok := cmd.Context().Value(telemetry.ClientContextKey{}).(*telemetry.Client); ok {
-				client.Flush(3 * time.Second)
-			}
-
-			log.Stop()
-
-			return nil
-		},
-		// RootCmd needs its own RunE (to show help on a bare "dr" invocation, after
-		// the first-run animation), which disqualifies it from setUnknownArgGuards'
-		// generic walk (that skips any command with a pre-existing RunE). So it gets
-		// the same "unknown command" Args validator explicitly here.
-		Args: func(_ *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return nil
-			}
-
-			return fmt.Errorf("unknown command: %s", args[0])
-		},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	},
+	productionFactory = NewRootFactory()
+	RootCmd = productionFactory.Build()
 }
 
 // ExecuteContext executes the root command with the given context.
-// It adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
+// This is called by main.main(). It only needs to happen once per process.
 func ExecuteContext(ctx context.Context) error {
 	if err := RootCmd.ExecuteContext(ctx); err != nil {
 		return fmt.Errorf("execute root command: %w", err)
 	}
 
 	return nil
-}
-
-// bindUniversal binds name to viper and annotates the flag for forwarding to
-// plugin subprocesses as DATAROBOT_CLI_<NAME>. The suffix is derived from the
-// flag name (uppercased, hyphens → underscores). This is the single
-// registration point — adding a new universal flag only requires one call here.
-func bindUniversal(name string) {
-	flag := RootCmd.PersistentFlags().Lookup(name)
-	_ = viperx.BindPFlag(name, flag)
-
-	if flag.Annotations == nil {
-		flag.Annotations = map[string][]string{}
-	}
-
-	flag.Annotations[config.UniversalAnnotationKey] = []string{strings.ToUpper(strings.ReplaceAll(name, "-", "_"))}
-}
-
-func init() {
-	// Allow invoking commands in a case-insensitive manner
-	cobra.EnableCaseInsensitive = true
-
-	// Disable Cobra's default completion command since we have our own under 'self'
-	RootCmd.CompletionOptions.DisableDefaultCmd = true
-
-	// Set custom version template to match our unified format
-	RootCmd.SetVersionTemplate(internalVersion.GetAppNameVersionText() + "\n\nTo update: dr self update\n")
-
-	// Configure persistent flags
-	RootCmd.PersistentFlags().StringVar(&configFilePath, "config", "",
-		"path to config file (default location: $HOME/.config/datarobot/drconfig.yaml)")
-	RootCmd.PersistentFlags().BoolP("version", "V", false, "display the version")
-	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
-	RootCmd.PersistentFlags().Bool("debug", false, "debug output")
-	RootCmd.PersistentFlags().Bool("all-commands", false, "display all available commands and their flags in tree format")
-	RootCmd.PersistentFlags().Bool(config.SkipAuthKey, false, "skip authentication checks (for advanced users)")
-	RootCmd.PersistentFlags().Bool("force-interactive", false, "force setup wizards to run even if already completed")
-	RootCmd.PersistentFlags().Duration("plugin-discovery-timeout", 2*time.Second, "timeout for plugin discovery (0s disables)")
-	RootCmd.PersistentFlags().Duration("plugin-update-check-interval", internalPlugin.DefaultUpdateCheckInterval, "cooldown between plugin update checks (0s disables)")
-	RootCmd.PersistentFlags().Bool("skip-plugin-update-check", false, "skip plugin update checks before running plugins")
-	RootCmd.PersistentFlags().Bool("disable-telemetry", false, "disable usage telemetry")
-
-	// Private CA / TLS flags
-	RootCmd.PersistentFlags().BoolP("skip-certificate-check", "k", false, "skip TLS certificate verification (insecure)")
-	RootCmd.PersistentFlags().String("ca-cert", "", "path to a PEM-encoded CA certificate bundle")
-	registerExportWindowsCertsFlag(RootCmd.Command)
-
-	outputformat.AddPersistentFlag(RootCmd.Command, &rootOutputFormat)
-
-	// Universal flags: bound to viper AND forwarded to plugin subprocesses as DATAROBOT_CLI_* env vars.
-	// To add a new universal flag, call bindUniversal here next to its registration above.
-	bindUniversal("debug")
-	bindUniversal("disable-telemetry")
-	bindUniversal("verbose")
-	bindUniversal("skip-certificate-check")
-	bindUniversal("ca-cert")
-
-	// Non-universal flags: bound to viper only.
-	_ = viperx.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config"))
-	_ = viperx.BindPFlag(config.SkipAuthKey, RootCmd.PersistentFlags().Lookup(config.SkipAuthKey))
-	_ = viperx.BindPFlag("force-interactive", RootCmd.PersistentFlags().Lookup("force-interactive"))
-	_ = viperx.BindPFlag("plugin-discovery-timeout", RootCmd.PersistentFlags().Lookup("plugin-discovery-timeout"))
-	_ = viperx.BindPFlag("plugin-update-check-interval", RootCmd.PersistentFlags().Lookup("plugin-update-check-interval"))
-	_ = viperx.BindPFlag("skip-plugin-update-check", RootCmd.PersistentFlags().Lookup("skip-plugin-update-check"))
-	_ = viperx.BindPFlag("output-format", RootCmd.PersistentFlags().Lookup("output-format"))
-
-	// Add command groups (plugin group added conditionally by registerPluginCommands)
-	RootCmd.AddGroup(
-		&cobra.Group{ID: "core", Title: tui.BaseTextStyle.Render("Core Commands:")},
-		&cobra.Group{ID: "self", Title: tui.BaseTextStyle.Render("Self Commands:")},
-		&cobra.Group{ID: "advanced", Title: tui.BaseTextStyle.Render("Advanced Commands:")},
-	)
-
-	// Add commands here to ensure that they are available to users.
-	// Be sure to set the command's GroupID field appropriately;
-	// otherwise the command will be added under 'Additional Commands'.
-	// Commands with disabled feature gates are automatically filtered by cli.CommandAdder.
-	RootCmd.AddCommand(
-		artifact.Cmd(),
-		auth.Cmd(),
-		component.Cmd(),
-		dependencies.Cmd(),
-		dotenv.Cmd(),
-		llmgateway.Cmd(),
-		run.Cmd(),
-		self.Cmd(),
-		start.Cmd(),
-		task.Cmd(),
-		templates.Cmd(),
-		workload.Cmd(),
-		plugin.Cmd(),
-		pipeline.Cmd(),
-	)
-
-	// Discover and register plugin commands
-	plugin.RegisterPluginCommands(RootCmd.Command)
-
-	// Guard parent commands against unrecognised positional args.
-	// Must run after all commands (including plugins) are registered.
-	setUnknownArgGuards(RootCmd.Command)
-
-	// Override the default help command to add --all-commands flag
-	defaultHelpFunc := RootCmd.HelpFunc()
-
-	RootCmd.SetUsageTemplate(CustomUsageTemplate)
-
-	// Set on the root, so every subcommand's failure reads as one. Only the
-	// prefix is styled: the message itself is often multi-line and is the part
-	// a user copies into a bug report.
-	RootCmd.SetErrPrefix(tui.ErrorStyle.Render("Error:"))
-
-	RootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		showAllCommands, _ := cmd.Flags().GetBool("all-commands")
-		showVersion, _ := cmd.Flags().GetBool("version")
-
-		if showAllCommands {
-			output := allcommands.GenerateCommandTree(cmd.Root())
-
-			_, _ = fmt.Fprint(cmd.OutOrStdout(), output)
-		} else if showVersion {
-			// Route through self version with explicit --output-format text
-			versionCmd := selfversion.Cmd()
-			// Suppress automatic error/usage output from cobra to prevent double-printing.
-			// Error handling is done explicitly below.
-			versionCmd.SilenceErrors = true
-			versionCmd.SilenceUsage = true
-			versionCmd.SetArgs([]string{"--output-format", "text"})
-			versionCmd.SetOut(cmd.OutOrStdout())
-			versionCmd.SetErr(cmd.ErrOrStderr())
-
-			if err := versionCmd.Execute(); err != nil {
-				fmt.Fprintln(cmd.ErrOrStderr(), err)
-			} else {
-				// Only print the update hint on success
-				fmt.Fprintln(cmd.OutOrStdout(), "\nTo update: dr self update")
-			}
-		} else {
-			// Use default help behavior but with customized template
-			RootCmd.SetHelpTemplate(CustomHelpTemplate)
-			defaultHelpFunc(cmd, args)
-		}
-	})
-}
-
-// setUnknownArgGuards walks the command tree and installs a RunE + Args validator
-// on every pure-parent command (has subcommands, no Run/RunE, no explicit Args set).
-//
-// Cobra checks !Runnable() before ValidateArgs, so a non-runnable parent silently
-// shows help for any arg. Making the command runnable lets Args fire first and
-// return a clear error; the RunE fallback shows help when no args are given.
-func setUnknownArgGuards(root *cobra.Command) {
-	for _, cmd := range root.Commands() {
-		setUnknownArgGuards(cmd)
-	}
-
-	if !root.HasSubCommands() {
-		return
-	}
-
-	if root.Args != nil || root.RunE != nil || root.Run != nil {
-		return
-	}
-
-	root.Args = func(_ *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return nil
-		}
-
-		return fmt.Errorf("unknown command: %s", args[0])
-	}
-
-	root.RunE = func(cmd *cobra.Command, _ []string) error {
-		return cmd.Help()
-	}
-}
-
-// initializeConfig initializes the configuration by reading from
-// various sources such as environment variables and config files.
-func initializeConfig(_ *cobra.Command) error {
-	var err error
-
-	// Set up Viper to process environment variables
-	// First automatically map any environment variables
-	// that are prefixed with DATAROBOT_CLI_ to config keys
-	viperx.SetEnvPrefix("DATAROBOT_CLI")
-	viperx.AutomaticEnv()
-	viperx.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
-
-	// map VISUAL and EDITOR to external-editor config key,
-	// but set a default value
-	viperx.SetDefault("external-editor", "vi")
-
-	_ = viperx.BindEnv("external-editor", "VISUAL", "EDITOR")
-
-	// API consumer tracking is enabled by default.
-	// Set DATAROBOT_API_CONSUMER_TRACKING_ENABLED=false to opt out,
-	// matching the Python SDK convention.
-	viperx.SetDefault(config.APIConsumerTrackingEnabled, true)
-
-	_ = viperx.BindEnv(config.APIConsumerTrackingEnabled, "DATAROBOT_API_CONSUMER_TRACKING_ENABLED")
-
-	// If DATAROBOT_CLI_CONFIG is set and no explicit --config flag was provided,
-	// use the environment variable value
-	if configFilePath == "" {
-		if envConfigPath := viperx.GetString("config"); envConfigPath != "" {
-			configFilePath = envConfigPath
-		}
-	}
-
-	// Now read the config file
-	err = config.ReadConfigFile(configFilePath)
-	if err != nil {
-		return fmt.Errorf("Failed to read config file: %w", err)
-	}
-
-	return nil
-}
-
-// showFirstRunAnimation displays the animated DataRobot logo inline (no alt-screen)
-// on the very first CLI invocation, so the final settled frame remains in normal
-// terminal scrollback and whatever runs next (help text, or dr start's own inline
-// wizard) continues directly below it instead of hard-cutting from a full-screen
-// takeover. It checks global state to avoid showing it more than once, only runs
-// in interactive terminals, and is skipped entirely under automation (e.g. tools
-// like expect that attach a real pty and would otherwise see animation frames
-// mixed into output they're pattern-matching).
-func showFirstRunAnimation() {
-	if reader.IsNonInteractive() {
-		return
-	}
-
-	if !state.IsFirstRun() {
-		return
-	}
-
-	// Only show animation when stdout is a terminal (not piped or redirected)
-	fi, err := os.Stdout.Stat()
-	if err != nil || (fi.Mode()&os.ModeCharDevice) == 0 {
-		return
-	}
-
-	m := tui.NewLogoAnimationModel()
-
-	_, _ = tui.Run(m)
-
-	state.MarkAnimationShown()
 }

--- a/cmd/root_factory.go
+++ b/cmd/root_factory.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/datarobot/cli/cmd/artifact"
@@ -179,6 +180,13 @@ func WithPluginRegistrar(fn PluginRegistrarFunc) Option {
 // ---------------------------------------------------------------------------
 // RootFactory
 // ---------------------------------------------------------------------------
+
+// finalizerGen is a process-global Execute counter shared by ALL factories.
+// It must be package-level (not per-factory) because cobra's finalizer list
+// is process-global: finalizers registered by one factory's tree are replayed
+// when another factory's tree executes, so the guard can only work if every
+// factory compares against the same counter. See persistentPreRun.
+var finalizerGen atomic.Int64
 
 // RootFactory assembles the root cobra command from a set of injectable
 // Dependencies. Each call to Build() produces a fresh, fully-wired
@@ -381,7 +389,21 @@ func (f *RootFactory) persistentPreRun(cmd *cobra.Command, args []string) error 
 	// Store telemetry client in context for use by sub-commands.
 	cmd.SetContext(context.WithValue(cmd.Context(), telemetry.ClientContextKey{}, client))
 
+	// cobra.OnFinalize appends to a process-global, append-only list that is
+	// replayed in full after EVERY Execute in the process — of any tree,
+	// built by any factory. Without a guard, execute N would re-track the
+	// events of executes 1..N-1 on their old (captured) clients — harmless
+	// in production (one Execute per process) but a source of phantom
+	// duplicate events in tests. The process-global generation counter
+	// ensures only the finalizer registered by the most recent Execute acts;
+	// stale finalizers from earlier executes no-op.
+	gen := finalizerGen.Add(1)
+
 	cobra.OnFinalize(func() {
+		if gen != finalizerGen.Load() {
+			return
+		}
+
 		if event, ok := telemetry.EventFor(cmd, args); ok {
 			client.Track(event)
 		}

--- a/cmd/root_factory.go
+++ b/cmd/root_factory.go
@@ -12,6 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// root_factory.go defines RootFactory — the injectable constructor for the root
+// cobra command. Call NewRootFactory (with optional With* overrides) to obtain
+// a fully-wired *cli.CommandAdder whose dependencies can be swapped for test
+// doubles. Production code relies on the singleton built in root.go's init().
+//
+// Extending the factory:
+//   - To add a new command: register it in addSubcommands.
+//   - To add a new injectable behaviour: define a *Func type, add a field to
+//     Dependencies, add a With* option, wire it in the appropriate method, and
+//     set a production default in DefaultDependencies.
+//   - See docs/development/root-factory.md for worked examples.
 package cmd
 
 import (

--- a/cmd/root_factory.go
+++ b/cmd/root_factory.go
@@ -62,9 +62,10 @@ import (
 // ---------------------------------------------------------------------------
 
 // ConfigInitializerFunc initializes viperx and reads the config file. It
-// receives the cobra command being executed so flag values are accessible.
-// Replace this in tests to skip disk I/O and prevent env-var bleed.
-type ConfigInitializerFunc func(cmd *cobra.Command, configFilePath string) error
+// receives the cobra command being executed so flag values (e.g. --config)
+// are accessible. Replace this in tests to skip disk I/O and prevent
+// env-var bleed.
+type ConfigInitializerFunc func(cmd *cobra.Command) error
 
 // TLSSetupFunc configures http.DefaultTransport based on TLS-related flags
 // and the persisted ca-cert config value. Replace in tests to be a no-op.
@@ -189,10 +190,6 @@ func WithPluginRegistrar(fn PluginRegistrarFunc) Option {
 type RootFactory struct {
 	// deps holds the injectable collaborators for this factory.
 	deps Dependencies
-
-	// configFilePath is the per-build config file override, populated from
-	// the --config flag or DATAROBOT_CLI_CONFIG env var during Build().
-	configFilePath string
 
 	// telemetryClient holds the active client for the current process-level
 	// build. It is also stored in the cobra context, but we keep a reference
@@ -336,7 +333,7 @@ func (f *RootFactory) persistentPreRun(cmd *cobra.Command, args []string) error 
 	cmd.SilenceUsage = true
 
 	// Read drconfig.yaml and bind env vars into viper.
-	if err := f.deps.ConfigInitializer(cmd, f.configFilePath); err != nil {
+	if err := f.deps.ConfigInitializer(cmd); err != nil {
 		return err
 	}
 
@@ -538,7 +535,7 @@ func (f *RootFactory) configureHelp(adder *cli.CommandAdder) {
 // defaultConfigInitializer is the production ConfigInitializerFunc. It sets up
 // viper's env-var prefix, binds standard overrides, and reads drconfig.yaml from
 // disk. Tests can replace this with a no-op to skip disk I/O and isolate env state.
-func defaultConfigInitializer(cmd *cobra.Command, configFilePath string) error {
+func defaultConfigInitializer(cmd *cobra.Command) error {
 	// Map any environment variables prefixed with DATAROBOT_CLI_ to config keys.
 	viperx.SetEnvPrefix("DATAROBOT_CLI")
 	viperx.AutomaticEnv()
@@ -554,12 +551,14 @@ func defaultConfigInitializer(cmd *cobra.Command, configFilePath string) error {
 	viperx.SetDefault(config.APIConsumerTrackingEnabled, true)
 	_ = viperx.BindEnv(config.APIConsumerTrackingEnabled, "DATAROBOT_API_CONSUMER_TRACKING_ENABLED")
 
-	// Resolve the config file path: flag > env var > default.
-	resolved := configFilePath
+	// Resolve the config file path: --config flag > DATAROBOT_CLI_CONFIG env
+	// var > default location. The flag value is read from cobra directly
+	// (rather than via the viper binding) so resolution keeps working even
+	// when a test stubs out the viper binding.
+	resolved, _ := cmd.Flags().GetString("config")
+
 	if resolved == "" {
-		if envPath := viperx.GetString("config"); envPath != "" {
-			resolved = envPath
-		}
+		resolved = viperx.GetString("config")
 	}
 
 	if err := config.ReadConfigFile(resolved); err != nil {

--- a/cmd/root_factory.go
+++ b/cmd/root_factory.go
@@ -88,6 +88,15 @@ type AnimationFunc func()
 // Replace in tests with a no-op.
 type PluginRegistrarFunc func(cmd *cobra.Command)
 
+// ViperBinderFunc binds the root persistent flags to the global viper
+// instance and annotates the universal flags for forwarding to plugin
+// subprocesses. The default implementation re-points the global viper
+// bindings at the newest tree on every Build; replace with a no-op in tests
+// that must not mutate global viper state (with the caveat that viper-backed
+// reads such as debug/verbose or ca-cert then won't resolve this tree's
+// flag values).
+type ViperBinderFunc func(adder *cli.CommandAdder)
+
 // Dependencies bundles every injectable collaborator for the root command.
 // The zero-value is not useful; use DefaultDependencies() or NewRootFactory()
 // to get a properly populated instance.
@@ -109,6 +118,9 @@ type Dependencies struct {
 
 	// PluginRegistrar discovers and wires plugin subcommands.
 	PluginRegistrar PluginRegistrarFunc
+
+	// ViperBinder binds persistent flags to the global viper instance.
+	ViperBinder ViperBinderFunc
 }
 
 // DefaultDependencies returns the production-ready set of dependencies
@@ -121,6 +133,7 @@ func DefaultDependencies() Dependencies {
 		TelemetryClient:   telemetry.NewClient,
 		Animation:         showFirstRunAnimation,
 		PluginRegistrar:   plugin.RegisterPluginCommands,
+		ViperBinder:       bindViperFlags,
 	}
 }
 
@@ -174,6 +187,14 @@ func WithAnimation(fn AnimationFunc) Option {
 func WithPluginRegistrar(fn PluginRegistrarFunc) Option {
 	return func(f *RootFactory) {
 		f.deps.PluginRegistrar = fn
+	}
+}
+
+// WithViperBinder overrides the viper flag-binding step. Pass a no-op in
+// tests that must leave the global viper instance untouched.
+func WithViperBinder(fn ViperBinderFunc) Option {
+	return func(f *RootFactory) {
+		f.deps.ViperBinder = fn
 	}
 }
 
@@ -242,7 +263,7 @@ func (f *RootFactory) Build() *cli.CommandAdder {
 	adder := &cli.CommandAdder{Command: cmd}
 
 	f.registerFlags(adder, &outputFormat)
-	f.bindViperFlags(adder)
+	f.deps.ViperBinder(adder)
 	f.addGroups(adder)
 	f.addSubcommands(adder)
 	f.deps.PluginRegistrar(adder.Command)
@@ -457,9 +478,14 @@ func (f *RootFactory) registerFlags(adder *cli.CommandAdder, outputFormat *outpu
 	outputformat.AddPersistentFlag(adder.Command, outputFormat)
 }
 
-// bindViperFlags wires persistent flags to viper and annotates the universal
-// ones for forwarding to plugin subprocesses as DATAROBOT_CLI_* env vars.
-func (f *RootFactory) bindViperFlags(adder *cli.CommandAdder) {
+// bindViperFlags is the production ViperBinderFunc. It wires persistent
+// flags to the global viper instance and annotates the universal ones for
+// forwarding to plugin subprocesses as DATAROBOT_CLI_* env vars.
+//
+// Note: viper is process-global, so this re-points the shared bindings at
+// the newest tree on every Build — only the last-built tree's flags resolve
+// through viperx.Get*.
+func bindViperFlags(adder *cli.CommandAdder) {
 	// bindUniversal binds name to viper AND annotates it for plugin forwarding.
 	bindUniversalOn := func(name string) {
 		flag := adder.PersistentFlags().Lookup(name)

--- a/cmd/root_factory.go
+++ b/cmd/root_factory.go
@@ -1,0 +1,589 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/datarobot/cli/cmd/artifact"
+	"github.com/datarobot/cli/cmd/auth"
+	"github.com/datarobot/cli/cmd/component"
+	"github.com/datarobot/cli/cmd/dependencies"
+	"github.com/datarobot/cli/cmd/dotenv"
+	llmgateway "github.com/datarobot/cli/cmd/llm-gateway"
+	"github.com/datarobot/cli/cmd/pipeline"
+	"github.com/datarobot/cli/cmd/plugin"
+	"github.com/datarobot/cli/cmd/self"
+	"github.com/datarobot/cli/cmd/start"
+	"github.com/datarobot/cli/cmd/task"
+	"github.com/datarobot/cli/cmd/task/run"
+	"github.com/datarobot/cli/cmd/templates"
+	"github.com/datarobot/cli/cmd/workload"
+	"github.com/datarobot/cli/internal/cli"
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/outputformat"
+	internalPlugin "github.com/datarobot/cli/internal/plugin"
+	"github.com/datarobot/cli/internal/telemetry"
+	internalVersion "github.com/datarobot/cli/internal/version"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+// ---------------------------------------------------------------------------
+// Dependencies
+// ---------------------------------------------------------------------------
+
+// ConfigInitializerFunc initializes viperx and reads the config file. It
+// receives the cobra command being executed so flag values are accessible.
+// Replace this in tests to skip disk I/O and prevent env-var bleed.
+type ConfigInitializerFunc func(cmd *cobra.Command, configFilePath string) error
+
+// TLSSetupFunc configures http.DefaultTransport based on TLS-related flags
+// and the persisted ca-cert config value. Replace in tests to be a no-op.
+type TLSSetupFunc func(cmd *cobra.Command) error
+
+// TelemetryPropsFunc collects the common telemetry properties for an
+// invocation. Replace in tests to return nil (disables telemetry).
+type TelemetryPropsFunc func() *telemetry.CommonProperties
+
+// TelemetryClientFunc builds a telemetry client from the collected properties.
+// Replace in tests to return a no-op client.
+type TelemetryClientFunc func(props *telemetry.CommonProperties) *telemetry.Client
+
+// AnimationFunc is called once during the first CLI invocation to display the
+// DataRobot logo animation. Replace in tests with a no-op.
+type AnimationFunc func()
+
+// PluginRegistrarFunc discovers and registers plugin subcommands on cmd.
+// Replace in tests with a no-op.
+type PluginRegistrarFunc func(cmd *cobra.Command)
+
+// Dependencies bundles every injectable collaborator for the root command.
+// The zero-value is not useful; use DefaultDependencies() or NewRootFactory()
+// to get a properly populated instance.
+type Dependencies struct {
+	// ConfigInitializer initializes viperx and reads drconfig.yaml.
+	ConfigInitializer ConfigInitializerFunc
+
+	// TLSSetup configures the default HTTP transport for TLS.
+	TLSSetup TLSSetupFunc
+
+	// TelemetryProps collects common Amplitude properties once per invocation.
+	TelemetryProps TelemetryPropsFunc
+
+	// TelemetryClient builds the Amplitude client from collected properties.
+	TelemetryClient TelemetryClientFunc
+
+	// Animation runs the first-run logo animation.
+	Animation AnimationFunc
+
+	// PluginRegistrar discovers and wires plugin subcommands.
+	PluginRegistrar PluginRegistrarFunc
+}
+
+// DefaultDependencies returns the production-ready set of dependencies
+// wired to the real implementations used by the CLI binary.
+func DefaultDependencies() Dependencies {
+	return Dependencies{
+		ConfigInitializer: defaultConfigInitializer,
+		TLSSetup:          setupTLS,
+		TelemetryProps:    telemetry.CollectCommonProperties,
+		TelemetryClient:   telemetry.NewClient,
+		Animation:         showFirstRunAnimation,
+		PluginRegistrar:   plugin.RegisterPluginCommands,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Option helpers
+// ---------------------------------------------------------------------------
+
+// Option is a functional option applied to a RootFactory.
+type Option func(*RootFactory)
+
+// WithConfigInitializer overrides the config-initialization step. Useful in
+// tests that need to skip disk reads or inject fixed viper state.
+func WithConfigInitializer(fn ConfigInitializerFunc) Option {
+	return func(f *RootFactory) {
+		f.deps.ConfigInitializer = fn
+	}
+}
+
+// WithTLSSetup overrides the TLS-setup step. Useful in tests that do not
+// have a valid TLS environment.
+func WithTLSSetup(fn TLSSetupFunc) Option {
+	return func(f *RootFactory) {
+		f.deps.TLSSetup = fn
+	}
+}
+
+// WithTelemetryProps overrides the telemetry-properties collector. Pass a
+// function that returns nil to disable all telemetry in a test.
+func WithTelemetryProps(fn TelemetryPropsFunc) Option {
+	return func(f *RootFactory) {
+		f.deps.TelemetryProps = fn
+	}
+}
+
+// WithTelemetryClient overrides the telemetry-client constructor. Useful in
+// tests that want to capture or suppress telemetry events.
+func WithTelemetryClient(fn TelemetryClientFunc) Option {
+	return func(f *RootFactory) {
+		f.deps.TelemetryClient = fn
+	}
+}
+
+// WithAnimation overrides the first-run animation hook. Pass a no-op in tests.
+func WithAnimation(fn AnimationFunc) Option {
+	return func(f *RootFactory) {
+		f.deps.Animation = fn
+	}
+}
+
+// WithPluginRegistrar overrides the plugin-discovery hook. Pass a no-op in tests.
+func WithPluginRegistrar(fn PluginRegistrarFunc) Option {
+	return func(f *RootFactory) {
+		f.deps.PluginRegistrar = fn
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RootFactory
+// ---------------------------------------------------------------------------
+
+// RootFactory assembles the root cobra command from a set of injectable
+// Dependencies. Each call to Build() produces a fresh, fully-wired
+// *cli.CommandAdder, so multiple builds (e.g. in parallel tests) are
+// independent of each other and of any package-level state.
+//
+// Use NewRootFactory(opts...) to construct one, or rely on the
+// package-level RootCmd variable for the production singleton.
+type RootFactory struct {
+	// deps holds the injectable collaborators for this factory.
+	deps Dependencies
+
+	// configFilePath is the per-build config file override, populated from
+	// the --config flag or DATAROBOT_CLI_CONFIG env var during Build().
+	configFilePath string
+
+	// telemetryClient holds the active client for the current process-level
+	// build. It is also stored in the cobra context, but we keep a reference
+	// here so Exit() can flush events when main's error path fires.
+	telemetryClient *telemetry.Client
+}
+
+// NewRootFactory creates a RootFactory with the given functional options
+// applied on top of DefaultDependencies(). This is the primary constructor
+// for both production (zero options) and tests (injected overrides).
+func NewRootFactory(opts ...Option) *RootFactory {
+	f := &RootFactory{
+		deps: DefaultDependencies(),
+	}
+
+	for _, o := range opts {
+		o(f)
+	}
+
+	return f
+}
+
+// TelemetryClient returns the telemetry client that was wired during the
+// most recent Build() call. cmd.Exit uses this to flush events on error
+// paths where only the signal context, not a cobra context, is available.
+func (f *RootFactory) TelemetryClient() *telemetry.Client {
+	return f.telemetryClient
+}
+
+// Build constructs and returns a fully-wired *cli.CommandAdder. The returned
+// command includes all registered sub-commands, persistent flags, help
+// overrides, plugin discovery, and unknown-arg guards. Each call is
+// self-contained: it does not mutate any package-level state.
+func (f *RootFactory) Build() *cli.CommandAdder {
+	// outputFormat is captured per-build (not package-level) so parallel
+	// builds in tests cannot race on a shared variable.
+	var outputFormat outputformat.OutputFormat
+
+	cmd := f.buildRootCommand(&outputFormat)
+	adder := &cli.CommandAdder{Command: cmd}
+
+	f.registerFlags(adder, &outputFormat)
+	f.bindViperFlags(adder)
+	f.addGroups(adder)
+	f.addSubcommands(adder)
+	f.deps.PluginRegistrar(adder.Command)
+
+	// Guard every pure-parent command against unrecognised positional args.
+	// Must run after all sub-commands (including plugins) are registered.
+	setUnknownArgGuards(adder.Command)
+
+	f.configureHelp(adder)
+
+	return adder
+}
+
+// buildRootCommand constructs the bare cobra.Command with its Use, Long, and
+// PersistentPreRunE / PersistentPostRunE hooks wired to the factory's deps.
+func (f *RootFactory) buildRootCommand(outputFormat *outputformat.OutputFormat) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     internalVersion.CliName,
+		Version: internalVersion.Version,
+		Short:   "Build AI Applications Faster",
+
+		// TraverseChildren causes cobra to parse persistent flags left-to-right
+		// before descending into each subcommand. This lets universal flags such
+		// as --debug be placed before a plugin name (e.g. "dr --debug myplugin")
+		// and still be consumed by core. Plugin commands set DisableFlagParsing:true
+		// so args appearing AFTER the plugin name are never seen by core —
+		// preserving the kubectl/helm "core stays blind to plugin args" model.
+		TraverseChildren: true,
+
+		Long: `
+The DataRobot CLI helps you quickly set up, configure, and deploy AI applications
+using pre-built templates. Get from idea to production in minutes, not hours.
+
+✨ ` + tui.BaseTextStyle.Render("What you can do:") + `
+  • Choose from ready-made AI application templates
+  • Set up your development environment quickly
+  • Deploy to DataRobot with a single command
+  • Manage environment variables and configurations
+
+🎯 ` + tui.BaseTextStyle.Render("Quick Start:") + `
+  dr start             # Create your first AI app (start here!)
+  dr self update       # Update DataRobot CLI to latest version
+  dr --help            # Show all available commands
+
+💡 ` + tui.BaseTextStyle.Render("New to AI development?") + ` Perfect! Run 'dr start' and we'll guide you through everything.`,
+
+		// PersistentPreRunE is called after flags are parsed but before the
+		// command runs. All global initialization (logging, config, TLS,
+		// telemetry) lives here so every sub-command inherits it automatically.
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return f.persistentPreRun(cmd, args)
+		},
+
+		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
+			return f.persistentPostRun(cmd)
+		},
+
+		// RootCmd needs its own RunE (to show help on a bare "dr" invocation,
+		// after the first-run animation), which disqualifies it from
+		// setUnknownArgGuards' generic walk (that skips any command with a
+		// pre-existing RunE). So it gets the same "unknown command" Args
+		// validator explicitly here.
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return nil
+			}
+
+			return fmt.Errorf("unknown command: %s", args[0])
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+
+	// Allow invoking commands in a case-insensitive manner.
+	cobra.EnableCaseInsensitive = true
+
+	// Disable Cobra's default completion command since we have our own under 'self'.
+	cmd.CompletionOptions.DisableDefaultCmd = true
+
+	// Set custom version template to match our unified format.
+	cmd.SetVersionTemplate(internalVersion.GetAppNameVersionText() + "\n\nTo update: dr self update\n")
+
+	// Only the prefix is styled; the message itself is often multi-line and is
+	// the part a user copies into a bug report.
+	cmd.SetErrPrefix(tui.ErrorStyle.Render("Error:"))
+
+	return cmd
+}
+
+// persistentPreRun runs all global initialization in the correct order:
+// logging, config, TLS, telemetry collection, and the first-run animation.
+func (f *RootFactory) persistentPreRun(cmd *cobra.Command, args []string) error {
+	log.Start()
+
+	// Suppress cobra's usage printout for runtime errors — only show it for
+	// flag-parsing failures, which happen before this hook runs.
+	cmd.SilenceUsage = true
+
+	// Read drconfig.yaml and bind env vars into viper.
+	if err := f.deps.ConfigInitializer(cmd, f.configFilePath); err != nil {
+		return err
+	}
+
+	// Configure the default HTTP transport (ca-cert, skip-verify).
+	if err := f.deps.TLSSetup(cmd); err != nil {
+		return err
+	}
+
+	// Collect common properties for telemetry (and optional debug logging).
+	// Always collect even in dry-run mode; transmission is gated inside Client.
+	props := f.deps.TelemetryProps()
+
+	if props != nil {
+		// Stamp command_kind so every event knows whether it came from a core
+		// command or a plugin.
+		if telemetry.IsPluginCommand(cmd) {
+			props.CommandKind = "plugin"
+		} else {
+			props.CommandKind = "core"
+		}
+	}
+
+	// Log the detected shell only when debug is active. Reuse Shell from
+	// telemetry props (already collected above) when available to avoid
+	// spawning a redundant ps(1) subprocess on macOS.
+	if log.GetLevel() <= log.DebugLevel {
+		var shell string
+
+		if props != nil {
+			shell = props.Shell
+		} else {
+			shell = telemetry.DetectShell()
+		}
+
+		log.Debug("Shell", "name", shell)
+	}
+
+	client := f.deps.TelemetryClient(props)
+
+	// Store as factory-level client so cmd.Exit can flush on the main error path.
+	f.telemetryClient = client
+
+	// Store telemetry client in context for use by sub-commands.
+	cmd.SetContext(context.WithValue(cmd.Context(), telemetry.ClientContextKey{}, client))
+
+	cobra.OnFinalize(func() {
+		if event, ok := telemetry.EventFor(cmd, args); ok {
+			client.Track(event)
+		}
+
+		client.Flush(3 * time.Second)
+
+		log.Stop()
+	})
+
+	config.SetAPIConsumerTrace(config.CommandPathToTrace(cmd.CommandPath()))
+
+	f.deps.Animation()
+
+	return nil
+}
+
+// persistentPostRun flushes telemetry and stops the logger after a command
+// completes successfully.
+func (f *RootFactory) persistentPostRun(cmd *cobra.Command) error {
+	if client, ok := cmd.Context().Value(telemetry.ClientContextKey{}).(*telemetry.Client); ok {
+		client.Flush(3 * time.Second)
+	}
+
+	log.Stop()
+
+	return nil
+}
+
+// registerFlags attaches all persistent flags to the command adder.
+func (f *RootFactory) registerFlags(adder *cli.CommandAdder, outputFormat *outputformat.OutputFormat) {
+	flags := adder.PersistentFlags()
+
+	flags.String("config", "",
+		"path to config file (default location: $HOME/.config/datarobot/drconfig.yaml)")
+	flags.BoolP("version", "V", false, "display the version")
+	flags.BoolP("verbose", "v", false, "verbose output")
+	flags.Bool("debug", false, "debug output")
+	flags.Bool("all-commands", false, "display all available commands and their flags in tree format")
+	flags.Bool(config.SkipAuthKey, false, "skip authentication checks (for advanced users)")
+	flags.Bool("force-interactive", false, "force setup wizards to run even if already completed")
+	flags.Duration("plugin-discovery-timeout", 2*time.Second, "timeout for plugin discovery (0s disables)")
+	flags.Duration("plugin-update-check-interval", internalPlugin.DefaultUpdateCheckInterval, "cooldown between plugin update checks (0s disables)")
+	flags.Bool("skip-plugin-update-check", false, "skip plugin update checks before running plugins")
+	flags.Bool("disable-telemetry", false, "disable usage telemetry")
+
+	// Private CA / TLS flags.
+	flags.BoolP("skip-certificate-check", "k", false, "skip TLS certificate verification (insecure)")
+	flags.String("ca-cert", "", "path to a PEM-encoded CA certificate bundle")
+	registerExportWindowsCertsFlag(adder.Command)
+
+	outputformat.AddPersistentFlag(adder.Command, outputFormat)
+}
+
+// bindViperFlags wires persistent flags to viper and annotates the universal
+// ones for forwarding to plugin subprocesses as DATAROBOT_CLI_* env vars.
+func (f *RootFactory) bindViperFlags(adder *cli.CommandAdder) {
+	// bindUniversal binds name to viper AND annotates it for plugin forwarding.
+	bindUniversalOn := func(name string) {
+		flag := adder.PersistentFlags().Lookup(name)
+		_ = viperx.BindPFlag(name, flag)
+
+		if flag.Annotations == nil {
+			flag.Annotations = map[string][]string{}
+		}
+
+		flag.Annotations[config.UniversalAnnotationKey] = []string{
+			strings.ToUpper(strings.ReplaceAll(name, "-", "_")),
+		}
+	}
+
+	// Universal flags: bound to viper AND forwarded to plugin subprocesses as
+	// DATAROBOT_CLI_* env vars. To add a new universal flag, call bindUniversalOn
+	// next to its registration in registerFlags.
+	bindUniversalOn("debug")
+	bindUniversalOn("disable-telemetry")
+	bindUniversalOn("verbose")
+	bindUniversalOn("skip-certificate-check")
+	bindUniversalOn("ca-cert")
+
+	// Non-universal flags: bound to viper only (not forwarded to plugins).
+	pflags := adder.PersistentFlags()
+
+	_ = viperx.BindPFlag("config", pflags.Lookup("config"))
+	_ = viperx.BindPFlag(config.SkipAuthKey, pflags.Lookup(config.SkipAuthKey))
+	_ = viperx.BindPFlag("force-interactive", pflags.Lookup("force-interactive"))
+	_ = viperx.BindPFlag("plugin-discovery-timeout", pflags.Lookup("plugin-discovery-timeout"))
+	_ = viperx.BindPFlag("plugin-update-check-interval", pflags.Lookup("plugin-update-check-interval"))
+	_ = viperx.BindPFlag("skip-plugin-update-check", pflags.Lookup("skip-plugin-update-check"))
+	_ = viperx.BindPFlag("output-format", pflags.Lookup("output-format"))
+}
+
+// addGroups registers the named command groups used by the help template.
+func (f *RootFactory) addGroups(adder *cli.CommandAdder) {
+	adder.AddGroup(
+		&cobra.Group{ID: "core", Title: tui.BaseTextStyle.Render("Core Commands:")},
+		&cobra.Group{ID: "self", Title: tui.BaseTextStyle.Render("Self Commands:")},
+		&cobra.Group{ID: "advanced", Title: tui.BaseTextStyle.Render("Advanced Commands:")},
+	)
+}
+
+// addSubcommands registers all first-party sub-commands on the adder.
+// Commands whose feature gates are disabled are silently dropped by
+// cli.CommandAdder.AddCommand.
+func (f *RootFactory) addSubcommands(adder *cli.CommandAdder) {
+	adder.AddCommand(
+		artifact.Cmd(),
+		auth.Cmd(),
+		component.Cmd(),
+		dependencies.Cmd(),
+		dotenv.Cmd(),
+		llmgateway.Cmd(),
+		run.Cmd(),
+		self.Cmd(),
+		start.Cmd(),
+		task.Cmd(),
+		templates.Cmd(),
+		workload.Cmd(),
+		plugin.Cmd(),
+		pipeline.Cmd(),
+	)
+}
+
+// configureHelp installs custom usage/help templates and the --all-commands /
+// --version help-func overrides on the adder's root command.
+func (f *RootFactory) configureHelp(adder *cli.CommandAdder) {
+	adder.SetUsageTemplate(CustomUsageTemplate)
+
+	defaultHelpFunc := adder.HelpFunc()
+
+	adder.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		showAllCommands, _ := cmd.Flags().GetBool("all-commands")
+		showVersion, _ := cmd.Flags().GetBool("version")
+
+		switch {
+		case showAllCommands:
+			output := allCommandsOutput(cmd.Root())
+			_, _ = fmt.Fprint(cmd.OutOrStdout(), output)
+
+		case showVersion:
+			runVersionCommand(cmd)
+
+		default:
+			adder.SetHelpTemplate(CustomHelpTemplate)
+			defaultHelpFunc(cmd, args)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// defaultConfigInitializer — production implementation of ConfigInitializerFunc
+// ---------------------------------------------------------------------------
+
+// defaultConfigInitializer is the production ConfigInitializerFunc. It sets up
+// viper's env-var prefix, binds standard overrides, and reads drconfig.yaml from
+// disk. Tests can replace this with a no-op to skip disk I/O and isolate env state.
+func defaultConfigInitializer(cmd *cobra.Command, configFilePath string) error {
+	// Map any environment variables prefixed with DATAROBOT_CLI_ to config keys.
+	viperx.SetEnvPrefix("DATAROBOT_CLI")
+	viperx.AutomaticEnv()
+	viperx.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
+	// Map VISUAL and EDITOR to external-editor, with a safe default.
+	viperx.SetDefault("external-editor", "vi")
+
+	_ = viperx.BindEnv("external-editor", "VISUAL", "EDITOR")
+
+	// API consumer tracking is enabled by default; operators can opt out with
+	// DATAROBOT_API_CONSUMER_TRACKING_ENABLED=false (matches the Python SDK).
+	viperx.SetDefault(config.APIConsumerTrackingEnabled, true)
+	_ = viperx.BindEnv(config.APIConsumerTrackingEnabled, "DATAROBOT_API_CONSUMER_TRACKING_ENABLED")
+
+	// Resolve the config file path: flag > env var > default.
+	resolved := configFilePath
+	if resolved == "" {
+		if envPath := viperx.GetString("config"); envPath != "" {
+			resolved = envPath
+		}
+	}
+
+	if err := config.ReadConfigFile(resolved); err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers delegated to from configureHelp
+// ---------------------------------------------------------------------------
+
+// allCommandsOutput renders the full command tree and is the implementation
+// delegated to when --all-commands is set. Exists as a named helper so the
+// import of allcommands can live in root.go (the production side) while the
+// factory stays import-light. Overridden in root.go via allCommandsOutputFn.
+var allCommandsOutputFn func(root *cobra.Command) string
+
+// allCommandsOutput calls the registered output function (set by root.go).
+func allCommandsOutput(root *cobra.Command) string {
+	if allCommandsOutputFn != nil {
+		return allCommandsOutputFn(root)
+	}
+
+	return ""
+}
+
+// runVersionCommandFn is the implementation delegated to when --version is set
+// in a help context. Set by root.go so the factory avoids importing cmd/self/version.
+var runVersionCommandFn func(cmd *cobra.Command)
+
+// runVersionCommand calls the registered version runner.
+func runVersionCommand(cmd *cobra.Command) {
+	if runVersionCommandFn != nil {
+		runVersionCommandFn(cmd)
+	}
+}

--- a/cmd/root_factory.go
+++ b/cmd/root_factory.go
@@ -241,6 +241,39 @@ func NewRootFactory(opts ...Option) *RootFactory {
 	return f
 }
 
+// NewIsolatedRootFactory returns a factory whose dependencies are all
+// side-effect-free: no config-file reads, no env binding, no TLS setup, no
+// first-run animation, no telemetry transmission, no viper flag binding,
+// and no plugin discovery (which would otherwise execute every dr-* binary
+// found on PATH). This is the safe starting point for unit tests.
+//
+// Caller options are applied after the no-op defaults, so individual
+// dependencies can still be overridden per test:
+//
+//	root := NewIsolatedRootFactory(
+//		WithConfigInitializer(func(_ *cobra.Command) error {
+//			viperx.Set("api-token", "test-token")
+//			return nil
+//		}),
+//	).Build()
+func NewIsolatedRootFactory(opts ...Option) *RootFactory {
+	defaults := make([]Option, 0, 7+len(opts))
+
+	defaults = append(defaults,
+		WithConfigInitializer(func(_ *cobra.Command) error { return nil }),
+		WithTLSSetup(func(_ *cobra.Command) error { return nil }),
+		WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
+		WithTelemetryClient(func(_ *telemetry.CommonProperties) *telemetry.Client {
+			return telemetry.NewTestClient(nil, nil)
+		}),
+		WithAnimation(func() {}),
+		WithPluginRegistrar(func(_ *cobra.Command) {}),
+		WithViperBinder(func(_ *cli.CommandAdder) {}),
+	)
+
+	return NewRootFactory(append(defaults, opts...)...)
+}
+
 // TelemetryClient returns the telemetry client from the factory's most
 // recent command execution. The client is created in persistentPreRun at
 // Execute time, not during Build — a built-but-never-executed tree leaves

--- a/cmd/root_factory.go
+++ b/cmd/root_factory.go
@@ -212,9 +212,11 @@ func NewRootFactory(opts ...Option) *RootFactory {
 	return f
 }
 
-// TelemetryClient returns the telemetry client that was wired during the
-// most recent Build() call. cmd.Exit uses this to flush events on error
-// paths where only the signal context, not a cobra context, is available.
+// TelemetryClient returns the telemetry client from the factory's most
+// recent command execution. The client is created in persistentPreRun at
+// Execute time, not during Build — a built-but-never-executed tree leaves
+// this nil. cmd.Exit uses it to flush events on error paths where only the
+// signal context, not a cobra context, is available.
 func (f *RootFactory) TelemetryClient() *telemetry.Client {
 	return f.telemetryClient
 }

--- a/cmd/root_factory.go
+++ b/cmd/root_factory.go
@@ -211,8 +211,14 @@ var finalizerGen atomic.Int64
 
 // RootFactory assembles the root cobra command from a set of injectable
 // Dependencies. Each call to Build() produces a fresh, fully-wired
-// *cli.CommandAdder, so multiple builds (e.g. in parallel tests) are
-// independent of each other and of any package-level state.
+// *cli.CommandAdder whose flags, sub-commands, and hooks are independent of
+// every other tree's.
+//
+// Independence is scoped to the cobra tree itself: some wiring still goes
+// through process-global state (global viper bindings, cobra.OnFinalize,
+// http.DefaultTransport, the log package). See docs/development/
+// root-factory.md ("What stays shared") for the full list and the resulting
+// "one live tree at a time" rule.
 //
 // Use NewRootFactory(opts...) to construct one, or rely on the
 // package-level RootCmd variable for the production singleton.
@@ -285,8 +291,14 @@ func (f *RootFactory) TelemetryClient() *telemetry.Client {
 
 // Build constructs and returns a fully-wired *cli.CommandAdder. The returned
 // command includes all registered sub-commands, persistent flags, help
-// overrides, plugin discovery, and unknown-arg guards. Each call is
-// self-contained: it does not mutate any package-level state.
+// overrides, plugin discovery, and unknown-arg guards.
+//
+// The returned tree is self-contained — fresh flags, sub-commands, and a
+// per-build output format — but Build is not free of shared-state effects:
+// the default ViperBinder re-points the global viper bindings at the new
+// tree, and the default PluginRegistrar reads global viper config and
+// executes any dr-* binaries found on PATH. Use NewIsolatedRootFactory to
+// build a tree with none of those side effects.
 func (f *RootFactory) Build() *cli.CommandAdder {
 	// outputFormat is captured per-build (not package-level) so parallel
 	// builds in tests cannot race on a shared variable.

--- a/cmd/root_factory_test.go
+++ b/cmd/root_factory_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/amplitude/analytics-go/amplitude"
+	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingClient is a test double for amplitude.Client that records Track
+// calls; every other method is a no-op.
+type countingClient struct {
+	mu     sync.Mutex
+	events []amplitude.Event
+}
+
+func (c *countingClient) Track(event amplitude.Event) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.events = append(c.events, event)
+}
+
+func (c *countingClient) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return len(c.events)
+}
+
+func (c *countingClient) Identify(amplitude.Identify, amplitude.EventOptions)                      {}
+func (c *countingClient) GroupIdentify(string, string, amplitude.Identify, amplitude.EventOptions) {}
+func (c *countingClient) SetGroup(string, []string, amplitude.EventOptions)                        {}
+func (c *countingClient) Revenue(amplitude.Revenue, amplitude.EventOptions)                        {}
+func (c *countingClient) Flush()                                                                   {}
+func (c *countingClient) Shutdown()                                                                {}
+func (c *countingClient) Add(amplitude.Plugin)                                                     {}
+func (c *countingClient) Remove(string)                                                            {}
+
+func (c *countingClient) Config() amplitude.Config { return amplitude.Config{} }
+
+// executeStubOnce builds a fully-isolated tree whose telemetry client is
+// backed by client, attaches a tracked stub command, and executes it once.
+func executeStubOnce(t *testing.T, client *countingClient) {
+	t.Helper()
+
+	root := NewRootFactory(
+		WithConfigInitializer(func(_ *cobra.Command) error { return nil }),
+		WithTLSSetup(func(_ *cobra.Command) error { return nil }),
+		WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
+		WithTelemetryClient(func(_ *telemetry.CommonProperties) *telemetry.Client {
+			return telemetry.NewTestClient(client, nil)
+		}),
+		WithAnimation(func() {}),
+		WithPluginRegistrar(func(_ *cobra.Command) {}),
+	).Build()
+
+	stub := &cobra.Command{
+		Use:  "stub",
+		RunE: func(_ *cobra.Command, _ []string) error { return nil },
+	}
+
+	telemetry.Track(stub)
+	root.AddCommand(stub)
+
+	root.SetArgs([]string{"stub"})
+	require.NoError(t, root.Execute())
+}
+
+// TestStaleFinalizersDoNotRetrack verifies that executing a second
+// factory-built tree does not cause the first tree's finalizer to re-track
+// its stale event. cobra.OnFinalize appends to a process-global list that is
+// replayed in full on every Execute; the factory's generation guard
+// suppresses those stale replays so each execute tracks exactly one event.
+func TestStaleFinalizersDoNotRetrack(t *testing.T) {
+	clientA := &countingClient{}
+	executeStubOnce(t, clientA)
+	assert.Equal(t, 1, clientA.count(), "first execute should track exactly one event")
+
+	clientB := &countingClient{}
+	executeStubOnce(t, clientB)
+
+	assert.Equal(t, 1, clientB.count(), "second execute should track exactly one event")
+	assert.Equal(t, 1, clientA.count(), "stale finalizer from first execute must not re-track")
+}

--- a/cmd/root_factory_test.go
+++ b/cmd/root_factory_test.go
@@ -62,15 +62,10 @@ func (c *countingClient) Config() amplitude.Config { return amplitude.Config{} }
 func executeStubOnce(t *testing.T, client *countingClient) {
 	t.Helper()
 
-	root := NewRootFactory(
-		WithConfigInitializer(func(_ *cobra.Command) error { return nil }),
-		WithTLSSetup(func(_ *cobra.Command) error { return nil }),
-		WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
+	root := NewIsolatedRootFactory(
 		WithTelemetryClient(func(_ *telemetry.CommonProperties) *telemetry.Client {
 			return telemetry.NewTestClient(client, nil)
 		}),
-		WithAnimation(func() {}),
-		WithPluginRegistrar(func(_ *cobra.Command) {}),
 	).Build()
 
 	stub := &cobra.Command{

--- a/cmd/root_helpers.go
+++ b/cmd/root_helpers.go
@@ -12,6 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// root_helpers.go contains standalone helpers used by RootFactory that would
+// cause import cycles if they lived inside root_factory.go:
+//
+//   - showFirstRunAnimation: displays the one-time DataRobot logo animation on
+//     a user's first CLI invocation. Injected into the factory as AnimationFunc
+//     so tests can replace it with a no-op.
+//   - setUnknownArgGuards: walks the command tree after registration and installs
+//     an Args validator + RunE on every pure-parent command so unrecognised
+//     positional arguments produce a clear error instead of silently showing help.
 package cmd
 
 import (

--- a/cmd/root_helpers.go
+++ b/cmd/root_helpers.go
@@ -1,0 +1,90 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/state"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+// showFirstRunAnimation displays the animated DataRobot logo inline (no
+// alt-screen) on the very first CLI invocation, so the final settled frame
+// remains in normal terminal scrollback and whatever runs next continues
+// directly below it instead of hard-cutting from a full-screen takeover.
+//
+// It checks global state to avoid showing the animation more than once, only
+// runs in interactive terminals, and is skipped entirely under automation
+// (e.g. tools like expect that attach a real pty and would otherwise see
+// animation frames mixed into output they are pattern-matching).
+func showFirstRunAnimation() {
+	if reader.IsNonInteractive() {
+		return
+	}
+
+	if !state.IsFirstRun() {
+		return
+	}
+
+	// Only show the animation when stdout is a terminal (not piped or redirected).
+	fi, err := os.Stdout.Stat()
+	if err != nil || (fi.Mode()&os.ModeCharDevice) == 0 {
+		return
+	}
+
+	m := tui.NewLogoAnimationModel()
+
+	_, _ = tui.Run(m)
+
+	state.MarkAnimationShown()
+}
+
+// setUnknownArgGuards walks the command tree and installs a RunE + Args
+// validator on every pure-parent command (has subcommands, no Run/RunE, no
+// explicit Args set).
+//
+// Cobra checks !Runnable() before ValidateArgs, so a non-runnable parent
+// silently shows help for any arg. Making the command runnable lets Args fire
+// first and return a clear error; the RunE fallback shows help when no args
+// are given.
+func setUnknownArgGuards(root *cobra.Command) {
+	for _, cmd := range root.Commands() {
+		setUnknownArgGuards(cmd)
+	}
+
+	if !root.HasSubCommands() {
+		return
+	}
+
+	if root.Args != nil || root.RunE != nil || root.Run != nil {
+		return
+	}
+
+	root.Args = func(_ *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return nil
+		}
+
+		return fmt.Errorf("unknown command: %s", args[0])
+	}
+
+	root.RunE = func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	}
+}

--- a/docs/development/root-factory.md
+++ b/docs/development/root-factory.md
@@ -170,13 +170,7 @@ now you get a clean isolated tree:
 
 ```go
 func TestMyFeatureCmd(t *testing.T) {
-    root := cmd.NewRootFactory(
-        cmd.WithConfigInitializer(func(_ *cobra.Command) error { return nil }),
-        cmd.WithTLSSetup(func(_ *cobra.Command) error { return nil }),
-        cmd.WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
-        cmd.WithPluginRegistrar(func(_ *cobra.Command) {}),
-        cmd.WithAnimation(func() {}),
-    ).Build()
+    root := cmd.NewIsolatedRootFactory().Build()
 
     var buf bytes.Buffer
     root.SetOut(&buf)
@@ -187,14 +181,10 @@ func TestMyFeatureCmd(t *testing.T) {
 }
 ```
 
-Once `newIsolatedRootCmd()` is available (from the test-isolation follow-up PR),
-this reduces to:
-
-```go
-root := newIsolatedRootCmd()
-root.SetArgs([]string{"myfeature"})
-require.NoError(t, root.Execute())
-```
+`NewIsolatedRootFactory` pre-applies no-op overrides for every dependency, so
+the test touches no disk, no environment, no global viper state, and no plugin
+binaries. Pass your own options after the defaults to override specific
+dependencies per test.
 
 **The short version:** commands are written identically to before — they return a
 `*cobra.Command` from a `Cmd()` constructor, get registered in one place, and
@@ -223,17 +213,13 @@ func TestSomethingThatSetsEnvVars(t *testing.T) {
     //
     // With the factory: the no-op ConfigInitializer never calls
     // viperx.AutomaticEnv(), so viper never sees the env var at all.
-    root := cmd.NewRootFactory(
+    root := cmd.NewIsolatedRootFactory(
         cmd.WithConfigInitializer(func(_ *cobra.Command) error {
             // Optionally seed specific viper keys your command needs,
             // without calling AutomaticEnv() or ReadConfigFile().
             viperx.Set("api-token", "test-token")
             return nil
         }),
-        cmd.WithTLSSetup(func(_ *cobra.Command) error { return nil }),
-        cmd.WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
-        cmd.WithPluginRegistrar(func(_ *cobra.Command) {}),
-        cmd.WithAnimation(func() {}),
     ).Build()
 
     root.SetArgs([]string{"mycommand"})
@@ -241,18 +227,15 @@ func TestSomethingThatSetsEnvVars(t *testing.T) {
 }
 ```
 
-Similarly, override `WithTelemetryProps` to avoid hitting the network or disk
-for device/user IDs, and `WithPluginRegistrar` to skip filesystem discovery:
+`NewIsolatedRootFactory` already no-ops every dependency, including the ones
+with surprising side effects: the default `TelemetryProps` hits the network or
+disk for device/user IDs, and the default `PluginRegistrar` executes every
+`dr-*` binary found on PATH to fetch its manifest. Prefer the preset over
+hand-assembling stubs:
 
 ```go
 // Minimal no-op factory — safe for any unit test.
-root := cmd.NewRootFactory(
-    cmd.WithConfigInitializer(func(_ *cobra.Command) error { return nil }),
-    cmd.WithTLSSetup(func(_ *cobra.Command) error { return nil }),
-    cmd.WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
-    cmd.WithPluginRegistrar(func(_ *cobra.Command) {}),
-    cmd.WithAnimation(func() {}),
-).Build()
+root := cmd.NewIsolatedRootFactory().Build()
 ```
 
 > **Why not just use the global `RootCmd`?** The global singleton is built once
@@ -336,6 +319,12 @@ func (f *RootFactory) persistentPreRun(cmd *cobra.Command, args []string) error 
 That's it. Tests override it with `WithAuditLogger(func(...) error { return nil })`;
 production gets `defaultAuditLogger` for free.
 
+> **Planned next field:** an `IOStreams` dependency (stdin/stdout/stderr
+> abstraction, à la GitHub CLI's `cmdutil.Factory`). The injection rails are in
+> place, but it only pays off once command constructors consume injected
+> streams instead of writing to `os.Stdout` directly — a cross-cutting
+> migration tracked as a follow-up to this stack.
+
 ---
 
 ## Feature-gating a command
@@ -403,13 +392,7 @@ factory tree — or skip when the gate state doesn't match what the test expects
 ```go
 func TestMyFeatureHiddenByDefault(t *testing.T) {
     // Build a fresh tree with no feature gate enabled.
-    root := cmd.NewRootFactory(
-        cmd.WithConfigInitializer(func(_ *cobra.Command) error { return nil }),
-        cmd.WithTLSSetup(func(_ *cobra.Command) error { return nil }),
-        cmd.WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
-        cmd.WithPluginRegistrar(func(_ *cobra.Command) {}),
-        cmd.WithAnimation(func() {}),
-    ).Build()
+    root := cmd.NewIsolatedRootFactory().Build()
 
     for _, sub := range root.Commands() {
         assert.NotEqual(t, "myfeature", sub.Name(),
@@ -420,7 +403,7 @@ func TestMyFeatureHiddenByDefault(t *testing.T) {
 func TestMyFeatureVisibleWhenGateEnabled(t *testing.T) {
     t.Setenv("DATAROBOT_CLI_FEATURE_MYFEATURE", "true")
 
-    root := cmd.NewRootFactory( /* same no-op deps */ ).Build()
+    root := cmd.NewIsolatedRootFactory().Build()
 
     var found bool
     for _, sub := range root.Commands() {

--- a/docs/development/root-factory.md
+++ b/docs/development/root-factory.md
@@ -18,7 +18,6 @@ Production code (via `main`) uses the singleton built in `init()`. Tests use
 classDiagram
     class RootFactory {
         +deps Dependencies
-        +configFilePath string
         +telemetryClient *Client
         +Build() *CommandAdder
         +TelemetryClient() *Client
@@ -171,7 +170,7 @@ now you get a clean isolated tree:
 ```go
 func TestMyFeatureCmd(t *testing.T) {
     root := cmd.NewRootFactory(
-        cmd.WithConfigInitializer(func(_ *cobra.Command, _ string) error { return nil }),
+        cmd.WithConfigInitializer(func(_ *cobra.Command) error { return nil }),
         cmd.WithTLSSetup(func(_ *cobra.Command) error { return nil }),
         cmd.WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
         cmd.WithPluginRegistrar(func(_ *cobra.Command) {}),
@@ -224,7 +223,7 @@ func TestSomethingThatSetsEnvVars(t *testing.T) {
     // With the factory: the no-op ConfigInitializer never calls
     // viperx.AutomaticEnv(), so viper never sees the env var at all.
     root := cmd.NewRootFactory(
-        cmd.WithConfigInitializer(func(_ *cobra.Command, _ string) error {
+        cmd.WithConfigInitializer(func(_ *cobra.Command) error {
             // Optionally seed specific viper keys your command needs,
             // without calling AutomaticEnv() or ReadConfigFile().
             viperx.Set("api-token", "test-token")
@@ -247,7 +246,7 @@ for device/user IDs, and `WithPluginRegistrar` to skip filesystem discovery:
 ```go
 // Minimal no-op factory — safe for any unit test.
 root := cmd.NewRootFactory(
-    cmd.WithConfigInitializer(func(_ *cobra.Command, _ string) error { return nil }),
+    cmd.WithConfigInitializer(func(_ *cobra.Command) error { return nil }),
     cmd.WithTLSSetup(func(_ *cobra.Command) error { return nil }),
     cmd.WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
     cmd.WithPluginRegistrar(func(_ *cobra.Command) {}),
@@ -404,7 +403,7 @@ factory tree — or skip when the gate state doesn't match what the test expects
 func TestMyFeatureHiddenByDefault(t *testing.T) {
     // Build a fresh tree with no feature gate enabled.
     root := cmd.NewRootFactory(
-        cmd.WithConfigInitializer(func(_ *cobra.Command, _ string) error { return nil }),
+        cmd.WithConfigInitializer(func(_ *cobra.Command) error { return nil }),
         cmd.WithTLSSetup(func(_ *cobra.Command) error { return nil }),
         cmd.WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
         cmd.WithPluginRegistrar(func(_ *cobra.Command) {}),

--- a/docs/development/root-factory.md
+++ b/docs/development/root-factory.md
@@ -200,10 +200,22 @@ assemble the tree.
 ## Overriding a dependency in a test
 
 The most common reason to override a dependency is preventing viperx state from
-leaking between tests. When two tests both call `Execute()` on the same shared
-`RootCmd` singleton, the first test's `t.Setenv(...)` can still be visible to
-the second test via viper's global state — even after the env var is restored —
-because `AutomaticEnv` re-reads the environment on the next access.
+leaking between tests. Viper resolves a key in this precedence order:
+
+    viperx.Set()  >  changed pflag  >  env var (live)  >  config file  >  defaults
+
+Env vars are read live — `os.LookupEnv` on every `Get` — so `t.Setenv` cleanup
+is visible immediately, and env vars are *not* the leak vector. The sticky
+layers are the other three:
+
+- **`viperx.Set(...)` overrides** persist until `viperx.Reset()` and, being
+  highest-precedence, shadow live env reads for every later test in the
+  process.
+- **Config-file contents** parsed by `ReadInConfig` persist in the global
+  instance until the next read or `viperx.Reset()`.
+- **Changed-flag state on the shared `RootCmd` singleton**: once a test
+  executes it with a flag (e.g. `--debug`), the pflag binding serves that
+  value with priority over env and config for the rest of the process.
 
 The fix is to give each test its own command tree built with a no-op
 `ConfigInitializer` that never touches viper:
@@ -212,15 +224,21 @@ The fix is to give each test its own command tree built with a no-op
 func TestSomethingThatSetsEnvVars(t *testing.T) {
     t.Setenv("DATAROBOT_CLI_API_TOKEN", "test-token")
 
-    // Without the factory: this env var could bleed into the next test
-    // via viper's shared global state.
+    // Without the factory: Set overrides and config-file contents from
+    // earlier tests persist in the global viper instance and shadow this
+    // test's env vars.
     //
     // With the factory: the no-op ConfigInitializer never calls
-    // viperx.AutomaticEnv(), so viper never sees the env var at all.
+    // viperx.AutomaticEnv() or ReadConfigFile(), so this tree resolves
+    // only what the test seeds explicitly.
     root := cmd.NewIsolatedRootFactory(
         cmd.WithConfigInitializer(func(_ *cobra.Command) error {
-            // Optionally seed specific viper keys your command needs,
-            // without calling AutomaticEnv() or ReadConfigFile().
+            // Seed the viper keys your command needs without calling
+            // AutomaticEnv() or ReadConfigFile(). Note: viperx.Set writes
+            // a highest-precedence override that persists until
+            // viperx.Reset() (which itself wipes flag bindings, so it is
+            // only safe when the next use is a fresh Build). Prefer
+            // seeding keys only in isolated-tree tests like this one.
             viperx.Set("api-token", "test-token")
             return nil
         }),
@@ -242,13 +260,14 @@ hand-assembling stubs:
 root := cmd.NewIsolatedRootFactory().Build()
 ```
 
-> **Why not just use the global `RootCmd`?** The global singleton is built once
-> in `init()` with the production `ConfigInitializer`. Every `Execute()` call on
-> it runs `viperx.AutomaticEnv()` and `ReadConfigFile()` against the live
-> environment. Env vars set with `t.Setenv()` are restored after the test, but
-> viper's internal cache may retain values until the next `AutomaticEnv()` sweep
-> — which happens in the *next* test's `Execute()`. A fresh factory tree sidesteps
-> this entirely.
+> **Why not just use the global `RootCmd`?** The singleton is built once in
+> `init()` with the production dependencies, and every `Execute()` on it runs
+> `ReadInConfig` against the live environment and marks its bound flags
+> Changed. Both effects stick: config contents stay in the global viper
+> instance until the next read, and a changed flag keeps outranking env vars
+> for the rest of the process. (There is no env-var caching involved — viper
+> reads `os.LookupEnv` live on every `Get`.) A fresh factory tree sidesteps
+> both, and `NewIsolatedRootFactory()` skips the config read entirely.
 
 ---
 

--- a/docs/development/root-factory.md
+++ b/docs/development/root-factory.md
@@ -84,48 +84,6 @@ sequenceDiagram
     Note over F: cobra.OnFinalize flushes telemetry
 ```
 
-### How #803 extends the factory
-
-`StampInteractionMode` and `IsNonInteractive` slot into the existing pre-run
-hook. The factory is the only callsite — commands just read the result.
-
-```mermaid
-flowchart TD
-    subgraph 802 ["#802 — RootFactory"]
-        PR[persistentPreRun]
-        TP[deps.TelemetryProps]
-        SK[stamp CommandKind]
-        PR --> TP --> SK
-    end
-
-    subgraph 803 ["#803 — non-interactive telemetry"]
-        SI["telemetry.StampInteractionMode(props, cmd)"]
-        NI["cli.IsNonInteractive(cmd)"]
-        YF["cli.YesFlagName const"]
-        SI --> NI
-        NI --> YF
-        NI --> ENV["DATAROBOT_CLI_NON_INTERACTIVE"]
-        NI --> VI["viperx: force-interactive"]
-    end
-
-    SK --> SI
-    SI --> AMP["props.NonInteractive → every Amplitude event"]
-
-    subgraph cmds ["Commands (#803 migration)"]
-        C1["artifact del/checkout/codesync/init"]
-        C2["deps install, dotenv, plugin install"]
-        C3["start, workload config/del/up"]
-    end
-
-    NI --> cmds
-```
-
-The key design point: **the factory is the single callsite for all pre-run
-wiring**. `#802` defines the hook; `#803` inserts `StampInteractionMode` into it
-and exports `IsNonInteractive` so commands never re-implement detection logic
-themselves. Any future automation signal only needs to be wired in
-`IsNonInteractive` — nothing else changes.
-
 ## Adding a new command
 
 ### 1. Register it

--- a/docs/development/root-factory.md
+++ b/docs/development/root-factory.md
@@ -382,65 +382,13 @@ production gets `defaultAuditLogger` for free.
 
 ## Feature-gating a command
 
-Feature gates hide commands behind an environment variable until they are ready
-for release. The factory's `addSubcommands` uses `cli.CommandAdder.AddCommand`,
-which automatically drops any command whose gate is not enabled.
+For gating mechanics — `features.SetGate`, env-var naming, and gating nested
+subcommands — see [feature-gates.md](feature-gates.md).
 
-### Gate a top-level command
-
-```go
-// cmd/myfeature/cmd.go
-func Cmd() *cobra.Command {
-    c := &cobra.Command{
-        Use:   "myfeature",
-        Short: "Coming soon",
-    }
-
-    // Gate this command behind DATAROBOT_CLI_FEATURE_MYFEATURE=true.
-    features.SetGate(c, "myfeature")
-
-    return c
-}
-```
-
-Register it normally in `addSubcommands` — `CommandAdder` handles the filtering:
-
-```go
-adder.AddCommand(
-    myfeature.Cmd(),  // silently dropped unless the gate is enabled
-)
-```
-
-### Gate a nested subcommand
-
-`CommandAdder.AddCommand` only filters at the level it's called from. To gate a
-subcommand inside an existing parent, wrap the parent with `CommandAdder`:
-
-```go
-func Cmd() *cobra.Command {
-    parent := &cobra.Command{Use: "parent"}
-    adder := &cli.CommandAdder{Command: parent}
-
-    adder.AddCommand(gatedChild.Cmd())  // dropped when gate is off
-
-    return parent
-}
-```
-
-### Enable a gate locally
-
-```sh
-DATAROBOT_CLI_FEATURE_MYFEATURE=true dr myfeature
-```
-
-The env var name is derived from the gate name: uppercased, hyphens replaced
-with underscores, prefixed with `DATAROBOT_CLI_FEATURE_`.
-
-### Test gated and ungated behaviour
-
-Because gate evaluation happens in `init()` (when the production `RootCmd` is
-built), tests that check for command presence or absence should use the fresh
-factory tree — or skip when the gate state doesn't match what the test expects:
+The factory-specific fact: gates are evaluated by `cli.CommandAdder.AddCommand`
+at **Build time**, so a built tree's gate state is frozen. The production
+singleton's gate state is fixed at `init()`; a test that needs a different
+gate state must set the env var first and then build a fresh tree:
 
 ```go
 func TestMyFeatureHiddenByDefault(t *testing.T) {

--- a/docs/development/root-factory.md
+++ b/docs/development/root-factory.md
@@ -1,0 +1,202 @@
+# Root Command Factory
+
+## Overview
+
+The `RootFactory` (`cmd/root_factory.go`) assembles the root cobra command from
+injectable dependencies. Each call to `Build()` returns a fresh, fully-wired
+`*cli.CommandAdder` with no shared mutable state — this is the key property that
+prevents cross-test env-var leakage and lets tests run in isolation.
+
+Production code (via `main`) uses the singleton built in `init()`. Tests use
+`NewRootFactory(...)` directly with stubbed dependencies.
+
+## Diagrams
+
+### Factory structure
+
+```mermaid
+classDiagram
+    class RootFactory {
+        +deps Dependencies
+        +configFilePath string
+        +telemetryClient *Client
+        +Build() *CommandAdder
+        +TelemetryClient() *Client
+    }
+
+    class Dependencies {
+        +ConfigInitializer func
+        +TLSSetup func
+        +TelemetryProps func
+        +TelemetryClient func
+        +Animation func
+        +PluginRegistrar func
+    }
+
+    class CommandAdder {
+        +Command *cobra.Command
+        +AddCommand(...)
+        +ExecuteContext(ctx)
+    }
+
+    class Options {
+        WithConfigInitializer()
+        WithTLSSetup()
+        WithTelemetryProps()
+        WithTelemetryClient()
+        WithAnimation()
+        WithPluginRegistrar()
+    }
+
+    RootFactory --> Dependencies : owns
+    RootFactory --> CommandAdder : Build() produces
+    Options ..> RootFactory : configure
+```
+
+### Runtime sequence
+
+How a command execution flows from `main` through the factory.
+
+```mermaid
+sequenceDiagram
+    participant M as main
+    participant E as ExecuteContext
+    participant F as productionFactory
+    participant P as persistentPreRun
+    participant C as cobra cmd
+
+    Note over F: built once at init()
+    M->>E: ExecuteContext(ctx)
+    E->>F: RootCmd.ExecuteContext(ctx)
+    F->>P: cobra fires PersistentPreRunE
+    P->>P: deps.ConfigInitializer()
+    P->>P: deps.TLSSetup()
+    P->>P: deps.TelemetryProps()
+    P->>P: stamp CommandKind
+    P->>P: deps.TelemetryClient(props)
+    P->>P: deps.Animation()
+    P->>C: cmd.RunE()
+    C-->>M: error or nil
+    Note over F: cobra.OnFinalize flushes telemetry
+```
+
+### How #803 extends the factory
+
+`StampInteractionMode` and `IsNonInteractive` slot into the existing pre-run
+hook. The factory is the only callsite — commands just read the result.
+
+```mermaid
+flowchart TD
+    subgraph 802 ["#802 — RootFactory"]
+        PR[persistentPreRun]
+        TP[deps.TelemetryProps]
+        SK[stamp CommandKind]
+        PR --> TP --> SK
+    end
+
+    subgraph 803 ["#803 — non-interactive telemetry"]
+        SI["telemetry.StampInteractionMode(props, cmd)"]
+        NI["cli.IsNonInteractive(cmd)"]
+        YF["cli.YesFlagName const"]
+        SI --> NI
+        NI --> YF
+        NI --> ENV["DATAROBOT_CLI_NON_INTERACTIVE"]
+        NI --> VI["viperx: force-interactive"]
+    end
+
+    SK --> SI
+    SI --> AMP["props.NonInteractive → every Amplitude event"]
+
+    subgraph cmds ["Commands (#803 migration)"]
+        C1["artifact del/checkout/codesync/init"]
+        C2["deps install, dotenv, plugin install"]
+        C3["start, workload config/del/up"]
+    end
+
+    NI --> cmds
+```
+
+The key design point: **the factory is the single callsite for all pre-run
+wiring**. `#802` defines the hook; `#803` inserts `StampInteractionMode` into it
+and exports `IsNonInteractive` so commands never re-implement detection logic
+themselves. Any future automation signal only needs to be wired in
+`IsNonInteractive` — nothing else changes.
+
+## Adding a new command
+
+### 1. Register it
+
+```go
+// cmd/root_factory.go — addSubcommands()
+func (f *RootFactory) addSubcommands(adder *cli.CommandAdder) {
+    adder.AddCommand(
+        // ...existing commands...
+        myfeature.Cmd(),  // ← add it here
+    )
+}
+```
+
+### 2. Write the command
+
+Commands have no knowledge of the factory. Same cobra pattern as always:
+
+```go
+// cmd/myfeature/cmd.go
+package myfeature
+
+func Cmd() *cobra.Command {
+    c := &cobra.Command{
+        Use:   "myfeature",
+        Short: "Does the thing",
+        RunE:  run,
+    }
+
+    telemetry.Track(c)  // wired once, fires automatically via cobra.OnFinalize
+
+    return c
+}
+
+func run(cmd *cobra.Command, args []string) error {
+    // config, TLS, and telemetry client are already set up by the factory's
+    // PersistentPreRunE — nothing to initialize here
+    return nil
+}
+```
+
+### 3. Write a test
+
+This is where the factory pays off. Previously you'd fight shared viperx state;
+now you get a clean isolated tree:
+
+```go
+func TestMyFeatureCmd(t *testing.T) {
+    root := cmd.NewRootFactory(
+        cmd.WithConfigInitializer(func(_ *cobra.Command, _ string) error { return nil }),
+        cmd.WithTLSSetup(func(_ *cobra.Command) error { return nil }),
+        cmd.WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
+        cmd.WithPluginRegistrar(func(_ *cobra.Command) {}),
+        cmd.WithAnimation(func() {}),
+    ).Build()
+
+    var buf bytes.Buffer
+    root.SetOut(&buf)
+    root.SetArgs([]string{"myfeature"})
+
+    require.NoError(t, root.Execute())
+    assert.Contains(t, buf.String(), "expected output")
+}
+```
+
+Once `newIsolatedRootCmd()` is available (from the test-isolation follow-up PR),
+this reduces to:
+
+```go
+root := newIsolatedRootCmd()
+root.SetArgs([]string{"myfeature"})
+require.NoError(t, root.Execute())
+```
+
+**The short version:** commands are written identically to before — they return a
+`*cobra.Command` from a `Cmd()` constructor, get registered in one place, and
+know nothing about the factory. The factory only changes how tests and `main`
+assemble the tree.

--- a/docs/development/root-factory.md
+++ b/docs/development/root-factory.md
@@ -30,6 +30,7 @@ classDiagram
         +TelemetryClient func
         +Animation func
         +PluginRegistrar func
+        +ViperBinder func
     }
 
     class CommandAdder {

--- a/docs/development/root-factory.md
+++ b/docs/development/root-factory.md
@@ -200,3 +200,235 @@ require.NoError(t, root.Execute())
 `*cobra.Command` from a `Cmd()` constructor, get registered in one place, and
 know nothing about the factory. The factory only changes how tests and `main`
 assemble the tree.
+
+---
+
+## Overriding a dependency in a test
+
+The most common reason to override a dependency is preventing viperx state from
+leaking between tests. When two tests both call `Execute()` on the same shared
+`RootCmd` singleton, the first test's `t.Setenv(...)` can still be visible to
+the second test via viper's global state — even after the env var is restored —
+because `AutomaticEnv` re-reads the environment on the next access.
+
+The fix is to give each test its own command tree built with a no-op
+`ConfigInitializer` that never touches viper:
+
+```go
+func TestSomethingThatSetsEnvVars(t *testing.T) {
+    t.Setenv("DATAROBOT_CLI_API_TOKEN", "test-token")
+
+    // Without the factory: this env var could bleed into the next test
+    // via viper's shared global state.
+    //
+    // With the factory: the no-op ConfigInitializer never calls
+    // viperx.AutomaticEnv(), so viper never sees the env var at all.
+    root := cmd.NewRootFactory(
+        cmd.WithConfigInitializer(func(_ *cobra.Command, _ string) error {
+            // Optionally seed specific viper keys your command needs,
+            // without calling AutomaticEnv() or ReadConfigFile().
+            viperx.Set("api-token", "test-token")
+            return nil
+        }),
+        cmd.WithTLSSetup(func(_ *cobra.Command) error { return nil }),
+        cmd.WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
+        cmd.WithPluginRegistrar(func(_ *cobra.Command) {}),
+        cmd.WithAnimation(func() {}),
+    ).Build()
+
+    root.SetArgs([]string{"mycommand"})
+    require.NoError(t, root.Execute())
+}
+```
+
+Similarly, override `WithTelemetryProps` to avoid hitting the network or disk
+for device/user IDs, and `WithPluginRegistrar` to skip filesystem discovery:
+
+```go
+// Minimal no-op factory — safe for any unit test.
+root := cmd.NewRootFactory(
+    cmd.WithConfigInitializer(func(_ *cobra.Command, _ string) error { return nil }),
+    cmd.WithTLSSetup(func(_ *cobra.Command) error { return nil }),
+    cmd.WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
+    cmd.WithPluginRegistrar(func(_ *cobra.Command) {}),
+    cmd.WithAnimation(func() {}),
+).Build()
+```
+
+> **Why not just use the global `RootCmd`?** The global singleton is built once
+> in `init()` with the production `ConfigInitializer`. Every `Execute()` call on
+> it runs `viperx.AutomaticEnv()` and `ReadConfigFile()` against the live
+> environment. Env vars set with `t.Setenv()` are restored after the test, but
+> viper's internal cache may retain values until the next `AutomaticEnv()` sweep
+> — which happens in the *next* test's `Execute()`. A fresh factory tree sidesteps
+> this entirely.
+
+---
+
+## Adding a new dependency to the factory
+
+Follow these four steps whenever a new cross-cutting concern needs to be
+injectable (for example, a new HTTP client, a feature-flag provider, or an
+audit logger).
+
+### Step 1 — Define the function type
+
+Add a named function type to the top of `root_factory.go`. Named types make
+option signatures self-documenting and prevent callers from accidentally passing
+the wrong function:
+
+```go
+// AuditLoggerFunc writes an audit event for the current command invocation.
+// Replace in tests with a no-op or a recorder.
+type AuditLoggerFunc func(cmd *cobra.Command, args []string) error
+```
+
+### Step 2 — Add the field to `Dependencies`
+
+```go
+type Dependencies struct {
+    ConfigInitializer ConfigInitializerFunc
+    TLSSetup          TLSSetupFunc
+    // ... existing fields ...
+
+    // AuditLogger writes an audit event before each command runs.
+    AuditLogger AuditLoggerFunc
+}
+```
+
+### Step 3 — Set the production default and add a `With*` option
+
+```go
+func DefaultDependencies() Dependencies {
+    return Dependencies{
+        // ... existing defaults ...
+        AuditLogger: defaultAuditLogger,
+    }
+}
+
+// WithAuditLogger overrides the audit-logging step.
+// Pass a no-op in tests that don't need audit coverage.
+func WithAuditLogger(fn AuditLoggerFunc) Option {
+    return func(f *RootFactory) {
+        f.deps.AuditLogger = fn
+    }
+}
+```
+
+### Step 4 — Call it in the right factory method
+
+Most new dependencies belong in `persistentPreRun` (runs before every command)
+or `addSubcommands` (runs once at build time). For something like an audit
+logger that needs to fire before each command:
+
+```go
+func (f *RootFactory) persistentPreRun(cmd *cobra.Command, args []string) error {
+    // ... existing setup ...
+
+    if err := f.deps.AuditLogger(cmd, args); err != nil {
+        return err
+    }
+
+    return nil
+}
+```
+
+That's it. Tests override it with `WithAuditLogger(func(...) error { return nil })`;
+production gets `defaultAuditLogger` for free.
+
+---
+
+## Feature-gating a command
+
+Feature gates hide commands behind an environment variable until they are ready
+for release. The factory's `addSubcommands` uses `cli.CommandAdder.AddCommand`,
+which automatically drops any command whose gate is not enabled.
+
+### Gate a top-level command
+
+```go
+// cmd/myfeature/cmd.go
+func Cmd() *cobra.Command {
+    c := &cobra.Command{
+        Use:   "myfeature",
+        Short: "Coming soon",
+    }
+
+    // Gate this command behind DATAROBOT_CLI_FEATURE_MYFEATURE=true.
+    features.SetGate(c, "myfeature")
+
+    return c
+}
+```
+
+Register it normally in `addSubcommands` — `CommandAdder` handles the filtering:
+
+```go
+adder.AddCommand(
+    myfeature.Cmd(),  // silently dropped unless the gate is enabled
+)
+```
+
+### Gate a nested subcommand
+
+`CommandAdder.AddCommand` only filters at the level it's called from. To gate a
+subcommand inside an existing parent, wrap the parent with `CommandAdder`:
+
+```go
+func Cmd() *cobra.Command {
+    parent := &cobra.Command{Use: "parent"}
+    adder := &cli.CommandAdder{Command: parent}
+
+    adder.AddCommand(gatedChild.Cmd())  // dropped when gate is off
+
+    return parent
+}
+```
+
+### Enable a gate locally
+
+```sh
+DATAROBOT_CLI_FEATURE_MYFEATURE=true dr myfeature
+```
+
+The env var name is derived from the gate name: uppercased, hyphens replaced
+with underscores, prefixed with `DATAROBOT_CLI_FEATURE_`.
+
+### Test gated and ungated behaviour
+
+Because gate evaluation happens in `init()` (when the production `RootCmd` is
+built), tests that check for command presence or absence should use the fresh
+factory tree — or skip when the gate state doesn't match what the test expects:
+
+```go
+func TestMyFeatureHiddenByDefault(t *testing.T) {
+    // Build a fresh tree with no feature gate enabled.
+    root := cmd.NewRootFactory(
+        cmd.WithConfigInitializer(func(_ *cobra.Command, _ string) error { return nil }),
+        cmd.WithTLSSetup(func(_ *cobra.Command) error { return nil }),
+        cmd.WithTelemetryProps(func() *telemetry.CommonProperties { return nil }),
+        cmd.WithPluginRegistrar(func(_ *cobra.Command) {}),
+        cmd.WithAnimation(func() {}),
+    ).Build()
+
+    for _, sub := range root.Commands() {
+        assert.NotEqual(t, "myfeature", sub.Name(),
+            "myfeature should not be present when gate is disabled")
+    }
+}
+
+func TestMyFeatureVisibleWhenGateEnabled(t *testing.T) {
+    t.Setenv("DATAROBOT_CLI_FEATURE_MYFEATURE", "true")
+
+    root := cmd.NewRootFactory( /* same no-op deps */ ).Build()
+
+    var found bool
+    for _, sub := range root.Commands() {
+        if sub.Name() == "myfeature" {
+            found = true
+        }
+    }
+
+    assert.True(t, found, "myfeature should be present when gate is enabled")
+}
+```

--- a/docs/development/root-factory.md
+++ b/docs/development/root-factory.md
@@ -4,11 +4,15 @@
 
 The `RootFactory` (`cmd/root_factory.go`) assembles the root cobra command from
 injectable dependencies. Each call to `Build()` returns a fresh, fully-wired
-`*cli.CommandAdder` with no shared mutable state — this is the key property that
-prevents cross-test env-var leakage and lets tests run in isolation.
+`*cli.CommandAdder` whose flags, sub-commands, and hooks are independent of
+every other tree's — the key property that prevents cross-test leakage and
+lets tests run in isolation. Some wiring still goes through process-global
+state; see [What stays shared](#what-stays-shared) for the list and the
+resulting rules.
 
 Production code (via `main`) uses the singleton built in `init()`. Tests use
-`NewRootFactory(...)` directly with stubbed dependencies.
+`NewRootFactory(...)` directly with stubbed dependencies, or
+`NewIsolatedRootFactory()` for an all-no-op preset.
 
 ## Diagrams
 
@@ -245,6 +249,36 @@ root := cmd.NewIsolatedRootFactory().Build()
 > viper's internal cache may retain values until the next `AutomaticEnv()` sweep
 > — which happens in the *next* test's `Execute()`. A fresh factory tree sidesteps
 > this entirely.
+
+---
+
+## What stays shared
+
+`Build()` gives each test its own cobra tree, but some wiring still goes
+through process-global state. Knowing exactly what remains shared tells you
+which test topologies are safe.
+
+| Shared global | Touched when | Effect |
+| --- | --- | --- |
+| viper flag bindings | every `Build()` (default `ViperBinder`) | bindings re-point at the newest tree; only the last-built tree's flags resolve via `viperx.Get*` |
+| viper config contents | `Execute()` via `ReadInConfig`, read at `Build()` by plugin discovery | parsed file contents persist in the global instance until the next read or `viperx.Reset()` |
+| `cobra.EnableCaseInsensitive` | every `Build()` | idempotent global write |
+| `cobra.OnFinalize` list | every Execute | append-only and replayed on every Execute; the factory's generation guard neutralizes stale replays |
+| `http.DefaultTransport` | Execute (TLS setup) | last-executed tree's TLS config wins |
+| `log` package logger | Execute (`log.Start` / `log.Stop`) | single global logger |
+| `config.SetAPIConsumerTrace` | Execute | last-executed tree's trace string wins |
+
+The practical rules:
+
+- **Serial build-then-execute is safe**, especially via
+  `NewIsolatedRootFactory()`, which skips the viper binding and plugin
+  discovery entirely.
+- **Mixing `RootCmd` with factory trees is not**: the newest `Build()`
+  hijacks the global viper bindings from any previously built tree, so only
+  one tree's bound flags resolve at a time ("one live tree at a time").
+- **`t.Parallel` across trees is not safe** with default dependencies —
+  parallel trees race on every global listed above. True parallel isolation
+  requires an injected viper instance, tracked as a backlog follow-up.
 
 ---
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -111,6 +111,13 @@ func NewClient(props *CommonProperties) *Client {
 	}
 }
 
+// NewTestClient returns a Client backed by the given amplitude.Client, for
+// tests that need to capture tracked events. Production code uses NewClient.
+// Passing a nil amp yields the same safe no-op behavior as a disabled client.
+func NewTestClient(amp amplitude.Client, props *CommonProperties) *Client {
+	return &Client{amp: amp, props: props}
+}
+
 // Track queues an event for delivery to Amplitude. Common properties from the
 // client's CommonProperties are merged into the event's EventProperties before
 // sending. UserID is set as a top-level event field (required by Amplitude).


### PR DESCRIPTION
## RATIONALE

As Carson noted, the CLI's root command setup uses package-level globals and `init()` side effects inherited from a basic cobra template. This creates two concrete problems:

1. **Env-var leakage in tests** — viperx state set by one test bleeds into the next because the production `RootCmd` singleton (built at `init()` time) reads live env vars on every Execute call.
2. **Inconsistent telemetry context** — properties like `command_kind` and `non_interactive` have to be stamped ad-hoc inside `PersistentPreRunE` against a shared global, making it easy to miss them in new commands or test scenarios.

GitHub CLI (`pkg/cmdutil.Factory`) and kubectl (`pkg/cmd/util.Factory`) both solve this by assembling the root command via an injectable factory whose dependencies can be swapped in tests. This PR brings the same pattern to the DataRobot CLI.

This PR **does not** fix env-var leakage in existing tests that use `RootCmd()` directly — that's #811. Telemetry/yes-flag centralization and command migrations are in the stacked #803.

## DIAGRAMS?

If you want all the gory details, go to [docs/development/root-factory.md](https://github.com/datarobot-oss/cli/blob/862e5f596b2039d30425101996cf43b0a3b8d50b/docs/development/root-factory.md). Here are the more important ones:

<img width="482" height="845" alt="9a082257f754" src="https://github.com/user-attachments/assets/05bb121e-2cee-408a-ae84-f961b39e59c6" />

<img width="807" height="755" alt="b26ebd55c100" src="https://github.com/user-attachments/assets/9f887575-5ef2-410b-a6d2-6d69a1ee3089" />

## CHANGES

### New: `cmd/root_factory.go`

- Defines `RootFactory`, a `Dependencies` struct, and seven `With*` functional option helpers (`WithConfigInitializer`, `WithTLSSetup`, `WithTelemetryProps`, `WithTelemetryClient`, `WithAnimation`, `WithPluginRegistrar`, `WithViperBinder`).
- `Build()` returns a fresh, fully-wired `*cli.CommandAdder` per call. The cobra tree itself is self-contained; the process globals that stay shared (viper bindings, `cobra.OnFinalize`, `http.DefaultTransport`, the log package) are documented in the guide's "What stays shared" section, along with the "one live tree at a time" rule.
- All wiring that was in `init()` (flag registration, viper binding, group/subcommand registration, help overrides, plugin discovery, unknown-arg guards) now runs per-build inside factory methods.
- A process-global generation guard on `cobra.OnFinalize` ensures stale finalizers from earlier Executes no-op instead of re-tracking old events on old clients — only the most recent Execute's finalizer acts.
- `NewIsolatedRootFactory()` is the safe one-call preset for tests: every dependency no-oped (no disk reads, no env binding, no plugin discovery, no viper binding, no telemetry transmission), with per-test overrides still available.

### New: `cmd/root_factory_test.go`

Regression test proving two sequentially executed trees each track exactly one telemetry event (verified to fail without the `OnFinalize` guard).

### Updated: `internal/telemetry/telemetry.go`

Adds `NewTestClient`, a test seam for capturing tracked events via an injected `amplitude.Client`. Production behavior is unchanged.

### New: `cmd/root_helpers.go`

Extracts `showFirstRunAnimation` and `setUnknownArgGuards` from the old `root.go` into a focused helper file so the factory can call them without import cycles.

### Refactored: `cmd/root.go`

Reduced to ~90 lines. Its only jobs now are:

1. Register import-cycle-breaking function values (`allCommandsOutputFn`, `runVersionCommandFn`).
2. Build the production singleton via `NewRootFactory()`.
3. Expose the backward-compatible `RootCmd` package-level var so existing tests need no changes.

### Updated: `cmd/exit.go`

Reads the telemetry client from `productionFactory.TelemetryClient()` at flush time rather than a bare package-level pointer.

## TESTING

- `go build ./...` — clean
- `go test -race ./cmd/... ./internal/cli/... ./internal/telemetry/...` — all green
- `task lint` — 0 issues across linux, darwin, and windows
- All pre-commit hooks pass

## RELATED

- #803 — stacked: telemetry/yes-flag centralization and command migrations
- #810 — stacked: thread `cmd` through `plugin install` confirm path
- #811 — stacked: migrate `root_test.go` to use `NewRootFactory` with stubbed deps

## FOLLOW-UP

- `IOStreams` (stdin/stdout/stderr injection, à la gh's factory) as the next `Dependencies` field — separate PR
- Viper instance-mode (injected viper per tree) is tracked separately in the backlog; the guide documents the current shared-state limitations instead

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors CLI bootstrap (config, TLS, telemetry flush, cobra hooks) while keeping the production singleton. Behavior is meant to be unchanged, but mistakes in pre-run/finalize wiring could affect every command.
> 
> **Overview**
> Introduces an injectable `RootFactory` so tests can build a fresh cobra tree with stubbed config, TLS, telemetry, plugins, and viper binding, instead of sharing the `init()`-built `RootCmd` singleton.
> 
> Production still uses that singleton (`RootCmd` / `ExecuteContext` unchanged for callers). Wiring that lived in `root.go` now runs per `Build()`: flags, groups, subcommands, help, plugin discovery, and unknown-arg guards. `cmd.Exit` flushes telemetry from `productionFactory` rather than a package-level client pointer.
> 
> `NewIsolatedRootFactory` no-ops those side effects for unit tests. A generation guard on `cobra.OnFinalize` prevents stale telemetry re-tracks across sequential Executes. Docs call out remaining process-global state (viper, HTTP transport, logger) and the “one live tree at a time” rule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0fa61934168d54db854871e756088d1f5cc3f18. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
