### PR TITLE
[RAPTOR-19526] fix(workload): clear the stale workloadId on delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Added
 
-- TBU
+- `dr workload delete --dir <path>`: which project's manifest holds the binding to clear, matching the flag `up` and `config` already take.
+
+## Fixed
+
+- `dr workload delete` now clears a `workloadId` written as a YAML alias. The reader resolves the alias before answering, so such a binding is the one the project deploys to, but the removal compared the unresolved node and left the file as stale as it found it while reporting the delete a success.
+- `dr workload up --dir <path>` now says which flag named a path that is not a directory, instead of failing with a bare `not a directory`, matching what `dr workload delete --dir` already said.
+- An empty `.datarobot.yaml` now gets one explanation and one remedy whichever command reaches it, rather than a generic "root must be a YAML mapping" from the write path and a friendlier sentence from the read path.
 
 ## Changed
 
-- TBU
+- `dr workload delete` now removes the `workloadId` it wrote from a `.datarobot.yaml` bound to the workload it deleted, so the next `dr workload up` is not pointed at something that no longer exists. Only a manifest naming that exact id is touched, the id is compared inside the same edit that removes it, and the artifact link under `.datarobot/` is left alone so the next deploy reuses the artifact; the command names that artifact and how to unlink from it. A workload that was already gone leaves the binding alone: a 404 means "not on this instance", which is not proof the binding is stale.
+- `dr workload up` now mints a new artifact when the one this project is linked to no longer says what `.datarobot.yaml` says. An artifact's spec is fixed when it is created, so reusing a diverged one deployed the frozen answer and reported success. A read that fails is not treated as a difference: the run stops and names the artifact it could not read, so a timeout never starts a new artifact lineage.
+- `dr workload up` now treats a binding that resolves to nothing as drift and creates a new workload, instead of refusing and asking for the id to be cleared by hand. The plan and the JSON envelope both name the id it could not find, so a run pointed at the wrong instance is visible rather than silent. A terminated workload is still refused, because it continues to exist and to hold its name and artifact; the message now names `dr workload delete`, which clears the way and the binding together.

--- a/cmd/workload/del/cmd.go
+++ b/cmd/workload/del/cmd.go
@@ -20,15 +20,20 @@ package del
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"path/filepath"
 
 	"github.com/datarobot/cli/cmd/helpers"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/fsutil"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
 )
@@ -44,6 +49,13 @@ replicas first, then removes the workload. The artifact it was created from
 is not deleted with it; remove that separately with
 'dr artifact delete <artifact-id>' once no workload references it.
 
+If the .datarobot.yaml found from --dir (the current directory by default,
+searched upward from there) is bound to the workload being deleted, its
+workloadId is removed too, so the next 'dr workload up' creates a new
+workload rather than pointing at one that is gone. Only a manifest naming
+that exact id is touched. Pass the same --dir you deployed with: a manifest
+in a subdirectory is not visible from its parent.
+
 Without --yes the command asks for confirmation.
 
 Example:
@@ -58,17 +70,35 @@ Example:
 				return err
 			}
 
+			// Not discarded: a lookup failure means the flag was renamed or
+			// dropped, and the silent fallback is a search from the working
+			// directory, which is the behaviour --dir exists to replace.
+			dir, err := cmd.Flags().GetString("dir")
+			if err != nil {
+				return fmt.Errorf("cannot read --dir: %w", err)
+			}
+
+			// Checked before the delete, not after: a typo is worth catching
+			// while it still costs nothing, and the cleanup that reports it
+			// runs on the far side of an irreversible call.
+			if dir != "" && !fsutil.DirExists(dir) {
+				return fmt.Errorf("--dir %s: %w", dir, manifest.ErrNotADirectory)
+			}
+
 			if err := workload.DeleteWorkload(args[0]); err != nil {
 				return handleDeleteError(err, args[0])
 			}
 
 			fmt.Println(tui.BaseTextStyle.Render("Deleted workload: " + args[0]))
 
+			clearStaleBinding(cmd.ErrOrStderr(), dir, args[0])
+
 			return nil
 		},
 	}
 
 	cmd.Flags().BoolP("yes", "y", false, "Skip the confirmation prompt.")
+	cmd.Flags().String("dir", "", "Project directory whose manifest holds the binding, searched upward from here.")
 
 	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
 	// flag itself is read directly from cmd.Flags() so an explicit --yes does
@@ -117,6 +147,15 @@ func confirmDelete(cmd *cobra.Command, workloadID string) (bool, error) {
 // handleDeleteError converts a 404 into a friendly informational message
 // (returns nil) so the user does not see a stack-trace-style HTTP error
 // for what is effectively a no-op.
+//
+// The binding is deliberately left alone here. A 404 says the workload is not
+// on this instance, which is not the same as saying it is gone: the same
+// manifest read against the wrong endpoint, organisation or token answers
+// exactly this way. `up` treats that ambiguity by naming the id and letting
+// the user look; rewriting a committed file on the strength of it, in the one
+// branch where nothing was actually deleted, would be the stronger claim made
+// on the weaker evidence. A binding that really is dead is cleared by the
+// deploy that recreates it.
 func handleDeleteError(err error, workloadID string) error {
 	var httpErr *drapi.HTTPError
 
@@ -127,4 +166,106 @@ func handleDeleteError(err error, workloadID string) error {
 	}
 
 	return err
+}
+
+// clearStaleBinding takes back the workloadId the CLI wrote into a manifest,
+// now that the workload it names has been deleted.
+//
+// The id is matched inside the edit itself, so this only ever touches a file
+// that is demonstrably about the workload just deleted, and the value it
+// checks is the value it removes. A manifest naming some other workload is
+// none of its business.
+//
+// dir is where to start looking, and it exists because Locate only walks
+// upward. A project deployed with `up --dir site` and then deleted from the
+// repository root is invisible from there, which is the reported bug's own
+// reproduction; --dir is how the two commands agree on which project this is.
+// A path that is not a directory is a typo worth naming, because Locate would
+// otherwise walk past it to an ancestor and quietly edit the wrong project.
+//
+// Nothing here can fail the command. The workload is already gone by the time
+// this runs, so a manifest that cannot be found, read or written is stepped
+// over rather than turned into a failure for an operation that succeeded. The
+// unwritable case still says so, because the user has to finish it by hand.
+func clearStaleBinding(w io.Writer, dir, workloadID string) {
+	if dir == "" {
+		dir = "."
+	}
+
+	path, err := manifest.Locate(dir)
+	if err != nil {
+		// Locate is the one place that decides what counts as a directory, so
+		// its answer is used rather than re-derived here. Reaching this needs
+		// the directory to have gone away between the check that runs before
+		// the delete and this line, which is rare and still worth a word: the
+		// binding was not looked at, so it may well still be there.
+		if errors.Is(err, manifest.ErrNotADirectory) {
+			fmt.Fprintln(w, tui.DimStyle.Render("No manifest was checked: "+err.Error()+"."))
+		}
+
+		return
+	}
+
+	cleared, err := manifest.ClearWorkloadID(path, workloadID)
+
+	// A file that cannot be parsed cannot be checked, so there is nothing to
+	// say: it may not be this project's manifest at all, and `up` reports an
+	// unreadable one in its own words. A failure past that point is on a file
+	// whose binding was matched, so it is this command's business to report.
+	if errors.Is(err, manifest.ErrUnreadable) {
+		return
+	}
+
+	// The manifest package's refusals each carry the remedy that fits them,
+	// and they differ: one says delete the file, another says edit it by hand.
+	// Appending a single generic "remove that line" walked the user into the
+	// empty manifest the only-key refusal exists to prevent.
+	if err != nil {
+		fmt.Fprintln(w, tui.DimStyle.Render("Could not remove workloadId from "+path+": "+err.Error()))
+
+		return
+	}
+
+	if !cleared {
+		return
+	}
+
+	fmt.Fprintln(w, tui.DimStyle.Render(
+		"Removed workloadId from "+path+"; the next 'dr workload up"+manifest.DirFlag(dir)+"' creates a new workload."))
+
+	noteLinkedArtifact(w, filepath.Dir(path))
+}
+
+// noteLinkedArtifact names the artifact this project is linked to, and how to
+// stop being linked to it.
+//
+// Deleting a workload leaves its artifact alone, by design and as this
+// command's help promises, so the link under .datarobot/ is still accurate and
+// is deliberately left in place. It is only surprising when it is invisible,
+// which is what this line fixes.
+//
+// It states that the artifact survived and stops there. Saying the next deploy
+// reuses it would be false twice over: a locked artifact makes the next deploy
+// refuse instead, and a manifest naming a published image or an artifactId
+// never consults the link at all.
+//
+// The remedy is the state directory, not `dr artifact delete`. Deleting the
+// artifact is refused outright while it is locked, and for an unlocked one it
+// leaves the link pointing at something gone, which the next deploy reports as
+// a bare 404 naming no fix. Removing the directory is what `up` itself already
+// tells the user to do when a locked artifact blocks a deploy, so this says
+// the same thing rather than inventing a second answer.
+func noteLinkedArtifact(w io.Writer, projectDir string) {
+	if !wapi.Exists(projectDir) {
+		return
+	}
+
+	cfg, err := wapi.LoadConfig(projectDir)
+	if err != nil || cfg.ArtifactID == "" {
+		return
+	}
+
+	fmt.Fprintln(w, tui.DimStyle.Render(
+		"This project is still linked to artifact "+cfg.ArtifactID+", which was not deleted with the workload. "+
+			"To unlink it, delete "+wapi.Dir(projectDir)+"."))
 }

--- a/cmd/workload/del/cmd_test.go
+++ b/cmd/workload/del/cmd_test.go
@@ -15,9 +15,15 @@
 package del
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -85,4 +91,257 @@ func TestConfirmDelete_YesSources(t *testing.T) {
 			assert.Equal(t, c.wantConfirmed, confirmed)
 		})
 	}
+}
+
+const boundManifest = `workloadId: 68b0c1d2e3f4a5b6c7d8e9f0
+name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+`
+
+func writeManifest(t *testing.T, dir, body string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, manifest.FileName)
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+
+	return path
+}
+
+// The reported bug: the id the CLI wrote is the CLI's to take back, so the
+// next deploy is not pointed at something that no longer exists.
+func TestClearStaleBinding_ClearsAMatchingID(t *testing.T) {
+	dir := t.TempDir()
+	path := writeManifest(t, dir, boundManifest)
+	t.Chdir(dir)
+
+	var buf bytes.Buffer
+
+	clearStaleBinding(&buf, ".", "68b0c1d2e3f4a5b6c7d8e9f0")
+
+	out := buf.String()
+
+	parsed, err := manifest.Load(path)
+	require.NoError(t, err)
+	assert.Empty(t, parsed.WorkloadID())
+	assert.Contains(t, out, "Removed workloadId")
+}
+
+// delete is addressed by id and can be run from any directory. A manifest
+// about some other workload is none of its business, and editing it would be
+// the CLI touching a file it was never asked about.
+func TestClearStaleBinding_LeavesAnotherWorkloadsManifestAlone(t *testing.T) {
+	dir := t.TempDir()
+	path := writeManifest(t, dir, boundManifest)
+	t.Chdir(dir)
+
+	var buf bytes.Buffer
+
+	clearStaleBinding(&buf, ".", "68b0ffffffffffffffffffff")
+
+	out := buf.String()
+
+	parsed, err := manifest.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", parsed.WorkloadID())
+	assert.Empty(t, out)
+}
+
+// The workload is already gone by the time this runs, so nothing here may
+// turn a successful deletion into a failure.
+func TestClearStaleBinding_SilentWithNoManifest(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	var buf bytes.Buffer
+
+	clearStaleBinding(&buf, ".", "68b0c1d2e3f4a5b6c7d8e9f0")
+
+	out := buf.String()
+
+	assert.Empty(t, out)
+}
+
+// An unparseable manifest is stepped over rather than reported: the id cannot
+// be compared, so there is nothing to say about a file that may well be about
+// a different workload entirely.
+func TestClearStaleBinding_SilentWhenTheManifestCannotBeRead(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "name: [unclosed\n")
+	t.Chdir(dir)
+
+	var buf bytes.Buffer
+
+	clearStaleBinding(&buf, ".", "68b0c1d2e3f4a5b6c7d8e9f0")
+
+	out := buf.String()
+
+	assert.Empty(t, out)
+}
+
+// Deleting a workload leaves its artifact alone, so the local link stays
+// accurate and the next deploy reuses it. That is only surprising when it is
+// invisible, which is what this line exists to prevent. The remedy it names is
+// the state directory, which is what `up` itself tells the user to remove when
+// a locked artifact blocks a deploy; deleting the artifact instead is refused
+// while it is locked and dead-ends the next deploy while it is not.
+func TestClearStaleBinding_NamesTheStillLinkedArtifact(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, boundManifest)
+	require.NoError(t, wapi.Initialize(dir, wapi.InitOptions{ArtifactID: "68b0aaaa0000000000000001"}))
+	t.Chdir(dir)
+
+	var buf bytes.Buffer
+
+	clearStaleBinding(&buf, ".", "68b0c1d2e3f4a5b6c7d8e9f0")
+
+	out := buf.String()
+
+	assert.Contains(t, out, "68b0aaaa0000000000000001")
+	assert.Contains(t, out, "was not deleted with the workload")
+	assert.Contains(t, out, wapi.Dir(dir), "the remedy has to name the directory to remove")
+	assert.NotContains(t, out, "dr artifact delete", "advice that dead-ends is what this ticket is fixing")
+}
+
+// A project that never linked to an artifact has nothing to say about one.
+func TestClearStaleBinding_NoArtifactNoteWithoutAStateDir(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, boundManifest)
+	t.Chdir(dir)
+
+	var buf bytes.Buffer
+
+	clearStaleBinding(&buf, ".", "68b0c1d2e3f4a5b6c7d8e9f0")
+
+	out := buf.String()
+
+	assert.Contains(t, out, "Removed workloadId")
+	assert.NotContains(t, out, "still linked to artifact")
+}
+
+// The reporter's own reproduction deploys with --dir site and then deletes
+// from the repository root. Locate walks upward, so a manifest in a
+// subdirectory is invisible from there and the binding it holds would survive
+// the cleanup that exists to remove it.
+func TestClearStaleBinding_FindsAManifestUnderDir(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "site")
+	require.NoError(t, os.Mkdir(project, 0o750))
+
+	path := writeManifest(t, project, boundManifest)
+	t.Chdir(root)
+
+	var buf bytes.Buffer
+
+	clearStaleBinding(&buf, "site", "68b0c1d2e3f4a5b6c7d8e9f0")
+
+	out := buf.String()
+
+	parsed, err := manifest.Load(path)
+	require.NoError(t, err)
+	assert.Empty(t, parsed.WorkloadID())
+	assert.Contains(t, out, "Removed workloadId")
+}
+
+// The workload is gone by the time the manifest is touched, so a write that
+// fails must not fail the command. It does have to say so, because the user is
+// the one who has to finish the job.
+func TestClearStaleBinding_WarnsWhenTheManifestCannotBeWritten(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permission bits do not block rename the same way on Windows")
+	}
+
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores directory permission bits")
+	}
+
+	dir := t.TempDir()
+	path := writeManifest(t, dir, boundManifest)
+	t.Chdir(dir)
+
+	// The write is atomic, so it needs to create a temporary file alongside
+	// the target; a directory that refuses new entries is what breaks it.
+	require.NoError(t, os.Chmod(dir, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o750) })
+
+	var buf bytes.Buffer
+
+	clearStaleBinding(&buf, ".", "68b0c1d2e3f4a5b6c7d8e9f0")
+
+	out := buf.String()
+
+	assert.Contains(t, out, "Could not remove workloadId")
+
+	// The binding is still there, so the message is telling the truth.
+	parsed, err := manifest.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", parsed.WorkloadID())
+}
+
+// A --dir that is not a directory would otherwise be walked straight past, and
+// Locate would edit an ancestor's manifest instead of the one the flag named.
+// The wording covers both shapes it can take: absent, and a path that exists
+// but is a file.
+func TestClearStaleBinding_NamesADirThatIsNotADirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := writeManifest(t, dir, boundManifest)
+	t.Chdir(dir)
+
+	var buf bytes.Buffer
+
+	clearStaleBinding(&buf, "sight", "68b0c1d2e3f4a5b6c7d8e9f0")
+
+	assert.Contains(t, buf.String(), "No manifest was checked")
+	assert.Contains(t, buf.String(), manifest.ErrNotADirectory.Error())
+	assert.Contains(t, buf.String(), "sight", "the path that was refused")
+
+	parsed, err := manifest.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", parsed.WorkloadID(),
+		"a typo must not fall back to editing whatever manifest is nearby")
+}
+
+// A manifest that cannot be walked safely is stepped over in silence, the same
+// as one that cannot be parsed: nothing can say whether it is even about the
+// workload just deleted, and `up` reports such a file in its own words.
+func TestClearStaleBinding_SilentOnAnUnwalkableManifest(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "a: &a [1,1]\nb: &b [*a,*a]\nc: &c [*b,*b]\nworkloadId: *c\n")
+	t.Chdir(dir)
+
+	var buf bytes.Buffer
+
+	clearStaleBinding(&buf, ".", "68b0c1d2e3f4a5b6c7d8e9f0")
+
+	assert.Empty(t, buf.String())
+}
+
+// The manifest path itself is the likeliest typo for --dir, and it exists, so
+// a check that only asked whether the path was there would walk past it.
+func TestClearStaleBinding_RejectsAFileAsDir(t *testing.T) {
+	dir := t.TempDir()
+	path := writeManifest(t, dir, boundManifest)
+	t.Chdir(dir)
+
+	var buf bytes.Buffer
+
+	clearStaleBinding(&buf, path, "68b0c1d2e3f4a5b6c7d8e9f0")
+
+	assert.Contains(t, buf.String(), manifest.ErrNotADirectory.Error())
+
+	parsed, err := manifest.Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", parsed.WorkloadID())
+}
+
+// The flag is registered here and read by name in RunE, so nothing in the
+// package fails if it is renamed or dropped: GetString would return "" and the
+// command would quietly go back to searching upward from the working
+// directory, which is the behaviour --dir exists to replace.
+func TestCmd_RegistersDirFlag(t *testing.T) {
+	flag := Cmd().Flags().Lookup("dir")
+
+	require.NotNil(t, flag, "RunE reads --dir by name; renaming it here fails nothing else")
+	assert.Equal(t, "string", flag.Value.Type())
 }

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -29,9 +29,11 @@ import (
 	"github.com/datarobot/cli/cmd/internal/pollflags"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/fsutil"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/internal/workload/up"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
@@ -245,8 +247,18 @@ func run(cmd *cobra.Command, f flags, poll pollflags.Set, format outputformat.Ou
 }
 
 // resolveDir defaults --dir to where the shell is standing.
+//
+// A flag that names something other than a directory is refused here rather
+// than left to the manifest search, which knows the path but not that a flag
+// supplied it: the same typo told `dr workload delete` which flag to blame, and
+// the two commands are printed at each other often enough that answering it
+// differently is its own small confusion.
 func resolveDir(dir string) (string, error) {
 	if dir != "" {
+		if !fsutil.DirExists(dir) {
+			return "", fmt.Errorf("--dir %s: %w", dir, manifest.ErrNotADirectory)
+		}
+
 		return dir, nil
 	}
 

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -18,9 +18,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/internal/workload/up"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -191,6 +194,30 @@ func TestCmd_RefusesBindingFlags(t *testing.T) {
 	}
 }
 
