### PR TITLE
[RAPTOR-19535] feat(workload): hide advanced config fields, make the readiness probe optional

### DIFF
--- a/cmd/workload/config/cmd.go
+++ b/cmd/workload/config/cmd.go
@@ -168,9 +168,12 @@ func addFlags(cmd *cobra.Command, f *flags) {
 	// A flag of its own rather than an empty --health. Declining a probe is a
 	// different act from not mentioning one, and a flag that says so is both
 	// greppable in a CI script and impossible to type by accident.
+	// Deliberately about the file rather than about the running workload: `up`
+	// leaves out what the file leaves out, so a probe already deployed goes
+	// only when the artifact is rebuilt for some other reason.
 	cmd.Flags().BoolVar(&f.answers.NoProbe, "no-readiness-probe", false,
 		"Write no readiness probe, so traffic is not gated on a health check. Exclusive with --health. "+
-			"With --workload-id this removes the probe the workload runs with today.")
+			"With --workload-id it drops the probe from the manifest; a deployed probe goes on the next artifact build.")
 
 	cmd.Flags().IntVar(&f.answers.Replicas, "replicas", 0, "Replica count (default 1).")
 	cmd.Flags().Float64Var(&f.answers.CPU, "cpu", 0, "CPU per replica (default 0.5).")

