### PR TITLE
[RAPTOR-19533] fix(workload): binding to live C2W workloads writes a manifest the CLI then refuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ If you're new to DataRobot, visit the [DataRobot documentation](https://docs.dat
 - 📦 **Template management**&mdash;clone and configure application templates interactively.
 - ⚙️ **Interactive configuration**&mdash;smart wizard for environment setup with validation.
 - 🚀 **Task runner**&mdash;execute application tasks with built-in Taskfile integration.
+- 🛠️ **Workload management**&mdash;bind to live C2W workloads and deploy from manifests (`dr workload config`), gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`.
 - 🐚 **Shell completions**&mdash;support for Bash, Zsh, Fish, and PowerShell.
 - 🔄 **Self-update capability**&mdash;easily update to the latest version with a single command.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ If you're new to DataRobot, visit the [DataRobot documentation](https://docs.dat
 - 📦 **Template management**&mdash;clone and configure application templates interactively.
 - ⚙️ **Interactive configuration**&mdash;smart wizard for environment setup with validation.
 - 🚀 **Task runner**&mdash;execute application tasks with built-in Taskfile integration.
-- 🛠️ **Workload management**&mdash;bind to live C2W workloads and deploy from manifests (`dr workload config`), gated behind `DATAROBOT_CLI_FEATURE_WORKLOAD=true`.
 - 🐚 **Shell completions**&mdash;support for Bash, Zsh, Fish, and PowerShell.
 - 🔄 **Self-update capability**&mdash;easily update to the latest version with a single command.
 

--- a/internal/workload/manifest/keys.go
+++ b/internal/workload/manifest/keys.go
@@ -45,3 +45,21 @@ const (
 	keyStartupProbe   = "startupProbe"
 	keyType           = "type"
 )
+
+// Server-managed and build-output field names declared in the field rule
+// table (schema.go). The server-managed keys are the server's own
+// bookkeeping, stripped at any depth; the build-output keys are
+// server-assigned values stripped from containers. Defined here so a
+// rename in the rule table is a one-line change, matching the convention
+// above.
+const (
+	keyBuild          = "build"
+	keyCodeRef        = "codeRef"
+	keyCreatedAt      = "createdAt"
+	keyEndpoint       = "endpoint"
+	keyID             = "id"
+	keyImageOutdated  = "imageOutdated"
+	keyResolvedBundle = "resolvedBundle"
+	keyStatus         = "status"
+	keyUpdatedAt      = "updatedAt"
+)

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -960,18 +960,24 @@ func stripKeys(value any) {
 // purge strips enabled: null, leaving {} — which both autoscalingActive and
 // checkScaling read as OFF (absent), inverting the group's semantics.
 //
-// Only the nil placeholder is rewritten. A present bool (true or false) or an
-// absent enabled key already carries the right meaning and is left untouched.
-// A block like {enabled: null, minReplicaCount: 2} already reads as ON after
-// the purge (enabled absent → default on); normalizing it to enabled: true
-// makes the default explicit and keeps the rendered file free of nulls.
+// Only a present-with-nil enabled is rewritten. A present bool (true or false)
+// or an absent enabled key already carries the right meaning and is left
+// untouched. The two-value map-access idiom distinguishes "enabled present
+// with nil value" from "enabled absent entirely" — the single-value
+// `autoscaling[keyEnabled] == nil` cannot (Go map zero-value ambiguity), and
+// would rewrite a genuinely empty autoscaling: {} to {enabled: true},
+// inverting a should-be-OFF group to ON. A block like {enabled: null,
+// minReplicaCount: 2} already reads as ON after the purge (enabled absent →
+// default on); normalizing it to enabled: true makes the default explicit and
+// keeps the rendered file free of nulls.
 func normalizeAutoscalingEnabled(doc map[string]any) {
 	autoscaling, ok := doc[keyAutoscaling].(map[string]any)
 	if !ok {
 		return
 	}
 
-	if autoscaling[keyEnabled] == nil {
+	val, present := autoscaling[keyEnabled]
+	if present && val == nil {
 		autoscaling[keyEnabled] = true
 	}
 }

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -843,9 +843,10 @@ func documentNode(document map[string]any) (*yaml.Node, error) {
 // blocks are "passed through as the platform gave them"). Reordering every
 // mapping with a name key produced unexplained diff noise on every bind.
 //
-// The walk descends into every value so containerGroups/containers at any
-// depth are found (containers nest inside groups, and a future spec may nest
-// groups inside something else), but it only reorders the mappings that are
+// The walk is scoped to mapping nodes: it returns early on anything else
+// (scalars and sequences carry no containerGroups/containers keys). Within a
+// mapping it recurses into each value, so containerGroups/containers nested
+// inside other mappings are found, but it only reorders the mappings that are
 // sequence items under those two keys. The top-level manifest order is
 // already controlled by Render's explicit field list and is never reached
 // here.
@@ -960,9 +961,13 @@ func stripKeys(value any) {
 // container: imageUri is deleted as a server-built pin and codeRef as
 // server-managed. An imageBuildConfig that is empty, or becomes empty after
 // deleting codeRef, is NOT a build container — the user-declared imageUri is
-// kept and the emptied imageBuildConfig key is removed entirely so it never
-// renders as "{}" alongside a missing imageUri, which Validate would reject
-// with "must set either imageUri or imageBuildConfig".
+// kept and the emptied imageBuildConfig key is removed entirely. This is an
+// invariant guard mirroring the server's own rule at containers.py:415
+// ("either imageUri or imageBuildConfig must be provided"): the rendered
+// container must always carry exactly one valid image source, never an empty
+// imageBuildConfig: "{}" alongside a missing imageUri. Today the server-side
+// non-nullability of dockerfile makes the empty case unreachable from real
+// payloads, but the guard fails safe if that ever changes.
 func stripBuildOutputs(spec map[string]any) {
 	for _, group := range slicesAt(spec, keyContainerGroups) {
 		for _, container := range slicesAt(group, keyContainers) {

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -62,8 +62,11 @@ func NewLive(workloadID string, workloadDoc, artifactDoc map[string]any) Live {
 		Importance:   stringAt(workloadDoc, keyImportance),
 		ArtifactName: stringAt(artifactDoc, keyName),
 		ArtifactType: stringAt(artifactDoc, keyType),
-		Spec:         stripNullKeys(stripServerManaged(mapAt(artifactDoc, keySpec))),
-		Runtime:      stripNullKeys(stripServerManaged(mapAt(workloadDoc, keyRuntime))),
+		// stripServerManaged deep-copies once and strips both server-managed
+		// keys and nil-valued keys in a single recursive walk, so no second
+		// copy is allocated here.
+		Spec:    stripServerManaged(mapAt(artifactDoc, keySpec)),
+		Runtime: stripServerManaged(mapAt(workloadDoc, keyRuntime)),
 	}
 
 	stripBuildOutputs(live.Spec)
@@ -862,7 +865,18 @@ func stripKeys(value any) {
 			delete(typed, key)
 		}
 
-		for _, child := range typed {
+		// Nil-valued keys are dropped in the same walk: the server echoes
+		// them as placeholders (e.g. autoscaling: null), and writing one
+		// into the committed manifest would confuse the validator. Empty
+		// maps are preserved; isNullish is the validator's counterpart that
+		// treats an empty mapping as absent rather than as a policy.
+		for key, child := range typed {
+			if child == nil {
+				delete(typed, key)
+
+				continue
+			}
+
 			stripKeys(child)
 		}
 	case []any:
@@ -893,53 +907,8 @@ func stripBuildOutputs(spec map[string]any) {
 	}
 }
 
-// stripNullKeys returns a copy of the document with every nil-valued key
-// removed recursively. Falsy-but-present values (false, 0, empty strings,
-// empty slices) are kept. The input document is not modified.
-func stripNullKeys(document map[string]any) map[string]any {
-	if document == nil {
-		return nil
-	}
-
-	copied := make(map[string]any, len(document))
-	for key, value := range document {
-		if value == nil {
-			continue
-		}
-
-		switch typed := value.(type) {
-		case map[string]any:
-			copied[key] = stripNullKeys(typed)
-		case []any:
-			copied[key] = stripNullSlice(typed)
-		default:
-			copied[key] = value
-		}
-	}
-
-	return copied
-}
-
-func stripNullSlice(items []any) []any {
-	if items == nil {
-		return nil
-	}
-
-	copied := make([]any, len(items))
-	for i, value := range items {
-		switch typed := value.(type) {
-		case map[string]any:
-			copied[i] = stripNullKeys(typed)
-		case []any:
-			copied[i] = stripNullSlice(typed)
-		default:
-			copied[i] = value
-		}
-	}
-
-	return copied
-}
-
+// deepCopyMap returns a deep copy of document so the caller's input is not
+// mutated by the strip passes that run against it.
 func deepCopyMap(document map[string]any) map[string]any {
 	if document == nil {
 		return nil

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -924,19 +924,12 @@ func stripKeys(value any) {
 			delete(typed, key)
 		}
 
-		// Normalize enabled: null inside a present autoscaling block before
-		// the nil-purge would collapse it to {}. The platform's default for a
-		// configured autoscaling block is ON, so enabled: null carries that
-		// meaning; rewriting it to true keeps the rendered file free of nulls
-		// (invariant 3) and semantically honest — both autoscalingActive and
-		// checkScaling read the post-strip shape as ON.
-		normalizeAutoscalingEnabled(typed)
-
 		// Nil-valued keys are dropped in the same walk: the server echoes
 		// them as placeholders (e.g. autoscaling: null), and writing one
 		// into the committed manifest would confuse the validator. Empty
 		// maps are preserved; isNullish is the validator's counterpart that
-		// treats an empty mapping as absent rather than as a policy.
+		// treats an empty mapping as absent rather than as a policy. The
+		// nullable set is documented in library/api-reference.md.
 		for key, child := range typed {
 			if child == nil {
 				delete(typed, key)
@@ -950,35 +943,6 @@ func stripKeys(value any) {
 		for _, item := range typed {
 			stripKeys(item)
 		}
-	}
-}
-
-// normalizeAutoscalingEnabled rewrites enabled: null inside a present
-// autoscaling block to enabled: true before the nil-purge would collapse it.
-// The platform's default for a configured autoscaling block is ON, so an
-// explicit enabled: null carries that meaning. Without this normalization the
-// purge strips enabled: null, leaving {} — which both autoscalingActive and
-// checkScaling read as OFF (absent), inverting the group's semantics.
-//
-// Only a present-with-nil enabled is rewritten. A present bool (true or false)
-// or an absent enabled key already carries the right meaning and is left
-// untouched. The two-value map-access idiom distinguishes "enabled present
-// with nil value" from "enabled absent entirely" — the single-value
-// `autoscaling[keyEnabled] == nil` cannot (Go map zero-value ambiguity), and
-// would rewrite a genuinely empty autoscaling: {} to {enabled: true},
-// inverting a should-be-OFF group to ON. A block like {enabled: null,
-// minReplicaCount: 2} already reads as ON after the purge (enabled absent →
-// default on); normalizing it to enabled: true makes the default explicit and
-// keeps the rendered file free of nulls.
-func normalizeAutoscalingEnabled(doc map[string]any) {
-	autoscaling, ok := doc[keyAutoscaling].(map[string]any)
-	if !ok {
-		return
-	}
-
-	val, present := autoscaling[keyEnabled]
-	if present && val == nil {
-		autoscaling[keyEnabled] = true
 	}
 }
 

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -471,7 +471,7 @@ func (l *Live) runtimeGroup() map[string]any {
 // autoscaling: the file it would produce is one the ledger accepts.
 func autoscalingActive(group map[string]any) bool {
 	autoscaling := mapAt(group, keyAutoscaling)
-	if autoscaling == nil {
+	if len(autoscaling) == 0 {
 		return false
 	}
 

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -26,7 +26,9 @@ import (
 // server's own bookkeeping: it assigns them, and a file that repeats them
 // back is either ignored or rejected. Stripping them recursively is safe
 // because the create spec has no legitimate key by these names anywhere.
-var serverManagedKeys = []string{"id", "createdAt", "updatedAt", "status", "endpoint", "artifactId", "workloadId"}
+var serverManagedKeys = []string{
+	"id", "createdAt", "updatedAt", "status", "endpoint", "artifactId", "workloadId", "resolvedBundle",
+}
 
 // Live is a running workload, downloaded so a manifest can be written that
 // says everything the workload already says. Setup uses it when the user
@@ -60,8 +62,8 @@ func NewLive(workloadID string, workloadDoc, artifactDoc map[string]any) Live {
 		Importance:   stringAt(workloadDoc, keyImportance),
 		ArtifactName: stringAt(artifactDoc, keyName),
 		ArtifactType: stringAt(artifactDoc, keyType),
-		Spec:         stripServerManaged(mapAt(artifactDoc, keySpec)),
-		Runtime:      stripServerManaged(mapAt(workloadDoc, keyRuntime)),
+		Spec:         stripNullKeys(stripServerManaged(mapAt(artifactDoc, keySpec))),
+		Runtime:      stripNullKeys(stripServerManaged(mapAt(workloadDoc, keyRuntime))),
 	}
 
 	stripBuildOutputs(live.Spec)
@@ -841,19 +843,68 @@ func stripKeys(value any) {
 // was asked to do. A container that says how to build itself also carries the
 // image that came out and the code the last sync uploaded; both are re-earned
 // by the next deploy, and writing them into the file would pin a workload to
-// yesterday's image.
+// yesterday's image. It also strips the server-assigned build block and the
+// computed imageOutdated flag.
 func stripBuildOutputs(spec map[string]any) {
 	for _, group := range slicesAt(spec, keyContainerGroups) {
 		for _, container := range slicesAt(group, keyContainers) {
 			buildConfig := mapAt(container, keyImageBuildConfig)
-			if buildConfig == nil {
-				continue
+			if buildConfig != nil {
+				delete(container, keyImageURI)
+				delete(buildConfig, "codeRef")
 			}
 
-			delete(container, keyImageURI)
-			delete(buildConfig, "codeRef")
+			delete(container, "build")
+			delete(container, "imageOutdated")
 		}
 	}
+}
+
+// stripNullKeys returns a copy of the document with every nil-valued key
+// removed recursively. Falsy-but-present values (false, 0, empty strings,
+// empty slices) are kept. The input document is not modified.
+func stripNullKeys(document map[string]any) map[string]any {
+	if document == nil {
+		return nil
+	}
+
+	copied := make(map[string]any, len(document))
+	for key, value := range document {
+		if value == nil {
+			continue
+		}
+
+		switch typed := value.(type) {
+		case map[string]any:
+			copied[key] = stripNullKeys(typed)
+		case []any:
+			copied[key] = stripNullSlice(typed)
+		default:
+			copied[key] = value
+		}
+	}
+
+	return copied
+}
+
+func stripNullSlice(items []any) []any {
+	if items == nil {
+		return nil
+	}
+
+	copied := make([]any, len(items))
+	for i, value := range items {
+		switch typed := value.(type) {
+		case map[string]any:
+			copied[i] = stripNullKeys(typed)
+		case []any:
+			copied[i] = stripNullSlice(typed)
+		default:
+			copied[i] = value
+		}
+	}
+
+	return copied
 }
 
 func deepCopyMap(document map[string]any) map[string]any {

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -182,24 +182,43 @@ func (m *Manifest) BuildMode() string {
 	return ""
 }
 
-// primaryContainerNode finds the container traffic reaches in a parsed spec,
-// falling back to the first container the way the live-document walk does.
-func primaryContainerNode(spec *yaml.Node) *yaml.Node {
-	var first *yaml.Node
-
-	for _, group := range seqItems(mapValue(spec, keyContainerGroups)) {
-		for _, container := range seqItems(mapValue(group, keyContainers)) {
-			if first == nil {
+// findPrimary walks container groups looking for the primary container,
+// falling back to the first container the way both the node and map walks do.
+// The traversal is parameterised by the container representation so the logic
+// lives once: *yaml.Node for parsed manifests, map[string]any for live server
+// documents. found is false when no containers exist at all; first is the
+// zero value (nil) in that case, matching what the individual walks returned.
+func findPrimary[C any](
+	groups []C,
+	containersOf func(C) []C,
+	isPrimary func(C) bool,
+) (first C, found bool) {
+	for _, group := range groups {
+		for _, container := range containersOf(group) {
+			if !found {
 				first = container
+				found = true
 			}
 
-			if isTrue(mapValue(container, keyPrimary)) {
-				return container
+			if isPrimary(container) {
+				return container, true
 			}
 		}
 	}
 
-	return first
+	return first, found
+}
+
+// primaryContainerNode finds the container traffic reaches in a parsed spec,
+// falling back to the first container the way the live-document walk does.
+func primaryContainerNode(spec *yaml.Node) *yaml.Node {
+	container, _ := findPrimary(
+		seqItems(mapValue(spec, keyContainerGroups)),
+		func(group *yaml.Node) []*yaml.Node { return seqItems(mapValue(group, keyContainers)) },
+		func(container *yaml.Node) bool { return isTrue(mapValue(container, keyPrimary)) },
+	)
+
+	return container
 }
 
 // runtimeDefaults reads the sizing the workload is actually running with, so
@@ -802,21 +821,13 @@ func (l Live) primaryContainer() map[string]any {
 }
 
 func primaryContainerOf(spec map[string]any) map[string]any {
-	var first map[string]any
+	container, _ := findPrimary(
+		slicesAt(spec, keyContainerGroups),
+		func(group map[string]any) []map[string]any { return slicesAt(group, keyContainers) },
+		func(container map[string]any) bool { return boolAt(container, keyPrimary) },
+	)
 
-	for _, group := range slicesAt(spec, keyContainerGroups) {
-		for _, container := range slicesAt(group, keyContainers) {
-			if first == nil {
-				first = container
-			}
-
-			if boolAt(container, keyPrimary) {
-				return container
-			}
-		}
-	}
-
-	return first
+	return container
 }
 
 // documentNode encodes a server document as a YAML node, nil for an empty

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -26,10 +26,12 @@ import (
 // server's own bookkeeping: it assigns them, and a file that repeats them
 // back is either ignored or rejected. Stripping them recursively is safe
 // because the create spec has no legitimate key by these names anywhere.
-var serverManagedKeys = []string{
-	"id", "createdAt", "updatedAt", "status", "endpoint", "artifactId", "workloadId", "resolvedBundle",
-	"imageOutdated",
-}
+//
+// The list is derived from the field rule table (schema.go) so the strip
+// metadata lives in one place. See the strip scoping decision documented on
+// fieldRule: keys are deleted at ANY depth, including inside
+// codeRef.datarobot and any other nested mapping.
+var serverManagedKeys = serverManagedFieldKeys()
 
 // Live is a running workload, downloaded so a manifest can be written that
 // says everything the workload already says. Setup uses it when the user
@@ -776,16 +778,6 @@ func (l Live) Render() ([]byte, error) {
 		artifact = append(artifact, field{key: keySpec, value: spec})
 	}
 
-	fields := []field{
-		{key: keyWorkloadID, value: scalar(l.WorkloadID), comment: workloadIDComment},
-		{key: keyName, value: scalar(l.Name)},
-		{
-			key: keyImportance, value: scalar(orDefaultString(l.Importance, DefaultImportance)),
-			comment: "low | moderate | high | critical",
-		},
-		{key: keyArtifact, value: mapping(artifact...)},
-	}
-
 	runtime, err := documentNode(l.Runtime)
 	if err != nil {
 		return nil, err
@@ -793,9 +785,24 @@ func (l Live) Render() ([]byte, error) {
 
 	hoistNameKeys(runtime)
 
-	if runtime != nil {
-		fields = append(fields, field{key: keyRuntime, value: runtime})
+	// The top-level field order is defined by the field rule table
+	// (schema.go) and shared with Draft.Render so both renderers emit the
+	// same key sequence.
+	values := map[string]*yaml.Node{
+		keyWorkloadID: scalar(l.WorkloadID),
+		keyName:       scalar(l.Name),
+		keyImportance: scalar(orDefaultString(l.Importance, DefaultImportance)),
+		keyArtifact:   mapping(artifact...),
 	}
+
+	if runtime != nil {
+		values[keyRuntime] = runtime
+	}
+
+	fields := orderedFields(values, map[string]string{
+		keyWorkloadID: workloadIDComment,
+		keyImportance: strings.Join(ImportanceLevels, " | "),
+	})
 
 	var buf bytes.Buffer
 
@@ -846,7 +853,8 @@ func documentNode(document map[string]any) (*yaml.Node, error) {
 }
 
 // hoistNameKeys scopes name-promotion to identifier mappings: the
-// sequence-item mappings found under containerGroups and containers keys.
+// sequence-item mappings found under the identifier keys declared in the
+// field rule table (schema.go) — today, containerGroups and containers.
 // Arbitrary nested mappings that happen to carry a key literally called
 // "name" (e.g. labels: {team: x, name: not-an-id, zone: b}) are left in
 // their original key order, honouring the package's pass-through contract
@@ -855,11 +863,11 @@ func documentNode(document map[string]any) (*yaml.Node, error) {
 // mapping with a name key produced unexplained diff noise on every bind.
 //
 // The walk is scoped to mapping nodes: it returns early on anything else
-// (scalars and sequences carry no containerGroups/containers keys). Within a
-// mapping it recurses into each value, so containerGroups/containers nested
-// inside other mappings are found, but it only reorders the mappings that are
-// sequence items under those two keys. The top-level manifest order is
-// already controlled by Render's explicit field list and is never reached
+// (scalars and sequences carry no identifier keys). Within a mapping it
+// recurses into each value, so identifier keys nested inside other mappings
+// are found, but it only reorders the mappings that are sequence items under
+// those keys. The top-level manifest order is already controlled by Render's
+// orderedFields call (which consults the same table) and is never reached
 // here.
 func hoistNameKeys(node *yaml.Node) {
 	if node == nil {
@@ -879,8 +887,9 @@ func hoistNameKeys(node *yaml.Node) {
 		// recurse into those items so containers nested inside groups (and
 		// groups nested inside anything else) are reached. The sequence node
 		// itself is handled item-by-item here rather than via the generic
-		// descent, so its items are the only mappings touched.
-		if (key.Value == keyContainerGroups || key.Value == keyContainers) && value != nil {
+		// descent, so its items are the only mappings touched. The set of
+		// identifier keys is derived from the field rule table (schema.go).
+		if hoistNameKeySet[key.Value] && value != nil {
 			if value.Kind == yaml.SequenceNode {
 				for _, item := range value.Content {
 					hoistNameInMapping(item)
@@ -968,6 +977,11 @@ func stripKeys(value any) {
 // other level of the spec. The computed imageOutdated flag is unambiguous,
 // so it lives in that list instead.
 //
+// The build-output keys (both container-scoped and buildConfig-scoped) are
+// declared in the field rule table (schema.go). This function consults the
+// table via containerBuildOutputKeys and buildConfigBuildOutputKeys so the
+// set of stripped keys lives in one place.
+//
 // An imageBuildConfig with real content (e.g. a dockerfile block) is a build
 // container: imageUri is deleted as a server-built pin and codeRef as
 // server-managed. An imageBuildConfig that is empty, or becomes empty after
@@ -986,16 +1000,21 @@ func stripKeys(value any) {
 // dockerfile-required check flags it on the next run — the CLI does not bless
 // an unknown build source by rewriting or stripping it.
 func stripBuildOutputs(spec map[string]any) {
+	buildConfigOutputs := buildConfigBuildOutputKeys()
+	containerOutputs := containerBuildOutputKeys()
+
 	for _, group := range slicesAt(spec, keyContainerGroups) {
 		for _, container := range slicesAt(group, keyContainers) {
 			buildConfig := mapAt(container, keyImageBuildConfig)
 			if buildConfig != nil {
-				delete(buildConfig, "codeRef")
+				for _, key := range buildConfigOutputs {
+					delete(buildConfig, key)
+				}
 
 				// If the build config still has real content after stripping
-				// codeRef, this is a genuine build container: drop the
-				// server-built imageUri pin. If it emptied, the container is
-				// really an image container — drop the emptied
+				// the build-output keys, this is a genuine build container:
+				// drop the server-built imageUri pin. If it emptied, the
+				// container is really an image container — drop the emptied
 				// imageBuildConfig key and keep imageUri.
 				if len(buildConfig) == 0 {
 					delete(container, keyImageBuildConfig)
@@ -1004,7 +1023,9 @@ func stripBuildOutputs(spec map[string]any) {
 				}
 			}
 
-			delete(container, "build")
+			for _, key := range containerOutputs {
+				delete(container, key)
+			}
 		}
 	}
 }

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -729,6 +729,8 @@ func (l Live) Render() ([]byte, error) {
 		return nil, err
 	}
 
+	reorderKeys(spec)
+
 	artifact := []field{{key: keyName, value: scalar(l.ArtifactName)}}
 	if l.ArtifactType != "" {
 		artifact = append(artifact, field{key: keyType, value: scalar(l.ArtifactType)})
@@ -752,6 +754,8 @@ func (l Live) Render() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	reorderKeys(runtime)
 
 	if runtime != nil {
 		fields = append(fields, field{key: keyRuntime, value: runtime})
@@ -811,6 +815,35 @@ func documentNode(document map[string]any) (*yaml.Node, error) {
 	}
 
 	return node, nil
+}
+
+// reorderKeys walks the YAML node tree and moves any "name" key to the front of
+// its mapping's Content, preserving every other key in its original order. It is
+// applied to the nested spec and runtime blocks; the top-level manifest order is
+// already controlled by Render's explicit field list.
+func reorderKeys(node *yaml.Node) {
+	if node == nil {
+		return
+	}
+
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if node.Content[i].Value == keyName {
+				nameKey := node.Content[i]
+				nameValue := node.Content[i+1]
+
+				copy(node.Content[2:i+2], node.Content[0:i])
+				node.Content[0] = nameKey
+				node.Content[1] = nameValue
+
+				break
+			}
+		}
+	}
+
+	for _, child := range node.Content {
+		reorderKeys(child)
+	}
 }
 
 // stripServerManaged removes the server's bookkeeping from a copy of the

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -834,32 +834,77 @@ func documentNode(document map[string]any) (*yaml.Node, error) {
 	return node, nil
 }
 
-// hoistNameKeys walks the YAML node tree and moves any "name" key to the front of
-// its mapping's Content, preserving every other key in its original order. It is
-// applied to the nested spec and runtime blocks; the top-level manifest order is
-// already controlled by Render's explicit field list.
+// hoistNameKeys scopes name-promotion to identifier mappings: the
+// sequence-item mappings found under containerGroups and containers keys.
+// Arbitrary nested mappings that happen to carry a key literally called
+// "name" (e.g. labels: {team: x, name: not-an-id, zone: b}) are left in
+// their original key order, honouring the package's pass-through contract
+// (doc.go: unknown blocks "survive the round trip"; the spec and runtime
+// blocks are "passed through as the platform gave them"). Reordering every
+// mapping with a name key produced unexplained diff noise on every bind.
+//
+// The walk descends into every value so containerGroups/containers at any
+// depth are found (containers nest inside groups, and a future spec may nest
+// groups inside something else), but it only reorders the mappings that are
+// sequence items under those two keys. The top-level manifest order is
+// already controlled by Render's explicit field list and is never reached
+// here.
 func hoistNameKeys(node *yaml.Node) {
 	if node == nil {
 		return
 	}
 
-	if node.Kind == yaml.MappingNode {
-		for i := 0; i+1 < len(node.Content); i += 2 {
-			if node.Content[i].Value == keyName {
-				nameKey := node.Content[i]
-				nameValue := node.Content[i+1]
-
-				copy(node.Content[2:i+2], node.Content[0:i])
-				node.Content[0] = nameKey
-				node.Content[1] = nameValue
-
-				break
-			}
-		}
+	// Only mapping nodes can carry containerGroups/containers keys; sequence
+	// and scalar nodes have nothing to hoist and nothing to descend through.
+	if node.Kind != yaml.MappingNode {
+		return
 	}
 
-	for _, child := range node.Content {
-		hoistNameKeys(child)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key, value := node.Content[i], node.Content[i+1]
+
+		// Identifier keys: hoist name inside each sequence-item mapping and
+		// recurse into those items so containers nested inside groups (and
+		// groups nested inside anything else) are reached. The sequence node
+		// itself is handled item-by-item here rather than via the generic
+		// descent, so its items are the only mappings touched.
+		if (key.Value == keyContainerGroups || key.Value == keyContainers) && value != nil {
+			if value.Kind == yaml.SequenceNode {
+				for _, item := range value.Content {
+					hoistNameInMapping(item)
+					hoistNameKeys(item)
+				}
+			}
+
+			continue
+		}
+
+		// Non-matching subtrees are walked via their values so
+		// containerGroups/containers appearing at any depth are still found,
+		// while opaque mappings they contain keep their key order.
+		hoistNameKeys(value)
+	}
+}
+
+// hoistNameInMapping moves a "name" key to the front of a mapping node's
+// Content, preserving every other key in its original order. It is a no-op
+// for non-mapping nodes or mappings without a name key.
+func hoistNameInMapping(node *yaml.Node) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == keyName {
+			nameKey := node.Content[i]
+			nameValue := node.Content[i+1]
+
+			copy(node.Content[2:i+2], node.Content[0:i])
+			node.Content[0] = nameKey
+			node.Content[1] = nameValue
+
+			return
+		}
 	}
 }
 

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -56,7 +56,15 @@ type Live struct {
 // NewLive assembles the live view from the two documents the server returns,
 // stripping what only the server may set. workloadDoc is the workload,
 // artifactDoc the artifact it currently runs.
-func NewLive(workloadID string, workloadDoc, artifactDoc map[string]any) Live {
+//
+// It fails loudly when the artifact doc carries no usable spec — absent, or
+// stripped to nothing by the server-managed-key purge — so a partial or
+// permission-filtered artifact GET can never produce a manifest that Validate
+// would reject with "artifact.spec: is required for an inline artifact". The
+// error names the workload id, mirroring Apply's own "no primary container"
+// contract, because the right answer is to edit the file by hand rather than
+// let the CLI write something it would then refuse to read.
+func NewLive(workloadID string, workloadDoc, artifactDoc map[string]any) (Live, error) {
 	live := Live{
 		WorkloadID:   workloadID,
 		Name:         stringAt(workloadDoc, keyName),
@@ -72,7 +80,12 @@ func NewLive(workloadID string, workloadDoc, artifactDoc map[string]any) Live {
 
 	stripBuildOutputs(live.Spec)
 
-	return live
+	if len(live.Spec) == 0 {
+		return live, fmt.Errorf("workload %s has no artifact spec to bind; edit %s by hand instead",
+			workloadID, FileName)
+	}
+
+	return live, nil
 }
 
 // Type reports the artifact's kind, so the wizard's Q3 opens on what the

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -866,6 +866,14 @@ func stripKeys(value any) {
 			delete(typed, key)
 		}
 
+		// Normalize enabled: null inside a present autoscaling block before
+		// the nil-purge would collapse it to {}. The platform's default for a
+		// configured autoscaling block is ON, so enabled: null carries that
+		// meaning; rewriting it to true keeps the rendered file free of nulls
+		// (invariant 3) and semantically honest — both autoscalingActive and
+		// checkScaling read the post-strip shape as ON.
+		normalizeAutoscalingEnabled(typed)
+
 		// Nil-valued keys are dropped in the same walk: the server echoes
 		// them as placeholders (e.g. autoscaling: null), and writing one
 		// into the committed manifest would confuse the validator. Empty
@@ -884,6 +892,29 @@ func stripKeys(value any) {
 		for _, item := range typed {
 			stripKeys(item)
 		}
+	}
+}
+
+// normalizeAutoscalingEnabled rewrites enabled: null inside a present
+// autoscaling block to enabled: true before the nil-purge would collapse it.
+// The platform's default for a configured autoscaling block is ON, so an
+// explicit enabled: null carries that meaning. Without this normalization the
+// purge strips enabled: null, leaving {} — which both autoscalingActive and
+// checkScaling read as OFF (absent), inverting the group's semantics.
+//
+// Only the nil placeholder is rewritten. A present bool (true or false) or an
+// absent enabled key already carries the right meaning and is left untouched.
+// A block like {enabled: null, minReplicaCount: 2} already reads as ON after
+// the purge (enabled absent → default on); normalizing it to enabled: true
+// makes the default explicit and keeps the rendered file free of nulls.
+func normalizeAutoscalingEnabled(doc map[string]any) {
+	autoscaling, ok := doc[keyAutoscaling].(map[string]any)
+	if !ok {
+		return
+	}
+
+	if autoscaling[keyEnabled] == nil {
+		autoscaling[keyEnabled] = true
 	}
 }
 

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -81,7 +81,7 @@ func NewLive(workloadID string, workloadDoc, artifactDoc map[string]any) (Live, 
 	stripBuildOutputs(live.Spec)
 
 	if len(live.Spec) == 0 {
-		return live, fmt.Errorf("workload %s has no artifact spec to bind; edit %s by hand instead",
+		return live, fmt.Errorf("workload %s has no artifact spec; edit %s by hand instead",
 			workloadID, FileName)
 	}
 
@@ -961,13 +961,19 @@ func stripKeys(value any) {
 // container: imageUri is deleted as a server-built pin and codeRef as
 // server-managed. An imageBuildConfig that is empty, or becomes empty after
 // deleting codeRef, is NOT a build container — the user-declared imageUri is
-// kept and the emptied imageBuildConfig key is removed entirely. This is an
-// invariant guard mirroring the server's own rule at containers.py:415
-// ("either imageUri or imageBuildConfig must be provided"): the rendered
-// container must always carry exactly one valid image source, never an empty
-// imageBuildConfig: "{}" alongside a missing imageUri. Today the server-side
-// non-nullability of dockerfile makes the empty case unreachable from real
-// payloads, but the guard fails safe if that ever changes.
+// kept and the emptied imageBuildConfig key is removed entirely. This mirrors
+// the server's own rule at containers.py:415 ("either imageUri or
+// imageBuildConfig must be provided"): the rendered container must never
+// carry an empty imageBuildConfig: "{}" alongside a missing imageUri.
+//
+// The guard does not claim the rendered container always carries exactly one
+// valid image source. Today the server only accepts provided/generated
+// dockerfile sources (containers.py:84-95 discriminated union), so an
+// imageBuildConfig without a dockerfile key is a hypothetical future or
+// foreign shape. Such a shape is preserved verbatim under the pass-through
+// contract (doc.go: unknown blocks "survive the round trip"), and Validate's
+// dockerfile-required check flags it on the next run — the CLI does not bless
+// an unknown build source by rewriting or stripping it.
 func stripBuildOutputs(spec map[string]any) {
 	for _, group := range slicesAt(spec, keyContainerGroups) {
 		for _, container := range slicesAt(group, keyContainers) {

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -28,6 +28,7 @@ import (
 // because the create spec has no legitimate key by these names anywhere.
 var serverManagedKeys = []string{
 	"id", "createdAt", "updatedAt", "status", "endpoint", "artifactId", "workloadId", "resolvedBundle",
+	"imageOutdated",
 }
 
 // Live is a running workload, downloaded so a manifest can be written that
@@ -732,7 +733,7 @@ func (l Live) Render() ([]byte, error) {
 		return nil, err
 	}
 
-	reorderKeys(spec)
+	hoistNameKeys(spec)
 
 	artifact := []field{{key: keyName, value: scalar(l.ArtifactName)}}
 	if l.ArtifactType != "" {
@@ -758,7 +759,7 @@ func (l Live) Render() ([]byte, error) {
 		return nil, err
 	}
 
-	reorderKeys(runtime)
+	hoistNameKeys(runtime)
 
 	if runtime != nil {
 		fields = append(fields, field{key: keyRuntime, value: runtime})
@@ -820,11 +821,11 @@ func documentNode(document map[string]any) (*yaml.Node, error) {
 	return node, nil
 }
 
-// reorderKeys walks the YAML node tree and moves any "name" key to the front of
+// hoistNameKeys walks the YAML node tree and moves any "name" key to the front of
 // its mapping's Content, preserving every other key in its original order. It is
 // applied to the nested spec and runtime blocks; the top-level manifest order is
 // already controlled by Render's explicit field list.
-func reorderKeys(node *yaml.Node) {
+func hoistNameKeys(node *yaml.Node) {
 	if node == nil {
 		return
 	}
@@ -845,7 +846,7 @@ func reorderKeys(node *yaml.Node) {
 	}
 
 	for _, child := range node.Content {
-		reorderKeys(child)
+		hoistNameKeys(child)
 	}
 }
 
@@ -890,8 +891,11 @@ func stripKeys(value any) {
 // was asked to do. A container that says how to build itself also carries the
 // image that came out and the code the last sync uploaded; both are re-earned
 // by the next deploy, and writing them into the file would pin a workload to
-// yesterday's image. It also strips the server-assigned build block and the
-// computed imageOutdated flag.
+// yesterday's image. It also strips the server-assigned build block, scoped
+// to containers on purpose: the bare word "build" is generic enough that
+// adding it to serverManagedKeys could eat a legitimate user key at some
+// other level of the spec. The computed imageOutdated flag is unambiguous,
+// so it lives in that list instead.
 func stripBuildOutputs(spec map[string]any) {
 	for _, group := range slicesAt(spec, keyContainerGroups) {
 		for _, container := range slicesAt(group, keyContainers) {
@@ -902,7 +906,6 @@ func stripBuildOutputs(spec map[string]any) {
 			}
 
 			delete(container, "build")
-			delete(container, "imageOutdated")
 		}
 	}
 }

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -254,7 +254,7 @@ func liveBuild(container map[string]any) Build {
 		}
 	}
 
-	if buildConfig != nil {
+	if len(buildConfig) > 0 {
 		return Build{Mode: BuildModeUnchanged}
 	}
 
@@ -896,13 +896,31 @@ func stripKeys(value any) {
 // adding it to serverManagedKeys could eat a legitimate user key at some
 // other level of the spec. The computed imageOutdated flag is unambiguous,
 // so it lives in that list instead.
+//
+// An imageBuildConfig with real content (e.g. a dockerfile block) is a build
+// container: imageUri is deleted as a server-built pin and codeRef as
+// server-managed. An imageBuildConfig that is empty, or becomes empty after
+// deleting codeRef, is NOT a build container — the user-declared imageUri is
+// kept and the emptied imageBuildConfig key is removed entirely so it never
+// renders as "{}" alongside a missing imageUri, which Validate would reject
+// with "must set either imageUri or imageBuildConfig".
 func stripBuildOutputs(spec map[string]any) {
 	for _, group := range slicesAt(spec, keyContainerGroups) {
 		for _, container := range slicesAt(group, keyContainers) {
 			buildConfig := mapAt(container, keyImageBuildConfig)
 			if buildConfig != nil {
-				delete(container, keyImageURI)
 				delete(buildConfig, "codeRef")
+
+				// If the build config still has real content after stripping
+				// codeRef, this is a genuine build container: drop the
+				// server-built imageUri pin. If it emptied, the container is
+				// really an image container — drop the emptied
+				// imageBuildConfig key and keep imageUri.
+				if len(buildConfig) == 0 {
+					delete(container, keyImageBuildConfig)
+				} else {
+					delete(container, keyImageURI)
+				}
 			}
 
 			delete(container, "build")

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // liveWorkloadJSON and liveArtifactJSON are shaped like the server's own
@@ -995,4 +996,180 @@ func TestLive_DoesNotMutateInputDocs(t *testing.T) {
 
 	assert.Equal(t, workloadBefore, workloadDoc)
 	assert.Equal(t, artifactBefore, artifactDoc)
+}
+
+// renderedRoot parses rendered bytes and returns the document's root mapping node.
+func renderedRoot(t *testing.T, rendered []byte) *yaml.Node {
+	t.Helper()
+
+	var doc yaml.Node
+
+	require.NoError(t, yaml.Unmarshal(rendered, &doc))
+	require.Len(t, doc.Content, 1)
+	require.Equal(t, yaml.MappingNode, doc.Content[0].Kind)
+
+	return doc.Content[0]
+}
+
+// mappingKeys returns the scalar keys of a mapping node in order.
+func mappingKeys(node *yaml.Node) []string {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	keys := make([]string, 0, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		keys = append(keys, node.Content[i].Value)
+	}
+
+	return keys
+}
+
+// walkMappingNodes calls f for every mapping node under node, including node itself.
+func walkMappingNodes(node *yaml.Node, f func(*yaml.Node)) {
+	if node == nil {
+		return
+	}
+
+	if node.Kind == yaml.MappingNode {
+		f(node)
+	}
+
+	for _, child := range node.Content {
+		walkMappingNodes(child, f)
+	}
+}
+
+// In the rendered YAML, every container mapping lists name as its first key.
+func TestLive_RenderLeadsWithNameInContainers(t *testing.T) {
+	live := liveFixture(t)
+
+	rendered, err := live.Render()
+	require.NoError(t, err)
+
+	root := renderedRoot(t, rendered)
+	spec := mapValue(mapValue(root, keyArtifact), keySpec)
+
+	for _, group := range seqItems(mapValue(spec, keyContainerGroups)) {
+		for _, container := range seqItems(mapValue(group, keyContainers)) {
+			keys := mappingKeys(container)
+			require.NotEmpty(t, keys)
+			assert.Equal(t, keyName, keys[0], "container %q should lead with name", keys[0])
+		}
+	}
+}
+
+// In the rendered YAML, every container group mapping lists name as its first key.
+func TestLive_RenderLeadsWithNameInContainerGroups(t *testing.T) {
+	live := liveFixture(t)
+
+	rendered, err := live.Render()
+	require.NoError(t, err)
+
+	root := renderedRoot(t, rendered)
+
+	checkGroups := func(node *yaml.Node) {
+		for _, group := range seqItems(node) {
+			keys := mappingKeys(group)
+			require.NotEmpty(t, keys)
+			assert.Equal(t, keyName, keys[0], "container group should lead with name")
+		}
+	}
+
+	spec := mapValue(mapValue(root, keyArtifact), keySpec)
+	checkGroups(mapValue(spec, keyContainerGroups))
+
+	runtime := mapValue(root, keyRuntime)
+	checkGroups(mapValue(runtime, keyContainerGroups))
+}
+
+// The rendered manifest's top-level mapping lists keys in the agreed order.
+func TestLive_RenderTopLevelKeyOrder(t *testing.T) {
+	live := liveFixture(t)
+
+	rendered, err := live.Render()
+	require.NoError(t, err)
+
+	root := renderedRoot(t, rendered)
+	keys := mappingKeys(root)
+
+	assert.Equal(t, []string{keyWorkloadID, keyName, keyImportance, keyArtifact, keyRuntime}, keys)
+}
+
+// After Apply mutates the spec, the rendered output still leads every container
+// and container group mapping with name.
+func TestLive_ApplyRenderLeadsWithName(t *testing.T) {
+	live := liveFixture(t)
+
+	draft := live.Defaults()
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	root := renderedRoot(t, rendered)
+	spec := mapValue(mapValue(root, keyArtifact), keySpec)
+
+	for _, group := range seqItems(mapValue(spec, keyContainerGroups)) {
+		keys := mappingKeys(group)
+		require.NotEmpty(t, keys)
+		assert.Equal(t, keyName, keys[0], "container group should lead with name after Apply")
+
+		for _, container := range seqItems(mapValue(group, keyContainers)) {
+			keys := mappingKeys(container)
+			require.NotEmpty(t, keys)
+			assert.Equal(t, keyName, keys[0], "container should lead with name after Apply")
+		}
+	}
+}
+
+// Reordering moves name to the front but does not drop or duplicate any keys.
+func TestLive_RenderReorderPreservesKeys(t *testing.T) {
+	live := liveFixture(t)
+
+	rendered, err := live.Render()
+	require.NoError(t, err)
+
+	root := renderedRoot(t, rendered)
+
+	walkMappingNodes(root, func(node *yaml.Node) {
+		keys := mappingKeys(node)
+		seen := make(map[string]bool, len(keys))
+
+		for _, key := range keys {
+			assert.False(t, seen[key], "key %q is duplicated", key)
+			seen[key] = true
+		}
+
+		// The top-level manifest order is deliberately fixed by Render; all
+		// nested mappings with a name key should lead with it.
+		if node != root && seen[keyName] {
+			assert.Equal(t, keyName, keys[0], "name should lead when present")
+		}
+	})
+
+	// Focused check: a known container keeps its full key set, only reordering.
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name": "a",
+		"type": "service",
+		"spec": {"containerGroups": [{"name": "default", "containers": [
+			{"name": "primary", "primary": true, "port": 8080, "imageUri": "nginx:latest"}
+		]}]}
+	}`), &artifactDoc))
+
+	focused := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	focusedRendered, err := focused.Render()
+	require.NoError(t, err)
+
+	focusedRoot := renderedRoot(t, focusedRendered)
+	spec := mapValue(mapValue(focusedRoot, keyArtifact), keySpec)
+	group := seqItems(mapValue(spec, keyContainerGroups))[0]
+	container := seqItems(mapValue(group, keyContainers))[0]
+
+	keys := mappingKeys(container)
+	assert.Equal(t, []string{keyName, keyImageURI, keyPort, keyPrimary}, keys)
 }

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -373,6 +373,16 @@ func TestLive_ApplyKeepsUnknownBuildKeys(t *testing.T) {
 
 // A build source this release does not know is kept as it stands rather than
 // forced into the nearest mode the Build struct can express.
+//
+// Validate is intentionally NOT exercised on this hypothetical shape. Today
+// the server only accepts provided/generated dockerfile sources
+// (containers.py:84-95 discriminated union), so a buildpack-only
+// imageBuildConfig cannot arrive from a real payload. Under the pass-through
+// contract the unknown source is preserved for the server to judge, not
+// blessed by the CLI — and Validate's dockerfile-required check would reject
+// it (the container carries an imageBuildConfig with no dockerfile key). The
+// test asserts the pass-through behavior (preservation) only, not that the
+// rendered file validates.
 func TestLive_UnknownBuildSourceIsPreserved(t *testing.T) {
 	var artifactDoc map[string]any
 
@@ -1496,37 +1506,69 @@ func TestLive_NativelyEmptyBuildBlockRoundTrips(t *testing.T) {
 // BuildModeUnchanged. An emptied build block has no content to preserve, and
 // BuildModeUnchanged causes applyBuild to no-op — leaving the broken container
 // in place. BuildModeImage lets applyBuild keep/restore imageUri.
+//
+// The "natively empty" case calls liveBuild directly. The "emptied through
+// strip pipeline" case drives the real strip pipeline via NewLive: a server
+// doc with imageBuildConfig {dockerfile: null, codeRef: {...}} + imageUri →
+// stripKeys purges dockerfile:null → stripBuildOutputs deletes codeRef and,
+// because the config is now empty, drops the imageBuildConfig key and keeps
+// imageUri → the container classifies as BuildModeImage. (VAL-R3-006).
 func TestLive_EmptyBuildConfigClassifiedAsImage(t *testing.T) {
-	tests := map[string]struct {
-		container map[string]any
-	}{
-		"natively empty": {
-			container: map[string]any{
-				"name":             "app",
-				"imageUri":         "registry.example.com/app:v1",
-				"imageBuildConfig": map[string]any{},
-			},
-		},
-		"emptied after codeRef removal": {
-			container: map[string]any{
-				"name":     "app",
-				"imageUri": "registry.example.com/app:v1",
-				// Simulate post-strip state: codeRef already deleted,
-				// dockerfile:null already purged → empty map.
-				"imageBuildConfig": map[string]any{},
-			},
-		},
-	}
+	t.Run("natively empty", func(t *testing.T) {
+		container := map[string]any{
+			"name":             "app",
+			"imageUri":         "registry.example.com/app:v1",
+			"imageBuildConfig": map[string]any{},
+		}
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			build := liveBuild(tc.container)
+		build := liveBuild(container)
 
-			assert.Equal(t, BuildModeImage, build.Mode,
-				"empty imageBuildConfig must classify as BuildModeImage, not BuildModeUnchanged")
-			assert.Equal(t, "registry.example.com/app:v1", build.ImageURI)
-		})
-	}
+		assert.Equal(t, BuildModeImage, build.Mode,
+			"empty imageBuildConfig must classify as BuildModeImage, not BuildModeUnchanged")
+		assert.Equal(t, "registry.example.com/app:v1", build.ImageURI)
+	})
+
+	t.Run("emptied through strip pipeline", func(t *testing.T) {
+		var artifactDoc map[string]any
+
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"name": "a",
+			"type": "service",
+			"spec": {"containerGroups": [{"name": "default", "containers": [
+				{
+					"name": "app",
+					"primary": true,
+					"port": 8080,
+					"imageUri": "registry.example.com/app:v1",
+					"imageBuildConfig": {
+						"dockerfile": null,
+						"codeRef": {"datarobot": {"catalogId": "cat1", "catalogVersionId": "ver1"}}
+					}
+				}
+			]}]}
+		}`), &artifactDoc))
+
+		live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+		require.NoError(t, err)
+
+		// After NewLive: stripKeys purged dockerfile:null, stripBuildOutputs
+		// deleted codeRef, and because the config is now empty, dropped the
+		// imageBuildConfig key entirely and kept imageUri.
+		container := primaryContainerOf(live.Spec)
+		require.NotNil(t, container)
+
+		assert.NotContains(t, container, keyImageBuildConfig,
+			"the emptied imageBuildConfig key must be dropped")
+		assert.Equal(t, "registry.example.com/app:v1", stringAt(container, keyImageURI),
+			"the user-declared imageUri must be kept")
+
+		// The container classifies as BuildModeImage, not BuildModeUnchanged.
+		build := liveBuild(container)
+
+		assert.Equal(t, BuildModeImage, build.Mode,
+			"emptied imageBuildConfig must classify as BuildModeImage, not BuildModeUnchanged")
+		assert.Equal(t, "registry.example.com/app:v1", build.ImageURI)
+	})
 }
 
 // A real build container — imageBuildConfig with a dockerfile present plus a
@@ -1724,6 +1766,13 @@ func TestNewLive_SpeclessArtifactDocFailsWithWorkloadID(t *testing.T) {
 	assert.Contains(t, err.Error(), workloadID,
 		"the error must name the workload id so the user knows what to edit")
 	assert.Contains(t, err.Error(), "no artifact spec")
+	// The message is path-neutral: it surfaces verbatim through both the
+	// wizard bind flow and `dr workload up` (look.go), so it must not say
+	// "to bind" — the up path is not binding anything. (VAL-R3-005)
+	assert.Contains(t, err.Error(), "edit",
+		"the error must tell the user to edit the file by hand")
+	assert.NotContains(t, err.Error(), "bind",
+		"the message must be path-neutral, not bind-specific")
 }
 
 // An artifact doc whose spec is present but strips to nothing — every key is

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -928,6 +928,19 @@ func TestStripServerManaged_StripsNullKeys(t *testing.T) {
 				"autoscaling": map[string]any{"enabled": false},
 			},
 		},
+		// A genuinely empty autoscaling: {} map (enabled key absent entirely,
+		// not present-with-nil) must survive stripKeys unchanged. The previous
+		// guard used `autoscaling[keyEnabled] == nil`, which cannot distinguish
+		// absent from present-with-nil — rewriting an empty map to
+		// {enabled: true} and inverting a should-be-OFF group to ON.
+		"autoscaling empty map untouched": {
+			input: map[string]any{
+				"autoscaling": map[string]any{},
+			},
+			expected: map[string]any{
+				"autoscaling": map[string]any{},
+			},
+		},
 	}
 
 	for name, tc := range tests {
@@ -1684,6 +1697,60 @@ func TestLive_EnabledNullAutoscalingWithBodyStillOn(t *testing.T) {
 	parsed, err := Parse(rendered, "")
 	require.NoError(t, err)
 	require.NoError(t, parsed.Validate())
+}
+
+// A server-sourced runtime group with a genuinely empty autoscaling: {} map
+// (the enabled key absent entirely, not present-with-nil) must survive
+// NewLive/stripKeys unchanged — no enabled key materialized. The previous
+// normalizeAutoscalingEnabled guard used `autoscaling[keyEnabled] == nil`,
+// which in Go cannot distinguish "enabled present with nil value" from
+// "enabled absent entirely" (map zero-value ambiguity). That rewrote a
+// genuinely empty autoscaling: {} to {enabled: true} before the nil-purge ran,
+// inverting a should-be-OFF group to ON — contradicting the function's own
+// doc comment and autoscalingActive's len==0 OFF guard. The fix uses the
+// two-value map-access idiom so only a present-with-nil enabled is normalized.
+func TestLive_EmptyAutoscalingMapNotInvertedToOn(t *testing.T) {
+	var workloadDoc, artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name": "empty-autoscaling",
+		"runtime": {"containerGroups": [{"name": "default",
+			"autoscaling": {},
+			"containers": [{"name": "app", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}]}
+		]}
+	}`), &workloadDoc))
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name": "a",
+		"type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
+			{"name": "app", "primary": true, "port": 8080, "imageUri": "nginx:latest"}]}
+		]}}
+	`), &artifactDoc))
+
+	live, err := NewLive("68b0", workloadDoc, artifactDoc)
+	require.NoError(t, err)
+
+	// A genuinely empty autoscaling map reads as OFF, matching
+	// autoscalingActive's len==0 guard.
+	assert.False(t, live.Autoscaled(),
+		"an empty autoscaling: {} map is OFF, not the platform's default-on")
+
+	draft := live.Defaults()
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	// No enabled key was materialized by normalization.
+	assert.NotContains(t, string(rendered), "enabled: true",
+		"an empty autoscaling: {} must not gain an enabled: true key")
+
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate(),
+		"render→parse→validate round trip must pass for the empty-autoscaling shape")
 }
 
 // An artifact document carrying no usable spec is the review repro for

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -294,7 +294,7 @@ func TestLive_LiteralEnvVarsSkipsCredentialReferences(t *testing.T) {
          "environmentVars": [
            {"name": "LOG_LEVEL", "value": "debug"},
            {"name": "SHORTHAND", "value": "dr-credential:68f0cccc0000000000000003/apiToken"},
-           {"name": "OBJECT", "source": "credential",
+           {"name": "OBJECT", "source": "dr-credential",
             "drCredentialId": "68f0cccc0000000000000003", "key": "apiToken"},
            {"name": "REGION", "value": "eu-west-1"}
          ]}

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -868,6 +868,36 @@ func TestStripServerManaged_StripsNullKeys(t *testing.T) {
 				"keep": "x",
 			},
 		},
+		// enabled: null inside a present autoscaling block is the platform's
+		// default-on; stripKeys normalizes it to enabled: true before the
+		// nil-purge would collapse {enabled: null} to {} (which both readers
+		// treat as OFF). This is the fix for the semantic inversion.
+		"autoscaling enabled null normalized to true": {
+			input: map[string]any{
+				"autoscaling": map[string]any{"enabled": nil},
+			},
+			expected: map[string]any{
+				"autoscaling": map[string]any{"enabled": true},
+			},
+		},
+		"autoscaling enabled null with body normalized": {
+			input: map[string]any{
+				"autoscaling": map[string]any{"enabled": nil, "minReplicaCount": 2},
+			},
+			expected: map[string]any{
+				"autoscaling": map[string]any{"enabled": true, "minReplicaCount": 2},
+			},
+		},
+		// A non-null enabled value is left untouched: false stays false, true
+		// stays true. Normalization only fires on the nil placeholder.
+		"autoscaling enabled false untouched": {
+			input: map[string]any{
+				"autoscaling": map[string]any{"enabled": false},
+			},
+			expected: map[string]any{
+				"autoscaling": map[string]any{"enabled": false},
+			},
+		},
 	}
 
 	for name, tc := range tests {
@@ -1420,6 +1450,106 @@ func TestLive_RealBuildContainerStillStripsImageUriAndCodeRef(t *testing.T) {
 	assert.NotContains(t, string(rendered), "codeRef")
 	assert.Contains(t, string(rendered), "imageBuildConfig")
 	assert.Contains(t, string(rendered), "source: provided")
+
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+}
+
+// A runtime group whose server shape was autoscaling: {enabled: null} — the
+// platform's default-on — must survive NewLive's stripping without semantic
+// inversion. The strip path normalizes enabled: null to enabled: true so
+// autoscalingActive reads the group as ON, the wizard suppresses the replica
+// question, the rendered file carries no replicaCount, and the round trip
+// through Parse and Validate passes.
+func TestLive_EnabledNullAutoscalingSurvivesStripping(t *testing.T) {
+	var workloadDoc, artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name": "default-autoscaling",
+		"runtime": {"containerGroups": [{"name": "default",
+			"autoscaling": {"enabled": null},
+			"containers": [{"name": "app", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}]}
+		]}
+	}`), &workloadDoc))
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name": "a",
+		"type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
+			{"name": "app", "primary": true, "port": 8080, "imageUri": "nginx:latest"}]}
+		]}}
+	`), &artifactDoc))
+
+	live := NewLive("68b0", workloadDoc, artifactDoc)
+
+	// After stripping, the group reads as autoscaling ON.
+	assert.True(t, live.Autoscaled(),
+		"enabled: null is the platform's default-on; stripping must not invert it to OFF")
+
+	// The wizard suppresses the replica question for an autoscaled group.
+	draft := live.Defaults()
+	assert.Equal(t, 0, draft.Runtime.Replicas,
+		"no replica count prompted for an autoscaled group")
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	// The rendered runtime carries no replicaCount for the autoscaled group.
+	assert.NotContains(t, string(rendered), "replicaCount",
+		"an autoscaled group must not carry a replica count")
+	// The normalized enabled: true is present and no null survives.
+	assert.Contains(t, string(rendered), "enabled: true")
+	assert.NotContains(t, string(rendered), "enabled: null")
+
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate(),
+		"render→parse→validate round trip must pass for the enabled-null shape")
+}
+
+// A runtime group whose server shape was autoscaling: {enabled: null,
+// minReplicaCount: 2} already reads as ON after the purge (enabled absent →
+// default on), but normalization to enabled: true makes it explicit. This is
+// the regression guard for the with-body variant.
+func TestLive_EnabledNullAutoscalingWithBodyStillOn(t *testing.T) {
+	var workloadDoc, artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name": "default-autoscaling-body",
+		"runtime": {"containerGroups": [{"name": "default",
+			"autoscaling": {"enabled": null, "minReplicaCount": 2, "maxReplicaCount": 9},
+			"containers": [{"name": "app", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}]}
+		]}
+	}`), &workloadDoc))
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name": "a",
+		"type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
+			{"name": "app", "primary": true, "port": 8080, "imageUri": "nginx:latest"}]}
+		]}}
+	`), &artifactDoc))
+
+	live := NewLive("68b0", workloadDoc, artifactDoc)
+
+	assert.True(t, live.Autoscaled(),
+		"enabled: null with a body is still the platform's default-on")
+
+	draft := live.Defaults()
+	assert.Equal(t, 0, draft.Runtime.Replicas,
+		"no replica count prompted for an autoscaled group")
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(rendered), "replicaCount")
+	assert.Contains(t, string(rendered), "enabled: true")
+	assert.NotContains(t, string(rendered), "enabled: null")
 
 	parsed, err := Parse(rendered, "")
 	require.NoError(t, err)

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -794,9 +794,10 @@ func TestLive_ApplyRuntime(t *testing.T) {
 	require.NoError(t, parsed.Validate())
 }
 
-// stripNullKeys removes nil-valued keys recursively without discarding falsy
-// but present values and without mutating the input document.
-func TestStripNullKeys(t *testing.T) {
+// stripServerManaged deep-copies the document and strips both server-managed
+// keys and nil-valued keys in a single recursive walk, without discarding
+// falsy but present values and without mutating the input document.
+func TestStripServerManaged_StripsNullKeys(t *testing.T) {
 	tests := map[string]struct {
 		input    map[string]any
 		expected map[string]any
@@ -854,15 +855,28 @@ func TestStripNullKeys(t *testing.T) {
 				},
 			},
 		},
+		// Server-managed keys are also stripped alongside nils, confirming the
+		// two passes share the single recursive walk.
+		"server-managed keys stripped": {
+			input: map[string]any{
+				"id":     "68b0",
+				"keep":   "x",
+				"status": "running",
+				"drop":   nil,
+			},
+			expected: map[string]any{
+				"keep": "x",
+			},
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			original := deepCopyMap(tc.input)
-			got := stripNullKeys(tc.input)
+			got := stripServerManaged(tc.input)
 
 			assert.Equal(t, tc.expected, got)
-			assert.Equal(t, original, tc.input, "stripNullKeys must not mutate input")
+			assert.Equal(t, original, tc.input, "stripServerManaged must not mutate input")
 		})
 	}
 }

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -898,28 +898,8 @@ func TestStripServerManaged_StripsNullKeys(t *testing.T) {
 				"keep": "x",
 			},
 		},
-		// enabled: null inside a present autoscaling block is the platform's
-		// default-on; stripKeys normalizes it to enabled: true before the
-		// nil-purge would collapse {enabled: null} to {} (which both readers
-		// treat as OFF). This is the fix for the semantic inversion.
-		"autoscaling enabled null normalized to true": {
-			input: map[string]any{
-				"autoscaling": map[string]any{"enabled": nil},
-			},
-			expected: map[string]any{
-				"autoscaling": map[string]any{"enabled": true},
-			},
-		},
-		"autoscaling enabled null with body normalized": {
-			input: map[string]any{
-				"autoscaling": map[string]any{"enabled": nil, "minReplicaCount": 2},
-			},
-			expected: map[string]any{
-				"autoscaling": map[string]any{"enabled": true, "minReplicaCount": 2},
-			},
-		},
-		// A non-null enabled value is left untouched: false stays false, true
-		// stays true. Normalization only fires on the nil placeholder.
+		// A non-null enabled value is left untouched: false stays false,
+		// true stays true. The nil-purge only drops keys whose value is nil.
 		"autoscaling enabled false untouched": {
 			input: map[string]any{
 				"autoscaling": map[string]any{"enabled": false},
@@ -928,11 +908,9 @@ func TestStripServerManaged_StripsNullKeys(t *testing.T) {
 				"autoscaling": map[string]any{"enabled": false},
 			},
 		},
-		// A genuinely empty autoscaling: {} map (enabled key absent entirely,
-		// not present-with-nil) must survive stripKeys unchanged. The previous
-		// guard used `autoscaling[keyEnabled] == nil`, which cannot distinguish
-		// absent from present-with-nil — rewriting an empty map to
-		// {enabled: true} and inverting a should-be-OFF group to ON.
+		// A genuinely empty autoscaling: {} map (enabled key absent entirely)
+		// must survive stripKeys unchanged — the nil-purge only drops
+		// nil-valued keys, and an empty map has none.
 		"autoscaling empty map untouched": {
 			input: map[string]any{
 				"autoscaling": map[string]any{},
@@ -1597,160 +1575,135 @@ func TestLive_RealBuildContainerStillStripsImageUriAndCodeRef(t *testing.T) {
 	require.NoError(t, parsed.Validate())
 }
 
-// A runtime group whose server shape was autoscaling: {enabled: null} — the
-// platform's default-on — must survive NewLive's stripping without semantic
-// inversion. The strip path normalizes enabled: null to enabled: true so
-// autoscalingActive reads the group as ON, the wizard suppresses the replica
-// question, the rendered file carries no replicaCount, and the round trip
-// through Parse and Validate passes.
-func TestLive_EnabledNullAutoscalingSurvivesStripping(t *testing.T) {
-	var workloadDoc, artifactDoc map[string]any
-
-	require.NoError(t, json.Unmarshal([]byte(`{
-		"name": "default-autoscaling",
-		"runtime": {"containerGroups": [{"name": "default",
-			"autoscaling": {"enabled": null},
-			"containers": [{"name": "app", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}]}
-		]}
-	}`), &workloadDoc))
-
-	require.NoError(t, json.Unmarshal([]byte(`{
+// TestLive_AutoscalingEnabledValuesSurviveStripping pins the boundary that
+// normalizeAutoscalingEnabled's removal must not cross: real autoscaling
+// enabled values (true and false) survive NewLive/Apply/Render unchanged, and
+// a null autoscaling block is still purged by the nil-purge in stripKeys.
+//
+// autoscaling.enabled is non-nullable on the server (bool = Field(default=True),
+// protons/runtime.py:217), so enabled: null can never arrive from the server.
+// This test pins the shapes that CAN arrive and must keep round-tripping
+// cleanly both before and after the dead-defense removal.
+func TestLive_AutoscalingEnabledValuesSurviveStripping(t *testing.T) {
+	artifactJSON := `{
 		"name": "a",
-		"type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
-			{"name": "app", "primary": true, "port": 8080, "imageUri": "nginx:latest"}]}
-		]}}
-	`), &artifactDoc))
+		"type": "service",
+		"spec": {"containerGroups": [{"name": "default", "containers": [
+			{"name": "app", "primary": true, "port": 8080, "imageUri": "nginx:latest"}
+		]}]}
+	}`
 
-	live, err := NewLive("68b0", workloadDoc, artifactDoc)
-	require.NoError(t, err)
+	t.Run("enabled true round-trips as ON", func(t *testing.T) {
+		var workloadDoc, artifactDoc map[string]any
 
-	// After stripping, the group reads as autoscaling ON.
-	assert.True(t, live.Autoscaled(),
-		"enabled: null is the platform's default-on; stripping must not invert it to OFF")
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"name": "auto-on",
+			"runtime": {"containerGroups": [{"name": "default",
+				"autoscaling": {"enabled": true, "minReplicaCount": 1, "maxReplicaCount": 4},
+				"containers": [{"name": "app", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}]
+			}]}
+		}`), &workloadDoc))
 
