### PR TITLE
feat(telemetry): capture non-interactive mode; centralize yes-flag handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,11 +158,11 @@ For full details, see [docs/development/configuration.md](docs/development/confi
 - **Never bulk-bind subcommand flags to viper.** `viperx` does not expose
   `BindPFlags`. Bind only specific persistent flags explicitly via
   `viperx.BindPFlag` in `cmd/root.go::init()`.
-- **Read transient flags directly from cobra**: `cmd.Flags().GetBool("yes")`.
+- **Read transient flags directly from cobra**: e.g. `cmd.Flags().GetBool(cli.YesFlagName)`.
   Do not bind them with `viperx.BindPFlag`.
 - **Env-var override for a transient flag:** register only the env var via
-  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and OR the two sources at the call site:
-  `yesFlag, _ := cmd.Flags().GetBool("yes"); yes := yesFlag || viperx.GetBool("yes")`.
+  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and merge the sources with
+  `cli.IsNonInteractive(cmd)` rather than inlining the flag/env OR yourself.
 - **To make a key persistable**, add it to `config.PersistableKeys` and have the
   write site call `config.UpdateConfigFile("my-key")`.
 

--- a/cmd/artifact/code/checkout/cmd.go
+++ b/cmd/artifact/code/checkout/cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/datarobot/cli/cmd/artifact/code/internal/dirprompt"
 	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi/filesapi"
 	"github.com/datarobot/cli/internal/outputformat"
@@ -49,7 +50,7 @@ func defaultDeps() Deps {
 
 func init() {
 	// Per project rules: bind only the env var, read the flag directly from cobra.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 }
 
 func Cmd() *cobra.Command {
@@ -98,14 +99,13 @@ Example:
 
 	c.Flags().String("dir", "", "Project directory (default: current directory).")
 	c.Flags().Bool("clean", false, "Remove checkout directories instead of downloading.")
-	c.Flags().BoolP("yes", "y", false, "Skip interactive prompts.")
+	c.Flags().BoolP(cli.YesFlagName, "y", false, "Skip interactive prompts.")
 
 	return c
 }
 
 func runCheckout(cmd *cobra.Command, args []string, outputFormat outputformat.OutputFormat, deps Deps) error {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	yes := yesFlag || viperx.GetBool("yes")
+	yes := cli.IsNonInteractive(cmd)
 
 	dirFlag, _ := cmd.Flags().GetString("dir")
 	clean, _ := cmd.Flags().GetBool("clean")

--- a/cmd/artifact/code/codesync/cmd.go
+++ b/cmd/artifact/code/codesync/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/datarobot/cli/cmd/artifact/code/internal/dirprompt"
 	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/misc/reader"
@@ -93,7 +94,7 @@ func defaultDeps() Deps {
 
 func init() {
 	// --yes is read directly from cobra; only the env var binds to viper
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 }
 
 // Cmd returns the cobra.Command for `dr artifact code sync`.
@@ -142,7 +143,7 @@ Example:
 	c.Flags().String("dir", "", "Project directory (default: current directory).")
 	c.Flags().Bool("dry-run", false, "Show plan, no writes.")
 	c.Flags().Bool("diff", false, "Show plan + per-file unified diffs, no writes.")
-	c.Flags().BoolP("yes", "y", false, "Skip interactive prompts; auto-confirm.")
+	c.Flags().BoolP(cli.YesFlagName, "y", false, "Skip interactive prompts; auto-confirm.")
 	c.MarkFlagsMutuallyExclusive("dry-run", "diff")
 
 	telemetry.TrackWith(c, func(cmd *cobra.Command, _ []string) map[string]any {
@@ -206,14 +207,13 @@ func runSync(cmd *cobra.Command, outputFormat outputformat.OutputFormat, deps De
 // DATAROBOT_CLI_NON_INTERACTIVE env-var override into Yes, so the
 // downstream helpers see a single source of truth.
 func parseRunFlags(cmd *cobra.Command) runFlags {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	diff, _ := cmd.Flags().GetBool("diff")
 
 	return runFlags{
 		DryRun: dryRun,
 		Diff:   diff,
-		Yes:    yesFlag || viperx.GetBool("yes"),
+		Yes:    cli.IsNonInteractive(cmd),
 	}
 }
 

--- a/cmd/artifact/code/init/cmd.go
+++ b/cmd/artifact/code/init/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/datarobot/cli/cmd/artifact/code/internal/dirprompt"
 	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/outputformat"
@@ -72,16 +73,15 @@ Example:
 	outputformat.AddFlag(c, &outputFormat)
 
 	c.Flags().String("dir", "", "Project directory (default: current directory).")
-	c.Flags().BoolP("yes", "y", false, "Skip interactive prompts; use defaults.")
+	c.Flags().BoolP(cli.YesFlagName, "y", false, "Skip interactive prompts; use defaults.")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
 	// flag itself is read directly from cmd.Flags() in runInit so an explicit
 	// --yes does not leak into viper.AllSettings() and persist to drconfig.yaml.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(c, func(cmd *cobra.Command, args []string) map[string]any {
-		yesFlag, _ := cmd.Flags().GetBool("yes")
-		yes := yesFlag || viperx.GetBool("yes")
+		yes := cli.IsNonInteractive(cmd)
 
 		return map[string]any{
 			"artifact_id":   telemetry.FirstArg(args),
@@ -94,8 +94,7 @@ Example:
 }
 
 func runInit(cmd *cobra.Command, args []string, outputFormat outputformat.OutputFormat) error {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	yes := yesFlag || viperx.GetBool("yes")
+	yes := cli.IsNonInteractive(cmd)
 	dirFlag, _ := cmd.Flags().GetString("dir")
 
 	dir, err := dirprompt.ResolveDir(dirFlag, yes, dirprompt.AskWithDefault)

--- a/cmd/artifact/del/cmd.go
+++ b/cmd/artifact/del/cmd.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/helpers"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/misc/reader"
@@ -69,19 +70,17 @@ Example:
 		},
 	}
 
-	cmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt.")
+	cmd.Flags().BoolP(cli.YesFlagName, "y", false, "Skip the confirmation prompt.")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
 	// flag itself is read directly from cmd.Flags() so an explicit --yes does
 	// not leak into viper.AllSettings() and persist to drconfig.yaml.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(cmd *cobra.Command, args []string) map[string]any {
-		yesFlag, _ := cmd.Flags().GetBool("yes")
-
 		return map[string]any{
 			"artifact_id": telemetry.FirstArg(args),
-			"yes":         yesFlag || viperx.GetBool("yes"),
+			"yes":         cli.IsNonInteractive(cmd),
 		}
 	})
 
@@ -89,8 +88,7 @@ Example:
 }
 
 func confirmDelete(cmd *cobra.Command, artifactID string) (bool, error) {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	if yesFlag || viperx.GetBool("yes") {
+	if cli.IsNonInteractive(cmd) {
 		return true, nil
 	}
 

--- a/cmd/dependencies/install/cmd.go
+++ b/cmd/dependencies/install/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/cmd/helpers"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/dependencies"
 	"github.com/datarobot/cli/internal/log"
@@ -46,7 +47,7 @@ func Cmd() *cobra.Command {
 		Short: "📦 Install missing template dependencies",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			yesFlag = opts.Yes
-			nonInteractive = viperx.GetBool("yes")
+			nonInteractive = cli.IsNonInteractive(cmd)
 
 			log.Debug("deps: install start", "yes", yesFlag, "non_interactive", nonInteractive)
 
@@ -97,9 +98,9 @@ func Cmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.Yes, "yes", "y", false, `Assume "yes" as answer to the install prompt.`)
+	cmd.Flags().BoolVarP(&opts.Yes, cli.YesFlagName, "y", false, `Assume "yes" as answer to the install prompt.`)
 
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/dependencies/install/cmd_test.go
+++ b/cmd/dependencies/install/cmd_test.go
@@ -69,7 +69,7 @@ func TestInstallCmd_PropExtractor_AllSatisfied(t *testing.T) {
 
 // TestInstallCmd_YesFlag_SkipsPromptAndInstalls verifies that --yes bypasses the
 // interactive prompt, that the install succeeds, and that the PropExtractor records
-// yes_flag=true / non_interactive=false.
+// yes_flag=true / non_interactive=true.
 func TestInstallCmd_YesFlag_SkipsPromptAndInstalls(t *testing.T) {
 	orig := tools.RequiredTools
 
@@ -94,7 +94,7 @@ func TestInstallCmd_YesFlag_SkipsPromptAndInstalls(t *testing.T) {
 	assert.Contains(t, installSuccess, "FakeTool")
 	assert.Empty(t, event.EventProperties["install_error"])
 	assert.Equal(t, true, event.EventProperties["yes_flag"])
-	assert.Equal(t, false, event.EventProperties["non_interactive"])
+	assert.Equal(t, true, event.EventProperties["non_interactive"])
 }
 
 // TestInstallCmd_NonInteractive_SkipsPromptAndInstalls verifies that

--- a/cmd/dotenv/cmd.go
+++ b/cmd/dotenv/cmd.go
@@ -152,13 +152,9 @@ This wizard will help you:
 		}
 
 		showAllPrompts, _ := cmd.Flags().GetBool("all")
-		// Read --yes directly from flags rather than through viper to
-		// avoid the flag value leaking into viper.AllSettings() (and from
-		// there into drconfig.yaml on subsequent writes). The
-		// DATAROBOT_CLI_NON_INTERACTIVE environment variable still flows
-		// through viper via BindEnv below.
-		yesFlag, _ := cmd.Flags().GetBool("yes")
-		yes := yesFlag || viperx.GetBool("yes")
+		// Merge --yes and DATAROBOT_CLI_NON_INTERACTIVE via the shared helper so the
+		// transient flag never leaks into viper.AllSettings().
+		yes := cli.IsNonInteractive(cmd)
 
 		// When --yes is set, run fully non-interactive setup without TUI
 		if yes {
@@ -230,15 +226,15 @@ This wizard will help you:
 func init() {
 	SetupCmd.Flags().Bool("if-needed", false, "Only run setup if '.env' file doesn't exist or there are missing env vars.")
 	SetupCmd.Flags().BoolP("all", "a", false, "Show all prompts including those with default values already set.")
-	SetupCmd.Flags().BoolP("yes", "y", false, "Skip interactive prompts and use defaults (useful for automation).")
+	SetupCmd.Flags().BoolP(cli.YesFlagName, "y", false, "Skip interactive prompts and use defaults (useful for automation).")
 	SetupCmd.Flags().StringP("output", "o", "", "Directory where the '.env' file should be written (defaults to repository root). This option skips the logic of finding the repository root.")
-	SetupCmd.MarkFlagsMutuallyExclusive("yes", "all")
+	SetupCmd.MarkFlagsMutuallyExclusive(cli.YesFlagName, "all")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper.
 	// The --yes flag itself is read directly from cmd.Flags() in RunE so
 	// that an explicit --yes does not leak into viper.AllSettings() and
 	// get persisted to drconfig.yaml on subsequent config writes.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.Track(SetupCmd)
 	telemetry.Track(UpdateCmd)

--- a/cmd/plugin/install/cmd.go
+++ b/cmd/plugin/install/cmd.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/datarobot/cli/cmd/plugin/shared"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/plugin"
@@ -71,14 +72,14 @@ Use --url to install directly from an HTTP/HTTPS URL instead of the registry.`,
 	cmd.Flags().BoolVar(&listPlugins, "list", false, "List available plugins from the registry")
 	cmd.Flags().StringVar(&filePath, "file", "", "Install from a local .tar.xz archive instead of the registry")
 	cmd.Flags().StringVar(&pluginURL, "url", "", "Install from an HTTP/HTTPS URL instead of the registry")
-	cmd.Flags().BoolVarP(&yesFlag, "yes", "y", false, `Assume "yes" when prompted to install plugin dependencies.`)
+	cmd.Flags().BoolVarP(&yesFlag, cli.YesFlagName, "y", false, `Assume "yes" when prompted to install plugin dependencies.`)
 
 	// Mark mutually exclusive flags
 	cmd.MarkFlagsMutuallyExclusive("list", "versions", "version", "file", "url")
 	cmd.MarkFlagsMutuallyExclusive("file", "registry-url")
 	cmd.MarkFlagsMutuallyExclusive("url", "registry-url")
 
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(c *cobra.Command, args []string) map[string]any {
 		ver, _ := c.Flags().GetString("version")
@@ -272,7 +273,7 @@ func (h *headingWriter) Write(p []byte) (int, error) {
 // missing plugin dependencies. Consent is granted automatically when -y/--yes
 // is set; otherwise the user is prompted interactively.
 func confirmPluginDepsInstall() bool {
-	if yesFlag || viperx.GetBool("yes") {
+	if yesFlag || cli.IsNonInteractive(nil) {
 		return true
 	}
 

--- a/cmd/root_factory.go
+++ b/cmd/root_factory.go
@@ -431,11 +431,11 @@ func (f *RootFactory) persistentPreRun(cmd *cobra.Command, args []string) error 
 			props.CommandKind = "core"
 		}
 
-		// Stamp the merged non-interactive signal (env var, --yes flag,
-		// --force-interactive override) so every event reports whether the
-		// invocation ran without human interaction. CollectCommonProperties
-		// only seeds the env-var signal, so this call is what lets --yes
-		// invocations show up as non_interactive in analytics.
+		// Stamp the merged non-interactive signal (env var, --yes flag) so
+		// every event reports whether the invocation ran without human
+		// interaction. CollectCommonProperties only seeds the env-var
+		// signal, so this call is what lets --yes invocations show up as
+		// non_interactive in analytics.
 		telemetry.StampInteractionMode(props, cmd)
 	}
 

--- a/cmd/root_factory.go
+++ b/cmd/root_factory.go
@@ -430,6 +430,13 @@ func (f *RootFactory) persistentPreRun(cmd *cobra.Command, args []string) error 
 		} else {
 			props.CommandKind = "core"
 		}
+
+		// Stamp the merged non-interactive signal (env var, --yes flag,
+		// --force-interactive override) so every event reports whether the
+		// invocation ran without human interaction. CollectCommonProperties
+		// only seeds the env-var signal, so this call is what lets --yes
+		// invocations show up as non_interactive in analytics.
+		telemetry.StampInteractionMode(props, cmd)
 	}
 
 	// Log the detected shell only when debug is active. Reuse Shell from

--- a/cmd/root_factory_test.go
+++ b/cmd/root_factory_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/amplitude/analytics-go/amplitude"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -95,4 +96,34 @@ func TestStaleFinalizersDoNotRetrack(t *testing.T) {
 
 	assert.Equal(t, 1, clientB.count(), "second execute should track exactly one event")
 	assert.Equal(t, 1, clientA.count(), "stale finalizer from first execute must not re-track")
+}
+
+// TestPersistentPreRunStampsInteractionMode verifies that persistentPreRun
+// stamps the merged non-interactive signal onto the collected telemetry
+// props: a --yes invocation must report NonInteractive even though the
+// collector only seeds the env-var signal. Without the StampInteractionMode
+// call in persistentPreRun, --yes-only invocations would report
+// non_interactive=false to analytics.
+func TestPersistentPreRunStampsInteractionMode(t *testing.T) {
+	// Seed props the way the production collector would for an interactive
+	// run: NonInteractive unset. persistentPreRun must overwrite it with the
+	// merged signal once flags are parsed.
+	props := &telemetry.CommonProperties{}
+
+	root := NewIsolatedRootFactory(
+		WithTelemetryProps(func() *telemetry.CommonProperties { return props }),
+	).Build()
+
+	stub := &cobra.Command{
+		Use:  "stub",
+		RunE: func(_ *cobra.Command, _ []string) error { return nil },
+	}
+
+	stub.Flags().Bool(cli.YesFlagName, false, "")
+	root.AddCommand(stub)
+
+	root.SetArgs([]string{"stub", "--yes"})
+	require.NoError(t, root.Execute())
+
+	assert.True(t, props.NonInteractive, "persistentPreRun must stamp non_interactive for --yes invocations")
 }

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -27,7 +27,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/dependencies"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/repo"
@@ -137,7 +137,7 @@ func NewStartModel(opts Options) Model {
 		repoRoot: repoRoot,
 		telemetry: telemetryCapture{
 			yesFlag:        opts.AnswerYes,
-			nonInteractive: viperx.GetBool("yes"),
+			nonInteractive: cli.IsNonInteractive(nil),
 		},
 	}
 }
@@ -351,7 +351,7 @@ func (m Model) handleDepsMissing(msg depsMissingMsg) (tea.Model, tea.Cmd) {
 	m.telemetry.missingMsgs = msg.checkResult.MissingMsgs
 	m.telemetry.wrongVersionMsgs = msg.checkResult.WrongVersionMsgs
 
-	autoInstall := m.opts.AnswerYes || viperx.GetBool("yes")
+	autoInstall := m.opts.AnswerYes || cli.IsNonInteractive(nil)
 
 	log.Debug("start: handling missing deps", "count", len(msg.prerequisites), "auto_install", autoInstall)
 
@@ -647,7 +647,7 @@ func findAndExecuteStart(m *Model) tea.Msg {
 		// Found a quickstart script
 		// Don't wait for confirmation if '--yes' flag is set or
 		// DATAROBOT_CLI_NON_INTERACTIVE env var is true
-		waitForConfirmation := !m.opts.AnswerYes && !viperx.GetBool("yes")
+		waitForConfirmation := !m.opts.AnswerYes && !cli.IsNonInteractive(nil)
 
 		return stepCompleteMsg{
 			message:              fmt.Sprintf("Found quickstart script at: %s\n", quickstartScript),

--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -136,8 +136,11 @@ func NewStartModel(opts Options) Model {
 		opts:     opts,
 		repoRoot: repoRoot,
 		telemetry: telemetryCapture{
-			yesFlag:        opts.AnswerYes,
-			nonInteractive: cli.IsNonInteractive(nil),
+			yesFlag: opts.AnswerYes,
+			// IsNonInteractive(nil) cannot see the --yes flag (it is bound to
+			// opts, not viper), so OR it in explicitly — same pattern as the
+			// prompt-skipping checks below.
+			nonInteractive: opts.AnswerYes || cli.IsNonInteractive(nil),
 		},
 	}
 }

--- a/cmd/start/model_test.go
+++ b/cmd/start/model_test.go
@@ -126,7 +126,7 @@ func TestNewStartModel_CapturesYesFlag(t *testing.T) {
 	m := NewStartModel(Options{AnswerYes: true})
 
 	assert.True(t, m.telemetry.yesFlag)
-	assert.False(t, m.telemetry.nonInteractive)
+	assert.True(t, m.telemetry.nonInteractive, "dr start --yes must report non_interactive=true")
 }
 
 func TestNewStartModel_CapturesNonInteractive(t *testing.T) {

--- a/cmd/workload/config/cmd.go
+++ b/cmd/workload/config/cmd.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -117,11 +118,13 @@ Examples:
 
 	// Only the env var binds to viper; --yes is read from cobra so it never
 	// persists into drconfig.yaml.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWith(cmd, func(cmd *cobra.Command, _ []string) map[string]any {
+		nonInteractive := cli.IsNonInteractive(cmd)
+
 		return map[string]any{
-			"yes":           f.yes || viperx.GetBool("yes"),
+			"yes":           nonInteractive,
 			"type":          f.answers.Type,
 			"build_mode":    f.answers.BuildMode,
 			"bound":         f.answers.WorkloadID != "",
@@ -140,7 +143,7 @@ func addFlags(cmd *cobra.Command, f *flags) {
 	// only guessing is what the project directory can be read for, so the
 	// help text has to say that rather than leave "defaults" to be read as
 	// the other command's meaning.
-	cmd.Flags().BoolVarP(&f.yes, "yes", "y", false,
+	cmd.Flags().BoolVarP(&f.yes, cli.YesFlagName, "y", false,
 		"Do not prompt; answer every question from flags and what the project directory shows. "+
 			"A question neither of those answers is an error naming the flag that would settle it.")
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "Print the manifest and write nothing.")
@@ -208,7 +211,7 @@ func run(cmd *cobra.Command, f flags, format outputformat.OutputFormat) error {
 
 	// JSON output implies non-interactive: a wizard on stderr alongside a
 	// machine-readable stdout is a trap for whoever is parsing it.
-	yes := f.yes || viperx.GetBool("yes")
+	yes := cli.IsNonInteractive(cmd)
 
 	result, err := wizard.Run(wizard.Options{
 		Dir:            dir,

--- a/cmd/workload/del/cmd.go
+++ b/cmd/workload/del/cmd.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/helpers"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/fsutil"
@@ -97,20 +98,18 @@ Example:
 		},
 	}
 
-	cmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt.")
+	cmd.Flags().BoolP(cli.YesFlagName, "y", false, "Skip the confirmation prompt.")
 	cmd.Flags().String("dir", "", "Project directory whose manifest holds the binding, searched upward from here.")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
 	// flag itself is read directly from cmd.Flags() so an explicit --yes does
 	// not leak into viper.AllSettings() and persist to drconfig.yaml.
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
 	telemetry.TrackWith(cmd, func(cmd *cobra.Command, args []string) map[string]any {
-		yesFlag, _ := cmd.Flags().GetBool("yes")
-
 		return map[string]any{
 			"workload_id": telemetry.FirstArg(args),
-			"yes":         yesFlag || viperx.GetBool("yes"),
+			"yes":         cli.IsNonInteractive(cmd),
 		}
 	})
 
@@ -122,8 +121,7 @@ Example:
 // interactively. A declined prompt is (false, nil) so the command exits 0
 // as a no-op.
 func confirmDelete(cmd *cobra.Command, workloadID string) (bool, error) {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	if yesFlag || viperx.GetBool("yes") {
+	if cli.IsNonInteractive(cmd) {
 		return true, nil
 	}
 

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/internal/pollflags"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/fsutil"
 	"github.com/datarobot/cli/internal/misc/reader"
@@ -165,11 +166,13 @@ Examples:
 	outputformat.AddFlag(cmd, &outputFormat)
 	addFlags(cmd, &f, &poll)
 
-	_ = viperx.BindEnv("yes", "DATAROBOT_CLI_NON_INTERACTIVE")
+	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWith(cmd, func(cmd *cobra.Command, _ []string) map[string]any {
+		nonInteractive := cli.IsNonInteractive(cmd)
+
 		return map[string]any{
-			"yes":           f.yes || viperx.GetBool("yes"),
+			"yes":           nonInteractive,
 			"dry_run":       f.dryRun,
 			"detach":        f.detach,
 			"lock":          f.lock,
@@ -183,7 +186,7 @@ Examples:
 
 func addFlags(cmd *cobra.Command, f *flags, poll *pollflags.Set) {
 	cmd.Flags().StringVar(&f.dir, "dir", "", "Project directory; the manifest is searched upward from here.")
-	cmd.Flags().BoolVarP(&f.yes, "yes", "y", false,
+	cmd.Flags().BoolVarP(&f.yes, cli.YesFlagName, "y", false,
 		"Do not prompt. With no manifest this is an error rather than a wizard, "+
 			"and rolling a locked production version is not confirmed.")
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false, "Print the plan and change nothing.")
@@ -221,7 +224,7 @@ func run(cmd *cobra.Command, f flags, poll pollflags.Set, format outputformat.Ou
 
 	json := format == outputformat.OutputFormatJSON
 
-	yes := f.yes || viperx.GetBool("yes")
+	yes := cli.IsNonInteractive(cmd)
 
 	// JSON output implies non-interactive: a wizard drawn on stderr while
 	// stdout is being parsed is a trap for whoever is parsing it.

--- a/docs/development/flags.md
+++ b/docs/development/flags.md
@@ -350,14 +350,15 @@ Outside `internal/config/...`, all viper interaction goes through the
 Quick rules for new flags:
 
 - **Transient flags** (per-invocation): read directly via
-  `cmd.Flags().GetBool(...)`. Do not bind to viper.
+  `cmd.Flags().GetBool(...)` (for example `cli.YesFlagName`). Do not bind to viper.
 - **Env-var override needed?** Register only the env var with
-  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and OR the two sources in your
-  handler:
+  `viperx.BindEnv(key, "DATAROBOT_CLI_…")` and merge the sources with the shared
+  helper:
 
   ```go
-  yesFlag, _ := cmd.Flags().GetBool("yes")
-  yes := yesFlag || viperx.GetBool("yes")
+  _ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
+
+  nonInteractive := cli.IsNonInteractive(cmd)
   ```
 
 - **Sticky CLI preferences** (rare): bind via `viperx.BindPFlag` *and*

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -264,7 +264,9 @@ current invocation is interactive. The helper runs exactly once in
 
 - `DATAROBOT_CLI_NON_INTERACTIVE=true` forces `non_interactive=true`
 - Any parsed `--yes` flag (including short `-y`) flips the flag for that session
-- `--force-interactive` overrides both so wizards still render during automation
+- `--force-interactive` is not an interaction signal: it only forces the setup wizard
+  to re-run (via `state.HasCompletedDotenvSetup`) and does not override `--yes` or the
+  env var for confirmation prompts
 - Commands can reuse the same logic directly via `cli.IsNonInteractive(cmd)`
 
 To expose another universal flag or environment override, extend

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -243,6 +243,8 @@ PersistentPreRunE (root.go)
     ├─ Initialize CommonProperties (session ID, user ID, env, ...)
     ├─ Stamp props.CommandKind = "core" or "plugin"
     │   based on telemetry.IsPluginCommand(cmd)
+    ├─ Stamp props.NonInteractive via telemetry.StampInteractionMode
+    │   so every event shares the same automation signal
     ├─ Build telemetry.Client
     └─ Register cobra.OnFinalize (closes over cmd, args, client)
     ↓
@@ -252,6 +254,23 @@ cobra.OnFinalize (via cobra's deferred postRun, fires on success and error paths
     ├─ telemetry.EventFor(cmd, args) → if tracked, client.Track(event)
     ├─ Flush telemetry (3-second timeout)
     └─ log.Stop()
+
+### Stamping universal interaction flags
+
+`telemetry.StampInteractionMode` centralizes everything that decides whether the
+current invocation is interactive. The helper runs exactly once in
+`root.PersistentPreRunE`, so every event in the session inherits the same
+`non_interactive` property without each command needing to parse flags on its own.
+
+- `DATAROBOT_CLI_NON_INTERACTIVE=true` forces `non_interactive=true`
+- Any parsed `--yes` flag (including short `-y`) flips the flag for that session
+- `--force-interactive` overrides both so wizards still render during automation
+- Commands can reuse the same logic directly via `cli.IsNonInteractive(cmd)`
+
+To expose another universal flag or environment override, extend
+`telemetry.StampInteractionMode` (and update its tests) rather than touching
+individual commands. **TODO:** when the next global automation flag is added,
+document its behavior here and wire it through the helper alongside `--yes`.
 ```
 
 ### Reading RunE results in a PropExtractor

--- a/docs/development/telemetry.md
+++ b/docs/development/telemetry.md
@@ -254,6 +254,7 @@ cobra.OnFinalize (via cobra's deferred postRun, fires on success and error paths
     ├─ telemetry.EventFor(cmd, args) → if tracked, client.Track(event)
     ├─ Flush telemetry (3-second timeout)
     └─ log.Stop()
+```
 
 ### Stamping universal interaction flags
 
@@ -273,7 +274,6 @@ To expose another universal flag or environment override, extend
 `telemetry.StampInteractionMode` (and update its tests) rather than touching
 individual commands. **TODO:** when the next global automation flag is added,
 document its behavior here and wire it through the helper alongside `--yes`.
-```
 
 ### Reading RunE results in a PropExtractor
 

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -1,0 +1,30 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cli provides shared primitives used across the DataRobot CLI command
+// layer. It sits between the cobra command definitions (cmd/) and the internal
+// domain packages (internal/*), holding cross-cutting concerns that individual
+// commands need but that do not belong in any single domain package.
+//
+// Current contents:
+//
+//   - CommandAdder: a cobra.Command wrapper that filters feature-gated
+//     subcommands at registration time (command.go).
+//   - YesFlagName: the canonical "--yes"/"-y" flag name constant (flags.go).
+//   - IsNonInteractive: merges the three sources of automation signal —
+//     DATAROBOT_CLI_NON_INTERACTIVE env var, --yes flag, and --force-interactive
+//     override — into a single boolean (runtime.go).
+//   - ErrSilent: a sentinel error for commands that have already printed their
+//     own user-facing message and want cobra to stay quiet (command.go).
+package cli

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -22,9 +22,9 @@
 //   - CommandAdder: a cobra.Command wrapper that filters feature-gated
 //     subcommands at registration time (command.go).
 //   - YesFlagName: the canonical "--yes"/"-y" flag name constant (flags.go).
-//   - IsNonInteractive: merges the three sources of automation signal —
-//     DATAROBOT_CLI_NON_INTERACTIVE env var, --yes flag, and --force-interactive
-//     override — into a single boolean (runtime.go).
+//   - IsNonInteractive: merges the two sources of automation signal —
+//     DATAROBOT_CLI_NON_INTERACTIVE env var and the --yes flag — into a
+//     single boolean (runtime.go).
 //   - ErrSilent: a sentinel error for commands that have already printed their
 //     own user-facing message and want cobra to stay quiet (command.go).
 package cli

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -1,0 +1,20 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+// YesFlagName is the canonical name used for non-interactive confirmation flags.
+// Commands that accept "--yes"/"-y" should derive their flag registration from
+// this constant so shared helpers (telemetry, env bindings, etc.) can consume it.
+const YesFlagName = "yes"

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// flags.go defines shared flag-name constants used across command definitions.
+// Centralising flag names here prevents magic strings from drifting out of sync
+// between the registration site, viperx bindings, and shared helpers like
+// IsNonInteractive.
 package cli
 
 // YesFlagName is the canonical name used for non-interactive confirmation flags.

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -1,0 +1,47 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/spf13/cobra"
+)
+
+// IsNonInteractive reports whether the current command invocation should skip prompts.
+// It merges the non-interactive environment variable, any explicit --yes flag, and the
+// global --force-interactive override into a single truthy signal for automation.
+func IsNonInteractive(cmd *cobra.Command) bool {
+	if viperx.GetBool("force-interactive") {
+		return false
+	}
+
+	if reader.IsNonInteractive() {
+		return true
+	}
+
+	if cmd == nil {
+		return viperx.GetBool(YesFlagName)
+	}
+
+	flag := cmd.Flags().Lookup(YesFlagName)
+	if flag != nil {
+		if yes, err := cmd.Flags().GetBool(YesFlagName); err == nil && yes {
+			return true
+		}
+	}
+
+	return viperx.GetBool(YesFlagName)
+}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -28,13 +28,14 @@ import (
 )
 
 // IsNonInteractive reports whether the current command invocation should skip prompts.
-// It merges the non-interactive environment variable, any explicit --yes flag, and the
-// global --force-interactive override into a single truthy signal for automation.
+// It merges the non-interactive environment variable and any explicit --yes flag
+// into a single truthy signal for automation.
+//
+// --force-interactive is deliberately NOT consulted here: its documented scope is
+// forcing setup wizards to re-run (state.HasCompletedDotenvSetup), not vetoing
+// automation consent. Letting it override --yes would silently block scripted
+// invocations for any user who happens to set both.
 func IsNonInteractive(cmd *cobra.Command) bool {
-	if viperx.GetBool("force-interactive") {
-		return false
-	}
-
 	if reader.IsNonInteractive() {
 		return true
 	}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// runtime.go provides helpers that commands call during execution to query the
+// ambient runtime context — specifically whether the current invocation is
+// running in a non-interactive (automated) mode.
+//
+// IsNonInteractive is the single authoritative check for prompt-skipping. Any
+// new automation signal (a future --no-prompt flag, a CI env var, etc.) should
+// be added here rather than inlined in individual commands.
 package cli
 
 import (

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNonInteractiveEnv(t *testing.T) {
+	t.Cleanup(viperx.Reset)
+	t.Setenv(reader.NonInteractiveEnv, "1")
+
+	assert.True(t, IsNonInteractive(nil))
+}
+
+func TestIsNonInteractiveFlag(t *testing.T) {
+	t.Cleanup(viperx.Reset)
+	t.Setenv(reader.NonInteractiveEnv, "")
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().BoolP(YesFlagName, "y", false, "skip prompts")
+	require.NoError(t, cmd.ParseFlags([]string{"--" + YesFlagName}))
+
+	assert.True(t, IsNonInteractive(cmd))
+}
+
+func TestIsNonInteractiveForceInteractiveOverrides(t *testing.T) {
+	t.Cleanup(viperx.Reset)
+	t.Setenv(reader.NonInteractiveEnv, "true")
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool(YesFlagName, false, "skip prompts")
+	require.NoError(t, cmd.ParseFlags([]string{"--" + YesFlagName}))
+
+	viperx.Set("force-interactive", true)
+
+	assert.False(t, IsNonInteractive(cmd))
+}

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -42,7 +42,7 @@ func TestIsNonInteractiveFlag(t *testing.T) {
 	assert.True(t, IsNonInteractive(cmd))
 }
 
-func TestIsNonInteractiveForceInteractiveOverrides(t *testing.T) {
+func TestIsNonInteractiveForceInteractiveDoesNotOverride(t *testing.T) {
 	t.Cleanup(viperx.Reset)
 	t.Setenv(reader.NonInteractiveEnv, "true")
 
@@ -52,5 +52,7 @@ func TestIsNonInteractiveForceInteractiveOverrides(t *testing.T) {
 
 	viperx.Set("force-interactive", true)
 
-	assert.False(t, IsNonInteractive(cmd))
+	// --force-interactive only forces setup wizards to re-run; it must not
+	// veto --yes / non-interactive consent for confirmation prompts.
+	assert.True(t, IsNonInteractive(cmd))
 }

--- a/internal/telemetry/interaction.go
+++ b/internal/telemetry/interaction.go
@@ -1,0 +1,35 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"github.com/datarobot/cli/internal/cli"
+	"github.com/spf13/cobra"
+)
+
+// StampInteractionMode annotates props with whether the current invocation is running
+// in non-interactive mode. This happens once in root PersistentPreRunE so every event
+// shares the same interaction metadata without per-command duplication.
+//
+// TODO: fold additional universal automation flags (e.g. future --non-interactive variants)
+//
+//	into this helper instead of re-implementing the logic in individual commands.
+func StampInteractionMode(props *CommonProperties, cmd *cobra.Command) {
+	if props == nil {
+		return
+	}
+
+	props.NonInteractive = cli.IsNonInteractive(cmd)
+}

--- a/internal/telemetry/interaction.go
+++ b/internal/telemetry/interaction.go
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// interaction.go bridges the cli package's runtime detection into the telemetry
+// layer. StampInteractionMode is called once per invocation from the factory's
+// PersistentPreRunE so that every Amplitude event carries a consistent
+// non_interactive property without per-command duplication.
+//
+// The actual detection logic lives in cli.IsNonInteractive — this file is
+// intentionally thin so that the telemetry package has no direct dependency on
+// flag-parsing or environment-variable details.
 package telemetry
 
 import (

--- a/internal/telemetry/interaction_test.go
+++ b/internal/telemetry/interaction_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/cli"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStampInteractionMode_NonInteractiveEnv(t *testing.T) {
+	t.Setenv(reader.NonInteractiveEnv, "1")
+	t.Cleanup(viperx.Reset)
+
+	props := &CommonProperties{}
+
+	StampInteractionMode(props, nil)
+
+	// The environment variable alone should flip the telemetry flag.
+	assert.True(t, props.NonInteractive)
+}
+
+func TestStampInteractionMode_YesFlag(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().BoolP(cli.YesFlagName, "y", false, "skip prompts")
+	t.Setenv(reader.NonInteractiveEnv, "")
+	t.Cleanup(viperx.Reset)
+
+	require.NoError(t, cmd.ParseFlags([]string{"--yes"}))
+
+	props := &CommonProperties{}
+
+	StampInteractionMode(props, cmd)
+
+	// Any explicit --yes invocation is tracked as non-interactive.
+	assert.True(t, props.NonInteractive)
+}
+
+func TestStampInteractionMode_ForceInteractiveOverrides(t *testing.T) {
+	t.Cleanup(viperx.Reset)
+
+	// Simulate both automation signals; force-interactive should still win.
+	t.Setenv(reader.NonInteractiveEnv, "true")
+	viperx.Set("force-interactive", true)
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool(cli.YesFlagName, false, "skip prompts")
+	require.NoError(t, cmd.ParseFlags([]string{"--yes"}))
+
+	props := &CommonProperties{NonInteractive: true}
+
+	StampInteractionMode(props, cmd)
+
+	assert.False(t, props.NonInteractive)
+}

--- a/internal/telemetry/interaction_test.go
+++ b/internal/telemetry/interaction_test.go
@@ -53,10 +53,10 @@ func TestStampInteractionMode_YesFlag(t *testing.T) {
 	assert.True(t, props.NonInteractive)
 }
 
-func TestStampInteractionMode_ForceInteractiveOverrides(t *testing.T) {
+func TestStampInteractionMode_ForceInteractiveDoesNotOverride(t *testing.T) {
 	t.Cleanup(viperx.Reset)
 
-	// Simulate both automation signals; force-interactive should still win.
+	// Simulate both automation signals plus --force-interactive.
 	t.Setenv(reader.NonInteractiveEnv, "true")
 	viperx.Set("force-interactive", true)
 
@@ -64,9 +64,11 @@ func TestStampInteractionMode_ForceInteractiveOverrides(t *testing.T) {
 	cmd.Flags().Bool(cli.YesFlagName, false, "skip prompts")
 	require.NoError(t, cmd.ParseFlags([]string{"--yes"}))
 
-	props := &CommonProperties{NonInteractive: true}
+	props := &CommonProperties{}
 
 	StampInteractionMode(props, cmd)
 
-	assert.False(t, props.NonInteractive)
+	// --force-interactive scopes to setup-wizard rerun (state package); it
+	// must not flip the telemetry non_interactive signal back to false.
+	assert.True(t, props.NonInteractive)
 }

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/internal/shell"
 	"github.com/datarobot/cli/internal/state"
@@ -52,6 +53,7 @@ type CommonProperties struct {
 	Shell             string  // Name of the user's shell (e.g. "zsh", "bash", "powershell")
 	DataRobotInstance string  // Base URL of configured DataRobot instance
 	CommandKind       string  // "core" or "plugin", set by the root command after dispatch
+	NonInteractive    bool    // True when the invocation runs in non-interactive mode (env var, --yes flag, or automation)
 	OrganizationID    *string // DataRobot org ID from GET /api/v2/account/info/, cached to disk; nil on network failure or auth issues
 	TenantID          *string // DataRobot tenant ID from GET /api/v2/account/info/, cached to disk; nil if unavailable (legit absent for legacy/system accounts)
 	TemplateName      *string // Name of the DataRobot template used to create this project; nil when not inside a template project
@@ -84,7 +86,10 @@ func CollectCommonProperties() *CommonProperties {
 		OSVersion:     detectOSVersion(),
 		Language:      detectLanguage(),
 		GoVersion:     runtime.Version(),
-		Shell:         DetectShell(),
+		// Seed the interaction mode with the environment variable so automation workflows
+		// are marked even if the command itself lacks a --yes flag.
+		NonInteractive: reader.IsNonInteractive(),
+		Shell:          DetectShell(),
 	}
 
 	// Get DataRobot instance info from config
@@ -134,6 +139,8 @@ func (p *CommonProperties) AsMap() map[string]any {
 		"shell":              p.Shell,
 		"datarobot_instance": p.DataRobotInstance,
 		"command_kind":       p.CommandKind,
+		// non_interactive tells analytics when commands ran without human input.
+		"non_interactive": p.NonInteractive,
 	}
 
 	if p.OrganizationID != nil {


### PR DESCRIPTION
## RATIONALE

We need to understand when the CLI is executing without human interaction — either through `--yes` or automation — so downstream analytics can measure scripted usage. Capturing that signal once per invocation keeps individual commands from having to wire their own telemetry.

This also eliminates a recurring code smell across a dozen commands:

```go
// before
yesFlag, _ := cmd.Flags().GetBool("yes")
yes := yesFlag || viperx.GetBool("yes")

// after
yes := cli.IsNonInteractive(cmd)
```

## DIAGRAMS!?

```mermaid
flowchart TD
    subgraph PR802["#802 — RootFactory"]
        PR[persistentPreRun]
        TP[deps.TelemetryProps]
        SK[stamp CommandKind]
    end

    subgraph PR803["#803 — non-interactive telemetry"]
        SI["telemetry.StampInteractionMode(props, cmd)"]
        NI["cli.IsNonInteractive(cmd)"]
        YF["--yes flag (cmd.Flags)"]
        ENV["DATAROBOT_CLI_NON_INTERACTIVE"]
        VIP["viperx.GetBool('yes') — env fallback"]
        FI["--force-interactive (setup wizard only)"]
    end

    AMP["props.NonInteractive → every Amplitude event"]

    subgraph CMDS["Commands (#803 migration)"]
        C1["artifact del/checkout/codesync/init"]
        C2["deps install, dotenv, plugin install"]
        C3["start, workload config/del/up"]
    end

    PR --> TP --> SK --> SI
    SI --> NI
    NI --> YF
    NI --> ENV
    NI --> VIP
    SI --> AMP
    NI --> CMDS

    NI -.->|"not consulted"| FI

    classDef notConsulted stroke-dasharray: 5 5,opacity:0.5
    class FI notConsulted
```

## CHANGES

### New: `internal/cli/flags.go`

Defines `YesFlagName = "yes"` as the single canonical constant for `--yes`/`-y` flag registration.

### New: `internal/cli/runtime.go` + `runtime_test.go`

`IsNonInteractive(cmd)` centralizes the two-source check — `DATAROBOT_CLI_NON_INTERACTIVE` env var, `--yes` flag — replacing the inline two-line OR pattern. Three unit tests cover all paths. `--force-interactive` is deliberately not consulted here: its documented scope is forcing setup wizards to re-run (`state.HasCompletedDotenvSetup` consults it directly), not vetoing automation consent.

### New: `internal/telemetry/interaction.go` + `interaction_test.go`

`StampInteractionMode` is called once in the factory's `persistentPreRun`. Delegates to `cli.IsNonInteractive` — no local flag-name constants or helper functions needed. Three unit tests.

### Updated: `internal/telemetry/properties.go`

- Adds `NonInteractive bool` to `CommonProperties`, seeded from `reader.IsNonInteractive()` at collection time.
- Adds `"non_interactive"` to `AsMap()` so it appears on every Amplitude event.

### Command migrations

All replace the two-line pattern with `cli.IsNonInteractive(cmd)`:

- `cmd/artifact/code/checkout`, `codesync`, `init`
- `cmd/artifact/del`
- `cmd/dependencies/install` (+ test)
- `cmd/dotenv`
- `cmd/plugin/install`
- `cmd/start`
- `cmd/workload/config`, `del`, `up`

### Docs

`AGENTS.md`, `docs/development/flags.md`, `docs/development/telemetry.md` describe `IsNonInteractive` and `YesFlagName` as the canonical patterns going forward.

## TESTING

- `go test -race ./cmd/... ./internal/cli/... ./internal/telemetry/...` — all green
- `task lint` — 0 issues across linux, darwin, and windows
- All pre-commit hooks pass

## FOLLOW-UP

- `cmd/plugin/install` still has `yesFlag || cli.IsNonInteractive(nil)` in `confirmPluginDepsInstall` — needs `cmd` threaded down to fully clean up. fixed in #810

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787721016.366299 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches prompt-skipping across many commands. Telemetry property semantics shift (e.g. `--yes` now counts as non-interactive). `--force-interactive` is deliberately not consulted by `IsNonInteractive` (setup-wizard scope only).
> 
> **Overview**
> Centralizes how the CLI decides to skip prompts and reports that signal on every Amplitude event.
> 
> **`cli.IsNonInteractive(cmd)`** merges `DATAROBOT_CLI_NON_INTERACTIVE` and `--yes`/`-y` (`cli.YesFlagName`); `--force-interactive` is deliberately not consulted (setup-wizard scope only). Commands that used `flag || viperx.GetBool("yes")` now call this helper. Root `PersistentPreRunE` stamps the same result onto `telemetry.CommonProperties.NonInteractive` via `StampInteractionMode`, so `--yes` invocations are no longer reported as interactive.
> 
> Docs (`AGENTS.md`, flags/telemetry guides) prescribe the helper as the canonical pattern. `plugin install` still ORs a package-level `yesFlag` with `IsNonInteractive(nil)` because `cmd` is not threaded through that confirm path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f21ba7b9836dc4c416c526e41824aaa7133865. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