+// A --dir the OS would not call a directory is refused by name, the same as
+// `dr workload delete` refuses it. Left to the manifest search it came back as
+// a bare "not a directory: <abs path>" with nothing saying which flag put that
+// path there, and the two commands print this flag at each other.
+func TestCmd_RefusesADirThatIsNotADirectory(t *testing.T) {
+	for name, dir := range map[string]string{
+		"absent": "no-such-directory",
+		"a file": filepath.Join(t.TempDir(), "file"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if name == "a file" {
+				require.NoError(t, os.WriteFile(dir, []byte("x"), 0o600))
+			}
+
+			stubRun(t, deployed(), nil)
+
+			_, _, err := runCmd(t, "--dir", dir)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--dir "+dir)
+			assert.ErrorIs(t, err, manifest.ErrNotADirectory)
+		})
+	}
+}
+
 func TestCmd_DryRunSaysSoAndPrintsNoEndpoint(t *testing.T) {
 	result := deployed()
 	result.Endpoint = ""
@@ -207,10 +234,13 @@ func TestCmd_DryRunSaysSoAndPrintsNoEndpoint(t *testing.T) {
 func TestCmd_PassesTheFlagsThrough(t *testing.T) {
 	seen := stubRun(t, deployed(), nil)
 
-	_, _, err := runCmd(t, "--detach", "--dir", "/tmp/project")
+	// A real directory, because --dir is now checked before the deploy runs.
+	project := t.TempDir()
+
+	_, _, err := runCmd(t, "--detach", "--dir", project)
 	require.NoError(t, err)
 	assert.True(t, seen.Detach)
-	assert.Equal(t, "/tmp/project", seen.Dir)
+	assert.Equal(t, project, seen.Dir)
 
 	locking := stubRun(t, deployed(), nil)
 

--- a/docs/commands/workload.md
+++ b/docs/commands/workload.md
@@ -146,12 +146,19 @@ dr workload list [--status <status>] [--limit N] [--output-format text|json]
 Delete a workload by id. A running workload is stopped first and then removed. The artifact it was created from is not deleted. You are asked to confirm unless `--yes` is set.
 
 ```bash
-dr workload delete <workload-id> [--yes]
+dr workload delete <workload-id> [--yes] [--dir <path>]
 ```
 
 **Flags:**
 
 - `--yes`, `-y`: skip the confirmation prompt. Also honored via `DATAROBOT_CLI_NON_INTERACTIVE=1`.
+- `--dir <path>`: project directory whose manifest holds the binding, searched upward from there. Defaults to the current directory. Pass the same value you deployed with, since a manifest in a subdirectory is not visible from its parent.
+
+If the manifest found from `--dir` is bound to the workload just deleted, the `workloadId` line the CLI wrote is removed with it, so the next `dr workload up` creates a new workload instead of pointing at one that is gone. Only a manifest naming that exact id is touched. The artifact link under `.datarobot/` is left alone, because the artifact itself survives the deletion. The command names the artifact so the link is not left invisible, and names the state directory to remove if you want to unlink from it. These notes go to stderr, so stdout stays the command's result.
+
+A manifest this edit cannot make sound again is refused rather than rewritten, with the reason and the remedy: a binding whose value something else aliases, repeated `workloadId` keys that disagree, a file whose only recognized key is the binding, and a file carrying more than one YAML document.
+
+A workload that was already gone before the command ran is reported, and the binding is left alone: a 404 says the workload is not on this instance, which is not the same as saying it no longer exists. That case, and deletion from the UI or by a teammate, is handled at deploy time instead: `dr workload up` treats a binding that resolves to nothing as drift, creates a new workload, and names the id it could not find in both the plan and the JSON envelope.
 
 ### `start` / `stop`
 

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -186,7 +186,14 @@ func NewArtifactOutput(a Artifact) ArtifactOutput {
 }
 
 func (a *Artifact) IsLocked() bool {
-	return strings.EqualFold(a.Status, ArtifactStatusLocked)
+	return IsLockedStatus(a.Status)
+}
+
+// IsLockedStatus is the same question asked of a status read off a raw
+// document, for a caller that already has the artifact as the server sent it
+// and should not fetch it again to get a typed struct to ask.
+func IsLockedStatus(status string) bool {
+	return strings.EqualFold(status, ArtifactStatusLocked)
 }
 
 // primaryContainer is the single definition of which container the CLI reads

--- a/internal/workload/manifest/manifest.go
+++ b/internal/workload/manifest/manifest.go
@@ -32,6 +32,25 @@ const FileName = ".datarobot.yaml"
 // with errors.Is, e.g. to fall into the setup wizard instead of failing.
 var ErrNotFound = errors.New("no " + FileName + " manifest found")
 
+// ErrEmptyFile reports a manifest with nothing in it. Named with its remedy
+// because the likeliest way to get here is a write that was killed between
+// reserving the path and filling it. The reservation is what stops two setups
+// racing, so it is kept, and what it can leave behind is a file the user has to
+// be told to delete rather than one they are left guessing at.
+//
+// Shared rather than phrased at each site: the same file reaches the reader
+// through Parse and the write-back through editRoot, and two explanations of
+// one state, differing by which function happened to touch the file first, is
+// one explanation too many.
+var ErrEmptyFile = errors.New(
+	"file is empty, which an interrupted write can leave behind: delete it and run the command again")
+
+// ErrNotADirectory reports that the path a search was told to start from is
+// not a directory. It is deliberately not ErrNotFound: nothing was searched,
+// so falling back to whatever a missing manifest triggers would act on a
+// directory the caller never named.
+var ErrNotADirectory = errors.New("not a directory")
+
 // recognizedKeys are the top-level keys that identify a workload manifest. A
 // file with none of them is rejected as foreign rather than deployed as an
 // all-defaults workload.
@@ -95,12 +114,7 @@ func Parse(data []byte, dir string) (*Manifest, error) {
 	}
 
 	if root.Kind == 0 {
-		// Named with its remedy because the likeliest way to get here is a
-		// write that was killed between reserving the path and filling it.
-		// The reservation is what stops two setups racing, so it is kept, and
-		// what it can leave behind is a file the user has to be told to
-		// delete rather than one they are left guessing at.
-		return nil, errors.New("file is empty, which an interrupted write can leave behind: delete it and run the command again")
+		return nil, ErrEmptyFile
 	}
 
 	if root.Kind != yaml.MappingNode {
@@ -120,6 +134,46 @@ func Parse(data []byte, dir string) (*Manifest, error) {
 	return &Manifest{Dir: dir, root: root}, nil
 }
 
+// DirFlag is the " --dir <path>" a remedy has to carry to reach the project in
+// dir, and empty when the working directory already does.
+//
+// One implementation, because two commands print this suffix at each other: a
+// message that names 'dr workload delete <id>' without it is false in exactly
+// the layout --dir was added for, and a message that adds it when the shell is
+// already standing in the project tells the reader to type something that does
+// nothing. Two notions of "already there" would eventually disagree about one
+// directory, and the disagreement would be between the two commands this
+// binding is passed between.
+//
+// The path is resolved rather than compared as text, so "." , "./." and a
+// trailing slash all answer the same way. A directory that cannot be resolved
+// answers empty: a suffix guessed from a path the OS would not confirm is worse
+// than none.
+func DirFlag(dir string) string {
+	if dir == "" {
+		return ""
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+
+	project, err := filepath.Abs(dir)
+	if err != nil || project == cwd {
+		return ""
+	}
+
+	// Relative when it is shorter to read and still lands in the same place;
+	// absolute otherwise, which is what a project on another branch of the tree
+	// gets rather than a ../../.. chain.
+	if rel, err := filepath.Rel(cwd, project); err == nil && rel != "" && !strings.HasPrefix(rel, "..") {
+		return " --dir " + rel
+	}
+
+	return " --dir " + project
+}
+
 // Locate searches for the manifest in startDir and each ancestor, the way
 // git finds its repository root. The walk is lexical: symlinks are not
 // resolved, and it stops after checking the user's home directory or the
@@ -129,6 +183,16 @@ func Locate(startDir string) (string, error) {
 	dir, err := filepath.Abs(startDir)
 	if err != nil {
 		return "", fmt.Errorf("cannot resolve %s: %w", startDir, err)
+	}
+
+	// Checked here rather than at each caller, because the hazard belongs to
+	// the walk: a directory that is not there has no manifest of its own, so
+	// the loop below sails past it to an ancestor and answers with a different
+	// project's file. That is a wrong answer, not a missing one, so it is not
+	// ErrNotFound: a caller that falls back to the setup wizard on ErrNotFound
+	// would otherwise configure the parent of the directory it was pointed at.
+	if !fsutil.DirExists(dir) {
+		return "", fmt.Errorf("%w: %s", ErrNotADirectory, startDir)
 	}
 
 	home, _ := os.UserHomeDir()

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -110,6 +111,13 @@ const (
 // atomicWrite is the durable write, a variable so a test can make it fail and
 // check that the reservation is taken back.
 var atomicWrite = fsutil.AtomicWriteFile
+
+// ErrUnreadable reports that a manifest could not be read or parsed at all, as
+// distinct from an edit that failed after the file was understood. A caller
+// editing a file it merely found, rather than one it was handed, needs to tell
+// those apart: an unparseable file may not be about its business, while a
+// write that fails on a file whose contents it matched certainly is.
+var ErrUnreadable = errors.New("manifest could not be read")
 
 // ErrExists reports that a manifest is already present at the target path.
 // Setup never rewrites one: the file is the interface after the first write,
@@ -308,49 +316,209 @@ func Write(path string, data []byte) error {
 // workload exists, so the next run finds it. Comments, unknown keys and their
 // order are preserved, because the file is re-emitted from the tree it was
 // parsed into rather than regenerated.
+func WriteWorkloadID(path, workloadID string) error {
+	_, err := editRoot(path, "record the workload id", false, func(root *yaml.Node) (bool, error) {
+		setWorkloadID(root, workloadID)
+
+		return true, nil
+	})
+
+	return err
+}
+
+// ClearWorkloadID removes the binding, but only when it is the one the caller
+// expects, and reports whether it did. It is what `dr workload delete` calls
+// once the workload it names is gone: the id the CLI wrote is the CLI's to
+// take back, and leaving it behind points the next deploy at something that no
+// longer exists.
+//
+// The id is compared inside the same parse that performs the removal. Checking
+// it against a separate read would leave a window in which a concurrent `up`
+// writes a fresh binding, and this call then deletes a live id it never
+// looked at.
+//
+// A manifest with no binding, or a different one, is not an error: both report
+// false and write nothing. A file this cannot edit without damaging it is an
+// error carrying its own remedy, because the caller prints what it is given.
+func ClearWorkloadID(path, wantWorkloadID string) (bool, error) {
+	changed, err := editRoot(path, "clear the workload id", true, func(root *yaml.Node) (bool, error) {
+		return clearWorkloadID(root, wantWorkloadID)
+	})
+
+	return changed, err
+}
+
+// editRoot is the read-modify-write both binding edits share: parse to a node
+// tree, hand the root mapping to mutate, and re-emit only if something
+// changed. Re-emitting preserves comments, unknown keys and their order, which
+// regenerating from a struct would not.
+//
+// action names the edit for the errors that mention it, so a failure says what
+// the CLI was trying to do rather than only where it stopped.
+//
+// markUnreadable wraps the read and parse failures in ErrUnreadable. Only the
+// caller that edits a file it merely found wants that: it stays quiet about a
+// file it cannot judge relevant. The write-back knows its file, and tagging its
+// failures as unreadable makes its own caller report "could not be written:
+// manifest could not be read".
 //
 // This is the one way into the package that does not go through Parse, so it
 // runs the alias guard itself. Reaching here means the file already parsed
-// once, and neither the top-level walk below nor the encoder expands an alias,
-// so nothing known today needs the check. It is here because that reasoning is
-// about the current implementation of two other functions, and a guard that
-// holds only while nobody edits them is not one.
-func WriteWorkloadID(path, workloadID string) error {
+// once, and neither the walks below nor the encoder expands an alias, so
+// nothing known today needs the check. It is here because that reasoning is
+// about the current implementation of other functions, and a guard that holds
+// only while nobody edits them is not one.
+func editRoot(path, action string, markUnreadable bool, mutate func(root *yaml.Node) (bool, error)) (bool, error) {
+	unreadable := func(format string, args ...any) error {
+		err := fmt.Errorf(format, args...)
+		if markUnreadable {
+			return fmt.Errorf("%w: %w", ErrUnreadable, err)
+		}
+
+		return err
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("cannot read %s: %w", path, err)
+		return false, unreadable("cannot read %s: %w", path, err)
 	}
 
-	var doc yaml.Node
-
-	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return fmt.Errorf("cannot parse %s: %w", path, err)
+	doc, root, err := soleDocument(data, path, action, unreadable)
+	if err != nil {
+		return false, err
 	}
 
-	if len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
-		return fmt.Errorf("cannot record the workload id in %s: root must be a YAML mapping", path)
+	// The mutator's own message says what it refused and why, and every caller
+	// already has the path it passed in.
+	changed, err := mutate(root)
+	if err != nil || !changed {
+		return false, err
 	}
 
-	if err := checkAliases(doc.Content[0]); err != nil {
-		return fmt.Errorf("cannot record the workload id in %s: %w", path, err)
+	rendered, err := encodeDoc(doc)
+	if err != nil {
+		return false, fmt.Errorf("cannot render %s: %w", path, err)
 	}
 
-	setWorkloadID(doc.Content[0], workloadID)
+	// Reported as unchanged when the write fails: the caller's question is
+	// whether the file on disk now lacks the binding, and it does not.
+	if err := fsutil.AtomicWriteFile(path, matchLineEndings(data, rendered)); err != nil {
+		return false, err
+	}
 
+	return true, nil
+}
+
+// soleDocument reads the one document a manifest is, and hands back its root
+// mapping. Everything it refuses is a file this edit cannot put back the way
+// it found it.
+func soleDocument(
+	data []byte, path, action string, unreadable func(string, ...any) error,
+) (*yaml.Node, *yaml.Node, error) {
+	docs, err := decodeAll(data)
+	if err != nil {
+		return nil, nil, unreadable("cannot parse %s: %w", path, err)
+	}
+
+	// The reader never looks past the first document. Editing a file that
+	// carries more would have to put the rest back byte for byte, and it
+	// cannot: yaml.v3 hangs a comment that opens the second document off the
+	// end of the first, so re-emitting moves the user's text between them.
+	// Not marked unreadable: the file parsed, so a caller can tell it is a
+	// manifest and that this is a refusal to edit rather than an inability to
+	// judge it. Swallowing it would leave `dr workload delete` reporting
+	// nothing at all about a binding it declined to take back.
+	if len(docs) > 1 {
+		return nil, nil, fmt.Errorf(
+			"the file holds %d YAML documents, and this edit would not put them back as it found them. "+
+				"Edit it by hand", len(docs))
+	}
+
+	// An empty file is its own diagnosis with its own remedy, and it is the
+	// same file Parse would refuse in the same words. A generic "root must be a
+	// YAML mapping" here would explain one state two ways depending on which
+	// function reached the file first.
+	if len(docs) == 0 || len(docs[0].Content) == 0 {
+		return nil, nil, unreadable("cannot %s in %s: %w", action, path, ErrEmptyFile)
+	}
+
+	if docs[0].Content[0].Kind != yaml.MappingNode {
+		return nil, nil, unreadable("cannot %s in %s: root must be a YAML mapping", action, path)
+	}
+
+	root := docs[0].Content[0]
+
+	// An alias bomb is unreadable in the sense that matters here: the file
+	// cannot be walked safely, so nothing can say whether it is even about the
+	// caller's business.
+	if err := checkAliases(root); err != nil {
+		return nil, nil, unreadable("cannot %s in %s: %w", action, path, err)
+	}
+
+	return docs[0], root, nil
+}
+
+// decodeAll reads every document in the file, so a caller can tell a manifest
+// from a stream that merely starts like one.
+func decodeAll(data []byte) ([]*yaml.Node, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+
+	var docs []*yaml.Node
+
+	for {
+		var doc yaml.Node
+
+		err := dec.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		docs = append(docs, &doc)
+	}
+
+	return docs, nil
+}
+
+// encodeDoc renders one document back to bytes.
+func encodeDoc(doc *yaml.Node) ([]byte, error) {
 	var buf bytes.Buffer
 
 	enc := yaml.NewEncoder(&buf)
 	enc.SetIndent(2)
 
-	if err := enc.Encode(&doc); err != nil {
-		return fmt.Errorf("cannot render %s: %w", path, err)
+	if err := enc.Encode(doc); err != nil {
+		return nil, err
 	}
 
 	if err := enc.Close(); err != nil {
-		return fmt.Errorf("cannot render %s: %w", path, err)
+		return nil, err
 	}
 
-	return fsutil.AtomicWriteFile(path, buf.Bytes())
+	return buf.Bytes(), nil
+}
+
+// matchLineEndings gives the rewritten file back the line endings it came
+// with. The YAML encoder only ever emits LF, so re-emitting a CRLF file would
+// convert every line in it: a one-key edit would land in review as a
+// whole-file diff.
+//
+// Only a file that is wholly CRLF is converted back. A mixed file is left as
+// the encoder produced it, because guessing from one stray terminator is how
+// a single CRLF line, or a CRLF sitting inside a block scalar where it is
+// content rather than a line ending, converts everything around it.
+func matchLineEndings(original, rendered []byte) []byte {
+	crlf := bytes.Count(original, []byte("\r\n"))
+	if crlf == 0 || crlf != bytes.Count(original, []byte("\n")) {
+		return rendered
+	}
+
+	rendered = bytes.ReplaceAll(rendered, []byte("\r\n"), []byte("\n"))
+
+	return bytes.ReplaceAll(rendered, []byte("\n"), []byte("\r\n"))
 }
 
 // setWorkloadID replaces the binding in place when the key is there, and
@@ -375,6 +543,195 @@ func setWorkloadID(root *yaml.Node, workloadID string) {
 	}
 
 	root.Content = append([]*yaml.Node{key, scalar(workloadID)}, root.Content...)
+}
+
+// clearWorkloadID drops the binding when it is the one the caller named, and
+// reports whether it found it. It is the inverse of setWorkloadID, and the file
+// it edits belongs to the user, so it gives back everything that function moved
+// and takes nothing that was not the binding's.
+//
+// Every occurrence goes, not just the first. YAML calls a repeated key invalid
+// and this reader does not: it returns the first match and never looks further,
+// so a hand-edited file can hold a second binding nothing reports. Repeated
+// keys that disagree are refused outright rather than half-removed, because
+// removing the one the reader reports would promote the other to the binding
+// without anyone asking.
+//
+// Three refusals carry their own remedy, because the caller prints what it is
+// given and each needs a different answer:
+//
+//   - the binding is the file's only recognized key, so removing it leaves a
+//     document Parse rejects as not a manifest, and because the file still
+//     exists nothing falls back to the wizard;
+//   - the binding carries a YAML anchor something else aliases, so removing it
+//     strands the alias and the file never loads again;
+//   - repeated keys disagree.
+func clearWorkloadID(root *yaml.Node, wantWorkloadID string) (bool, error) {
+	// Gathered first, because what to do about a value that does not match
+	// depends on how many bindings there are. One is simply another project's
+	// file and none of this command's business; two that disagree cannot be
+	// resolved by removing either.
+	var at []int
+
+	matches := 0
+
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value != keyWorkloadID {
+			continue
+		}
+
+		at = append(at, i)
+
+		// Through the alias, because the reader is: WorkloadID resolves one
+		// before answering, so a binding written as an alias is the binding
+		// this project deploys to. Comparing the raw node would read the
+		// anchor's name, match nothing, and leave the file exactly as stale as
+		// before while reporting success on the delete.
+		if resolveAlias(root.Content[i+1]).Value == wantWorkloadID {
+			matches++
+		}
+	}
+
+	if len(at) == 0 || matches == 0 {
+		return false, nil
+	}
+
+	if err := removable(root, at, matches); err != nil {
+		return false, err
+	}
+
+	kept, banner, trailing := partition(root)
+
+	// Reuses the reader's own notion of what makes a file a manifest, so the
+	// two cannot drift apart and start disagreeing about one file.
+	if !hasRecognizedKey(&yaml.Node{Kind: yaml.MappingNode, Content: kept}) {
+		return false, fmt.Errorf(
+			"%s is the only key this file is recognized by, and a manifest without it is not one. "+
+				"Delete the file instead", keyWorkloadID)
+	}
+
+	kept[0].HeadComment = joinComments(banner, kept[0].HeadComment)
+
+	// A comment that sat under the binding belongs where it sat. Hoisting a
+	// bottom-of-file note to the first key moves the user's text somewhere
+	// they never put it.
+	if trailing != "" {
+		if at[len(at)-1]+2 >= len(root.Content) {
+			last := kept[len(kept)-1]
+			last.FootComment = joinComments(trailing, last.FootComment)
+		} else {
+			kept[0].HeadComment = joinComments(kept[0].HeadComment, trailing)
+		}
+	}
+
+	root.Content = kept
+
+	return true, nil
+}
+
+// partition splits the root into what survives and the comments the removed
+// pairs were carrying: the file's banner, when the binding held the first key,
+// and whatever sat underneath the binding.
+func partition(root *yaml.Node) (kept []*yaml.Node, banner, trailing string) {
+	kept = make([]*yaml.Node, 0, len(root.Content))
+
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		key, value := root.Content[i], root.Content[i+1]
+
+		if key.Value != keyWorkloadID {
+			kept = append(kept, key, value)
+
+			continue
+		}
+
+		if i == 0 {
+			banner = joinComments(banner, key.HeadComment)
+		}
+
+		trailing = joinComments(trailing, joinComments(key.FootComment, value.FootComment))
+	}
+
+	return kept, banner, trailing
+}
+
+// removable refuses the two shapes that cannot be edited into a sound file:
+// repeated keys that disagree, and a binding whose anchor something else
+// aliases.
+func removable(root *yaml.Node, at []int, matches int) error {
+	if matches != len(at) {
+		return fmt.Errorf(
+			"%s appears %d times with different values, so removing one would make another the binding "+
+				"without anyone choosing it. Edit the file by hand", keyWorkloadID, len(at))
+	}
+
+	for _, i := range at {
+		if anchor := anchorOn(root.Content[i], root.Content[i+1]); anchor != "" && aliasesAnchor(root, anchor, i) {
+			return fmt.Errorf(
+				"the %s value carries the anchor %q, which the rest of the file refers to. Removing it would "+
+					"leave that reference pointing at nothing. Edit the file by hand", keyWorkloadID, anchor)
+		}
+	}
+
+	return nil
+}
+
+// anchorOn reports the anchor a binding carries, on either node of the pair.
+func anchorOn(key, value *yaml.Node) string {
+	if value.Anchor != "" {
+		return value.Anchor
+	}
+
+	return key.Anchor
+}
+
+// aliasesAnchor reports whether anything outside the pair at skip refers to
+// the anchor. yaml.v3 resolves aliases at decode time, so the alias nodes are
+// still in the tree and the encoder writes them back as aliases; dropping what
+// they point at leaves a file that never loads again.
+func aliasesAnchor(root *yaml.Node, anchor string, skip int) bool {
+	found := false
+
+	var walk func(n *yaml.Node)
+
+	walk = func(n *yaml.Node) {
+		if n == nil || found {
+			return
+		}
+
+		if n.Kind == yaml.AliasNode && n.Value == anchor {
+			found = true
+
+			return
+		}
+
+		for _, child := range n.Content {
+			walk(child)
+		}
+	}
+
+	for i, node := range root.Content {
+		if i == skip || i == skip+1 {
+			continue
+		}
+
+		walk(node)
+	}
+
+	return found
+}
+
+// joinComments stacks two comment blocks, keeping either when the other is
+// empty. yaml.Node comments are newline-separated blocks already, so this is
+// the whole of it.
+func joinComments(above, below string) string {
+	switch {
+	case above == "":
+		return below
+	case below == "":
+		return above
+	}
+
+	return above + "\n" + below
 }
 
 const workloadIDComment = "managed by the CLI"

--- a/internal/workload/manifest/write_test.go
+++ b/internal/workload/manifest/write_test.go
@@ -372,6 +372,198 @@ func TestWriteWorkloadID_MissingFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot read")
 }
 
+func TestClearWorkloadID_RemovesTheBinding(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), validManifest)
+
+	m, err := Load(path)
+	require.NoError(t, err)
+	require.NotEmpty(t, m.WorkloadID(), "the fixture has to start bound for this to mean anything")
+
+	require.NoError(t, clearOK(t, path))
+
+	cleared, err := Load(path)
+	require.NoError(t, err)
+	assert.Empty(t, cleared.WorkloadID())
+
+	// The rest of the manifest still has to parse and validate: clearing the
+	// binding returns the file to a project that has never deployed, not to a
+	// broken one.
+	require.NoError(t, cleared.Validate())
+}
+
+// Clearing is the same single-key edit the write-back is, in the other
+// direction: everything the user owns survives it.
+func TestClearWorkloadID_PreservesTheRestOfTheFile(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), `workloadId: 68b0ffff0000000000000009 # managed by the CLI
+name: my-app          # the workload
+somethingTheApiAddedLater: true
+artifact:
+  # how the image is built
+  name: my-app-artifact
+  type: service
+  spec:
+`)
+
+	require.NoError(t, clearOK(t, path))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, `name: my-app # the workload
+somethingTheApiAddedLater: true
+artifact:
+  # how the image is built
+  name: my-app-artifact
+  type: service
+  spec:
+`, string(got))
+}
+
+// The mirror of KeepsFileBannerOnTop: the write-back moved the banner up onto
+// the key it inserted, so removing that key has to hand it back rather than
+// take the file's own header with it.
+func TestClearWorkloadID_KeepsFileBannerOnTop(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), `# Deploy config for my-app. Edit freely.
+workloadId: 68b0ffff0000000000000009 # managed by the CLI
+name: my-app
+`)
+
+	require.NoError(t, clearOK(t, path))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, `# Deploy config for my-app. Edit freely.
+name: my-app
+`, string(got))
+}
+
+// A comment further down describes the key it sits on, so it goes when that
+// key goes. Only the first key's head comment is the file's.
+func TestClearWorkloadID_DropsACommentOnItsOwnKey(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), `name: my-app
+# the workload this checkout deploys to
+workloadId: 68b0ffff0000000000000009
+importance: low
+`)
+
+	require.NoError(t, clearOK(t, path))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, `name: my-app
+importance: low
+`, string(got))
+}
+
+// A manifest with no binding is the ordinary state of a project that has never
+// deployed, so clearing one is a no-op rather than an error, and it must not
+// rewrite the file: re-emitting would reformat a file nobody asked it to.
+func TestClearWorkloadID_AbsentKeyLeavesTheFileByteForByte(t *testing.T) {
+	original := "name:    my-app\nimportance:   low\n"
+	path := writeManifest(t, t.TempDir(), original)
+
+	require.NoError(t, clearOK(t, path))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got))
+}
+
+// A hand-edited file can hold two bindings: the reader returns the first match
+// and never looks further, so the second is invisible to it. Clearing only the
+// one it reports would leave the next deploy bound to what was behind it.
+func TestClearWorkloadID_RemovesEveryOccurrence(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), `workloadId: 68b0ffff0000000000000009
+name: my-app
+workloadId: 68b0ffff0000000000000009
+`)
+
+	before, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, "68b0ffff0000000000000009", before.WorkloadID(),
+		"the reader stops at the first match, so the second binding is the one nothing reports")
+
+	cleared, err := ClearWorkloadID(path, "68b0ffff0000000000000009")
+	require.NoError(t, err)
+	assert.True(t, cleared)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "name: my-app\n", string(got),
+		"removing only the one the reader reports would leave the deploy still bound")
+}
+
+// Repeated keys carrying different ids are a file nothing can reason about:
+// the reader reports one, and removing it would promote the other to the
+// binding without anyone asking. Refusing leaves the ambiguity visible.
+func TestClearWorkloadID_RefusesDisagreeingDuplicates(t *testing.T) {
+	original := `workloadId: 68b0ffff0000000000000009
+name: my-app
+workloadId: 68b0aaaa0000000000000001
+`
+	path := writeManifest(t, t.TempDir(), original)
+
+	cleared, err := ClearWorkloadID(path, "68b0ffff0000000000000009")
+	require.Error(t, err)
+	assert.False(t, cleared)
+	assert.Contains(t, err.Error(), "different values")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got))
+}
+
+func TestClearWorkloadID_RejectsAnAliasBomb(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), aliasBomb)
+
+	_, err := ClearWorkloadID(path, "68b0ffff0000000000000009")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "too large")
+	require.ErrorIs(t, err, ErrUnreadable,
+		"a file that cannot be walked safely cannot be judged relevant either")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, aliasBomb, string(got))
+}
+
+func TestClearWorkloadID_RejectsNonMapping(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), "- name: my-app\n")
+
+	_, err := ClearWorkloadID(path, "68b0ffff0000000000000009")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "root must be a YAML mapping")
+}
+
+func TestClearWorkloadID_MissingFile(t *testing.T) {
+	_, err := ClearWorkloadID(Path(t.TempDir()), "68b0aaaa0000000000000001")
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "cannot read")
+}
+
+// Written and cleared leaves the file it started as, which is the property
+// that makes the pair safe to run in either order.
+func TestWorkloadID_WriteThenClearRoundTrips(t *testing.T) {
+	original := `# Deploy config for my-app. Edit freely.
+name: my-app # the workload
+somethingTheApiAddedLater: true
+`
+
+	path := writeManifest(t, t.TempDir(), original)
+
+	require.NoError(t, WriteWorkloadID(path, "68b0ffff0000000000000009"))
+	require.NoError(t, clearOK(t, path))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got))
+}
+
 func TestArtifactName(t *testing.T) {
 	assert.Equal(t, "my-app-artifact", ArtifactName("my-app"))
 }
