### PR TITLE
Add assist plugin v0.1.36

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.36",
+          "url": "assist/assist-0.1.36.tar.xz",
+          "sha256": "99c5fb3a0f6014a9c9605d01a450115571e1202bb46ec59794472f78e6e2930c",
+          "releaseDate": "2026-08-20"
+        },
+        {
           "version": "0.1.35",
           "url": "assist/assist-0.1.35.tar.xz",
           "sha256": "16112f61778656f9b9e57c64ce87534cc482b1679650ad2d91d30639c85f8484",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.36 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.36
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.36
- **SHA256:** `99c5fb3a0f6014a9c9605d01a450115571e1202bb46ec59794472f78e6e2930c`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787234751.807169 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7e0731eac4951786856a7d92b1490ad9f9a63229. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->