### PR TITLE
[CFX-7754] Reject browser-forged API keys during dr auth login

### DIFF
--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -519,10 +519,13 @@ Properties of this flow:
 - The callback listener is bound to localhost only
 
 > [!IMPORTANT]
-> The API key arrives as a URL query parameter and is stored in plaintext. There is no
-> `state` parameter, so any local process able to reach `localhost:51164` while a login
-> is in flight could deliver a key. Treat `drconfig.yaml` as a secret and prefer
-> `DATAROBOT_API_TOKEN` in shared or automated environments.
+> The API key arrives as a URL query parameter and is stored in plaintext. The callback
+> refuses browser requests that a page can forge (an `<img>` or background `fetch` carries
+> a `Sec-Fetch-Dest` other than `document`), so a web page you have open cannot plant a
+> key while a login is in flight. It still has no `state` parameter, so a local process
+> that can forge request headers, or a page that forces a full-page navigation, can deliver
+> one. Treat `drconfig.yaml` as a secret and prefer `DATAROBOT_API_TOKEN` in shared or
+> automated environments.
 
 ## Configuration file
 

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -520,12 +520,15 @@ Properties of this flow:
 
 > [!IMPORTANT]
 > The API key arrives as a URL query parameter and is stored in plaintext. The callback
-> refuses browser requests that a page can forge (an `<img>` or background `fetch` carries
-> a `Sec-Fetch-Dest` other than `document`), so a web page you have open cannot plant a
-> key while a login is in flight. It still has no `state` parameter, so a local process
-> that can forge request headers, or a page that forces a full-page navigation, can deliver
-> one. Treat `drconfig.yaml` as a secret and prefer `DATAROBOT_API_TOKEN` in shared or
-> automated environments.
+> refuses the requests a page can make invisibly: a hidden `<img>` carries
+> `Sec-Fetch-Dest: image` and a background `fetch` or `XMLHttpRequest` carries `empty`, and
+> the listener turns both away, so a page you have open cannot silently plant a key while a
+> login is in flight. The gate accepts only `Sec-Fetch-Dest: document` and has no `state`
+> parameter, so it does not stop a real top-level navigation to the callback URL (`window.open`,
+> a link click, or setting `window.location`) or a local process that can forge headers. A
+> document navigation is at least visible to you, because the tab moves or a popup opens.
+> Treat `drconfig.yaml` as a secret and prefer `DATAROBOT_API_TOKEN` in shared or automated
+> environments.
 
 ## Configuration file
 

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -130,7 +130,7 @@ openErr := flow.OpenBrowser()          // best effort; report the link if non-ni
 key, err := flow.Wait(ctx)             // serves until the callback arrives
 ```
 
-Two rules matter when changing this code:
+Three rules matter when changing this code:
 
 - **Bind before opening the browser.** `NewBrowserFlow` binds the listener so a fast
   redirect cannot arrive before anything is listening.
@@ -138,6 +138,13 @@ Two rules matter when changing this code:
   pass it through `auth.BrowserStateFor` and let `auth.RenderBrowserPrompt` choose the
   wording. Telling users to watch for a browser that never opened is the bug CFX-6318
   fixed.
+- **Keep the callback's `Sec-Fetch-Dest` gate present-and-wrong, never absent.**
+  `handleCallback` refuses a request whose `Sec-Fetch-Dest` is set to anything but
+  `document`, which turns away a page's `<img>` or `fetch` without touching the real
+  callback (a top-level navigation). An absent header must still be accepted: the
+  CLI-to-CLI port handover in `listenReclaimingPort` uses a Go `http.Client`, which sends
+  no fetch metadata, so rejecting absent would deadlock two concurrent logins. Do not
+  gate on `Sec-Fetch-Site`: the genuine callback is legitimately cross-site.
 
 `auth.RunBrowserLoginWith` accepts `LoginOptions{NoBrowser: true}` for `--no-browser`,
 which renders the link prominently without reporting a failure.

--- a/internal/auth/browserflow.go
+++ b/internal/auth/browserflow.go
@@ -176,15 +176,27 @@ func (f *BrowserFlow) Close() error {
 	return f.closeErr
 }
 
-// handleCallback receives the redirect from the DataRobot web app, which carries
-// the API key as the "key" query parameter.
+// handleCallback receives the API key from the web app's redirect ("key" query param).
+// Sec-Fetch-Dest present and not "document" refuses; absent accepts (port handover sends none).
 func (f *BrowserFlow) handleCallback(w http.ResponseWriter, r *http.Request) {
+	if dest := r.Header.Get("Sec-Fetch-Dest"); dest != "" && dest != "document" {
+		log.Debugf("Refusing auth callback with Sec-Fetch-Dest %q", dest)
+		http.Error(w, "forbidden", http.StatusForbidden)
+
+		return
+	}
+
 	apiKey := r.URL.Query().Get("key")
 
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// The keyless interrupt sentinel is read by a Go client that ignores the body.
+	if apiKey == "" {
+		w.WriteHeader(http.StatusNoContent)
+	} else {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
-	if err := assets.Write(w, "templates/success.html"); err != nil {
-		log.Debugf("Failed to render auth success page: %v", err)
+		if err := assets.Write(w, "templates/success.html"); err != nil {
+			log.Debugf("Failed to render auth success page: %v", err)
+		}
 	}
 
 	// Non-blocking: the channel holds one key and Wait may already have returned.

--- a/internal/auth/browserflow.go
+++ b/internal/auth/browserflow.go
@@ -177,11 +177,11 @@ func (f *BrowserFlow) Close() error {
 }
 
 // handleCallback receives the API key from the web app's redirect ("key" query param).
-// Sec-Fetch-Dest present and not "document" refuses; absent accepts (port handover sends none).
+// Sec-Fetch-Dest accepts "document" (real callback) and absent (port handover sends none); any other value refuses.
 func (f *BrowserFlow) handleCallback(w http.ResponseWriter, r *http.Request) {
 	if dest := r.Header.Get("Sec-Fetch-Dest"); dest != "" && dest != "document" {
 		log.Debugf("Refusing auth callback with Sec-Fetch-Dest %q", dest)
-		http.Error(w, "forbidden", http.StatusForbidden)
+		http.Error(w, "forbidden: request type not allowed", http.StatusForbidden)
 
 		return
 	}

--- a/internal/auth/browserflow_test.go
+++ b/internal/auth/browserflow_test.go
@@ -100,11 +100,104 @@ func TestBrowserFlow_EmptyKeyIsInterrupt(t *testing.T) {
 	}()
 
 	resp := waitForCallback(t, callbackURL(t, flow, ""))
+	body, readErr := io.ReadAll(resp.Body)
+	require.NoError(t, readErr)
 	require.NoError(t, resp.Body.Close())
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Empty(t, body, "the sentinel response must not be the success page")
 
 	err := <-errCh
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrLoginInterrupted)
+}
+
+func TestBrowserFlow_RefusesForgedBrowserCallbacks(t *testing.T) {
+	// An <img> carries Sec-Fetch-Dest "image" and a fetch()/XHR carries "empty";
+	// a page cannot forge these headers, so neither can plant a key (CFX-7754).
+	for _, dest := range []string{"image", "empty"} {
+		t.Run(dest, func(t *testing.T) {
+			flow := newTestFlow(t)
+
+			keyCh := make(chan string, 1)
+			errCh := make(chan error, 1)
+
+			go func() {
+				key, err := flow.Wait(context.Background())
+
+				keyCh <- key
+
+				errCh <- err
+			}()
+
+			forged := waitForCallback(t, callbackURL(t, flow, "?key=planted-by-attacker"),
+				"Sec-Fetch-Dest", dest)
+			require.NoError(t, forged.Body.Close())
+			assert.Equal(t, http.StatusForbidden, forged.StatusCode)
+
+			// The login must still be waiting: a genuine headerless callback completes
+			// it, and the planted key never surfaces.
+			genuine := waitForCallback(t, callbackURL(t, flow, "?key=real-key"))
+			require.NoError(t, genuine.Body.Close())
+
+			require.NoError(t, <-errCh)
+			assert.Equal(t, "real-key", <-keyCh)
+		})
+	}
+}
+
+func TestBrowserFlow_AcceptsDocumentNavigation(t *testing.T) {
+	// The real callback is a top-level navigation, marked Sec-Fetch-Dest "document".
+	flow := newTestFlow(t)
+
+	keyCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		key, err := flow.Wait(context.Background())
+
+		keyCh <- key
+
+		errCh <- err
+	}()
+
+	resp := waitForCallback(t, callbackURL(t, flow, "?key=real-key"), "Sec-Fetch-Dest", "document")
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotEmpty(t, body, "the navigation must still receive the success page")
+
+	require.NoError(t, <-errCh)
+	assert.Equal(t, "real-key", <-keyCh)
+}
+
+func TestBrowserFlow_KeylessBrowserProbeDoesNotInterrupt(t *testing.T) {
+	// A favicon probe is keyless with Sec-Fetch-Dest "image". It used to be mistaken
+	// for the port-handover sentinel and aborted the login in progress.
+	flow := newTestFlow(t)
+
+	keyCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		key, err := flow.Wait(context.Background())
+
+		keyCh <- key
+
+		errCh <- err
+	}()
+
+	probe := waitForCallback(t, callbackURL(t, flow, ""), "Sec-Fetch-Dest", "image")
+	require.NoError(t, probe.Body.Close())
+	assert.Equal(t, http.StatusForbidden, probe.StatusCode)
+
+	resp := waitForCallback(t, callbackURL(t, flow, "?key=real-key"))
+	require.NoError(t, resp.Body.Close())
+
+	require.NoError(t, <-errCh)
+	assert.Equal(t, "real-key", <-keyCh)
 }
 
 func TestBrowserFlow_WaitHonoursContextCancellation(t *testing.T) {
@@ -227,14 +320,21 @@ func TestBrowserFlow_ReclaimsPortFromStaleServer(t *testing.T) {
 }
 
 // waitForCallback issues the callback request, retrying briefly because Wait
-// starts the server asynchronously.
-func waitForCallback(t *testing.T, url string) *http.Response {
+// starts the server asynchronously. headers are alternating name/value pairs.
+func waitForCallback(t *testing.T, url string, headers ...string) *http.Response {
 	t.Helper()
 
 	deadline := time.Now().Add(5 * time.Second)
 
 	for {
-		resp, err := http.Get(url) //nolint:noctx,gosec // test-controlled localhost URL
+		req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+		require.NoError(t, reqErr)
+
+		for i := 0; i+1 < len(headers); i += 2 {
+			req.Header.Set(headers[i], headers[i+1])
+		}
+
+		resp, err := http.DefaultClient.Do(req)
 		if err == nil {
 			return resp
 		}

--- a/internal/auth/browserflow_test.go
+++ b/internal/auth/browserflow_test.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -144,6 +145,50 @@ func TestBrowserFlow_RefusesForgedBrowserCallbacks(t *testing.T) {
 			assert.Equal(t, "real-key", <-keyCh)
 		})
 	}
+}
+
+func TestBrowserFlow_RefusesConcurrentForgedProbes(t *testing.T) {
+	// The real attack fires forged probes concurrently with the genuine navigation;
+	// every probe must 403 and none may reach keyCh (CFX-7754).
+	flow := newTestFlow(t)
+
+	keyCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		key, err := flow.Wait(t.Context())
+
+		keyCh <- key
+
+		errCh <- err
+	}()
+
+	const probes = 10
+
+	var wg sync.WaitGroup
+
+	wg.Add(probes)
+
+	for range probes {
+		go func() {
+			defer wg.Done()
+
+			forged := waitForCallback(t, callbackURL(t, flow, "?key=planted-by-attacker"),
+				"Sec-Fetch-Dest", "image")
+
+			assert.Equal(t, http.StatusForbidden, forged.StatusCode)
+			assert.NoError(t, forged.Body.Close())
+		}()
+	}
+
+	wg.Wait()
+
+	// Still waiting after the storm: the genuine callback completes it, no key planted.
+	genuine := waitForCallback(t, callbackURL(t, flow, "?key=real-key"))
+	require.NoError(t, genuine.Body.Close())
+
+	require.NoError(t, <-errCh)
+	assert.Equal(t, "real-key", <-keyCh)
 }
 
 func TestBrowserFlow_AcceptsDocumentNavigation(t *testing.T) {
@@ -323,11 +368,12 @@ func TestBrowserFlow_ReclaimsPortFromStaleServer(t *testing.T) {
 // starts the server asynchronously. headers are alternating name/value pairs.
 func waitForCallback(t *testing.T, url string, headers ...string) *http.Response {
 	t.Helper()
+	require.Equal(t, 0, len(headers)%2, "headers must be alternating name/value pairs")
 
 	deadline := time.Now().Add(5 * time.Second)
 
 	for {
-		req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+		req, reqErr := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
 		require.NoError(t, reqErr)
 
 		for i := 0; i+1 < len(headers); i += 2 {

--- a/internal/auth/browserflow_test.go
+++ b/internal/auth/browserflow_test.go
@@ -165,6 +165,16 @@ func TestBrowserFlow_RefusesConcurrentForgedProbes(t *testing.T) {
 
 	const probes = 10
 
+	// Warm the server on the test goroutine so the probes need no retry, and no
+	// require, inside their goroutines, which testifylint's go-require forbids.
+	forgedURL := callbackURL(t, flow, "?key=planted-by-attacker")
+	warm := waitForCallback(t, forgedURL, "Sec-Fetch-Dest", "image")
+
+	assert.Equal(t, http.StatusForbidden, warm.StatusCode)
+	require.NoError(t, warm.Body.Close())
+
+	codes := make(chan int, probes)
+
 	var wg sync.WaitGroup
 
 	wg.Add(probes)
@@ -173,15 +183,30 @@ func TestBrowserFlow_RefusesConcurrentForgedProbes(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			forged := waitForCallback(t, callbackURL(t, flow, "?key=planted-by-attacker"),
-				"Sec-Fetch-Dest", "image")
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, forgedURL, nil)
+			if !assert.NoError(t, err) {
+				return
+			}
 
-			assert.Equal(t, http.StatusForbidden, forged.StatusCode)
-			assert.NoError(t, forged.Body.Close())
+			req.Header.Set("Sec-Fetch-Dest", "image")
+
+			resp, err := http.DefaultClient.Do(req)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			assert.NoError(t, resp.Body.Close())
+
+			codes <- resp.StatusCode
 		}()
 	}
 
 	wg.Wait()
+	close(codes)
+
+	for code := range codes {
+		assert.Equal(t, http.StatusForbidden, code)
+	}
 
 	// Still waiting after the storm: the genuine callback completes it, no key planted.
 	genuine := waitForCallback(t, callbackURL(t, flow, "?key=real-key"))


### PR DESCRIPTION
## Summary

During `dr auth login` the CLI runs a local listener on `localhost:51164` for 5 minutes, waiting for the browser to hand back your API key. It accepted any request on that port, so a web page you had open could plant an attacker's key with `<img src="http://localhost:51164/?key=ATTACKER_KEY">` and the CLI would store it as your credential, so every later `dr` command ran against the attacker's account. The callback now refuses the forgeable browser requests.

## Notes for review

The gate is `Sec-Fetch-Dest` present and not `document`. Absent must stay accepted: the CLI-to-CLI port handover uses a Go http client that sends no fetch metadata, and rejecting absent would deadlock two concurrent logins. It does not gate on `Sec-Fetch-Site`, since the real callback is legitimately cross-site.

Partial by design. It does not stop a page that forces a full-page navigation (a real `document` request, visible in the tab) or browsers older than Safari 16.4. The complete fix is a callback nonce, tracked separately since it needs a web app change.

Blocking manual gate, a real login must still work in the browser. DataRobot officially supports Chrome only, so Chrome is the gate:
- Chrome (macOS): pass
- Safari (macOS): pass (verified as an extra WebKit data point, not officially supported)
- Firefox, Edge: outside official support, not gating
- Chrome (Windows): to confirm post-release. Fetch metadata is per-engine not per-OS, so the same Chromium build sends identical `Sec-Fetch-*` headers on Windows. This confirms rather than gates.

## Output

```
$ curl -s -o /dev/null -w "%{http_code}\n" -H "Sec-Fetch-Dest: image" "http://localhost:51164/?key=PLANTED-BY-ATTACKER"
403
$ curl -s -o /dev/null -w "%{http_code}\n" -H "Sec-Fetch-Dest: document" "http://localhost:51164/?key=REAL-KEY"
200
```

## Technical Changes

- `browserflow.go`: refuse when `Sec-Fetch-Dest` is present and not `document`; success page only for a keyed request, 204 for the keyless handover sentinel.
- `browserflow_test.go`: image/empty refused, document accepted, headerless accepted, keyless image no longer interrupts, keyless headerless still hands over.
- auth docs: corrected the security note, added the editing rule for the gate.

### Breakdown

- code: +17 / -5
- tests: +103 / -3
- docs: +15 / -5

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787786617.099849 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches the login callback that accepts and stores API keys. The gate is partial by design (no `state`/nonce), so mistakes here can still accept attacker credentials or break concurrent logins.
> 
> **Overview**
> Hardens `dr auth login` so a page cannot plant an API key via a forgeable request (`<img>` / `fetch`) to the localhost callback while login is in flight.
> 
> `handleCallback` now returns **403** when `Sec-Fetch-Dest` is present and not `document`. An **absent** header is still accepted so CLI-to-CLI port handover (Go `http.Client`, no fetch metadata) does not deadlock. Keyless handover gets **204** instead of the success HTML; a keyless browser probe (e.g. favicon) is refused and no longer aborts login.
> 
> This is a partial mitigation: full-page navigation and clients that can set headers are still in scope. Docs and tests cover the gate, genuine `document` callbacks, and the handover sentinel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 385eb4a150d2258b5720e9848bbf09f2f53fc53c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->