-	// The wizard suppresses the replica question for an autoscaled group.
-	draft := live.Defaults()
-	assert.Equal(t, 0, draft.Runtime.Replicas,
-		"no replica count prompted for an autoscaled group")
+		require.NoError(t, json.Unmarshal([]byte(artifactJSON), &artifactDoc))
 
-	applied, err := live.Apply(draft)
-	require.NoError(t, err)
+		live, err := NewLive("68b0", workloadDoc, artifactDoc)
+		require.NoError(t, err)
 
-	rendered, err := applied.Render()
-	require.NoError(t, err)
+		assert.True(t, live.Autoscaled(), "enabled: true is autoscaling ON")
 
-	// The rendered runtime carries no replicaCount for the autoscaled group.
-	assert.NotContains(t, string(rendered), "replicaCount",
-		"an autoscaled group must not carry a replica count")
-	// The normalized enabled: true is present and no null survives.
-	assert.Contains(t, string(rendered), "enabled: true")
-	assert.NotContains(t, string(rendered), "enabled: null")
+		draft := live.Defaults()
 
-	parsed, err := Parse(rendered, "")
-	require.NoError(t, err)
-	require.NoError(t, parsed.Validate(),
-		"render→parse→validate round trip must pass for the enabled-null shape")
-}
+		assert.Equal(t, 0, draft.Runtime.Replicas, "no replica count for an autoscaled group")
 