--- a/cmd/workload/config/cmd.go
+++ b/cmd/workload/config/cmd.go
@@ -164,7 +164,7 @@ func addFlags(cmd *cobra.Command, f *flags) {
 	cmd.Flags().StringVar(&f.answers.Image, "image", "", "Published image URI. Required with --build-mode image.")
 
 	cmd.Flags().IntVar(&f.answers.Port, "port", 0, "Container port (default: the Dockerfile's EXPOSE, else 8080).")
-	cmd.Flags().StringVar(&f.answers.HealthPath, "health", "", "Readiness path (default /health).")
+	cmd.Flags().StringVar(&f.answers.HealthPath, "health", "", "Readiness path (default /). Use --no-readiness-probe to write none.")
 	// A flag of its own rather than an empty --health. Declining a probe is a
 	// different act from not mentioning one, and a flag that says so is both
 	// greppable in a CI script and impossible to type by accident.

--- a/cmd/workload/config/cmd.go
+++ b/cmd/workload/config/cmd.go
@@ -165,10 +165,24 @@ func addFlags(cmd *cobra.Command, f *flags) {
 
 	cmd.Flags().IntVar(&f.answers.Port, "port", 0, "Container port (default: the Dockerfile's EXPOSE, else 8080).")
 	cmd.Flags().StringVar(&f.answers.HealthPath, "health", "", "Readiness path (default /health).")
+	// A flag of its own rather than an empty --health. Declining a probe is a
+	// different act from not mentioning one, and a flag that says so is both
+	// greppable in a CI script and impossible to type by accident.
+	cmd.Flags().BoolVar(&f.answers.NoProbe, "no-readiness-probe", false,
+		"Write no readiness probe, so traffic is not gated on a health check. Exclusive with --health. "+
+			"With --workload-id this removes the probe the workload runs with today.")
 
 	cmd.Flags().IntVar(&f.answers.Replicas, "replicas", 0, "Replica count (default 1).")
 	cmd.Flags().Float64Var(&f.answers.CPU, "cpu", 0, "CPU per replica (default 0.5).")
 	cmd.Flags().StringVar(&f.answers.Memory, "memory", "", "Memory per replica (default 512MB).")
+	// Applied when the workload is created. `up` compares the artifact spec and
+	// the runtime block, and importance is neither, so changing it for a
+	// workload that already exists is an edit the file records and the next
+	// deploy does not carry.
+	cmd.Flags().StringVar(&f.answers.Importance, "importance", "",
+		"Scheduling priority when capacity is constrained: "+
+			strings.Join(manifest.ImportanceLevels, ", ")+
+			" (default "+manifest.DefaultImportance+", or the bound workload's own level). Applied on create.")
 }
 
 func run(cmd *cobra.Command, f flags, format outputformat.OutputFormat) error {

--- a/cmd/workload/config/cmd_test.go
+++ b/cmd/workload/config/cmd_test.go
@@ -143,8 +143,6 @@ func TestCmd_DockerfileFlagIsPinned(t *testing.T) {
 }
 
 func TestCmd_RejectsBadFlagCombinations(t *testing.T) {
-	dir := project(t)
-
 	tests := map[string][]string{
 		"id and name":       {"--workload-id", "68b0", "--name", "my-app"},
 		"unsupported type":  {"--name", "my-app", "--type", "nim"},
@@ -152,15 +150,41 @@ func TestCmd_RejectsBadFlagCombinations(t *testing.T) {
 		"relative health":   {"--name", "my-app", "--health", "health"},
 		"privileged port":   {"--name", "my-app", "--port", "80"},
 		"image mode no uri": {"--name", "my-app", "--build-mode", "image"},
+		"probe and no probe": {
+			"--name", "my-app", "--no-readiness-probe", "--health", "/ready",
+		},
+		"unsupported importance": {"--name", "my-app", "--importance", "urgent"},
 	}
 
 	for name, args := range tests {
 		t.Run(name, func(t *testing.T) {
+			// A directory each: sharing one means a case that stops erroring
+			// writes a manifest the remaining cases then find already there,
+			// and they all fail without naming the one that regressed.
+			dir := project(t)
+
 			_, _, err := runCmd(t, append([]string{"--dir", dir, "--yes"}, args...)...)
 			require.Error(t, err)
 			assert.NoFileExists(t, manifest.Path(dir))
 		})
 	}
+}
+
+// The two fields the settings screen hides have to stay reachable without a
+// terminal, which for the probe means a flag of its own: an empty --health
+// cannot be told apart from an absent one.
+func TestCmd_HiddenFieldsAreReachableByFlag(t *testing.T) {
+	dir := project(t)
+
+	_, _, err := runCmd(t, "--dir", dir, "--yes", "--name", "my-app",
+		"--no-readiness-probe", "--importance", "high")
+	require.NoError(t, err)
+
+	written, err := os.ReadFile(manifest.Path(dir))
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(written), "readinessProbe")
+	assert.Contains(t, string(written), "importance: high")
 }
 
 func TestCmd_RejectsPositionalArgs(t *testing.T) {

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -87,7 +87,6 @@ func (l Live) Defaults() Draft {
 		Type:       ArtifactTypeOrDefault(l.Type()),
 		A2AEnabled: boolAt(l.Spec, keyA2AEnabled),
 		Port:       DefaultPort,
-		HealthPath: DefaultHealthPath,
 		Build:      Build{Mode: BuildModeDockerfile},
 		Runtime:    l.runtimeDefaults(),
 	}
@@ -101,6 +100,11 @@ func (l Live) Defaults() Draft {
 		draft.Port = port
 	}
 
+	// The health path is left empty when the container has no readiness probe,
+	// rather than falling back to DefaultHealthPath like everything else here.
+	// A workload running without a probe has to arrive saying so: the screen
+	// shows the absence, and Apply can then read a path as the answer someone
+	// gave rather than as a default it must be careful not to attach.
 	if path := stringAt(mapAt(container, keyReadinessProbe), keyPath); path != "" {
 		draft.HealthPath = path
 	}
@@ -108,6 +112,28 @@ func (l Live) Defaults() Draft {
 	draft.Build = liveBuild(container)
 
 	return draft
+}
+
+// ReadinessProbe reports what the running workload does about readiness:
+// whether the primary container declares a probe at all, and whether this
+// release can read a path out of it.
+//
+// The two are separate questions, and Defaults answers neither on its own: it
+// reports a probe with no readable path the same way it reports no probe, as an
+// empty HealthPath. Only the screens care about the difference, and they care a
+// lot, because an empty field means "no probe" to everything downstream.
+func (l Live) ReadinessProbe() (present, readable bool) {
+	container := l.primaryContainer()
+	if container == nil {
+		return false, false
+	}
+
+	probe := mapAt(container, keyReadinessProbe)
+	if probe == nil {
+		return false, false
+	}
+
+	return true, stringAt(probe, keyPath) != ""
 }
 
 // BuildMode reports how the primary container's image comes to be, in the
@@ -516,11 +542,15 @@ func (l Live) primaryContainerName() string {
 	return stringAt(container, keyName)
 }
 
-// applyReadiness writes the port and, where the workload already has a
-// readiness probe, keeps it pointing at the same place. It does not add one:
-// a workload deliberately running without a probe should not acquire the
-// wizard's default /health, which a container that does not serve it would
-// never pass.
+// applyReadiness writes the port and points the readiness probe wherever the
+// answers say, which includes having no probe at all.
+//
+// The draft's path is empty unless something asked for one: Defaults leaves it
+// empty for a container running without a probe, so a workload deliberately
+// running without one cannot acquire the wizard's default /health, which a
+// container that does not serve it would never pass. What reaches here
+// non-empty was typed on a screen or passed as a flag, and adding the probe is
+// then the answer rather than an invention.
 func applyReadiness(container map[string]any, draft Draft) {
 	previous, hadPort := intAt(container, keyPort)
 
@@ -531,27 +561,70 @@ func applyReadiness(container map[string]any, draft Draft) {
 	// nothing would otherwise produce a file rejecting its own port.
 	container[keyPrimary] = true
 
-	if probe := mapAt(container, keyReadinessProbe); probe != nil {
-		probe[keyPath] = draft.HealthPath
-		probe[keyPort] = draft.Port
-	}
+	rewritten := applyProbe(container, draft)
 
 	if !hadPort || previous == draft.Port {
 		return
 	}
 
-	// The other probes are blocks the wizard has no question for, and they are
-	// preserved as they stand. One that was watching the container's port still
-	// has to follow it: a startup probe left behind on the old port is how a
-	// changed port becomes a deploy that never reports ready. A probe aimed
-	// somewhere else was aimed there deliberately and keeps its own port.
-	for _, key := range []string{keyStartupProbe, keyLivenessProbe} {
+	// Probes the wizard has no question for are preserved as they stand. One
+	// that was watching the container's port still has to follow it: a startup
+	// probe left behind on the old port is how a changed port becomes a deploy
+	// that never reports ready. A probe aimed somewhere else was aimed there
+	// deliberately and keeps its own port.
+	following := []string{keyStartupProbe, keyLivenessProbe}
+	if !rewritten {
+		// A readiness probe this release could not read was left alone above,
+		// so it follows the same rule as the other two rather than keeping a
+		// port the container no longer listens on.
+		following = append(following, keyReadinessProbe)
+	}
+
+	for _, key := range following {
 		probe := mapAt(container, key)
 
 		if port, ok := intAt(probe, keyPort); ok && port == previous {
 			probe[keyPort] = draft.Port
 		}
 	}
+}
+
+// applyProbe settles the readiness probe and reports whether it rewrote or
+// removed one, so the caller knows whether the block still needs the port
+// treatment every other probe gets.
+//
+// A block whose path this release cannot read is left exactly as it stands. An
+// empty draft path means "no probe", but only for a probe the user could see:
+// Defaults reports a TCP, gRPC or otherwise unmodelled probe as an empty path
+// too, and deleting on that would throw away a running workload's own
+// configuration because the reader did not recognize its shape.
+func applyProbe(container map[string]any, draft Draft) bool {
+	probe := mapAt(container, keyReadinessProbe)
+
+	switch {
+	case probe != nil && stringAt(probe, keyPath) == "":
+		return false
+
+	case !draft.WantsReadinessProbe():
+		// Declined. The block goes rather than being left pointing at an empty
+		// path, which is neither a probe nor an absence of one.
+		delete(container, keyReadinessProbe)
+
+	case probe != nil:
+		probe[keyPath] = draft.HealthPath
+		probe[keyPort] = draft.Port
+
+	default:
+		// Asked for on a workload that has none. Only the two fields the wizard
+		// knows about are written; the timings are the platform's defaults,
+		// which is what a probe added here has always meant.
+		container[keyReadinessProbe] = map[string]any{
+			keyPath: draft.HealthPath,
+			keyPort: draft.Port,
+		}
+	}
+
+	return true
 }
 
 // applyBuild sets the image source, editing the live build block in place

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -568,10 +568,16 @@ func applyReadiness(container map[string]any, draft Draft) {
 	}
 
 	// Probes the wizard has no question for are preserved as they stand. One
-	// that was watching the container's port still has to follow it: a startup
-	// probe left behind on the old port is how a changed port becomes a deploy
-	// that never reports ready. A probe aimed somewhere else was aimed there
-	// deliberately and keeps its own port.
+	// whose own port was watching the container's still has to follow it: a
+	// startup probe left behind on the old port is how a changed port becomes a
+	// deploy that never reports ready. A probe aimed somewhere else was aimed
+	// there deliberately and keeps its own port.
+	//
+	// Nested ports follow too. A tcpSocket or gRPC probe keeps its port one
+	// level down, and leaving that on a port the container no longer listens on
+	// is the same never-reports-ready deploy this loop exists to prevent. Only
+	// a port that matched the container's old one moves, so a probe deliberately
+	// aimed elsewhere is still left alone whatever shape it is written in.
 	following := []string{keyStartupProbe, keyLivenessProbe}
 	if !rewritten {
 		// A readiness probe this release could not read was left alone above,
@@ -581,10 +587,31 @@ func applyReadiness(container map[string]any, draft Draft) {
 	}
 
 	for _, key := range following {
-		probe := mapAt(container, key)
+		followPort(mapAt(container, key), previous, draft.Port)
+	}
+}
 
-		if port, ok := intAt(probe, keyPort); ok && port == previous {
-			probe[keyPort] = draft.Port
+// followPort moves a probe from one port to another, at the probe's own level
+// and one level down, which is where the shapes this release does not model
+// keep theirs. It descends no further: past that, a "port" is as likely to
+// belong to something the probe merely mentions as to the thing it dials.
+func followPort(probe map[string]any, from, to int) {
+	if probe == nil {
+		return
+	}
+
+	if port, ok := intAt(probe, keyPort); ok && port == from {
+		probe[keyPort] = to
+	}
+
+	for _, value := range probe {
+		nested, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if port, ok := intAt(nested, keyPort); ok && port == from {
+			nested[keyPort] = to
 		}
 	}
 }
@@ -611,7 +638,7 @@ func applyProbe(container map[string]any, draft Draft) bool {
 		delete(container, keyReadinessProbe)
 
 	case probe != nil:
-		probe[keyPath] = draft.HealthPath
+		probe[keyPath] = draft.healthPath()
 		probe[keyPort] = draft.Port
 
 	default:
@@ -619,7 +646,7 @@ func applyProbe(container map[string]any, draft Draft) bool {
 		// knows about are written; the timings are the platform's defaults,
 		// which is what a probe added here has always meant.
 		container[keyReadinessProbe] = map[string]any{
-			keyPath: draft.HealthPath,
+			keyPath: draft.healthPath(),
 			keyPort: draft.Port,
 		}
 	}

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -504,11 +504,11 @@ func TestLive_ApplyMovesAnUnreadableProbeWithThePort(t *testing.T) {
 	rendered, err := applied.Render()
 	require.NoError(t, err)
 
-	// The probe's own port follows the container. What sits inside a block this
-	// release does not model is left exactly as it was, which is why the nested
-	// tcpSocket port is still 9000.
+	// Both ports follow: the probe's own, and the one the tcpSocket shape keeps
+	// a level down. A probe still dialling 9000 would never report ready.
 	assert.Contains(t, string(rendered), "readinessProbe:\n              port: 9100")
-	assert.Contains(t, string(rendered), "tcpSocket:\n                port: 9000")
+	assert.Contains(t, string(rendered), "tcpSocket:\n                port: 9100")
+	assert.NotContains(t, string(rendered), "port: 9000")
 }
 
 // probelessLive is a workload running without a readiness probe.

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -379,17 +379,13 @@ func TestLive_UnknownBuildSourceIsPreserved(t *testing.T) {
 }
 
 // A workload deliberately running without a readiness probe must not acquire
-// the wizard's default one, which its container would never pass.
+// the wizard's default one, which its container would never pass. The rule
+// lives in Defaults, which reads the absence as an empty path, so nothing
+// downstream has to tell a default apart from an answer.
 func TestLive_ApplyDoesNotInventAReadinessProbe(t *testing.T) {
-	var artifactDoc map[string]any
+	live := probelessLive(t)
 
-	require.NoError(t, json.Unmarshal([]byte(`{
-      "name": "a",
-      "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
-        {"name": "primary", "primary": true, "port": 9000, "imageUri": "registry/a:v1"}]}]}
-    }`), &artifactDoc))
-
-	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.Empty(t, live.Defaults().HealthPath, "no probe has to arrive as no path")
 
 	applied, err := live.Apply(live.Defaults())
 	require.NoError(t, err)
@@ -398,16 +394,136 @@ func TestLive_ApplyDoesNotInventAReadinessProbe(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotContains(t, string(rendered), "readinessProbe")
+}
 
-	// One that does have a probe keeps it pointing where the answers say.
+// Asking for one is the other half of that: a path only reaches Apply because
+// a screen or a flag put it there, and the confirm screen shows the diff before
+// anything is written.
+func TestLive_ApplyAddsTheProbeThatWasAskedFor(t *testing.T) {
+	live := probelessLive(t)
+
 	draft := live.Defaults()
 	draft.HealthPath = "/ready"
 
-	applied, err = live.Apply(draft)
+	applied, err := live.Apply(draft)
 	require.NoError(t, err)
-	rendered, err = applied.Render()
+
+	rendered, err := applied.Render()
 	require.NoError(t, err)
-	assert.NotContains(t, string(rendered), "/ready", "no probe means nothing to point")
+
+	// Asserted as the block rather than as two loose lines: the container
+	// carries a port of its own, so "port: 9000" alone passes whether or not
+	// the probe ever got one.
+	assert.Contains(t, string(rendered), "readinessProbe:\n              path: /ready\n              port: 9000")
+}
+
+// And clearing the path takes the block away rather than leaving one pointed
+// at nothing, which is neither a probe nor an absence of one.
+func TestLive_ApplyRemovesADeclinedProbe(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
+        {"name": "primary", "primary": true, "port": 9000, "imageUri": "registry/a:v1",
+         "readinessProbe": {"path": "/health", "port": 9000, "periodSeconds": 10}}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	draft := live.Defaults()
+	require.Equal(t, "/health", draft.HealthPath)
+
+	draft.HealthPath = ""
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(rendered), "readinessProbe")
+	assert.NotContains(t, string(rendered), "periodSeconds", "the whole block goes, not only the path")
+}
+
+// A probe this release cannot read a path out of is not the same thing as no
+// probe, and Apply must not confuse the two: reading it as "declined" would
+// delete a running workload's own configuration because the reader did not
+// recognize its shape.
+func TestLive_ApplyKeepsAProbeItCannotRead(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
+        {"name": "primary", "primary": true, "port": 9000, "imageUri": "registry/a:v1",
+         "readinessProbe": {"tcpSocket": {"port": 9000}, "periodSeconds": 10, "failureThreshold": 30}}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	present, readable := live.ReadinessProbe()
+	assert.True(t, present, "the block is there")
+	assert.False(t, readable, "but not as a path this release understands")
+
+	// The wizard's own answers, unchanged: nobody declined anything.
+	require.Empty(t, live.Defaults().HealthPath)
+
+	applied, err := live.Apply(live.Defaults())
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "tcpSocket")
+	assert.Contains(t, string(rendered), "failureThreshold: 30")
+	assert.NotContains(t, string(rendered), "path:", "nothing was added to a probe we do not model")
+}
+
+// And when the container's port moves, that probe follows it the way the
+// startup and liveness probes do, rather than being left watching a port
+// nothing listens on.
+func TestLive_ApplyMovesAnUnreadableProbeWithThePort(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
+        {"name": "primary", "primary": true, "port": 9000, "imageUri": "registry/a:v1",
+         "readinessProbe": {"tcpSocket": {"port": 9000}, "port": 9000}}]}]}
+    }`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	draft := live.Defaults()
+	draft.Port = 9100
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	// The probe's own port follows the container. What sits inside a block this
+	// release does not model is left exactly as it was, which is why the nested
+	// tcpSocket port is still 9000.
+	assert.Contains(t, string(rendered), "readinessProbe:\n              port: 9100")
+	assert.Contains(t, string(rendered), "tcpSocket:\n                port: 9000")
+}
+
+// probelessLive is a workload running without a readiness probe.
+func probelessLive(t *testing.T) Live {
+	t.Helper()
+
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "a",
+      "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
+        {"name": "primary", "primary": true, "port": 9000, "imageUri": "registry/a:v1"}]}]}
+    }`), &artifactDoc))
+
+	return NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
 }
 
 // A workload can carry probes the wizard has no question for. Changing the

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -152,7 +152,14 @@ type Draft struct {
 // is the one place the empty-path convention is spelled out, so the write, the
 // live merge and the screens cannot drift about what an empty path means.
 func (d Draft) WantsReadinessProbe() bool {
-	return strings.TrimSpace(d.HealthPath) != ""
+	return d.healthPath() != ""
+}
+
+// healthPath is the path as it should be written, which is the trimmed one:
+// WantsReadinessProbe already ignores surrounding space, so writing the raw
+// field would let " /ready " through as a path no router matches.
+func (d Draft) healthPath() string {
+	return strings.TrimSpace(d.HealthPath)
 }
 
 // EnvVar is one .env variable as the manifest will carry it. Deciding which
@@ -422,7 +429,7 @@ func (d Draft) artifact(build field) *yaml.Node {
 
 	if d.WantsReadinessProbe() {
 		container = append(container, field{key: keyReadinessProbe, value: mapping(
-			field{key: keyPath, value: scalar(d.HealthPath)},
+			field{key: keyPath, value: scalar(d.healthPath())},
 			field{key: keyPort, value: number(d.Port)},
 		)})
 	}

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -125,7 +125,11 @@ type Draft struct {
 	A2AEnabled bool
 	Build      Build
 	// Port is the primary container's port, and the readiness probe's.
-	Port       int
+	Port int
+	// HealthPath is the readiness probe's path, and empty means the workload
+	// runs without a probe: the platform does not require one, and a probe
+	// aimed at an endpoint the container does not serve never passes. Read it
+	// through WantsReadinessProbe rather than comparing it here and there.
 	HealthPath string
 	Runtime    Runtime
 	// EnvVars are the variables a local .env defines, already classified by
@@ -134,6 +138,13 @@ type Draft struct {
 	// CredentialPlaceholder, because no credential exists for it yet. An
 	// empty slice writes nothing.
 	EnvVars []EnvVar
+}
+
+// WantsReadinessProbe reports whether the answers ask for a probe at all. It
+// is the one place the empty-path convention is spelled out, so the write, the
+// live merge and the screens cannot drift about what an empty path means.
+func (d Draft) WantsReadinessProbe() bool {
+	return strings.TrimSpace(d.HealthPath) != ""
 }
 
 // EnvVar is one .env variable as the manifest will carry it. Deciding which
@@ -394,17 +405,18 @@ func (d Draft) artifact(build field) *yaml.Node {
 		})
 	}
 
-	probe := mapping(
-		field{key: keyPath, value: scalar(d.HealthPath)},
-		field{key: keyPort, value: number(d.Port)},
-	)
-
 	container := []field{
 		{key: keyName, value: scalar(PrimaryContainerName)},
 		{key: keyPrimary, value: boolean(true)},
 		{key: keyPort, value: number(d.Port), comment: "must be 1024 or above"},
 		build,
-		{key: keyReadinessProbe, value: probe},
+	}
+
+	if d.WantsReadinessProbe() {
+		container = append(container, field{key: keyReadinessProbe, value: mapping(
+			field{key: keyPath, value: scalar(d.HealthPath)},
+			field{key: keyPort, value: number(d.Port)},
+		)})
 	}
 
 	if vars := d.environmentVars(); vars != nil {

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -84,7 +84,15 @@ func ValidImportance(value string) bool {
 const (
 	DefaultImportance = "low"
 	DefaultPort       = 8080
-	DefaultHealthPath = "/health"
+	// DefaultHealthPath is the root rather than /health because the probe has
+	// to pass on an application nobody wrote it for. Almost every HTTP service
+	// answers something at /, where /health is an endpoint the app has to have
+	// implemented; pointing a probe at one that does not exist is the most
+	// common first-deploy failure, and it presents as a deploy that never
+	// becomes ready rather than as a misconfigured probe. An app with a real
+	// health endpoint says so on the settings screen, and one that wants no
+	// probe at all clears the field.
+	DefaultHealthPath = "/"
 	DefaultReplicas   = 1
 	DefaultCPU        = 0.5
 	DefaultMemory     = "512MB"

--- a/internal/workload/manifest/write_test.go
+++ b/internal/workload/manifest/write_test.go
@@ -65,7 +65,7 @@ artifact:
               dockerfile:
                 source: provided
             readinessProbe:
-              path: /health
+              path: /
               port: 8080
 
 runtime:

--- a/internal/workload/manifest/write_test.go
+++ b/internal/workload/manifest/write_test.go
@@ -78,6 +78,22 @@ runtime:
 `, string(out))
 }
 
+// A readiness probe is optional to the platform, and one aimed at an endpoint
+// the container does not serve never passes. No path means no block: the
+// alternative is a probe with an empty path, which is neither.
+func TestRender_NoHealthPathWritesNoProbe(t *testing.T) {
+	draft := serviceDraft()
+	draft.HealthPath = ""
+
+	out, err := draft.Render()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(out), keyReadinessProbe)
+	// The container's own port is unaffected: it is what traffic arrives on,
+	// not something the probe brought with it.
+	assert.Contains(t, string(out), "port: 8080")
+}
+
 // An unbound draft writes no workloadId at all, so the first up knows the
 // workload has to be created rather than found.
 func TestRender_UnboundOmitsWorkloadID(t *testing.T) {

--- a/internal/workload/wizard/answers.go
+++ b/internal/workload/wizard/answers.go
@@ -48,9 +48,18 @@ type Answers struct {
 	Entrypoint string
 	Port       int
 	HealthPath string
-	Replicas   int
-	CPU        float64
-	Memory     string
+	// NoProbe writes no readinessProbe block at all. Declining is a separate
+	// field rather than an empty HealthPath because this struct is the wizard's
+	// own vocabulary and is filled in from more than one place: "" here means
+	// "nobody said", and a caller that never touches cobra has no other way to
+	// say "no probe" out loud.
+	NoProbe  bool
+	Replicas int
+	CPU      float64
+	Memory   string
+	// Importance is the scheduling priority, one of
+	// manifest.ImportanceLevels.
+	Importance string
 	// SkipEnv leaves the project's .env out of the manifest entirely. By
 	// default the variables are carried across, because a deploy that
 	// silently drops the app's configuration is the worse default.
@@ -67,7 +76,9 @@ var ErrCancelled = errors.New("cancelled")
 // incomplete are the headless path's business: interactively they are just
 // questions that have not been answered yet.
 func (a Answers) check() error {
-	for _, check := range []func() error{a.checkBinding, a.checkKind, a.checkImageSource, a.checkReadiness, a.checkSizing} {
+	for _, check := range []func() error{
+		a.checkBinding, a.checkKind, a.checkImageSource, a.checkReadiness, a.checkSizing, a.checkImportance,
+	} {
 		if err := check(); err != nil {
 			return err
 		}
@@ -118,6 +129,12 @@ func (a Answers) checkImageSource() error {
 }
 
 func (a Answers) checkReadiness() error {
+	if a.NoProbe && a.HealthPath != "" {
+		return fmt.Errorf("--no-readiness-probe and --health %q are exclusive: "+
+			"pass --health alone to probe that path, or --no-readiness-probe alone to run without a probe",
+			a.HealthPath)
+	}
+
 	if a.HealthPath != "" && !strings.HasPrefix(a.HealthPath, "/") {
 		return fmt.Errorf("--health %q must start with /", a.HealthPath)
 	}
@@ -175,6 +192,34 @@ func (a Answers) checkSizing() error {
 	return nil
 }
 
+// checkImportance holds the flag to the enum. The reader passes an
+// unrecognized level through and lets the platform decide, but a level nobody
+// meant to type is worth refusing here rather than after a round trip.
+func (a Answers) checkImportance() error {
+	if a.Importance != "" && !manifest.ValidImportance(a.importance()) {
+		return fmt.Errorf("--importance %q is not supported: use one of %s",
+			a.Importance, strings.Join(manifest.ImportanceLevels, ", "))
+	}
+
+	return nil
+}
+
+// importance is the level to write, lowercased because the casing is the
+// user's business and the file's is settled.
+func (a Answers) importance() string {
+	return strings.ToLower(strings.TrimSpace(a.Importance))
+}
+
+// healthPath is the path to probe: the flag, the documented default, or
+// nothing at all when the probe was declined.
+func (a Answers) healthPath() string {
+	if a.NoProbe {
+		return ""
+	}
+
+	return orDefault(a.HealthPath, manifest.DefaultHealthPath)
+}
+
 // The range a primary container's port may fall in. The floor is the
 // manifest ledger's; below it an unprivileged container cannot bind, so the
 // workload never becomes ready.
@@ -199,11 +244,11 @@ func (a Answers) draft(detected Detected) (manifest.Draft, error) {
 	draft := manifest.Draft{
 		WorkloadID: a.WorkloadID,
 		Name:       name,
-		Importance: manifest.DefaultImportance,
+		Importance: orDefault(a.importance(), manifest.DefaultImportance),
 		Type:       manifest.ArtifactTypeOrDefault(a.Type),
 		A2AEnabled: a.A2AEnabled,
 		Port:       a.Port,
-		HealthPath: orDefault(a.HealthPath, manifest.DefaultHealthPath),
+		HealthPath: a.healthPath(),
 		Runtime:    a.runtime(),
 		EnvVars:    a.envVars(detected),
 	}

--- a/internal/workload/wizard/answers.go
+++ b/internal/workload/wizard/answers.go
@@ -192,6 +192,37 @@ func (a Answers) checkSizing() error {
 	return nil
 }
 
+// checkProbeEditable refuses a probe answer the CLI cannot carry out, which is
+// only possible once the workload has been read.
+//
+// A readiness probe that declares no path is not the HTTP probe these flags
+// describe, and binding preserves it rather than rewriting a shape this release
+// does not model. Preserving is right when nobody said anything about the
+// probe. When a flag did say something, staying silent would mean the run
+// reports success having ignored the one thing it was asked to change, and
+// without a screen there is nothing else to notice it.
+func (a Answers) checkProbeEditable(live manifest.Live) error {
+	if !a.NoProbe && a.HealthPath == "" {
+		return nil
+	}
+
+	present, readable := live.ReadinessProbe()
+	if !present || readable {
+		return nil
+	}
+
+	flag := "--health " + a.HealthPath
+	if a.NoProbe {
+		flag = "--no-readiness-probe"
+	}
+
+	return fmt.Errorf(
+		"%s runs a readiness probe with no path, which this CLI keeps as it is rather than rewriting a shape it "+
+			"does not model, so %s cannot be applied to it. Drop the flag to bind without touching the probe, "+
+			"or change the probe where it was defined",
+		live.Name, flag)
+}
+
 // checkImportance holds the flag to the enum. The reader passes an
 // unrecognized level through and lets the platform decide, but a level nobody
 // meant to type is worth refusing here rather than after a round trip.

--- a/internal/workload/wizard/answers.go
+++ b/internal/workload/wizard/answers.go
@@ -128,11 +128,24 @@ func (a Answers) checkImageSource() error {
 	}
 }
 
-func (a Answers) checkReadiness() error {
+// checkProbeExclusive is the one readiness rule no screen can settle, so it is
+// the only one the interactive path refuses up front. The settings screen has a
+// single health field and cannot represent "both were passed"; a path that
+// simply lacks its leading slash, or an importance outside the enum, is a value
+// the screen can show and the user can correct.
+func (a Answers) checkProbeExclusive() error {
 	if a.NoProbe && a.HealthPath != "" {
 		return fmt.Errorf("--no-readiness-probe and --health %q are exclusive: "+
 			"pass --health alone to probe that path, or --no-readiness-probe alone to run without a probe",
 			a.HealthPath)
+	}
+
+	return nil
+}
+
+func (a Answers) checkReadiness() error {
+	if err := a.checkProbeExclusive(); err != nil {
+		return err
 	}
 
 	if a.HealthPath != "" && !strings.HasPrefix(a.HealthPath, "/") {

--- a/internal/workload/wizard/answers_test.go
+++ b/internal/workload/wizard/answers_test.go
@@ -91,6 +91,12 @@ func TestAnswers_Check(t *testing.T) {
 		"privileged port": {
 			Answers{Port: 80}, "--port 80 is too low",
 		},
+		"a probe and no probe at once": {
+			Answers{NoProbe: true, HealthPath: "/ready"}, "--no-readiness-probe and --health",
+		},
+		"unsupported importance": {
+			Answers{Importance: "urgent"}, `--importance "urgent" is not supported`,
+		},
 	}
 
 	for name, test := range tests {
@@ -158,6 +164,38 @@ func TestAnswers_FlagsWinOverDetection(t *testing.T) {
 	assert.Equal(t, 3, draft.Runtime.Replicas)
 	assert.InEpsilon(t, 2.0, draft.Runtime.CPU, 0.0001)
 	assert.Equal(t, "4GB", draft.Runtime.Memory)
+}
+
+// The probe is optional to the platform, so declining it has to be reachable
+// without a terminal. An empty --health cannot say this: a string flag cannot
+// tell an empty value from an absent one, which is why the answer is a flag of
+// its own.
+func TestAnswers_NoProbeWritesNoProbe(t *testing.T) {
+	detected := Detect(writeDockerfile(t, t.TempDir(), "FROM scratch\nEXPOSE 3000\n"))
+
+	draft, err := Answers{NoProbe: true}.draft(detected)
+	require.NoError(t, err)
+	assert.Empty(t, draft.HealthPath)
+
+	content, err := draft.Render()
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), "readinessProbe")
+
+	// And what comes out is still a manifest this CLI reads.
+	parsed, err := manifest.Parse(content, detected.Dir)
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+}
+
+// Importance is written to every manifest and the screen keeps it behind the
+// advanced row, so the flag is the only way a headless run can say anything
+// but the default.
+func TestAnswers_ImportanceFlag(t *testing.T) {
+	detected := Detect(writeDockerfile(t, t.TempDir(), "FROM scratch\n"))
+
+	draft, err := Answers{Importance: "HIGH"}.draft(detected)
+	require.NoError(t, err)
+	assert.Equal(t, "high", draft.Importance, "the casing is the user's business, the file's is settled")
 }
 
 // With nothing to build and nothing said, the error names the flags that

--- a/internal/workload/wizard/interactive.go
+++ b/internal/workload/wizard/interactive.go
@@ -48,11 +48,11 @@ func (a Answers) partialDraft(detected Detected) manifest.Draft {
 	draft := manifest.Draft{
 		WorkloadID: a.WorkloadID,
 		Name:       orDefault(a.Name, detected.Name),
-		Importance: manifest.DefaultImportance,
+		Importance: orDefault(a.importance(), manifest.DefaultImportance),
 		Type:       kind,
 		A2AEnabled: a.A2AEnabled && kind == manifest.TypeAgent,
 		Port:       a.Port,
-		HealthPath: orDefault(a.HealthPath, manifest.DefaultHealthPath),
+		HealthPath: a.healthPath(),
 		Runtime:    a.runtime(),
 		EnvVars:    a.envVars(detected),
 	}

--- a/internal/workload/wizard/model.go
+++ b/internal/workload/wizard/model.go
@@ -838,12 +838,9 @@ func (f *flow) acceptSettings() (tea.Cmd, error) {
 		return nil, err
 	}
 
-	// An empty path is the answer "no readiness probe", which the file records
-	// by carrying no probe block at all. A path that is set still has to be one.
 	path := f.field(fieldHealthPath)
-	if path != "" && !strings.HasPrefix(path, "/") {
-		return nil, f.reveal(fieldHealthPath,
-			errors.New("the health path must start with /, or leave it empty to run without a probe"))
+	if err := f.acceptHealthPath(path); err != nil {
+		return nil, f.reveal(fieldHealthPath, err)
 	}
 
 	replicas, err := f.acceptReplicas()
@@ -880,6 +877,29 @@ func (f *flow) acceptSettings() (tea.Cmd, error) {
 	f.draft.Runtime = manifest.Runtime{Replicas: replicas, CPU: cpu, Memory: memory}
 
 	return nil, nil
+}
+
+// acceptHealthPath holds the probe field to what the file can express. An
+// empty path is the answer "no readiness probe", which the file records by
+// carrying no probe block at all; a path that is set still has to be one.
+//
+// The third case is a bound workload whose probe declares no path. That shape
+// is preserved rather than rewritten, so a path typed here would be accepted
+// and then quietly dropped by the merge. It is refused while the answer can
+// still be taken back, and the note beside the field says why.
+func (f flow) acceptHealthPath(path string) error {
+	if path != "" && !strings.HasPrefix(path, "/") {
+		return errors.New("the health path must start with /, or leave it empty to run without a probe")
+	}
+
+	if present, readable := f.liveReadinessProbe(); present && !readable && path != "" {
+		return fmt.Errorf(
+			"%s runs a readiness probe with no path, which is kept as it is rather than rewritten, "+
+				"so a path here would not reach the file; clear the field to leave it alone",
+			f.live.Name)
+	}
+
+	return nil
 }
 
 // reveal puts the cursor on the field a validation error is about, opening the

--- a/internal/workload/wizard/model.go
+++ b/internal/workload/wizard/model.go
@@ -289,6 +289,10 @@ func (f flow) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	f.failed = nil
 
+	if f.at == screenSettings && msg.String() == advancedKey {
+		return f, f.toggleAdvanced()
+	}
+
 	switch msg.String() {
 	case "esc":
 		return f.back()
@@ -297,9 +301,7 @@ func (f flow) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// still submitted with enter from any of its fields, which is where the
 		// cursor starts.
 		if f.onAdvancedRow() {
-			f.advancedOpen = !f.advancedOpen
-
-			return f, nil
+			return f, f.toggleAdvanced()
 		}
 
 		return f.advance()
@@ -1144,6 +1146,22 @@ func (f *flow) moveFocus(msg tea.KeyMsg) tea.Cmd {
 	}
 
 	f.focus = stops[(at+step+len(stops))%len(stops)]
+
+	return f.applyFocus()
+}
+
+// toggleAdvanced shows or hides the fields behind the row and puts the cursor
+// somewhere that still exists afterwards: on the first revealed field when it
+// opens, since reaching them is the point, and back on the port when it closes,
+// since the field the cursor was in has just gone.
+func (f *flow) toggleAdvanced() tea.Cmd {
+	f.advancedOpen = !f.advancedOpen
+
+	if f.advancedOpen {
+		f.focus = firstAdvancedField
+	} else {
+		f.focus = fieldPort
+	}
 
 	return f.applyFocus()
 }

--- a/internal/workload/wizard/model.go
+++ b/internal/workload/wizard/model.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -80,7 +81,13 @@ type flow struct {
 	envTable envTable
 	picker   rowTable
 	inputs   []textinput.Model
-	focus    int
+	// focus is the settings screen's cursor: a field index, or advancedStop
+	// when the row that opens the rest of the screen is what is focused.
+	focus int
+	// advancedOpen is whether that row is open. It survives leaving the screen
+	// and coming back, so back-navigation returns to the screen the user left
+	// rather than folding their own fields away again.
+	advancedOpen bool
 
 	// loading is the message shown while a screen waits on the network.
 	loading string
@@ -286,6 +293,15 @@ func (f flow) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc":
 		return f.back()
 	case "enter":
+		// On the advanced row enter is the row's own action. The screen is
+		// still submitted with enter from any of its fields, which is where the
+		// cursor starts.
+		if f.onAdvancedRow() {
+			f.advancedOpen = !f.advancedOpen
+
+			return f, nil
+		}
+
 		return f.advance()
 	}
 
@@ -333,17 +349,7 @@ func (f flow) delegate(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return f, nil
 
 	case screenName, screenEntrypoint, screenImage, screenSettings:
-		if key, ok := msg.(tea.KeyMsg); ok && f.at == screenSettings && isFocusKey(key) {
-			f.moveFocus(key)
-
-			return f, nil
-		}
-
-		var cmd tea.Cmd
-
-		f.inputs[f.focus], cmd = f.inputs[f.focus].Update(msg)
-
-		return f, cmd
+		return f.delegateToInput(msg)
 
 	case screenConfirm:
 		var cmd tea.Cmd
@@ -354,6 +360,35 @@ func (f flow) delegate(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return f, nil
+}
+
+// delegateToInput routes a message on the text-entry screens: to the focus
+// ring when the key moves between fields, and to the focused field otherwise.
+func (f flow) delegateToInput(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, isKey := msg.(tea.KeyMsg)
+
+	if isKey && f.at == screenSettings && isFocusKey(key) {
+		return f, f.moveFocus(key)
+	}
+
+	// The advanced row is not a field, so a keystroke on it has nowhere to be
+	// typed. Without this it would go into whichever input the index happened
+	// to reach, or panic on the one it does not have. Only keystrokes are
+	// swallowed: everything else routed here belongs to a component that is
+	// still on screen, and dropping it would end whatever it is driving.
+	if isKey && f.onAdvancedRow() {
+		return f, nil
+	}
+
+	if f.focus < 0 {
+		return f, nil
+	}
+
+	var cmd tea.Cmd
+
+	f.inputs[f.focus], cmd = f.inputs[f.focus].Update(msg)
+
+	return f, cmd
 }
 
 // updateSelection routes a key to whichever selection component the current
@@ -667,10 +702,13 @@ func (f *flow) acceptBinding() (tea.Cmd, error) {
 	if item.id == createNewID {
 		// Start over rather than carrying the previous pick's name, kind and
 		// image forward: "create a new workload" after looking at an existing
-		// one must not prefill a copy of it.
+		// one must not prefill a copy of it. Starting over means from this
+		// run's own flags, not from nothing: a flag the user passed is an
+		// answer they gave, and looking at a workload and declining it is not
+		// a reason to withdraw it.
 		if f.live != nil {
 			f.live = nil
-			f.draft = defaultDraft(f.detected)
+			f.draft = f.answers.partialDraft(f.detected)
 		}
 
 		f.draft.WorkloadID = ""
@@ -787,6 +825,9 @@ func (f flow) autoscaled() bool {
 
 // acceptSettings validates every field before recording any of them, so a
 // screen that is refused leaves the answers exactly as the user left them.
+// Fields behind the advanced row are validated too, since a bad --cpu has to
+// fail here rather than at write time, and a refusal there opens the row: an
+// error naming a field nobody can see is a screen with no way forward.
 func (f *flow) acceptSettings() (tea.Cmd, error) {
 	port, err := strconv.Atoi(f.field(fieldPort))
 	if err != nil {
@@ -797,33 +838,40 @@ func (f *flow) acceptSettings() (tea.Cmd, error) {
 		return nil, err
 	}
 
+	// An empty path is the answer "no readiness probe", which the file records
+	// by carrying no probe block at all. A path that is set still has to be one.
 	path := f.field(fieldHealthPath)
-	if !strings.HasPrefix(path, "/") {
-		return nil, errors.New("the health path must start with /")
+	if path != "" && !strings.HasPrefix(path, "/") {
+		return nil, f.reveal(fieldHealthPath,
+			errors.New("the health path must start with /, or leave it empty to run without a probe"))
 	}
 
 	replicas, err := f.acceptReplicas()
 	if err != nil {
-		return nil, err
+		return nil, f.reveal(fieldReplicas, err)
 	}
 
 	cpu, err := f.acceptCPU()
 	if err != nil {
-		return nil, err
+		return nil, f.reveal(fieldCPU, err)
 	}
 
 	memory := f.field(fieldMemory)
 	if !manifest.ValidMemory(memory) {
-		return nil, fmt.Errorf("memory must be a byte count or a 1000-based unit (%s), such as 512MB or 4GB",
-			strings.Join(manifest.MemoryUnits(), ", "))
+		return nil, f.reveal(fieldMemory, fmt.Errorf(
+			"memory must be a byte count or a 1000-based unit (%s), such as 512MB or 4GB",
+			strings.Join(manifest.MemoryUnits(), ", ")))
 	}
 
 	memory = manifest.NormalizeMemory(memory)
 
-	importance := strings.ToLower(f.field(fieldImportance))
+	// An empty field takes the documented default, the same as the headless
+	// path, rather than being the one field on this screen where clearing is
+	// fatal.
+	importance := orDefault(strings.ToLower(f.field(fieldImportance)), manifest.DefaultImportance)
 	if !manifest.ValidImportance(importance) {
-		return nil, fmt.Errorf("importance must be one of %s",
-			strings.Join(manifest.ImportanceLevels, ", "))
+		return nil, f.reveal(fieldImportance, fmt.Errorf("importance must be one of %s",
+			strings.Join(manifest.ImportanceLevels, ", ")))
 	}
 
 	f.draft.Port = port
@@ -832,6 +880,20 @@ func (f *flow) acceptSettings() (tea.Cmd, error) {
 	f.draft.Runtime = manifest.Runtime{Replicas: replicas, CPU: cpu, Memory: memory}
 
 	return nil, nil
+}
+
+// reveal puts the cursor on the field a validation error is about, opening the
+// advanced row when that is where the field lives. The error is returned
+// unchanged so the caller reads as one statement.
+func (f *flow) reveal(field int, err error) error {
+	if field >= firstAdvancedField {
+		f.advancedOpen = true
+	}
+
+	f.focus = field
+	f.applyFocus()
+
+	return err
 }
 
 // field is the trimmed contents of one input on the current screen.
@@ -1040,14 +1102,66 @@ func isFocusKey(msg tea.KeyMsg) bool {
 	return false
 }
 
-func (f *flow) moveFocus(msg tea.KeyMsg) {
-	f.inputs[f.focus].Blur()
+// moveFocus walks the settings screen's stops: the port, the advanced row, and
+// the fields that row reveals while it is open. Only the settings screen has
+// more than one thing to move between, which is why this is not reached from
+// the other input screens.
+func (f *flow) moveFocus(msg tea.KeyMsg) tea.Cmd {
+	stops := f.settingsStops()
 
-	if msg.String() == "shift+tab" || msg.String() == "up" {
-		f.focus = (f.focus - 1 + len(f.inputs)) % len(f.inputs)
-	} else {
-		f.focus = (f.focus + 1) % len(f.inputs)
+	// Not found and the first stop are different things, and slices.Index
+	// spells both -1 and the sentinel this ring uses the same way. A focus that
+	// is not a stop is a broken invariant rather than a reason to move, so it
+	// restarts the walk deliberately instead of being clamped into one.
+	at := slices.Index(stops, f.focus)
+	if at < 0 {
+		at = 0
 	}
 
-	f.inputs[f.focus].Focus()
+	step := 1
+	if msg.String() == "shift+tab" || msg.String() == "up" {
+		step = -1
+	}
+
+	f.focus = stops[(at+step+len(stops))%len(stops)]
+
+	return f.applyFocus()
+}
+
+// settingsStops is the order the cursor visits, built from the one field order
+// so a field added to it needs no second edit here.
+func (f flow) settingsStops() []int {
+	stops := []int{fieldPort, advancedStop}
+
+	if !f.advancedOpen {
+		return stops
+	}
+
+	for field := firstAdvancedField; field < settingsFieldCount; field++ {
+		stops = append(stops, field)
+	}
+
+	return stops
+}
+
+// applyFocus puts the cursor in the focused field, and in none of them when
+// the advanced row is what is focused.
+//
+// The command it returns starts the cursor blinking in the newly focused
+// field, and has to reach the caller: dropped, the field keeps a static block
+// where the caret should be, which reads as a field that cannot be typed into.
+func (f *flow) applyFocus() tea.Cmd {
+	var cmd tea.Cmd
+
+	for i := range f.inputs {
+		if i == f.focus {
+			cmd = f.inputs[i].Focus()
+
+			continue
+		}
+
+		f.inputs[i].Blur()
+	}
+
+	return cmd
 }

--- a/internal/workload/wizard/model.go
+++ b/internal/workload/wizard/model.go
@@ -88,6 +88,10 @@ type flow struct {
 	// and coming back, so back-navigation returns to the screen the user left
 	// rather than folding their own fields away again.
 	advancedOpen bool
+	// focusCmd parks the cursor-blink command from a focus change that happened
+	// somewhere with no tea.Cmd to return, so the caller that does have one can
+	// hand it on.
+	focusCmd tea.Cmd
 
 	// loading is the message shown while a screen waits on the network.
 	loading string
@@ -290,7 +294,12 @@ func (f flow) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	f.failed = nil
 
 	if f.at == screenSettings && msg.String() == advancedKey {
-		return f, f.toggleAdvanced()
+		// Assigned before returning, not called inside the return list: the
+		// call mutates f through a pointer receiver, and Go does not specify
+		// whether the f being returned is copied before or after it runs.
+		cmd := f.toggleAdvanced()
+
+		return f, cmd
 	}
 
 	switch msg.String() {
@@ -301,7 +310,9 @@ func (f flow) key(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// still submitted with enter from any of its fields, which is where the
 		// cursor starts.
 		if f.onAdvancedRow() {
-			return f, f.toggleAdvanced()
+			cmd := f.toggleAdvanced()
+
+			return f, cmd
 		}
 
 		return f.advance()
@@ -370,7 +381,9 @@ func (f flow) delegateToInput(msg tea.Msg) (tea.Model, tea.Cmd) {
 	key, isKey := msg.(tea.KeyMsg)
 
 	if isKey && f.at == screenSettings && isFocusKey(key) {
-		return f, f.moveFocus(key)
+		cmd := f.moveFocus(key)
+
+		return f, cmd
 	}
 
 	// The advanced row is not a field, so a keystroke on it has nowhere to be
@@ -430,7 +443,10 @@ func (f flow) advance() (tea.Model, tea.Cmd) {
 	if err != nil {
 		f.failed = err
 
-		return f, nil
+		// A refusal still moves the cursor to the field it is about, and the
+		// blink that goes with it has to be scheduled or the caret sits frozen
+		// in a field the user is being asked to edit.
+		return f, f.takeFocusCmd()
 	}
 
 	if cmd != nil {
@@ -833,11 +849,11 @@ func (f flow) autoscaled() bool {
 func (f *flow) acceptSettings() (tea.Cmd, error) {
 	port, err := strconv.Atoi(f.field(fieldPort))
 	if err != nil {
-		return nil, errors.New("the port must be a number")
+		return nil, f.reveal(fieldPort, errors.New("the port must be a number"))
 	}
 
 	if err := checkPort(port, "port"); err != nil {
-		return nil, err
+		return nil, f.reveal(fieldPort, err)
 	}
 
 	path := f.field(fieldHealthPath)
@@ -913,7 +929,7 @@ func (f *flow) reveal(field int, err error) error {
 	}
 
 	f.focus = field
-	f.applyFocus()
+	f.focusCmd = f.applyFocus()
 
 	return err
 }
@@ -925,35 +941,48 @@ func (f flow) field(i int) string {
 
 // onEnter starts whatever the screen needs before it can be answered.
 func (f *flow) onEnter(at screen) tea.Cmd {
+	// Whatever entering the screen did to the cursor rides along with the work
+	// the screen starts, since both reach bubbletea through this one return.
+	focus := f.takeFocusCmd()
+
 	switch at {
 	case screenExecEnv:
 		if len(f.execEnvs) > 0 {
 			// Already fetched, and enter() has rebuilt the table from it.
-			return nil
+			return focus
 		}
 
 		f.loading = "Loading base images…"
 
-		return func() tea.Msg {
+		return tea.Batch(focus, func() tea.Msg {
 			environments, err := listExecEnvsFn(execEnvPickLimit)
 
 			return execEnvsLoadedMsg{environments: environments, err: err}
-		}
+		})
 
 	case screenConfirm:
 		if err := f.render(); err != nil {
 			f.failed = err
 		}
 
-		return nil
+		return focus
 
 	case screenBinding, screenName, screenKind, screenA2A, screenSource,
 		screenEntrypoint, screenImage, screenSettings, screenEnv:
 		// Everything these screens show is already in hand.
-		return nil
+		return focus
 	}
 
-	return nil
+	return focus
+}
+
+// takeFocusCmd hands over the parked cursor-blink command and clears it, so it
+// is scheduled once rather than on every later return.
+func (f *flow) takeFocusCmd() tea.Cmd {
+	cmd := f.focusCmd
+	f.focusCmd = nil
+
+	return cmd
 }
 
 // render produces the file the confirm screen shows, and for a bound workload
@@ -1025,6 +1054,17 @@ func (f flow) liveLoaded(msg liveLoadedMsg) (tea.Model, tea.Cmd) {
 	}
 
 	live := msg.live
+
+	// The same refusal the headless bind makes, for the same reason: a probe
+	// flag this workload cannot honour is an instruction the run would carry
+	// out nowhere, and the screen it would go unnoticed on is one the user has
+	// to open a drawer to reach. Same flags, same answer, terminal or not.
+	if err := f.answers.checkProbeEditable(live); err != nil {
+		f.fatal = err
+
+		return f, tea.Quit
+	}
+
 	f.live = &live
 	// The live spec is the new set of defaults, not the new set of answers:
 	// --replicas and --memory were given before the fetch and still stand.
@@ -1042,7 +1082,7 @@ func (f flow) liveLoaded(msg liveLoadedMsg) (tea.Model, tea.Cmd) {
 	f.at = screenKind
 	f.enter(f.at)
 
-	return f, nil
+	return f, f.takeFocusCmd()
 }
 
 func (f flow) execEnvsLoaded(msg execEnvsLoadedMsg) (tea.Model, tea.Cmd) {
@@ -1166,8 +1206,10 @@ func (f *flow) toggleAdvanced() tea.Cmd {
 	return f.applyFocus()
 }
 
-// settingsStops is the order the cursor visits, built from the one field order
-// so a field added to it needs no second edit here.
+// settingsStops is the order the cursor visits. The advanced half is built
+// from the field order, so a field added behind the row needs no second edit
+// here; the visible half is the port and the row, and making a second field
+// always-visible does mean editing this literal.
 func (f flow) settingsStops() []int {
 	stops := []int{fieldPort, advancedStop}
 

--- a/internal/workload/wizard/model_test.go
+++ b/internal/workload/wizard/model_test.go
@@ -80,6 +80,10 @@ func keyMsg(key string) tea.KeyMsg {
 func typeInto(t *testing.T, model flow, value string) flow {
 	t.Helper()
 
+	// The advanced row is a focus stop with no input behind it, so a test that
+	// drifts onto it should say that rather than panic on index -1.
+	require.GreaterOrEqual(t, model.focus, 0, "no field is focused")
+
 	model.inputs[model.focus].SetValue("")
 
 	for _, r := range value {

--- a/internal/workload/wizard/model_test.go
+++ b/internal/workload/wizard/model_test.go
@@ -69,6 +69,8 @@ func keyMsg(key string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyUp}
 	case "tab":
 		return tea.KeyMsg{Type: tea.KeyTab}
+	case advancedKey:
+		return tea.KeyMsg{Type: tea.KeyCtrlO}
 	case "backspace":
 		return tea.KeyMsg{Type: tea.KeyBackspace}
 	default:

--- a/internal/workload/wizard/regression_test.go
+++ b/internal/workload/wizard/regression_test.go
@@ -745,6 +745,70 @@ func TestFlow_HealthPathPlaceholderSaysNoProbe(t *testing.T) {
 	assert.NotContains(t, healthPlaceholder, manifest.DefaultHealthPath)
 }
 
+// On the row, enter is the way to open it and the chord would be a second
+// entry saying the same word. The legend has room for one of them.
+func TestFlow_AdvancedRowLegendSaysOneThingOnce(t *testing.T) {
+	onRow := press(t, atSettings(t), "tab")
+	require.Equal(t, advancedStop, onRow.focus)
+
+	view := onRow.View()
+	assert.Contains(t, view, "[enter] "+advancedLabel)
+	assert.NotContains(t, view, "["+advancedKey+"]", "the chord duplicates enter here")
+}
+
+// Moving the cursor to a refused field has to schedule that field's cursor
+// blink too, or the caret sits frozen in a field the user is being asked to fix.
+func TestFlow_RefusedFieldSchedulesItsCursor(t *testing.T) {
+	model := openAdvanced(t, atSettings(t))
+
+	model = press(t, withField(model, fieldMemory, "4Gi"), "shift+tab", "enter")
+	require.False(t, model.advancedOpen)
+
+	updated, cmd := model.Update(keyMsg("enter"))
+
+	next, ok := updated.(flow)
+	require.True(t, ok)
+	require.Error(t, next.failed)
+
+	assert.True(t, next.advancedOpen)
+	assert.NotNil(t, cmd, "the cursor moved, so its blink has to be scheduled")
+}
+
+// A port that is refused takes the cursor back to the port, wherever it was.
+func TestFlow_PortFailureMovesTheCursorToThePort(t *testing.T) {
+	model := openAdvanced(t, atSettings(t))
+
+	model = press(t, withField(model, fieldPort, "80"), "enter")
+
+	require.Error(t, model.failed)
+	assert.Contains(t, model.failed.Error(), "too low")
+	assert.Equal(t, fieldPort, model.focus)
+}
+
+// A probe flag the bound workload cannot honour is refused on the terminal
+// path too. Applying it nowhere and saying nothing is what the headless path
+// already refuses to do.
+func TestFlow_BoundUneditableProbeRefusesTheFlag(t *testing.T) {
+	stubLive(t, documentFrom(t, `{"name": "tcp-app", "artifactId": "68a1"}`),
+		documentFrom(t, `{"name": "tcp-app-artifact", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
+			{"name": "primary", "primary": true, "port": 9000, "imageUri": "registry/tcp:v1",
+			 "readinessProbe": {"tcpSocket": {"port": 9000}, "periodSeconds": 10}}]}]}}`))
+
+	model := newFlow(dockerfileProject(t), nil, Answers{
+		WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0",
+		NoProbe:    true,
+	})
+
+	updated, _ := model.Update(liveLoadedMsg{live: mustFetchLive(t, "68b0c1d2e3f4a5b6c7d8e9f0")})
+
+	next, ok := updated.(flow)
+	require.True(t, ok)
+
+	require.Error(t, next.fatal)
+	assert.Contains(t, next.fatal.Error(), "--no-readiness-probe")
+	assert.Contains(t, next.fatal.Error(), "does not model")
+}
+
 // openAdvanced reveals the fields behind the advanced row and leaves the
 // cursor on the first of them, which is where a test that wants one of those
 // fields has to start.

--- a/internal/workload/wizard/regression_test.go
+++ b/internal/workload/wizard/regression_test.go
@@ -574,15 +574,14 @@ func TestFlow_EnvTableOverridesAreIndependentAndPersist(t *testing.T) {
 	assert.Equal(t, EnvSecret, returned.envTable.rows[0].Kind)
 }
 
-// Importance is written to every manifest, so it is worth one field rather
-// than a hand edit. The enum is not verified against a running platform, so
-// the prompt checks it while the reader passes anything through.
-func TestFlow_ImportanceIsAskedAndValidated(t *testing.T) {
-	model := newFlow(dockerfileProject(t), nil, Answers{})
-	model = press(t, pastName(t, model), "enter", "enter")
-	require.Equal(t, screenSettings, model.at)
+// Importance has a working default and most users have no basis to answer it,
+// so it sits behind the advanced row rather than on the screen. The enum is
+// not verified against a running platform, so the prompt checks it while the
+// reader passes anything through.
+func TestFlow_ImportanceIsBehindAdvancedAndValidated(t *testing.T) {
+	model := openAdvanced(t, atSettings(t))
 
-	last := len(settingsLabels) - 1
+	last := settingsFieldCount - 1
 	assert.Equal(t, manifest.DefaultImportance, model.inputs[last].Placeholder)
 
 	// The note for the field explains it, once the cursor is on it.
@@ -601,6 +600,135 @@ func TestFlow_ImportanceIsAskedAndValidated(t *testing.T) {
 	require.NoError(t, accepted.failed)
 	assert.Equal(t, "high", accepted.draft.Importance)
 	assert.Contains(t, string(accepted.content), "importance: high")
+}
+
+// The screen is made of text inputs, so a letter is text. Nothing on it can
+// be a bare-key command: [a] would land in the port rather than opening the
+// row it names.
+func TestFlow_LettersAreTypedRatherThanTakenAsCommands(t *testing.T) {
+	model := press(t, atSettings(t), "a")
+
+	assert.False(t, model.advancedOpen, "no bare key opens the row")
+	assert.Equal(t, "3000a", model.inputs[fieldPort].Value(), "the keystroke belongs to the focused field")
+}
+
+// A run that never opens the advanced row writes exactly what the wizard has
+// always written: moving five fields out of sight moved no values.
+func TestFlow_HiddenFieldsKeepTheirValues(t *testing.T) {
+	detected := dockerfileProject(t)
+
+	model := press(t, pastName(t, newFlow(detected, nil, Answers{})), "enter", "enter", "enter")
+	require.Equal(t, screenConfirm, model.at)
+	require.NoError(t, model.failed)
+	require.False(t, model.advancedOpen)
+
+	expected := defaultDraft(detected)
+	expected.Name = "test-app"
+
+	want, err := expected.Render()
+	require.NoError(t, err)
+
+	assert.Equal(t, string(want), string(model.content))
+
+	// And the confirm screen states each of them, so nothing is written that
+	// was never on screen.
+	view := model.View()
+	assert.Contains(t, view, "1 replica")
+	assert.Contains(t, view, "0.5 cpu")
+	assert.Contains(t, view, "importance low")
+	assert.Contains(t, view, "Readiness: /health on port 3000")
+}
+
+// Clearing the health path is how the screen declines the probe, and what
+// comes out carries no probe block and still validates.
+func TestFlow_ClearedHealthPathWritesNoProbe(t *testing.T) {
+	model := openAdvanced(t, atSettings(t))
+	require.Equal(t, firstAdvancedField, model.focus)
+
+	model = press(t, withField(model, fieldHealthPath, ""), "enter")
+	require.Equal(t, screenConfirm, model.at)
+	require.NoError(t, model.failed)
+
+	assert.NotContains(t, string(model.content), "readinessProbe")
+	assert.Contains(t, model.View(), "no probe")
+
+	parsed, err := manifest.Parse(model.content, model.detected.Dir)
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate(), "a workload without a probe is a valid workload")
+}
+
+// A path that is set still has to be one, so the rule the empty field relaxes
+// is not the rule the field enforces.
+func TestFlow_HealthPathStillHasToBeAPath(t *testing.T) {
+	model := openAdvanced(t, atSettings(t))
+
+	model = press(t, withField(model, fieldHealthPath, "health"), "enter")
+
+	require.Equal(t, screenSettings, model.at)
+	require.Error(t, model.failed)
+	assert.Contains(t, model.failed.Error(), "must start with /")
+}
+
+// A field that fails validation while it is out of sight has to come into
+// sight. An error naming a field nobody can see is a screen with no way
+// forward, and the value being refused often came from a flag or from the
+// bound workload rather than from anything typed here.
+func TestFlow_RefusedHiddenFieldOpensTheAdvancedRow(t *testing.T) {
+	model := openAdvanced(t, atSettings(t))
+
+	// Close the row again, leaving a bad value behind it.
+	model = press(t, withField(model, fieldMemory, "4Gi"), "shift+tab", "enter")
+	require.False(t, model.advancedOpen)
+
+	model = press(t, model, "tab", "enter") // back to the port, then submit
+
+	require.Equal(t, screenSettings, model.at)
+	require.Error(t, model.failed)
+	assert.Contains(t, model.failed.Error(), "1000-based unit")
+
+	assert.True(t, model.advancedOpen, "the row opens on the field that was refused")
+	assert.Equal(t, fieldMemory, model.focus, "and the cursor is on it")
+	assert.Contains(t, model.View(), "Memory", "so the error names something on screen")
+}
+
+// Clearing importance takes the documented default rather than being refused,
+// which is what the headless path does with the same input. It is the field
+// next to the health path, where clearing is meaningful, so two adjacent
+// fields disagreeing about the same gesture would be its own trap.
+func TestFlow_ClearedImportanceTakesTheDefault(t *testing.T) {
+	model := openAdvanced(t, atSettings(t))
+
+	model = press(t, withField(model, fieldImportance, ""), "enter")
+
+	require.Equal(t, screenConfirm, model.at)
+	require.NoError(t, model.failed)
+	assert.Equal(t, manifest.DefaultImportance, model.draft.Importance)
+}
+
+// The placeholder has to say what an empty field means, because here it means
+// the opposite of what a placeholder means everywhere else on the screen.
+func TestFlow_HealthPathPlaceholderSaysNoProbe(t *testing.T) {
+	model := newFlow(dockerfileProject(t), nil, Answers{NoProbe: true})
+	model = press(t, pastName(t, model), "enter", "enter")
+	require.Equal(t, screenSettings, model.at)
+
+	assert.Empty(t, model.inputs[fieldHealthPath].Value())
+	assert.Equal(t, healthPlaceholder, model.inputs[fieldHealthPath].Placeholder)
+	assert.NotContains(t, healthPlaceholder, manifest.DefaultHealthPath)
+}
+
+// openAdvanced reveals the fields behind the advanced row and leaves the
+// cursor on the first of them, which is where a test that wants one of those
+// fields has to start.
+func openAdvanced(t *testing.T, model flow) flow {
+	t.Helper()
+
+	model = press(t, model, "tab", "enter", "tab")
+
+	require.True(t, model.advancedOpen)
+	require.Equal(t, firstAdvancedField, model.focus)
+
+	return model
 }
 
 // The confirm screen names the file it is about to write, because --dir means
@@ -640,21 +768,39 @@ func withField(model flow, i int, value string) flow {
 }
 
 // Each field explains itself when the cursor reaches it, so the screen stays
-// readable on a narrow terminal instead of running a hint off the edge.
+// readable on a narrow terminal instead of running a hint off the edge. The
+// walk starts at the port, passes the advanced row, and reaches the rest only
+// once that row is open.
 func TestFlow_SettingsNotesFollowTheCursor(t *testing.T) {
-	model := newFlow(dockerfileProject(t), nil, Answers{})
-	model = press(t, pastName(t, model), "enter", "enter")
-	require.Equal(t, screenSettings, model.at)
+	model := atSettings(t)
 
 	// The port note carries its provenance, which no other field has.
 	assert.Contains(t, model.View(), "1024 or above")
 	assert.Contains(t, model.View(), "EXPOSE 3000")
 
+	model = press(t, model, "tab")
+	assert.Contains(t, model.View(), "working default", "the row says what it holds")
+
+	model = press(t, model, "enter")
+	require.True(t, model.advancedOpen)
+	require.Equal(t, screenSettings, model.at, "the row's enter opens it rather than submitting the screen")
+
 	wanted := []string{"Readiness probe path", "protons", "Fractional values", "Binary units", "Scheduling priority"}
 	for i, want := range wanted {
 		model = press(t, model, "tab")
-		assert.Containsf(t, model.View(), want, "note for %s", settingsLabels[i+1])
+		assert.Containsf(t, model.View(), want, "note for %s", settingsLabels[firstAdvancedField+i])
 	}
+}
+
+// atSettings walks a fresh Dockerfile project to the settings screen, which
+// several tests need before they can say anything about it.
+func atSettings(t *testing.T) flow {
+	t.Helper()
+
+	model := press(t, pastName(t, newFlow(dockerfileProject(t), nil, Answers{})), "enter", "enter")
+	require.Equal(t, screenSettings, model.at)
+
+	return model
 }
 
 // Walking back to the base-image screen shows the list again. Arrival work
@@ -1210,6 +1356,93 @@ func mustFetchLive(t *testing.T, id string) manifest.Live {
 	require.NoError(t, err)
 
 	return live
+}
+
+// stubProbelessLive points the binding path at a workload running without a
+// readiness probe, which the platform allows and which the wizard must not
+// quietly fix.
+func stubProbelessLive(t *testing.T) {
+	t.Helper()
+
+	stubLive(t, documentFrom(t, `{"name": "no-probe-app", "importance": "low", "artifactId": "68a1",
+			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 2,
+				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 2, "memory": "4GB"}}]}]}}`),
+		documentFrom(t, `{"name": "no-probe-app-artifact", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 9100, "imageUri": "registry/np:v1"}]}]}}`))
+}
+
+// boundAtSettings binds to whatever the live stubs describe and walks to the
+// settings screen, which for an image-built workload is three screens in.
+func boundAtSettings(t *testing.T) flow {
+	t.Helper()
+
+	model := newFlow(dockerfileProject(t), nil, Answers{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"})
+
+	updated, _ := model.Update(liveLoadedMsg{live: mustFetchLive(t, "68b0c1d2e3f4a5b6c7d8e9f0")})
+
+	model, ok := updated.(flow)
+	require.True(t, ok)
+
+	model = press(t, model, "enter", "enter", "enter") // kind, source, keep the live image
+	require.Equal(t, screenSettings, model.at)
+
+	return model
+}
+
+// Bound to a workload that runs without a probe, the field arrives empty and
+// the screen says why. It used to arrive showing /health, accept anything
+// typed over it, and discard it: the workload's own configuration was neither
+// shown nor changeable.
+func TestFlow_BoundWorkloadWithoutAProbeSaysSo(t *testing.T) {
+	stubProbelessLive(t)
+
+	model := openAdvanced(t, boundAtSettings(t))
+
+	assert.Empty(t, model.inputs[fieldHealthPath].Value())
+	assert.Contains(t, model.View(), "runs without a readiness probe")
+
+	model = press(t, model, "enter")
+	require.Equal(t, screenConfirm, model.at)
+	require.NoError(t, model.failed)
+
+	assert.NotContains(t, string(model.content), "readinessProbe")
+	assert.Empty(t, model.diff, "leaving it alone changes nothing about the workload")
+}
+
+// Typing a path on that screen is an answer, so it adds the probe. The rule
+// the wizard keeps is that it never adds one nobody asked for, not that it
+// cannot add one at all.
+func TestFlow_BoundWorkloadTakesAProbeWhenAsked(t *testing.T) {
+	stubProbelessLive(t)
+
+	model := openAdvanced(t, boundAtSettings(t))
+	model = press(t, withField(model, fieldHealthPath, "/ready"), "enter")
+
+	require.Equal(t, screenConfirm, model.at)
+	require.NoError(t, model.failed)
+
+	assert.Contains(t, string(model.content), "path: /ready")
+	assert.Contains(t, model.diff, "readinessProbe", "adding one is a change to something running, so it is shown")
+}
+
+// And clearing the path of a workload that has one takes the block away
+// rather than leaving it pointed at nothing.
+func TestFlow_BoundWorkloadDropsAClearedProbe(t *testing.T) {
+	stubLiveDocs(t)
+
+	model := openAdvanced(t, boundAtSettings(t))
+	require.Equal(t, "/alive", model.inputs[fieldHealthPath].Value())
+
+	model = press(t, withField(model, fieldHealthPath, ""), "enter")
+	require.Equal(t, screenConfirm, model.at)
+	require.NoError(t, model.failed)
+
+	assert.NotContains(t, string(model.content), "readinessProbe")
+	// Named rather than checked for a "-": every unified diff carries one in
+	// its own header, so that would pass for any change at all.
+	assert.Contains(t, model.diff, "-            readinessProbe:",
+		"removing it is a change to something running")
+	assert.Contains(t, model.diff, "-              path: /alive")
 }
 
 // --skip-env is an answer. Interactively it has to skip the screen, not show

--- a/internal/workload/wizard/regression_test.go
+++ b/internal/workload/wizard/regression_test.go
@@ -602,6 +602,32 @@ func TestFlow_ImportanceIsBehindAdvancedAndValidated(t *testing.T) {
 	assert.Contains(t, string(accepted.content), "importance: high")
 }
 
+// The row is reachable directly, and the legend says so: tabbing onto a row
+// and pressing enter is not something anyone guesses from a screen that shows
+// one field.
+func TestFlow_AdvancedKeyOpensTheRowFromAnyField(t *testing.T) {
+	model := atSettings(t)
+
+	assert.Contains(t, model.View(), "["+advancedKey+"]", "the legend advertises the key")
+	require.Equal(t, fieldPort, model.focus)
+
+	model = press(t, model, advancedKey)
+	assert.True(t, model.advancedOpen)
+	assert.Equal(t, firstAdvancedField, model.focus, "opening lands on the first revealed field")
+	assert.Contains(t, model.View(), "Health path")
+
+	// And from inside a revealed field it closes, putting the cursor somewhere
+	// that still exists.
+	model = press(t, model, "tab", advancedKey)
+	assert.False(t, model.advancedOpen)
+	assert.Equal(t, fieldPort, model.focus)
+	assert.NotContains(t, model.View(), "Health path")
+
+	// The screen is still submitted from there.
+	model = press(t, model, "enter")
+	assert.Equal(t, screenConfirm, model.at)
+}
+
 // The screen is made of text inputs, so a letter is text. Nothing on it can
 // be a bare-key command: [a] would land in the port rather than opening the
 // row it names.
@@ -636,7 +662,7 @@ func TestFlow_HiddenFieldsKeepTheirValues(t *testing.T) {
 	assert.Contains(t, view, "1 replica")
 	assert.Contains(t, view, "0.5 cpu")
 	assert.Contains(t, view, "importance low")
-	assert.Contains(t, view, "Readiness: /health on port 3000")
+	assert.Contains(t, view, "Readiness: "+manifest.DefaultHealthPath+" on port 3000")
 }
 
 // Clearing the health path is how the screen declines the probe, and what
@@ -676,11 +702,13 @@ func TestFlow_HealthPathStillHasToBeAPath(t *testing.T) {
 func TestFlow_RefusedHiddenFieldOpensTheAdvancedRow(t *testing.T) {
 	model := openAdvanced(t, atSettings(t))
 
-	// Close the row again, leaving a bad value behind it.
+	// Close the row again, leaving a bad value behind it. Closing puts the
+	// cursor back on the port, so enter from there submits the screen.
 	model = press(t, withField(model, fieldMemory, "4Gi"), "shift+tab", "enter")
 	require.False(t, model.advancedOpen)
+	require.Equal(t, fieldPort, model.focus)
 
-	model = press(t, model, "tab", "enter") // back to the port, then submit
+	model = press(t, model, "enter")
 
 	require.Equal(t, screenSettings, model.at)
 	require.Error(t, model.failed)
@@ -723,7 +751,9 @@ func TestFlow_HealthPathPlaceholderSaysNoProbe(t *testing.T) {
 func openAdvanced(t *testing.T, model flow) flow {
 	t.Helper()
 
-	model = press(t, model, "tab", "enter", "tab")
+	// Opening puts the cursor on the first revealed field, so no tab is needed
+	// to reach it.
+	model = press(t, model, "tab", "enter")
 
 	require.True(t, model.advancedOpen)
 	require.Equal(t, firstAdvancedField, model.focus)
@@ -785,9 +815,13 @@ func TestFlow_SettingsNotesFollowTheCursor(t *testing.T) {
 	require.True(t, model.advancedOpen)
 	require.Equal(t, screenSettings, model.at, "the row's enter opens it rather than submitting the screen")
 
+	// Opening lands on the first revealed field, so its note is already up.
 	wanted := []string{"Readiness probe path", "protons", "Fractional values", "Binary units", "Scheduling priority"}
 	for i, want := range wanted {
-		model = press(t, model, "tab")
+		if i > 0 {
+			model = press(t, model, "tab")
+		}
+
 		assert.Containsf(t, model.View(), want, "note for %s", settingsLabels[firstAdvancedField+i])
 	}
 }

--- a/internal/workload/wizard/regression_test.go
+++ b/internal/workload/wizard/regression_test.go
@@ -1358,6 +1358,43 @@ func mustFetchLive(t *testing.T, id string) manifest.Live {
 	return live
 }
 
+// stubUnreadableProbeLive points the binding path at a workload whose probe
+// declares no path: a shape this release preserves rather than rewrites.
+func stubUnreadableProbeLive(t *testing.T) {
+	t.Helper()
+
+	stubLive(t, documentFrom(t, `{"name": "tcp-app", "importance": "low", "artifactId": "68a1",
+			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
+				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
+		documentFrom(t, `{"name": "tcp-app-artifact", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 9100, "imageUri": "registry/tcp:v1",
+				 "readinessProbe": {"tcpSocket": {"port": 9100}, "periodSeconds": 10}}]}]}}`))
+}
+
+// A path typed for a probe the merge will not rewrite is refused while the
+// answer can still be taken back, rather than accepted and dropped on the way
+// to the file.
+func TestFlow_UnreadableProbeRefusesATypedPath(t *testing.T) {
+	stubUnreadableProbeLive(t)
+
+	model := openAdvanced(t, boundAtSettings(t))
+	require.Empty(t, model.inputs[fieldHealthPath].Value())
+	// Asserted on a phrase short enough to survive the note's wrapping.
+	assert.Contains(t, model.View(), "readiness probe with no path")
+
+	model = press(t, withField(model, fieldHealthPath, "/ready"), "enter")
+
+	require.Equal(t, screenSettings, model.at)
+	require.Error(t, model.failed)
+	assert.Contains(t, model.failed.Error(), "would not reach the file")
+
+	// Leaving it alone is still the way through, and the probe survives.
+	accepted := press(t, withField(model, fieldHealthPath, ""), "enter")
+	require.Equal(t, screenConfirm, accepted.at)
+	require.NoError(t, accepted.failed)
+	assert.Contains(t, string(accepted.content), "tcpSocket")
+}
+
 // stubProbelessLive points the binding path at a workload running without a
 // readiness probe, which the platform allows and which the wizard must not
 // quietly fix.

