### PR TITLE
[CFX-7713] fix(task): name the real template markers in the not-in-template error

### DIFF
--- a/internal/repo/detect.go
+++ b/internal/repo/detect.go
@@ -83,7 +83,7 @@ func IsTemplateDir(dir string) bool {
 	// Older versions were incorrectly creating state.yaml file outside of template directories
 	// return true if any file other than state.yaml exists in .datarobot/cli
 	cliConfigDirPresent := slices.ContainsFunc(entries, func(entry os.DirEntry) bool {
-		return entry.Name() != "state.yaml"
+		return entry.Name() != TemplateDetectStateFileName
 	})
 
 	if cliConfigDirPresent {

--- a/internal/repo/paths.go
+++ b/internal/repo/paths.go
@@ -23,4 +23,8 @@ const (
 	QuickstartScriptPath = ".datarobot/cli/bin"
 	// LocalPluginDir is the project-local plugin directory relative to CWD.
 	LocalPluginDir = ".datarobot/cli/bin"
+	// TemplateDetectStateFileName is the one entry in DataRobotTemplateDetectCliPath
+	// that does not mark a directory as a template. Older CLI versions wrote it
+	// outside template directories, so its presence alone proves nothing.
+	TemplateDetectStateFileName = "state.yaml"
 )

--- a/internal/task/discovery.go
+++ b/internal/task/discovery.go
@@ -202,9 +202,17 @@ func (d *Discovery) Discover(root string, maxDepth int) (string, error) {
 // and return cli.ErrSilent (or the returned error directly).
 func FormatDiscoveryError(err error) error {
 	if errors.Is(err, ErrNotInTemplate) {
-		return fmt.Errorf("%s\n%s",
+		requirement := fmt.Sprintf(
+			"This command requires a '%s' folder, or a '%s' folder holding something other than '%s'.",
+			repo.DataRobotTemplateDetectAnswersPath,
+			repo.DataRobotTemplateDetectCliPath,
+			repo.TemplateDetectStateFileName,
+		)
+
+		return fmt.Errorf("%s\n%s\n%s",
 			tui.BaseTextStyle.Render("You don't seem to be in a DataRobot Template directory."),
-			tui.BaseTextStyle.Render("This command requires a '.datarobot' folder to be present."))
+			tui.BaseTextStyle.Render(requirement),
+			tui.BaseTextStyle.Render("Run 'dr template setup' to create one, or switch to an existing template directory."))
 	}
 
 	if errors.Is(err, ErrTaskfileHasDotenv) {

--- a/internal/task/discovery_test.go
+++ b/internal/task/discovery_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/datarobot/cli/internal/repo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -179,4 +180,40 @@ func (suite *DiscoveryTestSuite) TestFindComponentsSkipsHiddenDirs() {
 	suite.Require().NoError(err)
 	suite.Len(includes, 1)
 	suite.Equal("visible", includes[0].Name)
+}
+
+// TestFormatDiscoveryErrorNamesRealTemplateMarkers guards the ErrNotInTemplate text
+// against drifting away from repo.IsTemplateDir, which is what actually gates the
+// command. The previous message promised a bare '.datarobot' folder was enough.
+func (suite *DiscoveryTestSuite) TestFormatDiscoveryErrorNamesRealTemplateMarkers() {
+	msg := FormatDiscoveryError(ErrNotInTemplate).Error()
+
+	suite.Contains(msg, repo.DataRobotTemplateDetectAnswersPath)
+	suite.Contains(msg, repo.DataRobotTemplateDetectCliPath)
+	suite.Contains(msg, repo.TemplateDetectStateFileName)
+}
+
+// TestTemplateMarkersMatchAdvertisedRequirement pins the predicate to what the
+// message tells the user to do: the advertised markers must pass, and the two
+// shapes the message excludes must fail.
+func (suite *DiscoveryTestSuite) TestTemplateMarkersMatchAdvertisedRequirement() {
+	bare := filepath.Join(suite.tempDir, "bare")
+	suite.Require().NoError(os.MkdirAll(filepath.Join(bare, ".datarobot"), 0o755))
+	suite.False(repo.IsTemplateDir(bare), "a bare .datarobot folder must not satisfy the gate")
+
+	answers := filepath.Join(suite.tempDir, "answers")
+	suite.Require().NoError(os.MkdirAll(filepath.Join(answers, repo.DataRobotTemplateDetectAnswersPath), 0o755))
+	suite.True(repo.IsTemplateDir(answers), "the advertised answers folder must satisfy the gate")
+
+	stateOnly := filepath.Join(suite.tempDir, "state-only")
+	stateCli := filepath.Join(stateOnly, repo.DataRobotTemplateDetectCliPath)
+	suite.Require().NoError(os.MkdirAll(stateCli, 0o755))
+	suite.Require().NoError(os.WriteFile(filepath.Join(stateCli, repo.TemplateDetectStateFileName), []byte("{}"), 0o644))
+	suite.False(repo.IsTemplateDir(stateOnly), "state.yaml alone must not satisfy the gate")
+
+	withConfig := filepath.Join(suite.tempDir, "with-config")
+	configCli := filepath.Join(withConfig, repo.DataRobotTemplateDetectCliPath)
+	suite.Require().NoError(os.MkdirAll(configCli, 0o755))
+	suite.Require().NoError(os.WriteFile(filepath.Join(configCli, "config.yaml"), []byte("{}"), 0o644))
+	suite.True(repo.IsTemplateDir(withConfig), "cli config beyond state.yaml must satisfy the gate")
 }


### PR DESCRIPTION
Potentially a blocker before I release CLI 0.3.0!

# RATIONALE

The "not in a template directory" error tells users to create a folder they are already standing in.

#791 replaced `internal/task.IsTemplateDir` (a bare `os.Stat` on `.datarobot`) with `repo.IsTemplateDir`, which is a strictly narrower predicate: it wants `.datarobot/answers`, or a `.datarobot/cli` holding something other than `state.yaml`. That consolidation was the right call — the old check treated the stray `.datarobot/cli/state.yaml` that older CLI versions scattered outside template directories as proof of a template.

But the error text did not move with it. So the users most likely to hit the stricter gate — the ones whose `.datarobot` folder exists and is no longer sufficient — get told:

> This command requires a '.datarobot' folder to be present.

They have one. The message sends them looking for something they already did, and says nothing about the marker actually missing. It affects `dr task list`, `dr run`, and shell completion, since the gate runs first in `Discovery.Discover`, ahead of the `PreferRootTaskfile` fallback.

## CHANGES

- Build the `ErrNotInTemplate` message from the same constants the predicate reads, so it names the real markers and points at `dr template setup` instead of leaving the remedy to guesswork.
- Add `repo.TemplateDetectStateFileName`. The `state.yaml` exemption was a bare literal in `repo.IsTemplateDir`; hardcoding it a second time in the message would have rebuilt the same drift this PR is fixing, so predicate and message now read one constant.

## BEFORE / AFTER

Fixture: a directory containing a bare `.datarobot/` folder.

Before (current `main`):

```console
$ dr task list
You don't seem to be in a DataRobot Template directory.
This command requires a '.datarobot' folder to be present.
$ echo $?
1
```

After (this PR):

```console
$ dr task list
You don't seem to be in a DataRobot Template directory.
This command requires a '.datarobot/answers' folder, or a '.datarobot/cli' folder holding something other than 'state.yaml'.
Run 'dr template setup' to create one, or switch to an existing template directory.
$ echo $?
1
```

Checked against three fixtures — a bare `.datarobot/`, a `.datarobot/cli/` holding only `state.yaml`, and a bare `.datarobot/` alongside a committed root `Taskfile.yaml`. Output is identical between `main` and this PR on all three except the message text, which is the intended blast radius: no behavior change, same exit code, same gate.

## NOTE

There is a separate regression around `dr run`, discovered while testing here, but I've split that out and have moved it to CFX-7712.

## TESTING

Two tests in `internal/task/discovery_test.go` pin the text to the predicate:

- `TestFormatDiscoveryErrorNamesRealTemplateMarkers` — the message must name
  every marker `repo.IsTemplateDir` checks.
- `TestTemplateMarkersMatchAdvertisedRequirement` — the directory shapes the
  message advertises must pass the gate, and the two it excludes (a bare
  `.datarobot`, and a `.datarobot/cli` holding only `state.yaml`) must fail it.

Both fail against the previous message. Verified by temporarily restoring the old
text: it trips the `.datarobot/cli` and `state.yaml` assertions, then passes once
the fix is back.

`task lint` clean across all three GOOS. Full `task test` green, no races.

## NOTES

Related: #808 covers the other half of the release review that surfaced this (the
versioning guidance in `releasing.md`). Independent of this PR.

Worth a reviewer's judgment: naming `state.yaml` in user-facing copy leaks a
detail most people will not care about. I kept it because without it a user with
a `.datarobot/cli` folder has no way to understand why they still fail the check.
Happy to drop it if you would rather keep the message shorter.

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787261637.431709 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing error copy and a shared filename constant only; template detection logic is unchanged.
> 
> **Overview**
> Fixes the **not-in-template** error so it matches `repo.IsTemplateDir` instead of telling users a bare `.datarobot` folder is enough.
> 
> `FormatDiscoveryError` now names `.datarobot/answers` or a `.datarobot/cli` folder with something other than `state.yaml`, and points users at `dr template setup`. The `state.yaml` exemption is a shared `TemplateDetectStateFileName` constant so the message cannot drift from the predicate. Tests pin the copy to those markers and to the directory shapes that pass vs fail the gate. Detection behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdcdada1011c2a58ef1fea41488c61ac6ff8b8e3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->