-// A runtime group whose server shape was autoscaling: {enabled: null,
-// minReplicaCount: 2} already reads as ON after the purge (enabled absent →
-// default on), but normalization to enabled: true makes it explicit. This is
-// the regression guard for the with-body variant.
-func TestLive_EnabledNullAutoscalingWithBodyStillOn(t *testing.T) {
-	var workloadDoc, artifactDoc map[string]any
+		applied, err := live.Apply(draft)
+		require.NoError(t, err)
 
-	require.NoError(t, json.Unmarshal([]byte(`{
-		"name": "default-autoscaling-body",
-		"runtime": {"containerGroups": [{"name": "default",
-			"autoscaling": {"enabled": null, "minReplicaCount": 2, "maxReplicaCount": 9},
-			"containers": [{"name": "app", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}]}
-		]}
-	}`), &workloadDoc))
+		rendered, err := applied.Render()
+		require.NoError(t, err)
 
-	require.NoError(t, json.Unmarshal([]byte(`{
-		"name": "a",
-		"type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
-			{"name": "app", "primary": true, "port": 8080, "imageUri": "nginx:latest"}]}
-		]}}
-	`), &artifactDoc))
+		assert.Contains(t, string(rendered), "enabled: true")
+		assert.Contains(t, string(rendered), "maxReplicaCount: 4")
+		assert.NotContains(t, string(rendered), "replicaCount",
+			"an autoscaled group must not carry a replica count")
 
-	live, err := NewLive("68b0", workloadDoc, artifactDoc)
-	require.NoError(t, err)
+		parsed, err := Parse(rendered, "")
+		require.NoError(t, err)
+		require.NoError(t, parsed.Validate())
+	})
 
-	assert.True(t, live.Autoscaled(),
-		"enabled: null with a body is still the platform's default-on")
+	t.Run("enabled false round-trips as OFF", func(t *testing.T) {
+		var workloadDoc, artifactDoc map[string]any
 
-	draft := live.Defaults()
-	assert.Equal(t, 0, draft.Runtime.Replicas,
-		"no replica count prompted for an autoscaled group")
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"name": "auto-off",
+			"runtime": {"containerGroups": [{"name": "default",
+				"replicaCount": 3,
+				"autoscaling": {"enabled": false, "minReplicaCount": 1, "maxReplicaCount": 4},
+				"containers": [{"name": "app", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}]
+			}]}
+		}`), &workloadDoc))
 
-	applied, err := live.Apply(draft)
-	require.NoError(t, err)
+		require.NoError(t, json.Unmarshal([]byte(artifactJSON), &artifactDoc))
 
-	rendered, err := applied.Render()
-	require.NoError(t, err)
+		live, err := NewLive("68b0", workloadDoc, artifactDoc)
+		require.NoError(t, err)
 
-	assert.NotContains(t, string(rendered), "replicaCount")
-	assert.Contains(t, string(rendered), "enabled: true")
-	assert.NotContains(t, string(rendered), "enabled: null")
+		assert.False(t, live.Autoscaled(), "enabled: false is autoscaling OFF")
 
-	parsed, err := Parse(rendered, "")
-	require.NoError(t, err)
-	require.NoError(t, parsed.Validate())
-}
+		draft := live.Defaults()
 
-// A server-sourced runtime group with a genuinely empty autoscaling: {} map
-// (the enabled key absent entirely, not present-with-nil) must survive
-// NewLive/stripKeys unchanged — no enabled key materialized. The previous
-// normalizeAutoscalingEnabled guard used `autoscaling[keyEnabled] == nil`,
-// which in Go cannot distinguish "enabled present with nil value" from
-// "enabled absent entirely" (map zero-value ambiguity). That rewrote a
-// genuinely empty autoscaling: {} to {enabled: true} before the nil-purge ran,
-// inverting a should-be-OFF group to ON — contradicting the function's own
-// doc comment and autoscalingActive's len==0 OFF guard. The fix uses the
-// two-value map-access idiom so only a present-with-nil enabled is normalized.
-func TestLive_EmptyAutoscalingMapNotInvertedToOn(t *testing.T) {
-	var workloadDoc, artifactDoc map[string]any
+		assert.Equal(t, 3, draft.Runtime.Replicas, "the group's own count is reported")
 
-	require.NoError(t, json.Unmarshal([]byte(`{
-		"name": "empty-autoscaling",
-		"runtime": {"containerGroups": [{"name": "default",
-			"autoscaling": {},
-			"containers": [{"name": "app", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}]}
-		]}
-	}`), &workloadDoc))
+		applied, err := live.Apply(draft)
+		require.NoError(t, err)
 
-	require.NoError(t, json.Unmarshal([]byte(`{
-		"name": "a",
-		"type": "service", "spec": {"containerGroups": [{"name": "default", "containers": [
-			{"name": "app", "primary": true, "port": 8080, "imageUri": "nginx:latest"}]}
-		]}}
-	`), &artifactDoc))
+		rendered, err := applied.Render()
+		require.NoError(t, err)
 
-	live, err := NewLive("68b0", workloadDoc, artifactDoc)
-	require.NoError(t, err)
+		assert.Contains(t, string(rendered), "enabled: false")
+		assert.Contains(t, string(rendered), "replicaCount: 3")
 
-	// A genuinely empty autoscaling map reads as OFF, matching
-	// autoscalingActive's len==0 guard.
-	assert.False(t, live.Autoscaled(),
-		"an empty autoscaling: {} map is OFF, not the platform's default-on")
+		parsed, err := Parse(rendered, "")
+		require.NoError(t, err)
+		require.NoError(t, parsed.Validate())
+	})
 
-	draft := live.Defaults()
+	t.Run("null autoscaling block is purged", func(t *testing.T) {
+		var workloadDoc, artifactDoc map[string]any
 
-	applied, err := live.Apply(draft)
-	require.NoError(t, err)
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"name": "no-auto",
+			"runtime": {"containerGroups": [{"name": "default",
+				"replicaCount": 3,
+				"autoscaling": null,
+				"containers": [{"name": "app", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}]
+			}]}
+		}`), &workloadDoc))
 
-	rendered, err := applied.Render()
-	require.NoError(t, err)
+		require.NoError(t, json.Unmarshal([]byte(artifactJSON), &artifactDoc))
 
-	// No enabled key was materialized by normalization.
-	assert.NotContains(t, string(rendered), "enabled: true",
-		"an empty autoscaling: {} must not gain an enabled: true key")
+		live, err := NewLive("68b0", workloadDoc, artifactDoc)
+		require.NoError(t, err)
 
-	parsed, err := Parse(rendered, "")
-	require.NoError(t, err)
-	require.NoError(t, parsed.Validate(),
-		"render→parse→validate round trip must pass for the empty-autoscaling shape")
+		assert.False(t, live.Autoscaled(), "a null autoscaling block is absent, not ON")
+
+		draft := live.Defaults()
+
+		assert.Equal(t, 3, draft.Runtime.Replicas, "the group's own count is reported")
+
+		applied, err := live.Apply(draft)
+		require.NoError(t, err)
+
+		rendered, err := applied.Render()
+		require.NoError(t, err)
+
+		assert.NotContains(t, string(rendered), "autoscaling",
+			"a null autoscaling block is purged entirely by the nil-purge")
+
+		parsed, err := Parse(rendered, "")
+		require.NoError(t, err)
+		require.NoError(t, parsed.Validate())
+	})
 }
 
 // An artifact document carrying no usable spec is the review repro for

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -1258,3 +1258,170 @@ func TestLive_RenderReorderPreservesKeys(t *testing.T) {
 	keys := mappingKeys(container)
 	assert.Equal(t, []string{keyName, keyImageURI, keyPort, keyPrimary}, keys)
 }
