### PR TITLE
test(cmd): migrate root_test.go to use isolated RootFactory builds

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -31,34 +31,21 @@ import (
 // Test isolation helper
 // ---------------------------------------------------------------------------
 
-// newIsolatedRootCmd returns a fresh *cli.CommandAdder built by a new
-// RootFactory with all side-effecting dependencies replaced by safe no-ops.
-// Each call returns an independent command tree so that:
+// newIsolatedRootCmd returns a fresh *cli.CommandAdder built by
+// NewIsolatedRootFactory, which replaces every side-effecting dependency
+// with a safe no-op. Each call returns an independent command tree so that:
 //   - viperx global state set by one test cannot bleed into the next
+//   - global viper flag bindings are not re-pointed at the test tree
 //   - http.DefaultTransport is not mutated by TLS setup
 //   - Plugin discovery (filesystem + network) is skipped
 //   - The first-run animation is suppressed
+//   - No telemetry client is constructed or transmitted with
 //
 // Use this helper for any test that calls Execute() on the root command.
 // Tests that only inspect the static command tree (flags, subcommands,
 // annotations) may continue to reference the package-level RootCmd singleton.
 func newIsolatedRootCmd() *cli.CommandAdder {
-	return NewRootFactory(
-		// Skip viperx initialization and drconfig.yaml reads so env vars set
-		// by one test cannot bleed into the next via shared viper state.
-		WithConfigInitializer(func(_ *cobra.Command, _ string) error { return nil }),
-		// Skip http.DefaultTransport mutation to avoid TLS state leaking across tests.
-		WithTLSSetup(func(_ *cobra.Command) error { return nil }),
-		// Return a minimal props struct instead of hitting the network or disk
-		// for device/user IDs, account info, etc.
-		WithTelemetryProps(func() *telemetry.CommonProperties {
-			return &telemetry.CommonProperties{}
-		}),
-		// Skip plugin discovery (filesystem walk + subprocess invocations).
-		WithPluginRegistrar(func(_ *cobra.Command) {}),
-		// Suppress the first-run animation; there is no TTY in test processes.
-		WithAnimation(func() {}),
-	).Build()
+	return NewIsolatedRootFactory().Build()
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -16,11 +16,9 @@ package cmd
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 
-	"github.com/datarobot/cli/internal/config"
-	"github.com/datarobot/cli/internal/features"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/tools"
@@ -28,6 +26,44 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// ---------------------------------------------------------------------------
+// Test isolation helper
+// ---------------------------------------------------------------------------
+
+// newIsolatedRootCmd returns a fresh *cli.CommandAdder built by a new
+// RootFactory with all side-effecting dependencies replaced by safe no-ops.
+// Each call returns an independent command tree so that:
+//   - viperx global state set by one test cannot bleed into the next
+//   - http.DefaultTransport is not mutated by TLS setup
+//   - Plugin discovery (filesystem + network) is skipped
+//   - The first-run animation is suppressed
+//
+// Use this helper for any test that calls Execute() on the root command.
+// Tests that only inspect the static command tree (flags, subcommands,
+// annotations) may continue to reference the package-level RootCmd singleton.
+func newIsolatedRootCmd() *cli.CommandAdder {
+	return NewRootFactory(
+		// Skip viperx initialization and drconfig.yaml reads so env vars set
+		// by one test cannot bleed into the next via shared viper state.
+		WithConfigInitializer(func(_ *cobra.Command, _ string) error { return nil }),
+		// Skip http.DefaultTransport mutation to avoid TLS state leaking across tests.
+		WithTLSSetup(func(_ *cobra.Command) error { return nil }),
+		// Return a minimal props struct instead of hitting the network or disk
+		// for device/user IDs, account info, etc.
+		WithTelemetryProps(func() *telemetry.CommonProperties {
+			return &telemetry.CommonProperties{}
+		}),
+		// Skip plugin discovery (filesystem walk + subprocess invocations).
+		WithPluginRegistrar(func(_ *cobra.Command) {}),
+		// Suppress the first-run animation; there is no TTY in test processes.
+		WithAnimation(func() {}),
+	).Build()
+}
+
+// ---------------------------------------------------------------------------
+// Tests that execute commands (use newIsolatedRootCmd for isolation)
+// ---------------------------------------------------------------------------
 
 func TestCaseInsensitiveCommands(t *testing.T) {
 	tests := []struct {
@@ -64,18 +100,15 @@ func TestCaseInsensitiveCommands(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a new root command for each test to ensure isolation
-			cmd := RootCmd
+			// Build a fresh, isolated command tree for each subtest so that
+			// PersistentPreRunE side effects (viperx, TLS) don't bleed.
+			cmd := newIsolatedRootCmd()
 
-			// Capture output
 			buf := new(bytes.Buffer)
 			cmd.SetOut(buf)
 			cmd.SetErr(buf)
-
-			// Set the args
 			cmd.SetArgs(tt.args)
 
-			// Execute the command
 			err := cmd.Execute()
 
 			if tt.shouldError {
@@ -98,14 +131,10 @@ func TestVersionFlag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// pflag does not reset flag values between Parse calls, so the
-			// version flag stays true after this test. Reset it so subsequent
-			// tests that execute the root command aren't affected.
-			t.Cleanup(func() {
-				_ = RootCmd.PersistentFlags().Set("version", "false")
-			})
+			// Fresh command tree per subtest: pflag flag values do not carry
+			// over between builds, so no manual cleanup of the version flag is needed.
+			cmd := newIsolatedRootCmd()
 
-			cmd := RootCmd
 			buf := new(bytes.Buffer)
 			cmd.SetOut(buf)
 			cmd.SetErr(buf)
@@ -132,17 +161,19 @@ func TestTelemetryPropExtractor_OnSuccessPath(t *testing.T) {
 		{Name: "echo-tool", Command: "echo 1.0.0", MinimumVersion: "1.0.0"},
 	}
 
-	cmd := RootCmd
-	cmd.SetArgs([]string{"dependency", "check"})
+	root := newIsolatedRootCmd()
+	root.SetArgs([]string{"dependency", "check"})
 
 	var outBuf bytes.Buffer
 
-	cmd.SetOut(&outBuf)
+	root.SetOut(&outBuf)
 
-	err := cmd.Execute()
+	err := root.Execute()
 	require.NoError(t, err)
 
-	checkCmd := findCommandByPath(RootCmd.Command, "dr dependency check")
+	// Locate the executed command in this build's command tree (not the
+	// production singleton) so annotations are read from the same instance.
+	checkCmd := findCommandByPath(root.Command, "dr dependency check")
 	require.NotNil(t, checkCmd)
 
 	event, ok := telemetry.EventFor(checkCmd, []string{})
@@ -164,16 +195,17 @@ func TestTelemetryPropExtractor_OnErrorPath(t *testing.T) {
 		{Name: "FakeTool", Command: "nonexistent_dr_fake_xyz", URL: "https://example.com"},
 	}
 
-	cmd := RootCmd
-	cmd.SetArgs([]string{"dependency", "check"})
+	root := newIsolatedRootCmd()
+	root.SetArgs([]string{"dependency", "check"})
 
 	var errBuf bytes.Buffer
 
-	cmd.SetErr(&errBuf)
+	root.SetErr(&errBuf)
 
-	_ = cmd.Execute() // returns error: missing dep
+	_ = root.Execute() // returns error: missing dep
 
-	checkCmd := findCommandByPath(RootCmd.Command, "dr dependency check")
+	// Find the command in this build's tree so annotations are authoritative.
+	checkCmd := findCommandByPath(root.Command, "dr dependency check")
 	require.NotNil(t, checkCmd)
 
 	event, ok := telemetry.EventFor(checkCmd, []string{})
@@ -218,7 +250,7 @@ func TestUnknownArgGuard(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmd := RootCmd
+			cmd := newIsolatedRootCmd()
 
 			var buf bytes.Buffer
 
@@ -238,20 +270,9 @@ func TestUnknownArgGuard(t *testing.T) {
 	}
 }
 
-// requireGateDisabled skips the calling test when the named feature gate is
-// enabled in the ambient environment. Gate filtering happens in init(), long
-// before a test can unset the variable, so the only sound option is to skip.
-func requireGateDisabled(t *testing.T, name string) {
-	t.Helper()
-
-	if !features.Enabled(name) {
-		return
-	}
-
-	t.Skipf("feature gate %q is enabled in the environment (%sFEATURE_%s); "+
-		"gating is applied at init() so this default-state test cannot run",
-		name, config.EnvPrefix, strings.ToUpper(strings.ReplaceAll(name, "-", "_")))
-}
+// ---------------------------------------------------------------------------
+// setUnknownArgGuards unit tests (pure cobra.Command, no RootCmd dependency)
+// ---------------------------------------------------------------------------
 
 func TestSetUnknownArgGuards_AppliesGuardToPureParent(t *testing.T) {
 	child := &cobra.Command{
@@ -295,7 +316,7 @@ func TestSetUnknownArgGuards_SkipsCommandWithRunE(t *testing.T) {
 // command (pure parent, no RunE) rejects an unrecognised first arg with the
 // expected "unknown command" message.
 //
-// Uses a fresh, isolated command tree rather than the global RootCmd to avoid
+// Uses a bare cobra.Command tree rather than the global RootCmd to avoid
 // state pollution from cobra's package-level finalizers slice, which accumulates
 // across Execute calls in other tests and can cause RootCmd to appear non-runnable
 // by the time this assertion runs in the full test suite.
@@ -338,16 +359,17 @@ func TestSetUnknownArgGuards_SkipsExplicitArgs(t *testing.T) {
 	assert.NotContains(t, err.Error(), "unknown command:", "explicit Args validator should not be overridden")
 }
 
+// ---------------------------------------------------------------------------
+// Structural tests against the production singleton (read-only, no Execute)
+// ---------------------------------------------------------------------------
+
+// TestWorkloadCommandNotPresentByDefault verifies that workload is absent from
+// the default command tree. The feature gate is evaluated during init() so we
+// inspect the production singleton; no execution is required.
 func TestWorkloadCommandNotPresentByDefault(t *testing.T) {
-	requireGateDisabled(t, "workload")
-
-	// Verify that workload command is not present by default (feature not enabled).
-	// The feature gating happens during init(), so this tests the actual state.
-	cmd := RootCmd
-
 	var found bool
 
-	for _, subCmd := range cmd.Commands() {
+	for _, subCmd := range RootCmd.Commands() {
 		if subCmd.Name() == "workload" {
 			found = true
 			break
@@ -357,17 +379,14 @@ func TestWorkloadCommandNotPresentByDefault(t *testing.T) {
 	assert.False(t, found, "workload command should not be present when feature gate is not enabled")
 }
 
+// TestArtifactCommandNotPresentByDefault verifies that artifact is absent from
+// the default command tree. The artifact command shares the "workload" feature
+// gate, so it is filtered out by cli.CommandAdder during init() when the gate
+// is not enabled (the default).
 func TestArtifactCommandNotPresentByDefault(t *testing.T) {
-	requireGateDisabled(t, "workload")
-
-	// The artifact command shares the "workload" feature gate, so it is
-	// filtered out by cli.CommandAdder during init() when the gate is not
-	// enabled (the default).
-	cmd := RootCmd
-
 	var found bool
 
-	for _, subCmd := range cmd.Commands() {
+	for _, subCmd := range RootCmd.Commands() {
 		if subCmd.Name() == "artifact" {
 			found = true
 			break
@@ -377,10 +396,9 @@ func TestArtifactCommandNotPresentByDefault(t *testing.T) {
 	assert.False(t, found, "artifact command should not be present when feature gate is not enabled")
 }
 
-// TestPrivateCATLSFlagsAlwaysRegistered verifies that the private-ca
-// TLS flags are always registered on RootCmd (no longer feature-gated).
-// Flag registration happens during init(), so this tests the actual
-// registered state.
+// TestPrivateCATLSFlagsAlwaysRegistered verifies that the private-CA TLS flags
+// are always registered on RootCmd (no longer feature-gated). Flag registration
+// happens during init(); no execution is required.
 func TestPrivateCATLSFlagsAlwaysRegistered(t *testing.T) {
 	for _, name := range []string{"skip-certificate-check", "ca-cert"} {
 		assert.NotNil(t, RootCmd.PersistentFlags().Lookup(name),
@@ -398,12 +416,14 @@ func TestRootCmdTraverseChildrenEnabled(t *testing.T) {
 			"placed before a plugin name are consumed by core and not forwarded as raw args")
 }
 
-// TestUniversalFlagsParsedOnCoreSubcommand verifies that a universal flag such as
-// --debug is parsed correctly when it appears after a core subcommand and that
-// subcommand's own flags (e.g. "dr <cmd> --set-url http://x --debug").
-// This guards the TraverseChildren behaviour for core commands: unlike plugins,
-// core subcommands have no DisableFlagParsing so cobra continues to parse flags
-// after the command name, including persistent flags from root.
+// TestUniversalFlagsParsedOnCoreSubcommand verifies that a universal flag such
+// as --debug is parsed correctly when it appears after a core subcommand and
+// that subcommand's own flags (e.g. "dr <cmd> --set-url http://x --debug").
+// This guards the TraverseChildren behaviour for core commands.
+//
+// A fresh isolated command tree is used so the sentinel command does not
+// permanently mutate the production RootCmd and the --debug flag state is
+// automatically discarded after the test.
 func TestUniversalFlagsParsedOnCoreSubcommand(t *testing.T) {
 	var parsedDebug bool
 
@@ -420,22 +440,24 @@ func TestUniversalFlagsParsedOnCoreSubcommand(t *testing.T) {
 	}
 	sentinel.Flags().String("set-url", "", "test flag")
 
-	RootCmd.AddCommand(sentinel)
+	// Build a fresh isolated tree and add the sentinel to it. No cleanup of
+	// the command tree or the debug flag is needed — the tree is discarded when
+	// this test returns.
+	root := newIsolatedRootCmd()
+	root.AddCommand(sentinel)
 
-	defer func() {
-		RootCmd.RemoveCommand(sentinel)
-		// Reset the debug persistent flag so it does not bleed into other tests.
-		_ = RootCmd.PersistentFlags().Set("debug", "false")
-	}()
+	root.SetArgs([]string{"sentinel-universal-flags-test", "--set-url", "http://example.com", "--debug"})
 
-	RootCmd.SetArgs([]string{"sentinel-universal-flags-test", "--set-url", "http://example.com", "--debug"})
-
-	err := RootCmd.Execute()
+	err := root.Execute()
 	require.NoError(t, err)
 
 	assert.True(t, parsedDebug,
 		"--debug must be parsed by core when it appears after a core subcommand and its own flags")
 }
+
+// ---------------------------------------------------------------------------
+// showFirstRunAnimation isolation test
+// ---------------------------------------------------------------------------
 
 // TestShowFirstRunAnimationSkipsWhenNonInteractive guards against tools like
 // `expect` (used by the smoke test suite) attaching a real pty to dr's

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -347,16 +347,21 @@ func TestSetUnknownArgGuards_SkipsExplicitArgs(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Structural tests against the production singleton (read-only, no Execute)
+// Structural tests (read-only, no Execute)
 // ---------------------------------------------------------------------------
 
 // TestWorkloadCommandNotPresentByDefault verifies that workload is absent from
-// the default command tree. The feature gate is evaluated during init() so we
-// inspect the production singleton; no execution is required.
+// the default command tree. Uses a fresh isolated build with the feature-gate
+// env var neutralized so the test passes even when
+// DATAROBOT_CLI_FEATURE_WORKLOAD is set in the ambient environment.
 func TestWorkloadCommandNotPresentByDefault(t *testing.T) {
+	t.Setenv("DATAROBOT_CLI_FEATURE_WORKLOAD", "")
+
+	root := newIsolatedRootCmd()
+
 	var found bool
 
-	for _, subCmd := range RootCmd.Commands() {
+	for _, subCmd := range root.Commands() {
 		if subCmd.Name() == "workload" {
 			found = true
 			break
@@ -368,12 +373,17 @@ func TestWorkloadCommandNotPresentByDefault(t *testing.T) {
 
 // TestArtifactCommandNotPresentByDefault verifies that artifact is absent from
 // the default command tree. The artifact command shares the "workload" feature
-// gate, so it is filtered out by cli.CommandAdder during init() when the gate
-// is not enabled (the default).
+// gate, so it is filtered out by cli.CommandAdder during Build() when the gate
+// is not enabled. Uses a fresh isolated build with the env var neutralized so
+// the test passes even when DATAROBOT_CLI_FEATURE_WORKLOAD is set.
 func TestArtifactCommandNotPresentByDefault(t *testing.T) {
+	t.Setenv("DATAROBOT_CLI_FEATURE_WORKLOAD", "")
+
+	root := newIsolatedRootCmd()
+
 	var found bool
 
-	for _, subCmd := range RootCmd.Commands() {
+	for _, subCmd := range root.Commands() {
 		if subCmd.Name() == "artifact" {
 			found = true
 			break


### PR DESCRIPTION
## RATIONALE

Part of the RootFactory stack (#802, #803, #810). Replaces every test that called `Execute()` on the shared production `RootCmd` singleton with a fresh command tree built via `newIsolatedRootCmd()`.

(**This is what @carsongee wanted fixed. :)**)

The helper delegates to `NewIsolatedRootFactory()`, which stubs every side-effecting dependency with a no-op so that:
- env vars set by `t.Setenv()` in one test cannot bleed into the next through shared viper state
- global viper flag bindings are not re-pointed at the test tree on every `Build()`
- `http.DefaultTransport` is not mutated between tests
- no disk/network I/O for device/user IDs or account info, and no telemetry client is constructed
- plugin filesystem discovery and subprocess invocations are skipped
- the first-run TTY animation is suppressed

Tests that only inspect static structure (flag registration, annotations, `TraverseChildren`) continue to reference the production `RootCmd` singleton, which is appropriate since that state is set once at `init()` time and never mutated by the structural assertions. The gate-presence tests are an exception: they use a fresh isolated build with the feature-gate env var neutralized, since `RootCmd`'s gate is baked at `init()` and cannot be unset.

`TestUniversalFlagsParsedOnCoreSubcommand` previously added and removed a sentinel command on the production singleton and manually reset `--debug` in a `t.Cleanup`. It now adds the sentinel to a fresh isolated tree, so no mutation of shared state occurs and no cleanup is needed.

`requireGateDisabled` is removed: the workload/artifact gate tests now use `newIsolatedRootCmd()` with `t.Setenv("DATAROBOT_CLI_FEATURE_WORKLOAD", "")` to build a fresh tree with the gate off, so they pass regardless of the ambient environment.

## CHANGES

- Add `newIsolatedRootCmd()` helper (delegates to `NewIsolatedRootFactory`)
- Migrate all `Execute()`-calling tests to use it
- Remove `requireGateDisabled` and the `config`/`features`/`strings` imports that supported it
- Gate-presence tests use `newIsolatedRootCmd()` with `t.Setenv` so they pass even when `DATAROBOT_CLI_FEATURE_WORKLOAD` is set
- Restructure with section comments: execute tests / pure-cobra unit tests / structural singleton tests / animation test

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787721241.420499 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 12aa57413dfc6542a83f1c3a3248581802eba875. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

