### PR TITLE
[RAPTOR-19601] feat(workload): warn when a deploy runs a draft artifact

### DIFF
--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -337,14 +337,13 @@ func reportable(result up.Result) bool {
 }
 
 // draftIsServing reports whether this run left, or would leave, a draft
-// artifact serving. A draft is mutable and unversioned, the platform reclaims
-// it, and the workload stops on its own once it has been idle, none of which
-// the deploy output ever said.
+// artifact serving. A workload on a draft is stopped eight hours after it
+// starts running, whatever it is serving, and the deploy output never said so.
 //
-// Result.Locked is the whole signal and costs no extra call. It starts as the
-// status of the artifact the workload is already running and is only ever
-// flipped true by an actual lock, so its negation covers every path a deploy
-// can take: create, roll, retune, start, and a run that changed nothing.
+// Result.Locked is the whole signal. It starts as the status of the artifact
+// the workload is already running and is only ever flipped true by an actual
+// lock, so its negation covers every path a deploy can take: create, roll,
+// retune, start, and a run that changed nothing.
 //
 // The three refusals, in order:
 //
@@ -359,13 +358,11 @@ func reportable(result up.Result) bool {
 // to check and previewing a first deploy is exactly who this is for; and a
 // real run qualifies once it has a workload, the same guard nextSteps uses.
 //
-// One shape slips through: a manifest bound by artifactId to an artifact that
-// is already locked, creating a workload from it. Nothing reads that
-// artifact's status before the deploy, so the run reports a draft and this
-// warns wrongly. Rolling that shape is refused by the platform, which will
-// not swap a draft for a locked version, so only the create case can reach
-// it. Reading the status to be sure would mean a fetch in the planner for a
-// rare shape, which is not worth what it buys.
+// The one shape live state cannot answer, a manifest bound by artifact id
+// creating a workload that does not exist yet, is settled before the result
+// gets here: see bindLocked in internal/workload/up. Without it a promotion
+// of a locked artifact onto a fresh workload would be called temporary and
+// then advised to lock what is already locked.
 func draftIsServing(f flags, result up.Result, failed bool) bool {
 	if failed || f.lock || result.Locked {
 		return false
@@ -393,7 +390,7 @@ func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, resul
 
 	if f.dryRun {
 		fmt.Fprintln(cmd.ErrOrStderr(), "\nDry run: nothing was changed.")
-		draftWarning(cmd.ErrOrStderr(), draft)
+		draftWarning(cmd.ErrOrStderr(), draft, true)
 
 		return nil
 	}
@@ -415,7 +412,7 @@ func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, resul
 		fmt.Fprintln(cmd.OutOrStdout(), result.Endpoint)
 	}
 
-	draftWarning(cmd.ErrOrStderr(), draft)
+	draftWarning(cmd.ErrOrStderr(), draft, false)
 	nextSteps(cmd.ErrOrStderr(), result, draft)
 
 	return nil
@@ -439,13 +436,20 @@ func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, resul
 // The command is named inline rather than left to nextSteps, because a dry run
 // returns before nextSteps ever gets to speak and would otherwise state a
 // problem with no remedy attached.
-func draftWarning(w io.Writer, draft bool) {
+func draftWarning(w io.Writer, draft, planned bool) {
 	if !draft {
 		return
 	}
 
-	fmt.Fprintf(w, "\n  %s %s\n",
-		tui.WarnStyle.Render("⚠"), tui.WarnStyle.Render("This workload is running a draft artifact."))
+	// A dry run has changed nothing and may be previewing a workload that does
+	// not exist, so the present tense would contradict the "nothing was
+	// changed" line printed immediately above it.
+	headline := "This workload is running a draft artifact."
+	if planned {
+		headline = "This workload would run a draft artifact."
+	}
+
+	fmt.Fprintf(w, "\n  %s %s\n", tui.WarnStyle.Render("⚠"), tui.WarnStyle.Render(headline))
 
 	// One sentence per line, and rendered a line at a time. Wrapping prose to a
 	// fixed width breaks it mid-clause at whatever column the source happened to

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -336,6 +336,44 @@ func reportable(result up.Result) bool {
 	return result.WorkloadID != "" || result.BuildID != ""
 }
 
+// draftIsServing reports whether this run left, or would leave, a draft
+// artifact serving. A draft is mutable and unversioned, the platform reclaims
+// it, and the workload stops on its own once it has been idle, none of which
+// the deploy output ever said.
+//
+// Result.Locked is the whole signal and costs no extra call. It starts as the
+// status of the artifact the workload is already running and is only ever
+// flipped true by an actual lock, so its negation covers every path a deploy
+// can take: create, roll, retune, start, and a run that changed nothing.
+//
+// The three refusals, in order:
+//
+//   - A failed run says nothing. The error is what the reader needs, and
+//     "your broken deploy is also temporary" buries it.
+//   - --lock says nothing, because the run is the remedy. This also covers a
+//     --lock whose lock failed, where the returned error names the artifact
+//     and explains the state better than a generic warning would.
+//   - A locked artifact is permanent, which is the whole point of locking.
+//
+// Then a dry run always qualifies, because a first deploy has no workload id
+// to check and previewing a first deploy is exactly who this is for; and a
+// real run qualifies once it has a workload, the same guard nextSteps uses.
+//
+// One shape slips through: a manifest bound by artifactId to an artifact that
+// is already locked, creating a workload from it. Nothing reads that
+// artifact's status before the deploy, so the run reports a draft and this
+// warns wrongly. Rolling that shape is refused by the platform, which will
+// not swap a draft for a locked version, so only the create case can reach
+// it. Reading the status to be sure would mean a fetch in the planner for a
+// rare shape, which is not worth what it buys.
+func draftIsServing(f flags, result up.Result, failed bool) bool {
+	if failed || f.lock || result.Locked {
+		return false
+	}
+
+	return f.dryRun || result.WorkloadID != ""
+}
+
 func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, result up.Result, failed bool) error {
 	if format == outputformat.OutputFormatJSON {
 		return outputformat.PrintJSONEnvelope(cmd.OutOrStdout(), "up", upResult{
@@ -351,8 +389,11 @@ func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, resul
 		})
 	}
 
+	draft := draftIsServing(f, result, failed)
+
 	if f.dryRun {
 		fmt.Fprintln(cmd.ErrOrStderr(), "\nDry run: nothing was changed.")
+		draftWarning(cmd.ErrOrStderr(), draft)
 
 		return nil
 	}
@@ -374,24 +415,77 @@ func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, resul
 		fmt.Fprintln(cmd.OutOrStdout(), result.Endpoint)
 	}
 
-	nextSteps(cmd.ErrOrStderr(), result)
+	draftWarning(cmd.ErrOrStderr(), draft)
+	nextSteps(cmd.ErrOrStderr(), result, draft)
 
 	return nil
+}
+
+// draftWarning says that the endpoint just printed has a clock on it, and what
+// to run to stop that being true.
+//
+// The eight hours is the platform's own published figure, carried in the
+// OpenAPI description of an artifact's status, and behind it a hardcoded
+// constant rather than anything a cluster or a user can vary. Printing it is
+// therefore safe in a way that guessing at a policy would not have been.
+//
+// The clause about use is not padding. The sweep selects on how long the
+// workload has been running, never on whether it has served anything, so
+// calling this an inactivity timeout would mislead exactly the person who
+// shares an endpoint and keeps using it. Nothing deletes the draft artifact
+// itself; only the running workload is stopped, which is why this warns about
+// the workload rather than the artifact.
+//
+// The command is named inline rather than left to nextSteps, because a dry run
+// returns before nextSteps ever gets to speak and would otherwise state a
+// problem with no remedy attached.
+func draftWarning(w io.Writer, draft bool) {
+	if !draft {
+		return
+	}
+
+	fmt.Fprintf(w, "\n  %s %s\n",
+		tui.WarnStyle.Render("⚠"), tui.WarnStyle.Render("This workload is running a draft artifact."))
+
+	// One sentence per line, and rendered a line at a time. Wrapping prose to a
+	// fixed width breaks it mid-clause at whatever column the source happened to
+	// end on, and lipgloss pads a multi-line string out to its widest line,
+	// leaving trailing spaces on every other one.
+	for _, line := range []string{
+		"Draft workloads are stopped after 8 hours, whether or not they are in use.",
+		"Run 'dr workload up --lock' to version the artifact and make it permanent.",
+	} {
+		fmt.Fprintf(w, "    %s\n", tui.HintStyle.Render(line))
+	}
 }
 
 // nextSteps lists what to run against the workload this deploy just touched,
 // on stderr so the endpoint on stdout stays pipeable. Nothing is printed for a
 // run that produced no workload: a list of commands that need an id is no help
 // to someone who has not got one.
-func nextSteps(w io.Writer, result up.Result) {
+//
+// A draft deploy trades the stop line for --lock, and puts it first so it sits
+// directly under the warning that explains why it is there. Someone who wants
+// to switch a workload off goes looking for the command; someone whose
+// workload switches itself off does not know there is anything to look for,
+// and this list is the one place they will read either way.
+func nextSteps(w io.Writer, result up.Result, draft bool) {
 	if result.WorkloadID == "" {
 		return
 	}
 
 	steps := [][2]string{
-		{"dr workload logs " + result.WorkloadID, "what the container is saying"},
-		{"dr workload status " + result.WorkloadID, "whether it is healthy"},
-		{"dr workload stop " + result.WorkloadID, "switch it off, keeping the version"},
+		{"dr workload logs " + result.WorkloadID, "View the container logs"},
+		{"dr workload status " + result.WorkloadID, "Check the workload status"},
+	}
+
+	if draft {
+		steps = append([][2]string{
+			{"dr workload up --lock", "Lock the artifact to make it permanent"},
+		}, steps...)
+	} else {
+		steps = append(steps,
+			[2]string{"dr workload stop " + result.WorkloadID, "Stop the workload, retaining its version"})
 	}
 
 	// No build-logs line. It needs an artifact id as well as a build id, and

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -399,6 +399,162 @@ func TestCmd_NoTerminalHandsTheDeployNoQuestion(t *testing.T) {
 	assert.Nil(t, seen.Confirm)
 }
 
+// draftHeadline is the one phrase every draft warning has to carry. Asserting
+// on a whole sentence would break the moment the wording is tuned, and this is
+// the part that cannot change without the warning ceasing to be one.
+const draftHeadline = "This workload is running a draft artifact."
+
+// A deploy onto a draft is on a clock nothing in the output used to mention:
+// the artifact is reclaimed and the workload stops once idle, so an endpoint
+// shared in the afternoon can be dead by morning.
+func TestCmd_DraftDeploySaysItIsTemporary(t *testing.T) {
+	stubRun(t, deployed(), nil)
+
+	stdout, stderr, err := runCmd(t)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, draftHeadline)
+	assert.Contains(t, stderr, "stopped after 8 hours")
+	assert.Contains(t, stderr, "dr workload up --lock")
+
+	assert.Equal(t, "https://app.datarobot.com/workloads/68b0/\n", stdout,
+		"the warning is prose and belongs on stderr, so the endpoint stays pipeable")
+}
+
+// The deadline is stated, and stated as a running time rather than an idle
+// one. The platform's sweep selects on how long the workload has been running
+// and never on whether it served anything, so "idle" or "inactive" here would
+// be a comfortable lie to the one person who most needs the truth: someone
+// about to share an endpoint they intend to keep using.
+func TestCmd_DraftWarningStatesTheDeadline(t *testing.T) {
+	stubRun(t, deployed(), nil)
+
+	_, stderr, err := runCmd(t)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "8 hours", "the figure is the platform's own published contract")
+	assert.Contains(t, stderr, "whether or not they are in use", "the clock does not care about traffic")
+
+	for _, wrong := range []string{"idle", "inactiv", "reclaim"} {
+		assert.NotContains(t, stderr, wrong,
+			"nothing deletes the artifact, and the timeout is not an inactivity one")
+	}
+}
+
+// The trade the ticket asked for. Someone who wants to stop a workload goes
+// looking for the command; someone whose workload stops by itself does not
+// know there is anything to look for.
+func TestCmd_DraftDeployTradesStopForLock(t *testing.T) {
+	stubRun(t, deployed(), nil)
+
+	_, stderr, err := runCmd(t)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "dr workload up --lock")
+	assert.NotContains(t, stderr, "dr workload stop")
+	assert.Contains(t, stderr, "dr workload logs 68b0c1d2e3f4a5b6c7d8e9f0", "the other two lines stay")
+	assert.Contains(t, stderr, "dr workload status 68b0c1d2e3f4a5b6c7d8e9f0")
+}
+
+// A locked artifact is permanent, so there is nothing to warn about and the
+// stop line keeps its slot.
+func TestCmd_LockedDeploySaysNothingExtra(t *testing.T) {
+	result := deployed()
+	result.Locked = true
+
+	stubRun(t, result, nil)
+
+	_, stderr, err := runCmd(t)
+	require.NoError(t, err)
+
+	assert.NotContains(t, stderr, draftHeadline)
+	assert.NotContains(t, stderr, "dr workload up --lock")
+	assert.Contains(t, stderr, "dr workload stop 68b0c1d2e3f4a5b6c7d8e9f0")
+}
+
+// A --lock run is the remedy, so telling it about drafts would be telling it
+// what it just did.
+func TestCmd_LockFlagSaysNothingAboutDrafts(t *testing.T) {
+	stubRun(t, deployed(), nil)
+
+	_, stderr, err := runCmd(t, "--lock")
+	require.NoError(t, err)
+	assert.NotContains(t, stderr, draftHeadline)
+}
+
+// Someone previewing a first deploy is exactly who the warning is for, and a
+// first deploy has no workload id yet, so the dry run cannot be gated on one.
+func TestCmd_DryRunWarnsAboutADraftItWouldDeploy(t *testing.T) {
+	stubRun(t, up.Result{Action: up.ActionCreated}, nil)
+
+	stdout, stderr, err := runCmd(t, "--dry-run")
+	require.NoError(t, err)
+
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "nothing was changed")
+	assert.Contains(t, stderr, draftHeadline)
+	assert.Contains(t, stderr, "dr workload up --lock",
+		"a dry run never reaches the Next list, so the warning has to carry the remedy itself")
+}
+
+func TestCmd_DryRunWithLockDoesNotWarn(t *testing.T) {
+	stubRun(t, up.Result{Action: up.ActionCreated}, nil)
+
+	_, stderr, err := runCmd(t, "--dry-run", "--lock")
+	require.NoError(t, err)
+	assert.NotContains(t, stderr, draftHeadline)
+}
+
+// The purity rule, held against the one thing added since it was written: the
+// warning is prose, and prose never reaches a machine-readable stream.
+func TestCmd_JSONOutputCarriesNoDraftProse(t *testing.T) {
+	stubRun(t, deployed(), nil)
+
+	stdout, _, err := runCmd(t, "--output-format", "json")
+	require.NoError(t, err)
+
+	var envelope map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(stdout), &envelope), "stdout must stay one JSON document")
+	assert.NotContains(t, stdout, draftHeadline)
+
+	body, _ := envelope["up"].(map[string]any)
+	assert.Equal(t, false, body["locked"], "the envelope already says this in a form a machine can read")
+}
+
+// Nothing was deployed, so there is no endpoint with a clock on it and the
+// warning would be about nothing. Same guard the Next list already uses.
+func TestCmd_NoWorkloadSaysNothingAboutDrafts(t *testing.T) {
+	stubRun(t, up.Result{BuildID: "68c0000000000000000000b2"}, errors.New("build failed"))
+
+	_, stderr, err := runCmd(t)
+	require.Error(t, err)
+	assert.NotContains(t, stderr, draftHeadline)
+}
+
+// A failed deploy has one thing worth reading and it is the error. Telling
+// someone their broken deploy is also temporary buries it.
+func TestCmd_FailedDeployDoesNotWarnAboutDrafts(t *testing.T) {
+	stubRun(t, deployed(), errors.New("timed out waiting"))
+
+	_, stderr, err := runCmd(t)
+	require.Error(t, err)
+	assert.NotContains(t, stderr, draftHeadline)
+}
+
+// A run that changed nothing still leaves a draft serving on the same clock.
+// "Already up to date" is not the same as "this will still be here tomorrow".
+func TestCmd_UnchangedRunStillWarnsAboutTheDraft(t *testing.T) {
+	result := deployed()
+	result.Action = up.ActionUnchanged
+
+	stubRun(t, result, nil)
+
+	_, stderr, err := runCmd(t)
+	require.NoError(t, err)
+	assert.Contains(t, stderr, draftHeadline)
+}
+
 func TestCmd_IsRegisteredUnderWorkload(t *testing.T) {
 	cmd := Cmd()
 

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -399,14 +399,24 @@ func TestCmd_NoTerminalHandsTheDeployNoQuestion(t *testing.T) {
 	assert.Nil(t, seen.Confirm)
 }
 
-// draftHeadline is the one phrase every draft warning has to carry. Asserting
-// on a whole sentence would break the moment the wording is tuned, and this is
-// the part that cannot change without the warning ceasing to be one.
-const draftHeadline = "This workload is running a draft artifact."
+// The warning leads with one of these, and which one is not cosmetic. A dry
+// run has changed nothing and may be previewing a workload that does not exist
+// yet, so the present tense would contradict the "nothing was changed" line
+// printed directly above it.
+const (
+	draftHeadline     = "This workload is running a draft artifact."
+	draftHeadlinePlan = "This workload would run a draft artifact."
+)
+
+// draftWarned reports whether either tense reached the stream, for the tests
+// that assert silence and have no reason to care which one was suppressed.
+func draftWarned(stderr string) bool {
+	return strings.Contains(stderr, draftHeadline) || strings.Contains(stderr, draftHeadlinePlan)
+}
 
 // A deploy onto a draft is on a clock nothing in the output used to mention:
-// the artifact is reclaimed and the workload stops once idle, so an endpoint
-// shared in the afternoon can be dead by morning.
+// the workload is stopped eight hours after it starts running, whatever it is
+// serving, so an endpoint shared in the afternoon can be dead by morning.
 func TestCmd_DraftDeploySaysItIsTemporary(t *testing.T) {
 	stubRun(t, deployed(), nil)
 
@@ -467,7 +477,7 @@ func TestCmd_LockedDeploySaysNothingExtra(t *testing.T) {
 	_, stderr, err := runCmd(t)
 	require.NoError(t, err)
 
-	assert.NotContains(t, stderr, draftHeadline)
+	assert.False(t, draftWarned(stderr))
 	assert.NotContains(t, stderr, "dr workload up --lock")
 	assert.Contains(t, stderr, "dr workload stop 68b0c1d2e3f4a5b6c7d8e9f0")
 }
@@ -479,7 +489,7 @@ func TestCmd_LockFlagSaysNothingAboutDrafts(t *testing.T) {
 
 	_, stderr, err := runCmd(t, "--lock")
 	require.NoError(t, err)
-	assert.NotContains(t, stderr, draftHeadline)
+	assert.False(t, draftWarned(stderr))
 }
 
 // Someone previewing a first deploy is exactly who the warning is for, and a
@@ -492,7 +502,9 @@ func TestCmd_DryRunWarnsAboutADraftItWouldDeploy(t *testing.T) {
 
 	assert.Empty(t, stdout)
 	assert.Contains(t, stderr, "nothing was changed")
-	assert.Contains(t, stderr, draftHeadline)
+	assert.Contains(t, stderr, draftHeadlinePlan,
+		"a preview has deployed nothing, so it may not claim the workload is already running one")
+	assert.NotContains(t, stderr, draftHeadline)
 	assert.Contains(t, stderr, "dr workload up --lock",
 		"a dry run never reaches the Next list, so the warning has to carry the remedy itself")
 }
@@ -502,7 +514,7 @@ func TestCmd_DryRunWithLockDoesNotWarn(t *testing.T) {
 
 	_, stderr, err := runCmd(t, "--dry-run", "--lock")
 	require.NoError(t, err)
-	assert.NotContains(t, stderr, draftHeadline)
+	assert.False(t, draftWarned(stderr))
 }
 
 // The purity rule, held against the one thing added since it was written: the
@@ -516,7 +528,7 @@ func TestCmd_JSONOutputCarriesNoDraftProse(t *testing.T) {
 	var envelope map[string]any
 
 	require.NoError(t, json.Unmarshal([]byte(stdout), &envelope), "stdout must stay one JSON document")
-	assert.NotContains(t, stdout, draftHeadline)
+	assert.False(t, draftWarned(stdout))
 
 	body, _ := envelope["up"].(map[string]any)
 	assert.Equal(t, false, body["locked"], "the envelope already says this in a form a machine can read")
@@ -529,7 +541,7 @@ func TestCmd_NoWorkloadSaysNothingAboutDrafts(t *testing.T) {
 
 	_, stderr, err := runCmd(t)
 	require.Error(t, err)
-	assert.NotContains(t, stderr, draftHeadline)
+	assert.False(t, draftWarned(stderr))
 }
 
 // A failed deploy has one thing worth reading and it is the error. Telling
@@ -539,7 +551,7 @@ func TestCmd_FailedDeployDoesNotWarnAboutDrafts(t *testing.T) {
 
 	_, stderr, err := runCmd(t)
 	require.Error(t, err)
-	assert.NotContains(t, stderr, draftHeadline)
+	assert.False(t, draftWarned(stderr))
 }
 
 // A run that changed nothing still leaves a draft serving on the same clock.

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -174,6 +174,10 @@ func Run(opts Options) (Result, error) {
 		Locked:     live.Locked,
 	}
 
+	if err := bindLocked(loaded, plan, &result); err != nil {
+		return result, err
+	}
+
 	if err := Render(opts.Stderr, Summary{Name: result.Name, WorkloadID: result.WorkloadID}, plan); err != nil {
 		return result, err
 	}
@@ -200,6 +204,46 @@ func noteIgnoreFile(code CodeChange, opts Options) {
 	}
 
 	fmt.Fprintf(opts.Stderr, "  %s\n", tui.HintStyle.Render(code.IgnoreNotice))
+}
+
+// bindLocked settles Locked for the one shape live state cannot answer: a
+// manifest bound by artifact id, deploying to a workload that does not exist
+// yet. Locked is otherwise read off the artifact the workload is running, and
+// a create has no workload to read it from, so the result would say draft
+// about an artifact that may well be permanent.
+//
+// That is not a cosmetic slip. Deploying a locked, versioned artifact onto a
+// fresh workload is how a promotion works, and getting it wrong there tells
+// someone their permanent deploy is temporary and then advises 'up --lock',
+// which the platform answers with a 403 because the artifact is already
+// locked. The reader is left with a warning they cannot act on.
+//
+// Only creates ask. A roll onto a live workload cannot hit this, because the
+// platform refuses to swap a draft for a locked version and the run fails on
+// its own terms long before anything is printed.
+//
+// A failure to read is returned rather than shrugged off. The id came from
+// the file, so an artifact that cannot be read is one the deploy was going to
+// fail on anyway, and saying so here costs a create instead of a plan that
+// was never true.
+func bindLocked(loaded Loaded, plan Plan, result *Result) error {
+	if !plan.Creates || result.Locked {
+		return nil
+	}
+
+	bound := loaded.Compiled.ArtifactID
+	if bound == "" {
+		return nil
+	}
+
+	locked, err := lockedAlready(bound)
+	if err != nil {
+		return err
+	}
+
+	result.Locked = locked
+
+	return nil
 }
 
 // noteUnusedForce reports a --force-build that is about to do nothing,

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -184,11 +184,42 @@ func Run(opts Options) (Result, error) {
 
 	noteUnusedForce(plan, opts)
 
-	if opts.DryRun || plan.Empty() {
+	if opts.DryRun {
 		return result, nil
 	}
 
+	if plan.Empty() {
+		return lockOnly(live, result, opts)
+	}
+
 	return apply(loaded, live, plan, result, opts)
+}
+
+// lockOnly is the whole of a --lock run that found nothing else to do.
+//
+// --lock is about the end state rather than about what this run happened to
+// change: the flag says the artifact that ends up live should be permanent,
+// and an empty plan means the one already serving is that artifact. Returning
+// early on Empty, as this used to, printed "Already up to date" and exited 0
+// having locked nothing, which is the wrong answer twice over. It contradicts
+// the flag's own help, and it breaks the sequence the draft warning tells
+// people to follow: deploy, read the warning, run 'up --lock'. By then there
+// is nothing left to change, so the remedy silently did nothing at all.
+//
+// The live state is checked first because an empty plan is not the same as a
+// healthy workload. Only a stopped one is excluded by Empty itself; an errored
+// workload with no drift still lands here, and locking cannot be undone, so
+// this refuses rather than making something permanent out of something broken.
+func lockOnly(live Live, result Result, opts Options) (Result, error) {
+	if !opts.Lock || result.Locked {
+		return result, nil
+	}
+
+	if err := deployable(live, result.Name); err != nil {
+		return result, err
+	}
+
+	return lock(result, newReporter(opts.Stderr, opts.Spinner))
 }
 
 // noteIgnoreFile passes on the note about a deprecated ignore filename.

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -386,6 +386,55 @@ func TestRun_AlreadyUpToDate(t *testing.T) {
 	assert.Contains(t, stderr, "Already up to date")
 }
 
+// --lock is about the end state, not about what this run changed, so a run
+// that finds nothing to do still has to make the serving artifact permanent.
+// Returning early on an empty plan printed "Already up to date" and exited 0
+// having locked nothing, which silently broke the sequence the draft warning
+// asks for: deploy, read the warning, run 'up --lock'. By then the plan is
+// always empty.
+func TestRun_LockWithNothingToDoStillLocks(t *testing.T) {
+	locked := ""
+
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return doc(t, liveWorkloadJSON), nil },
+		artifactD: func(string) (workload.Document, error) { return draftArtifact(t), nil },
+		lock: func(id string) (*workload.Artifact, error) {
+			locked = id
+
+			return &workload.Artifact{ID: id, Status: workload.ArtifactStatusLocked}, nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	result, _, err := runIn(t, bound, Options{NonInteractive: true, Lock: true})
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, locked, "the artifact that is serving is the one --lock is about")
+	assert.Equal(t, result.ArtifactID, locked)
+	assert.True(t, result.Locked)
+}
+
+// The same run without the flag stays as cheap as it was. Locking is one-way,
+// so an empty plan must never take it on its own initiative.
+func TestRun_NothingToDoWithoutLockLocksNothing(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return doc(t, liveWorkloadJSON), nil },
+		artifactD: func(string) (workload.Document, error) { return draftArtifact(t), nil },
+		lock: func(string) (*workload.Artifact, error) {
+			t.Fatal("nothing asked for a lock")
+
+			return nil, nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	result, _, err := runIn(t, bound, Options{NonInteractive: true})
+	require.NoError(t, err)
+	assert.False(t, result.Locked)
+}
+
 // boundLiveManifest says exactly what the live fixture already says, so the
 // plan comes out empty.
 const boundLiveManifest = `name: gpt-oss-20b-vllm
@@ -1203,6 +1252,18 @@ func TestRun_DryRunOnABuildTrackSucceeds(t *testing.T) {
 	_, stderr, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true, DryRun: true})
 	require.NoError(t, err, "planning works on every track even where applying does not")
 	assert.Contains(t, stderr, "uploaded for the first time")
+}
+
+// draftArtifact is the live fixture before anyone locked it. The shared one is
+// locked, which is right for the roll tests and wrong for anything asking what
+// --lock does, since a locked artifact is exactly the case that short-circuits.
+func draftArtifact(t *testing.T) workload.Document {
+	t.Helper()
+
+	d := doc(t, liveArtifactJSON)
+	d["status"] = workload.ArtifactStatusDraft
+
+	return d
 }
 
 // stoppedWorkload is the live fixture, off. Everything else about it still

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -1137,6 +1137,9 @@ func TestRun_CreatesFromAnArtifactTheManifestNames(t *testing.T) {
 		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
+		getArtifact: func(id string) (*workload.Artifact, error) {
+			return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
+		},
 	})
 
 	result, _, err := runIn(t, boundArtifactManifest, Options{NonInteractive: true})
@@ -1145,6 +1148,49 @@ func TestRun_CreatesFromAnArtifactTheManifestNames(t *testing.T) {
 	assert.NotNil(t, payload)
 	assert.Equal(t, "wl-new", result.WorkloadID)
 	assert.Equal(t, ActionCreated, result.Action)
+	assert.False(t, result.Locked, "the artifact the file names is a draft")
+}
+
+// A create bound to an artifact that is already locked is a promotion: the
+// version is permanent before this run touches anything. Locked comes off the
+// artifact the workload is running, and a create has no workload, so without
+// asking the file's artifact directly the result would call a permanent deploy
+// a draft and the caller would advise locking what cannot be locked twice.
+func TestRun_CreatesFromALockedArtifactReportsItLocked(t *testing.T) {
+	install(t, fakes{
+		create:  func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		writeID: func(string, string) error { return nil },
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return running("wl-new"), nil
+		},
+		getArtifact: func(id string) (*workload.Artifact, error) {
+			return &workload.Artifact{ID: id, Status: workload.ArtifactStatusLocked}, nil
+		},
+	})
+
+	result, _, err := runIn(t, boundArtifactManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+	assert.True(t, result.Locked)
+}
+
+// The read is not optional. The id came out of the committed file, so an
+// artifact that cannot be read is one the create was going to fail on anyway,
+// and failing here costs a plan rather than a half-made workload.
+func TestRun_CreateBoundToAnUnreadableArtifactFails(t *testing.T) {
+	install(t, fakes{
+		create: func(any) (*workload.Workload, error) {
+			t.Fatal("nothing may be created once the artifact could not be read")
+
+			return nil, nil
+		},
+		getArtifact: func(string) (*workload.Artifact, error) {
+			return nil, errors.New("boom")
+		},
+	})
+
+	_, _, err := runIn(t, boundArtifactManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already locked")
 }
 
 func TestRun_DryRunOnABuildTrackSucceeds(t *testing.T) {


### PR DESCRIPTION
# RATIONALE

A deploy onto a draft artifact is on a clock and the CLI never mentioned it. You deploy, share the endpoint, and it is dead a few hours later with nothing in the output that hinted it would be. The remedy already existed as `dr workload up --lock`, discoverable only by reading `--help`.

## CHANGES

One warning on stderr when a run leaves a draft artifact serving, naming the deadline and the command that makes it permanent. On those runs the `Next:` list spends its third slot on `--lock` instead of `stop`.

`up.Result.Locked` already carries the state on every path (create, roll, retune, start, unchanged, dry run), so this needs no extra API call. Everything lands in `cmd/workload/up/`; `internal/workload/up` is untouched.

Silent on locked artifacts, `--lock` runs, failed deploys, and `--output-format json`.

```
  ⚠ This workload is running a draft artifact.
    Draft workloads are stopped after 8 hours, whether or not they are in use.
    Run 'dr workload up --lock' to version the artifact and make it permanent.

Next:
  dr workload up --lock       Lock the artifact to make it permanent
  dr workload logs <id>       View the container logs
  dr workload status <id>     Check the workload status
```

## NOTES

The ticket said not to print "8 hours" because the TTL varies by cluster. It does not. `CUTOFF_HOURS = 8` in workload-api `jobs/stop_draft_protons.py` is a module constant with no env, config or Helm override, and the figure is already published in the OpenAPI description of an artifact status.

Two further things that source settled, both of which an earlier draft of the warning had wrong: nothing deletes the draft artifact, only the running workload is stopped, and the sweep selects on how long the workload has been running rather than on traffic, so this is not an inactivity timeout.

The `Next:` descriptions are now imperative technical phrasing. Three of the four predate this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI messaging and next-step hints only; deploy behavior and `internal/workload/up` are unchanged.
> 
> **Overview**
> **`dr workload up`** now warns on **stderr** when a run leaves (or would leave) a **draft** artifact serving, so users see that the workload is stopped after **8 hours** regardless of traffic and how to make it permanent with **`dr workload up --lock`**.
> 
> Detection uses existing **`Result.Locked`** plus flags (**`--lock`**, **`--dry-run`**, failure, no workload)—no extra API calls. The warning is **suppressed** for locked artifacts, **`--lock`** runs, failed deploys, runs with no workload, and **JSON** output (machines still read **`locked`** in the envelope).
> 
> The **Next:** hints change for draft deploys: **`--lock`** is listed first instead of **`stop`**; non-draft runs still get **`stop`**. Dry runs get the remedy in the warning because they never reach **Next:**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8cabeda28df91311507c01227038c080dcba467. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->