### PR TITLE
[CFX-4371] Remind user to rerun dr start after a failed prereq check

### DIFF
--- a/cmd/start/model.go
+++ b/cmd/start/model.go
@@ -37,6 +37,10 @@ import (
 	"github.com/datarobot/cli/tui"
 )
 
+// rerunReminder is shown after a prerequisite failure ends the run without
+// installing the tools, so the user knows to rerun once they've fixed them.
+const rerunReminder = "Rerun dr start after installing or configuring the missing prerequisites."
+
 // step represents a single step in the quickstart process.
 type step struct {
 	// description is a brief summary of the step
@@ -59,6 +63,7 @@ type Model struct {
 	waitingToExecute     bool                 // Whether to wait for user input before proceeding
 	waitingToInstall     bool                 // Whether to wait for user confirmation before installing deps
 	depsToInstall        []tools.Prerequisite // Deps to install when user confirms
+	depsFailed           bool                 // Whether the run ended on an uninstalled prerequisite failure
 	needTemplateSetup    bool                 // Whether we need to run template setup after quitting
 	repoRoot             string
 	telemetry            telemetryCapture
@@ -367,6 +372,7 @@ func (m Model) handleDepsInstallComplete(msg depsInstallCompleteMsg) (tea.Model,
 	if msg.err != nil {
 		m.telemetry.installError = msg.err.Error()
 		m.err = msg.err
+		m.depsFailed = true
 
 		return m, tea.Quit
 	}
@@ -427,6 +433,7 @@ func (m Model) handleInstallConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		log.Debug("start: user cancelled deps install")
 
 		m.err = errors.New("Installation cancelled. Run 'dr dependencies install' to install missing dependencies.")
+		m.depsFailed = true
 
 		return m, tea.Quit
 	}
@@ -483,6 +490,10 @@ func (m Model) View() string { //nolint: cyclop
 	// Display error or status message
 	if m.err != nil {
 		fmt.Fprintf(&sb, "%s %s\n", tui.ErrorStyle.Render("Error: "), m.err.Error())
+
+		if m.depsFailed {
+			fmt.Fprintf(&sb, "\n%s\n", tui.InfoStyle.Render(rerunReminder))
+		}
 
 		return sb.String()
 	}

--- a/cmd/start/model_test.go
+++ b/cmd/start/model_test.go
@@ -319,6 +319,7 @@ func TestHandleInstallConfirmKey_CancelKeys(t *testing.T) {
 		resultModel := result.(Model)
 		require.Error(t, resultModel.err, "key %q should set an error", key.String())
 		assert.Contains(t, resultModel.err.Error(), "Installation cancelled", "key %q error message", key.String())
+		assert.True(t, resultModel.depsFailed, "key %q should mark deps failure", key.String())
 	}
 }
 
@@ -379,6 +380,7 @@ func TestHandleDepsInstallComplete_Error(t *testing.T) {
 
 	resultModel := result.(Model)
 	assert.Equal(t, installErr, resultModel.err)
+	assert.True(t, resultModel.depsFailed, "install failure should mark deps failure")
 }
 
 func TestHandleDepsInstallComplete_CapturesErrorTelemetry(t *testing.T) {
@@ -418,4 +420,27 @@ func TestView_WaitingToExecute_ShowsConfirmFooter(t *testing.T) {
 
 	assert.Contains(t, view, "confirm")
 	assert.NotContains(t, view, "install")
+}
+
+func TestView_DepsFailed_ShowsRerunReminder(t *testing.T) {
+	m := Model{
+		steps:      []step{{description: "Checking prerequisites...", fn: startQuickstart}},
+		err:        errors.New("Installation cancelled. Run 'dr dependencies install' to install missing dependencies."),
+		depsFailed: true,
+	}
+
+	view := m.View()
+
+	assert.Contains(t, view, rerunReminder)
+}
+
+func TestView_NonDepsError_OmitsRerunReminder(t *testing.T) {
+	m := Model{
+		steps: []step{{description: "Checking prerequisites...", fn: startQuickstart}},
+		err:   errors.New("something else broke"),
+	}
+
+	view := m.View()
+
+	assert.NotContains(t, view, rerunReminder)
 }


### PR DESCRIPTION
## Summary

When `dr start`'s prerequisite check fails and the run ends without the missing tools getting installed, it now prints a closing reminder to rerun `dr start` after fixing them. This covers the two exits where the user is left to install by hand: declining the install prompt, and an install that fails (including tools with no installer, like Node.js). The reminder is styled with `tui.InfoStyle`.

## Output

The last lines shown when the prereq check fails and the install does not complete:

```
Error:  Installation cancelled. Run 'dr dependencies install' to install missing dependencies.

Rerun dr start after installing or configuring the missing prerequisites.
```

## Technical Changes

- cmd/start/model.go: add a `depsFailed` flag, set it on the cancel and install-failure exits, and render the InfoStyle reminder in the `View()` error block when it is set.
- cmd/start/model_test.go: 4 tests. reminder shows on both failure paths, and is omitted for a non-deps error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only messaging on existing error paths; no auth, install, or control-flow changes beyond a display flag.
> 
> **Overview**
> When `dr start` exits because prerequisites were not installed, it now tells the user to rerun after fixing them.
> 
> The reminder appears after declining the install prompt or after an install failure, and is omitted for unrelated errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 021a5b36b2344ea607c01d529ca7a1f1268313a8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->