### PR TITLE
fix(plugin/install): thread cmd through confirmPluginDepsInstall

### DIFF
--- a/cmd/plugin/install/cmd.go
+++ b/cmd/plugin/install/cmd.go
@@ -36,7 +36,6 @@ var (
 	listVersions      bool
 	filePath          string
 	pluginURL         string
-	yesFlag           bool
 )
 
 func Cmd() *cobra.Command {
@@ -72,7 +71,7 @@ Use --url to install directly from an HTTP/HTTPS URL instead of the registry.`,
 	cmd.Flags().BoolVar(&listPlugins, "list", false, "List available plugins from the registry")
 	cmd.Flags().StringVar(&filePath, "file", "", "Install from a local .tar.xz archive instead of the registry")
 	cmd.Flags().StringVar(&pluginURL, "url", "", "Install from an HTTP/HTTPS URL instead of the registry")
-	cmd.Flags().BoolVarP(&yesFlag, cli.YesFlagName, "y", false, `Assume "yes" when prompted to install plugin dependencies.`)
+	cmd.Flags().BoolP(cli.YesFlagName, "y", false, `Assume "yes" when prompted to install plugin dependencies.`)
 
 	// Mark mutually exclusive flags
 	cmd.MarkFlagsMutuallyExclusive("list", "versions", "version", "file", "url")
@@ -93,19 +92,19 @@ Use --url to install directly from an HTTP/HTTPS URL instead of the registry.`,
 	return cmd
 }
 
