### PR TITLE
Add assist plugin v0.1.37

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -6,6 +6,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.37",
+          "url": "assist/assist-0.1.37.tar.xz",
+          "sha256": "97648b6030788756cfe02c94976fcfc32929eb633934495130fd4cbd63b0ea4d",
+          "releaseDate": "2026-08-21"
+        },
+        {
           "version": "0.1.36",
           "url": "assist/assist-0.1.36.tar.xz",
           "sha256": "99c5fb3a0f6014a9c9605d01a450115571e1202bb46ec59794472f78e6e2930c",


### PR DESCRIPTION
## Summary

Adds the `assist` plugin v0.1.37 to the CLI plugin index.

- **Plugin:** assist (AI agent design, coding, and deployment assistant)
- **Version:** 0.1.37
- **Release:** https://github.com/datarobot/dr-agent-cli/releases/tag/v0.1.37
- **SHA256:** `97648b6030788756cfe02c94976fcfc32929eb633934495130fd4cbd63b0ea4d`

## Test Plan

- [ ] `dr plugin install assist` installs successfully
- [ ] `dr assist --help` shows usage
- [ ] `dr assist` launches the agent UI

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787318632.822769 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog-only change to the plugin index; no install or auth logic is modified. Risk is limited to a wrong checksum or URL breaking assist installs.
> 
> **Overview**
> Publishes **assist** plugin **0.1.37** in the CLI plugin registry so `dr plugin install assist` (and updates) pick up this release.
> 
> Adds a new version entry at the top of `assist` in `docs/plugins/index.json`, pointing at `assist/assist-0.1.37.tar.xz` with SHA256 `97648b6030788756cfe02c94976fcfc32929eb633934495130fd4cbd63b0ea4d` (release date 2026-08-21). Older versions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66b56e32ef098fdbae8c94a2f9da1c07ac6f52a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->