@@ -554,4 +746,265 @@ func TestArtifactTypeOrDefault(t *testing.T) {
 	assert.Equal(t, TypeService, ArtifactTypeOrDefault(""),
 		"the platform creates a block that names no type as a service")
 	assert.Equal(t, TypeAgent, ArtifactTypeOrDefault(TypeAgent))
+}
+
+// clearOK clears whatever binding the file holds, which is what every fixture
+// here wants: the compare-and-clear contract is exercised on its own below.
+func clearOK(t *testing.T, path string) error {
+	t.Helper()
+
+	_, err := ClearWorkloadID(path, idIn(t, path))
+
+	return err
+}
+
+// idIn reads the binding a fixture was written with.
+func idIn(t *testing.T, path string) string {
+	t.Helper()
+
+	m, err := Load(path)
+	require.NoError(t, err)
+
+	return m.WorkloadID()
+}
+
+// The id is compared inside the same parse that removes it, so a binding that
+// is not the one the caller named is left alone. Checking against a separate
+// read would let a concurrent up write a fresh binding into the window and
+// have this delete an id it never looked at.
+func TestClearWorkloadID_LeavesADifferentBinding(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), validManifest)
+
+	cleared, err := ClearWorkloadID(path, "68b0ffffffffffffffffffff")
+	require.NoError(t, err)
+	assert.False(t, cleared)
+
+	m, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, "68b0aaaa0000000000000001", m.WorkloadID())
+}
+
+// setWorkloadID moves a file banner up onto the key it inserts. Removing that
+// key has to give the banner back without overwriting a comment the surviving
+// key already carries, because both belong to the user.
+func TestClearWorkloadID_KeepsBothTheBannerAndTheNextKeysComment(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), `# Deploy config for my-app. Edit freely.
+workloadId: 68b0ffff0000000000000009 # managed by the CLI
+# what this thing is called in the UI
+name: my-app
+importance: low
+`)
+
+	require.NoError(t, clearOK(t, path))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(got), "# Deploy config for my-app. Edit freely.")
+	assert.Contains(t, string(got), "# what this thing is called in the UI",
+		"a comment on the surviving key is the user's and must not be overwritten")
+}
+
+// A comment under the binding describes what follows it, not the binding.
+func TestClearWorkloadID_KeepsAFootComment(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), `name: my-app
+workloadId: 68b0ffff0000000000000009
+# remember to bump replicas before the demo
+importance: low
+`)
+
+	require.NoError(t, clearOK(t, path))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "# remember to bump replicas before the demo")
+}
+
+// A manifest is one document. Editing a file that carries more cannot put the
+// rest back as it found them, because yaml.v3 hangs a comment that opens the
+// second document off the end of the first, so re-emitting moves the user's
+// text between documents. Refusing says so rather than rearranging it.
+func TestClearWorkloadID_RefusesAMultiDocumentFile(t *testing.T) {
+	original := `workloadId: 68b0ffff0000000000000009
+name: my-app
+---
+# a note the user keeps
+name: notes-the-user-keeps-here
+`
+	path := writeManifest(t, t.TempDir(), original)
+
+	cleared, err := ClearWorkloadID(path, "68b0ffff0000000000000009")
+	require.Error(t, err)
+	assert.False(t, cleared)
+	assert.Contains(t, err.Error(), "2 YAML documents")
+	require.NotErrorIs(t, err, ErrUnreadable,
+		"the file parsed, so this is a refusal to edit and the caller has to be able to say so")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got), "a refusal must not have moved anything")
+}
+
+// Emptying the mapping would re-emit as "{}", which Parse then rejects as not
+// a manifest, and because the file still exists nothing falls back to the
+// wizard: every later deploy in that directory fails on a file the CLI wrote.
+func TestClearWorkloadID_RefusesToEmptyTheFile(t *testing.T) {
+	original := "workloadId: 68b0ffff0000000000000009\n"
+	path := writeManifest(t, t.TempDir(), original)
+
+	cleared, err := ClearWorkloadID(path, "68b0ffff0000000000000009")
+	require.Error(t, err)
+	assert.False(t, cleared)
+	assert.Contains(t, err.Error(), "only key")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got), "a refusal must not have edited the file")
+}
+
+// An unreadable file is distinguishable from an edit that failed after the
+// file was understood, so a caller editing a file it merely found can stay
+// quiet about one and speak up about the other.
+func TestClearWorkloadID_UnreadableIsItsOwnError(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), "name: [unclosed\n")
+
+	_, err := ClearWorkloadID(path, "68b0ffff0000000000000009")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnreadable)
+}
+
+// The write-back runs on every deploy, so it is the likelier of the two edits
+// to meet a file carrying more than one document. It refuses for the same
+// reason, rather than silently dropping or rearranging what it cannot restore.
+func TestWriteWorkloadID_RefusesAMultiDocumentFile(t *testing.T) {
+	original := `name: my-app
+---
+name: notes-the-user-keeps-here
+`
+	path := writeManifest(t, t.TempDir(), original)
+
+	err := WriteWorkloadID(path, "68b0ffff0000000000000009")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "2 YAML documents")
+	require.NotErrorIs(t, err, ErrUnreadable,
+		"the write-back knows its own file; tagging it unreadable makes its caller contradict itself")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got))
+}
+
+// Removing a binding whose value something else aliases would strand the
+// alias, and the file would never load again.
+func TestClearWorkloadID_RefusesAnAliasedBinding(t *testing.T) {
+	original := "workloadId: &wid 68b0ffff0000000000000009\nname: my-app\nimportance: *wid\n"
+	path := writeManifest(t, t.TempDir(), original)
+
+	cleared, err := ClearWorkloadID(path, "68b0ffff0000000000000009")
+	require.Error(t, err)
+	assert.False(t, cleared)
+	assert.Contains(t, err.Error(), "anchor")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got))
+
+	// The point of refusing: the file still loads.
+	_, err = Load(path)
+	require.NoError(t, err)
+}
+
+// A binding written as an alias is still this project's binding, because that
+// is how the reader resolves it. Matching on the raw node reads the anchor's
+// name, agrees with nothing, and leaves `delete` reporting success over a file
+// as stale as it found it.
+func TestClearWorkloadID_ClearsABindingWrittenAsAnAlias(t *testing.T) {
+	path := writeManifest(t, t.TempDir(),
+		"bindings:\n  primary: &wid 68b0ffff0000000000000009\nworkloadId: *wid\nname: my-app\n")
+
+	// The reader's own answer, which is what the delete compares against.
+	m, err := Load(path)
+	require.NoError(t, err)
+	require.Equal(t, "68b0ffff0000000000000009", m.WorkloadID())
+
+	cleared, err := ClearWorkloadID(path, "68b0ffff0000000000000009")
+	require.NoError(t, err)
+	assert.True(t, cleared)
+
+	after, err := Load(path)
+	require.NoError(t, err)
+	assert.Empty(t, after.WorkloadID())
+}
+
+// The other direction of the same rule: an alias that resolves to a different
+// id is a different project's binding and is left alone.
+func TestClearWorkloadID_LeavesAnAliasResolvingElsewhere(t *testing.T) {
+	original := "bindings:\n  primary: &wid 68b0ffff0000000000000009\nworkloadId: *wid\nname: my-app\n"
+	path := writeManifest(t, t.TempDir(), original)
+
+	cleared, err := ClearWorkloadID(path, "68b0aaaa0000000000000001")
+	require.NoError(t, err)
+	assert.False(t, cleared)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got))
+}
+
+// An anchor nothing refers to is not a reason to refuse.
+func TestClearWorkloadID_AllowsAnUnreferencedAnchor(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), "workloadId: &wid 68b0ffff0000000000000009\nname: my-app\n")
+
+	cleared, err := ClearWorkloadID(path, "68b0ffff0000000000000009")
+	require.NoError(t, err)
+	assert.True(t, cleared)
+}
+
+// Recognized keys are what Parse uses to decide a file is a manifest at all,
+// so a survivor set carrying none of them is a file every later command fails
+// on. workloadId is itself recognized, which is what makes this reachable.
+func TestClearWorkloadID_RefusesWhenNoRecognizedKeySurvives(t *testing.T) {
+	original := "workloadId: 68b0ffff0000000000000009\nsomethingElse: true\n"
+	path := writeManifest(t, t.TempDir(), original)
+
+	cleared, err := ClearWorkloadID(path, "68b0ffff0000000000000009")
+	require.Error(t, err)
+	assert.False(t, cleared)
+	assert.Contains(t, err.Error(), "Delete the file instead",
+		"the remedy for this one is not to remove a line")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got))
+}
+
+// A comment at the bottom of the file stays at the bottom. Hoisting it to the
+// first key is how an edit moves a user's text somewhere they never put it.
+func TestClearWorkloadID_KeepsABottomCommentAtTheBottom(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), `name: my-app
+importance: low
+workloadId: 68b0ffff0000000000000009
+# a note at the very bottom
+`)
+
+	require.NoError(t, clearOK(t, path))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "name: my-app\nimportance: low\n# a note at the very bottom\n", string(got))
+}
+
+// Repeated keys that disagree are refused with a message, not silently: the
+// caller prints what it is given, and "nothing happened" is indistinguishable
+// from "no binding here".
+func TestClearWorkloadID_DisagreeingDuplicatesAreObservable(t *testing.T) {
+	path := writeManifest(t, t.TempDir(), `workloadId: 68b0ffff0000000000000009
+name: my-app
+workloadId: 68b0aaaa0000000000000001
+`)
+
+	cleared, err := ClearWorkloadID(path, "68b0ffff0000000000000009")
+	require.Error(t, err)
+	assert.False(t, cleared)
+	assert.Contains(t, err.Error(), "different values")
 }

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -119,7 +119,7 @@ func reusedArtifactConflict(createErr error, artifactID, projectDir string) erro
 			"only one workload per draft artifact.\n"+
 			"  The link lives in %s and is what makes repeated deploys update one artifact rather than "+
 			"making a new one each time.\n"+