-func runInstall(_ *cobra.Command, args []string) error {
+func runInstall(cmd *cobra.Command, args []string) error {
 	if filePath != "" {
-		return runInstallFromFile(args)
+		return runInstallFromFile(cmd, args)
 	}
 
 	if pluginURL != "" {
-		return runInstallFromURL(args)
+		return runInstallFromURL(cmd, args)
 	}
 
-	return runInstallFromRegistry(args)
+	return runInstallFromRegistry(cmd, args)
 }
 
-func runInstallFromRegistry(args []string) error {
+func runInstallFromRegistry(cmd *cobra.Command, args []string) error {
 	finalRegistryURL := shared.NormalizeRegistryURL(registryURL)
 
 	var (
@@ -183,10 +182,10 @@ func runInstallFromRegistry(args []string) error {
 	fmt.Println()
 	fmt.Printf("Run `dr %s --help` to get started.\n", pluginEntry.Name)
 
-	return checkAndInstallPluginDeps(pluginEntry.Name)
+	return checkAndInstallPluginDeps(cmd, pluginEntry.Name)
 }
 
-func runInstallFromFile(args []string) error {
+func runInstallFromFile(cmd *cobra.Command, args []string) error {
 	name := ""
 	if len(args) > 0 {
 		name = args[0]
@@ -215,10 +214,10 @@ func runInstallFromFile(args []string) error {
 	fmt.Println()
 	fmt.Printf("Run `dr %s --help` to get started.\n", resolvedName)
 
-	return checkAndInstallPluginDeps(resolvedName)
+	return checkAndInstallPluginDeps(cmd, resolvedName)
 }
 
-func runInstallFromURL(args []string) error {
+func runInstallFromURL(cmd *cobra.Command, args []string) error {
 	name := ""
 	if len(args) > 0 {
 		name = args[0]
@@ -247,7 +246,7 @@ func runInstallFromURL(args []string) error {
 	fmt.Println()
 	fmt.Printf("Run `dr %s --help` to get started.\n", resolvedName)
 
-	return checkAndInstallPluginDeps(resolvedName)
+	return checkAndInstallPluginDeps(cmd, resolvedName)
 }
 
 // headingWriter is an io.Writer that prepends a styled heading the first time
@@ -271,9 +270,10 @@ func (h *headingWriter) Write(p []byte) (int, error) {
 
 // confirmPluginDepsInstall returns true when the user consents to installing
 // missing plugin dependencies. Consent is granted automatically when -y/--yes
-// is set; otherwise the user is prompted interactively.
-func confirmPluginDepsInstall() bool {
-	if yesFlag || cli.IsNonInteractive(nil) {
+// is set on cmd (or via the NON_INTERACTIVE env var / viper key, as resolved by
+// cli.IsNonInteractive); otherwise the user is prompted interactively.
+func confirmPluginDepsInstall(cmd *cobra.Command) bool {
+	if cli.IsNonInteractive(cmd) {
 		return true
 	}
 
@@ -285,10 +285,10 @@ func confirmPluginDepsInstall() bool {
 // checkAndInstallPluginDeps reads the plugin's versions.yaml, checks prerequisites,
 // and prompts the user to install any missing or outdated tools.
 // Skips silently when no versions.yaml is present.
-func checkAndInstallPluginDeps(pluginName string) error {
+func checkAndInstallPluginDeps(cmd *cobra.Command, pluginName string) error {
 	out := &headingWriter{w: os.Stdout, heading: "Plugin Dependencies"}
 
-	if err := plugin.CheckAndInstallDeps(pluginName, confirmPluginDepsInstall, out); err != nil {
+	if err := plugin.CheckAndInstallDeps(pluginName, func() bool { return confirmPluginDepsInstall(cmd) }, out); err != nil {
 		if errors.Is(err, plugin.ErrDepsDeclined) {
 			return nil
 		}

--- a/cmd/plugin/install/cmd_test.go
+++ b/cmd/plugin/install/cmd_test.go
@@ -19,12 +19,32 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/plugin"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// makeCmd builds a minimal *cobra.Command with the --yes/-y flag registered,
+// parsing --yes onto it when yes is true. It is used to exercise
+// confirmPluginDepsInstall and checkAndInstallPluginDeps without relying on
+// the package-level flag state that was removed.
+func makeCmd(t *testing.T, yes bool) *cobra.Command {
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "install"}
+
+	cmd.Flags().BoolP(cli.YesFlagName, "y", false, "")
+
+	if yes {
+		require.NoError(t, cmd.ParseFlags([]string{"--yes"}))
+	}
+
+	return cmd
+}
 
 // versionsYAMLSatisfied has a dep that is always present and its version requirement is met.
 const versionsYAMLSatisfied = `echo-tool:
@@ -70,13 +90,7 @@ func writePluginVersionsYAML(t *testing.T, pluginName, yamlContent string) {
 // --- confirmPluginDepsInstall ---
 
 func TestConfirmPluginDepsInstall_YesFlag(t *testing.T) {
-	origYesFlag := yesFlag
-
-	defer func() { yesFlag = origYesFlag }()
-
-	yesFlag = true
-
-	assert.True(t, confirmPluginDepsInstall())
+	assert.True(t, confirmPluginDepsInstall(makeCmd(t, true)))
 }
 
 func TestConfirmPluginDepsInstall_ViperYes(t *testing.T) {
@@ -84,7 +98,10 @@ func TestConfirmPluginDepsInstall_ViperYes(t *testing.T) {
 
 	viperx.Set("yes", true)
 
-	assert.True(t, confirmPluginDepsInstall())
+	// IsNonInteractive falls back to viperx.GetBool(YesFlagName) when the
+	// --yes flag is not set on the command, so a cmd without --yes still
+	// resolves to non-interactive here.
+	assert.True(t, confirmPluginDepsInstall(makeCmd(t, false)))
 }
 
 func TestConfirmPluginDepsInstall_UserAnswersY(t *testing.T) {
@@ -103,7 +120,7 @@ func TestConfirmPluginDepsInstall_UserAnswersY(t *testing.T) {
 		r.Close()
 	}()
 
-	assert.True(t, confirmPluginDepsInstall())
+	assert.True(t, confirmPluginDepsInstall(makeCmd(t, false)))
 }
 
 func TestConfirmPluginDepsInstall_UserAnswersN(t *testing.T) {
@@ -122,13 +139,13 @@ func TestConfirmPluginDepsInstall_UserAnswersN(t *testing.T) {
 		r.Close()
 	}()
 
-	assert.False(t, confirmPluginDepsInstall())
+	assert.False(t, confirmPluginDepsInstall(makeCmd(t, false)))
 }
 
 // --- checkAndInstallPluginDeps ---
 
 func TestCheckAndInstallPluginDeps_SkipsWhenNoVersionsYaml(t *testing.T) {
-	err := checkAndInstallPluginDeps("nonexistent-test-dr-cli-install-plugin-xyz")
+	err := checkAndInstallPluginDeps(makeCmd(t, false), "nonexistent-test-dr-cli-install-plugin-xyz")
 
 	assert.NoError(t, err)
 }
@@ -138,7 +155,7 @@ func TestCheckAndInstallPluginDeps_NilWhenAllDepsSatisfied(t *testing.T) {
 
 	writePluginVersionsYAML(t, pluginName, versionsYAMLSatisfied)
 
-	err := checkAndInstallPluginDeps(pluginName)
+	err := checkAndInstallPluginDeps(makeCmd(t, false), pluginName)
 
 	assert.NoError(t, err)
 }
@@ -147,12 +164,6 @@ func TestCheckAndInstallPluginDeps_SkipsInstallWhenUserDeclines(t *testing.T) {
 	const pluginName = "test-dr-cli-install-decline"
 
 	writePluginVersionsYAML(t, pluginName, versionsYAMLWrongVersion)
-
-	origYesFlag := yesFlag
-
-	defer func() { yesFlag = origYesFlag }()
-
-	yesFlag = false
 
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
@@ -169,7 +180,7 @@ func TestCheckAndInstallPluginDeps_SkipsInstallWhenUserDeclines(t *testing.T) {
 		r.Close()
 	}()
 
-	installErr := checkAndInstallPluginDeps(pluginName)
+	installErr := checkAndInstallPluginDeps(makeCmd(t, false), pluginName)
 
 	assert.NoError(t, installErr)
 }
@@ -179,13 +190,7 @@ func TestCheckAndInstallPluginDeps_AutoConfirmsWithYesFlag(t *testing.T) {
 
 	writePluginVersionsYAML(t, pluginName, versionsYAMLWrongVersion)
 
-	origYesFlag := yesFlag
-
-	defer func() { yesFlag = origYesFlag }()
-
-	yesFlag = true
-
-	err := checkAndInstallPluginDeps(pluginName)
+	err := checkAndInstallPluginDeps(makeCmd(t, true), pluginName)
 
 	assert.NoError(t, err)
 }
@@ -195,19 +200,11 @@ func TestCheckAndInstallPluginDeps_AutoConfirmsWithViperYes(t *testing.T) {
 
 	writePluginVersionsYAML(t, pluginName, versionsYAMLWrongVersion)
 
-	origYesFlag := yesFlag
-
-	defer func() {
-		yesFlag = origYesFlag
-
-		viperx.Reset()
-	}()
-
-	yesFlag = false
+	defer viperx.Reset()
 
 	viperx.Set("yes", true)
 
-	err := checkAndInstallPluginDeps(pluginName)
+	err := checkAndInstallPluginDeps(makeCmd(t, false), pluginName)
 
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
## RATIONALE

Part of the RootFactory stack (#802, #803). `confirmPluginDepsInstall` was closing over a package-level `yesFlag` variable and passing `nil` to `cli.IsNonInteractive`, bypassing the proper flag-read path.

When `cmd == nil`, `IsNonInteractive` falls back to the weaker `viperx.GetBool(YesFlagName)` path instead of reading the flag directly from the command. The package-level `yesFlag` is also shared state that leaks across successive `Execute()` calls in tests or any harness that re-uses the same process.

## CHANGES

- Remove the package-level `var yesFlag bool`; re-register the flag via `cmd.Flags().BoolP` (no package-level binding)
- Thread `*cobra.Command` through: `runInstall` → `runInstallFromRegistry` / `runInstallFromFile` / `runInstallFromURL` → `checkAndInstallPluginDeps` → `confirmPluginDepsInstall`
- Replace `yesFlag || cli.IsNonInteractive(nil)` with `cli.IsNonInteractive(cmd)`, which checks `--yes` via `cmd.Flags()`, the `NON_INTERACTIVE` env var, and `viperx` in priority order
- Update tests: add `makeCmd(t, yes bool)` helper, remove all `origYesFlag`/`defer` cleanup patterns

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787721161.613569 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI plumbing refactor for non-interactive confirmation; no auth, install, or dependency-install logic changes beyond how `--yes` is read.
> 
> **Overview**
> Stops plugin-install dep confirmation from using a package-level `yesFlag` and `cli.IsNonInteractive(nil)`, which skipped the real `--yes` flag path and leaked state across `Execute()` calls.
> 
> `--yes` is now registered without a package binding. `runInstall` threads `*cobra.Command` through the file/URL/registry install paths into `confirmPluginDepsInstall`, which uses `cli.IsNonInteractive(cmd)` so `--yes`, env, and viper are resolved in the intended order. Tests use a `makeCmd` helper instead of mutating global flag state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3e5760811a2fc9f8734afe41a95814c6fcf07d3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->