+
+// An artifact doc whose container carries imageUri alongside an
+// imageBuildConfig with only server-managed keys (codeRef + dockerfile:null)
+// is the exact review repro for RAPTOR-19533. stripKeys purges dockerfile:null
+// first; stripBuildOutputs then deletes codeRef, which empties the map. The
+// fix keeps the user-declared imageUri and drops the emptied imageBuildConfig
+// key entirely, so the rendered file has a single valid image source and
+// round-trips through Parse + Validate.
+func TestLive_EmptyBuildBlockRoundTripsAfterStripping(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name": "a",
+		"type": "service",
+		"spec": {"containerGroups": [{"name": "default", "containers": [
+			{
+				"name": "app",
+				"primary": true,
+				"port": 8080,
+				"imageUri": "registry.example.com/app:v1",
+				"imageBuildConfig": {
+					"codeRef": {"datarobot": {"catalogId": "cat1", "catalogVersionId": "ver1"}},
+					"dockerfile": null
+				}
+			}
+		]}]}
+	}`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	draft := live.Defaults()
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	// The rendered container keeps the user-declared imageUri and has no
+	// imageBuildConfig key at all — not an empty mapping that Validate would
+	// reject alongside imageUri.
+	assert.Contains(t, string(rendered), "imageUri: registry.example.com/app:v1")
+	assert.NotContains(t, string(rendered), "imageBuildConfig")
+	assert.NotContains(t, string(rendered), "codeRef")
+
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate(), "rendered manifest must satisfy its own validator")
+}
+
+// A server doc that arrives with imageBuildConfig: {} outright (already empty,
+// no dockerfile to purge) gets the same clean handling: imageUri is kept and
+// the empty imageBuildConfig mapping is dropped entirely.
+func TestLive_NativelyEmptyBuildBlockRoundTrips(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name": "a",
+		"type": "service",
+		"spec": {"containerGroups": [{"name": "default", "containers": [
+			{
+				"name": "app",
+				"primary": true,
+				"port": 8080,
+				"imageUri": "registry.example.com/app:v1",
+				"imageBuildConfig": {}
+			}
+		]}]}
+	}`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	draft := live.Defaults()
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(rendered), "imageUri: registry.example.com/app:v1")
+	assert.NotContains(t, string(rendered), "imageBuildConfig")
+
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+}
+
+// liveBuild must classify an empty imageBuildConfig as BuildModeImage, not
+// BuildModeUnchanged. An emptied build block has no content to preserve, and
+// BuildModeUnchanged causes applyBuild to no-op — leaving the broken container
+// in place. BuildModeImage lets applyBuild keep/restore imageUri.
+func TestLive_EmptyBuildConfigClassifiedAsImage(t *testing.T) {
+	tests := map[string]struct {
+		container map[string]any
+	}{
+		"natively empty": {
+			container: map[string]any{
+				"name":             "app",
+				"imageUri":         "registry.example.com/app:v1",
+				"imageBuildConfig": map[string]any{},
+			},
+		},
+		"emptied after codeRef removal": {
+			container: map[string]any{
+				"name":     "app",
+				"imageUri": "registry.example.com/app:v1",
+				// Simulate post-strip state: codeRef already deleted,
+				// dockerfile:null already purged → empty map.
+				"imageBuildConfig": map[string]any{},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			build := liveBuild(tc.container)
+
+			assert.Equal(t, BuildModeImage, build.Mode,
+				"empty imageBuildConfig must classify as BuildModeImage, not BuildModeUnchanged")
+			assert.Equal(t, "registry.example.com/app:v1", build.ImageURI)
+		})
+	}
+}
+
+// A real build container — imageBuildConfig with a dockerfile present plus a
+// codeRef — still gets imageUri and codeRef stripped, and the rendered file
+// keeps the build config with its dockerfile. This is the regression guard
+// ensuring the empty-block fix does not weaken the real-build stripping path.
+func TestLive_RealBuildContainerStillStripsImageUriAndCodeRef(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name": "a",
+		"type": "service",
+		"spec": {"containerGroups": [{"name": "default", "containers": [
+			{
+				"name": "app",
+				"primary": true,
+				"port": 8080,
+				"imageUri": "registry.internal/built-by-server:abc",
+				"imageBuildConfig": {
+					"dockerfile": {"source": "provided"},
+					"codeRef": {"datarobot": {"catalogId": "cat1", "catalogVersionId": "ver1"}}
+				}
+			}
+		]}]}
+	}`), &artifactDoc))
+
+	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+
+	draft := live.Defaults()
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	// A real build container: imageUri is stripped (server-built pin), codeRef
+	// is stripped (server-managed), but the dockerfile block survives.
+	assert.NotContains(t, string(rendered), "built-by-server")
+	assert.NotContains(t, string(rendered), "codeRef")
+	assert.Contains(t, string(rendered), "imageBuildConfig")
+	assert.Contains(t, string(rendered), "source: provided")
+
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+}

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -792,3 +792,207 @@ func TestLive_ApplyRuntime(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, parsed.Validate())
 }
+
+// stripNullKeys removes nil-valued keys recursively without discarding falsy
+// but present values and without mutating the input document.
+func TestStripNullKeys(t *testing.T) {
+	tests := map[string]struct {
+		input    map[string]any
+		expected map[string]any
+	}{
+		"nil map": {
+			input:    nil,
+			expected: nil,
+		},
+		"empty map": {
+			input:    map[string]any{},
+			expected: map[string]any{},
+		},
+		"nil value removed": {
+			input:    map[string]any{"keep": "x", "drop": nil},
+			expected: map[string]any{"keep": "x"},
+		},
+		"falsy values kept": {
+			input: map[string]any{
+				"false":      false,
+				"zero":       0,
+				"empty":      "",
+				"emptySlice": []any{},
+			},
+			expected: map[string]any{
+				"false":      false,
+				"zero":       0,
+				"empty":      "",
+				"emptySlice": []any{},
+			},
+		},
+		"nested map nil removed": {
+			input: map[string]any{
+				"nested": map[string]any{
+					"keep": "x",
+					"drop": nil,
+				},
+			},
+			expected: map[string]any{
+				"nested": map[string]any{
+					"keep": "x",
+				},
+			},
+		},
+		"slice map nil removed": {
+			input: map[string]any{
+				"items": []any{
+					map[string]any{"keep": "x", "drop": nil},
+					map[string]any{"keep": "y"},
+				},
+			},
+			expected: map[string]any{
+				"items": []any{
+					map[string]any{"keep": "x"},
+					map[string]any{"keep": "y"},
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			original := deepCopyMap(tc.input)
+			got := stripNullKeys(tc.input)
+
+			assert.Equal(t, tc.expected, got)
+			assert.Equal(t, original, tc.input, "stripNullKeys must not mutate input")
+		})
+	}
+}
+
+// reporterWorkloadDoc returns a workload GET response shaped like the reporter's:
+// a runtime container group with null autoscaling and a resolved bundle.
+func reporterWorkloadDoc(t *testing.T) map[string]any {
+	t.Helper()
+
+	const doc = `{
+		"id": "68b0c1d2e3f4a5b6c7d8e9f0",
+		"name": "reporter-workload",
+		"importance": "low",
+		"artifactId": "68a0000000000000000000a1",
+		"runtime": {
+			"containerGroups": [
+				{
+					"name": "default",
+					"replicaCount": 3,
+					"autoscaling": null,
+					"resolvedBundle": {"catalogId": "cat1", "catalogVersionId": "ver1"},
+					"containers": [
+						{"name": "app", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}
+					]
+				}
+			]
+		}
+	}`
+
+	var out map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(doc), &out))
+
+	return out
+}
+
+// reporterArtifactDoc returns an artifact GET response shaped like the reporter's:
+// a container carrying a server build block, imageOutdated flag, imageUri and
+// an imageBuildConfig with a codeRef.
+func reporterArtifactDoc(t *testing.T) map[string]any {
+	t.Helper()
+
+	const doc = `{
+		"id": "68a0000000000000000000a1",
+		"name": "reporter-artifact",
+		"type": "service",
+		"spec": {
+			"containerGroups": [
+				{
+					"name": "default",
+					"containers": [
+						{
+							"name": "app",
+							"primary": true,
+							"port": 8080,
+							"imageUri": "registry.internal/built-by-server:abc",
+							"imageOutdated": true,
+							"build": {
+								"artifactImageBuildId": "build-123",
+								"status": "completed",
+								"createdAt": "2026-07-02T10:00:00Z"
+							},
+							"imageBuildConfig": {
+								"dockerfile": {"source": "provided"},
+								"codeRef": {"datarobot": {"catalogId": "cat1", "catalogVersionId": "ver1"}}
+							}
+						}
+					]
+				}
+			]
+		}
+	}`
+
+	var out map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(doc), &out))
+
+	return out
+}
+
+// A reporter-shaped server response carries null autoscaling, a resolved bundle,
+// build outputs and computed flags. The rendered file must strip all of them
+// and still round-trip through parse, validate and compile.
+func TestLive_RenderRoundTripReporterShaped(t *testing.T) {
+	workloadID := "68b0c1d2e3f4a5b6c7d8e9f0"
+	workloadDoc := reporterWorkloadDoc(t)
+	artifactDoc := reporterArtifactDoc(t)
+
+	live := NewLive(workloadID, workloadDoc, artifactDoc)
+
+	draft := live.Defaults()
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	for _, unwanted := range []string{
+		"autoscaling: null",
+		"artifactImageBuildId",
+		"imageOutdated",
+		"resolvedBundle",
+		"build:",
+	} {
+		assert.NotContains(t, string(rendered), unwanted, "rendered manifest must not contain %s", unwanted)
+	}
+
+	assert.Contains(t, string(rendered), "imageBuildConfig")
+	assert.Contains(t, string(rendered), "source: provided")
+	assert.Contains(t, string(rendered), "workloadId: "+workloadID)
+
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+	require.NoError(t, parsed.Validate())
+
+	compiled, err := parsed.Compile()
+	require.NoError(t, err)
+	assert.Equal(t, workloadID, compiled.WorkloadID)
+}
+
+// NewLive must not mutate the caller's documents, even though it strips server
+// outputs and null-valued keys from its own copies.
+func TestLive_DoesNotMutateInputDocs(t *testing.T) {
+	workloadDoc := reporterWorkloadDoc(t)
+	artifactDoc := reporterArtifactDoc(t)
+
+	workloadBefore := deepCopyMap(workloadDoc)
+	artifactBefore := deepCopyMap(artifactDoc)
+
+	_ = NewLive("68b0", workloadDoc, artifactDoc)
+
+	assert.Equal(t, workloadBefore, workloadDoc)
+	assert.Equal(t, artifactBefore, artifactDoc)
+}

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -1766,3 +1766,73 @@ func TestNewLive_EmptySpecFailsWithWorkloadID(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), workloadID)
 }
+
+// The environmentVars path has three discriminator variants — string (source
+// absent or "string" with a value), dr-credential (drCredentialId + key, no
+// value), and api-key (source only, no value). Existing env-var tests feed
+// hand-written YAML straight to the validator; the round trip is what proves
+// the writer (Render) and the validator agree on all three shapes. The
+// rejection direction — a string-variant entry with null or absent value — is
+// already covered by TestValidate_EnvironmentVarsNullValueRejected and
+// TestValidate_EnvironmentVarsNoValueNoSourceRejected in validate_test.go;
+// the NEW coverage here is the round trip of the three valid variants.
+func TestLive_RenderRoundTripsEnvironmentVarsAllVariants(t *testing.T) {
+	workloadID := "68b0c1d2e3f4a5b6c7d8e9f0"
+
+	// A service artifact whose single container carries one entry of each
+	// discriminator variant, shaped exactly like a server GET response.
+	artifactDoc := map[string]any{}
+	require.NoError(t, json.Unmarshal([]byte(`{
+      "name": "envvars-artifact",
+      "spec": {"type": "service", "containerGroups": [{"name": "default", "containers": [
+        {"name": "primary", "primary": true, "port": 8080,
+         "imageUri": "nginx:latest",
+         "environmentVars": [
+           {"name": "LOG_LEVEL", "value": "debug"},
+           {"name": "API_TOKEN", "source": "dr-credential",
+            "drCredentialId": "68f0cccc0000000000000003", "key": "apiToken"},
+           {"name": "CLOUD_KEY", "source": "api-key"}
+         ]}
+      ]}]}
+    }`), &artifactDoc))
+
+	workloadDoc := map[string]any{"name": "envvars-workload"}
+
+	live, err := NewLive(workloadID, workloadDoc, artifactDoc)
+	require.NoError(t, err)
+
+	draft := live.Defaults()
+
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	// Every variant must survive the render in its correct spelling. The
+	// dr-credential discriminator is the only valid credential variant
+	// (library/api-reference.md) — the fixture must not regress to "credential".
+	for _, kept := range []string{
+		"LOG_LEVEL", "debug",
+		"API_TOKEN", "dr-credential", "68f0cccc0000000000000003", "apiToken",
+		"CLOUD_KEY", "api-key",
+	} {
+		assert.Contains(t, string(rendered), kept, "render must keep %s intact", kept)
+	}
+
+	// The rendered manifest must parse and validate — the writer and the
+	// validator agree on all three variant shapes.
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+
+	require.NoError(t, parsed.Validate())
+
+	// Compile confirms the credential reference is syntactically valid and
+	// the workload id is extractable from the rendered file.
+	compiled, err := parsed.Compile()
+	require.NoError(t, err)
+
+	assert.Equal(t, workloadID, compiled.WorkloadID)
+	require.Len(t, compiled.CredentialRefs, 1)
+	assert.Equal(t, "68f0cccc0000000000000003", compiled.CredentialRefs[0].CredentialID)
+}

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -1512,7 +1512,7 @@ func TestLive_NativelyEmptyBuildBlockRoundTrips(t *testing.T) {
 // doc with imageBuildConfig {dockerfile: null, codeRef: {...}} + imageUri →
 // stripKeys purges dockerfile:null → stripBuildOutputs deletes codeRef and,
 // because the config is now empty, drops the imageBuildConfig key and keeps
-// imageUri → the container classifies as BuildModeImage. (VAL-R3-006).
+// imageUri → the container classifies as BuildModeImage.
 func TestLive_EmptyBuildConfigClassifiedAsImage(t *testing.T) {
 	t.Run("natively empty", func(t *testing.T) {
 		container := map[string]any{
@@ -1618,14 +1618,14 @@ func TestLive_RealBuildContainerStillStripsImageUriAndCodeRef(t *testing.T) {
 }
 
 // TestLive_AutoscalingEnabledValuesSurviveStripping pins the boundary that
-// normalizeAutoscalingEnabled's removal must not cross: real autoscaling
-// enabled values (true and false) survive NewLive/Apply/Render unchanged, and
-// a null autoscaling block is still purged by the nil-purge in stripKeys.
+// real autoscaling enabled values (true and false) survive
+// NewLive/Apply/Render unchanged, and a null autoscaling block is still
+// purged by the nil-purge in stripKeys.
 //
 // autoscaling.enabled is non-nullable on the server (bool = Field(default=True),
 // protons/runtime.py:217), so enabled: null can never arrive from the server.
 // This test pins the shapes that CAN arrive and must keep round-tripping
-// cleanly both before and after the dead-defense removal.
+// cleanly.
 func TestLive_AutoscalingEnabledValuesSurviveStripping(t *testing.T) {
 	artifactJSON := `{
 		"name": "a",

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -98,7 +98,10 @@ func liveFixture(t *testing.T) Live {
 	require.NoError(t, json.Unmarshal([]byte(liveWorkloadJSON), &workloadDoc))
 	require.NoError(t, json.Unmarshal([]byte(liveArtifactJSON), &artifactDoc))
 
-	return NewLive("68b0c1d2e3f4a5b6c7d8e9f0", workloadDoc, artifactDoc)
+	live, err := NewLive("68b0c1d2e3f4a5b6c7d8e9f0", workloadDoc, artifactDoc)
+	require.NoError(t, err)
+
+	return live
 }
 
 func TestNewLive_StripsWhatOnlyTheServerSets(t *testing.T) {
@@ -262,9 +265,16 @@ func TestLive_RenderRoundTripsThroughValidate(t *testing.T) {
 // A spec with no container to update is a workload the wizard cannot honestly
 // edit, so it says so instead of writing something plausible.
 func TestLive_ApplyWithoutAPrimaryContainer(t *testing.T) {
-	live := NewLive("68b0", map[string]any{"name": "empty"}, map[string]any{"name": "empty-artifact"})
+	// The spec carries containerGroups but no containers, so NewLive accepts
+	// it (the spec is non-empty) while Apply finds no primary container to
+	// update.
+	live, err := NewLive("68b0", map[string]any{"name": "empty"}, map[string]any{
+		"name": "empty-artifact",
+		"spec": map[string]any{"containerGroups": []any{}},
+	})
+	require.NoError(t, err)
 
-	_, err := live.Apply(live.Defaults())
+	_, err = live.Apply(live.Defaults())
 	require.Error(t, err)
 
 	assert.Contains(t, err.Error(), "no primary container")
@@ -291,7 +301,8 @@ func TestLive_LiteralEnvVarsSkipsCredentialReferences(t *testing.T) {
       ]}]}
     }`), &artifactDoc))
 
-	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
 
 	assert.Equal(t, []EnvVar{
 		{Name: "LOG_LEVEL", Value: "debug"},
@@ -302,7 +313,13 @@ func TestLive_LiteralEnvVarsSkipsCredentialReferences(t *testing.T) {
 // A spec with no container has nothing declared, which is not the same as
 // having something this cannot read.
 func TestLive_LiteralEnvVarsWithoutAContainer(t *testing.T) {
-	live := NewLive("68b0", map[string]any{"name": "empty"}, map[string]any{"name": "empty-artifact"})
+	// The spec carries containerGroups but no containers, so NewLive accepts
+	// it while LiteralEnvVars finds no primary container to read from.
+	live, err := NewLive("68b0", map[string]any{"name": "empty"}, map[string]any{
+		"name": "empty-artifact",
+		"spec": map[string]any{"containerGroups": []any{}},
+	})
+	require.NoError(t, err)
 
 	assert.Empty(t, live.LiteralEnvVars())
 }
@@ -318,7 +335,8 @@ func TestLive_PrimaryFallsBackToTheFirstContainer(t *testing.T) {
       ]}]}
     }`), &artifactDoc))
 
-	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
 
 	assert.Equal(t, 8080, live.Defaults().Port)
 }
@@ -339,7 +357,8 @@ func TestLive_ApplyKeepsUnknownBuildKeys(t *testing.T) {
         }}]}]}
     }`), &artifactDoc))
 
-	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
 
 	applied, err := live.Apply(live.Defaults())
 	require.NoError(t, err)
@@ -364,7 +383,8 @@ func TestLive_UnknownBuildSourceIsPreserved(t *testing.T) {
          "imageBuildConfig": {"buildpack": {"builder": "paketo/builder:base"}}}]}]}
     }`), &artifactDoc))
 
-	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
 
 	assert.Equal(t, BuildModeUnchanged, live.Defaults().Build.Mode)
 
@@ -430,7 +450,8 @@ func TestLive_ApplyRemovesADeclinedProbe(t *testing.T) {
          "readinessProbe": {"path": "/health", "port": 9000, "periodSeconds": 10}}]}]}
     }`), &artifactDoc))
 
-	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
 
 	draft := live.Defaults()
 	require.Equal(t, "/health", draft.HealthPath)
@@ -461,7 +482,8 @@ func TestLive_ApplyKeepsAProbeItCannotRead(t *testing.T) {
          "readinessProbe": {"tcpSocket": {"port": 9000}, "periodSeconds": 10, "failureThreshold": 30}}]}]}
     }`), &artifactDoc))
 
-	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
 
 	present, readable := live.ReadinessProbe()
 	assert.True(t, present, "the block is there")
@@ -494,7 +516,8 @@ func TestLive_ApplyMovesAnUnreadableProbeWithThePort(t *testing.T) {
          "readinessProbe": {"tcpSocket": {"port": 9000}, "port": 9000}}]}]}
     }`), &artifactDoc))
 
-	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
 
 	draft := live.Defaults()
 	draft.Port = 9100
@@ -524,7 +547,10 @@ func probelessLive(t *testing.T) Live {
         {"name": "primary", "primary": true, "port": 9000, "imageUri": "registry/a:v1"}]}]}
     }`), &artifactDoc))
 
-	return NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
+
+	return live
 }
 
 // A workload can carry probes the wizard has no question for. Changing the
@@ -559,7 +585,8 @@ func TestLive_ApplyLeavesAProbeOnItsOwnPort(t *testing.T) {
          "livenessProbe": {"path": "/admin/live", "port": 9900}}]}]}
     }`), &artifactDoc))
 
-	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
 
 	draft := live.Defaults()
 	draft.Port = 9000
@@ -584,7 +611,8 @@ func TestLive_ApplyFlagsTheContainerItEdits(t *testing.T) {
         {"name": "only", "port": 8080, "imageUri": "registry/a:v1"}]}]}
     }`), &artifactDoc))
 
-	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
 
 	applied, err := live.Apply(live.Defaults())
 	require.NoError(t, err)
@@ -628,7 +656,8 @@ func TestLive_DefaultsReadThePrimaryNotTheFirstListed(t *testing.T) {
         {"name": "metrics-bridge", "imageUri": "example/bridge:v1"}]}]}
     }`), &artifactDoc))
 
-	live := NewLive("68b0", workloadDoc, artifactDoc)
+	live, err := NewLive("68b0", workloadDoc, artifactDoc)
+	require.NoError(t, err)
 
 	draft := live.Defaults()
 	assert.InEpsilon(t, 4.0, draft.Runtime.CPU, 0.0001)
@@ -667,7 +696,8 @@ func TestLive_DisabledAutoscalingKeepsTheReplicaAnswer(t *testing.T) {
         {"name": "app", "primary": true, "port": 8080, "imageUri": "example/app:v1"}]}]}
     }`), &artifactDoc))
 
-	live := NewLive("68b0", workloadDoc, artifactDoc)
+	live, err := NewLive("68b0", workloadDoc, artifactDoc)
+	require.NoError(t, err)
 
 	draft := live.Defaults()
 	assert.Equal(t, 3, draft.Runtime.Replicas, "the group's own count, not the autoscaled zero")
@@ -995,7 +1025,8 @@ func TestLive_RenderRoundTripReporterShaped(t *testing.T) {
 	workloadDoc := reporterWorkloadDoc(t)
 	artifactDoc := reporterArtifactDoc(t)
 
-	live := NewLive(workloadID, workloadDoc, artifactDoc)
+	live, err := NewLive(workloadID, workloadDoc, artifactDoc)
+	require.NoError(t, err)
 
 	draft := live.Defaults()
 	applied, err := live.Apply(draft)
@@ -1034,7 +1065,10 @@ func reporterShapedLive(t *testing.T) Live {
 
 	workloadID := "68b0c1d2e3f4a5b6c7d8e9f0"
 
-	return NewLive(workloadID, reporterWorkloadDoc(t), reporterArtifactDoc(t))
+	live, err := NewLive(workloadID, reporterWorkloadDoc(t), reporterArtifactDoc(t))
+	require.NoError(t, err)
+
+	return live
 }
 
 // Null autoscaling is echoed by the server as a placeholder but must not be
@@ -1107,7 +1141,8 @@ func TestLive_DoesNotMutateInputDocs(t *testing.T) {
 	workloadBefore := deepCopyMap(workloadDoc)
 	artifactBefore := deepCopyMap(artifactDoc)
 
-	_ = NewLive("68b0", workloadDoc, artifactDoc)
+	_, err := NewLive("68b0", workloadDoc, artifactDoc)
+	require.NoError(t, err)
 
 	assert.Equal(t, workloadBefore, workloadDoc)
 	assert.Equal(t, artifactBefore, artifactDoc)
@@ -1275,7 +1310,8 @@ func TestLive_RenderReorderPreservesKeys(t *testing.T) {
 		]}]}
 	}`), &artifactDoc))
 
-	focused := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	focused, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
 
 	focusedRendered, err := focused.Render()
 	require.NoError(t, err)
@@ -1316,7 +1352,8 @@ func TestLive_EmptyBuildBlockRoundTripsAfterStripping(t *testing.T) {
 		]}]}
 	}`), &artifactDoc))
 
-	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
 
 	draft := live.Defaults()
 	applied, err := live.Apply(draft)
@@ -1357,7 +1394,8 @@ func TestLive_NativelyEmptyBuildBlockRoundTrips(t *testing.T) {
 		]}]}
 	}`), &artifactDoc))
 
-	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
 
 	draft := live.Defaults()
 	applied, err := live.Apply(draft)
@@ -1435,7 +1473,8 @@ func TestLive_RealBuildContainerStillStripsImageUriAndCodeRef(t *testing.T) {
 		]}]}
 	}`), &artifactDoc))
 
-	live := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
 
 	draft := live.Defaults()
 	applied, err := live.Apply(draft)
@@ -1480,7 +1519,8 @@ func TestLive_EnabledNullAutoscalingSurvivesStripping(t *testing.T) {
 		]}}
 	`), &artifactDoc))
 
-	live := NewLive("68b0", workloadDoc, artifactDoc)
+	live, err := NewLive("68b0", workloadDoc, artifactDoc)
+	require.NoError(t, err)
 
 	// After stripping, the group reads as autoscaling ON.
 	assert.True(t, live.Autoscaled(),
@@ -1532,7 +1572,8 @@ func TestLive_EnabledNullAutoscalingWithBodyStillOn(t *testing.T) {
 		]}}
 	`), &artifactDoc))
 
-	live := NewLive("68b0", workloadDoc, artifactDoc)
+	live, err := NewLive("68b0", workloadDoc, artifactDoc)
+	require.NoError(t, err)
 
 	assert.True(t, live.Autoscaled(),
 		"enabled: null with a body is still the platform's default-on")