--- a/internal/workload/wizard/run.go
+++ b/internal/workload/wizard/run.go
@@ -333,9 +333,19 @@ func (a Answers) applyKind(draft *manifest.Draft) {
 	}
 }
 
+// applyReadiness layers the port and the probe. Declining the probe is an
+// answer like any other, and on a bound workload it removes the block the
+// workload runs with, which the confirm screen shows as a diff before anything
+// is written.
 func (a Answers) applyReadiness(draft *manifest.Draft) {
 	if a.Port != 0 {
 		draft.Port = a.Port
+	}
+
+	if a.NoProbe {
+		draft.HealthPath = ""
+
+		return
 	}
 
 	if a.HealthPath != "" {
@@ -354,6 +364,10 @@ func (a Answers) applyEnv(draft *manifest.Draft, detected Detected) {
 // Anything left at zero keeps what the workload is already running with,
 // rather than resetting it to the documented default.
 func (a Answers) applySizing(draft *manifest.Draft) {
+	if a.Importance != "" {
+		draft.Importance = a.importance()
+	}
+
 	if a.Replicas != 0 {
 		draft.Runtime.Replicas = a.Replicas
 	}

--- a/internal/workload/wizard/run.go
+++ b/internal/workload/wizard/run.go
@@ -257,6 +257,10 @@ func (o Options) resolveHeadlessBound(detected Detected) ([]byte, manifest.Draft
 		return nil, manifest.Draft{}, err
 	}
 
+	if err := o.Answers.checkProbeEditable(live); err != nil {
+		return nil, manifest.Draft{}, err
+	}
+
 	draft, err := o.Answers.applyTo(live.Defaults(), detected)
 	if err != nil {
 		return nil, manifest.Draft{}, err

--- a/internal/workload/wizard/run_test.go
+++ b/internal/workload/wizard/run_test.go
@@ -63,6 +63,42 @@ func swapLiveFns(t *testing.T, getWorkload, getArtifact func(string) (workload.D
 	t.Cleanup(func() { getWorkloadFn, getArtifactFn = originalWorkload, originalArtifact })
 }
 
+// Headless there is no screen to explain that a probe is being preserved, so a
+// flag that cannot be carried out is an error rather than a run that reports
+// success having ignored the one thing it was asked to change.
+func TestRun_ProbeFlagOnAnUnmodelledProbeIsRefused(t *testing.T) {
+	stubLive(t, documentFrom(t, `{"name": "tcp-app", "artifactId": "68a1",
+			"runtime": {"containerGroups": [{"name": "default", "replicaCount": 1,
+				"containers": [{"name": "primary", "resourceAllocation": {"cpu": 1, "memory": "2GB"}}]}]}}`),
+		documentFrom(t, `{"name": "tcp-app-artifact", "type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
+				{"name": "primary", "primary": true, "port": 9100, "imageUri": "registry/tcp:v1",
+				 "readinessProbe": {"tcpSocket": {"port": 9100}, "periodSeconds": 10}}]}]}}`))
+
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+
+	for name, answers := range map[string]Answers{
+		"declined": {WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0", NoProbe: true},
+		"a path":   {WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0", HealthPath: "/ready"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := Run(Options{Dir: dir, NonInteractive: true, Answers: answers})
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "readiness probe with no path")
+			assert.NoFileExists(t, manifest.Path(dir))
+		})
+	}
+
+	// Binding without saying anything about the probe still works, and keeps it.
+	result, err := Run(Options{
+		Dir: dir, NonInteractive: true,
+		Answers: Answers{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"},
+		DryRun:  true,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(result.Content), "tcpSocket")
+}
+
 func documentFrom(t *testing.T, raw string) workload.Document {
 	t.Helper()
 

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -688,8 +688,9 @@ func (f flow) liveProbeNote() string {
 		return ""
 
 	case present:
-		return liveStyle.Render(f.live.Name) + " runs a readiness probe this release cannot edit, so it is " +
-			"kept exactly as it is and this field does not apply to it."
+		return liveStyle.Render(f.live.Name) + " runs a readiness probe with no path, so this field does not " +
+			"apply to it. Its shape is kept as it is; only its port follows the container's, the way the " +
+			"startup and liveness probes do."
 
 	default:
 		return liveStyle.Render(f.live.Name) + " runs without a readiness probe. Leaving this empty keeps it that way; " +
@@ -874,7 +875,7 @@ func (f flow) readinessLine() string {
 	// A probe shape this release does not model is carried over untouched, so
 	// the answers do not describe it and neither should this line.
 	if present, readable := f.liveReadinessProbe(); present && !readable {
-		return "Readiness: kept as " + f.live.Name + " has it; this release does not edit that probe's shape."
+		return "Readiness: " + f.live.Name + "'s own probe, kept as it is apart from the port it watches."
 	}
 
 	if !f.draft.WantsReadinessProbe() {

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -45,9 +45,9 @@ const defaultEditor = "vi"
 
 // healthPlaceholder says what an empty health path means rather than showing
 // the default, which is what every other placeholder on that screen does.
-// Ghosting "/health" there would advertise the opposite of what accepting the
-// empty field does, and the field is only ever empty when a probe has been
-// declined or the bound workload runs without one.
+// Ghosting the default path there would advertise the opposite of what
+// accepting the empty field does, and the field is only ever empty when a probe
+// has been declined or the bound workload runs without one.
 const healthPlaceholder = "none: no readiness probe"
 
 // namePlaceholder shows the shape of a workload name without proposing one.
@@ -631,15 +631,22 @@ func (f flow) onAdvancedRow() bool {
 	return f.at == screenSettings && f.focus == advancedStop
 }
 
-// advancedKeyLabel is what enter does while the row is focused, which is not
-// what it does anywhere else on the screen.
-func (f flow) advancedKeyLabel() string {
-	if f.advancedOpen {
-		return "hide advanced options"
-	}
+// advancedKey opens and closes the advanced row from anywhere on the settings
+// screen, so the fields behind it are reachable without first discovering that
+// tab lands on a row.
+//
+// A chord rather than a letter, because every stop on this screen but the row
+// itself is a text input and a bare key is text there. ctrl+a would have been
+// the mnemonic; the input already binds it to line-start, along with b, d, e,
+// f, h, k, n, p, u, v and w, and taking a standard editing key away from a
+// field to save one keystroke elsewhere is a poor trade.
+const advancedKey = "ctrl+o"
 
-	return "show advanced options"
-}
+// advancedLabel is what both keys that toggle the row are called in the
+// legend. One word in either state, because the row's own arrow already says
+// which way it will go and a label that changes width wraps the legend onto a
+// second line at eighty columns, pushing [esc] back off the end of the first.
+const advancedLabel = "advanced"
 
 // settingsNote explains whatever the cursor is on. The port's note carries its
 // provenance too, since that is the one value detection can vouch for.
@@ -925,6 +932,7 @@ var screenKeys = map[screen][]keyBinding{
 	},
 	screenSettings: {
 		{Key: "tab", Does: "next field"},
+		{Key: advancedKey, Does: "advanced"},
 		{Key: "enter", Does: "continue"},
 		{Key: "esc", Does: "back"},
 	},
@@ -971,12 +979,12 @@ func (f flow) keys() string {
 		bindings = append([]keyBinding{{Key: "↑/↓", Does: "scroll"}}, bindings...)
 	}
 
-	// On the advanced row enter belongs to the row, not to the screen, so the
-	// legend has to say what it will actually do. Only that one entry changes:
+	// On the row itself enter belongs to the row rather than to the screen, so
+	// it is labelled for what it does there. Only that entry changes:
 	// rebuilding the list here would quietly drop any key the screen gains
 	// later, in the one state where the legend matters most.
 	if f.onAdvancedRow() {
-		bindings = withKey(bindings, "enter", f.advancedKeyLabel())
+		bindings = withKey(bindings, "enter", advancedLabel)
 	}
 
 	// With a filter in place, esc undoes that first. Saying "back" would be a

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -42,6 +43,13 @@ const createNewID = "\x00create-new"
 // the same thing whether or not that registration has run.
 const defaultEditor = "vi"
 
+// healthPlaceholder says what an empty health path means rather than showing
+// the default, which is what every other placeholder on that screen does.
+// Ghosting "/health" there would advertise the opposite of what accepting the
+// empty field does, and the field is only ever empty when a probe has been
+// declined or the bound workload runs without one.
+const healthPlaceholder = "none: no readiness probe"
+
 // namePlaceholder shows the shape of a workload name without proposing one.
 // The directory is a poor suggestion often enough (src, app, cli, tmp) that
 // offering it invites a name nobody chose, and this name ends up on a
@@ -52,12 +60,17 @@ const namePlaceholder = "my-app-name"
 // agreed to. The workload list is fetched up front because the first screen
 // depends on it: with nothing to bind to, there is no binding question.
 func runInteractiveFlow(opts Options, detected Detected) ([]byte, manifest.Draft, error) {
-	// No screen can settle this one, so it is not a question the wizard gets
-	// to ask. Started anyway, the error would sit behind the loading view
-	// while the fetch ran, and arriving at the first screen would clear it
-	// and drop --name without saying so.
-	if err := opts.Answers.checkBinding(); err != nil {
-		return nil, manifest.Draft{}, err
+	// No screen can settle these, so they are not questions the wizard gets to
+	// ask. Started anyway, the error would sit behind the loading view while
+	// the fetch ran, and arriving at the first screen would clear it and drop
+	// the flag without saying so: contradictory flags have to be refused before
+	// the terminal is taken over.
+	for _, check := range []func() error{
+		opts.Answers.checkBinding, opts.Answers.checkReadiness, opts.Answers.checkImportance,
+	} {
+		if err := check(); err != nil {
+			return nil, manifest.Draft{}, err
+		}
 	}
 
 	var workloads []workload.Workload
@@ -225,7 +238,7 @@ func (f *flow) enterInputs(at screen) {
 	case screenSettings:
 		inputs := make([]textinput.Model, settingsFieldCount)
 		inputs[fieldPort] = newInput(strconv.Itoa(f.draft.Port), "8080")
-		inputs[fieldHealthPath] = newInput(f.draft.HealthPath, manifest.DefaultHealthPath)
+		inputs[fieldHealthPath] = newInput(f.draft.HealthPath, healthPlaceholder)
 		inputs[fieldReplicas] = newInput(replicaValue(f.draft.Runtime.Replicas), replicaPlaceholder(f.autoscaled()))
 		inputs[fieldCPU] = newInput(formatCPU(f.draft.Runtime.CPU), "0.5")
 		inputs[fieldMemory] = newInput(f.draft.Runtime.Memory, manifest.DefaultMemory)
@@ -233,9 +246,10 @@ func (f *flow) enterInputs(at screen) {
 
 		f.inputs = inputs
 
-		for i := range f.inputs[1:] {
-			f.inputs[i+1].Blur()
-		}
+		// newInput focuses everything it builds, so exactly one is left
+		// focused here. Through applyFocus rather than a hardcoded index, so
+		// arrival and movement agree on where the cursor is by construction.
+		f.applyFocus()
 
 	case screenBinding, screenExecEnv, screenKind, screenA2A, screenSource, screenEnv, screenConfirm:
 		// No text entry.
@@ -348,8 +362,17 @@ func (f flow) liveValuesNote() string {
 		return ""
 	}
 
-	return "These are " + liveStyle.Render(f.live.Name) +
+	values := "These are " + liveStyle.Render(f.live.Name) +
 		"'s current values. Changing one changes the workload."
+
+	// On the settings screen most of those values are behind the advanced row,
+	// so the sentence would otherwise promise a review of things that are not
+	// on screen.
+	if f.at == screenSettings && !f.advancedOpen {
+		return values + " The rest are under advanced options."
+	}
+
+	return values
 }
 
 // sourceConflictNote warns when the workload builds a Dockerfile that this
@@ -446,12 +469,19 @@ var questions = map[screen]string{
 	screenExecEnv:    "Which execution environment should the build use?",
 	screenEntrypoint: "What is your app's entrypoint?",
 	screenImage:      "Which image should it run?",
-	screenSettings:   "How should this workload run?",
+	screenSettings:   "Which port does your app listen on?",
 	screenEnv:        "Which variables should the manifest declare?",
 	screenConfirm:    "Ready to write " + manifest.FileName,
 }
 
 func (f flow) question() string {
+	// The settings screen asks about the port until the advanced row is
+	// opened, at which point five more fields are on screen and naming one of
+	// them stops describing what is being answered.
+	if f.at == screenSettings && f.advancedOpen {
+		return "How should this workload run?"
+	}
+
 	return questions[f.at]
 }
 
@@ -504,6 +534,24 @@ const (
 	settingsFieldCount
 )
 
+// The two positions that are not fields. They live outside the block above
+// because a constant with an explicit value ends its iota run: written there,
+// the next field appended with no value of its own would silently repeat -1
+// instead of continuing the count, which is the opposite of what that block
+// promises.
+const (
+	// firstAdvancedField is where the shown-by-default part of the screen
+	// ends. Everything from here on is behind the advanced row, which is why
+	// the field order puts the port first: the advanced set is a suffix of one
+	// list rather than a second list that could fall out of step with it.
+	firstAdvancedField = fieldHealthPath
+
+	// advancedStop is where the cursor sits when the advanced row itself is
+	// focused. It is not a field, so it indexes nothing; every place that
+	// reads f.focus as a field has to allow for it.
+	advancedStop = -1
+)
+
 // settingsLabels name the fields. Everything here has a working default, so
 // the screen is a review as much as a question.
 var settingsLabels = [settingsFieldCount]string{
@@ -521,42 +569,132 @@ var settingsLabels = [settingsFieldCount]string{
 // explaining anyway.
 var settingsNotes = [settingsFieldCount]string{
 	fieldPort:       "Port the container listens on. Must be 1024 or above: containers run unprivileged.",
-	fieldHealthPath: "Readiness probe path. Traffic is withheld until this endpoint reports success.",
+	fieldHealthPath: "Readiness probe path. While it is set, traffic is withheld until this endpoint reports success. Leave it empty to run without a probe.",
 	fieldReplicas:   "Container instances to run. Reported as protons in status output and logs.",
 	fieldCPU:        "CPU cores per replica. Fractional values are allowed.",
 	fieldMemory:     "Memory per replica. A byte count or a 1000-based unit (" + strings.Join(manifest.MemoryUnits(), ", ") + "). Binary units such as Gi are rejected: they would be read as their decimal equivalents.",
 	fieldImportance: "Scheduling priority when capacity is constrained: " + strings.Join(manifest.ImportanceLevels, ", ") + ".",
 }
 
+// settingsView shows the one field that decides whether the container is
+// reachable, and offers the rest behind a row that opens.
+//
+// The hidden fields all have a working default and are all settable by flag,
+// and the confirm screen states every one of them before anything is written,
+// so a user who never opens the row still sees what they are agreeing to.
 func (f flow) settingsView() string {
 	var b strings.Builder
 
-	width := 0
-	for _, label := range settingsLabels {
-		width = max(width, len(label))
+	fmt.Fprintf(&b, "  %s  %s\n\n",
+		labelStyle.Render(settingsLabels[fieldPort]), f.inputs[fieldPort].View())
+	fmt.Fprintf(&b, "  %s\n", f.advancedRow())
+
+	if !f.advancedOpen {
+		return strings.TrimRight(b.String(), "\n")
 	}
 
-	for i, label := range settingsLabels {
-		padded := label + strings.Repeat(" ", width-len(label))
-		fmt.Fprintf(&b, "  %s  %s\n", labelStyle.Render(padded), f.inputs[i].View())
+	width := 0
+	for field := firstAdvancedField; field < settingsFieldCount; field++ {
+		width = max(width, len(settingsLabels[field]))
+	}
+
+	// Indented under the row that revealed them, so the screen reads as one
+	// field and a drawer rather than as six fields again.
+	for field := firstAdvancedField; field < settingsFieldCount; field++ {
+		padded := settingsLabels[field] + strings.Repeat(" ", width-len(settingsLabels[field]))
+		fmt.Fprintf(&b, "    %s  %s\n", labelStyle.Render(padded), f.inputs[field].View())
 	}
 
 	return strings.TrimRight(b.String(), "\n")
 }
 
-// settingsNote explains the field the cursor is on. The port's note carries
-// its provenance too, since that is the one value detection can vouch for.
+// advancedRow is the control that shows and hides the rest of the screen. The
+// arrow points the way pressing it goes, and the row highlights like any other
+// answer under the cursor, because that is what it is.
+func (f flow) advancedRow() string {
+	label := "▸ Advanced options"
+	if f.advancedOpen {
+		label = "▾ Advanced options"
+	}
+
+	if f.focus == advancedStop {
+		return selectedStyle.Render(label)
+	}
+
+	return labelStyle.Render(label)
+}
+
+// onAdvancedRow is the one place that says what the advanced row being focused
+// looks like, so the sentinel is read the same way everywhere rather than
+// spelled out with and without the screen check depending on the call site.
+func (f flow) onAdvancedRow() bool {
+	return f.at == screenSettings && f.focus == advancedStop
+}
+
+// advancedKeyLabel is what enter does while the row is focused, which is not
+// what it does anywhere else on the screen.
+func (f flow) advancedKeyLabel() string {
+	if f.advancedOpen {
+		return "hide advanced options"
+	}
+
+	return "show advanced options"
+}
+
+// settingsNote explains whatever the cursor is on. The port's note carries its
+// provenance too, since that is the one value detection can vouch for.
 func (f flow) settingsNote() string {
+	if f.onAdvancedRow() {
+		return "Readiness probe, sizing and scheduling. Every one has a working default, " +
+			"and the confirm screen shows what will be written whether or not you open this."
+	}
+
 	if f.focus < 0 || f.focus >= len(settingsNotes) {
 		return ""
 	}
 
 	note := settingsNotes[f.focus]
-	if f.focus == 0 {
-		note += " " + capitalize(f.detected.PortSource) + "."
+
+	switch f.focus {
+	case fieldPort:
+		// Provenance is about what this checkout showed. A bound workload's
+		// port came from the workload, so quoting the Dockerfile there would
+		// credit a source the value on screen did not come from.
+		if f.live == nil {
+			note += " " + capitalize(f.detected.PortSource) + "."
+		}
+	case fieldHealthPath:
+		note = joinNotes(note, f.liveProbeNote())
 	}
 
 	return note
+}
+
+// liveProbeNote explains an empty field on a bound workload, which has two
+// quite different causes. The workload may genuinely run without a probe, in
+// which case the empty field is its own configuration rather than something
+// the wizard failed to fill in. Or it may run a probe shaped in a way this
+// release cannot read, in which case the field is not about that probe at all
+// and nothing typed here will touch it.
+func (f flow) liveProbeNote() string {
+	if f.live == nil {
+		return ""
+	}
+
+	present, readable := f.liveReadinessProbe()
+
+	switch {
+	case readable:
+		return ""
+
+	case present:
+		return liveStyle.Render(f.live.Name) + " runs a readiness probe this release cannot edit, so it is " +
+			"kept exactly as it is and this field does not apply to it."
+
+	default:
+		return liveStyle.Render(f.live.Name) + " runs without a readiness probe. Leaving this empty keeps it that way; " +
+			"a path adds one, and the container has to serve it."
+	}
 }
 
 // capitalize raises the first letter so a detection phrase reads as a
@@ -669,7 +807,11 @@ func (f flow) scrollablePreview() bool {
 const (
 	defaultPreviewHeight = 20
 	minPreviewHeight     = 6
-	previewChrome        = 12
+	// Grown twice over: the confirm note now carries a readiness line as well
+	// as the runtime one, and the runtime line wraps on an 80-column terminal
+	// once importance is on it. Under-reserving here does not shrink the
+	// preview, it pushes the key legend off the bottom of the screen.
+	previewChrome = 15
 )
 
 func previewHeight(terminalHeight int) int {
@@ -690,13 +832,15 @@ func (f flow) confirmNote() string {
 	return strings.Join([]string{
 		"Writing to " + ShortPath(manifest.Path(f.detected.Dir)),
 		f.runtimeLine(),
+		f.readinessLine(),
 		f.nextStep(),
 	}, "\n")
 }
 
-// runtimeLine summarises the sizing the file will carry. A bound workload
-// reports its own, not the documented defaults, because this is the line the
-// user is consenting to.
+// runtimeLine summarises the sizing and scheduling the file will carry. A
+// bound workload reports its own, not the documented defaults, because this is
+// the line the user is consenting to. The settings screen keeps all of it
+// behind the advanced row, so this line is where most users see it at all.
 func (f flow) runtimeLine() string {
 	sizing := fmt.Sprintf("%s cpu · %s",
 		strconv.FormatFloat(f.draft.Runtime.CPU, 'g', -1, 64), f.draft.Runtime.Memory)
@@ -709,7 +853,45 @@ func (f flow) runtimeLine() string {
 		}
 	}
 
-	return "Runtime: " + replicas + " · " + sizing + "    (edit the file for GPU/autoscaling)"
+	importance := orDefault(f.draft.Importance, manifest.DefaultImportance)
+
+	return "Runtime: " + replicas + " · " + sizing + " · importance " + importance +
+		"    (edit the file for GPU/autoscaling)"
+}
+
+// readinessLine says what the file will carry for the probe, the other value
+// the advanced row hides. An absent probe is stated rather than left out, so
+// the two cases cannot be told apart only by what is missing.
+//
+// It describes the answers, so it says nothing once the file has been edited
+// by hand: the bytes on screen are then the truth, and a summary derived from
+// the draft would contradict the preview directly above it.
+func (f flow) readinessLine() string {
+	if f.handEdited {
+		return ""
+	}
+
+	// A probe shape this release does not model is carried over untouched, so
+	// the answers do not describe it and neither should this line.
+	if present, readable := f.liveReadinessProbe(); present && !readable {
+		return "Readiness: kept as " + f.live.Name + " has it; this release does not edit that probe's shape."
+	}
+
+	if !f.draft.WantsReadinessProbe() {
+		return "Readiness: no probe, so traffic is not held back for a health check."
+	}
+
+	return fmt.Sprintf("Readiness: %s on port %d", f.draft.HealthPath, f.draft.Port)
+}
+
+// liveReadinessProbe is what the bound workload does about readiness, and
+// false for an unbound run, so callers can ask without repeating the nil check.
+func (f flow) liveReadinessProbe() (present, readable bool) {
+	if f.live == nil {
+		return false, false
+	}
+
+	return f.live.ReadinessProbe()
 }
 
 func (f flow) nextStep() string {
@@ -758,6 +940,24 @@ var defaultKeys = []keyBinding{
 	{Key: "esc", Does: "back"},
 }
 
+// withKey re-labels one key in a screen's legend, copying first because
+// screenKeys is a package-level map and the slices in it are shared by every
+// render. A key the screen does not have is added rather than dropped, so a
+// caller cannot silently say nothing.
+func withKey(bindings []keyBinding, key, does string) []keyBinding {
+	out := slices.Clone(bindings)
+
+	for i := range out {
+		if out[i].Key == key {
+			out[i].Does = does
+
+			return out
+		}
+	}
+
+	return append(out, keyBinding{Key: key, Does: does})
+}
+
 func (f flow) keys() string {
 	bindings, ok := screenKeys[f.at]
 	if !ok {
@@ -768,6 +968,14 @@ func (f flow) keys() string {
 	// never advertises a key that does nothing.
 	if f.at == screenConfirm && f.scrollablePreview() {
 		bindings = append([]keyBinding{{Key: "↑/↓", Does: "scroll"}}, bindings...)
+	}
+
+	// On the advanced row enter belongs to the row, not to the screen, so the
+	// legend has to say what it will actually do. Only that one entry changes:
+	// rebuilding the list here would quietly drop any key the screen gains
+	// later, in the one state where the legend matters most.
+	if f.onAdvancedRow() {
+		bindings = withKey(bindings, "enter", f.advancedKeyLabel())
 	}
 
 	// With a filter in place, esc undoes that first. Saying "back" would be a

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -63,11 +63,13 @@ func runInteractiveFlow(opts Options, detected Detected) ([]byte, manifest.Draft
 	// No screen can settle these, so they are not questions the wizard gets to
 	// ask. Started anyway, the error would sit behind the loading view while
 	// the fetch ran, and arriving at the first screen would clear it and drop
-	// the flag without saying so: contradictory flags have to be refused before
-	// the terminal is taken over.
-	for _, check := range []func() error{
-		opts.Answers.checkBinding, opts.Answers.checkReadiness, opts.Answers.checkImportance,
-	} {
+	// the flag without saying so.
+	//
+	// Only those two. A bad --port, a path missing its slash and an importance
+	// outside the enum are all values a screen shows and the user can correct,
+	// and refusing them here would turn a recoverable typo into a run that
+	// never starts.
+	for _, check := range []func() error{opts.Answers.checkBinding, opts.Answers.checkProbeExclusive} {
 		if err := check(); err != nil {
 			return nil, manifest.Draft{}, err
 		}
@@ -249,7 +251,9 @@ func (f *flow) enterInputs(at screen) {
 		// newInput focuses everything it builds, so exactly one is left
 		// focused here. Through applyFocus rather than a hardcoded index, so
 		// arrival and movement agree on where the cursor is by construction.
-		f.applyFocus()
+		// The blink command is parked for onEnter to hand on: arriving at a
+		// screen has no tea.Cmd of its own to return it through.
+		f.focusCmd = f.applyFocus()
 
 	case screenBinding, screenExecEnv, screenKind, screenA2A, screenSource, screenEnv, screenConfirm:
 		// No text entry.
@@ -797,7 +801,7 @@ func (f *flow) buildPreview() {
 
 	// A short manifest keeps its own height: padding it out to a fixed window
 	// would put the key legend below the fold for no reason.
-	f.preview = viewport.New(contentWidth(f.width), min(previewHeight(f.height), lines))
+	f.preview = viewport.New(contentWidth(f.width), min(f.previewHeight(), lines))
 	f.preview.SetContent(text)
 }
 
@@ -815,19 +819,23 @@ func (f flow) scrollablePreview() bool {
 const (
 	defaultPreviewHeight = 20
 	minPreviewHeight     = 6
-	// Grown twice over: the confirm note now carries a readiness line as well
-	// as the runtime one, and the runtime line wraps on an 80-column terminal
-	// once importance is on it. Under-reserving here does not shrink the
-	// preview, it pushes the key legend off the bottom of the screen.
-	previewChrome = 15
+	// What the screen spends on everything that is not the note: the question,
+	// the key legend and the blank lines between the blocks. The note is
+	// measured rather than budgeted for, because its height moves with the
+	// terminal's width and with how much there is to say.
+	previewChrome = 9
 )
 
-func previewHeight(terminalHeight int) int {
-	if terminalHeight <= 0 {
+// previewHeight is what the terminal has left for the file itself. Measuring
+// the note beats reserving a constant for it: a fixed budget large enough for
+// a wrapped four-line note steals a line from every screen that has three, and
+// one tuned to three pushes the key legend off the bottom on a narrow terminal.
+func (f flow) previewHeight() int {
+	if f.height <= 0 {
 		return defaultPreviewHeight
 	}
 
-	return max(terminalHeight-previewChrome, minPreviewHeight)
+	return max(f.height-previewChrome-lipgloss.Height(f.note(f.confirmNote())), minPreviewHeight)
 }
 
 // confirmNote is what the user is agreeing to, beyond the file itself: where
@@ -837,12 +845,14 @@ func (f flow) confirmNote() string {
 		return ""
 	}
 
-	return strings.Join([]string{
-		"Writing to " + ShortPath(manifest.Path(f.detected.Dir)),
+	// joinNotes rather than strings.Join: readinessLine says nothing about a
+	// hand-edited file, and an empty entry would leave a blank line mid-note.
+	return joinNotes(
+		"Writing to "+ShortPath(manifest.Path(f.detected.Dir)),
 		f.runtimeLine(),
 		f.readinessLine(),
 		f.nextStep(),
-	}, "\n")
+	)
 }
 
 // runtimeLine summarises the sizing and scheduling the file will carry. A
@@ -951,8 +961,9 @@ var defaultKeys = []keyBinding{
 
 // withKey re-labels one key in a screen's legend, copying first because
 // screenKeys is a package-level map and the slices in it are shared by every
-// render. A key the screen does not have is added rather than dropped, so a
-// caller cannot silently say nothing.
+// render. A key the screen does not list is left alone: every caller relabels a
+// binding the screen already has, and appending one instead would put a key in
+// the legend that nothing on that screen answers.
 func withKey(bindings []keyBinding, key, does string) []keyBinding {
 	out := slices.Clone(bindings)
 
@@ -960,11 +971,19 @@ func withKey(bindings []keyBinding, key, does string) []keyBinding {
 		if out[i].Key == key {
 			out[i].Does = does
 
-			return out
+			break
 		}
 	}
 
-	return append(out, keyBinding{Key: key, Does: does})
+	return out
+}
+
+// withoutKey drops a binding, for the states where a key the screen normally
+// offers is not the way to do the thing any more.
+func withoutKey(bindings []keyBinding, key string) []keyBinding {
+	return slices.DeleteFunc(slices.Clone(bindings), func(b keyBinding) bool {
+		return b.Key == key
+	})
 }
 
 func (f flow) keys() string {
@@ -979,12 +998,13 @@ func (f flow) keys() string {
 		bindings = append([]keyBinding{{Key: "↑/↓", Does: "scroll"}}, bindings...)
 	}
 
-	// On the row itself enter belongs to the row rather than to the screen, so
-	// it is labelled for what it does there. Only that entry changes:
-	// rebuilding the list here would quietly drop any key the screen gains
-	// later, in the one state where the legend matters most.
+	// On the row itself enter is the row's own action, so it is labelled for
+	// that and the chord drops out: two entries reading "advanced" say the
+	// screen has two ways to do one thing, in the one place that is not worth
+	// the width. Derived from the table rather than rewritten, so a key the
+	// screen gains later still appears here.
 	if f.onAdvancedRow() {
-		bindings = withKey(bindings, "enter", advancedLabel)
+		bindings = withoutKey(withKey(bindings, "enter", advancedLabel), advancedKey)
 	}
 
 	// With a filter in place, esc undoes that first. Saying "back" would be a


### PR DESCRIPTION
# RATIONALE

User feedback on `dr workload config` was that the settings step asks too much at once, and that the health-path note reads as if traffic will never flow without a readiness probe. The platform does not require one, which the same thread confirmed.

Triaging the whole screen rather than that one note turned up that it had drifted from the RAPTOR-18975 design anyway: replicas, cpu and memory were on the never-asked list and were being prompted for regardless. So most of this is putting the screen back where it was meant to be.

## CHANGES

The settings screen asks for the port. Health path, replicas, cpu, memory and importance move behind an "Advanced options" row, reachable with `ctrl+o` from anywhere on the screen or by tabbing onto the row. All five still appear on the confirm screen whether or not you open it, so nothing is written that was never shown. The shortest path drops from eleven answers to six.

A readiness probe is now declinable. An empty health path means no `readinessProbe` block, and `--no-readiness-probe` says the same thing headlessly.

**The default probe path changes from `/health` to `/`.** A probe has to pass on an application nobody wrote it for. Almost every HTTP service answers something at the root, where `/health` is an endpoint the app has to have implemented, and pointing a probe at one that does not exist is the most common first-deploy failure. It presents as a deploy that never becomes ready rather than as a misconfigured probe, which is the worst way to learn about it.

`--importance` is new. It was missing rather than removed, and hiding that field without it would have stranded the value.

Three things worth a reviewer's attention:

- **Binding no longer confuses "no probe" with "a probe we cannot read".** `Live.Defaults()` reported both as an empty path, so the health field silently discarded whatever you typed on a bound workload. Those are separate questions now; a probe whose shape this release does not model is preserved the way startup and liveness probes are, and it follows the container port when that moves.
- **A flag we cannot carry out is refused rather than ignored.** `--health` or `--no-readiness-probe` against a workload whose probe we cannot rewrite used to report success having changed nothing, and headlessly there is no screen to notice it.
- **A hidden field that fails validation opens the row and takes the cursor.** The value being refused often comes from a flag or from the bound workload rather than from typing, so the error would otherwise name a field that is not on screen.

## NOTES

Verified against staging: the default writes the probe, `--no-readiness-probe` omits exactly that block and nothing else, and the result passes `Load` and `Validate` on a second run.

Two gaps this does not close, both pre-existing and both made more visible by the new flags, so the help text says what actually happens rather than promising otherwise. `up` cannot carry a probe removal to the platform, because a key the file omits is a key `up` leaves alone by design. And `importance` is neither `artifact.spec` nor `runtime`, so it reaches the platform at create only.

The bound path could not be exercised end to end against staging, because every workload on the account trips RAPTOR-19533. It is covered by tests over recorded live documents instead.

## RELATED

RAPTOR-19535
