### PR TITLE
[RAPTOR-19648] fix(workload): deploy past a locked artifact instead of refusing

### DIFF
--- a/cmd/artifact/code/codesync/cmd.go
+++ b/cmd/artifact/code/codesync/cmd.go
@@ -48,6 +48,7 @@ type engineRunner interface {
 	StaleRollbackRestored() bool
 	StateMigrationNotice() string
 	IgnoreFileNotice() string
+	LockedNotice() string
 	Fetcher() display.ContentFetcher
 }
 
@@ -192,6 +193,7 @@ func runSync(cmd *cobra.Command, outputFormat outputformat.OutputFormat, deps De
 	// and stdout has to stay parseable under --output-format json.
 	format.StateNotice(cmd.ErrOrStderr(), engine.StateMigrationNotice())
 	format.StateNotice(cmd.ErrOrStderr(), engine.IgnoreFileNotice())
+	format.StateNotice(cmd.ErrOrStderr(), engine.LockedNotice())
 
 	if engine.StaleRollbackRestored() {
 		fmt.Fprintln(cmd.ErrOrStderr(), tui.DimStyle.Render("Recovered from interrupted sync. Working tree restored."))
@@ -281,7 +283,7 @@ func shouldPromptConflicts(plan *sync.SyncPlan, yes bool) bool {
 // plan is emitted and no Execute is run, so callers can inspect the
 // plan and re-invoke with --yes if they want to proceed.
 func finishJSON(engine engineRunner, plan *sync.SyncPlan, out io.Writer, flags runFlags) error {
-	if err := display.RenderPlanJSON(out, plan); err != nil {
+	if err := display.RenderPlanJSON(out, plan, engine.LockedNotice() != ""); err != nil {
 		return err
 	}
 

--- a/cmd/artifact/code/codesync/cmd_test.go
+++ b/cmd/artifact/code/codesync/cmd_test.go
@@ -314,6 +314,41 @@ func TestRunE_JSONOutput(t *testing.T) {
 	assert.Contains(t, out, `"v2"`)
 }
 
+// Exit is 0 and the upload list reads as a sync that will work, so this flag
+// is the only thing in the document that says the plan can never be applied.
+// The stderr notice does not reach a script.
+func TestRunE_JSONOutput_LockedIsFlagged(t *testing.T) {
+	dir := t.TempDir()
+	linkProject(t, dir)
+
+	fe := &fakeEngine{
+		plan:       &sync.SyncPlan{Uploads: []sync.FileAction{{Path: "a.py"}}},
+		lockedNote: "Artifact art-1 is locked, so this is a preview only.",
+	}
+
+	flags := map[string]string{"dir": dir, "yes": "true", "dry-run": "true", "output-format": "json"}
+
+	_, stdout, _, err := runWithDeps(t, fakeEngineDeps(fe), flags)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), `"locked": true`)
+	assert.False(t, fe.executed)
+}
+
+// The ordinary case says so too, rather than leaving a reader to infer it from
+// a key that is not there.
+func TestRunE_JSONOutput_UnlockedIsFlagged(t *testing.T) {
+	dir := t.TempDir()
+	linkProject(t, dir)
+
+	fe := &fakeEngine{plan: &sync.SyncPlan{Uploads: []sync.FileAction{{Path: "a.py"}}}}
+
+	flags := map[string]string{"dir": dir, "yes": "true", "dry-run": "true", "output-format": "json"}
+
+	_, stdout, _, err := runWithDeps(t, fakeEngineDeps(fe), flags)
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), `"locked": false`)
+}
+
 // TestRunE_JSONOutput_ConflictWithoutYes: with conflicts present and
 // no --yes, the JSON path must emit the plan and stop — it must NOT
 // auto-execute. Mirrors the human-path quit branch and prevents a

--- a/cmd/artifact/code/codesync/cmd_test.go
+++ b/cmd/artifact/code/codesync/cmd_test.go
@@ -41,6 +41,7 @@ type fakeEngine struct {
 	stale         bool
 	migrationNote string
 	ignoreNotice  string
+	lockedNote    string
 	fetcher       display.ContentFetcher
 	closeErr      error
 
@@ -67,6 +68,8 @@ func (f *fakeEngine) StaleRollbackRestored() bool { return f.stale }
 func (f *fakeEngine) StateMigrationNotice() string { return f.migrationNote }
 
 func (f *fakeEngine) IgnoreFileNotice() string { return f.ignoreNotice }
+
+func (f *fakeEngine) LockedNotice() string { return f.lockedNote }
 
 func (f *fakeEngine) Fetcher() display.ContentFetcher { return f.fetcher }
 
@@ -187,6 +190,27 @@ func TestRunE_DryRun_NonEmpty_NoExecute(t *testing.T) {
 
 	_, _, _, err := runWithDeps(t, fakeEngineDeps(fe), flags)
 	require.NoError(t, err)
+	assert.False(t, fe.executed)
+}
+
+// The engine lets a preview plan against a locked artifact, because the
+// deploy needs the count. What the preview must never do is read as a sync
+// that is going to work, so whatever the engine says about the lock has to
+// reach the reader.
+func TestRunE_LockedNoticeReachesStderr(t *testing.T) {
+	dir := t.TempDir()
+	linkProject(t, dir)
+
+	fe := &fakeEngine{
+		plan:       &sync.SyncPlan{Uploads: []sync.FileAction{{Path: "a.py"}}},
+		lockedNote: "Artifact art-1 is locked, so this is a preview only.",
+	}
+
+	flags := map[string]string{"dir": dir, "yes": "true", "dry-run": "true"}
+
+	_, _, stderr, err := runWithDeps(t, fakeEngineDeps(fe), flags)
+	require.NoError(t, err)
+	assert.Contains(t, stderr.String(), "is locked")
 	assert.False(t, fe.executed)
 }
 

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -130,7 +130,10 @@ Deploying onto a workload that already exists rolls it: a new version is made
 from the file and swapped in, the endpoint does not change, and the version
 already serving keeps serving until the new one is ready. When that version is
 locked, meaning production, an interactive run asks for the workload name to
-be typed back. A run with no terminal, or --yes, rolls without asking.
+be typed back. A run with no terminal, or --yes, rolls without asking. Locking
+is one-way, so the new version is a new artifact rather than a change to the
+locked one, and it is locked to match. That is why a locked workload keeps
+deploying without --lock being passed again.
 
 A change that moves only the sizing, such as a replica count or a resource
 allocation, is applied in place instead. Nothing is built and no version is

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -51,6 +51,13 @@ type Artifact struct {
 	Name   string `json:"name"`
 	Status string `json:"status"`
 
+	// Type is what kind of thing this is: a service, an agent. It sits beside
+	// the spec rather than in it, because the platform reads the discriminator
+	// from the artifact and pops any type sent inside the spec. An artifact
+	// repository takes its own type from whichever artifact opened it, so this
+	// is what says whether a later version can still join that lineage.
+	Type string `json:"type"`
+
 	// ArtifactRepositoryID is the lineage this artifact belongs to. Successive
 	// versions of one thing share it, which is the only way to tell them from
 	// unrelated artifacts that happen to carry the same name.

--- a/internal/workload/sync/display/json.go
+++ b/internal/workload/sync/display/json.go
@@ -36,7 +36,7 @@ type PlanJSON struct {
 	// one case where a full upload list means the opposite of what it looks
 	// like, and a script reading only this document has nothing else to go on:
 	// the human warning goes to stderr and the exit status is 0.
-	Locked bool `json:"locked,omitempty"`
+	Locked bool `json:"locked"`
 }
 
 type FileActionJSON struct {

--- a/internal/workload/sync/display/json.go
+++ b/internal/workload/sync/display/json.go
@@ -30,6 +30,13 @@ type PlanJSON struct {
 	Deletes   []FileActionJSON `json:"deletes"`
 	Conflicts []FileActionJSON `json:"conflicts"`
 	Stats     PlanStatsJSON    `json:"stats"`
+
+	// Locked marks a plan that can never be applied, because the artifact it
+	// was computed against is immutable. A preview of a locked artifact is the
+	// one case where a full upload list means the opposite of what it looks
+	// like, and a script reading only this document has nothing else to go on:
+	// the human warning goes to stderr and the exit status is 0.
+	Locked bool `json:"locked,omitempty"`
 }
 
 type FileActionJSON struct {
@@ -52,15 +59,16 @@ type PlanStatsJSON struct {
 }
 
 // RenderPlanJSON writes plan as pretty-printed JSON to w.
-func RenderPlanJSON(w io.Writer, plan *sync.SyncPlan) error {
+func RenderPlanJSON(w io.Writer, plan *sync.SyncPlan, locked bool) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 
 	if plan == nil {
-		return enc.Encode(PlanJSON{})
+		return enc.Encode(PlanJSON{Locked: locked})
 	}
 
 	out := PlanJSON{
+		Locked:    locked,
 		Uploads:   actionsJSON(plan.Uploads),
 		Downloads: actionsJSON(plan.Downloads),
 		Deletes:   actionsJSON(plan.Deletes),

--- a/internal/workload/sync/engine.go
+++ b/internal/workload/sync/engine.go
@@ -111,6 +111,7 @@ type Engine struct {
 	staleNote      bool
 	migrationNote  string
 	ignoreNotice   string
+	lockedNote     string
 
 	lockfileFn        LockfileRunner
 	lockfileGenerated bool
@@ -202,7 +203,7 @@ func (e *Engine) Run() (*Result, error) {
 		return nil, err
 	}
 
-	if e.opts.DryRun || e.opts.ShowDiffs || plan.IsEmpty() {
+	if e.previewOnly() || plan.IsEmpty() {
 		if relErr := e.releaseLock(); relErr != nil {
 			return nil, fmt.Errorf("release lock: %w", relErr)
 		}
@@ -239,6 +240,25 @@ func (e *Engine) StateMigrationNotice() string { return e.migrationNote }
 // ignore-file problems that cost the user something go through log.Warn with
 // the rest of the phase warnings, so they survive a later phase failing.
 func (e *Engine) IgnoreFileNotice() string { return e.ignoreNotice }
+
+// LockedNotice is Phase 1's one-line account of a plan computed against an
+// artifact that can no longer take code, empty in the ordinary case. Only a
+// preview can reach it, and a preview that printed a plan without saying so
+// would read as a sync that is going to work.
+func (e *Engine) LockedNotice() string { return e.lockedNote }
+
+// previewOnly reports that this run stops after Plan and sends nothing to the
+// platform, which is what makes the artifact's own mutability beside the point
+// in phase 1. It is not a promise that the working tree is untouched: phase 0
+// restores a stale rollback and the lockfile phase can still generate a
+// uv.lock, both of which a preview needs in order to plan the tree it would
+// actually upload.
+//
+// One owner for the question, because phase 1's locked-artifact exemption is
+// only safe while the set of modes that skip Execute is the same set that gets
+// exempted. Two spellings of it could drift into a preview that plans against
+// something immutable and then executes.
+func (e *Engine) previewOnly() bool { return e.opts.DryRun || e.opts.ShowDiffs }
 
 func (e *Engine) releaseLock() error {
 	if e.lock == nil {

--- a/internal/workload/sync/engine_test.go
+++ b/internal/workload/sync/engine_test.go
@@ -264,10 +264,13 @@ func TestEngine_Plan_FastPathUpToDate(t *testing.T) {
 	assert.False(t, calledAllFiles, "AllFiles must not be called when not drifted")
 }
 
-func TestEngine_Plan_LockedArtifactRejected(t *testing.T) {
-	dir := initProject(t, nil)
+// lockedEngine is an engine bound to dir whose artifact is immutable. The
+// casing is the platform's own inconsistency, and reading it as a draft is the
+// failure the fixture exists to catch.
+func lockedEngine(t *testing.T, dir string, opts Options) *Engine {
+	t.Helper()
 
-	e, err := newWithDeps(dir, Options{}, Deps{
+	e, err := newWithDeps(dir, opts, Deps{
 		Files: &fakeFilesClient{},
 		Artifacts: &fakeArtifactStore{
 			GetFn: func(id string) (*workload.Artifact, error) {
@@ -280,7 +283,60 @@ func TestEngine_Plan_LockedArtifactRejected(t *testing.T) {
 
 	t.Cleanup(func() { _ = e.Close() })
 
-	_, err = e.Plan()
+	return e
+}
+
+func TestEngine_Plan_LockedArtifactRejected(t *testing.T) {
+	dir := initProject(t, nil)
+
+	e := lockedEngine(t, dir, Options{})
+
+	_, err := e.Plan()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "locked")
+}
+
+// A preview writes nothing, so the one reason to refuse a locked artifact
+// does not apply to it. `dr workload up` asks for exactly this plan before it
+// decides what to do with the code, and on a locked version what it decides is
+// to mint a new one: refusing the count refuses the deploy that gets past the
+// lock.
+func TestEngine_Plan_LockedArtifactAllowedForPreviews(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts Options
+	}{
+		{"dry run", Options{DryRun: true}},
+		{"diff", Options{ShowDiffs: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := initProject(t, map[string]string{"app.py": "print('hi')\n"})
+
+			e := lockedEngine(t, dir, tc.opts)
+
+			plan, err := e.Plan()
+			require.NoError(t, err)
+			require.NotNil(t, plan)
+
+			assert.Contains(t, e.LockedNotice(), "locked",
+				"a preview that printed a plan without saying so reads as a sync that is going to work")
+		})
+	}
+}
+
+// The exemption above is for the plan only. Nothing stops a caller planning
+// and then executing anyway, and an upload reaching something immutable is
+// the one outcome it must never produce.
+func TestEngine_Execute_RefusesALockedArtifact(t *testing.T) {
+	dir := initProject(t, map[string]string{"app.py": "print('hi')\n"})
+
+	e := lockedEngine(t, dir, Options{DryRun: true})
+
+	plan, err := e.Plan()
+	require.NoError(t, err)
+	require.False(t, plan.IsEmpty(), "the fixture has to give phase 5 something to refuse")
+
+	_, err = e.Execute(plan)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "locked")
 }

--- a/internal/workload/sync/phase0_preflight.go
+++ b/internal/workload/sync/phase0_preflight.go
@@ -30,7 +30,7 @@ import (
 // anything on disk, and they read fine either way because the path helpers
 // fall back to the legacy location on their own.
 func phase0Preflight(e *Engine) error {
-	if !e.opts.DryRun && !e.opts.ShowDiffs {
+	if !e.previewOnly() {
 		e.migrationNote = wapi.EnsureMigrated(e.projectDir)
 	}
 

--- a/internal/workload/sync/phase1_gather.go
+++ b/internal/workload/sync/phase1_gather.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/internal/workload"
+	wlmanifest "github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/internal/workload/wapi"
 )
 
@@ -48,8 +49,26 @@ func phase1Gather(e *Engine) error {
 		return fmt.Errorf("fetch artifact %s: %w", cfg.ArtifactID, err)
 	}
 
+	// A locked artifact is immutable, so nothing can be pushed into it. That
+	// refuses a sync, but it must not refuse a plan: `dr workload up` asks for
+	// this diff before it decides what to do with the code, and on a locked
+	// version what it decides is to mint a new one and roll onto it. Refusing
+	// to count the files refuses the very deploy that gets past the lock, which
+	// is how a locked artifact became a one-way door. Phase 5 checks again, so
+	// the exemption cannot let a write through.
 	if art.IsLocked() {
-		return errors.New("artifact is locked (immutable); cannot sync. Create a new draft with 'dr artifact create' (or in the DataRobot UI) to continue")
+		if !e.previewOnly() {
+			return fmt.Errorf(
+				"artifact %s is locked (immutable); cannot sync.\n"+
+					"  A project with a %s deploys past this on its own: 'dr workload up' creates a new "+
+					"version, points this directory at it, and rolls onto it.\n"+
+					"  Otherwise make one with 'dr artifact create' (or in the DataRobot UI), then delete %s "+
+					"and re-link with 'dr artifact code init <new-id>'",
+				art.ID, wlmanifest.FileName, wapi.Dir(e.projectDir))
+		}
+
+		e.lockedNote = fmt.Sprintf(
+			"Artifact %s is locked, so this is a preview only: syncing into it needs a new version.", art.ID)
 	}
 
 	e.artifact = art

--- a/internal/workload/sync/phase5_execute.go
+++ b/internal/workload/sync/phase5_execute.go
@@ -28,6 +28,17 @@ import (
 // deletes, uploads. Any error after the rollback dir is created triggers
 // a Restore to pre-sync state.
 func phase5Execute(e *Engine) error {
+	// Above the empty-plan return, because this is a statement about the
+	// artifact rather than about the plan: phase 6 writes local state and a
+	// history entry for an empty plan too, and recording a sync against
+	// something immutable is the same lie as performing one. Phase 1 lets a
+	// preview plan against a locked artifact and Run returns before this phase
+	// in both preview modes, but nothing stops a caller holding the engine from
+	// planning and then executing anyway.
+	if e.artifact != nil && e.artifact.IsLocked() {
+		return fmt.Errorf("artifact %s is locked (immutable); refusing to execute a plan against it", e.artifact.ID)
+	}
+
 	if e.plan == nil || e.plan.IsEmpty() {
 		return nil
 	}

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -37,15 +37,32 @@ import (
 // pointing at an image that does not exist yet, visible in the UI and unable
 // to start, for as long as the build took.
 func buildAndCreate(loaded Loaded, code CodeChange, result Result, opts Options, report *reporter) (Result, error) {
-	artifactID, fresh, err := ensureArtifact(loaded, report)
+	made, err := ensureArtifact(loaded, report)
+
+	// Recorded before the error check, the same way roll records the build it
+	// ran: an artifact created and then stranded by a link that would not write
+	// is the one failure the envelope has to be able to name.
+	result.ArtifactID = made.ID
+
 	if err != nil {
 		return result, err
 	}
 
-	result.ArtifactID = artifactID
+	artifactID, fresh := made.ID, made.Fresh
 
 	synced, err := syncCode(loaded.ProjectDir, report)
 	if err != nil {
+		return result, err
+	}
+
+	// Asked unconditionally, exactly as the roll path asks it. A sync that
+	// minted a version answers immediately; the cases that reach further are a
+	// version standing in for a locked one, whose tree was already synced and
+	// so may upload nothing, and a run resuming after an earlier one relinked
+	// and died. Neither is distinguishable from the ordinary case by then: the
+	// link has already moved, so the only record of what happened is the
+	// catalog version in the project's own state, which is what this reads.
+	if err := inheritCode(loaded.ProjectDir, artifactID, synced, report); err != nil {
 		return result, err
 	}
 
@@ -128,77 +145,84 @@ func workloadOn(artifactID string) string {
 }
 
 // ensureArtifact returns the artifact this project builds into, creating one
-// and linking the directory to it the first time. fresh reports which of the
-// two happened, because an artifact that was just created has no image and
+// and linking the directory to it the first time. Fresh reports that this run
+// made it, because an artifact that was just created has no image and
 // therefore always needs a build.
 //
 // The link lives in the project's own state directory rather than in the
 // manifest. The manifest describes what to deploy and is committed; which
 // artifact a particular checkout has been pushing to is local, and writing it
 // into a shared file would have two developers fighting over one draft.
-func ensureArtifact(loaded Loaded, report *reporter) (string, bool, error) {
-	if projectLinkedFn(loaded.ProjectDir) {
-		cfg, err := loadProjectFn(loaded.ProjectDir)
-		if err != nil {
-			return "", false, fmt.Errorf("cannot read which artifact %s is linked to: %w", loaded.ProjectDir, err)
-		}
-
-		if err := usableArtifact(loaded.ProjectDir, cfg.ArtifactID); err != nil {
-			return "", false, err
-		}
-
-		return cfg.ArtifactID, false, nil
+func ensureArtifact(loaded Loaded, report *reporter) (version, error) {
+	if !projectLinkedFn(loaded.ProjectDir) {
+		return freshArtifact(loaded, "", labelFirstArtifact, report)
 	}
 
-	var created *workload.Artifact
-
-	err := report.run("Creating the artifact", func() error {
-		payload, payloadErr := loaded.Compiled.ArtifactPayload()
-		if payloadErr != nil {
-			return payloadErr
-		}
-
-		artifact, createErr := createArtifactFn(payload)
-		created = artifact
-
-		return createErr
-	})
+	cfg, err := loadProjectFn(loaded.ProjectDir)
 	if err != nil {
-		return "", false, err
+		return version{}, fmt.Errorf("cannot read which artifact %s is linked to: %w", loaded.ProjectDir, err)
 	}
 
-	// The artifact exists and nothing records that fact yet, so a failure
-	// here strands it: the next run would create a second one. Saying which
-	// id was lost is the difference between a re-run and a support ticket.
-	if err := initProjectFn(loaded.ProjectDir, wapi.InitOptions{ArtifactID: created.ID}); err != nil {
-		return "", false, fmt.Errorf(
-			"artifact %s was created but %s could not be linked to it, so the next deploy would create another. "+
-				"Run 'dr artifact code init %s' here, then deploy again: %w",
-			created.ID, loaded.ProjectDir, created.ID, err)
+	linked, err := getArtifactFn(cfg.ArtifactID)
+	if err != nil {
+		return version{}, fmt.Errorf("cannot read artifact %s, which this project is linked to: %w", cfg.ArtifactID, err)
 	}
 
-	return created.ID, true, nil
+	if linked == nil || !linked.IsLocked() {
+		return version{ID: cfg.ArtifactID}, nil
+	}
+
+	// Locking is one-way, so a locked link can take neither new code nor a new
+	// image and there is nothing to wait for. The answer is the same one the
+	// roll path already gives: this project's next version is a new artifact,
+	// in the lineage the locked one belongs to, and the link moves to it. The
+	// alternative was telling the reader to delete the state directory, which
+	// works but throws away the catalog and the last-synced version with it,
+	// so the following sync re-uploads a tree the platform already holds.
+	// Phrased as what the run needs rather than what it did, because the create
+	// below can still fail and a line already claiming the version exists would
+	// be the last thing printed before the error saying it does not.
+	report.say("  Artifact %s is locked, so this deploy needs a new version.\n", cfg.ArtifactID)
+
+	return freshArtifact(loaded, redraftRepository(loaded, linked), labelNewVersion, report)
 }
 
-// usableArtifact refuses a locked artifact before the sync finds out the hard
-// way. Locking is one-way and makes the artifact immutable, so neither the
-// code push nor the build that follows can land; the platform would refuse
-// the PATCH halfway through with a 403 that says nothing about what to do.
-func usableArtifact(projectDir, artifactID string) error {
-	artifact, err := getArtifactFn(artifactID)
+// redraftRepository is the lineage the replacement joins, "" when it has to
+// start one of its own. It is the same question sameRepository answers for a
+// roll, asked of the linked artifact rather than the live one because on this
+// path there is no live workload to read a type off.
+//
+// A file that changed the artifact's kind is the case that has to start fresh:
+// a repository carries the type of the artifact that opened it, and the
+// platform answers 422 for one that disagrees. createInRepository would recover
+// from that by retrying without the id, so the cost of not asking is a wasted
+// round trip and a line blaming the repository for something the file did.
+func redraftRepository(loaded Loaded, linked *workload.Artifact) string {
+	wanted, err := loaded.ArtifactType()
 	if err != nil {
-		return fmt.Errorf("cannot read artifact %s, which this project is linked to: %w", artifactID, err)
+		return ""
 	}
 
-	if artifact.IsLocked() {
-		return fmt.Errorf(
-			"artifact %s is locked, so it can take neither new code nor a new image. "+
-				"Locking is permanent, so deploying a change means a new artifact: "+
-				"delete %s and run up again to make one",
-			artifactID, wapi.Dir(projectDir))
+	if !manifest.SameArtifactType(
+		manifest.ArtifactTypeOrDefault(wanted),
+		manifest.ArtifactTypeOrDefault(linked.Type),
+	) {
+		return ""
 	}
 
-	return nil
+	return linked.ArtifactRepositoryID
+}
+
+// freshArtifact mints the artifact and points the project at it. The two are
+// one act: an artifact nothing records is one the next run cannot find, so it
+// would create a second and leave the first unreachable.
+func freshArtifact(loaded Loaded, repositoryID, label string, report *reporter) (version, error) {
+	made, err := createVersion(loaded, repositoryID, label, report)
+	if err != nil {
+		return made, err
+	}
+
+	return made, linkProject(loaded.ProjectDir, made, report)
 }
 
 // syncCode uploads the working tree to the artifact's code store. The engine

--- a/internal/workload/up/doc.go
+++ b/internal/workload/up/doc.go
@@ -66,6 +66,18 @@
 // minting a version and promoting it leaves a draft nothing points at, and
 // the next run continues with it rather than adding another to the pile.
 //
+// Locking is one-way, and it is the rule both deploy shapes have to obey the
+// same way: a locked artifact can take neither new code nor a new image, so
+// the next version of a locked thing is a new artifact rather than a change to
+// it. It joins the lineage the locked one belongs to, the checkout's link
+// moves onto it, and the code the locked one was running is carried across
+// when the working tree has nothing to upload. Whether the successor is itself
+// locked is the one part that differs: a roll onto a locked version has to
+// lock it, because the platform refuses to put a draft where a locked artifact
+// was, while a first deploy leaves it a draft unless the run asked for a lock.
+// A deploy that refused instead would be a one-way door, since a workload that
+// must stay up has to be locked and a locked one could then never be changed.
+//
 // Non-scope: no terminal output and no cobra. Rendering a plan and running
 // the phases belong to the command; this package hands back values.
 package up

--- a/internal/workload/up/plan.go
+++ b/internal/workload/up/plan.go
@@ -50,6 +50,12 @@ type CodeChange struct {
 	// only part of a run that a --dry-run does, so carrying it here is what
 	// lets the preview mention it at all.
 	IgnoreNotice string
+
+	// LinkLocked reports that the artifact this project pushes into can no
+	// longer take code. The deploy answers by minting one that can and moving
+	// the link onto it, which the plan says out loud because nothing in the
+	// file asked for it.
+	LinkLocked bool
 }
 
 // Changed reports whether the code needs syncing and rebuilding.
@@ -71,6 +77,13 @@ type Plan struct {
 	Code     CodeChange
 	Artifact []Change
 	Runtime  []Change
+
+	// Locked reports that the version now serving is immutable. Its successor
+	// has to be locked too before the platform will take it, so a deploy onto
+	// locked production locks something whether or not --lock was passed, and
+	// that cannot be undone. The plan is where it belongs: --dry-run is how a
+	// locked deploy is reviewed before it happens.
+	Locked bool
 }
 
 // Empty reports that the live state already matches the file. `up` prints
@@ -121,6 +134,7 @@ func Build(loaded Loaded, live Live, code CodeChange) (Plan, error) {
 		State:   live.State,
 		Creates: live.State == StateUnbound,
 		Code:    code,
+		Locked:  live.Locked,
 	}
 
 	// Nothing exists to compare against, so every field is trivially an

--- a/internal/workload/up/plan.go
+++ b/internal/workload/up/plan.go
@@ -107,6 +107,15 @@ func (p Plan) RollsArtifact() bool {
 	return !p.Creates && (p.Code.Changed() || len(p.Artifact) > 0)
 }
 
+// MintsVersion reports whether this run will produce a new artifact. Only a
+// run that does can lock one, so it is what decides whether the plan says
+// anything about locking: a change that moves the sizing alone is applied in
+// place, and a stopped workload is simply started, both leaving the locked
+// artifact exactly as it is.
+func (p Plan) MintsVersion() bool {
+	return p.Creates || p.RollsArtifact()
+}
+
 // Action names the outcome, for the summary line and the JSON envelope.
 func (p Plan) Action() string {
 	switch {

--- a/internal/workload/up/render.go
+++ b/internal/workload/up/render.go
@@ -127,6 +127,7 @@ func lines(s Summary, plan Plan) []string {
 		out = append(out, entry("~", "code", codeDetail(plan.Code)))
 	}
 
+	out = append(out, lockLines(plan)...)
 	out = append(out, artifactLines(plan)...)
 	out = append(out, runtimeLines(plan)...)
 
@@ -151,6 +152,35 @@ func codeDetail(code CodeChange) string {
 	}
 
 	return fmt.Sprintf("%d %s changed since the last deploy", code.Files, plural(code.Files, "file", "files"))
+}
+
+// lockLines says what the deploy will do about a version that cannot be
+// changed. Locking is the one act a deploy performs that the file never asks
+// for and that cannot be undone, so it belongs in the plan rather than only in
+// the running commentary: a run with --yes never sees a prompt, and --dry-run
+// is the whole of the review it gets.
+func lockLines(plan Plan) []string {
+	// Only a run that actually mints a version can lock one. A change that
+	// moves the sizing alone is applied to the workload in place, and a stopped
+	// one is simply started: both leave the locked artifact exactly as it is,
+	// so saying a version was created and locked would describe a deploy that
+	// is not the one about to happen.
+	if !plan.Creates && !plan.RollsArtifact() {
+		return nil
+	}
+
+	switch {
+	case plan.Locked:
+		return []string{entry("~", "lock",
+			"the running version is locked, so a new one is created and locked to match. Locking is permanent")}
+
+	case plan.Code.LinkLocked:
+		return []string{entry("~", "lock",
+			"this project's artifact is locked, so a new one is created and the project pushes to that instead")}
+
+	default:
+		return nil
+	}
 }
 
 // artifactLines describes the new immutable version, when there is one. Code

--- a/internal/workload/up/render.go
+++ b/internal/workload/up/render.go
@@ -165,7 +165,7 @@ func lockLines(plan Plan) []string {
 	// one is simply started: both leave the locked artifact exactly as it is,
 	// so saying a version was created and locked would describe a deploy that
 	// is not the one about to happen.
-	if !plan.Creates && !plan.RollsArtifact() {
+	if !plan.MintsVersion() {
 		return nil
 	}
 
@@ -292,9 +292,17 @@ func plural(n int, one, many string) string {
 // secret would be worse than a human-readable one, since it ends up in CI
 // artifacts.
 type PlanJSON struct {
-	Action   string   `json:"action"`
-	State    string   `json:"state"`
-	Creates  bool     `json:"creates"`
+	Action  string `json:"action"`
+	State   string `json:"state"`
+	Creates bool   `json:"creates"`
+
+	// Locked reports that this run will permanently lock the version it
+	// deploys, because the one it replaces is locked and the platform will not
+	// put a draft where a locked artifact was. It is the one consequence of a
+	// deploy that cannot be undone and that nothing in the file asked for, so a
+	// caller reading only this document has to be able to see it coming.
+	Locked bool `json:"locked"`
+
 	Code     CodeJSON `json:"code"`
 	Artifact []string `json:"artifact"`
 	Runtime  []string `json:"runtime"`
@@ -308,19 +316,32 @@ type CodeJSON struct {
 	Changed     bool `json:"changed"`
 	Files       int  `json:"files"`
 	FirstDeploy bool `json:"firstDeploy"`
+
+	// LinkLocked reports that the artifact this project pushes into can no
+	// longer take code, so the run will mint one that can and move the link
+	// onto it. The live workload is not locked in that case, so the envelope's
+	// own Locked field says nothing about it.
+	LinkLocked bool `json:"linkLocked"`
 }
 
 // JSON projects the plan into its machine-readable shape.
 func (p Plan) JSON() PlanJSON {
+	// Both lock facts are gated on the same question the printed plan asks, so
+	// the two renderings of one plan cannot come to disagree about whether this
+	// run locks anything.
+	mints := p.MintsVersion()
+
 	return PlanJSON{
 		Action:  p.Action(),
 		State:   p.State.String(),
 		Creates: p.Creates,
+		Locked:  p.Locked && mints,
 		Code: CodeJSON{
 			Applies:     p.Code.Applies,
 			Changed:     p.Code.Changed(),
 			Files:       p.Code.Files,
 			FirstDeploy: p.Code.FirstDeploy,
+			LinkLocked:  p.Code.LinkLocked && mints,
 		},
 		Artifact: describeAll(p.Artifact),
 		Runtime:  describeAll(p.Runtime),

--- a/internal/workload/up/render_test.go
+++ b/internal/workload/up/render_test.go
@@ -313,3 +313,44 @@ func TestRender_RedraftOfALockedLinkIsAnnounced(t *testing.T) {
 	assert.Contains(t, out, "~ lock")
 	assert.Contains(t, out, "pushes to that instead")
 }
+
+// A caller reading only the JSON has no other way to learn that this run will
+// lock a version for good, or that it will redraft a locked link and move the
+// project onto something else. The envelope's own Locked field is the live
+// artifact's state, which is false on the create path precisely when the
+// redraft is what is about to happen.
+func TestPlanJSON_CarriesTheLockFacts(t *testing.T) {
+	rolls := Plan{
+		State:  StateRunning,
+		Locked: true,
+		Code:   CodeChange{Applies: true, Files: 1},
+	}.JSON()
+
+	assert.True(t, rolls.Locked)
+
+	redrafts := Plan{
+		State:   StateUnbound,
+		Creates: true,
+		Code:    CodeChange{Applies: true, FirstDeploy: true, LinkLocked: true},
+	}.JSON()
+
+	assert.True(t, redrafts.Code.LinkLocked)
+	assert.False(t, redrafts.Locked, "no live artifact is being replaced on a create")
+}
+
+// The JSON is gated on the same question the printed plan is, or the two
+// renderings of one plan would disagree about whether it locks anything.
+func TestPlanJSON_NoLockFactsWhenNothingIsMinted(t *testing.T) {
+	sizing := Plan{
+		State:   StateRunning,
+		Locked:  true,
+		Runtime: []Change{{Path: "containerGroups[default].replicaCount", Have: 1.0, Want: 3.0}},
+	}.JSON()
+
+	assert.False(t, sizing.Locked, "a sizing change is applied in place and mints nothing")
+
+	start := Plan{State: StateStopped, Locked: true, Code: CodeChange{Applies: true, LinkLocked: true}}.JSON()
+
+	assert.False(t, start.Locked)
+	assert.False(t, start.Code.LinkLocked)
+}

--- a/internal/workload/up/render_test.go
+++ b/internal/workload/up/render_test.go
@@ -262,3 +262,54 @@ func TestPlanJSON_RedactsToo(t *testing.T) {
 	assert.NotContains(t, string(encoded), secret)
 	assert.Contains(t, string(encoded), "OPENAI_API_KEY")
 }
+
+// A locked artifact is only replaced by a run that mints a version. Saying so
+// above a plan that changes the sizing in place, or one that only starts a
+// stopped workload, describes a deploy that is not about to happen: both leave
+// the locked artifact exactly where it is.
+func TestRender_LockIsNotAnnouncedWhenNothingIsMinted(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		plan Plan
+	}{
+		{"sizing alone", Plan{
+			State:   StateRunning,
+			Locked:  true,
+			Runtime: []Change{{Path: "containerGroups[default].replicaCount", Have: 1.0, Want: 3.0}},
+		}},
+		{"a start", Plan{State: StateStopped, Locked: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.NotContains(t, render(t, appSummary, tc.plan), "lock")
+		})
+	}
+}
+
+// The other half: a run that does mint one has to say that the successor is
+// locked too, because nothing in the file asked for that and it cannot be
+// undone. A --yes run is never prompted, so the plan is the only warning.
+func TestRender_LockIsAnnouncedWhenAVersionIsMinted(t *testing.T) {
+	out := render(t, appSummary, Plan{
+		State:  StateRunning,
+		Locked: true,
+		Code:   CodeChange{Applies: true, Files: 1},
+	})
+
+	assert.Contains(t, out, "~ lock")
+	assert.Contains(t, out, "locked to match")
+	assert.Contains(t, out, "permanent")
+}
+
+// A project whose link points at a locked artifact is redrafted onto a new one
+// and the link moves, which the preview has to say: it is invisible, and a
+// re-run does not undo it.
+func TestRender_RedraftOfALockedLinkIsAnnounced(t *testing.T) {
+	out := render(t, Summary{Name: "my-app"}, Plan{
+		State:   StateUnbound,
+		Creates: true,
+		Code:    CodeChange{Applies: true, FirstDeploy: true, LinkLocked: true},
+	})
+
+	assert.Contains(t, out, "~ lock")
+	assert.Contains(t, out, "pushes to that instead")
+}

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -107,7 +107,7 @@ func candidateArtifact(
 		return buildVersion(loaded, live, code, repository, opts, report)
 	}
 
-	return createVersion(loaded, repository, report)
+	return createVersion(loaded, repository, labelNewVersion, report)
 }
 
 // sameRepository is the repository the new version joins, "" when it should

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -520,18 +520,8 @@ func builtRoll(tr *track) fakes {
 
 		return nil
 	}
-	f.save = func(_ string, cfg wapi.Config) error {
-		tr.steps = append(tr.steps, "relink")
-		tr.savedCfg = cfg
-
-		return nil
-	}
-	f.codeRef = func(artifactID, catalogID, versionID string) error {
-		tr.steps = append(tr.steps, "carry-code")
-		tr.carried = []string{artifactID, catalogID, versionID}
-
-		return nil
-	}
+	f.save = relinkStep(tr)
+	f.codeRef = carryCodeStep(tr)
 	f.sync = func(string) (*sync.Result, error) {
 		tr.steps = append(tr.steps, "sync")
 
@@ -554,6 +544,38 @@ func builtRoll(tr *track) fakes {
 func builtDrift() string {
 	return "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" +
 		strings.Replace(boundLiveManifest, "port: 8000", "port: 9000", 1)
+}
+
+// emptySync is a sync that found nothing to do, which is the precondition of
+// every test about carrying code onto a version that has none of its own.
+func emptySync(tr *track) func(string) (*sync.Result, error) {
+	return func(string) (*sync.Result, error) {
+		tr.steps = append(tr.steps, "sync")
+
+		return &sync.Result{}, nil
+	}
+}
+
+// relinkStep records a project re-pointed at a new version, and carryCodeStep
+// the patch that gives that version the code the old one was running. Both
+// fixtures are shared with the create path's tests, so the step names the
+// suite pins stay in one place.
+func relinkStep(tr *track) func(string, wapi.Config) error {
+	return func(_ string, cfg wapi.Config) error {
+		tr.steps = append(tr.steps, "relink")
+		tr.savedCfg = cfg
+
+		return nil
+	}
+}
+
+func carryCodeStep(tr *track) func(string, string, string) error {
+	return func(artifactID, catalogID, versionID string) error {
+		tr.steps = append(tr.steps, "carry-code")
+		tr.carried = []string{artifactID, catalogID, versionID}
+
+		return nil
+	}
 }
 
 // syncedProject is a project that has pushed code before, linked to the
@@ -594,6 +616,34 @@ func TestRun_RollsABuiltProjectOntoAFreshlyBuiltVersion(t *testing.T) {
 	assert.Equal(t, ActionRolled, result.Action)
 	assert.Equal(t, "bld-2", result.BuildID, "the envelope has to be able to name the build")
 	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", result.WorkloadID)
+}
+
+// A built project whose live version is locked, and whose link therefore
+// points at something immutable. Nothing here is new machinery. The roll
+// already mints a version, moves the link and locks to match, so what is being
+// asserted is that the run reaches any of it, which a preflight refusal
+// computing the file count used to prevent.
+func TestRun_RollsABuiltProjectOffALockedVersion(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.artifactD = func(string) (workload.Document, error) { return docOf(liveArtifactJSON), nil }
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("68a0000000000000000000a1")
+
+	install(t, f)
+
+	result, stderr, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"guard", "create-artifact", "relink", "sync", "build",
+		"guard", "lock:art-2", "replace:art-2", "await-rollout", "settle",
+	}, tr.steps)
+	assert.Equal(t, "art-2", tr.savedCfg.ArtifactID, "the link has to leave the locked version behind")
+	assert.True(t, result.Locked, "a locked version is replaced by a locked one")
+	assert.Contains(t, stderr, "the running version is locked, so a new one is created and locked to match",
+		"a --yes run locks something without being asked to, and the plan has to say so")
 }
 
 // The project is linked to the version that is serving, which is the state a
@@ -788,11 +838,7 @@ func TestRun_SpecOnlyRollCarriesTheCodeOver(t *testing.T) {
 	f := builtRoll(&tr)
 	f.linked = func(string) bool { return true }
 	f.project = syncedProject("68a0000000000000000000a1")
-	f.sync = func(string) (*sync.Result, error) {
-		tr.steps = append(tr.steps, "sync")
-
-		return &sync.Result{}, nil
-	}
+	f.sync = emptySync(&tr)
 
 	install(t, f)
 
@@ -818,11 +864,7 @@ func TestRun_SpecOnlyRollWithNoCodeToCarryStopsBeforeTheBuild(t *testing.T) {
 	f.project = func(string) (wapi.Config, error) {
 		return wapi.Config{ArtifactID: "68a0000000000000000000a1"}, nil
 	}
-	f.sync = func(string) (*sync.Result, error) {
-		tr.steps = append(tr.steps, "sync")
-
-		return &sync.Result{}, nil
-	}
+	f.sync = emptySync(&tr)
 
 	install(t, f)
 
@@ -850,7 +892,9 @@ func TestRun_RollLinkFailureNamesTheStrandedVersion(t *testing.T) {
 	_, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "art-2")
-	assert.Contains(t, err.Error(), "dr artifact code init art-2")
+	assert.Contains(t, err.Error(), "artifactId",
+		"the directory is already linked, so 'dr artifact code init' would refuse: name the file to edit")
+	assert.Contains(t, err.Error(), "config.json")
 	assert.NotContains(t, tr.steps, "sync", "nothing may be pushed at a version nothing points to")
 }
 

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -687,6 +687,12 @@ func lock(result Result, report *reporter) (Result, error) {
 // The engine acquires the project lock between planning and executing, so
 // this closes it immediately: nothing here is going to sync, and holding the
 // lock across a build would block the very command that comes next.
+//
+// DryRun is what makes this safe to ask of a locked artifact. The engine
+// refuses to sync into one, and rightly, but this is a measurement rather than
+// a sync: the count it produces is what tells the deploy to mint a new version
+// and roll onto it. A refusal here would refuse that deploy, which is the only
+// way past a lock.
 func defaultCodeChange(loaded Loaded, _ Live) (change CodeChange, err error) {
 	mode := loaded.Manifest.BuildMode()
 	if mode != manifest.BuildModeDockerfile && mode != manifest.BuildModeGenerated {
@@ -729,6 +735,10 @@ func defaultCodeChange(loaded Loaded, _ Live) (change CodeChange, err error) {
 		Applies:      true,
 		Files:        len(plan.Uploads) + len(plan.Deletes),
 		IgnoreNotice: notice,
+		// The engine says so rather than this asking a second time: it fetched
+		// the artifact to build the plan, and a locked one is the reason it
+		// left a notice at all.
+		LinkLocked: engine.LockedNotice() != "",
 	}, nil
 }
 

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -891,26 +891,104 @@ func TestRun_ConflictOnAFreshArtifactIsNotBlamedOnTheLink(t *testing.T) {
 	assert.NotContains(t, err.Error(), "only one workload per draft artifact")
 }
 
-// A locked artifact can take neither code nor an image, so the deploy stops
-// before the sync rather than failing halfway through with the platform's
-// 403, which says nothing about what to do next.
-func TestRun_LockedArtifactStopsBeforeThePush(t *testing.T) {
+// lockedLink is a project pointed at an artifact that has since been locked,
+// which is what a deploy that locked its own artifact leaves behind. The
+// repository is the lineage the replacement has to join.
+func lockedLink(f fakes, tr *track) fakes {
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("art-locked")
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{
+			ID: id, Status: workload.ArtifactStatusLocked, ArtifactRepositoryID: "repo-1",
+		}, nil
+	}
+	f.save = relinkStep(tr)
+
+	return f
+}
+
+// A locked artifact can take neither code nor an image, and locking cannot be
+// undone, so the deploy makes the version the lock made necessary rather than
+// refusing. The link moves with it, which is what keeps the catalog and the
+// last-synced version: telling the reader to delete the state directory works
+// too, and costs a full re-upload of a tree the platform already holds.
+func TestRun_LockedLinkIsRedrafted(t *testing.T) {
+	var tr track
+
+	install(t, lockedLink(wiredBuild(&tr), &tr))
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]string{"create-artifact", "relink", "sync", "build", "create-workload"}, tr.steps)
+	assert.Equal(t, "art-1", tr.savedCfg.ArtifactID, "the project has to push at the version that can take code")
+	require.NotNil(t, tr.savedCfg.CatalogID, "the code store has to survive the redraft")
+	assert.Equal(t, "cat1", *tr.savedCfg.CatalogID,
+		"the code store survives the redraft, or the next sync re-uploads the whole tree")
+
+	// The replacement joins the lineage it replaces. Without the repository the
+	// Registry grows a second entry under the same name on every lock, and the
+	// workload's versions stop reading as versions of one thing.
+	payload, ok := tr.artifactIn.(json.RawMessage)
+	require.True(t, ok, "the create has to have been given the artifact block")
+	assert.Contains(t, string(payload), "repo-1")
+
+	// The whole point is which artifact the rest of the run targets. Step names
+	// alone would stay identical if the build and the create kept using the
+	// locked id, which is the one outcome this must never produce.
+	workloadIn, ok := tr.workloadIn.(json.RawMessage)
+	require.True(t, ok)
+	assert.Contains(t, string(workloadIn), "art-1")
+	assert.NotContains(t, string(workloadIn), "art-locked")
+}
+
+// The tree was already synced into the artifact that got locked, so the sync
+// onto its replacement can have nothing to upload, and the new version would
+// go to the builder with no code reference at all. The code the locked one
+// was running is carried across instead.
+func TestRun_RedraftedArtifactInheritsTheSyncedCode(t *testing.T) {
+	var tr track
+
+	f := lockedLink(wiredBuild(&tr), &tr)
+	f.sync = emptySync(&tr)
+	f.codeRef = carryCodeStep(&tr)
+
+	install(t, f)
+
+	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"art-1", "cat1", "ver1"}, tr.carried)
+	assert.Contains(t, tr.steps, "carry-code")
+}
+
+// A first deploy whose sync uploaded nothing has no code anywhere: not on the
+// artifact, and not in a previous version to carry over. Building it would ask
+// the platform to make an image out of nothing and fail minutes later saying
+// so in its own words, so the run stops here and says which directory it
+// looked in.
+func TestRun_FirstDeployWithNothingToUploadStopsBeforeTheBuild(t *testing.T) {
 	var tr track
 
 	f := wiredBuild(&tr)
-	f.linked = func(string) bool { return true }
-	f.project = func(string) (wapi.Config, error) { return wapi.Config{ArtifactID: "art-locked"}, nil }
-	f.getArtifact = func(id string) (*workload.Artifact, error) {
-		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusLocked}, nil
+	f.sync = emptySync(&tr)
+
+	// What the link this run just wrote holds: an artifact and nothing else,
+	// because no sync has ever produced a version to record.
+	f.project = func(string) (wapi.Config, error) { return wapi.Config{ArtifactID: "art-1"}, nil }
+	f.codeRef = func(string, string, string) error {
+		t.Fatal("a first deploy has no earlier version whose code it could carry over")
+
+		return nil
 	}
 
 	install(t, f)
 
 	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "art-locked")
-	assert.Contains(t, err.Error(), "locked")
-	assert.Empty(t, tr.steps, "nothing may be pushed at an artifact that cannot accept it")
+	assert.Contains(t, err.Error(), "nothing to build")
+	assert.NotContains(t, tr.steps, "build", "an artifact with no code must not reach the builder")
 }
 
 // The artifact exists and only the local record of it failed to write, which

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -1009,6 +1009,34 @@ func TestRun_LinkFailureNamesTheStrandedArtifact(t *testing.T) {
 	assert.NotContains(t, tr.steps, "sync")
 }
 
+// The other half of the same accident, on a directory that is already linked,
+// which is what every roll and every redraft is. The advice has to differ:
+// 'dr artifact code init' refuses a directory holding state, so naming it here
+// would send the reader in a circle, and deleting the state to force it would
+// throw away the catalog the redraft exists to keep. The artifact id still has
+// to reach the envelope, or a run that stranded one reports none.
+func TestRun_RelinkFailureNamesTheFileToEditInstead(t *testing.T) {
+	var tr track
+
+	f := lockedLink(wiredBuild(&tr), &tr)
+	f.save = func(string, wapi.Config) error { return errors.New("permission denied") }
+
+	install(t, f)
+
+	result, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "art-1", "the stranded artifact has to be named")
+	assert.Contains(t, err.Error(), "artifactId")
+	assert.Contains(t, err.Error(), "config.json")
+	assert.NotContains(t, err.Error(), "dr artifact code init",
+		"that command refuses a directory that already has state")
+
+	assert.Equal(t, "art-1", result.ArtifactID,
+		"a run that created an artifact and then stranded it still has to report which")
+	assert.NotContains(t, tr.steps, "sync", "nothing may be pushed once the link is unknown")
+}
+
 // A build that fails is the end of the deploy. Creating the workload anyway
 // would produce something that cannot start, and the message points at the
 // logs that say why rather than repeating that it failed.

--- a/internal/workload/up/version.go
+++ b/internal/workload/up/version.go
@@ -104,20 +104,28 @@ func versionArtifact(loaded Loaded, live Live, repositoryID string, report *repo
 		return version{ID: id}, nil
 	}
 
-	return createVersion(loaded, repositoryID, report)
+	return createVersion(loaded, repositoryID, labelNewVersion, report)
 }
+
+// The two things a create can be. A project's first artifact is not a new
+// version of anything, and saying so in a fresh directory reads as though the
+// run found something it did not.
+const (
+	labelFirstArtifact = "Creating the artifact"
+	labelNewVersion    = "Creating the new version"
+)
 
 // createVersion mints an artifact from the file's artifact block, into
 // repositoryID when the run has a lineage for it to join. An empty
 // repositoryID leaves the platform to open one, which is what the first deploy
 // of anything wants.
-func createVersion(loaded Loaded, repositoryID string, report *reporter) (version, error) {
+func createVersion(loaded Loaded, repositoryID, label string, report *reporter) (version, error) {
 	var (
 		created  *workload.Artifact
 		fellBack bool
 	)
 
-	err := report.run("Creating the new version", func() error {
+	err := report.run(label, func() error {
 		payload, payloadErr := loaded.Compiled.ArtifactPayload()
 		if payloadErr != nil {
 			return payloadErr
@@ -401,6 +409,10 @@ func linkProject(projectDir string, made version, report *reporter) error {
 		return nil
 	}
 
+	// From here the directory is already linked, which rules out the advice
+	// below: 'dr artifact code init' refuses a directory that has state, so
+	// naming it would send the reader to a command that cannot run.
+
 	cfg, err := loadProjectFn(projectDir)
 	if err != nil {
 		return fmt.Errorf("cannot read which artifact %s is linked to: %w", projectDir, err)
@@ -409,7 +421,7 @@ func linkProject(projectDir string, made version, report *reporter) error {
 	cfg.ArtifactID = made.ID
 
 	if err := saveProjectFn(projectDir, cfg); err != nil {
-		return linkFailure(made.ID, projectDir, err)
+		return relinkFailure(made.ID, projectDir, err)
 	}
 
 	report.say("  Project now pushes to artifact %s.\n", made.ID)
@@ -417,14 +429,29 @@ func linkProject(projectDir string, made version, report *reporter) error {
 	return nil
 }
 
-// linkFailure says which artifact was stranded. The artifact exists and
-// nothing records that fact, so the next run would make another; naming the
-// id is the difference between a re-run and a support ticket.
+// linkFailure says which artifact was stranded, for a directory that had no
+// link to begin with. The artifact exists and nothing records that fact, so the
+// next run would make another; naming the id is the difference between a re-run
+// and a support ticket.
 func linkFailure(artifactID, projectDir string, err error) error {
 	return fmt.Errorf(
 		"artifact %s was created but %s could not be pointed at it, so the next deploy would create another. "+
 			"Run 'dr artifact code init %s' here, then deploy again: %w",
 		artifactID, projectDir, artifactID, err)
+}
+
+// relinkFailure is the same accident on a directory that is already linked,
+// which is every roll and every redraft of a locked artifact. It cannot name
+// 'dr artifact code init', because that command refuses a directory holding
+// state and would send the reader in a circle; and deleting the state to force
+// it would throw away the catalog and the last-synced version, which is the
+// cost the relink exists to avoid. What is left is the file itself, so the
+// error names it and the one field to change.
+func relinkFailure(artifactID, projectDir string, err error) error {
+	return fmt.Errorf(
+		"artifact %s was created but %s could not be pointed at it, so the next deploy would create another. "+
+			"Fix whatever stopped the write, then set \"artifactId\" to %s in %s by hand and deploy again: %w",
+		artifactID, projectDir, artifactID, wapi.ConfigPath(projectDir), err)
 }
 
 // inheritCode gives the new version the code the old one was running, when
@@ -437,7 +464,13 @@ func linkFailure(artifactID, projectDir string, err error) error {
 // start. Pointing it at the version last synced is what makes "a new version
 // of the same code" true.
 func inheritCode(projectDir, artifactID string, synced *sync.Result, report *reporter) error {
-	if synced != nil && synced.NewVersion != "" {
+	// A sync that moved anything has already pointed the artifact at what it
+	// produced, so only one that found nothing to do leaves a version with no
+	// code of its own. Minting a version is the usual proof of that, but not
+	// the only one: a sync whose whole plan was remote deletes can move the
+	// code store without the engine reporting a new version, and inheriting
+	// then would pin the artifact at the state before those deletes.
+	if synced != nil && (synced.NewVersion != "" || synced.UploadedCount > 0 || synced.DeletedCount > 0) {
 		return nil
 	}
 


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

A workload on a draft artifact is stopped after 8 hours, so locking it is mandatory for anything with a URL people are expected to open, but once locked every subsequent `dr workload up` failed permanently and no flag got past it. That left no steady state: either the workload dies overnight, or every deploy needs a four step manual repair the error message never mentioned. The cause was much narrower than the symptom, since `up` asks the sync engine for a file count to put in its plan and the engine refused any locked artifact outright, including a run that was never going to write.

## CHANGES

A preview may now plan against a locked artifact, and the refusal moves to where a write would actually happen; everything downstream already minted a new version, moved the checkout's link, built and re-locked to match. The first deploy path redrafts the same way instead of telling you to delete local state, which worked but discarded the catalog and forced a full re-upload, and the plan now warns about the permanent lock before it happens rather than after. Three further bugs found by running the built binary against staging are fixed here too, the worst being a redraft interrupted after the relink that would build an artifact with no code reference at all.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production deploy and sync path for immutable artifacts (new versions, relinks, inherited codeRefs). Execute still refuses locked artifacts, but a bug here could skip a lock, target the wrong id, or build without code.
> 
> **Overview**
> `dr workload up` no longer dead-ends on a locked artifact. Previews can plan against one so the deploy can mint a successor, move the project link, carry over already-synced code, and lock the new version to match production.
> 
> The sync engine still **refuses Execute** on an immutable artifact. Dry-run/diff only get a plan plus a stderr/`locked` JSON notice so a preview cannot look like a working sync.
> 
> First-deploy redrafts into the locked artifact’s repository instead of telling users to delete local state (which discarded the catalog and forced a full re-upload). The plan warns when a lock will be applied without `--lock`. `inheritCode` now runs on create as well as roll, so a redraft with nothing to upload still gets a codeRef.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2da221daaf3afc5455ee0f3bcdeca8689dc22ee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->