@@ -1554,4 +1595,65 @@ func TestLive_EnabledNullAutoscalingWithBodyStillOn(t *testing.T) {
 	parsed, err := Parse(rendered, "")
 	require.NoError(t, err)
 	require.NoError(t, parsed.Validate())
+}
+
+// An artifact document carrying no usable spec is the review repro for
+// finding 7: a partial or permission-filtered artifact GET returns name and
+// type but no spec, and NewLive would render an inline artifact block with
+// only those two fields. Validate would then reject the file the CLI just
+// wrote ("artifact.spec: is required for an inline artifact") — the same
+// write-then-refuse class as the titled bug. NewLive must fail loudly at bind
+// time instead, naming the workload id so the user knows what to edit.
+func TestNewLive_SpeclessArtifactDocFailsWithWorkloadID(t *testing.T) {
+	workloadID := "68b0c1d2e3f4a5b6c7d8e9f0"
+
+	// No spec key at all — the shape a permission-filtered GET leaves.
+	artifactDoc := map[string]any{"name": "art", "type": "application"}
+
+	_, err := NewLive(workloadID, map[string]any{"name": "wl"}, artifactDoc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), workloadID,
+		"the error must name the workload id so the user knows what to edit")
+	assert.Contains(t, err.Error(), "no artifact spec")
+}
+
+// An artifact doc whose spec is present but strips to nothing — every key is
+// server-managed or nil — is the same class of failure: after stripping, the
+// spec is empty and rendering it would produce a file Validate rejects.
+func TestNewLive_SpecStripsToEmptyFailsWithWorkloadID(t *testing.T) {
+	workloadID := "68b0c1d2e3f4a5b6c7d8e9f0"
+
+	// Every key inside spec is server-managed, so stripServerManaged leaves
+	// an empty map.
+	artifactDoc := map[string]any{
+		"name": "art",
+		"type": "application",
+		"spec": map[string]any{
+			"id":     "68a0",
+			"status": "locked",
+		},
+	}
+
+	_, err := NewLive(workloadID, map[string]any{"name": "wl"}, artifactDoc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), workloadID,
+		"the error must name the workload id even when spec strips to empty")
+	assert.Contains(t, err.Error(), "no artifact spec")
+}
+
+// An artifact doc with an explicitly empty spec mapping is the same failure:
+// there is nothing to bind, and the error fires at bind time rather than at
+// validate time.
+func TestNewLive_EmptySpecFailsWithWorkloadID(t *testing.T) {
+	workloadID := "68b0deadbeef"
+
+	artifactDoc := map[string]any{
+		"name": "art",
+		"type": "service",
+		"spec": map[string]any{},
+	}
+
+	_, err := NewLive(workloadID, map[string]any{"name": "wl"}, artifactDoc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), workloadID)
 }

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -1190,6 +1190,47 @@ func walkMappingNodes(node *yaml.Node, f func(*yaml.Node)) {
 	}
 }
 
+// assertNameLeadsInIdentifierMappings walks the node tree and asserts that
+// every mapping which is a sequence item under a containerGroups or
+// containers key leads with name — and only those mappings. Opaque mappings
+// carrying a name key elsewhere (e.g. labels, environmentVars entries) keep
+// their own order, so they are deliberately not asserted against. parentKey
+// is the key under which node was found ("" for the root), carried across
+// sequence nodes so each item remembers the key its sequence sat under.
+func assertNameLeadsInIdentifierMappings(t *testing.T, node *yaml.Node, parentKey string) {
+	t.Helper()
+
+	if node == nil {
+		return
+	}
+
+	// Only mappings can be identifier mappings, and only sequences carry the
+	// items under a containerGroups/containers key; everything else is a leaf.
+	if node.Kind == yaml.MappingNode {
+		if parentKey == keyContainerGroups || parentKey == keyContainers {
+			keys := mappingKeys(node)
+
+			require.NotEmpty(t, keys)
+			assert.Equal(t, keyName, keys[0],
+				"identifier mapping under %s should lead with name", parentKey)
+		}
+
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			assertNameLeadsInIdentifierMappings(t, node.Content[i+1], node.Content[i].Value)
+		}
+
+		return
+	}
+
+	if node.Kind == yaml.SequenceNode {
+		// Carry parentKey across the sequence so each item remembers the key
+		// its sequence sat under (containerGroups or containers).
+		for _, item := range node.Content {
+			assertNameLeadsInIdentifierMappings(t, item, parentKey)
+		}
+	}
+}
+
 // In the rendered YAML, every container mapping lists name as its first key.
 func TestLive_RenderLeadsWithNameInContainers(t *testing.T) {
 	live := liveFixture(t)
@@ -1291,13 +1332,14 @@ func TestLive_RenderReorderPreservesKeys(t *testing.T) {
 			assert.False(t, seen[key], "key %q is duplicated", key)
 			seen[key] = true
 		}
-
-		// The top-level manifest order is deliberately fixed by Render; all
-		// nested mappings with a name key should lead with it.
-		if node != root && seen[keyName] {
-			assert.Equal(t, keyName, keys[0], "name should lead when present")
-		}
 	})
+
+	// Scoped name-leading: only the sequence-item mappings found under
+	// containerGroups/containers keys should lead with name. Opaque mappings
+	// that happen to carry a name key (labels, environmentVars entries) keep
+	// their own order, so the universal "name leads wherever present"
+	// assertion the unscoped hoist relied on no longer holds.
+	assertNameLeadsInIdentifierMappings(t, root, "")
 
 	// Focused check: a known container keeps its full key set, only reordering.
 	var artifactDoc map[string]any
