### PR TITLE
docs(releasing): document the pre-1.0 version mapping

### DIFF
--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -42,6 +42,43 @@ Use **PATCH** version when making backward-compatible bug fixes, including:
 - Documentation updates
 - Performance improvements
 
+### Pre-1.0 versions
+
+The CLI is still on `0.x`, and SemVer treats a major version of zero as an
+unstable public API ([SemVer item 4](https://semver.org/#spec-item-4)). Until
+`v1.0.0` ships, shift the guidelines above one position to the right:
+
+| Change | At 1.0 and later | Pre-1.0 (today) |
+| --- | --- | --- |
+| Breaks an existing workflow | MAJOR | **MINOR** (`v0.2.7` to `v0.3.0`) |
+| Adds functionality, backward-compatible | MINOR | **PATCH** (`v0.2.7` to `v0.2.8`) |
+| Fixes a bug, backward-compatible | PATCH | **PATCH** (`v0.2.7` to `v0.2.8`) |
+
+Two consequences worth stating plainly:
+
+- A breaking change bumps the **minor** version. It does not force `v1.0.0`.
+  Reserve `v1.0.0` for a deliberate decision to freeze the command-line
+  interface, never as a side effect of a single breaking change.
+- New features and bug fixes share the patch slot, so a breaking change is the
+  only thing that moves the minor version. That makes identifying one the whole
+  job of step 3.
+
+### Identifying a breaking change
+
+Review the diff since the last stable tag and ask:
+
+- Does an invocation that succeeded on the previous release now fail?
+- Does a command now reject a project or repository shape it previously accepted?
+- Does a default change such that an unmodified workflow behaves differently?
+- Does existing output change shape in a way a script could be parsing?
+
+Any "yes" is a breaking change, even when the change is a bug fix and the old
+behavior was wrong. Fixing a permissive check to be correctly strict still
+breaks whoever depended on the permissive version.
+
+When you find one, bump the minor version, record it in `CHANGELOG.md` with
+migration notes, and repeat it prominently in the GitHub release description.
+
 ## Create a release
 
 ### 1. Configure remotes (if using a fork)
@@ -81,7 +118,11 @@ task lint
 
 ### 3. Determine the next version
 
-Review any recent changes and decide on the next version number based on the [semantic versioning](#versioning) guidelines.
+Review any recent changes and decide on the next version number based on the
+[semantic versioning](#versioning) guidelines. While the CLI is on `0.x`, the
+[pre-1.0 mapping](#pre-10-versions) is the one that applies; work through
+[identifying a breaking change](#identifying-a-breaking-change) against the diff
+since the last stable tag before settling on the number.
 
 ### 4. Run smoke tests (recommended)
 
@@ -267,7 +308,7 @@ This is useful for verifying installation scripts work correctly before or after
 5. Communicate breaking changes.
    - Update documentation
    - Add prominent notes in the release description
-   - Consider a major version bump
+   - Bump the minor version while on `0.x`, per the [pre-1.0 mapping](#pre-10-versions)
 
 6. Test the installation.
    - Test the install script after the release


### PR DESCRIPTION
# RATIONALE

While reviewing the `v0.2.86..main` diff to pick the next stable version, the
versioning guidance in `releasing.md` turned out to give no usable answer.

The doc says a breaking command-line change takes a **MAJOR** bump, and offers no
carve-out for `0.x`. Read literally, the next release containing a breaking change
is `v1.0.0` — which nobody intends while the interface is still moving. So the
person cutting the release has to either ignore the doc or freeze the CLI by
accident. Neither is good, and the answer shouldn't depend on who happens to be
doing the release that week.

This also matters right now: the current `main` contains a behavior change that
narrows template detection (`repo.IsTemplateDir` replacing the old bare
`.datarobot` check), which is exactly the kind of call this section should be able
to settle.

## CHANGES

- Add a **Pre-1.0 versions** subsection with the mapping that actually applies
  today: breaking → minor, features and fixes → patch. That is not a new policy,
  it is what `v0.2.84` and `v0.2.85` already shipped (both carried `feat` commits
  as patch releases).
- State plainly that a breaking change bumps the minor version and does **not**
  force `v1.0.0`, and that `v1.0.0` should be a deliberate decision to freeze the
  CLI rather than a side effect of one breaking change.
- Add an **Identifying a breaking change** checklist. Since features and fixes
  share the patch slot pre-1.0, spotting the breaking change is the entire job of
  step 3. The checklist includes the case that is easiest to miss: a bug fix that
  tightens a previously permissive check still breaks whoever depended on the
  permissive behavior.
- Point step 3 and best practice 5 at the new mapping. Both still said MAJOR.

Docs only — no code, no workflow changes.

## NOTES

Open question for reviewers: the checklist treats "existing output changes shape"
as breaking, on the assumption that someone somewhere is parsing our stdout. If we
would rather scope that to `--output-format json` only and treat human-readable
output as unstable, say so and I will narrow it.

There is a pre-existing MD032 markdownlint warning further down this file (the
"To fix a failed release" list). Left alone to keep this diff focused.