-			"  To deploy to that workload, add 'workloadId: %s' to %s.\n"+
+			"  To deploy to that workload, set 'workloadId: %s' in %s, replacing any already there.\n"+
 			"  To deploy a separate workload from this directory, delete %s: the next run then creates "+
 			"an artifact of its own.\n"+
 			"  %w",
@@ -153,6 +153,20 @@ func workloadOn(artifactID string) string {
 // manifest. The manifest describes what to deploy and is committed; which
 // artifact a particular checkout has been pushing to is local, and writing it
 // into a shared file would have two developers fighting over one draft.
+//
+// A linked artifact is reused only while it can still take this deploy and
+// still says what the file says. Two things end that, and they have one
+// answer. Locking is one-way, so a locked link can take neither new code nor a
+// new image. A spec that has diverged is the other: the link records which
+// artifact this checkout pushes to, not what that artifact contains, and an
+// artifact's spec is fixed when it is created, so reusing a diverged one
+// deploys the frozen answer and reports success. The reconcile path guards
+// that already, in describes(); this path reaches the same artifact by another
+// route and needs the same guard, or editing a port in the file and
+// redeploying changes nothing and says nothing.
+//
+// Either way the answer is the one the roll path already gives: mint a new
+// version, in the lineage the old one belongs to, and move the link onto it.
 func ensureArtifact(loaded Loaded, report *reporter) (version, error) {
 	if !projectLinkedFn(loaded.ProjectDir) {
 		return freshArtifact(loaded, "", labelFirstArtifact, report)
@@ -163,26 +177,51 @@ func ensureArtifact(loaded Loaded, report *reporter) (version, error) {
 		return version{}, fmt.Errorf("cannot read which artifact %s is linked to: %w", loaded.ProjectDir, err)
 	}
 
-	linked, err := getArtifactFn(cfg.ArtifactID)
+	// One read answers every question asked of the linked artifact below:
+	// whether it is locked, which lineage a replacement would join, and whether
+	// its spec still says what the file says. Reading it once per question had
+	// every deploy of a linked project pay several sequential round trips to a
+	// single resource on the way to one decision.
+	linked, err := getArtifactDocFn(cfg.ArtifactID)
 	if err != nil {
-		return version{}, fmt.Errorf("cannot read artifact %s, which this project is linked to: %w", cfg.ArtifactID, err)
+		return version{}, fmt.Errorf(
+			"cannot read artifact %s, which this project is linked to: %w", cfg.ArtifactID, err)
 	}
 
-	if linked == nil || !linked.IsLocked() {
+	// Nothing came back and nothing failed, which says neither that the
+	// artifact can take this deploy nor that it cannot. Reusing it on that
+	// basis rolls out whatever it happens to contain; replacing it discards the
+	// lineage over a fault nobody established. Stopping is the only answer that
+	// does not act on an unread state.
+	if linked == nil {
+		return version{}, fmt.Errorf(
+			"the platform returned nothing for artifact %s, which this project is linked to, so there is no "+
+				"way to tell whether it can still take this deploy", cfg.ArtifactID)
+	}
+
+	if workload.IsLockedStatus(linked.String(keyStatus)) {
+		// Phrased as what the run needs rather than what it did, because the
+		// create below can still fail and a line already claiming the version
+		// exists would be the last thing printed before the error saying it
+		// does not.
+		//
+		// The alternative was telling the reader to delete the state
+		// directory, which works but throws away the catalog and the
+		// last-synced version with it, so the following sync re-uploads a tree
+		// the platform already holds.
+		report.say("  Artifact %s is locked, so this deploy needs a new version.\n", cfg.ArtifactID)
+
+		return freshArtifact(loaded, redraftRepository(loaded, linked), labelNewVersion, report)
+	}
+
+	// Cannot tell reads as yes. Replacing on a comparison that never completed
+	// would discard the artifact this project pushes to over a fault that was
+	// never established, and the read that could have failed already has.
+	if matches, err := specMatches(loaded, linked); err != nil || matches {
 		return version{ID: cfg.ArtifactID}, nil
 	}
 
-	// Locking is one-way, so a locked link can take neither new code nor a new
-	// image and there is nothing to wait for. The answer is the same one the
-	// roll path already gives: this project's next version is a new artifact,
-	// in the lineage the locked one belongs to, and the link moves to it. The
-	// alternative was telling the reader to delete the state directory, which
-	// works but throws away the catalog and the last-synced version with it,
-	// so the following sync re-uploads a tree the platform already holds.
-	// Phrased as what the run needs rather than what it did, because the create
-	// below can still fail and a line already claiming the version exists would
-	// be the last thing printed before the error saying it does not.
-	report.say("  Artifact %s is locked, so this deploy needs a new version.\n", cfg.ArtifactID)
+	report.say("  Artifact %s no longer matches %s; making a new one.\n", cfg.ArtifactID, manifest.FileName)
 
 	return freshArtifact(loaded, redraftRepository(loaded, linked), labelNewVersion, report)
 }
@@ -197,7 +236,10 @@ func ensureArtifact(loaded Loaded, report *reporter) (version, error) {
 // platform answers 422 for one that disagrees. createInRepository would recover
 // from that by retrying without the id, so the cost of not asking is a wasted
 // round trip and a line blaming the repository for something the file did.
-func redraftRepository(loaded Loaded, linked *workload.Artifact) string {
+//
+// The type and the repository are read off the document the caller already
+// has, rather than a typed artifact fetched again for two fields.
+func redraftRepository(loaded Loaded, linked workload.Document) string {
 	wanted, err := loaded.ArtifactType()
 	if err != nil {
 		return ""
@@ -205,12 +247,12 @@ func redraftRepository(loaded Loaded, linked *workload.Artifact) string {
 
 	if !manifest.SameArtifactType(
 		manifest.ArtifactTypeOrDefault(wanted),
-		manifest.ArtifactTypeOrDefault(linked.Type),
+		manifest.ArtifactTypeOrDefault(linked.String(keyType)),
 	) {
 		return ""
 	}
 
-	return linked.ArtifactRepositoryID
+	return linked.String(keyArtifactRepositoryID)
 }
 
 // freshArtifact mints the artifact and points the project at it. The two are

--- a/internal/workload/up/look.go
+++ b/internal/workload/up/look.go
@@ -116,7 +116,11 @@ func Look(workloadID string) (Live, error) {
 	workloadDoc, err := getWorkloadDocFn(workloadID)
 	if err != nil {
 		if isNotFound(err) {
-			return Live{State: StateMissing}, nil
+			// The id travels on even though nothing answers to it. What the
+			// file was bound to is the whole difference between "this creates a
+			// workload" and "the thing you were pointing at is gone", and the
+			// plan is the only place that gets said.
+			return Live{Live: manifest.Live{WorkloadID: workloadID}, State: StateMissing}, nil
 		}
 
 		return Live{}, fmt.Errorf("cannot read workload %s: %w", workloadID, err)

--- a/internal/workload/up/plan.go
+++ b/internal/workload/up/plan.go
@@ -69,10 +69,25 @@ type Plan struct {
 	// cannot actually be deployed onto.
 	State State
 
-	// Creates is a workload that does not exist yet, in which case Artifact
-	// and Runtime are empty: everything in the file is new, and listing it
+	// Creates is a workload the apply has to make rather than reconcile,
+	// because nothing is bound or what was bound is gone. Artifact and Runtime
+	// are empty in that case: everything in the file is new, and listing it
 	// field by field would be noise rather than a plan.
 	Creates bool
+
+	// PriorWorkloadID is the binding this create replaces, set only when the
+	// file named a workload the platform no longer has. A first deploy leaves
+	// it empty. The plan prints it, because a run that creates something where
+	// the file expected to find it is the one case where the user may be
+	// pointed at the wrong instance rather than at a deleted workload.
+	PriorWorkloadID string
+
+	// LinkedArtifact means this project already pushes to an artifact. Whether
+	// a create actually reuses it depends on the build mode: only a build
+	// consults the link, while a manifest naming a published image posts its
+	// artifact inline. Set by the caller rather than computed here, because
+	// this package deliberately never touches the filesystem.
+	LinkedArtifact bool
 
 	Code     CodeChange
 	Artifact []Change
@@ -97,6 +112,53 @@ func (p Plan) Empty() bool {
 		len(p.Artifact) == 0 &&
 		len(p.Runtime) == 0 &&
 		p.State != StateStopped
+}
+
+// creates reports the states whose apply is a create rather than a reconcile.
+//
+// Unbound is the first deploy. Missing is the same answer for a different
+// reason: the file names a workload the platform does not have, and `up` is a
+// reconciler, so a target that no longer exists is drift like any other and
+// the file is what says what should be there. Refusing instead leaves the
+// binding for the user to clear by hand, which is a dead end on exactly the
+// recovery path where it is least welcome.
+//
+// Terminated is deliberately not among them, though it reads like it should
+// be. A terminated workload still exists: the platform returns it, and it goes
+// on holding its name and its artifact. Creating over it collides with the
+// name it still owns, and every line the plan would print about it would be
+// false, starting with the claim that it no longer exists.
+//
+// The risk this trades against is a 404 that means "not here" rather than
+// "deleted": a manifest deployed against the wrong instance, organisation or
+// token resolves to nothing and would be recreated somewhere unintended. That
+// is why the plan names the id it could not find, and why Terraform, which
+// treats a vanished resource the same way, is safe doing it while confirming
+// at apply. `up` announces rather than confirms, so the announcement is what
+// has to carry it.
+func creates(state State) bool {
+	switch state {
+	case StateUnbound, StateMissing:
+		return true
+
+	case StateTerminated, StateStopped, StateSettling, StateRunning, StateErrored:
+		return false
+
+	default:
+		return false
+	}
+}
+
+// priorBinding is the id a create is about to replace. A first deploy has
+// none, and only a binding that resolved to nothing has one worth printing:
+// the plan says which id went missing so a run pointed at the wrong instance
+// reads differently from one recovering a deleted workload.
+func priorBinding(live Live) string {
+	if live.State == StateMissing {
+		return live.WorkloadID
+	}
+
+	return ""
 }
 
 // RollsArtifact reports whether a new artifact version has to be minted and
@@ -140,10 +202,11 @@ func (p Plan) Action() string {
 // and hands over the count.
 func Build(loaded Loaded, live Live, code CodeChange) (Plan, error) {
 	plan := Plan{
-		State:   live.State,
-		Creates: live.State == StateUnbound,
-		Code:    code,
-		Locked:  live.Locked,
+		State:           live.State,
+		Creates:         creates(live.State),
+		PriorWorkloadID: priorBinding(live),
+		Code:            code,
+		Locked:          live.Locked,
 	}
 
 	// Nothing exists to compare against, so every field is trivially an

--- a/internal/workload/up/plan_test.go
+++ b/internal/workload/up/plan_test.go
@@ -330,20 +330,64 @@ func TestBuild_UnboundDoesNotDiff(t *testing.T) {
 	assert.True(t, plan.Code.Changed())
 }
 
-// TestBuild_MissingWorkloadStillPlans: a workload deleted from under the
-// manifest is refused at apply time, but --dry-run still has to say what
-// would have happened, so the plan is computed rather than short-circuited.
-func TestBuild_MissingWorkloadStillPlans(t *testing.T) {
+// TestBuild_MissingWorkloadPlansACreate: a workload deleted from under the
+// manifest is drift, and the apply for it is a create. The plan says so in one
+// line rather than listing every field the file names against an empty live
+// object, which is what a comparison would produce and what a reader would
+// have to wade through.
+func TestBuild_MissingWorkloadPlansACreate(t *testing.T) {
 	plan, err := Build(
 		loadedFrom(planPayload),
-		Live{State: StateMissing},
+		Live{Live: manifest.Live{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"}, State: StateMissing},
 		builtCode(0),
 	)
 	require.NoError(t, err)
 
-	assert.False(t, plan.Creates, "a vanished workload is not a licence to create a second one")
+	assert.True(t, plan.Creates)
 	assert.Equal(t, StateMissing, plan.State)
-	assert.NotEmpty(t, plan.Artifact, "with no live spec, everything the file names is an addition")
+	assert.Equal(t, ActionCreated, plan.Action())
+	assert.Empty(t, plan.Artifact, "a create says so once instead of per field")
+	assert.Empty(t, plan.Runtime)
+}
+
+// TestBuild_MissingWorkloadKeepsTheDeadID: the id the file was bound to is the
+// only thing separating "deleted, recreate it" from "you are pointed at the
+// wrong instance", so the plan has to be able to print it.
+func TestBuild_MissingWorkloadKeepsTheDeadID(t *testing.T) {
+	plan, err := Build(
+		loadedFrom(planPayload),
+		Live{Live: manifest.Live{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"}, State: StateMissing},
+		builtCode(0),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", plan.PriorWorkloadID)
+}
+
+// TestBuild_TerminatedWorkloadIsNotACreate: a terminated workload still
+// exists and still owns its name, so the apply for it is a refusal, not a
+// create. Planning one would announce a name the create would not use and a
+// binding that has not gone anywhere.
+func TestBuild_TerminatedWorkloadIsNotACreate(t *testing.T) {
+	plan, err := Build(
+		loadedFrom(planPayload),
+		Live{Live: manifest.Live{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"}, State: StateTerminated},
+		builtCode(0),
+	)
+	require.NoError(t, err)
+
+	assert.False(t, plan.Creates)
+	assert.Empty(t, plan.PriorWorkloadID)
+}
+
+// TestBuild_FirstDeployHasNoPriorBinding: a create only names an id when it is
+// replacing a binding, so an unbound manifest must not print one.
+func TestBuild_FirstDeployHasNoPriorBinding(t *testing.T) {
+	plan, err := Build(loadedFrom(planPayload), Live{State: StateUnbound}, builtCode(0))
+	require.NoError(t, err)
+
+	assert.True(t, plan.Creates)
+	assert.Empty(t, plan.PriorWorkloadID)
 }
 
 func TestBuild_CarriesCodeAndStateThrough(t *testing.T) {
@@ -450,4 +494,66 @@ func TestBuild_NoTypeInTheFileIsNotDrift(t *testing.T) {
 
 	assert.Empty(t, plan.Artifact)
 	assert.True(t, plan.Empty())
+}
+
+// creates() and deployable() are two switches over the same enum answering two
+// halves of one question: which states an apply may proceed from, and which of
+// those it creates in rather than reconciles. `exhaustive` catches a new State
+// missing from either switch, but not an existing one filed under the wrong
+// branch in only one of them, and the two ways that goes wrong are the two
+// worst outcomes this change has: creating over a workload that is still there,
+// or refusing one that this change exists to recover.
+//
+// So the relationship is asserted rather than left to two lists staying in step
+// by inspection: a state a create can happen in must be a state an apply is
+// allowed to proceed from at all.
+func TestCreates_IsASubsetOfWhatDeployableAllows(t *testing.T) {
+	for _, state := range allStates() {
+		if !creates(state) {
+			continue
+		}
+
+		err := deployable(Live{State: state}, "my-app", "")
+		assert.NoError(t, err, "%s creates but is refused, so nothing can act on the plan", state)
+	}
+}
+
+// The other direction, stated as the classification it is rather than derived,
+// so moving a state between the two branches has to be a deliberate edit here
+// as well. Terminated is the one that reads like it belongs with Missing and
+// does not: the workload still exists, still holds its name and still owns its
+// artifact, so a create collides with the name and every line of the plan about
+// it would be false.
+func TestCreates_ClassifiesEveryState(t *testing.T) {
+	want := map[State]bool{
+		StateUnbound:    true,
+		StateMissing:    true,
+		StateTerminated: false,
+		StateStopped:    false,
+		StateSettling:   false,
+		StateRunning:    false,
+		StateErrored:    false,
+	}
+
+	require.Len(t, want, len(allStates()), "a new State needs a row here")
+
+	for _, state := range allStates() {
+		expected, ok := want[state]
+		require.True(t, ok, "%s is not classified", state)
+		assert.Equal(t, expected, creates(state), "%s", state)
+	}
+}
+
+// allStates is every value of the enum, so a table over it cannot silently miss
+// one that was added since.
+func allStates() []State {
+	return []State{
+		StateUnbound,
+		StateMissing,
+		StateTerminated,
+		StateStopped,
+		StateSettling,
+		StateRunning,
+		StateErrored,
+	}
 }

--- a/internal/workload/up/render.go
+++ b/internal/workload/up/render.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/tui"
 )
 
@@ -112,7 +113,7 @@ func lines(s Summary, plan Plan) []string {
 	var out []string
 
 	if plan.Creates {
-		out = append(out, entry("+", "workload", createDetail(s)))
+		out = append(out, entry("+", "workload", createDetail(s, plan)))
 	}
 
 	// A stopped workload is the one plan whose reason to act is the state
@@ -137,12 +138,68 @@ func lines(s Summary, plan Plan) []string {
 // createDetail names the workload about to be created. The plan is printed
 // before anything happens, and --dry-run prints it instead of acting, so it
 // says what will happen rather than what has.
-func createDetail(s Summary) string {
+//
+// A create that replaces a binding reads differently from a first deploy and
+// has to say so. The file expected to find something and did not, which is
+// either a workload that was deleted, the ordinary case, or a run pointed at
+// an instance that never had it. Naming the id is what lets the reader tell
+// those apart, and it is the only warning there is: the plan is announced and
+// then applied, never confirmed.
+func createDetail(s Summary, plan Plan) string {
 	if s.Name == "" {
+		// Only reachable before a name exists to print; Validate requires one,
+		// so both branches below name the workload.
 		return "will be created, with its first artifact"
 	}
 
-	return s.Name + " will be created, with its first artifact"
+	if plan.PriorWorkloadID == "" {
+		return s.Name + " will be created" + fromArtifact(plan)
+	}
+
+	// The dead binding leads, because it is the warning: the plan is announced
+	// and then applied, never confirmed, so the one line that distinguishes a
+	// deleted workload from a run pointed at the wrong instance has to come
+	// first. Which artifact the new workload comes up on follows it rather than
+	// being dropped, since the flow this most often follows produces both facts
+	// at once: a workload deleted outside the CLI leaves the binding stale and
+	// the artifact link exactly where it was.
+	line := fmt.Sprintf("%s will be created: %s is bound to %s, which no longer exists",
+		s.Name, manifest.FileName, shortID(plan.PriorWorkloadID))
+
+	if !reusesLink(plan) {
+		return line
+	}
+
+	return line + "; it comes up on the artifact this project is linked to"
+}
+
+// fromArtifact says which artifact a create is working from.
+func fromArtifact(plan Plan) string {
+	// A locked link is neither reused nor a first artifact: a new one is made
+	// and the link moves onto it. The lock line below says exactly that, so
+	// this says nothing rather than contradicting it two lines above.
+	if plan.Code.LinkLocked {
+		return ""
+	}
+
+	// Saying "its first artifact" of a project that already pushes to one is
+	// wrong in the flow this most often follows: a delete clears the binding
+	// and leaves the artifact link exactly where it was.
+	if reusesLink(plan) {
+		return ", on the artifact this project is linked to"
+	}
+
+	return ", with its first artifact"
+}
+
+// reusesLink reports whether the create will consult the project's artifact
+// link at all. Only a build does: a manifest naming a published image posts its
+// artifact inline and never reads the state directory, so a project can be
+// linked and still be getting a brand new artifact.
+// A locked link is not reused either: it cannot take code, so the run mints a
+// replacement and moves the project onto that.
+func reusesLink(plan Plan) bool {
+	return plan.LinkedArtifact && plan.Code.Applies && !plan.Code.LinkLocked
 }
 
 // codeDetail says how much of the tree is going up.
@@ -303,6 +360,14 @@ type PlanJSON struct {
 	// caller reading only this document has to be able to see it coming.
 	Locked bool `json:"locked"`
 
+	// PriorWorkloadID is the binding this create replaces, empty on a first
+	// deploy. It is carried because the text plan's warning about a dead
+	// binding is a line on stderr, which nothing machine-readable can gate on:
+	// a CI job whose token resolves to the wrong organisation sees every
+	// workload 404, and without this field its envelope is identical to a
+	// legitimate first deploy.
+	PriorWorkloadID string `json:"priorWorkloadId"`
+
 	Code     CodeJSON `json:"code"`
 	Artifact []string `json:"artifact"`
 	Runtime  []string `json:"runtime"`
@@ -332,10 +397,11 @@ func (p Plan) JSON() PlanJSON {
 	mints := p.MintsVersion()
 
 	return PlanJSON{
-		Action:  p.Action(),
-		State:   p.State.String(),
-		Creates: p.Creates,
-		Locked:  p.Locked && mints,
+		Action:          p.Action(),
+		State:           p.State.String(),
+		Creates:         p.Creates,
+		Locked:          p.Locked && mints,
+		PriorWorkloadID: p.PriorWorkloadID,
 		Code: CodeJSON{
 			Applies:     p.Code.Applies,
 			Changed:     p.Code.Changed(),

--- a/internal/workload/up/render_test.go
+++ b/internal/workload/up/render_test.go
@@ -98,6 +98,23 @@ func TestRender_FirstDeploy(t *testing.T) {
 	assert.Contains(t, out, "~ code       all project files, uploaded for the first time")
 }
 
+// A create that replaces a dead binding is not a first deploy and must not
+// read as one. The plan is announced and then applied without a confirm, so
+// this line is the entire warning a run pointed at the wrong instance gets.
+func TestRender_RecreateNamesTheDeadBinding(t *testing.T) {
+	out := render(t, Summary{Name: "my-app"}, Plan{
+		State:           StateMissing,
+		Creates:         true,
+		PriorWorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0",
+		Code:            CodeChange{Applies: true, FirstDeploy: true},
+	})
+
+	assert.Contains(t, out, "+ workload   my-app will be created: .datarobot.yaml is bound to 68b0c1d2, "+
+		"which no longer exists")
+	assert.NotContains(t, out, "with its first artifact",
+		"this is a replacement for something that existed, not a first deploy")
+}
+
 // TestRender_PublishedImageNeverMentionsCode: a manifest naming an image has
 // no code to sync, and a "0 files changed" line would invite the reader to
 // expect a rebuild that is never going to happen.
@@ -353,4 +370,98 @@ func TestPlanJSON_NoLockFactsWhenNothingIsMinted(t *testing.T) {
 
 	assert.False(t, start.Locked)
 	assert.False(t, start.Code.LinkLocked)
+}
+
+// A project that already pushes to an artifact is not getting its first one.
+// This is the flow a delete leaves behind: the binding is cleared and the
+// artifact link is deliberately left exactly where it was.
+func TestRender_CreateOnALinkedProjectDoesNotClaimAFirstArtifact(t *testing.T) {
+	out := render(t, Summary{Name: "my-app"}, Plan{
+		State:          StateUnbound,
+		Creates:        true,
+		LinkedArtifact: true,
+		Code:           CodeChange{Applies: true, FirstDeploy: true},
+	})
+
+	assert.Contains(t, out, "on the artifact this project is linked to")
+	assert.NotContains(t, out, "with its first artifact")
+}
+
+// The two facts are independent, and the flow a UI-side delete leaves behind
+// produces both: the binding is stale and the artifact link is untouched. A
+// line reporting only the dead binding drops the one thing that says which
+// artifact the new workload comes up on.
+func TestRender_RecreateOnALinkedProjectSaysBoth(t *testing.T) {
+	out := render(t, Summary{Name: "my-app"}, Plan{
+		State:           StateMissing,
+		Creates:         true,
+		PriorWorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0",
+		LinkedArtifact:  true,
+		Code:            CodeChange{Applies: true, FirstDeploy: true},
+	})
+
+	assert.Contains(t, out, "is bound to 68b0c1d2, which no longer exists")
+	assert.Contains(t, out, "it comes up on the artifact this project is linked to")
+}
+
+// A published image consults no link, so a recreate says only what it knows.
+func TestRender_RecreateOnAPublishedImageMentionsNoLink(t *testing.T) {
+	out := render(t, Summary{Name: "my-app"}, Plan{
+		State:           StateMissing,
+		Creates:         true,
+		PriorWorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0",
+		LinkedArtifact:  true,
+		Code:            CodeChange{Applies: false},
+	})
+
+	assert.Contains(t, out, "is bound to 68b0c1d2, which no longer exists")
+	assert.NotContains(t, out, "linked to")
+}
+
+// A locked link is not reused: the run mints a replacement and moves the
+// project onto it, which the lock line says in full. Claiming the create comes
+// up on the linked artifact two lines above that is a plan contradicting
+// itself, and the reader has no way to tell which half is true.
+func TestRender_LockedLinkIsNotDescribedAsReused(t *testing.T) {
+	out := render(t, Summary{Name: "my-app"}, Plan{
+		State:          StateUnbound,
+		Creates:        true,
+		LinkedArtifact: true,
+		Code:           CodeChange{Applies: true, FirstDeploy: true, LinkLocked: true},
+	})
+
+	assert.NotContains(t, out, "on the artifact this project is linked to")
+	assert.NotContains(t, out, "with its first artifact",
+		"a project that already pushes to an artifact is not getting its first")
+	assert.Contains(t, out, "pushes to that instead", "the lock line is what explains this create")
+}
+
+// The same rule on the recreate line, which carries the dead binding first and
+// the artifact fact second.
+func TestRender_RecreateOnALockedLinkClaimsNoReuse(t *testing.T) {
+	out := render(t, Summary{Name: "my-app"}, Plan{
+		State:           StateMissing,
+		Creates:         true,
+		PriorWorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0",
+		LinkedArtifact:  true,
+		Code:            CodeChange{Applies: true, FirstDeploy: true, LinkLocked: true},
+	})
+
+	assert.Contains(t, out, "is bound to 68b0c1d2, which no longer exists")
+	assert.NotContains(t, out, "it comes up on the artifact this project is linked to")
+}
+
+// A manifest naming a published image posts its artifact inline and never
+// consults the link, so a linked project really is getting a new artifact.
+// Claiming otherwise would describe a reuse that does not happen.
+func TestRender_LinkedProjectOnAPublishedImageStillGetsANewArtifact(t *testing.T) {
+	out := render(t, Summary{Name: "my-app"}, Plan{
+		State:          StateUnbound,
+		Creates:        true,
+		LinkedArtifact: true,
+		Code:           CodeChange{Applies: false},
+	})
+
+	assert.Contains(t, out, "with its first artifact")
+	assert.NotContains(t, out, "linked to")
 }

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -163,9 +163,13 @@ func Run(opts Options) (Result, error) {
 		return Result{}, err
 	}
 
+	// Read here rather than in Build, which is kept off the filesystem so its
+	// tests can stay there too.
+	plan.LinkedArtifact = projectLinkedFn(loaded.ProjectDir)
+
 	result := Result{
 		Plan:       plan,
-		WorkloadID: live.WorkloadID,
+		WorkloadID: boundID(live),
 		Name:       name(loaded, live),
 		Status:     plan.State.String(),
 		Endpoint:   live.Endpoint,
@@ -189,7 +193,7 @@ func Run(opts Options) (Result, error) {
 	}
 
 	if plan.Empty() {
-		return lockOnly(live, result, opts)
+		return lockOnly(loaded, live, result, opts)
 	}
 
 	return apply(loaded, live, plan, result, opts)
@@ -210,12 +214,16 @@ func Run(opts Options) (Result, error) {
 // healthy workload. Only a stopped one is excluded by Empty itself; an errored
 // workload with no drift still lands here, and locking cannot be undone, so
 // this refuses rather than making something permanent out of something broken.
-func lockOnly(live Live, result Result, opts Options) (Result, error) {
+func lockOnly(loaded Loaded, live Live, result Result, opts Options) (Result, error) {
 	if !opts.Lock || result.Locked {
 		return result, nil
 	}
 
-	if err := deployable(live, result.Name); err != nil {
+	// loaded is threaded through for the remedy a refusal names: a terminated
+	// workload is cleared by `dr workload delete`, and that command only finds
+	// this project's manifest if the message carries the same --dir the deploy
+	// was given.
+	if err := deployable(live, result.Name, dirFlagFor(loaded)); err != nil {
 		return result, err
 	}
 
@@ -324,6 +332,41 @@ func load(dir string, opts Options) (Loaded, error) {
 	return Load(dir)
 }
 
+// boundID is the workload this run is about, for the envelope and for a
+// failure that has to report something.
+//
+// A binding that resolved to nothing is deliberately not it. Nothing answers
+// to that id, so handing it to a caller gives them something whose only use is
+// a 404, and a run that then fails to create would have reported a workload
+// that has never existed. The create overwrites this on success; the plan
+// carries the dead id separately, for a reader rather than for a script.
+//
+// Keyed on the state rather than on plan.PriorWorkloadID, which today tracks
+// the same thing. Deciding what the envelope reports by testing a render field
+// welds the two together across files: the moment anything populates that
+// field for a second state, this empties WorkloadID, reportable() goes false,
+// and the whole JSON document disappears from stdout on a failed run.
+func boundID(live Live) string {
+	if live.State == StateMissing {
+		return ""
+	}
+
+	return live.WorkloadID
+}
+
+// dirFlagFor is the " --dir <path>" a remedy has to carry to reach this
+// project, and empty when the working directory already does.
+//
+// A message that names `dr workload delete <id>` without it is false in
+// exactly the layout --dir was added for: a project one level down is
+// invisible to a search that only walks upward, so the command runs, finds
+// nothing, and prints nothing. `delete` prints the same suffix back at `up`,
+// so both go through one implementation rather than two notions of "already
+// there" that can disagree about one directory.
+func dirFlagFor(loaded Loaded) string {
+	return manifest.DirFlag(loaded.ProjectDir)
+}
+
 // name is what to call this workload: the live one's name once it exists, the
 // file's before that.
 func name(loaded Loaded, live Live) string {
@@ -336,7 +379,7 @@ func name(loaded Loaded, live Live) string {
 
 // apply carries out the plan, or explains why it cannot.
 func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Result, error) {
-	if err := deployable(live, result.Name); err != nil {
+	if err := deployable(live, result.Name, dirFlagFor(loaded)); err != nil {
 		return result, err
 	}
 
@@ -401,20 +444,29 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 }
 
 // deployable refuses the live states that cannot take a deploy, one message
-// each. None of them are guesses: a workload that is gone stays gone, and one
-// that is unsettled may still be on its way somewhere.
+// each. None is a guess: an unsettled workload may still be on its way
+// somewhere, an errored one has nothing safe underneath it, and a terminated
+// one is not coming back.
 //
-// Stopped is not among them. A stopped workload is one POST away from being
-// deployable, and `up` means "make the file true", which for something that
-// is not running means starting it.
-func deployable(live Live, workloadName string) error {
+// Missing is not among them. A binding that resolves to nothing is drift, and
+// the apply for it is a create; the plan says which id went missing so a
+// wrong-instance run is visible rather than silent.
+//
+// Terminated is, even though it too names something that will never run again.
+// The difference is that it still exists: it holds its name and its artifact,
+// so a create collides with itself, and the message has to name the one thing
+// that clears the way rather than pretend the workload is gone.
+//
+// Stopped is not among them either. A stopped workload is one POST away from
+// being deployable, and `up` means "make the file true", which for something
+// that is not running means starting it.
+func deployable(live Live, workloadName, dirFlag string) error {
 	switch live.State {
-	case StateMissing, StateTerminated:
+	case StateTerminated:
 		return fmt.Errorf(
-			"the workload this manifest is bound to is %s. "+
-				"Bind to a live one with 'dr workload config --workload-id <id>', or remove workloadId from %s "+
-				"to create a new workload on the next deploy",
-			live.State, manifest.FileName)
+			"workload %s is terminated, which cannot be undone, and it still holds its name and artifact. "+
+				"Remove it with 'dr workload delete %s%s', which also clears the binding in %s, then deploy again",
+			workloadName, live.WorkloadID, dirFlag, manifest.FileName)
 
 	case StateErrored:
 		return fmt.Errorf(
@@ -427,7 +479,7 @@ func deployable(live Live, workloadName string) error {
 			"workload %s is still settling. Wait for it to finish, then deploy",
 			workloadName)
 
-	case StateUnbound, StateRunning:
+	case StateUnbound, StateMissing, StateRunning:
 		return nil
 
 	case StateStopped:
@@ -493,7 +545,8 @@ func create(
 	if err := writeWorkloadIDFn(loaded.Path, created.ID); err != nil {
 		return result, fmt.Errorf(
 			"workload %s was created but its id could not be written to %s. "+
-				"Add 'workloadId: %s' by hand, or the next deploy will create a second workload: %w",
+				"Set 'workloadId: %s' by hand, replacing any workloadId already there, "+
+				"or the next deploy will create a second workload: %w",
 			created.ID, loaded.Path, created.ID, err)
 	}
 
@@ -598,7 +651,8 @@ func nameTaken(createErr error, workloadName, path string) error {
 
 		return fmt.Errorf(
 			"a workload named %s already exists (%s) and nothing was deployed onto it. "+
-				"If it is this project's, add 'workloadId: %s' to %s and deploy again, which will print "+
+				"If it is this project's, set 'workloadId: %s' in %s, replacing any already there, "+
+				"and deploy again, which will print "+
 				"what would change before changing it. If it is not, rename this one in %s: %w",
 			workloadName, existing[i].ID, existing[i].ID, path, path, createErr)
 	}

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -87,6 +87,38 @@ runtime:
           resourceAllocation: {cpu: 0.5, memory: 512MB}
 `
 
+// linkedArtifactDoc is the artifact unboundDockerfileManifest describes, in the
+// shape the comparison expects to find it. A test that leaves this out is not
+// testing reuse: the failed read folds into "reuse it" and the comparison never
+// runs, so the assertion passes for the wrong reason.
+//
+// The kind sits inside the spec because that is where the manifest above puts
+// it, and the two sides have to agree for a match. A real platform hoists it to
+// the document root, so a manifest spelling it here and an artifact returning it
+// there never match and the project mints an artifact per deploy. That is not
+// this change's to fix; the fixture mirrors the manifest so these tests measure
+// what they say they measure.
+func linkedArtifactDoc(id string) (workload.Document, error) {
+	return workload.Document{
+		"id":     id,
+		"status": workload.ArtifactStatusDraft,
+		"spec": map[string]any{
+			"type": "service",
+			"containerGroups": []any{map[string]any{
+				"name": "default",
+				"containers": []any{map[string]any{
+					"name":    "primary",
+					"primary": true,
+					"port":    float64(8080),
+					"imageBuildConfig": map[string]any{
+						"dockerfile": map[string]any{"source": "provided"},
+					},
+				}},
+			}},
+		},
+	}, nil
+}
+
 // boundArtifactManifest names an artifact the platform already holds instead
 // of describing one. There is no container to read a build mode from, so the
 // mode is empty, and the create is the same single POST as a published image.
@@ -636,7 +668,6 @@ func TestRun_RefusesTheStatesThatCannotTakeADeploy(t *testing.T) {
 		status string
 		want   string
 	}{
-		{workload.WorkloadStatusTerminated, "remove workloadId"},
 		{workload.WorkloadStatusErrored, "dr workload logs"},
 		{workload.WorkloadStatusProvisioning, "still settling"},
 	}
@@ -664,10 +695,103 @@ func TestRun_RefusesTheStatesThatCannotTakeADeploy(t *testing.T) {
 	}
 }
 
-func TestRun_MissingWorkloadNamesTheRebind(t *testing.T) {
+// TestRun_MissingWorkloadIsRecreated is the reported bug: a workload deleted
+// out from under the manifest used to leave the user with a binding only a
+// hand edit could clear. It is drift, so the deploy recreates and rebinds.
+func TestRun_MissingWorkloadIsRecreated(t *testing.T) {
+	var writtenID string
+
 	install(t, fakes{
 		workloadD: func(string) (workload.Document, error) {
 			return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
+		},
+		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		writeID: func(_, id string) error {
+			writtenID = id
+
+			return nil
+		},
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return running("wl-new"), nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + unboundImageManifest
+
+	result, _, err := runIn(t, bound, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, "wl-new", result.WorkloadID)
+	assert.Equal(t, ActionCreated, result.Action)
+	assert.Equal(t, "wl-new", writtenID, "the stale binding is replaced, not left for the user")
+}
+
+// TestRun_MissingWorkloadNamesTheDeadBinding: recreating is right when the
+// workload was deleted and wrong when the run is pointed at an instance that
+// never had it. `up` cannot tell those apart from a 404, and it applies
+// without confirming, so naming the id it could not find is the only warning
+// the wrong-instance case gets.
+func TestRun_MissingWorkloadNamesTheDeadBinding(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
+		},
+		create:  func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		writeID: func(string, string) error { return nil },
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return running("wl-new"), nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + unboundImageManifest
+
+	_, stderr, err := runIn(t, bound, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "no longer exists")
+	assert.Contains(t, stderr, "68b0c1d2", "the dead id is what tells a deletion from a wrong endpoint")
+}
+
+// TestRun_FailedRecreateReportsNoWorkloadID: a create that fails leaves
+// nothing behind, and the id the file was bound to answers to nothing either.
+// Reporting it in the envelope would hand a caller an id whose only use is a
+// 404.
+func TestRun_FailedRecreateReportsNoWorkloadID(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
+		},
+		create: func(any) (*workload.Workload, error) {
+			return nil, errors.New("platform said no")
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + unboundImageManifest
+
+	result, _, err := runIn(t, bound, Options{NonInteractive: true})
+	require.Error(t, err)
+
+	assert.Empty(t, result.WorkloadID, "the dead binding is not this run's workload")
+}
+
+// TestRun_TerminatedWorkloadIsRefused: terminated looks like missing from the
+// file's side and is not. The workload still exists, still holds its name and
+// still owns its artifact, so a create would collide with it, and every line a
+// create plan prints about it would be false. The message names the one thing
+// that clears the way.
+func TestRun_TerminatedWorkloadIsRefused(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			return workload.Document{
+				"id": "68b0c1d2e3f4a5b6c7d8e9f0", "name": "my-app",
+				"status": workload.WorkloadStatusTerminated,
+			}, nil
+		},
+		artifactD: func(string) (workload.Document, error) { return nil, nil },
+		create: func(any) (*workload.Workload, error) {
+			t.Fatal("a terminated workload still owns its name; creating over it collides")
+
+			return nil, nil
 		},
 	})
 
@@ -675,8 +799,32 @@ func TestRun_MissingWorkloadNamesTheRebind(t *testing.T) {
 
 	_, _, err := runIn(t, bound, Options{NonInteractive: true})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--workload-id")
-	assert.Contains(t, err.Error(), "remove workloadId")
+
+	assert.Contains(t, err.Error(), "terminated")
+	assert.Contains(t, err.Error(), "dr workload delete 68b0c1d2e3f4a5b6c7d8e9f0",
+		"the remedy has to be one that works, and deleting it also clears the binding")
+}
+
+// A refusal must not have announced a create, because nothing is being
+// created and the name it would print is the dead workload's.
+func TestRun_TerminatedWorkloadDoesNotAnnounceACreate(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			return workload.Document{
+				"id": "68b0c1d2e3f4a5b6c7d8e9f0", "name": "old-name",
+				"status": workload.WorkloadStatusTerminated,
+			}, nil
+		},
+		artifactD: func(string) (workload.Document, error) { return nil, nil },
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + unboundImageManifest
+
+	_, stderr, err := runIn(t, bound, Options{NonInteractive: true})
+	require.Error(t, err)
+
+	assert.NotContains(t, stderr, "will be created")
+	assert.NotContains(t, stderr, "no longer exists", "it does still exist")
 }
 
 // track records what the build path did, in order, so a test can pin the
@@ -797,6 +945,7 @@ func TestRun_LinkedProjectReusesItsArtifact(t *testing.T) {
 	f.getArtifact = func(id string) (*workload.Artifact, error) {
 		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
 	}
+	f.artifactD = linkedArtifactDoc
 	f.newArtifact = func(any) (*workload.Artifact, error) {
 		t.Fatal("the project is already linked; a second artifact would orphan the first")
 
@@ -825,6 +974,7 @@ func TestRun_ConflictOnAReusedArtifactExplainsTheLink(t *testing.T) {
 	f.getArtifact = func(id string) (*workload.Artifact, error) {
 		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
 	}
+	f.artifactD = linkedArtifactDoc
 	f.create = func(any) (*workload.Workload, error) {
 		return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
 	}
@@ -856,6 +1006,7 @@ func TestRun_NameConflictOnALinkedProjectKeepsItsOwnMessage(t *testing.T) {
 	f.getArtifact = func(id string) (*workload.Artifact, error) {
 		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
 	}
+	f.artifactD = linkedArtifactDoc
 	f.create = func(any) (*workload.Workload, error) {
 		return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
 	}
@@ -900,6 +1051,16 @@ func lockedLink(f fakes, tr *track) fakes {
 	f.getArtifact = func(id string) (*workload.Artifact, error) {
 		return &workload.Artifact{
 			ID: id, Status: workload.ArtifactStatusLocked, ArtifactRepositoryID: "repo-1",
+		}, nil
+	}
+	// The same artifact as the server sends it. One read answers the lock, the
+	// lineage and the spec, so the document is what the deploy actually reads.
+	f.artifactD = func(id string) (workload.Document, error) {
+		return workload.Document{
+			"id":                   id,
+			"status":               workload.ArtifactStatusLocked,
+			"artifactRepositoryId": "repo-1",
+			"type":                 "service",
 		}, nil
 	}
 	f.save = relinkStep(tr)
@@ -1173,6 +1334,7 @@ func linkedAndSynced(tr *track) fakes {
 	f.getArtifact = func(id string) (*workload.Artifact, error) {
 		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
 	}
+	f.artifactD = linkedArtifactDoc
 	f.sync = func(string) (*sync.Result, error) {
 		tr.steps = append(tr.steps, "sync")
 
@@ -1803,4 +1965,214 @@ func TestDefaultCodeChange_SaysNothingForTheCurrentIgnoreFileName(t *testing.T) 
 
 	assert.True(t, code.FirstDeploy)
 	assert.Empty(t, code.IgnoreNotice)
+}
+
+// TestRun_LinkedArtifactThatNoLongerMatchesIsReplaced is the recovery flow the
+// missing-binding recreate advertises. The link records which artifact this
+// checkout pushes to, not what that artifact holds, and an artifact's spec is
+// fixed at creation. Reusing one whose spec has since diverged deploys the
+// frozen answer and reports success, so the edit the user just made never
+// leaves the machine.
+func TestRun_LinkedArtifactThatNoLongerMatchesIsReplaced(t *testing.T) {
+	var tr track
+
+	f := wiredBuild(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = func(string) (wapi.Config, error) { return wapi.Config{ArtifactID: "art-stale"}, nil }
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
+	}
+	f.save = func(_ string, cfg wapi.Config) error {
+		tr.linkedTo = wapi.InitOptions{ArtifactID: cfg.ArtifactID}
+
+		return nil
+	}
+	// The live artifact says port 9999; the manifest says 8080.
+	f.artifactD = func(string) (workload.Document, error) {
+		return workload.Document{"spec": map[string]any{
+			"type": "service",
+			"containerGroups": []any{map[string]any{
+				"name": "default",
+				"containers": []any{map[string]any{
+					"name": "primary", "primary": true, "port": 9999,
+				}},
+			}},
+		}}, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, tr.steps, "create-artifact",
+		"a linked artifact that no longer says what the file says has to be replaced, not reused")
+	assert.NotEqual(t, "art-stale", decodePayload(t, tr.workloadIn)["artifactId"])
+	assert.Equal(t, decodePayload(t, tr.workloadIn)["artifactId"], tr.linkedTo.ArtifactID,
+		"the project has to end up pointing at the artifact it just deployed")
+}
+
+// divergedLink is a project whose linked artifact still takes code but no
+// longer says what the file says: it holds port 9999 where the manifest asks
+// for 8080. The repository is the lineage the replacement has to join, exactly
+// as it is for a locked one.
+func divergedLink(f fakes, tr *track) fakes {
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("art-stale")
+	f.artifactD = func(id string) (workload.Document, error) {
+		return workload.Document{
+			"id":                   id,
+			"status":               workload.ArtifactStatusDraft,
+			"artifactRepositoryId": "repo-1",
+			"type":                 "service",
+			"spec": map[string]any{
+				"containerGroups": []any{map[string]any{
+					"name": "default",
+					"containers": []any{map[string]any{
+						"name": "primary", "primary": true, "port": 9999,
+					}},
+				}},
+			},
+		}, nil
+	}
+	f.save = relinkStep(tr)
+
+	return f
+}
+
+// A spec that has diverged and a lock that cannot be undone are two reasons for
+// the same act, so the replacement they produce has to be the same one. Locking
+// got the lineage right and this route reached the create by a different path,
+// which is where the two could quietly come apart: a replacement that opens a
+// repository of its own leaves the Registry with a second entry under the same
+// name, and the workload's versions stop reading as versions of one thing.
+func TestRun_ReplacementForADivergedSpecJoinsTheSameLineage(t *testing.T) {
+	var tr track
+
+	install(t, divergedLink(wiredBuild(&tr), &tr))
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	payload, ok := tr.artifactIn.(json.RawMessage)
+	require.True(t, ok, "the create has to have been given the artifact block")
+	assert.Contains(t, string(payload), "repo-1")
+
+	assert.Equal(t, "art-1", tr.savedCfg.ArtifactID, "the link moves to what the run just made")
+	require.NotNil(t, tr.savedCfg.CatalogID, "the code store has to survive the replacement")
+	assert.Equal(t, "cat1", *tr.savedCfg.CatalogID)
+}
+
+// The other half of that equivalence. The tree was already synced into the
+// artifact the file has since diverged from, so the sync onto its replacement
+// can find nothing to upload and the new version would go to the builder with
+// no code reference at all. The code the old one was running is carried across
+// instead, which is what makes this a new version of the same code rather than
+// a build of nothing.
+func TestRun_ReplacementForADivergedSpecInheritsTheSyncedCode(t *testing.T) {
+	var tr track
+
+	f := divergedLink(wiredBuild(&tr), &tr)
+	f.sync = emptySync(&tr)
+	f.codeRef = carryCodeStep(&tr)
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"art-1", "cat1", "ver1"}, tr.carried)
+	assert.Contains(t, tr.steps, "carry-code")
+}
+
+// A read that fails is not a difference. Minting on it would orphan the
+// artifact this project pushes to because of a timeout, so the run stops and
+// names the artifact it could not read instead of guessing either way.
+//
+// The lock check and the spec comparison are one read, so there is one failure
+// to answer rather than two, and reusing an artifact whose state was never
+// established is no better than replacing it: the sync that follows fetches the
+// same artifact and would fail a step later with a worse message.
+func TestRun_UnreadableLinkedArtifactStopsRatherThanGuessing(t *testing.T) {
+	var tr track
+
+	f := wiredBuild(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = func(string) (wapi.Config, error) { return wapi.Config{ArtifactID: "art-existing"}, nil }
+	f.artifactD = func(string) (workload.Document, error) { return nil, errors.New("gateway timeout") }
+	f.newArtifact = func(any) (*workload.Artifact, error) {
+		t.Fatal("a timeout is not a reason to start a new artifact lineage")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "art-existing", "the artifact the link names")
+	assert.Contains(t, err.Error(), "linked to")
+	assert.Contains(t, err.Error(), "gateway timeout", "the platform's own reason has to survive")
+	assert.Nil(t, tr.workloadIn, "nothing is deployed on a state that was never established")
+}
+
+// StateMissing is the one state this change converted from a refusal into a
+// mutating create, so --dry-run over it is the combination that most needs
+// holding: a dry run that creates would be the worst possible regression here.
+func TestRun_DryRunOnAMissingBindingMutatesNothing(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
+		},
+		create: func(any) (*workload.Workload, error) {
+			t.Fatal("--dry-run must not create a workload")
+
+			return nil, nil
+		},
+		writeID: func(string, string) error {
+			t.Fatal("--dry-run must not rebind the manifest")
+
+			return nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + unboundImageManifest
+
+	result, stderr, err := runIn(t, bound, Options{NonInteractive: true, DryRun: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "no longer exists")
+	assert.Equal(t, ActionCreated, result.Action, "the plan still says what it would do")
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", result.Plan.PriorWorkloadID)
+}
+
+// A create that reports no id cannot be linked to. SaveConfig does not
+// validate the way Initialize does, so relinking to an empty id wrote a
+// config.json every later command rejected as corrupt: the run failed anyway,
+// but two steps later and having damaged the project on the way.
+func TestRun_ArtifactCreatedWithoutAnIDIsRefusedBeforeLinking(t *testing.T) {
+	var tr track
+
+	f := wiredBuild(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = func(string) (wapi.Config, error) { return wapi.Config{ArtifactID: "art-stale"}, nil }
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
+	}
+	f.artifactD = func(string) (workload.Document, error) {
+		return workload.Document{"spec": map[string]any{"type": "service"}}, nil
+	}
+	f.newArtifact = func(any) (*workload.Artifact, error) { return &workload.Artifact{ID: ""}, nil }
+	f.save = func(string, wapi.Config) error {
+		t.Fatal("nothing may be written when there is no id to write")
+
+		return nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reported no id")
 }

--- a/internal/workload/up/state.go
+++ b/internal/workload/up/state.go
@@ -28,14 +28,33 @@ const (
 	StateUnbound State = iota
 
 	// StateMissing is a manifest naming a workload the platform does not
-	// have, usually because it was deleted from the UI. `up` errors and
-	// names the fix rather than quietly creating a second workload, because
-	// creating one would leave the user with two things called the same and
-	// no idea which one their URL points at.
+	// have, usually because it was deleted from the UI or with
+	// `dr workload delete`. It is drift like any other: the file says what
+	// should exist, so `up` creates it and the plan names the id that went
+	// missing.
+	//
+	// This reverses an earlier rule that refused and told the user to rebind
+	// or clear the id by hand. The reasoning behind that rule does not hold:
+	// it feared leaving two workloads of the same name with no way to tell
+	// which one the URL pointed at, but a 404 means the first one is gone, so
+	// there is no pair. What refusing did produce was a dead end, on the
+	// recovery path, pointing at a `config --workload-id` that will not edit
+	// an existing manifest.
+	//
+	// The hazard that is real: a 404 also means "not on this instance". A
+	// manifest deployed against the wrong endpoint, organisation or token
+	// resolves to nothing and is recreated somewhere unintended. Refusing
+	// everyone to catch that case was the wrong trade, so the plan names the
+	// missing id instead. That line is the whole warning, because the plan is
+	// announced and applied without a confirm.
 	StateMissing
 
 	// StateTerminated is the end of a workload's life and is not restartable.
-	// Treated like StateMissing: rebind or clear the id.
+	// It is not treated like StateMissing, though the two look alike from the
+	// file's side. A terminated workload still exists: the platform returns
+	// it, and it keeps its name and its artifact, so creating over it collides
+	// with the name it still owns. `up` refuses and names the one thing that
+	// clears the way, which is deleting it.
 	StateTerminated
 
 	// StateStopped covers stopped, suspended and interrupted. `up` starts it

--- a/internal/workload/up/version.go
+++ b/internal/workload/up/version.go
@@ -150,6 +150,15 @@ func createVersion(loaded Loaded, repositoryID, label string, report *reporter) 
 			repositoryID)
 	}
 
+	// An id is the whole of what a link records, and SaveConfig does not
+	// validate the way Initialize does: linking to an empty one writes a
+	// config.json every later command rejects as corrupt. Refusing here keeps a
+	// malformed response from turning into damaged local state, and keeps the
+	// dereference below from panicking on a body that decoded to null.
+	if created == nil || created.ID == "" {
+		return version{}, errors.New("the platform accepted the artifact but reported no id for it")
+	}
+
 	return version{ID: created.ID, Fresh: true}, nil
 }
 
@@ -351,20 +360,38 @@ func joinable(draft *workload.Artifact, repositoryID string) bool {
 // nobody promotes; promoting one whose spec was never confirmed costs a
 // rollout of the wrong thing.
 func describes(loaded Loaded, artifactID string) bool {
-	payload, err := loaded.Compiled.ArtifactPayload()
+	doc, err := getArtifactDocFn(artifactID)
 	if err != nil {
 		return false
+	}
+
+	matches, err := specMatches(loaded, doc)
+
+	return err == nil && matches
+}
+
+// specMatches is describes with the failure kept separate, for a caller whose
+// answer to "cannot tell" is not the same as its answer to "no".
+//
+// Reusing a draft that might not match costs a rollout of the wrong thing, so
+// describes folds an unreadable artifact into "no". Replacing one costs the
+// artifact being replaced, so a caller that mints on "no" must not mint on a
+// fault: that orphans the artifact the project is pushing to and starts the
+// lineage again for a reason that was never established.
+//
+// The document is passed in rather than fetched, so a caller that already has
+// it, or that needs the lock status off the same read, pays one round trip
+// instead of two to the same resource.
+func specMatches(loaded Loaded, doc workload.Document) (bool, error) {
+	payload, err := loaded.Compiled.ArtifactPayload()
+	if err != nil {
+		return false, err
 	}
 
 	var want map[string]any
 
 	if err := json.Unmarshal(payload, &want); err != nil {
-		return false
-	}
-
-	doc, err := getArtifactDocFn(artifactID)
-	if err != nil {
-		return false
+		return false, err
 	}
 
 	// The name is the CLI's own, derived from the workload's, and the block
@@ -386,7 +413,7 @@ func describes(loaded Loaded, artifactID string) bool {
 	// leaves everything the file still mentions matching, the leftover is
 	// reused, and it is rolled out still carrying the variable that was
 	// deleted, which minting a fresh artifact would have dropped.
-	return len(Subset(want, doc)) == 0 && len(Extra(want, doc)) == 0
+	return len(Subset(want, doc)) == 0 && len(Extra(want, doc)) == 0, nil
 }
 
 // linkProject points the project at the new version, so the sync uploads into


### PR DESCRIPTION
# RATIONALE

`dr workload delete` removed the workload on the server and left behind the `workloadId` it had written into `.datarobot.yaml`. The next `dr workload up` was bound to something that no longer existed, and the only way out was hand-editing a file marked `# managed by the CLI`.

It bites on the recovery path, which is the worst place for it: the realistic sequence is a first deploy going wrong, deleting the broken workload to start clean, and then finding the CLI's own state stale.

Two things in the ticket did not survive contact with the code, and they changed what got built. `up` did not silently target the dead id, it errored and named two remedies. But one of them, `dr workload config --workload-id <id>`, is refused whenever a manifest exists, so the error pointed at a command that will not act.

# CHANGES

**`dr workload delete` clears a binding it can prove is its own.** The id is compared inside the same parse that removes it, so a concurrent `up` cannot have a fresh binding deleted by a check that saw a different value. It gained `--dir`, without which it never finds the manifest of a project deployed with `up --dir site` and deleted from the repository root, which is the reported reproduction. A 404 deliberately leaves the file alone: it means the workload is not on *this* instance, which is not proof the binding is stale.

**`up` treats a binding that resolves to nothing as drift and creates.** This reverses the rule recorded in `state.go` and in RAPTOR-18979's live-state table, so it is the part most worth a reviewer's attention; 18979 has been amended to match. That rule feared leaving two workloads of one name, but a 404 means the first is gone. The hazard that is real is a 404 meaning "not on this instance", so the plan line and the JSON envelope both name the id that went missing, which is what lets CI tell a wrong-org run from a legitimate first deploy.

**A terminated workload is still refused.** It continues to exist and to hold its name and its artifact, so a create collides with it. Folding it in with "missing" also made `up --lock` silently skip locking on a one-way operation.

**`up` mints a new artifact when the linked one no longer matches the file.** An artifact's spec is fixed at creation, so reusing a diverged one deployed the frozen answer and reported success. A read that fails is not treated as a difference, so a timeout never starts a new artifact lineage.

**The shared manifest edit layer stops losing things the user owns:** comments above and below the binding, and the line endings of a CRLF checkout. It refuses, with the reason and a remedy, on four shapes it cannot make sound again: an aliased binding, disagreeing repeated keys, a file whose only recognized key is the binding, and a multi-document file.

## NOTES

Larger than the usual budget at ~1.8k lines. Roughly half is the fixes from a `/code-review max` pass that found 15 issues, and unpicking those from the code they fix would not leave two reviewable commits.

`.datarobot/workload/` is deliberately left alone. It binds the project to an *artifact*, not to a workload, and the artifact survives the deletion. `delete` names it rather than removing it.

## RELATED

- RAPTOR-18979 — live-state row amended for the reversal above
- RAPTOR-19595 — the state directory has no lifecycle, and `rm -rf` is the documented answer in three places
- RAPTOR-19602 — a refused deploy still prints a plan and a `Next:` block for work it will not do
- RAPTOR-19604 — `fsutil.AtomicWriteFile` replaces a symlink instead of writing through it

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787658016.790379 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Reverses `up` so a 404 binding becomes an unconfirmed create, which can deploy to the wrong instance/org; it also rewrites user-owned YAML. Terminated workloads stay refused and the plan/JSON name the missing id.
> 
> **Overview**
> **`dr workload delete` takes back the `workloadId` it wrote** when the located `.datarobot.yaml` names that exact id, so the next `up` is not bound to a gone workload. Adds `--dir` so a project deployed from a subdirectory is found. A 404 does not rewrite the file. The `.datarobot/` artifact link is left in place and named on stderr.
> 
> **`up` now treats a missing binding as drift and creates**, instead of refusing and asking for a hand edit. The plan and JSON `priorWorkloadId` name the id that 404’d so a wrong-instance run is visible. Terminated workloads still exist and are refused, with a remedy that points at `delete` (including `--dir` when needed).
> 
> **Linked artifacts are reused only while their spec still matches the file.** A mismatch mints a new artifact and relinks without wiping the sync baseline; a failed read is not treated as a mismatch, so a timeout does not start a new lineage.
> 
> Manifest edits share a safer read-modify-write: comments and CRLF are preserved; aliased bindings, disagreeing duplicate keys, emptying the file, and multi-document YAML are refused rather than rewritten.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c2dcd4ded2af24f9e39418893f6637ca2bbbbf4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->