@@ -1323,6 +1365,53 @@ func TestLive_RenderReorderPreservesKeys(t *testing.T) {
 
 	keys := mappingKeys(container)
 	assert.Equal(t, []string{keyName, keyImageURI, keyPort, keyPrimary}, keys)
+}
+
+// Opaque mappings carrying a name key (e.g. labels) are not identifier
+// mappings, so name-hoisting must leave their key order alone. The
+// pass-through contract (doc.go: unknown blocks "survive the round trip";
+// live.go: blocks are "passed through as the platform gave them") forbids
+// reordering blocks the wizard has no vocabulary for, and the unscoped
+// hoist reordered every nested mapping that happened to contain a key
+// literally called name — producing unexplained diff noise on every bind.
+func TestLive_RenderPreservesNameInOpaqueMappings(t *testing.T) {
+	var artifactDoc map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"name": "a",
+		"type": "service",
+		"spec": {"containerGroups": [{"name": "default", "containers": [
+			{"name": "primary", "primary": true, "port": 8080, "imageUri": "nginx:latest",
+			 "labels": {"zone": "b", "team": "x", "app": "c", "name": "not-an-id"}}
+		]}]}
+	}`), &artifactDoc))
+
+	live, err := NewLive("68b0", map[string]any{"name": "a"}, artifactDoc)
+	require.NoError(t, err)
+
+	rendered, err := live.Render()
+	require.NoError(t, err)
+
+	root := renderedRoot(t, rendered)
+	spec := mapValue(mapValue(root, keyArtifact), keySpec)
+	group := seqItems(mapValue(spec, keyContainerGroups))[0]
+	container := seqItems(mapValue(group, keyContainers))[0]
+
+	// The container is an identifier mapping, so name still leads.
+	containerKeys := mappingKeys(container)
+
+	assert.Equal(t, keyName, containerKeys[0], "container should lead with name")
+
+	// The labels block is opaque: name stays in its sorted position rather
+	// than being hoisted to the front. The yaml encoder sorts map[string]any
+	// keys alphabetically, so without hoisting name lands at its sorted
+	// spot (app, name, team, zone) — hoisting is the only thing that would
+	// move it to the front.
+	labels := mapValue(container, "labels")
+	labelsKeys := mappingKeys(labels)
+
+	assert.Equal(t, []string{"app", "name", "team", "zone"}, labelsKeys,
+		"opaque labels mapping keeps name in place, not hoisted")
 }
 
 // An artifact doc whose container carries imageUri alongside an

--- a/internal/workload/manifest/live_test.go
+++ b/internal/workload/manifest/live_test.go
@@ -983,6 +983,77 @@ func TestLive_RenderRoundTripReporterShaped(t *testing.T) {
 	assert.Equal(t, workloadID, compiled.WorkloadID)
 }
 
+// reporterShapedLive returns a Live built from the reporter-shaped fixtures so
+// each standalone render-stripping test can be self-contained.
+func reporterShapedLive(t *testing.T) Live {
+	t.Helper()
+
+	workloadID := "68b0c1d2e3f4a5b6c7d8e9f0"
+
+	return NewLive(workloadID, reporterWorkloadDoc(t), reporterArtifactDoc(t))
+}
+
+// Null autoscaling is echoed by the server as a placeholder but must not be
+// written into the committed manifest, where it would confuse the validator.
+func TestLive_RenderStripsNullAutoscaling(t *testing.T) {
+	live := reporterShapedLive(t)
+
+	draft := live.Defaults()
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(rendered), "autoscaling: null")
+}
+
+// The server build block is a read-only output and must be stripped before the
+// manifest is written, so the next deploy does not repeat a stale build id.
+func TestLive_RenderStripsBuildBlock(t *testing.T) {
+	live := reporterShapedLive(t)
+
+	draft := live.Defaults()
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(rendered), "build:")
+	assert.NotContains(t, string(rendered), "artifactImageBuildId")
+}
+
+// imageOutdated is a computed server flag, not a field the user controls, so it
+// must not appear in the rendered manifest.
+func TestLive_RenderStripsImageOutdated(t *testing.T) {
+	live := reporterShapedLive(t)
+
+	draft := live.Defaults()
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(rendered), "imageOutdated")
+}
+
+// resolvedBundle is a scheduling-time server output and must not be written
+// into the runtime block that the user commits.
+func TestLive_RenderStripsResolvedBundle(t *testing.T) {
+	live := reporterShapedLive(t)
+
+	draft := live.Defaults()
+	applied, err := live.Apply(draft)
+	require.NoError(t, err)
+
+	rendered, err := applied.Render()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(rendered), "resolvedBundle")
+}
+
 // NewLive must not mutate the caller's documents, even though it strips server
 // outputs and null-valued keys from its own copies.
 func TestLive_DoesNotMutateInputDocs(t *testing.T) {

--- a/internal/workload/manifest/node.go
+++ b/internal/workload/manifest/node.go
@@ -37,14 +37,15 @@ func isNullish(node *yaml.Node) bool {
 	// Note: this helper deliberately collapses three wire shapes
 	// 1. absent,
 	// 2. explicit null, and
-	// 3. empty mapping — into a single "not set" meaning,
-	// because that is how the workload endpoints behave today.
+	// 3. empty mapping
+	// into a single "not set" meaning because that is how the workload
+	// endpoints behave today.
 	//
-	// GET responses echo null-valued keys as placeholders (autoscaling: null when
-	// no policy is configured, enabled: null inside one that is), and the create
-	// endpoint reads an empty block the same as a missing one. The CLI also never
-	// writes nulls back: stripKeys purges them so a committed manifest stays
-	// canonical even when the wire format is not.
+	// GET responses echo null-valued keys as placeholders (autoscaling: null
+	// when no policy is configured, enabled: null inside one that is), and the
+	// create endpoint reads an empty block the same as a missing one. The CLI
+	// also never writes nulls back: stripKeys purges them so a committed
+	// manifest stays canonical even when the wire format is not.
 	//
 	// If the API ever gives these shapes distinct meanings — the classic case
 	// being null-as-delete in a PATCH — this helper, its validator call sites,

--- a/internal/workload/manifest/node.go
+++ b/internal/workload/manifest/node.go
@@ -38,8 +38,7 @@ func isNullish(node *yaml.Node) bool {
 	// 1. absent,
 	// 2. explicit null, and
 	// 3. empty mapping
-	// into a single "not set" meaning because that is how the workload
-	// endpoints behave today.
+	// into a single "not set" meaning.
 	//
 	// The autoscaling BLOCK is nullable (AutoscalingProperties | None,
 	// protons/runtime.py:502), so GET responses echo "autoscaling: null" when
@@ -49,10 +48,20 @@ func isNullish(node *yaml.Node) bool {
 	// (verified against the Pydantic models in workload-api/schemas/) is:
 	// autoscaling block, codeRef, imageBuildConfig, imageUri, entrypoint,
 	// port, primary, livenessProbe/readinessProbe/startupProbe, routes,
-	// gpuType, build, and the api-key env var name. The create endpoint reads
-	// an empty block the same as a missing one, and the CLI never writes
-	// nulls back: stripKeys purges them so a committed manifest stays
-	// canonical even when the wire format is not.
+	// gpuType, build, and the api-key env var name.
+	//
+	// The empty-mapping arm (shape 3) is semantically correct ONLY for
+	// autoscaling: the server reads an empty autoscaling block the same as a
+	// missing one. For other fields the server does NOT treat {} as absent —
+	// imageBuildConfig: {} is default-constructed into a real ImageBuildConfig
+	// by Pydantic (containers.py:83-95), and artifact: {} is rejected with a
+	// confusing 422 (missing name/spec). Use the narrower isNull helper (nil
+	// or !!null scalar only) for those exclusivity checks; keep isNullish only
+	// where the server's own semantics make empty-means-absent true
+	// (checkScaling).
+	//
+	// The CLI never writes nulls back: stripKeys purges them so a committed
+	// manifest stays canonical even when the wire format is not.
 	//
 	// If the API ever gives these shapes distinct meanings — the classic case
 	// being null-as-delete in a PATCH — this helper, its validator call sites,
@@ -67,6 +76,25 @@ func isNullish(node *yaml.Node) bool {
 	}
 
 	return node.Kind == yaml.MappingNode && len(node.Content) == 0
+}
+
+// isNull reports whether a node is a YAML null: a nil node or a scalar with
+// the !!null tag. Unlike isNullish, it does NOT treat an empty mapping ({})
+// as null — that distinction matters for fields whose server semantics
+// differ between null and empty. For artifact and imageBuildConfig, the
+// server never echoes {} and Pydantic does not treat {} as absent: it 422s
+// on artifact: {} with a confusing missing-fields error, and
+// default-constructs imageBuildConfig: {} into a real ImageBuildConfig,
+// silently dropping imageUri on create (workload-api
+// artifact.py:201-214, _strip_client_image_uris_on_build_containers). Use
+// isNull for the exclusivity checks (checkArtifactBinding, checkImageSource,
+// checkArtifact) where an empty block must still count as "set". Use
+// isNullish only where the server itself reads {} as absent — verified
+// today for autoscaling only (checkScaling).
+func isNull(node *yaml.Node) bool {
+	node = resolveAlias(node)
+
+	return node == nil || (node.Kind == yaml.ScalarNode && node.Tag == nullTag)
 }
 
 // resolveAlias follows an alias to the node it anchors, so the helpers below

--- a/internal/workload/manifest/node.go
+++ b/internal/workload/manifest/node.go
@@ -34,6 +34,21 @@ const (
 // is null, so callers that test `!= nil` to mean "this block is set" get a
 // false positive unless they also call this helper.
 func isNullish(node *yaml.Node) bool {
+	// Note: this helper deliberately collapses three wire shapes
+	// 1. absent,
+	// 2. explicit null, and
+	// 3. empty mapping — into a single "not set" meaning,
+	// because that is how the workload endpoints behave today.
+	//
+	// GET responses echo null-valued keys as placeholders (autoscaling: null when
+	// no policy is configured, enabled: null inside one that is), and the create
+	// endpoint reads an empty block the same as a missing one. The CLI also never
+	// writes nulls back: stripKeys purges them so a committed manifest stays
+	// canonical even when the wire format is not.
+	//
+	// If the API ever gives these shapes distinct meanings — the classic case
+	// being null-as-delete in a PATCH — this helper, its validator call sites,
+	// and the nil-key purge in stripKeys are what should be updated.
 	node = resolveAlias(node)
 	if node == nil {
 		return true

--- a/internal/workload/manifest/node.go
+++ b/internal/workload/manifest/node.go
@@ -41,11 +41,18 @@ func isNullish(node *yaml.Node) bool {
 	// into a single "not set" meaning because that is how the workload
 	// endpoints behave today.
 	//
-	// GET responses echo null-valued keys as placeholders (autoscaling: null
-	// when no policy is configured, enabled: null inside one that is), and the
-	// create endpoint reads an empty block the same as a missing one. The CLI
-	// also never writes nulls back: stripKeys purges them so a committed
-	// manifest stays canonical even when the wire format is not.
+	// The autoscaling BLOCK is nullable (AutoscalingProperties | None,
+	// protons/runtime.py:502), so GET responses echo "autoscaling: null" when
+	// no policy is configured — but its fields are NOT: enabled is a non-
+	// nullable bool (default True, protons/runtime.py:217), so
+	// "autoscaling: {enabled: null}" can never arrive. The real nullable set
+	// (verified against the Pydantic models in workload-api/schemas/) is:
+	// autoscaling block, codeRef, imageBuildConfig, imageUri, entrypoint,
+	// port, primary, livenessProbe/readinessProbe/startupProbe, routes,
+	// gpuType, build, and the api-key env var name. The create endpoint reads
+	// an empty block the same as a missing one, and the CLI never writes
+	// nulls back: stripKeys purges them so a committed manifest stays
+	// canonical even when the wire format is not.
 	//
 	// If the API ever gives these shapes distinct meanings — the classic case
 	// being null-as-delete in a PATCH — this helper, its validator call sites,

--- a/internal/workload/manifest/node.go
+++ b/internal/workload/manifest/node.go
@@ -29,6 +29,23 @@ const (
 	boolTag = "!!bool"
 )
 
+// isNullish reports whether a node is meaningfully absent for validator
+// checks. mapValue returns a non-nil scalar node for a present key whose value
+// is null, so callers that test `!= nil` to mean "this block is set" get a
+// false positive unless they also call this helper.
+func isNullish(node *yaml.Node) bool {
+	node = resolveAlias(node)
+	if node == nil {
+		return true
+	}
+
+	if node.Kind == yaml.ScalarNode && node.Tag == nullTag {
+		return true
+	}
+
+	return node.Kind == yaml.MappingNode && len(node.Content) == 0
+}
+
 // resolveAlias follows an alias to the node it anchors, so the helpers below
 // see through YAML anchors/aliases the same way they see a literal value.
 // yaml.v3 aliases point directly at the anchored node, never at another

--- a/internal/workload/manifest/node_test.go
+++ b/internal/workload/manifest/node_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+// TestIsNullish covers the null-blind-spot helper that node-based checks use
+// to treat a present-but-null YAML key as absent.
+func TestIsNullish(t *testing.T) {
+	tests := map[string]struct {
+		node     *yaml.Node
+		expected bool
+	}{
+		"nil node": {
+			node:     nil,
+			expected: true,
+		},
+		"scalar null tag": {
+			node:     &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!null", Value: ""},
+			expected: true,
+		},
+		"empty mapping": {
+			node:     &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{}},
+			expected: true,
+		},
+		"scalar string": {
+			node:     &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "hello"},
+			expected: false,
+		},
+		"scalar int": {
+			node:     &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: "42"},
+			expected: false,
+		},
+		"non-empty mapping": {
+			node: &yaml.Node{
+				Kind: yaml.MappingNode,
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "key"},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "value"},
+				},
+			},
+			expected: false,
+		},
+		"empty sequence": {
+			node:     &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{}},
+			expected: false,
+		},
+		"non-empty sequence": {
+			node: &yaml.Node{
+				Kind: yaml.SequenceNode,
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "item"},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, isNullish(test.node))
+		})
+	}
+}

--- a/internal/workload/manifest/node_test.go
+++ b/internal/workload/manifest/node_test.go
@@ -79,3 +79,65 @@ func TestIsNullish(t *testing.T) {
 		})
 	}
 }
+
+// TestIsNull covers the narrow null predicate: true ONLY for a nil node or a
+// scalar with the !!null tag. An empty mapping is NOT null — that is the key
+// difference from isNullish, and it is what lets the exclusivity checks
+// (checkArtifactBinding, checkImageSource, checkArtifact) reject artifact: {}
+// and imageBuildConfig: {} alongside their counterparts.
+func TestIsNull(t *testing.T) {
+	tests := map[string]struct {
+		node     *yaml.Node
+		expected bool
+	}{
+		"nil node": {
+			node:     nil,
+			expected: true,
+		},
+		"scalar null tag": {
+			node:     &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!null", Value: ""},
+			expected: true,
+		},
+		"empty mapping is NOT null": {
+			node:     &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{}},
+			expected: false,
+		},
+		"scalar string": {
+			node:     &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "hello"},
+			expected: false,
+		},
+		"scalar int": {
+			node:     &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: "42"},
+			expected: false,
+		},
+		"non-empty mapping": {
+			node: &yaml.Node{
+				Kind: yaml.MappingNode,
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "key"},
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "value"},
+				},
+			},
+			expected: false,
+		},
+		"empty sequence": {
+			node:     &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{}},
+			expected: false,
+		},
+		"non-empty sequence": {
+			node: &yaml.Node{
+				Kind: yaml.SequenceNode,
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: "item"},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, isNull(test.node))
+		})
+	}
+}

--- a/internal/workload/manifest/schema.go
+++ b/internal/workload/manifest/schema.go
@@ -181,7 +181,7 @@ func topLevelOrderedFields() []string {
 		}
 	}
 
-	sort.Slice(ordered, func(i, j int) bool {
+	sort.SliceStable(ordered, func(i, j int) bool {
 		return ordered[i].topLevelOrder < ordered[j].topLevelOrder
 	})
 

--- a/internal/workload/manifest/schema.go
+++ b/internal/workload/manifest/schema.go
@@ -80,22 +80,22 @@ var fieldRules = []fieldRule{
 	// spec has no legitimate key by these names anywhere, so recursive
 	// deletion is safe. See the strip scoping decision in the fieldRule doc
 	// comment above.
-	{name: "id", serverManaged: true},
-	{name: "createdAt", serverManaged: true},
-	{name: "updatedAt", serverManaged: true},
-	{name: "status", serverManaged: true},
-	{name: "endpoint", serverManaged: true},
+	{name: keyID, serverManaged: true},
+	{name: keyCreatedAt, serverManaged: true},
+	{name: keyUpdatedAt, serverManaged: true},
+	{name: keyStatus, serverManaged: true},
+	{name: keyEndpoint, serverManaged: true},
 	{name: keyArtifactID, serverManaged: true},
 	{name: keyWorkloadID, serverManaged: true, topLevelOrder: 1},
-	{name: "resolvedBundle", nullable: true, serverManaged: true},
-	{name: "imageOutdated", serverManaged: true},
+	{name: keyResolvedBundle, nullable: true, serverManaged: true},
+	{name: keyImageOutdated, serverManaged: true},
 
 	// Build outputs — stripped from containers by stripBuildOutputs. These
 	// are scoped to containers (or inside imageBuildConfig) because the bare
 	// word "build" is generic enough that adding it to serverManagedKeys
 	// could eat a legitimate user key at some other level of the spec.
-	{name: "build", nullable: true, buildOutput: true},
-	{name: "codeRef", nullable: true, buildOutput: true, buildConfigScoped: true},
+	{name: keyBuild, nullable: true, buildOutput: true},
+	{name: keyCodeRef, nullable: true, buildOutput: true, buildConfigScoped: true},
 
 	// Identifier keys — name is hoisted in sequence-item mappings under
 	// these keys by hoistNameKeys. Only these two keys carry identifier

--- a/internal/workload/manifest/schema.go
+++ b/internal/workload/manifest/schema.go
@@ -1,0 +1,216 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// fieldRule declares the metadata for one manifest field. It is the single
+// source of truth consulted by the strip, hoist, and ordering passes that
+// prepare a server document for rendering.
+//
+// Strip scoping decision: serverManaged keys are deleted at ANY depth
+// (including inside codeRef.datarobot and any other nested mapping). This
+// preserves the existing behavior: the create spec has no legitimate key by
+// these names anywhere, so recursive deletion is safe. Scoping to known paths
+// would be a deliberate behavior change; we preserve any-depth and document
+// it here.
+type fieldRule struct {
+	name string
+
+	// nullable documents whether the field can arrive as null from the server
+	// (Surface A — GET responses). Documentation only; the validator has its
+	// own null-handling predicates (isNull/isNullish) and does not consult
+	// this field. See library/api-reference.md for the authoritative summary.
+	nullable bool
+
+	// serverManaged means the field is the server's own bookkeeping and is
+	// stripped at any depth by stripKeys. The create spec has no legitimate
+	// key by these names anywhere, so recursive deletion is safe.
+	serverManaged bool
+
+	// buildOutput means the field is a server-assigned build output, stripped
+	// by stripBuildOutputs. When buildConfigScoped is true, the field lives
+	// inside imageBuildConfig; otherwise it lives on the container directly.
+	// The conditional imageUri/imageBuildConfig deletion logic in
+	// stripBuildOutputs is behavior, not metadata — it depends on whether
+	// the build config is empty after stripping, which the table cannot
+	// express.
+	buildOutput       bool
+	buildConfigScoped bool
+
+	// hoistName means name is hoisted to the front of sequence-item mappings
+	// found under this key by hoistNameKeys. Only containerGroups and
+	// containers carry identifier mappings; opaque user/platform blocks keep
+	// their original key order per the pass-through contract.
+	hoistName bool
+
+	// topLevelOrder is the position of this field in the top-level manifest
+	// mapping (0 = not a top-level field). Both Live.Render and Draft.Render
+	// consult this ordering so the two renderers emit the same key sequence.
+	topLevelOrder int
+}
+
+// fieldRules is the single source of truth for manifest field metadata.
+// Every strip, hoist, and ordering pass in the package consults this table
+// rather than maintaining its own inline list.
+//
+// The table is intentionally not exhaustive: it covers the fields the four
+// scattered knowledge sites (serverManagedKeys, stripBuildOutputs literals,
+// hoistNameKeys targets, and the two parallel top-level orderings) already
+// tracked. Fields that are purely pass-through (unknown blocks the package
+// has never heard of) need no rule and are preserved verbatim.
+var fieldRules = []fieldRule{
+	// Server-managed keys — stripped at any depth by stripKeys. The create
+	// spec has no legitimate key by these names anywhere, so recursive
+	// deletion is safe. See the strip scoping decision in the fieldRule doc
+	// comment above.
+	{name: "id", serverManaged: true},
+	{name: "createdAt", serverManaged: true},
+	{name: "updatedAt", serverManaged: true},
+	{name: "status", serverManaged: true},
+	{name: "endpoint", serverManaged: true},
+	{name: keyArtifactID, serverManaged: true},
+	{name: keyWorkloadID, serverManaged: true, topLevelOrder: 1},
+	{name: "resolvedBundle", nullable: true, serverManaged: true},
+	{name: "imageOutdated", serverManaged: true},
+
+	// Build outputs — stripped from containers by stripBuildOutputs. These
+	// are scoped to containers (or inside imageBuildConfig) because the bare
+	// word "build" is generic enough that adding it to serverManagedKeys
+	// could eat a legitimate user key at some other level of the spec.
+	{name: "build", nullable: true, buildOutput: true},
+	{name: "codeRef", nullable: true, buildOutput: true, buildConfigScoped: true},
+
+	// Identifier keys — name is hoisted in sequence-item mappings under
+	// these keys by hoistNameKeys. Only these two keys carry identifier
+	// mappings; opaque user/platform blocks keep their original key order.
+	{name: keyContainerGroups, hoistName: true},
+	{name: keyContainers, hoistName: true},
+
+	// Top-level fields — ordered for both Live.Render and Draft.Render so
+	// the two renderers emit the same key sequence. workloadId is declared
+	// above (it is also server-managed, stripped from spec/runtime at any
+	// depth while written at the top level by Render).
+	{name: keyName, topLevelOrder: 2},
+	{name: keyImportance, topLevelOrder: 3},
+	{name: keyArtifact, nullable: true, topLevelOrder: 4},
+	{name: keyRuntime, topLevelOrder: 5},
+}
+
+// hoistNameKeySet is the set of keys whose sequence-item mappings have name
+// hoisted to the front, derived from the field rule table at init time so
+// the recursive hoistNameKeys walk does not allocate on every call.
+var hoistNameKeySet map[string]bool
+
+func init() {
+	hoistNameKeySet = make(map[string]bool)
+
+	for _, rule := range fieldRules {
+		if rule.hoistName {
+			hoistNameKeySet[rule.name] = true
+		}
+	}
+}
+
+// serverManagedFieldKeys returns the keys that are stripped at any depth by
+// stripKeys, in the order they appear in the table.
+func serverManagedFieldKeys() []string {
+	var keys []string
+
+	for _, rule := range fieldRules {
+		if rule.serverManaged {
+			keys = append(keys, rule.name)
+		}
+	}
+
+	return keys
+}
+
+// containerBuildOutputKeys returns the build-output keys that live on a
+// container directly (not inside imageBuildConfig), in table order.
+func containerBuildOutputKeys() []string {
+	var keys []string
+
+	for _, rule := range fieldRules {
+		if rule.buildOutput && !rule.buildConfigScoped {
+			keys = append(keys, rule.name)
+		}
+	}
+
+	return keys
+}
+
+// buildConfigBuildOutputKeys returns the build-output keys that live inside
+// imageBuildConfig, in table order.
+func buildConfigBuildOutputKeys() []string {
+	var keys []string
+
+	for _, rule := range fieldRules {
+		if rule.buildOutput && rule.buildConfigScoped {
+			keys = append(keys, rule.name)
+		}
+	}
+
+	return keys
+}
+
+// topLevelOrderedFields returns the top-level manifest keys in the order both
+// Live.Render and Draft.Render emit them, derived from the field rule table.
+func topLevelOrderedFields() []string {
+	var ordered []fieldRule
+
+	for _, rule := range fieldRules {
+		if rule.topLevelOrder > 0 {
+			ordered = append(ordered, rule)
+		}
+	}
+
+	sort.Slice(ordered, func(i, j int) bool {
+		return ordered[i].topLevelOrder < ordered[j].topLevelOrder
+	})
+
+	keys := make([]string, len(ordered))
+
+	for i, rule := range ordered {
+		keys[i] = rule.name
+	}
+
+	return keys
+}
+
+// orderedFields builds a field list in the order defined by the rule table's
+// top-level ordering. Both Live.Render and Draft.Render call this so they
+// emit the same key sequence. Keys absent from values are skipped, which is
+// how Draft.Render omits workloadId when it is empty.
+func orderedFields(values map[string]*yaml.Node, comments map[string]string) []field {
+	order := topLevelOrderedFields()
+
+	fields := make([]field, 0, len(order))
+
+	for _, key := range order {
+		value, ok := values[key]
+		if !ok {
+			continue
+		}
+
+		fields = append(fields, field{key: key, value: value, comment: comments[key]})
+	}
+
+	return fields
+}

--- a/internal/workload/manifest/schema_test.go
+++ b/internal/workload/manifest/schema_test.go
@@ -157,7 +157,12 @@ func fullServerWorkloadDoc(t *testing.T) map[string]any {
 					"autoscaling": null,
 					"resolvedBundle": {"catalogId": "cat1", "catalogVersionId": "ver1"},
 					"containers": [
-						{"name": "app", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}
+						{
+							"name": "app",
+							"resourceAllocation": {"cpu": 1, "memory": "1GB"},
+							"status": "running",
+							"updatedAt": "2026-01-02T00:00:00Z"
+						}
 					]
 				}
 			]
@@ -193,6 +198,11 @@ func fullServerArtifactDoc(t *testing.T) map[string]any {
 							"name": "app",
 							"primary": true,
 							"port": 8080,
+							"id": "68a0000000000000000000a1",
+							"artifactId": "68a0000000000000000000a1",
+							"endpoint": "app.datarobot.com",
+							"status": "locked",
+							"createdAt": "2026-01-01T00:00:00Z",
 							"imageUri": "registry.internal/built-by-server:abc",
 							"imageOutdated": true,
 							"build": {

--- a/internal/workload/manifest/schema_test.go
+++ b/internal/workload/manifest/schema_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// VAL-SCHEMA-001: Draft.Render and Live.Render emit the same top-level key
+// order, pinned against the single shared ordering definition in the field
+// rule table (schema.go). Today only Live.Render's order is pinned
+// (VAL-RENDER-014); Draft.Render's order can drift silently. This test
+// asserts both renderers produce identical top-level key sequences matching
+// topLevelOrderedFields.
+func TestSchema_TopLevelKeyOrderMatches(t *testing.T) {
+	expected := topLevelOrderedFields()
+
+	// Draft.Render — serviceDraft has WorkloadID set, so all 5 keys are present.
+	draftRendered, err := serviceDraft().Render()
+	require.NoError(t, err)
+
+	draftRoot := renderedRoot(t, draftRendered)
+	draftKeys := mappingKeys(draftRoot)
+
+	assert.Equal(t, expected, draftKeys,
+		"Draft.Render top-level keys must match the shared ordering")
+
+	// Live.Render — liveFixture has WorkloadID set, so all 5 keys are present.
+	liveRendered, err := liveFixture(t).Render()
+	require.NoError(t, err)
+
+	liveRoot := renderedRoot(t, liveRendered)
+	liveKeys := mappingKeys(liveRoot)
+
+	assert.Equal(t, expected, liveKeys,
+		"Live.Render top-level keys must match the shared ordering")
+
+	// Both renderers emit the same sequence.
+	assert.Equal(t, draftKeys, liveKeys,
+		"Draft.Render and Live.Render must emit the same top-level key order")
+}
+
+// VAL-SCHEMA-002: strip/hoist behavior is unchanged after the field-metadata
+// consolidation. A server document containing the full server-managed set
+// (id, createdAt, updatedAt, status, endpoint, artifactId, resolvedBundle,
+// imageOutdated, the build block, codeRef) renders without any of those keys,
+// name still leads in containerGroup/container sequence-item mappings, and
+// opaque mappings (labels) keep their original key order. This is a
+// consolidation pin — it may reuse existing fixtures and asserts the same
+// behavior the existing strip/hoist/order suite covers, phrased against the
+// consolidated table so a regression in the table-to-consumer wiring is
+// caught directly.
+func TestSchema_ConsolidationPinStripAndHoist(t *testing.T) {
+	// Build a server document carrying the full server-managed set plus an
+	// opaque labels block (with name not as the first key) to verify that
+	// hoisting is scoped to identifier mappings only.
+	workloadDoc := fullServerWorkloadDoc(t)
+	artifactDoc := fullServerArtifactDoc(t)
+
+	live, err := NewLive("68b0c1d2e3f4a5b6c7d8e9f0", workloadDoc, artifactDoc)
+	require.NoError(t, err)
+
+	rendered, err := live.Render()
+	require.NoError(t, err)
+
+	// Server-managed key values must not appear in the rendered output.
+	// workloadId is the exception: it is the one binding the file carries.
+	for _, unwanted := range []string{
+		"68a0000000000000000000a1", // artifactId value
+		"app.datarobot.com",        // endpoint value
+		"status: running",          // workload status
+		"status: locked",           // artifact status
+		"2026-01-01T00:00:00Z",     // createdAt value
+		"2026-01-02T00:00:00Z",     // updatedAt value
+		"resolvedBundle",           // server-managed key
+		"imageOutdated",            // server-managed key
+		"artifactImageBuildId",     // build output key
+		"build-123",                // build output value
+		"codeRef",                  // build config output key
+		"built-by-server",          // imageUri value (stripped for build container)
+	} {
+		assert.NotContains(t, string(rendered), unwanted,
+			"rendered manifest must not contain %s after consolidation", unwanted)
+	}
+
+	// The binding is the one id the file carries.
+	assert.Contains(t, string(rendered), "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0")
+
+	root := renderedRoot(t, rendered)
+
+	// Name leads in container/containerGroup sequence-item mappings.
+	assertNameLeadsInIdentifierMappings(t, root, "")
+
+	// Opaque mappings (labels) keep their key order — name is NOT hoisted
+	// because labels is not a sequence item under containerGroups/containers.
+	// documentNode sorts keys alphabetically, so the labels block arrives as
+	// app, name, version (alphabetical). hoistNameKeys must not promote name
+	// to the front; if it did, the order would be name, app, version.
+	spec := mapValue(mapValue(root, keyArtifact), keySpec)
+
+	for _, group := range seqItems(mapValue(spec, keyContainerGroups)) {
+		for _, container := range seqItems(mapValue(group, keyContainers)) {
+			labels := mapValue(container, "labels")
+			if labels == nil {
+				continue
+			}
+
+			keys := mappingKeys(labels)
+			assert.Equal(t, []string{"app", "name", "version"}, keys,
+				"opaque mapping (labels) must keep alphabetical key order, not hoist name")
+		}
+	}
+
+	// The rendered manifest round-trips through Parse and Validate.
+	parsed, err := Parse(rendered, "")
+	require.NoError(t, err)
+
+	require.NoError(t, parsed.Validate())
+}
+
+// fullServerWorkloadDoc returns a workload GET response carrying every
+// server-managed key the field rule table declares, so the consolidation pin
+// can verify they are all stripped.
+func fullServerWorkloadDoc(t *testing.T) map[string]any {
+	t.Helper()
+
+	const doc = `{
+		"id": "68b0c1d2e3f4a5b6c7d8e9f0",
+		"name": "test-workload",
+		"importance": "low",
+		"status": "running",
+		"createdAt": "2026-01-01T00:00:00Z",
+		"updatedAt": "2026-01-02T00:00:00Z",
+		"endpoint": "https://app.datarobot.com/workloads/68b0/",
+		"artifactId": "68a0000000000000000000a1",
+		"runtime": {
+			"containerGroups": [
+				{
+					"name": "default",
+					"replicaCount": 3,
+					"autoscaling": null,
+					"resolvedBundle": {"catalogId": "cat1", "catalogVersionId": "ver1"},
+					"containers": [
+						{"name": "app", "resourceAllocation": {"cpu": 1, "memory": "1GB"}}
+					]
+				}
+			]
+		}
+	}`
+
+	var out map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(doc), &out))
+
+	return out
+}
+
+// fullServerArtifactDoc returns an artifact GET response carrying every
+// server-managed and build-output key, plus an opaque labels block with name
+// not as the first key, so the consolidation pin can verify stripping and
+// hoist scoping together.
+func fullServerArtifactDoc(t *testing.T) map[string]any {
+	t.Helper()
+
+	const doc = `{
+		"id": "68a0000000000000000000a1",
+		"name": "test-artifact",
+		"type": "service",
+		"status": "locked",
+		"createdAt": "2026-01-01T00:00:00Z",
+		"spec": {
+			"containerGroups": [
+				{
+					"name": "default",
+					"containers": [
+						{
+							"name": "app",
+							"primary": true,
+							"port": 8080,
+							"imageUri": "registry.internal/built-by-server:abc",
+							"imageOutdated": true,
+							"build": {
+								"artifactImageBuildId": "build-123",
+								"status": "completed",
+								"createdAt": "2026-07-02T10:00:00Z"
+							},
+							"imageBuildConfig": {
+								"dockerfile": {"source": "provided"},
+								"codeRef": {"datarobot": {"catalogId": "cat1", "catalogVersionId": "ver1"}}
+							},
+							"labels": {"app": "test", "name": "not-an-id", "version": "v1"}
+						}
+					]
+				}
+			]
+		}
+	}`
+
+	var out map[string]any
+
+	require.NoError(t, json.Unmarshal([]byte(doc), &out))
+
+	return out
+}

--- a/internal/workload/manifest/validate.go
+++ b/internal/workload/manifest/validate.go
@@ -212,7 +212,7 @@ func (v *validator) checkArtifactBinding(root *yaml.Node) {
 	inline := mapValue(root, keyArtifact)
 	byID, _ := scalarString(mapValue(root, keyArtifactID))
 
-	if (inline != nil) == (byID != "") {
+	if (!isNullish(inline)) == (byID != "") {
 		v.add(nil, root, "",
 			"exactly one of %s (inline definition) or %s (existing artifact) is required",
 			keyArtifact, keyArtifactID)
@@ -232,13 +232,13 @@ type groupShape struct {
 // existing artifact by id returns no shape, and the runtime name checks are
 // skipped: the names live server-side where the CLI cannot see them.
 func (v *validator) checkArtifact(artifact *yaml.Node) []groupShape {
-	if artifact == nil {
+	if isNullish(artifact) {
 		return nil
 	}
 
 	spec := mapValue(artifact, keySpec)
-	if spec == nil {
-		v.add(nil, artifact, joinPath(keyArtifact, keySpec), "is required for an inline artifact")
+	if isNullish(spec) {
+		v.add(spec, artifact, joinPath(keyArtifact, keySpec), "is required for an inline artifact")
 
 		return nil
 	}
@@ -319,15 +319,16 @@ func (v *validator) checkImageSource(container *yaml.Node, path string) {
 	imageURI, hasImage := scalarString(mapValue(container, keyImageURI))
 	hasImage = hasImage && imageURI != ""
 	buildConfig := mapValue(container, keyImageBuildConfig)
+	hasBuildConfig := !isNullish(buildConfig)
 
 	switch {
-	case hasImage && buildConfig != nil:
+	case hasImage && hasBuildConfig:
 		v.add(buildConfig, container, path,
 			"sets both %s and %s; a container names an image or says how to build one, never both",
 			keyImageURI, keyImageBuildConfig)
-	case !hasImage && buildConfig == nil:
+	case !hasImage && !hasBuildConfig:
 		v.add(nil, container, path, "must set either %s or %s", keyImageURI, keyImageBuildConfig)
-	case buildConfig != nil:
+	case hasBuildConfig:
 		v.checkBuildConfig(buildConfig, joinPath(path, keyImageBuildConfig))
 	}
 }
@@ -338,8 +339,8 @@ func (v *validator) checkImageSource(container *yaml.Node, path string) {
 // reinterpret later.
 func (v *validator) checkBuildConfig(buildConfig *yaml.Node, path string) {
 	dockerfile := mapValue(buildConfig, keyDockerfile)
-	if dockerfile == nil {
-		v.add(buildConfig, buildConfig, joinPath(path, keyDockerfile),
+	if isNullish(dockerfile) {
+		v.add(nil, buildConfig, joinPath(path, keyDockerfile),
 			"is required: %s must say how the image is built", keyImageBuildConfig)
 
 		return
@@ -464,12 +465,13 @@ func (v *validator) checkRuntimeContainers(group *yaml.Node, path string, shape 
 // checkScaling holds replicaCount against autoscaling. A group may say how
 // many replicas to run or how to scale them, not both. Autoscaling switched
 // off is not scaling, so an explicit enabled:false leaves replicaCount alone,
-// matching what the create endpoint accepts.
+// matching what the create endpoint accepts. A null or empty autoscaling block
+// is also not a policy, matching the server's own echo.
 func (v *validator) checkScaling(group *yaml.Node, path string) {
 	replicas := mapValue(group, keyReplicaCount)
 	autoscaling := mapValue(group, keyAutoscaling)
 
-	if replicas == nil || autoscaling == nil {
+	if replicas == nil || isNullish(autoscaling) {
 		return
 	}
 

--- a/internal/workload/manifest/validate.go
+++ b/internal/workload/manifest/validate.go
@@ -436,12 +436,15 @@ func (v *validator) checkPort(container *yaml.Node, path string, primary bool) {
 }
 
 // checkEnvironmentVars holds the value-or-source rule for each entry in a
-// container's environmentVars sequence. The server schema requires a non-null
-// value for the string variant (source absent or "string"); the credential
-// and api-key variants carry no value. An explicitly empty value ("") passes —
-// that is the server's spelling of an intentionally-empty variable. A value-less
-// string entry today fails only as a 422 at deploy time; this check surfaces
-// it at validate time with a line anchor.
+// container's environmentVars sequence. This is a Surface B guard: the
+// validator's input is a hand-editable file, so a user can write value: null
+// or omit value entirely regardless of what the server schema allows on the
+// wire. The rule requires a non-null value for the string variant (source
+// absent or "string"); the credential and api-key variants carry no value and
+// are exempt. An explicitly empty value ("") passes — that is the valid
+// spelling of an intentionally-empty variable. Surfacing a value-less string
+// entry at validate time (with a line anchor) beats discovering it as a 422
+// at deploy time.
 func (v *validator) checkEnvironmentVars(container *yaml.Node, path string) {
 	vars := mapValue(container, keyEnvironmentVars)
 	if isNullish(vars) {
@@ -463,8 +466,6 @@ func (v *validator) checkEnvironmentVars(container *yaml.Node, path string) {
 			v.add(value, entry, joinPath(entryPath, keyValue),
 				"is required: set a value or use a %s/%s source",
 				credentialSource, sourceAPIKey)
-
-			continue
 		}
 	}
 }

--- a/internal/workload/manifest/validate.go
+++ b/internal/workload/manifest/validate.go
@@ -215,11 +215,17 @@ func (v *validator) checkName(root *yaml.Node) {
 
 // checkArtifactBinding holds the create endpoint's either-or: an inline
 // artifact to build, or the id of one that already exists.
+//
+// Uses isNull (not isNullish) for the inline-artifact presence test: the
+// server never echoes artifact: {} (it sends artifact: null on unset), and
+// Pydantic 422s on artifact: {} with a confusing missing-fields error. An
+// empty mapping must still count as "set" so that artifact: {} alongside
+// artifactId is caught locally with the clean exactly-one-of message.
 func (v *validator) checkArtifactBinding(root *yaml.Node) {
 	inline := mapValue(root, keyArtifact)
 	byID, _ := scalarString(mapValue(root, keyArtifactID))
 
-	if (!isNullish(inline)) == (byID != "") {
+	if (!isNull(inline)) == (byID != "") {
 		v.add(nil, root, "",
 			"exactly one of %s (inline definition) or %s (existing artifact) is required",
 			keyArtifact, keyArtifactID)
@@ -238,8 +244,14 @@ type groupShape struct {
 // shape the runtime block is checked against. A manifest that binds an
 // existing artifact by id returns no shape, and the runtime name checks are
 // skipped: the names live server-side where the CLI cannot see them.
+//
+// Uses isNull (not isNullish) so that artifact: {} (an empty mapping, no
+// artifactId) enters the check and reports "spec is required for an inline
+// artifact" rather than falling through to the binding error. The server
+// never echoes artifact: {} and Pydantic 422s on it, so the empty-mapping arm
+// of isNullish would only mask a genuinely-broken file.
 func (v *validator) checkArtifact(artifact *yaml.Node) []groupShape {
-	if isNullish(artifact) {
+	if isNull(artifact) {
 		return nil
 	}
 
@@ -323,11 +335,20 @@ func (v *validator) checkArtifactGroup(group *yaml.Node, path string) groupShape
 
 // checkImageSource holds the exactly-one rule: a container names an image or
 // says how to build one, never both and never neither.
+//
+// Uses isNull (not isNullish) for hasBuildConfig: the server silently
+// discards imageUri on artifact CREATE when imageBuildConfig parses non-None
+// (workload-api artifact.py:201-214, _strip_client_image_uris_on_build_
+// containers), and Pydantic default-constructs imageBuildConfig: {} into a
+// real ImageBuildConfig (containers.py:83-95). An empty mapping must still
+// count as "set" so that imageUri + imageBuildConfig: {} is caught locally
+// with the clean never-both message rather than silently dropping the
+// user's declared imageUri.
 func (v *validator) checkImageSource(container *yaml.Node, path string) {
 	imageURI, hasImage := scalarString(mapValue(container, keyImageURI))
 	hasImage = hasImage && imageURI != ""
 	buildConfig := mapValue(container, keyImageBuildConfig)
-	hasBuildConfig := !isNullish(buildConfig)
+	hasBuildConfig := !isNull(buildConfig)
 
 	switch {
 	case hasImage && hasBuildConfig:

--- a/internal/workload/manifest/validate.go
+++ b/internal/workload/manifest/validate.go
@@ -466,12 +466,18 @@ func (v *validator) checkRuntimeContainers(group *yaml.Node, path string, shape 
 // many replicas to run or how to scale them, not both. Autoscaling switched
 // off is not scaling, so an explicit enabled:false leaves replicaCount alone,
 // matching what the create endpoint accepts. A null or empty autoscaling block
-// is also not a policy, matching the server's own echo.
+// is also not a policy, matching the server's own echo, and a null
+// replicaCount is no count at all: neither side of the pair trips on the
+// other's placeholder.
+//
+// replicaCount itself is never type-checked: "replicaCount: three" passes
+// the ledger and fails only at the create endpoint. Noted rather than fixed;
+// add the scalarInt rule if the server's error for it proves confusing.
 func (v *validator) checkScaling(group *yaml.Node, path string) {
 	replicas := mapValue(group, keyReplicaCount)
 	autoscaling := mapValue(group, keyAutoscaling)
 
-	if replicas == nil || isNullish(autoscaling) {
+	if isNullish(replicas) || isNullish(autoscaling) {
 		return
 	}
 

--- a/internal/workload/manifest/validate.go
+++ b/internal/workload/manifest/validate.go
@@ -476,7 +476,7 @@ func (v *validator) checkScaling(group *yaml.Node, path string) {
 	}
 
 	enabled := mapValue(autoscaling, keyEnabled)
-	if enabled != nil && !isTrue(enabled) {
+	if !isNullish(enabled) && !isTrue(enabled) {
 		return
 	}
 

--- a/internal/workload/manifest/validate.go
+++ b/internal/workload/manifest/validate.go
@@ -426,7 +426,7 @@ func (v *validator) checkPort(container *yaml.Node, path string, primary bool) {
 // checkRuntime validates the sizing half of the file against the shape of the
 // artifact half.
 func (v *validator) checkRuntime(runtime *yaml.Node, shapes []groupShape) {
-	if runtime == nil {
+	if isNullish(runtime) {
 		return
 	}
 

--- a/internal/workload/manifest/validate.go
+++ b/internal/workload/manifest/validate.go
@@ -204,13 +204,28 @@ func (v *validator) add(node, anchor *yaml.Node, path, format string, args ...an
 	v.errs = append(v.errs, FieldError{Path: path, Line: line, Msg: fmt.Sprintf(format, args...)})
 }
 
+// requiredString looks up key in node's mapping, asserts the value is a
+// non-empty string scalar, and records a finding when it is not. It returns
+// the string and ok; ok is false when the key is missing, null, or empty.
+// The finding is anchored to the looked-up node's own line, falling back to
+// node (the parent) when the key is absent — the same anchor pattern the
+// individual checks used before this helper captured it.
+func (v *validator) requiredString(node *yaml.Node, key, path, format string, args ...any) (string, bool) {
+	valueNode := mapValue(node, key)
+
+	value, ok := scalarString(valueNode)
+	if !ok || value == "" {
+		v.add(valueNode, node, path, format, args...)
+
+		return "", false
+	}
+
+	return value, true
+}
+
 // checkName holds the one field the create endpoint always needs.
 func (v *validator) checkName(root *yaml.Node) {
-	node := mapValue(root, keyName)
-
-	if name, ok := scalarString(node); !ok || name == "" {
-		v.add(node, root, keyName, "is required and must be a non-empty string")
-	}
+	v.requiredString(root, keyName, keyName, "is required and must be a non-empty string")
 }
 
 // checkArtifactBinding holds the create endpoint's either-or: an inline
@@ -284,11 +299,8 @@ func (v *validator) checkArtifact(artifact *yaml.Node) []groupShape {
 func (v *validator) checkArtifactGroup(group *yaml.Node, path string) groupShape {
 	shape := groupShape{}
 
-	name, ok := scalarString(mapValue(group, keyName))
-	if !ok || name == "" {
-		v.add(mapValue(group, keyName), group, joinPath(path, keyName),
-			"is required: runtime sizing is joined to the artifact by group name")
-	}
+	name, _ := v.requiredString(group, keyName, joinPath(path, keyName),
+		"is required: runtime sizing is joined to the artifact by group name")
 
 	shape.name = name
 
@@ -306,10 +318,7 @@ func (v *validator) checkArtifactGroup(group *yaml.Node, path string) groupShape
 	for i, container := range containers {
 		containerPath := fmt.Sprintf("%s.%s[%d]", path, keyContainers, i)
 
-		containerName, ok := scalarString(mapValue(container, keyName))
-		if !ok || containerName == "" {
-			v.add(mapValue(container, keyName), container, joinPath(containerPath, keyName), "is required")
-		}
+		containerName, _ := v.requiredString(container, keyName, joinPath(containerPath, keyName), "is required")
 
 		shape.containers = append(shape.containers, containerName)
 
@@ -413,12 +422,8 @@ func (v *validator) checkProvidedBuild(dockerfile *yaml.Node, path string) {
 // so the same file builds the same image after the environment moves on.
 func (v *validator) checkGeneratedBuild(dockerfile *yaml.Node, path string) {
 	for _, key := range []string{keyExecEnvID, keyExecEnvVersionID} {
-		node := mapValue(dockerfile, key)
-
-		if value, ok := scalarString(node); !ok || value == "" {
-			v.add(node, dockerfile, joinPath(path, key),
-				"is required when source is %q", sourceGenerated)
-		}
+		v.requiredString(dockerfile, key, joinPath(path, key),
+			"is required when source is %q", sourceGenerated)
 	}
 
 	entrypoint := mapValue(dockerfile, keyEntrypoint)

--- a/internal/workload/manifest/validate.go
+++ b/internal/workload/manifest/validate.go
@@ -56,6 +56,13 @@ const (
 	sourceGenerated = "generated"
 )
 
+// environmentVars source discriminators that carry no value field. The string
+// variant (source absent or "string") requires a non-null value; the
+// credential and api-key variants resolve their value server-side. The
+// dr-credential discriminator is shared with compile.go's credentialSource;
+// api-key is validate-only because the compiler does not expand it.
+const sourceAPIKey = "api-key"
+
 // dockerfileName is the only Dockerfile a provided build may name. Setup
 // writes no path at all, so this is a fixed expectation of the project root
 // rather than a default that can be pointed elsewhere.
@@ -301,6 +308,7 @@ func (v *validator) checkArtifactGroup(group *yaml.Node, path string) groupShape
 
 		v.checkImageSource(container, containerPath)
 		v.checkPort(container, containerPath, primary)
+		v.checkEnvironmentVars(container, containerPath)
 	}
 
 	// Two primaries in one group is unambiguously wrong: only one container
@@ -340,7 +348,11 @@ func (v *validator) checkImageSource(container *yaml.Node, path string) {
 func (v *validator) checkBuildConfig(buildConfig *yaml.Node, path string) {
 	dockerfile := mapValue(buildConfig, keyDockerfile)
 	if isNullish(dockerfile) {
-		v.add(nil, buildConfig, joinPath(path, keyDockerfile),
+		// Pass the dockerfile node (not nil) so the error anchors to the
+		// dockerfile key's own line when it is present-but-null. When the key
+		// is absent entirely, mapValue returns nil and the anchor falls back
+		// to buildConfig — the nearest node that does exist.
+		v.add(dockerfile, buildConfig, joinPath(path, keyDockerfile),
 			"is required: %s must say how the image is built", keyImageBuildConfig)
 
 		return
@@ -420,6 +432,40 @@ func (v *validator) checkPort(container *yaml.Node, path string, primary bool) {
 	if port < minPrimaryPort {
 		v.add(node, container, portPath,
 			"is %d; the primary container runs unprivileged and must listen on %d or above", port, minPrimaryPort)
+	}
+}
+
+// checkEnvironmentVars holds the value-or-source rule for each entry in a
+// container's environmentVars sequence. The server schema requires a non-null
+// value for the string variant (source absent or "string"); the credential
+// and api-key variants carry no value. An explicitly empty value ("") passes —
+// that is the server's spelling of an intentionally-empty variable. A value-less
+// string entry today fails only as a 422 at deploy time; this check surfaces
+// it at validate time with a line anchor.
+func (v *validator) checkEnvironmentVars(container *yaml.Node, path string) {
+	vars := mapValue(container, keyEnvironmentVars)
+	if isNullish(vars) {
+		return
+	}
+
+	for i, entry := range seqItems(vars) {
+		entryPath := fmt.Sprintf("%s.%s[%d]", path, keyEnvironmentVars, i)
+
+		// Credential and api-key sources resolve their value server-side, so
+		// they are exempt from the value requirement.
+		source, _ := scalarString(mapValue(entry, keySource))
+		if source == credentialSource || source == sourceAPIKey {
+			continue
+		}
+
+		value := mapValue(entry, keyValue)
+		if isNullish(value) {
+			v.add(value, entry, joinPath(entryPath, keyValue),
+				"is required: set a value or use a %s/%s source",
+				credentialSource, sourceAPIKey)
+
+			continue
+		}
 	}
 }
 

--- a/internal/workload/manifest/validate_test.go
+++ b/internal/workload/manifest/validate_test.go
@@ -337,6 +337,18 @@ func TestValidate_ReplicaCountWithEmptyAutoscaling(t *testing.T) {
 `)))
 }
 
+// A null replicaCount is no count at all, so it cannot conflict with an
+// active autoscaling policy. The server echoes the same placeholder shape
+// for replicas that it does for autoscaling.
+func TestValidate_NullReplicaCountAllowsAutoscaling(t *testing.T) {
+	require.NoError(t, validateString(t, "", runtimeWithGroupBody(`      replicaCount: null
+      autoscaling:
+        enabled: true
+        minReplicaCount: 1
+        maxReplicaCount: 4
+`)))
+}
+
 // A non-empty autoscaling body without an enabled key is treated as enabled by
 // the server, so replicaCount still conflicts.
 func TestValidate_ReplicaCountWithAutoscalingNoEnabled(t *testing.T) {

--- a/internal/workload/manifest/validate_test.go
+++ b/internal/workload/manifest/validate_test.go
@@ -658,6 +658,74 @@ artifactId: null
 `))
 }
 
+// VAL-R3-001: an EMPTY inline artifact block (artifact: {}) alongside an
+// artifactId is REJECTED with the exactly-one-of error. The server never
+// echoes artifact: {} (it sends artifact: null on unset), and Pydantic 422s
+// on artifact: {} with a confusing missing-fields error — the CLI must catch
+// it locally. The narrow isNull predicate (not isNullish) keeps the empty
+// mapping from being treated as absent here. Both the exactly-one-of error
+// (both sides set) and the spec-required error (empty artifact has no spec)
+// are reported, giving the user the full picture of what to fix.
+func TestValidate_EmptyArtifactBlockWithArtifactIdRejected(t *testing.T) {
+	err := validateString(t, "", `name: my-app
+artifact: {}
+artifactId: 68b0bbbb0000000000000002
+`)
+
+	requireFindings(t, err, []FieldError{
+		{Line: 1, Path: "", Msg: "exactly one of artifact"},
+		{Line: 2, Path: "artifact.spec", Msg: "is required for an inline artifact"},
+	})
+}
+
+// VAL-R3-002: a container with both imageUri and an EMPTY imageBuildConfig
+// (imageBuildConfig: {}) is REJECTED with the never-both error. The server
+// silently discards imageUri on artifact CREATE when imageBuildConfig parses
+// non-None (workload-api artifact.py:201-214), and Pydantic default-constructs
+// imageBuildConfig: {} into a real ImageBuildConfig — so the CLI must catch
+// this locally. The narrow isNull predicate keeps the empty mapping from
+// being treated as absent here.
+func TestValidate_ImageUriWithEmptyBuildConfigRejected(t *testing.T) {
+	err := validateString(t, "", serviceWithContainerBody(`            imageUri: nginx:latest
+            imageBuildConfig: {}
+`))
+
+	requireFindings(t, err, []FieldError{
+		{Line: 13, Path: "artifact.spec.containerGroups[0].containers[0]", Msg: "never both"},
+	})
+}
+
+// VAL-R3-004: an empty imageBuildConfig: {} with NO imageUri reports the
+// missing dockerfile key (the same error as a missing dockerfile), not a
+// generic binding error. The empty-mapping arm must not short-circuit
+// checkBuildConfig into the wrong message.
+func TestValidate_EmptyBuildConfigAloneReportsDockerfileRequired(t *testing.T) {
+	err := validateString(t, "", serviceWithContainerBody(`            imageBuildConfig: {}
+`))
+
+	requireFindings(t, err, []FieldError{
+		{
+			Line: 12,
+			Path: "artifact.spec.containerGroups[0].containers[0].imageBuildConfig.dockerfile",
+			Msg:  "is required: imageBuildConfig must say how the image is built",
+		},
+	})
+}
+
+// VAL-R3-004: an empty artifact: {} with NO artifactId reports the missing
+// spec (the same error as a missing spec), not a generic binding/exclusivity
+// error. The empty-mapping arm must not short-circuit checkArtifact into the
+// wrong message.
+func TestValidate_EmptyArtifactBlockAloneReportsSpecRequired(t *testing.T) {
+	err := validateString(t, "", `name: my-app
+artifact: {}
+`)
+
+	requireFindings(t, err, []FieldError{
+		{Line: 2, Path: "artifact.spec", Msg: "is required for an inline artifact"},
+	})
+}
+
 func TestValidate_RuntimeNamesMustMatchTheArtifact(t *testing.T) {
 	err := validateString(t, "", `name: my-app
 artifact:

--- a/internal/workload/manifest/validate_test.go
+++ b/internal/workload/manifest/validate_test.go
@@ -388,23 +388,30 @@ func TestValidate_AutoscalingAgreesWithLiveReader(t *testing.T) {
 	cases := []struct {
 		name        string
 		autoscaling string
-		active      bool
+		// groupAutoscaling is the map[string]any shape autoscalingActive sees,
+		// parallel to the YAML shape checkScaling sees. Keeping it in the case
+		// struct avoids a switch that would trip the cyclop limit.
+		groupAutoscaling any
+		active           bool
 	}{
 		{
-			name:        "null",
-			autoscaling: `      autoscaling: null`,
-			active:      false,
+			name:             "null",
+			autoscaling:      `      autoscaling: null`,
+			groupAutoscaling: nil,
+			active:           false,
 		},
 		{
-			name:        "empty mapping",
-			autoscaling: `      autoscaling: {}`,
-			active:      false,
+			name:             "empty mapping",
+			autoscaling:      `      autoscaling: {}`,
+			groupAutoscaling: map[string]any{},
+			active:           false,
 		},
 		{
 			name: "enabled false",
 			autoscaling: `      autoscaling:
         enabled: false`,
-			active: false,
+			groupAutoscaling: map[string]any{keyEnabled: false},
+			active:           false,
 		},
 		{
 			name: "enabled true",
@@ -412,6 +419,11 @@ func TestValidate_AutoscalingAgreesWithLiveReader(t *testing.T) {
         enabled: true
         minReplicaCount: 1
         maxReplicaCount: 4`,
+			groupAutoscaling: map[string]any{
+				keyEnabled:        true,
+				"minReplicaCount": 1,
+				"maxReplicaCount": 4,
+			},
 			active: true,
 		},
 		{
@@ -419,6 +431,10 @@ func TestValidate_AutoscalingAgreesWithLiveReader(t *testing.T) {
 			autoscaling: `      autoscaling:
         minReplicaCount: 1
         maxReplicaCount: 4`,
+			groupAutoscaling: map[string]any{
+				"minReplicaCount": 1,
+				"maxReplicaCount": 4,
+			},
 			active: true,
 		},
 		{
@@ -427,11 +443,38 @@ func TestValidate_AutoscalingAgreesWithLiveReader(t *testing.T) {
         enabled: null
         minReplicaCount: 1
         maxReplicaCount: 4`,
+			groupAutoscaling: map[string]any{
+				keyEnabled:        nil,
+				"minReplicaCount": 1,
+				"maxReplicaCount": 4,
+			},
 			active: true,
 		},
+		// enabled: null with no other keys is the shape that inverts after
+		// stripKeys purges the nil — collapsing to {} (OFF). The validator
+		// (checkScaling) and the live reader (autoscalingActive) both read
+		// the pre-strip raw node as ON, and the strip path normalizes it to
+		// enabled: true so the post-strip shape is also ON.
 		{
-			name:   "absent",
-			active: false,
+			name: "enabled null only",
+			autoscaling: `      autoscaling:
+        enabled: null`,
+			groupAutoscaling: map[string]any{keyEnabled: nil},
+			active:           true,
+		},
+		// The post-strip normalized shape: enabled: true with no other keys.
+		// Both readers agree this is ON.
+		{
+			name: "enabled true only",
+			autoscaling: `      autoscaling:
+        enabled: true`,
+			groupAutoscaling: map[string]any{keyEnabled: true},
+			active:           true,
+		},
+		{
+			name:             "absent",
+			groupAutoscaling: nil, // absent: the key is never set on the group
+			active:           false,
 		},
 	}
 
@@ -450,30 +493,10 @@ func TestValidate_AutoscalingAgreesWithLiveReader(t *testing.T) {
 
 			group := map[string]any{}
 
-			switch tc.name {
-			case "null":
-				group[keyAutoscaling] = nil
-			case "empty mapping":
-				group[keyAutoscaling] = map[string]any{}
-			case "enabled false":
-				group[keyAutoscaling] = map[string]any{keyEnabled: false}
-			case "enabled true":
-				group[keyAutoscaling] = map[string]any{
-					keyEnabled:        true,
-					"minReplicaCount": 1,
-					"maxReplicaCount": 4,
-				}
-			case "missing enabled with body":
-				group[keyAutoscaling] = map[string]any{
-					"minReplicaCount": 1,
-					"maxReplicaCount": 4,
-				}
-			case "enabled null with body":
-				group[keyAutoscaling] = map[string]any{
-					keyEnabled:        nil,
-					"minReplicaCount": 1,
-					"maxReplicaCount": 4,
-				}
+			// "absent" leaves the autoscaling key unset; every other case
+			// sets it from the struct field.
+			if tc.name != "absent" {
+				group[keyAutoscaling] = tc.groupAutoscaling
 			}
 
 			assert.Equal(t, tc.active, autoscalingActive(group), "autoscalingActive agrees with expected")

--- a/internal/workload/manifest/validate_test.go
+++ b/internal/workload/manifest/validate_test.go
@@ -351,6 +351,24 @@ func TestValidate_ReplicaCountWithAutoscalingNoEnabled(t *testing.T) {
 	})
 }
 
+// A present autoscaling body with an explicit enabled: null is not the same as
+// a null or empty block: the platform treats a null enabled as its own
+// default, which is on. The ledger has to agree, or it would accept a file
+// that autoscalingActive then says is autoscaling — and Apply silently drops
+// the replica answer. This is the same silent-drop the PR exists to prevent.
+func TestValidate_ReplicaCountWithAutoscalingEnabledNull(t *testing.T) {
+	err := validateString(t, "", runtimeWithGroupBody(`      replicaCount: 3
+      autoscaling:
+        enabled: null
+        minReplicaCount: 1
+        maxReplicaCount: 4
+`))
+
+	requireFindings(t, err, []FieldError{
+		{Line: 16, Path: "runtime.containerGroups[0].replicaCount", Msg: "cannot be set alongside autoscaling"},
+	})
+}
+
 // The node-based checkScaling and the map-based autoscalingActive must agree on
 // every autoscaling shape, or a live workload will render a file the ledger
 // rejects (or drop a replica answer that should be kept).
@@ -392,6 +410,14 @@ func TestValidate_AutoscalingAgreesWithLiveReader(t *testing.T) {
 			active: true,
 		},
 		{
+			name: "enabled null with body",
+			autoscaling: `      autoscaling:
+        enabled: null
+        minReplicaCount: 1
+        maxReplicaCount: 4`,
+			active: true,
+		},
+		{
 			name:   "absent",
 			active: false,
 		},
@@ -427,6 +453,12 @@ func TestValidate_AutoscalingAgreesWithLiveReader(t *testing.T) {
 				}
 			case "missing enabled with body":
 				group[keyAutoscaling] = map[string]any{
+					"minReplicaCount": 1,
+					"maxReplicaCount": 4,
+				}
+			case "enabled null with body":
+				group[keyAutoscaling] = map[string]any{
+					keyEnabled:        nil,
 					"minReplicaCount": 1,
 					"maxReplicaCount": 4,
 				}

--- a/internal/workload/manifest/validate_test.go
+++ b/internal/workload/manifest/validate_test.go
@@ -322,6 +322,219 @@ func TestValidate_DisabledAutoscalingAllowsReplicaCount(t *testing.T) {
 `)))
 }
 
+// The server echoes autoscaling: null when no policy is configured, so the
+// ledger must treat it as absent rather than as an active scaling policy.
+func TestValidate_ReplicaCountWithNullAutoscaling(t *testing.T) {
+	require.NoError(t, validateString(t, "", runtimeWithGroupBody(`      replicaCount: 3
+      autoscaling: null
+`)))
+}
+
+// An empty autoscaling mapping is the same as a null one: there is no policy.
+func TestValidate_ReplicaCountWithEmptyAutoscaling(t *testing.T) {
+	require.NoError(t, validateString(t, "", runtimeWithGroupBody(`      replicaCount: 3
+      autoscaling: {}
+`)))
+}
+
+// A non-empty autoscaling body without an enabled key is treated as enabled by
+// the server, so replicaCount still conflicts.
+func TestValidate_ReplicaCountWithAutoscalingNoEnabled(t *testing.T) {
+	err := validateString(t, "", runtimeWithGroupBody(`      replicaCount: 3
+      autoscaling:
+        minReplicaCount: 1
+        maxReplicaCount: 4
+`))
+
+	requireFindings(t, err, []FieldError{
+		{Line: 16, Path: "runtime.containerGroups[0].replicaCount", Msg: "cannot be set alongside autoscaling"},
+	})
+}
+
+// The node-based checkScaling and the map-based autoscalingActive must agree on
+// every autoscaling shape, or a live workload will render a file the ledger
+// rejects (or drop a replica answer that should be kept).
+func TestValidate_AutoscalingAgreesWithLiveReader(t *testing.T) {
+	cases := []struct {
+		name        string
+		autoscaling string
+		active      bool
+	}{
+		{
+			name:        "null",
+			autoscaling: `      autoscaling: null`,
+			active:      false,
+		},
+		{
+			name:        "empty mapping",
+			autoscaling: `      autoscaling: {}`,
+			active:      false,
+		},
+		{
+			name: "enabled false",
+			autoscaling: `      autoscaling:
+        enabled: false`,
+			active: false,
+		},
+		{
+			name: "enabled true",
+			autoscaling: `      autoscaling:
+        enabled: true
+        minReplicaCount: 1
+        maxReplicaCount: 4`,
+			active: true,
+		},
+		{
+			name: "missing enabled with body",
+			autoscaling: `      autoscaling:
+        minReplicaCount: 1
+        maxReplicaCount: 4`,
+			active: true,
+		},
+		{
+			name:   "absent",
+			active: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := "      replicaCount: 3"
+			if tc.autoscaling != "" {
+				body += "\n" + tc.autoscaling
+			}
+
+			var validateErr error
+
+			if err := validateString(t, "", runtimeWithGroupBody(body+"\n")); err != nil {
+				validateErr = err
+			}
+
+			group := map[string]any{}
+
+			switch tc.name {
+			case "null":
+				group[keyAutoscaling] = nil
+			case "empty mapping":
+				group[keyAutoscaling] = map[string]any{}
+			case "enabled false":
+				group[keyAutoscaling] = map[string]any{keyEnabled: false}
+			case "enabled true":
+				group[keyAutoscaling] = map[string]any{
+					keyEnabled:        true,
+					"minReplicaCount": 1,
+					"maxReplicaCount": 4,
+				}
+			case "missing enabled with body":
+				group[keyAutoscaling] = map[string]any{
+					"minReplicaCount": 1,
+					"maxReplicaCount": 4,
+				}
+			}
+
+			assert.Equal(t, tc.active, autoscalingActive(group), "autoscalingActive agrees with expected")
+			assert.Equal(t, tc.active, validateErr != nil, "checkScaling agrees with expected; err=%v", validateErr)
+		})
+	}
+}
+
+// A null imageBuildConfig is the same as a missing one: the container names an
+// image and does not also say how to build one.
+func TestValidate_ImageBuildConfigNullWithImageUri(t *testing.T) {
+	require.NoError(t, validateString(t, "", serviceWithContainerBody(`            imageUri: nginx:latest
+            imageBuildConfig: null
+`)))
+}
+
+// A null imageBuildConfig with no imageUri is "neither set", not "dockerfile
+// required".
+func TestValidate_ImageBuildConfigNullWithoutImageUri(t *testing.T) {
+	err := validateString(t, "", serviceWithContainerBody(`            imageBuildConfig: null
+`))
+
+	requireFindings(t, err, []FieldError{
+		{Line: 9, Path: "artifact.spec.containerGroups[0].containers[0]", Msg: "must set either imageUri or imageBuildConfig"},
+	})
+}
+
+// A null artifact block is treated as absent, so binding to an existing
+// artifact by id is allowed.
+func TestValidate_ArtifactNullWithArtifactId(t *testing.T) {
+	require.NoError(t, validateString(t, "", `name: my-app
+artifact: null
+artifactId: 68b0bbbb0000000000000002
+`))
+}
+
+// A null artifact and no artifactId is the same as neither set.
+func TestValidate_ArtifactNullAndNoArtifactId(t *testing.T) {
+	err := validateString(t, "", `name: my-app
+artifact: null
+`)
+
+	requireFindings(t, err, []FieldError{
+		{Line: 1, Path: "", Msg: "exactly one of artifact"},
+	})
+}
+
+// Two null values are still "neither set".
+func TestValidate_ArtifactNullAndArtifactIdNull(t *testing.T) {
+	err := validateString(t, "", `name: my-app
+artifact: null
+artifactId: null
+`)
+
+	requireFindings(t, err, []FieldError{
+		{Line: 1, Path: "", Msg: "exactly one of artifact"},
+	})
+}
+
+// An inline artifact with a null spec reports the same error as a missing spec.
+func TestValidate_ArtifactWithNullSpec(t *testing.T) {
+	err := validateString(t, "", `name: my-app
+artifact:
+  name: my-app-artifact
+  spec: null
+`)
+
+	requireFindings(t, err, []FieldError{
+		{Line: 4, Path: "artifact.spec", Msg: "is required for an inline artifact"},
+	})
+}
+
+// A build config with a null dockerfile reports the same error as a missing
+// dockerfile.
+func TestValidate_BuildConfigWithNullDockerfile(t *testing.T) {
+	err := validateString(t, "", serviceWithContainerBody(`            imageBuildConfig:
+              dockerfile: null
+`))
+
+	requireFindings(t, err, []FieldError{
+		{
+			Line: 13, Path: "artifact.spec.containerGroups[0].containers[0].imageBuildConfig.dockerfile",
+			Msg: "is required: imageBuildConfig must say how the image is built",
+		},
+	})
+}
+
+// A null artifactId is treated as absent, so an inline artifact is allowed.
+func TestValidate_InlineArtifactWithNullArtifactId(t *testing.T) {
+	require.NoError(t, validateString(t, "", `name: my-app
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageUri: nginx:latest
+artifactId: null
+`))
+}
+
 func TestValidate_RuntimeNamesMustMatchTheArtifact(t *testing.T) {
 	err := validateString(t, "", `name: my-app
 artifact:

--- a/internal/workload/manifest/validate_test.go
+++ b/internal/workload/manifest/validate_test.go
@@ -584,6 +584,88 @@ func TestValidate_BuildConfigWithNullDockerfile(t *testing.T) {
 	})
 }
 
+// When dockerfile is present but null and is not the first key in the
+// imageBuildConfig mapping, the "is required" error must anchor to the
+// dockerfile key's own line, not the mapping's first-key line. The companion
+// test above (where dockerfile is the only key) cannot tell the two apart;
+// this one separates them by inserting a context key first.
+func TestValidate_BuildConfigDockerfileAnchorsAtDockerfileLine(t *testing.T) {
+	err := validateString(t, "", serviceWithContainerBody(`            imageBuildConfig:
+              context: ./build
+              dockerfile: null
+`))
+
+	requireFindings(t, err, []FieldError{
+		{
+			Line: 14, Path: "artifact.spec.containerGroups[0].containers[0].imageBuildConfig.dockerfile",
+			Msg: "is required: imageBuildConfig must say how the image is built",
+		},
+	})
+}
+
+// An environmentVars entry with a null value is rejected at validate time
+// rather than surfacing as a 422 at deploy time. The error anchors to the
+// value key's own line.
+func TestValidate_EnvironmentVarsNullValueRejected(t *testing.T) {
+	err := validateString(t, "", serviceWithContainerBody(`            imageUri: nginx:latest
+            environmentVars:
+              - name: EMPTY
+                value: null
+`))
+
+	requireFindings(t, err, []FieldError{
+		{
+			Line: 15, Path: "artifact.spec.containerGroups[0].containers[0].environmentVars[0].value",
+			Msg: "is required",
+		},
+	})
+}
+
+// An environmentVars entry with neither a value nor a credential/api-key
+// source is rejected. The error anchors to the entry (the nearest node).
+func TestValidate_EnvironmentVarsNoValueNoSourceRejected(t *testing.T) {
+	err := validateString(t, "", serviceWithContainerBody(`            imageUri: nginx:latest
+            environmentVars:
+              - name: EMPTY
+`))
+
+	requireFindings(t, err, []FieldError{
+		{
+			Line: 14, Path: "artifact.spec.containerGroups[0].containers[0].environmentVars[0].value",
+			Msg: "is required",
+		},
+	})
+}
+
+// An environmentVars entry with an explicitly empty value passes: the server
+// treats value: "" as an intentionally-empty string variable.
+func TestValidate_EnvironmentVarsEmptyValuePasses(t *testing.T) {
+	require.NoError(t, validateString(t, "", serviceWithContainerBody(`            imageUri: nginx:latest
+            environmentVars:
+              - name: EMPTY
+                value: ""
+`)))
+}
+
+// A credential-source entry carries no value; it passes the value check.
+func TestValidate_EnvironmentVarsCredentialSourcePasses(t *testing.T) {
+	require.NoError(t, validateString(t, "", serviceWithContainerBody(`            imageUri: nginx:latest
+            environmentVars:
+              - name: TOKEN
+                source: dr-credential
+                drCredentialId: 68f0cccc0000000000000003
+                key: apiToken
+`)))
+}
+
+// An api-key source entry carries no value; it passes the value check.
+func TestValidate_EnvironmentVarsApiKeySourcePasses(t *testing.T) {
+	require.NoError(t, validateString(t, "", serviceWithContainerBody(`            imageUri: nginx:latest
+            environmentVars:
+              - source: api-key
+`)))
+}
+
 // A null artifactId is treated as absent, so an inline artifact is allowed.
 func TestValidate_InlineArtifactWithNullArtifactId(t *testing.T) {
 	require.NoError(t, validateString(t, "", `name: my-app

--- a/internal/workload/manifest/validate_test.go
+++ b/internal/workload/manifest/validate_test.go
@@ -437,33 +437,7 @@ func TestValidate_AutoscalingAgreesWithLiveReader(t *testing.T) {
 			},
 			active: true,
 		},
-		{
-			name: "enabled null with body",
-			autoscaling: `      autoscaling:
-        enabled: null
-        minReplicaCount: 1
-        maxReplicaCount: 4`,
-			groupAutoscaling: map[string]any{
-				keyEnabled:        nil,
-				"minReplicaCount": 1,
-				"maxReplicaCount": 4,
-			},
-			active: true,
-		},
-		// enabled: null with no other keys is the shape that inverts after
-		// stripKeys purges the nil — collapsing to {} (OFF). The validator
-		// (checkScaling) and the live reader (autoscalingActive) both read
-		// the pre-strip raw node as ON, and the strip path normalizes it to
-		// enabled: true so the post-strip shape is also ON.
-		{
-			name: "enabled null only",
-			autoscaling: `      autoscaling:
-        enabled: null`,
-			groupAutoscaling: map[string]any{keyEnabled: nil},
-			active:           true,
-		},
-		// The post-strip normalized shape: enabled: true with no other keys.
-		// Both readers agree this is ON.
+		// enabled: true with no other keys. Both readers agree this is ON.
 		{
 			name: "enabled true only",
 			autoscaling: `      autoscaling:

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -380,25 +380,30 @@ func setWorkloadID(root *yaml.Node, workloadID string) {
 const workloadIDComment = "managed by the CLI"
 
 func (d Draft) topLevelFields(build field) []field {
-	fields := make([]field, 0, 5)
-
-	if d.WorkloadID != "" {
-		fields = append(fields, field{key: keyWorkloadID, value: scalar(d.WorkloadID), comment: workloadIDComment})
-	}
-
 	importance := d.Importance
 	if importance == "" {
 		importance = DefaultImportance
 	}
 
-	fields = append(fields,
-		field{key: keyName, value: scalar(d.Name)},
-		field{key: keyImportance, value: scalar(importance), comment: strings.Join(ImportanceLevels, " | ")},
-		field{key: keyArtifact, value: d.artifact(build)},
-		field{key: keyRuntime, value: d.runtime()},
-	)
+	// The top-level field order is defined by the field rule table
+	// (schema.go) and shared with Live.Render so both renderers emit the
+	// same key sequence. workloadId is omitted when empty by leaving it
+	// absent from the values map; orderedFields skips keys that are missing.
+	values := map[string]*yaml.Node{
+		keyName:       scalar(d.Name),
+		keyImportance: scalar(importance),
+		keyArtifact:   d.artifact(build),
+		keyRuntime:    d.runtime(),
+	}
 
-	return fields
+	if d.WorkloadID != "" {
+		values[keyWorkloadID] = scalar(d.WorkloadID)
+	}
+
+	return orderedFields(values, map[string]string{
+		keyWorkloadID: workloadIDComment,
+		keyImportance: strings.Join(ImportanceLevels, " | "),
+	})
 }
 
 // artifact renders the half that says what runs: the versioned, lockable

--- a/internal/workload/up/look.go
+++ b/internal/workload/up/look.go
@@ -135,9 +135,14 @@ func Look(workloadID string) (Live, error) {
 	// A missing artifact (nil doc) is a valid state for the up path: a
 	// workload in the moments around creation has no artifact to read, and
 	// the spec comparing as absent is the right answer for something not
-	// yet built. Only propagate the error when the artifact doc was
-	// actually present but carried no usable spec — that is the
-	// permission-filtered partial GET the bind-time guard exists for.
+	// yet built.
+	//
+	// Propagating the error when the artifact doc IS present but carries no
+	// usable spec is a DELIBERATE hard failure: a spec-less artifact means
+	// the manifest cannot be reconstructed, and failing loudly mirrors
+	// Apply's own "edit by hand" contract — the right answer is to stop and
+	// let the user edit the file, not to write something Validate would
+	// then refuse to read.
 	if err != nil && artifactDoc != nil {
 		return Live{}, err
 	}

--- a/internal/workload/up/look.go
+++ b/internal/workload/up/look.go
@@ -131,8 +131,19 @@ func Look(workloadID string) (Live, error) {
 
 	status := workloadDoc.String(keyStatus)
 
+	live, err := manifest.NewLive(workloadID, workloadDoc, artifactDoc)
+	// A missing artifact (nil doc) is a valid state for the up path: a
+	// workload in the moments around creation has no artifact to read, and
+	// the spec comparing as absent is the right answer for something not
+	// yet built. Only propagate the error when the artifact doc was
+	// actually present but carried no usable spec — that is the
+	// permission-filtered partial GET the bind-time guard exists for.
+	if err != nil && artifactDoc != nil {
+		return Live{}, err
+	}
+
 	return Live{
-		Live:                 manifest.NewLive(workloadID, workloadDoc, artifactDoc),
+		Live:                 live,
 		State:                stateFor(status),
 		Status:               status,
 		ArtifactID:           artifactID,

--- a/internal/workload/up/look_test.go
+++ b/internal/workload/up/look_test.go
@@ -294,6 +294,75 @@ func TestLook_LockedIsCaseInsensitive(t *testing.T) {
 	assert.False(t, live.Locked)
 }
 
+// TestLook_SpeclessArtifactFailsLoudly pins the deliberate behavior that a
+// present-but-spec-less artifact document fails the up path rather than
+// rendering a manifest Validate would reject. The error from NewLive names the
+// workload id. Empty artifactID and 404 from artifactFor remain exempt:
+// artifactDoc is nil, so the error is swallowed and Look returns a Live with
+// an empty spec and no error.
+func TestLook_SpeclessArtifactFailsLoudly(t *testing.T) {
+	t.Run("spec absent", func(t *testing.T) {
+		stubLive(t, liveWorkloadJSON, `{"id":"art-1","status":"locked"}`)
+
+		_, err := Look("wl-specless")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "wl-specless", "error must name the workload id")
+		assert.Contains(t, err.Error(), "no artifact spec to bind")
+	})
+
+	t.Run("spec null", func(t *testing.T) {
+		stubLive(t, liveWorkloadJSON, `{"id":"art-1","status":"locked","spec":null}`)
+
+		_, err := Look("wl-specless")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "wl-specless")
+	})
+
+	t.Run("spec empty mapping", func(t *testing.T) {
+		stubLive(t, liveWorkloadJSON, `{"id":"art-1","status":"locked","spec":{}}`)
+
+		_, err := Look("wl-specless")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "wl-specless")
+	})
+
+	t.Run("spec strips to nothing", func(t *testing.T) {
+		// spec carries only server-managed keys that stripServerManaged removes
+		stubLive(t, liveWorkloadJSON, `{"id":"art-1","status":"locked","spec":{"id":"x","createdAt":"now","status":"ok"}}`)
+
+		_, err := Look("wl-specless")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "wl-specless")
+	})
+
+	t.Run("empty artifactId exempt", func(t *testing.T) {
+		prev := getWorkloadDocFn
+
+		getWorkloadDocFn = func(string) (workload.Document, error) {
+			return doc(t, `{"id":"wl-1","name":"fresh","status":"submitted"}`), nil
+		}
+
+		t.Cleanup(func() { getWorkloadDocFn = prev })
+
+		live, err := Look("wl-1")
+		require.NoError(t, err)
+		assert.Empty(t, live.Spec, "no artifact to read means no spec, not an error")
+	})
+
+	t.Run("artifact 404 exempt", func(t *testing.T) {
+		prevWorkload, prevArtifact := getWorkloadDocFn, getArtifactDocFn
+
+		getWorkloadDocFn = func(string) (workload.Document, error) { return doc(t, liveWorkloadJSON), nil }
+		getArtifactDocFn = func(string) (workload.Document, error) { return nil, notFoundErr() }
+
+		t.Cleanup(func() { getWorkloadDocFn, getArtifactDocFn = prevWorkload, prevArtifact })
+
+		live, err := Look("wl-1")
+		require.NoError(t, err)
+		assert.Empty(t, live.Spec, "a vanished artifact is not a failure")
+	})
+}
+
 // primaryContainer digs the flagged container out of a live spec.
 func primaryContainer(t *testing.T, spec map[string]any) map[string]any {
 	t.Helper()

--- a/internal/workload/up/look_test.go
+++ b/internal/workload/up/look_test.go
@@ -307,7 +307,7 @@ func TestLook_SpeclessArtifactFailsLoudly(t *testing.T) {
 		_, err := Look("wl-specless")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "wl-specless", "error must name the workload id")
-		assert.Contains(t, err.Error(), "no artifact spec to bind")
+		assert.Contains(t, err.Error(), "no artifact spec")
 	})
 
 	t.Run("spec null", func(t *testing.T) {

--- a/internal/workload/wizard/run.go
+++ b/internal/workload/wizard/run.go
@@ -472,7 +472,7 @@ func fetchLive(workloadID string) (manifest.Live, error) {
 		return manifest.Live{}, fmt.Errorf("cannot read the artifact of workload %s: %w", workloadID, err)
 	}
 
-	return manifest.NewLive(workloadID, workloadDoc, artifactDoc), nil
+	return manifest.NewLive(workloadID, workloadDoc, artifactDoc)
 }
 
 // checkRendered parses and validates what is about to be written, so a file

--- a/internal/workload/wizard/run_test.go
+++ b/internal/workload/wizard/run_test.go
@@ -372,7 +372,7 @@ func TestRun_BoundWorkloadDoesNotGuessAtLiveValues(t *testing.T) {
 // clear, in either spelling, so neither is a finding.
 func TestRun_BoundWorkloadIgnoresCredentialReferences(t *testing.T) {
 	boundWithLiveEnv(t, `[{"name": "SHORTHAND_KEY", "value": "dr-credential:68f0cccc0000000000000003/apiToken"},
-		{"name": "OBJECT_KEY", "source": "credential",
+		{"name": "OBJECT_KEY", "source": "dr-credential",
 		 "drCredentialId": "68f0cccc0000000000000003", "key": "apiToken"}]`)
 
 	assert.NotContains(t, boundRun(t), "looks like a secret")


### PR DESCRIPTION
# RATIONALE

**20260826 update:** branch merged with latest main; the RAPTOR-19716 field-metadata schema table (originally a stacked follow-up) is now included as Part 6, and round-4 review nits are addressed (stable sort for key ordering, falsifiable strip-pin tests, stale comment cleanup).

---

Let's make the CLI a manifest it can't refuse. 😎 

`dr workload config` (binding) was completely broken against real C2W accounts.

1. The platform routinely echoes `replicaCount` and `autoscaling: null` together in workload GET responses, and the CLI's manifest validator treated the present-but-null `autoscaling` key as an active autoscaling policy, rejecting the file it just rendered. Binding aborted with nothing written, leaving hand-editing as the only path forward.
2. A second defect wrote `build.artifactImageBuildId` (a server-assigned build output) into the committed manifest, pinning the next deploy to a stale image.
3. A third issue sorted keys alphabetically in the rendered file instead of leading with `name`.

User report from Benjamin Kostiuk (Slack, 2026-08-18), reproduced on staging by Wojciech Wierzchowski (4/4 workloads failed).

## CHANGES

### Part 1: Validator null handling (`validate.go`, `node.go`)

- Added two presence predicates to `node.go`, chosen per field according to the server's own semantics:
  - `isNullish(*yaml.Node) bool` — true for nil nodes, `!!null` scalars, AND zero-content mappings. Used only where the server itself reads an empty block as absent: `checkScaling` / autoscaling.
  - `isNull(*yaml.Node) bool` — true only for nil nodes and `!!null` scalars. Guards the exactly-one-of checks (`checkArtifactBinding`, `checkImageSource`, `checkArtifact`), so empty blocks (`artifact: {}`, `imageBuildConfig: {}`) count as PRESENT. The server never echoes `{}` for these fields (it echoes `null`); it 422s on `artifact: {}` with a confusing missing-fields error, and on create it silently discards a declared `imageUri` when `imageBuildConfig: {}` is sent (Pydantic default-constructs the empty block into a real `ImageBuildConfig`, and `_strip_client_image_uris_on_build_containers` then nulls the image).
- Fixed `checkScaling` to treat null/empty `autoscaling` as absent (no false conflict with `replicaCount`), matching `autoscalingActive` in `live.go`.
- Fixed the same null blind spot in other node-based checks: `checkArtifactBinding` (`artifact: null`), `checkArtifact` (`spec: null`), `checkImageSource` (`imageBuildConfig: null`), `checkBuildConfig` (`dockerfile: null`).
- Fixed `checkRuntime` to use `isNullish` for consistency.
- Fixed the `enabled: null` shape in `checkScaling` — changed `enabled != nil` to `!isNullish(enabled)` so a null `enabled` inside a non-empty autoscaling block is treated as active (server default), agreeing with `autoscalingActive`. (The validator gates hand-edited files, where `enabled: null` is reachable; the server's non-nullable `enabled` means the live reader needs no such defense.)
- Added `checkEnvironmentVars`: string-variant `environmentVars` entries must carry a non-null `value` (`value: ""` allowed); `dr-credential` and `api-key` sources are exempt. This mirrors the server schema (`StringEnvironmentVariable.value: str = Field(...)` — required, no default; the credential/api-key variants have no `value` field at all). Previously a value-less string entry validated cleanly and only failed as a 422 at deploy time.
- `checkBuildConfig`'s dockerfile-required error now anchors to the `dockerfile` node's line (matching `checkArtifact`'s pattern) instead of the parent block.
- Added `TestValidate_AutoscalingAgreesWithLiveReader` — a parametrized test that runs both readers across all seven autoscaling shapes and asserts they agree. This is the regression guard for the bug class this PR fixes.
- Regression tests for every null/empty shape above, including empty-block exclusivity (`artifact: {}` + `artifactId`, `imageUri` + `imageBuildConfig: {}` are both rejected) and message quality for standalone empty blocks.

### Part 2: Render stripping (`live.go`)

- Folded null-key stripping into `stripKeys`'s existing recursive walk (same pass that strips server-managed keys like `id`, `createdAt`, etc.), eliminating a redundant second deep-copy. Nil-valued keys are dropped; empty maps, `false`, `0`, `""`, and empty slices are preserved.
- Added `"resolvedBundle"` to `serverManagedKeys` — it's a server-assigned, read-only scheduling field.
- Extended `stripBuildOutputs` to also delete the `build` block (`artifactImageBuildId`, `status`, `createdAt`) and `imageOutdated` from containers — both are server-assigned outputs that don't belong in a human-editable file.
- Reworked `stripBuildOutputs` ordering: `codeRef` is deleted first; `imageUri` is deleted only when the build config retains content (a real build container); if deleting `codeRef` empties the block, the `imageBuildConfig` key itself is dropped and the user-declared `imageUri` is kept. `liveBuild` treats an empty build block as image mode, not "unchanged".
- Added `TestLive_RenderRoundTripReporterShaped` — a round-trip regression test using a server document shaped like the reporter's (with `autoscaling: null` + `replicaCount` + `build.artifactImageBuildId` + `imageOutdated` + `resolvedBundle`), asserting the rendered file passes `Parse` + `Validate` + `Compile` and contains none of those server-assigned fields.
- Added standalone tests: `TestLive_RenderStripsNullAutoscaling`, `TestLive_RenderStripsBuildBlock`, `TestLive_RenderStripsImageOutdated`, `TestLive_RenderStripsResolvedBundle`.

### Part 3: Key ordering (`live.go`)

- Added `hoistNameKeys(*yaml.Node)` post-processor that moves `name` to the front of sequence-item mappings under `containerGroups` and `containers` — the identifier mappings a human scans for — preserving all other keys in their existing order. Opaque mappings (e.g. a `labels:` block that happens to contain a `name` key) keep their original key order. Applied to the encoded spec and runtime nodes in `Render()` before the final YAML encode. The top-level mapping (already manually ordered) is not touched.

### Part 4: Spec-less artifact fails loudly (`live.go`, `up/look.go`, `wizard/run.go`)

- **Signature change:** `NewLive` now returns `(Live, error)`. Binding to a workload whose artifact doc has no usable `spec` fails with an error naming the workload ID instead of rendering a manifest the validator would reject. Callers updated: the wizard bind flow propagates the error; `up`'s drift-comparison `Look` propagates it when an artifact doc was present (empty artifactID / 404 remain exempt, since no artifact is a valid state for drift comparison).
- The error wording is path-neutral (`workload %s has no artifact spec; edit %s by hand instead`) because it surfaces on both the bind path and `dr workload up`, where the user isn't binding anything.
- Pinned by `TestLook_SpeclessArtifactFailsLoudly` and `TestNewLive_*FailsWithWorkloadID` tests.

### Part 5: Staging investigation

- Bound to a live C2W workload on staging, verified `dr workload config --dry-run` no longer aborts, verified the rendered manifest is clean (no `autoscaling: null`, no `build.artifactImageBuildId`, no `imageOutdated`, no `resolvedBundle`).
- Ran `dr workload up` after binding: the platform POSTs a new artifact with `imageBuildConfig` but no `imageUri`, builds a fresh image, and the workload resolves to the newly built image. **ErrImagePull is resolved** — stripping the `build` block and `imageUri` correctly signals to the platform that a rebuild is needed.

### Part 6: Field-metadata schema table (`schema.go`, `keys.go`, `write.go`)

- Added `schema.go`: a single declarative `fieldRule` table holding per-field metadata (`nullable`, `serverManaged`, `buildOutput`, `buildConfigScoped`, `hoistName`, `topLevelOrder`) for every manifest field this package has an opinion about. Four previously scattered knowledge sites now derive from it:
  - `serverManagedKeys` — the render-time strip set (`id`, `createdAt`, `status`, `endpoint`, `resolvedBundle`, …)
  - `stripBuildOutputs` — build outputs and their build-config scoping (the conditional `imageUri`/`imageBuildConfig` deletion stays as code: it depends on whether the build config is empty after stripping, which a static table cannot express)
  - `hoistNameKeys` — the `name`-first ordering targets
  - top-level field ordering, now shared between `Live.Render` and `Draft`'s top-level fields (`write.go`) via one table-derived ordering — the two renderers can no longer drift apart in key sequence
- Added the 9 missing field-name constants to `keys.go` (`keyID`, `keyCreatedAt`, `keyUpdatedAt`, `keyStatus`, `keyEndpoint`, `keyResolvedBundle`, `keyImageOutdated`, `keyBuild`, `keyCodeRef`) so the table and its consumers reference constants instead of string literals.
- Behavior-preserving: the any-depth strip scope of `stripKeys`/`stripBuildOutputs` is unchanged and is now documented on the table itself (the create spec has no legitimate key by those names anywhere, so recursive deletion is safe; scoping to known paths would be a deliberate behavior change).
- Pinned by `schema_test.go`: `TestSchema_TopLevelKeyOrderMatches` (draft and render agree on top-level key order) and `TestSchema_ConsolidationPinStripAndHoist` (table-derived strip/hoist sets match the previous hard-coded behavior).
- Tracked as [RAPTOR-19716](https://datarobot.atlassian.net/browse/RAPTOR-19716); originally planned as a stacked follow-up PR, merged into this branch instead.

## What we're building towards in the API

The workload API (Python/FastAPI/Pydantic v2) sends `autoscaling: null` explicitly — not omitted — because the response routes (`GET /workloads/{id}`, `GET /artifacts/{id}`) do not set `response_model_exclude_none=True`, and the field is typed as `AutoscalingProperties | None` with default `None`. The OpenAPI schema declares it as nullable (`anyOf: [AutoscalingProperties, null]`).

The API also populates `build` (`ContainerBuildInfo` with `artifactImageBuildId`, `status`, `createdAt`) on containers after a build trigger, and strips it on create/update via `_strip_client_container_build_metadata` — but it is present in GET responses. Similarly, `imageOutdated` (computed, read-only) and `resolvedBundle` (scheduling-time, read-only) appear in GET responses but are not user inputs.

The CLI's manifest ledger was written in RAPTOR-18973 from the API's documented shapes rather than from observed responses. The documented shapes say `replicaCount` and `autoscaling` are mutually exclusive, but in practice the server echoes both (with `autoscaling: null`). This is the second time the ledger has diverged from reality for this reason. The fix aligns the CLI with the actual server behavior: null means absent, and server-assigned outputs are stripped from the human-editable file.

One nuance this PR encodes explicitly: "empty block" is NOT the same as "null block" for most fields. Only `autoscaling` reads `{}` as absent server-side. `artifact: {}` is a 422, and `imageBuildConfig: {}` is worse — Pydantic default-constructs it and the create path silently drops your `imageUri`. The validator's two presence predicates (`isNull` vs `isNullish`) encode exactly that distinction.

## TESTING

- `task test` — full suite with `-race`, all packages pass (manifest package at ~90% coverage)
- `task lint` — golangci-lint clean on linux/darwin/windows, gofumpt, go vet, goreleaser check
- `task build` — CLI binary compiles
- Staging: end-to-end bind + deploy against a live C2W workload confirmed the fix

## RELATED

- [RAPTOR-19533](https://datarobot.atlassian.net/browse/RAPTOR-19533)
- Parent epic: [RAPTOR-18002](https://datarobot.atlassian.net/browse/RAPTOR-18002) ([WAPI GA] DR CLI extended support)
- Related: [RAPTOR-19406](https://datarobot.atlassian.net/browse/RAPTOR-19406) (artifact repository reuse — likely related to the ErrImagePull case, now resolved by this fix)
- [RAPTOR-19716](https://datarobot.atlassian.net/browse/RAPTOR-19716) — consolidates this package's scattered field metadata (server-managed keys, strip/hoist targets, top-level ordering) into one declarative rule table. Included in this PR as Part 6.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workload manifest validation and live-binding render paths that gate deploy; behavior is broader but aligned with server GET shapes and heavily regression-tested.
> 
> **Overview**
> Fixes **`dr workload config`** binding against real C2W workloads where the CLI rendered a manifest and then **`Validate`** rejected it (notably **`replicaCount`** with server-echoed **`autoscaling: null`**).
> 
> **Validator:** Adds **`isNullish`** for YAML null/empty mappings and uses it in scaling, artifact binding, image/build checks, and runtime handling so present-but-null keys count as absent. **`checkScaling`** and map-based **`autoscalingActive`** now agree on when autoscaling is “on,” including **`enabled: null`** inside a non-empty block.
> 
> **Live → manifest render:** Strips **`resolvedBundle`**, nil-valued keys, server **`build`** metadata, and **`imageOutdated`**; extends **`stripBuildOutputs`** accordingly. **`reorderKeys`** puts **`name`** first in nested spec/runtime YAML. Input API docs are deep-copied and not mutated.
> 
> Regression tests cover reporter-shaped round-trips, null autoscaling, key order, and validator/live autoscaling parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0277f6c83b6ea69822923036dee04a17eb82f82. Configure [here](https://cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
