### PR TITLE
[RAPTOR-18979] fix(workload): guard every rollout starter, and stop the artifact type drifting for ever

### DIFF
--- a/internal/workload/build.go
+++ b/internal/workload/build.go
@@ -148,7 +148,19 @@ type BuildSummary struct {
 // read exactly, a build answering "completed" would be polled until the
 // timeout and then fail a deploy whose image was already built.
 func IsTerminalBuildStatus(s string) bool {
-	return IsBuildErrorStatus(s) || strings.EqualFold(s, BuildStatusCompleted)
+	return IsBuildErrorStatus(s) || IsBuildCompleted(s)
+}
+
+// IsBuildCompleted reports whether s is the one terminal status that produced
+// an image.
+//
+// It exists so the question is asked the same way everywhere. Folding the
+// terminal check while a consumer went on comparing exactly was worse than not
+// folding at all: the wait would accept a lowercase "completed" and the code
+// reading the result would call the same build unfinished, so a deploy would
+// succeed its wait and then have no image to ship.
+func IsBuildCompleted(s string) bool {
+	return strings.EqualFold(s, BuildStatusCompleted)
 }
 
 // IsBuildErrorStatus reports whether s is a terminal failure.
@@ -346,7 +358,7 @@ func BuildSummaryFor(build *Build, tailLen int) (BuildSummary, error) {
 		DurationSeconds: buildDurationSeconds(*build),
 	}
 
-	if build.Status != BuildStatusCompleted {
+	if !IsBuildCompleted(build.Status) {
 		if IsBuildErrorStatus(build.Status) {
 			logs, lerr := GetArtifactBuildLogs(build.ArtifactID, build.ID)
 			if lerr != nil {

--- a/internal/workload/build.go
+++ b/internal/workload/build.go
@@ -141,23 +141,19 @@ type BuildSummary struct {
 // will not progress further (COMPLETED, FAILED, CANCELLED). Unknown statuses
 // are treated as non-terminal so polling keeps going rather than declaring
 // success on a status the server added without telling us.
+//
+// The comparison folds case, as the replacement and artifact classifiers do.
+// These constants are upper case where the workload's are lower, which is the
+// platform disagreeing with itself about the casing of its own status enums;
+// read exactly, a build answering "completed" would be polled until the
+// timeout and then fail a deploy whose image was already built.
 func IsTerminalBuildStatus(s string) bool {
-	switch s {
-	case BuildStatusCompleted, BuildStatusFailed, BuildStatusCancelled:
-		return true
-	}
-
-	return false
+	return IsBuildErrorStatus(s) || strings.EqualFold(s, BuildStatusCompleted)
 }
 
 // IsBuildErrorStatus reports whether s is a terminal failure.
 func IsBuildErrorStatus(s string) bool {
-	switch s {
-	case BuildStatusFailed, BuildStatusCancelled:
-		return true
-	}
-
-	return false
+	return strings.EqualFold(s, BuildStatusFailed) || strings.EqualFold(s, BuildStatusCancelled)
 }
 
 // TriggerArtifactBuild POSTs an empty body to /artifacts/{id}/builds/ and

--- a/internal/workload/build_test.go
+++ b/internal/workload/build_test.go
@@ -52,6 +52,7 @@ func TestBuildStatusClassifiersFoldCase(t *testing.T) {
 	} {
 		assert.Equal(t, c.terminal, IsTerminalBuildStatus(c.status), "terminal %q", c.status)
 		assert.Equal(t, c.failed, IsBuildErrorStatus(c.status), "failed %q", c.status)
+		assert.Equal(t, c.terminal && !c.failed, IsBuildCompleted(c.status), "completed %q", c.status)
 	}
 }
 
@@ -532,6 +533,45 @@ func TestBuildSummaryFor_SuccessSkipsLogs(t *testing.T) {
 	assert.Equal(t, "ecr/img:tag", summary.ImageURI)
 	assert.Empty(t, summary.LogTail)
 	assert.False(t, logsHit, "logs endpoint must not be hit on success")
+}
+
+// The consumers have to fold with the classifier. Folding the terminal check
+// while this went on comparing exactly was worse than not folding at all: the
+// wait accepts a lowercase "completed", then the code reading the result calls
+// the same build unfinished, so the deploy succeeds its wait and has no image
+// to show for it, and the next run rebuilds for nothing.
+func TestBuildSummaryFor_ReadsTheImageOffALowercaseCompleted(t *testing.T) {
+	installSkipAuth(t)
+
+	var logsHit bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/logs") {
+			logsHit = true
+
+			return
+		}
+
+		_, _ = w.Write([]byte(`{
+			"id":"art-1","name":"a","status":"draft",
+			"spec":{"containerGroups":[{"containers":[{"primary":true,"imageUri":"ecr/img:tag"}]}]},
+			"createdAt":"2026-06-09T10:00:00Z","updatedAt":"2026-06-09T10:00:00Z"
+		}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	summary, err := BuildSummaryFor(&Build{
+		ID:         "b-1",
+		ArtifactID: "art-1",
+		Status:     "completed",
+	}, DefaultBuildLogTail)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ecr/img:tag", summary.ImageURI, "the image is what a completed build is read for")
+	assert.False(t, logsHit, "a completed build has no failure logs to fetch")
 }
 
 func TestBuildSummaryFor_FailureFetchesLogs(t *testing.T) {

--- a/internal/workload/build_test.go
+++ b/internal/workload/build_test.go
@@ -30,6 +30,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// The build statuses are upper case where the workload's are lower, which is
+// the platform disagreeing with itself. Read exactly, a build answering
+// "completed" is polled to the timeout and then fails a deploy whose image is
+// already built.
+func TestBuildStatusClassifiersFoldCase(t *testing.T) {
+	for _, c := range []struct {
+		status   string
+		terminal bool
+		failed   bool
+	}{
+		{BuildStatusCompleted, true, false},
+		{BuildStatusFailed, true, true},
+		{BuildStatusCancelled, true, true},
+		{"completed", true, false},
+		{"Failed", true, true},
+		{"cancelled", true, true},
+		{BuildStatusInProgress, false, false},
+		{"in_progress", false, false},
+		{"", false, false},
+	} {
+		assert.Equal(t, c.terminal, IsTerminalBuildStatus(c.status), "terminal %q", c.status)
+		assert.Equal(t, c.failed, IsBuildErrorStatus(c.status), "failed %q", c.status)
+	}
+}
+
 func TestIsTerminalBuildStatus(t *testing.T) {
 	cases := []struct {
 		status string

--- a/internal/workload/replacement.go
+++ b/internal/workload/replacement.go
@@ -75,12 +75,15 @@ type Replacement struct {
 // IsTerminalReplacementStatus reports whether s is a status the replacement
 // will not progress from.
 //
-// The comparison is case-insensitive, for the reason the artifact's lock
-// check is: the platform's own docs disagree with themselves about the casing
-// of status enums. It is not a cosmetic difference here. Reading a settled
-// "COMPLETED" as still in progress makes GuardNoActiveReplacement refuse every
-// deploy for as long as the record lingers, with a message that calls a
-// finished replacement one in progress.
+// The comparison is case-insensitive. To be plain about why: this route has
+// only ever been seen answering in lower case, so the fold is hardening rather
+// than a fix for something observed. What justifies it is that the platform is
+// not consistent across resources, its build statuses being upper case where
+// these and the workload's are lower, and that the artifact's lock check
+// already folds for the same reason. The cost of being wrong is one-sided:
+// reading a settled "COMPLETED" as still in progress would refuse every deploy
+// for as long as the record lingers, with a message calling a finished
+// replacement one in progress.
 func IsTerminalReplacementStatus(s string) bool {
 	return IsFailedReplacementStatus(s) || strings.EqualFold(s, ReplacementStatusCompleted)
 }
@@ -106,7 +109,7 @@ func replacementURL(workloadID string) (string, error) {
 // answers the same way for a workload that does not exist, and the body
 // saying which never reaches this layer, because drapi.Get discards it. A
 // caller that has not already established the workload exists should use
-// GuardNoActiveReplacement, which pays for one extra request to tell the two
+// RefuseActiveReplacement, which asks the same question with the ambiguity
 // apart, rather than reading (nil, nil) as proof of anything.
 func GetActiveReplacement(workloadID string) (*Replacement, error) {
 	url, err := replacementURL(workloadID)
@@ -133,7 +136,7 @@ func GetActiveReplacement(workloadID string) (*Replacement, error) {
 //
 // It is not idempotent: called while a replacement is already in flight it
 // queues a second swap rather than rejecting, so callers guard with
-// GuardNoActiveReplacement first.
+// RefuseActiveReplacement first.
 //
 // Both artifacts must share draft or locked status; the platform rejects a
 // mismatch, which is why a locked workload has to have its successor locked
@@ -206,52 +209,28 @@ func CancelReplacement(workloadID string) error {
 	return nil
 }
 
-// GuardNoActiveReplacement refuses to proceed when workloadID already has a
-// replacement in flight, because POSTing another queues a second swap instead
+// RefuseActiveReplacement refuses to proceed when workloadID already has a
+// replacement in flight, because starting another queues a second swap instead
 // of erroring.
 //
 // How many times to call it follows from what sits between the check and the
 // call it protects. A roll mints and may lock an artifact in between, so it
-// runs the guard twice: once up front, so a doomed command fails before it
-// makes anything, and once immediately before StartReplacement, which is the
-// guard that actually holds, since the live state can change in between. A
-// caller with nothing in between runs it once, because there the up-front
-// check and the last moment before the call are the same moment.
+// runs this twice: once up front, so a doomed command fails before it makes
+// anything, and once immediately before the swap, which is the check that
+// actually holds, since the live state can change in between. A caller with
+// nothing in between runs it once, because there the two are the same moment.
 //
 // A refusal wraps ErrReplacementInFlight; everything else it returns is a
 // failure to find out. Callers that want to say which operation was stopped
 // should wrap the second kind and leave the first alone, since the refusal
 // already names the workload and the remedy.
 //
-// Being the up-front check is why it does not simply trust an empty answer.
-// The replacement route returns the same 404 for "nothing in flight" and for
-// "no such workload", so an unchecked guard would wave through exactly the
-// mistyped id it exists to catch, and the command would go on to create and
-// possibly lock an artifact before discovering the target was never real.
-// One extra request on the quiet path buys that, and the quiet path is about
-// to spend minutes rolling a workload.
-func GuardNoActiveReplacement(workloadID string) error {
-	active, err := GetActiveReplacement(workloadID)
-	if err != nil {
-		return err
-	}
-
-	if active == nil {
-		return confirmWorkloadExists(workloadID)
-	}
-
-	return refuseActive(workloadID, active)
-}
-
-// RefuseActiveReplacement is the same refusal without the existence probe, for
-// a caller that has already established the workload is there.
-//
-// That is the whole difference, and it is worth the second entry point because
-// the probe is not free: it is a second GET of a document such a caller has
-// already read, spent on the quiet path, where nothing is in flight. Reading a
-// 404 as "nothing to guard against" is only safe once something else has ruled
-// out "no such workload", so a caller that has not done that wants the guard
-// above instead.
+// It reads an empty answer as "nothing in flight", which is only safe because
+// every caller has already established the workload exists. The replacement
+// route answers the same 404 for "nothing in flight" and for "no such
+// workload", so a caller that has not settled that first would wave through
+// exactly the mistyped id it means to catch. `up` settles it in Look, before
+// the plan is even built.
 func RefuseActiveReplacement(workloadID string) error {
 	active, err := GetActiveReplacement(workloadID)
 	if err != nil {

--- a/internal/workload/replacement.go
+++ b/internal/workload/replacement.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
@@ -73,20 +74,22 @@ type Replacement struct {
 
 // IsTerminalReplacementStatus reports whether s is a status the replacement
 // will not progress from.
+//
+// The comparison is case-insensitive, for the reason the artifact's lock
+// check is: the platform's own docs disagree with themselves about the casing
+// of status enums. It is not a cosmetic difference here. Reading a settled
+// "COMPLETED" as still in progress makes GuardNoActiveReplacement refuse every
+// deploy for as long as the record lingers, with a message that calls a
+// finished replacement one in progress.
 func IsTerminalReplacementStatus(s string) bool {
-	switch s {
-	case ReplacementStatusCompleted, ReplacementStatusFailed, ReplacementStatusErrored:
-		return true
-	}
-
-	return false
+	return IsFailedReplacementStatus(s) || strings.EqualFold(s, ReplacementStatusCompleted)
 }
 
 // IsFailedReplacementStatus reports whether s is a terminal failure. On
 // failure the workload reverts to the artifact it was running before the
 // replacement started, so a failed rollout never promotes.
 func IsFailedReplacementStatus(s string) bool {
-	return s == ReplacementStatusFailed || s == ReplacementStatusErrored
+	return strings.EqualFold(s, ReplacementStatusFailed) || strings.EqualFold(s, ReplacementStatusErrored)
 }
 
 // replacementURL builds the single route all three verbs share.
@@ -205,10 +208,20 @@ func CancelReplacement(workloadID string) error {
 
 // GuardNoActiveReplacement refuses to proceed when workloadID already has a
 // replacement in flight, because POSTing another queues a second swap instead
-// of erroring. Callers should run it twice: once up front, so a doomed
-// command fails before it mutates anything, and once immediately before
-// StartReplacement, which is the guard that actually holds, since the live
-// state can change in between.
+// of erroring.
+//
+// How many times to call it follows from what sits between the check and the
+// call it protects. A roll mints and may lock an artifact in between, so it
+// runs the guard twice: once up front, so a doomed command fails before it
+// makes anything, and once immediately before StartReplacement, which is the
+// guard that actually holds, since the live state can change in between. A
+// caller with nothing in between runs it once, because there the up-front
+// check and the last moment before the call are the same moment.
+//
+// A refusal wraps ErrReplacementInFlight; everything else it returns is a
+// failure to find out. Callers that want to say which operation was stopped
+// should wrap the second kind and leave the first alone, since the refusal
+// already names the workload and the remedy.
 //
 // Being the up-front check is why it does not simply trust an empty answer.
 // The replacement route returns the same 404 for "nothing in flight" and for
@@ -227,6 +240,33 @@ func GuardNoActiveReplacement(workloadID string) error {
 		return confirmWorkloadExists(workloadID)
 	}
 
+	return refuseActive(workloadID, active)
+}
+
+// RefuseActiveReplacement is the same refusal without the existence probe, for
+// a caller that has already established the workload is there.
+//
+// That is the whole difference, and it is worth the second entry point because
+// the probe is not free: it is a second GET of a document such a caller has
+// already read, spent on the quiet path, where nothing is in flight. Reading a
+// 404 as "nothing to guard against" is only safe once something else has ruled
+// out "no such workload", so a caller that has not done that wants the guard
+// above instead.
+func RefuseActiveReplacement(workloadID string) error {
+	active, err := GetActiveReplacement(workloadID)
+	if err != nil {
+		return err
+	}
+
+	if active == nil {
+		return nil
+	}
+
+	return refuseActive(workloadID, active)
+}
+
+// refuseActive is the verdict both entry points share once a record is in hand.
+func refuseActive(workloadID string, active *Replacement) error {
 	// A settled replacement stays readable for a while after it ends, and
 	// WaitForReplacement returns the moment it sees a terminal status, so the
 	// record is usually still there when the next command looks. Refusing on
@@ -238,9 +278,45 @@ func GuardNoActiveReplacement(workloadID string) error {
 	}
 
 	return fmt.Errorf(
-		"workload %s already has a replacement in progress (to artifact %s, status %s); wait for it to settle before starting another",
-		workloadID, active.ArtifactID, active.Status,
+		"workload %s: %w%s; wait for it to settle before starting another",
+		workloadID, ErrReplacementInFlight, describeActive(active),
 	)
+}
+
+// ErrReplacementInFlight marks the refusal, so a caller can tell a rollout it
+// should wait out from a failure to find out whether there is one. The two
+// want different words: the first is a state, the second is a read that did
+// not happen, and a caller that wrapped both would put "cannot tell whether"
+// in front of a sentence that already knows.
+//
+// It reads as a whole sentence rather than as a fragment of the message above,
+// because a sentinel is the one error a caller may hand on by itself.
+var ErrReplacementInFlight = errors.New("a replacement is already in progress")
+
+// describeActive names what is in flight, carrying only the fields the
+// platform actually filled in.
+//
+// The artifact is one of them because a settings change rolls the workload
+// onto the artifact it is already running, and the platform returns no
+// candidate for it. Naming one unconditionally printed an empty field
+// mid-sentence, or the id of the version the plan had just reported as live,
+// which reads as a rollout onto itself.
+func describeActive(active *Replacement) string {
+	parts := make([]string, 0, 2)
+
+	if active.ArtifactID != "" {
+		parts = append(parts, "to artifact "+active.ArtifactID)
+	}
+
+	if active.Status != "" {
+		parts = append(parts, "status "+active.Status)
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return " (" + strings.Join(parts, ", ") + ")"
 }
 
 // confirmWorkloadExists turns the replacement route's ambiguous 404 into a

--- a/internal/workload/replacement_test.go
+++ b/internal/workload/replacement_test.go
@@ -30,7 +30,7 @@ import (
 const (
 	// notActiveBody is what the platform answers when nothing is in flight.
 	// The same 404 also means "no such workload", which is the ambiguity
-	// GuardNoActiveReplacement and CancelReplacement have to resolve.
+	// RefuseActiveReplacement and CancelReplacement have to resolve.
 	notActiveBody = `{"detail":"There is no active replacement for this workload."}`
 
 	replacementPath = "/api/v2/workloads/wl-1/replacement/"
@@ -311,32 +311,28 @@ func TestCancelReplacement_OtherErrorPropagates(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
 }
 
-func TestGuardNoActiveReplacement_PassesWhenNoneActive(t *testing.T) {
+func TestRefuseActiveReplacement_PassesWhenNoneActive(t *testing.T) {
 	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
 		notFound(w)
 	})
 
-	assert.NoError(t, GuardNoActiveReplacement("wl-1"))
+	require.NoError(t, RefuseActiveReplacement("wl-1"))
 }
 
-// TestGuardNoActiveReplacement_MissingWorkloadFailsFast is the whole reason
-// the guard pays for a second request. Without it the mistyped id sails
-// through the up-front check, and the command goes on to create and possibly
-// lock an artifact, which cannot be undone, before finding out the target was
-// never real.
-func TestGuardNoActiveReplacement_MissingWorkloadFailsFast(t *testing.T) {
+// An empty answer is read as "nothing in flight" rather than disambiguated,
+// which is only correct because every caller has established the workload
+// exists before asking. `up` settles it in Look, and refuses the states where
+// it is gone before the plan is built.
+func TestRefuseActiveReplacement_ReadsAnEmptyAnswerAsNothingInFlight(t *testing.T) {
 	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		notFound(w)
 	}))
 
-	err := GuardNoActiveReplacement("wl-1")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not exist")
+	require.NoError(t, RefuseActiveReplacement("wl-1"))
 }
 
-// TestGuardNoActiveReplacement_SkipsTheExistenceCheckWhenOneIsActive: a
-// replacement in flight is proof enough that the workload is there.
-func TestGuardNoActiveReplacement_SkipsTheExistenceCheckWhenOneIsActive(t *testing.T) {
+// A refusal names the candidate and the status, and costs one request.
+func TestRefuseActiveReplacement_NamesTheCandidateAndTheStatus(t *testing.T) {
 	var workloadFetches int32
 
 	mux := http.NewServeMux()
@@ -350,20 +346,20 @@ func TestGuardNoActiveReplacement_SkipsTheExistenceCheckWhenOneIsActive(t *testi
 
 	serveAPI(t, mux)
 
-	err := GuardNoActiveReplacement("wl-1")
+	err := RefuseActiveReplacement("wl-1")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "art-9")
 	assert.Contains(t, err.Error(), "switching")
 	assert.Zero(t, atomic.LoadInt32(&workloadFetches))
 }
 
-// TestGuardNoActiveReplacement_SettledReplacementDoesNotBlock covers the gap
+// TestRefuseActiveReplacement_SettledReplacementDoesNotBlock covers the gap
 // between a rollout ending and the platform collecting its record.
 // WaitForReplacement returns the instant it sees a terminal status, so that
 // record is usually still readable when the next command looks. Treating it
 // as in-flight would refuse a retry, and would say so with a message naming
 // the status as "completed" while calling it in progress.
-func TestGuardNoActiveReplacement_SettledReplacementDoesNotBlock(t *testing.T) {
+func TestRefuseActiveReplacement_SettledReplacementDoesNotBlock(t *testing.T) {
 	for _, status := range []string{
 		ReplacementStatusCompleted,
 		ReplacementStatusFailed,
@@ -374,21 +370,21 @@ func TestGuardNoActiveReplacement_SettledReplacementDoesNotBlock(t *testing.T) {
 				fmt.Fprintf(w, `{"candidateArtifactId":"art-2","status":"%s"}`, status)
 			})
 
-			assert.NoError(t, GuardNoActiveReplacement("wl-1"))
+			assert.NoError(t, RefuseActiveReplacement("wl-1"))
 		})
 	}
 }
 
-// TestGuardNoActiveReplacement_RefusalNamesOnlyWhatThePlatformFilledIn covers
+// TestRefuseActiveReplacement_RefusalNamesOnlyWhatThePlatformFilledIn covers
 // the settings-initiated replacement. A resize rolls the workload onto the
 // artifact it is already running, so the platform returns no candidate, and a
 // message that named one unconditionally printed an empty field mid-sentence.
-func TestGuardNoActiveReplacement_RefusalNamesOnlyWhatThePlatformFilledIn(t *testing.T) {
+func TestRefuseActiveReplacement_RefusalNamesOnlyWhatThePlatformFilledIn(t *testing.T) {
 	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, `{"id":"rep-9","workloadId":"wl-1","status":"pending"}`)
 	})
 
-	err := GuardNoActiveReplacement("wl-1")
+	err := RefuseActiveReplacement("wl-1")
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrReplacementInFlight,
 		"a refusal is a state to wait out, not a failure to find out, and callers branch on the difference")
@@ -396,12 +392,12 @@ func TestGuardNoActiveReplacement_RefusalNamesOnlyWhatThePlatformFilledIn(t *tes
 	assert.NotContains(t, err.Error(), "to artifact", "there is no candidate artifact to name")
 }
 
-func TestGuardNoActiveReplacement_PropagatesLookupFailure(t *testing.T) {
+func TestRefuseActiveReplacement_PropagatesLookupFailure(t *testing.T) {
 	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
-	err := GuardNoActiveReplacement("wl-1")
+	err := RefuseActiveReplacement("wl-1")
 	require.Error(t, err)
 
 	var httpErr *drapi.HTTPError
@@ -435,9 +431,7 @@ func TestRefuseActiveReplacement_AsksOnceForAKnownWorkload(t *testing.T) {
 		"the caller established the workload exists before asking")
 }
 
-// The refusal itself is the same one, so neither entry point can drift into
-// wording the other does not have.
-func TestRefuseActiveReplacement_RefusesTheSameWayTheGuardDoes(t *testing.T) {
+func TestRefuseActiveReplacement_RefusesWithTheSentinel(t *testing.T) {
 	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, `{"candidateArtifactId":"art-9","status":"switching"}`)
 	})

--- a/internal/workload/replacement_test.go
+++ b/internal/workload/replacement_test.go
@@ -73,6 +73,15 @@ func TestIsTerminalReplacementStatus(t *testing.T) {
 		{"candidate-warming", false},
 		{"switching", false},
 		{"", false},
+
+		// The platform's own docs disagree with themselves about the casing of
+		// status enums. Read case-sensitively, a settled "COMPLETED" counts as
+		// still in progress, which makes the rollout guard refuse every deploy
+		// for as long as the record lingers.
+		{"COMPLETED", true},
+		{"Failed", true},
+		{"ERRORED", true},
+		{"SWITCHING", false},
 	}
 
 	for _, c := range cases {
@@ -90,6 +99,9 @@ func TestIsFailedReplacementStatus(t *testing.T) {
 		{ReplacementStatusCompleted, false},
 		{"submitted", false},
 		{"", false},
+		{"FAILED", true},
+		{"Errored", true},
+		{"COMPLETED", false},
 	}
 
 	for _, c := range cases {
@@ -367,6 +379,23 @@ func TestGuardNoActiveReplacement_SettledReplacementDoesNotBlock(t *testing.T) {
 	}
 }
 
+// TestGuardNoActiveReplacement_RefusalNamesOnlyWhatThePlatformFilledIn covers
+// the settings-initiated replacement. A resize rolls the workload onto the
+// artifact it is already running, so the platform returns no candidate, and a
+// message that named one unconditionally printed an empty field mid-sentence.
+func TestGuardNoActiveReplacement_RefusalNamesOnlyWhatThePlatformFilledIn(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":"rep-9","workloadId":"wl-1","status":"pending"}`)
+	})
+
+	err := GuardNoActiveReplacement("wl-1")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrReplacementInFlight,
+		"a refusal is a state to wait out, not a failure to find out, and callers branch on the difference")
+	assert.Contains(t, err.Error(), "workload wl-1: a replacement is already in progress (status pending)")
+	assert.NotContains(t, err.Error(), "to artifact", "there is no candidate artifact to name")
+}
+
 func TestGuardNoActiveReplacement_PropagatesLookupFailure(t *testing.T) {
 	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -379,6 +408,45 @@ func TestGuardNoActiveReplacement_PropagatesLookupFailure(t *testing.T) {
 
 	require.ErrorAs(t, err, &httpErr, "a transport failure must not be reported as an in-flight replacement")
 	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+	assert.NotErrorIs(t, err, ErrReplacementInFlight,
+		"callers wrap a failure to find out and pass a refusal through, so the two must not carry the same mark")
+}
+
+// TestRefuseActiveReplacement_AsksOnceForAKnownWorkload is the difference
+// between the two entry points: a caller that has already read the workload
+// does not pay for the 404 disambiguation, which is a second GET of a document
+// it is holding.
+func TestRefuseActiveReplacement_AsksOnceForAKnownWorkload(t *testing.T) {
+	var workloadFetches int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(replacementPath, func(w http.ResponseWriter, _ *http.Request) {
+		notFound(w)
+	})
+	mux.HandleFunc(workloadPath, func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&workloadFetches, 1)
+		fmt.Fprint(w, `{"id":"wl-1"}`)
+	})
+
+	serveAPI(t, mux)
+
+	require.NoError(t, RefuseActiveReplacement("wl-1"))
+	assert.Zero(t, atomic.LoadInt32(&workloadFetches),
+		"the caller established the workload exists before asking")
+}
+
+// The refusal itself is the same one, so neither entry point can drift into
+// wording the other does not have.
+func TestRefuseActiveReplacement_RefusesTheSameWayTheGuardDoes(t *testing.T) {
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"candidateArtifactId":"art-9","status":"switching"}`)
+	})
+
+	err := RefuseActiveReplacement("wl-1")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrReplacementInFlight)
+	assert.Contains(t, err.Error(), "art-9")
+	assert.Contains(t, err.Error(), "switching")
 }
 
 func TestWaitForReplacement_TerminalCompletedReturnsNoError(t *testing.T) {

--- a/internal/workload/settings.go
+++ b/internal/workload/settings.go
@@ -38,6 +38,13 @@ import (
 // only starts the work, and the caller has to follow the replacement to know
 // whether the new sizing was promoted. The workload's own status is no help,
 // since it stays running throughout.
+//
+// That makes this a replacement-starter, with StartReplacement's contract and
+// not a plain field update: called while a replacement is already in flight it
+// queues a second swap rather than rejecting, so callers guard with
+// GuardNoActiveReplacement first. Nothing in the live state substitutes for
+// asking, because the workload goes on reporting itself running for the whole
+// of a swap.
 func UpdateWorkloadSettings(workloadID string, runtime json.RawMessage) (*Replacement, error) {
 	if len(runtime) == 0 {
 		return nil, errors.New("no runtime settings to update")

--- a/internal/workload/settings.go
+++ b/internal/workload/settings.go
@@ -42,7 +42,7 @@ import (
 // That makes this a replacement-starter, with StartReplacement's contract and
 // not a plain field update: called while a replacement is already in flight it
 // queues a second swap rather than rejecting, so callers guard with
-// GuardNoActiveReplacement first. Nothing in the live state substitutes for
+// RefuseActiveReplacement first. Nothing in the live state substitutes for
 // asking, because the workload goes on reporting itself running for the whole
 // of a swap.
 func UpdateWorkloadSettings(workloadID string, runtime json.RawMessage) (*Replacement, error) {

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -316,7 +316,7 @@ func hasImage(artifactID string) (bool, error) {
 	}
 
 	for _, build := range builds {
-		if build.Status == workload.BuildStatusCompleted {
+		if workload.IsBuildCompleted(build.Status) {
 			return true, nil
 		}
 	}

--- a/internal/workload/up/load.go
+++ b/internal/workload/up/load.go
@@ -64,6 +64,15 @@ func (l Loaded) WorkloadID() string {
 // the compiled payload rather than the file is what makes the comparison fair:
 // the shorthand is already expanded, so a credential reference does not look
 // like drift against the object form the platform stores.
+//
+// The type is removed rather than compared, because the live side never has
+// one: the platform reads the discriminator off the artifact and pops any type
+// sent inside the spec, so a spec that came back from the server carries only
+// the rest. A file that wrote its type there would otherwise report it missing
+// on every single run, mint a version and roll for it, and find it missing
+// again the next time, which is a deploy loop with no state that can end it.
+// ArtifactType below is what compares the type, from wherever the file put it,
+// and the wizard's own writer drops it from this block for the same reason.
 func (l Loaded) Spec() (map[string]any, error) {
 	payload, err := l.payload()
 	if err != nil {
@@ -71,15 +80,62 @@ func (l Loaded) Spec() (map[string]any, error) {
 	}
 
 	artifact, _ := payload["artifact"].(map[string]any)
+	hoistArtifactType(artifact)
+
 	spec, _ := artifact["spec"].(map[string]any)
 
 	return spec, nil
 }
 
+// hoistArtifactType moves a type written inside the spec up beside it, and
+// takes it out of the spec either way.
+//
+// It exists because the file may legitimately say the type in either place,
+// while the platform only ever answers in one: it reads the discriminator on
+// the way in from wherever it finds it, keeps it on the artifact, and returns
+// a spec without it. Any comparison of the file's artifact block against the
+// platform's own document has to reconcile that first, or the type reads as a
+// field the live side is missing, on every run, with nothing a deploy can do
+// to settle it: mint a version, roll it, find it missing again.
+//
+// The callers pass a freshly decoded copy, so this never edits the compiled
+// request. What a create sends is untouched, which is what keeps the two
+// placements equally valid on the way in.
+func hoistArtifactType(artifact map[string]any) {
+	spec, ok := artifact["spec"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	within, _ := spec[keyType].(string)
+
+	delete(spec, keyType)
+
+	if within == "" {
+		return
+	}
+
+	// Beside the spec wins when a file says both, because that is where the
+	// platform keeps the answer.
+	if beside, _ := artifact[keyType].(string); beside == "" {
+		artifact[keyType] = within
+	}
+}
+
 // ArtifactType is the kind of artifact the file asks for, "" when it names
-// none. It sits beside the spec rather than inside it, because the platform
-// reads the discriminator from the artifact itself and pops any type sent
-// within the spec, so Spec above can never see it.
+// none.
+//
+// It is read from beside the spec and from inside it, because a file can
+// legitimately have written it in either: the platform accepts both on the way
+// in and keeps the result on the artifact, and the manifest ledger blesses
+// neither placement over the other. This is the only place the answer is read,
+// since Spec above removes it so the spec walk cannot see it, so missing one
+// placement here would mean a file that names a type is treated as naming
+// none, and the walk never reverts what the file leaves out.
+//
+// Beside the spec wins when a file says both, because that is where the
+// platform keeps it and so where a reader checking the live artifact would
+// look for the answer.
 func (l Loaded) ArtifactType() (string, error) {
 	payload, err := l.payload()
 	if err != nil {
@@ -87,7 +143,9 @@ func (l Loaded) ArtifactType() (string, error) {
 	}
 
 	artifact, _ := payload["artifact"].(map[string]any)
-	artifactType, _ := artifact["type"].(string)
+	hoistArtifactType(artifact)
+
+	artifactType, _ := artifact[keyType].(string)
 
 	return artifactType, nil
 }

--- a/internal/workload/up/load_test.go
+++ b/internal/workload/up/load_test.go
@@ -163,7 +163,12 @@ func TestLoaded_SpecAndRuntimeComeFromTheCompiledPayload(t *testing.T) {
 
 	spec, err := loaded.Spec()
 	require.NoError(t, err)
-	assert.Equal(t, "service", spec["type"])
+	assert.NotContains(t, spec, "type",
+		"the live spec never carries a type, so comparing one reports drift no deploy can settle")
+
+	kind, err := loaded.ArtifactType()
+	require.NoError(t, err)
+	assert.Equal(t, "service", kind, "the file said it inside the spec, which is where it has to be read from")
 
 	groups, _ := spec["containerGroups"].([]any)
 	require.Len(t, groups, 1)

--- a/internal/workload/up/look.go
+++ b/internal/workload/up/look.go
@@ -39,6 +39,7 @@ const (
 	keyStatus     = "status"
 	keyEndpoint   = "endpoint"
 	keyArtifactID = "artifactId"
+	keySpec       = "spec"
 	keyType       = "type"
 
 	// keyArtifactRepositoryID is the repository an artifact belongs to. The
@@ -100,6 +101,27 @@ type Live struct {
 	Locked bool
 }
 
+// liveArtifactType reads the discriminator off the artifact document, falling
+// back to the spec.
+//
+// The platform hoists a type sent inside the spec and answers with it beside
+// the spec, which is what the fallback is for: the file's side is read from
+// both placements, and a live side that read only one would leave the two
+// halves of the same comparison enforcing different invariants. If a route
+// ever answered without hoisting, an agent would read as having no type, be
+// defaulted to a service, and drift against a file correctly calling it an
+// agent on every run.
+func liveArtifactType(artifactDoc workload.Document) string {
+	if beside := artifactDoc.String(keyType); beside != "" {
+		return beside
+	}
+
+	spec, _ := artifactDoc[keySpec].(map[string]any)
+	within, _ := spec[keyType].(string)
+
+	return within
+}
+
 // Look fetches the live workload and the artifact it runs.
 //
 // An empty workloadID is not an error: it is a manifest that has never been
@@ -136,7 +158,7 @@ func Look(workloadID string) (Live, error) {
 		State:                stateFor(status),
 		Status:               status,
 		ArtifactID:           artifactID,
-		ArtifactType:         artifactDoc.String(keyType),
+		ArtifactType:         liveArtifactType(artifactDoc),
 		ArtifactRepositoryID: artifactDoc.String(keyArtifactRepositoryID),
 		Endpoint:             workloadDoc.String(keyEndpoint),
 		Locked:               isLocked(artifactDoc.String(keyStatus)),

--- a/internal/workload/up/look_test.go
+++ b/internal/workload/up/look_test.go
@@ -309,3 +309,23 @@ func primaryContainer(t *testing.T, spec map[string]any) map[string]any {
 
 	return container
 }
+
+// The file's side reads the artifact type from either placement, so the live
+// side has to as well. A reader that only looked beside the spec would report
+// an agent as having no type, default it to a service, and drift against a
+// file correctly calling it an agent on every run.
+func TestLook_ArtifactTypeIsReadFromEitherPlacement(t *testing.T) {
+	assert.Equal(t, "agent", liveArtifactType(workload.Document{"type": "agent"}),
+		"beside the spec is where the platform keeps it")
+
+	assert.Equal(t, "agent", liveArtifactType(workload.Document{
+		"spec": map[string]any{"type": "agent"},
+	}), "a document that did not hoist it still answers")
+
+	assert.Equal(t, "agent", liveArtifactType(workload.Document{
+		"type": "agent",
+		"spec": map[string]any{"type": "service"},
+	}), "beside the spec wins")
+
+	assert.Empty(t, liveArtifactType(workload.Document{"spec": map[string]any{}}))
+}

--- a/internal/workload/up/plan.go
+++ b/internal/workload/up/plan.go
@@ -197,10 +197,22 @@ func Build(loaded Loaded, live Live, code CodeChange) (Plan, error) {
 	// resolve a difference the platform does not consider one, so a spelling
 	// the ledger accepts and the platform normalises would be drift that every
 	// run mints a version for and never clears.
-	if kind != "" && !manifest.SameArtifactType(kind, live.ArtifactType) {
+	// The live side is defaulted and the file's side is not, which is the same
+	// asymmetry the roll's repository check makes for the same reason. An
+	// unstated type in the file is the file having no opinion. An unstated type
+	// on the artifact is not: the platform defaults it to a service, so reading
+	// it as a difference would mint a version on every run of a file that
+	// correctly says service, and nothing the file can say would ever settle it.
+	//
+	// Have carries the defaulted value rather than the raw one, so the line the
+	// reader sees is the comparison that was actually made. Printing the empty
+	// string would render "artifact.type:  -> agent", a change with nothing on
+	// the left, about a side this code has just decided means service.
+	if running := manifest.ArtifactTypeOrDefault(live.ArtifactType); kind != "" &&
+		!manifest.SameArtifactType(kind, running) {
 		plan.Artifact = append(plan.Artifact, Change{
 			Path: keyArtifactType,
-			Have: live.ArtifactType,
+			Have: running,
 			Want: kind,
 		})
 	}

--- a/internal/workload/up/plan_test.go
+++ b/internal/workload/up/plan_test.go
@@ -365,6 +365,112 @@ func TestBuild_BadPayloadIsReported(t *testing.T) {
 	assert.Contains(t, err.Error(), "compiled manifest")
 }
 
+// A file may write the type inside the spec, which the platform accepts and
+// the ledger does not forbid. The live artifact still comes back without one,
+// so comparing the two blocks reported the type missing on every run: a
+// re-deploy of an untouched project minted a version and rolled, then found it
+// missing again, with no state anywhere that could end the loop. Reproduced
+// against staging before it was fixed.
+func TestBuild_TypeInsideTheSpecIsNotPerpetualDrift(t *testing.T) {
+	loaded := Loaded{Compiled: &manifest.Compiled{
+		Payload: json.RawMessage(`{
+		  "name": "my-app",
+		  "artifact": {"name": "my-app-artifact", "spec": {"type": "service"}}
+		}`),
+	}}
+
+	live := liveFrom(t, StateRunning, "", planLiveRuntime)
+	live.ArtifactType = "service"
+
+	plan, err := Build(loaded, live, builtCode(0))
+	require.NoError(t, err)
+
+	assert.Empty(t, paths(plan.Artifact), "the file and the workload agree about the type")
+	assert.True(t, plan.Empty(), "a re-deploy of an untouched project has nothing to do")
+}
+
+// The other half of that fix: reading the type from inside the spec must not
+// mean ignoring it. A file that turns a service into an agent there is asking
+// for a new lineage exactly as it would beside the spec.
+func TestBuild_TypeChangeInsideTheSpecIsStillARoll(t *testing.T) {
+	loaded := Loaded{Compiled: &manifest.Compiled{
+		Payload: json.RawMessage(`{
+		  "name": "my-app",
+		  "artifact": {"name": "my-app-artifact", "spec": {"type": "agent"}}
+		}`),
+	}}
+
+	live := liveFrom(t, StateRunning, "", planLiveRuntime)
+	live.ArtifactType = "service"
+
+	plan, err := Build(loaded, live, builtCode(0))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"artifact.type"}, paths(plan.Artifact))
+	assert.Equal(t, ActionRolled, plan.Action())
+}
+
+// Beside the spec wins when a file says both, because that is where the
+// platform keeps the answer.
+func TestBuild_TypeBesideTheSpecWinsOverTypeWithinIt(t *testing.T) {
+	loaded := Loaded{Compiled: &manifest.Compiled{
+		Payload: json.RawMessage(`{
+		  "name": "my-app",
+		  "artifact": {"name": "my-app-artifact", "type": "agent", "spec": {"type": "service"}}
+		}`),
+	}}
+
+	live := liveFrom(t, StateRunning, "", planLiveRuntime)
+	live.ArtifactType = "agent"
+
+	plan, err := Build(loaded, live, builtCode(0))
+	require.NoError(t, err)
+
+	assert.Empty(t, paths(plan.Artifact), "the type beside the spec is the one that counts")
+}
+
+// The line the reader sees has to be the comparison that was made. Reporting
+// the raw empty string rendered "artifact.type:  -> agent", a change with
+// nothing on the left, about a side this code had just decided means service.
+func TestBuild_TypeChangeAgainstAnUnstatedLiveTypeReadsAsService(t *testing.T) {
+	loaded := Loaded{Compiled: &manifest.Compiled{
+		Payload: json.RawMessage(`{
+		  "name": "my-app",
+		  "artifact": {"name": "my-app-artifact", "type": "agent", "spec": {}}
+		}`),
+	}}
+
+	live := liveFrom(t, StateRunning, "", planLiveRuntime)
+	live.ArtifactType = ""
+
+	plan, err := Build(loaded, live, builtCode(0))
+	require.NoError(t, err)
+
+	require.Len(t, plan.Artifact, 1)
+	assert.Equal(t, "service", plan.Artifact[0].Have, "the silence was read as a service, so that is what it says")
+	assert.Equal(t, "artifact.type: service -> agent", plan.Artifact[0].String())
+}
+
+// An artifact that states no type is a service, because that is what the
+// platform defaults it to. Reading the silence as a difference would be drift
+// a file saying "service" could never settle.
+func TestBuild_LiveArtifactWithNoStatedTypeIsAService(t *testing.T) {
+	loaded := Loaded{Compiled: &manifest.Compiled{
+		Payload: json.RawMessage(`{
+		  "name": "my-app",
+		  "artifact": {"name": "my-app-artifact", "type": "service", "spec": {}}
+		}`),
+	}}
+
+	live := liveFrom(t, StateRunning, "", planLiveRuntime)
+	live.ArtifactType = ""
+
+	plan, err := Build(loaded, live, builtCode(0))
+	require.NoError(t, err)
+
+	assert.Empty(t, paths(plan.Artifact))
+}
+
 // The type sits beside the spec, not in it: the platform reads the
 // discriminator off the artifact and pops any type sent within the spec, so
 // the spec walk is blind to it. Without a comparison of its own, turning a

--- a/internal/workload/up/retune.go
+++ b/internal/workload/up/retune.go
@@ -39,16 +39,37 @@ import (
 // the same block the plan was computed from, the platform takes it as a unit,
 // and sending a subset would leave the reader guessing which half of the file
 // is now live.
+//
+// Being a rollout is also why it is guarded. The replacement route is
+// documented to queue a second swap rather than refuse one; that the settings
+// route does the same is an inference from it answering with a replacement,
+// not something confirmed against a live instance. Guarding is the safer of
+// the two guesses: if the route turns out to refuse on its own, the cost is a
+// request and a message less specific than the platform's, while not guarding
+// costs a swap nobody asked for. Worth settling on the same staging run that
+// answers whether the settings PATCH merges or replaces.
+//
+// One guard rather than a roll's two, because nothing is minted in between, so
+// the check and the call are the same moment. It goes after the payload is
+// built, since that is local and free.
+//
+// The window it cannot close: the settings route answers 202, so a resize
+// started and not waited for may not be readable on the replacement route yet
+// when the next run looks. Two detached resizes back to back can still queue.
 func retune(loaded Loaded, result Result, opts Options, report *reporter) (Result, error) {
-	runtime, err := loaded.Compiled.RuntimePayload()
+	sizing, err := loaded.Compiled.RuntimePayload()
 	if err != nil {
+		return result, err
+	}
+
+	if err := guardRollout(result.WorkloadID, "its runtime settings were left alone"); err != nil {
 		return result, err
 	}
 
 	var started *workload.Replacement
 
 	err = report.run("Updating the runtime settings", func() error {
-		replacement, updateErr := updateSettingsFn(result.WorkloadID, runtime)
+		replacement, updateErr := updateSettingsFn(result.WorkloadID, sizing)
 		started = replacement
 
 		return updateErr

--- a/internal/workload/up/retune.go
+++ b/internal/workload/up/retune.go
@@ -42,12 +42,15 @@ import (
 //
 // Being a rollout is also why it is guarded. The replacement route is
 // documented to queue a second swap rather than refuse one; that the settings
-// route does the same is an inference from it answering with a replacement,
-// not something confirmed against a live instance. Guarding is the safer of
-// the two guesses: if the route turns out to refuse on its own, the cost is a
-// request and a message less specific than the platform's, while not guarding
-// costs a swap nobody asked for. Worth settling on the same staging run that
-// answers whether the settings PATCH merges or replaces.
+// route does the same is an inference from it answering with a replacement.
+// A staging run confirmed the half that could be confirmed without provoking
+// the bug: a settings-initiated replacement is published on the replacement
+// route, with a candidate artifact id, so the guard reads what the resize
+// writes. What the route does with a second PATCH while one is in flight was
+// not checked, because the guard is what stops it happening. Guarding is the
+// safer of the two guesses: if the route turns out to refuse on its own, the
+// cost is a request and a message less specific than the platform's, while not
+// guarding costs a swap nobody asked for.
 //
 // One guard rather than a roll's two, because nothing is minted in between, so
 // the check and the call are the same moment. It goes after the payload is
@@ -78,17 +81,23 @@ func retune(loaded Loaded, result Result, opts Options, report *reporter) (Resul
 		return result, fmt.Errorf("cannot update the runtime settings of workload %s: %w", result.WorkloadID, err)
 	}
 
-	result.Action = ActionUpdated
-
 	if opts.Detach {
+		// Nobody is waiting, so the request is the whole of what this run did.
+		result.Action = ActionUpdated
+
 		report.say("  Settings update for %s requested; not waiting.\n", result.WorkloadID)
 
 		return result, nil
 	}
 
+	// After the wait, for the reason a roll records it after its own: a
+	// settings replacement that ends failed leaves the workload on the sizing
+	// it had, so reporting an update would name something that did not happen.
 	if err := awaitResize(result.WorkloadID, started, opts, report); err != nil {
 		return result, err
 	}
+
+	result.Action = ActionUpdated
 
 	return settle(result.WorkloadID, result, opts, report)
 }

--- a/internal/workload/up/retune_test.go
+++ b/internal/workload/up/retune_test.go
@@ -17,6 +17,7 @@ package up
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -36,10 +37,20 @@ func retuned(from, to string) string {
 
 // wiredRetune answers the settings call and the two waits that follow it: the
 // replacement the platform starts to apply the sizing, then the workload.
+//
+// The guard is recorded rather than left to install's silent no-op, the way
+// the roll fixture records it. Otherwise the sequence assertions below read as
+// the whole of a resize while saying nothing about the one call that has to
+// come before the PATCH, and deleting it would leave them green.
 func wiredRetune(tr *track, sent *json.RawMessage) fakes {
 	return fakes{
 		workloadD: func(string) (workload.Document, error) { return docOf(liveWorkloadJSON), nil },
 		artifactD: func(string) (workload.Document, error) { return docOf(liveArtifactJSON), nil },
+		guard: func(workloadID string) error {
+			tr.steps = append(tr.steps, "guard:"+workloadID)
+
+			return nil
+		},
 		settings: func(workloadID string, runtime json.RawMessage) (*workload.Replacement, error) {
 			tr.steps = append(tr.steps, "settings:"+workloadID)
 			*sent = runtime
@@ -65,9 +76,10 @@ func wiredRetune(tr *track, sent *json.RawMessage) fakes {
 	}
 }
 
-// A resize costs one call. Nothing is built, nothing is minted and nothing is
+// A resize mutates once. Nothing is built, nothing is minted and nothing is
 // swapped, which is the entire reason this path exists rather than being
-// folded into a roll.
+// folded into a roll. The guard ahead of it is a read, and it is in the
+// sequence because a resize is a replacement like any other.
 func TestRun_RuntimeOnlyChangeIsAppliedInPlace(t *testing.T) {
 	var (
 		tr   track
@@ -92,8 +104,11 @@ func TestRun_RuntimeOnlyChangeIsAppliedInPlace(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]string{"settings:68b0c1d2e3f4a5b6c7d8e9f0", "await-resize", "settle"}, tr.steps,
-		"the platform resizes by rolling a replacement, so that is what has to be followed")
+		[]string{
+			"guard:68b0c1d2e3f4a5b6c7d8e9f0", "settings:68b0c1d2e3f4a5b6c7d8e9f0",
+			"await-resize", "settle",
+		}, tr.steps,
+		"the platform resizes by rolling a replacement, so that is what has to be guarded and followed")
 	assert.Equal(t, ActionUpdated, result.Action)
 	assert.Equal(t, workload.WorkloadStatusRunning, result.Status, "the wait has the last word on status")
 	assert.Equal(t, "68a0000000000000000000a1", result.ArtifactID, "the version serving does not change")
@@ -147,6 +162,67 @@ func TestRun_RetuneDoesNotVerifyCredentials(t *testing.T) {
 	_, _, err := runIn(t, retuned("cpu: 3", "cpu: 6"), Options{NonInteractive: true})
 	require.NoError(t, err)
 	assert.Contains(t, tr.steps, "settings:68b0c1d2e3f4a5b6c7d8e9f0")
+}
+
+// A resize is a replacement like any other, so it has to ask the question a
+// roll asks before the PATCH goes out.
+func TestRun_RetuneRefusesWhileAReplacementIsInFlight(t *testing.T) {
+	var (
+		tr   track
+		sent json.RawMessage
+	)
+
+	f := wiredRetune(&tr, &sent)
+	f.guard = func(workloadID string) error {
+		tr.steps = append(tr.steps, "guard:"+workloadID)
+
+		return fmt.Errorf("workload %s: %w (status switching); wait for it to settle before starting another",
+			workloadID, workload.ErrReplacementInFlight)
+	}
+	f.settings = func(string, json.RawMessage) (*workload.Replacement, error) {
+		t.Fatal("the sizing may not ride in behind a rollout that is still deciding")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	result, _, err := runIn(t, retuned("cpu: 3", "cpu: 6"), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "a replacement is already in progress")
+	assert.NotContains(t, err.Error(), "cannot tell whether",
+		"a refusal already names the workload and the remedy, so it travels in its own words")
+	assert.Equal(t, []string{"guard:68b0c1d2e3f4a5b6c7d8e9f0"}, tr.steps,
+		"the workload the file is bound to is the one that has to be clear")
+	assert.Equal(t, ActionUnchanged, result.Action,
+		"a run refused before it touched anything did not update anything")
+}
+
+// The guard has two failure modes and they read differently. A route that
+// cannot answer says nothing about the resize it stopped, so the operation is
+// named for it.
+func TestRun_RetuneNamesTheResizeWhenTheGuardCannotAnswer(t *testing.T) {
+	var (
+		tr   track
+		sent json.RawMessage
+	)
+
+	f := wiredRetune(&tr, &sent)
+	f.guard = func(string) error { return errors.New("HTTP error: 500 Internal Server Error") }
+	f.settings = func(string, json.RawMessage) (*workload.Replacement, error) {
+		t.Fatal("a guard that could not answer is not permission to proceed")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, retuned("cpu: 3", "cpu: 6"), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		"cannot tell whether workload 68b0c1d2e3f4a5b6c7d8e9f0 already has a rollout in progress, "+
+			"so its runtime settings were left alone")
+	assert.Contains(t, err.Error(), "500 Internal Server Error", "the reason survives the wrapping")
 }
 
 func TestRun_RetuneFailureNamesTheWorkload(t *testing.T) {
@@ -299,7 +375,8 @@ func TestRun_RetuneWithLockLocksTheServingArtifact(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{
-		"settings:68b0c1d2e3f4a5b6c7d8e9f0", "await-resize", "settle", "lock:68a0000000000000000000a1",
+		"guard:68b0c1d2e3f4a5b6c7d8e9f0", "settings:68b0c1d2e3f4a5b6c7d8e9f0",
+		"await-resize", "settle", "lock:68a0000000000000000000a1",
 	}, tr.steps, "the lock comes last, once the workload is serving again")
 	assert.True(t, result.Locked)
 }

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -42,7 +42,7 @@ import (
 // deleted. Taking the lock only once nothing is left that can say no is what
 // keeps a lost race from leaving one behind.
 func roll(loaded Loaded, live Live, plan Plan, result Result, opts Options, report *reporter) (Result, error) {
-	if err := guardReplacementFn(live.WorkloadID); err != nil {
+	if err := guardRollout(live.WorkloadID, "nothing was built or rolled out"); err != nil {
 		return result, err
 	}
 
@@ -71,12 +71,12 @@ func roll(loaded Loaded, live Live, plan Plan, result Result, opts Options, repo
 	// A file that moved the sizing as well as the version rides both in on the
 	// same swap: the platform takes runtime alongside the artifact, so there is
 	// no second call and no window where one half is live and the other is not.
-	runtime, err := rollRuntime(loaded, plan)
+	sizing, err := rollRuntime(loaded, plan)
 	if err != nil {
 		return result, err
 	}
 
-	return replace(live.WorkloadID, made, lock, runtime, result, opts, report)
+	return replace(live.WorkloadID, made, lock, sizing, result, opts, report)
 }
 
 // candidateArtifact is the version to roll onto.
@@ -253,13 +253,13 @@ func confirmRoll(workloadName string, opts Options) (bool, error) {
 			"Re-run with --yes to say so explicitly")
 }
 
-// replace starts the rollout and follows it to the end. runtime is nil unless
-// the sizing changed too, in which case it travels with the swap.
+// replace starts the rollout and follows it to the end. sizing is nil unless
+// the runtime block changed too, in which case it travels with the swap.
 func replace(
 	workloadID string,
 	made version,
 	lock bool,
-	runtime json.RawMessage,
+	sizing json.RawMessage,
 	result Result,
 	opts Options,
 	report *reporter,
@@ -267,7 +267,7 @@ func replace(
 	// The guard that actually holds. The live state can have changed since
 	// the one at the top, and this is the last moment before a swap that
 	// cannot be taken back by refusing it.
-	if err := guardReplacementFn(workloadID); err != nil {
+	if err := guardRollout(workloadID, "the version serving keeps serving"); err != nil {
 		return result, err
 	}
 
@@ -283,7 +283,7 @@ func replace(
 	var started *workload.Replacement
 
 	err := report.run("Rolling out the new version", func() error {
-		replacement, startErr := startReplacementFn(workloadID, made.ID, runtime)
+		replacement, startErr := startReplacementFn(workloadID, made.ID, sizing)
 		started = replacement
 
 		return startErr

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -267,7 +267,8 @@ func replace(
 	// The guard that actually holds. The live state can have changed since
 	// the one at the top, and this is the last moment before a swap that
 	// cannot be taken back by refusing it.
-	if err := guardRollout(workloadID, "the version serving keeps serving"); err != nil {
+	if err := guardRollout(workloadID,
+		"the version serving keeps serving and the one just minted is left unpromoted"); err != nil {
 		return result, err
 	}
 
@@ -292,17 +293,25 @@ func replace(
 		return result, fmt.Errorf("cannot roll workload %s onto artifact %s: %w", workloadID, made.ID, err)
 	}
 
-	result.Action = ActionRolled
-
 	if opts.Detach {
+		// Nobody is waiting, so the request is the whole of what this run did.
+		result.Action = ActionRolled
+
 		report.say("  Rollout of %s onto artifact %s requested; not waiting.\n", workloadID, made.ID)
 
 		return result, nil
 	}
 
+	// Recorded after the wait rather than after the POST. A rollout that ends
+	// failed never promotes and leaves the previous version serving, so a run
+	// that reported "rolled" would be naming an outcome the workload did not
+	// reach. What was attempted is still legible: the plan says what was
+	// wanted and the artifact and build ids say what was made.
 	if err := awaitRollout(workloadID, started, opts, report); err != nil {
 		return result, err
 	}
+
+	result.Action = ActionRolled
 
 	return settle(workloadID, result, opts, report)
 }

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -214,14 +214,37 @@ func TestRun_ReplacementInFlightStopsBeforeAnythingIsMade(t *testing.T) {
 	var tr track
 
 	f := wiredRoll(&tr)
-	f.guard = func(string) error { return errors.New("workload wl-1 already has a replacement in progress") }
+	f.guard = func(workloadID string) error {
+		return fmt.Errorf("workload %s: %w (status switching)", workloadID, workload.ErrReplacementInFlight)
+	}
 
 	install(t, f)
 
 	_, _, err := runIn(t, newImage(), Options{NonInteractive: true})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already has a replacement in progress")
+	assert.Contains(t, err.Error(), "a replacement is already in progress")
+	assert.NotContains(t, err.Error(), "cannot tell whether",
+		"a refusal travels in its own words; only a failure to find out gets the operation named for it")
 	assert.Empty(t, tr.steps, "nothing may be created while a rollout is running")
+}
+
+// The other half of the roll guard's contract: a route that could not answer
+// says nothing about the deploy it stopped, so the operation is named for it.
+func TestRun_RollNamesWhatItStoppedWhenTheGuardCannotAnswer(t *testing.T) {
+	var tr track
+
+	f := wiredRoll(&tr)
+	f.guard = func(string) error { return errors.New("HTTP error: 500 Internal Server Error") }
+
+	install(t, f)
+
+	_, _, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		"cannot tell whether workload 68b0c1d2e3f4a5b6c7d8e9f0 already has a rollout in progress, "+
+			"so nothing was built or rolled out")
+	assert.Contains(t, err.Error(), "500 Internal Server Error")
+	assert.Empty(t, tr.steps, "a guard that could not answer is not permission to proceed")
 }
 
 // Decision 1: rolling production is allowed, and typing the name is the whole
@@ -338,7 +361,7 @@ func TestRun_LockIsNotTakenWhenTheFinalGuardRefuses(t *testing.T) {
 			return nil
 		}
 
-		return errors.New("workload wl-1 already has a replacement in progress")
+		return fmt.Errorf("workload wl-1: %w (status switching)", workload.ErrReplacementInFlight)
 	}
 
 	install(t, f)
@@ -347,7 +370,8 @@ func TestRun_LockIsNotTakenWhenTheFinalGuardRefuses(t *testing.T) {
 		Confirm: func(string, string) (bool, error) { return true, nil },
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already has a replacement in progress")
+	assert.Contains(t, err.Error(), "a replacement is already in progress")
+	assert.NotContains(t, err.Error(), "cannot tell whether")
 	assert.NotContains(t, tr.steps, "lock:art-2",
 		"a refused rollout must not leave an artifact locked for a swap that never happened")
 }
@@ -696,6 +720,58 @@ func TestRun_RollReusesTheVersionAnEarlierAttemptLeft(t *testing.T) {
 		tr.steps)
 	assert.Equal(t, ActionRolled, result.Action)
 	assert.Contains(t, stderr, "earlier attempt")
+}
+
+// The same reuse against the shape the platform actually answers with. The
+// file states the artifact type inside the spec, which the platform accepts;
+// it hoists the discriminator and returns it beside the spec, so the two
+// blocks disagree about where the type lives. Unreconciled, that read as a
+// field the draft was missing, no leftover ever described the file, and every
+// attempt minted another one: the same drift the plan had, on the path whose
+// whole job is to stop the pile.
+//
+// The package's other fixtures answer with the type inside the spec, which is
+// not what staging returns, which is why nothing else here catches it.
+func TestRun_LeftoverDraftIsReusedWhenThePlatformHoistsTheType(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("art-abandoned")
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
+	}
+	f.newArtifact = func(any) (*workload.Artifact, error) {
+		t.Fatal("the leftover says what the file says, wherever each of them keeps the type")
+
+		return nil, nil
+	}
+
+	// The platform's own shape: type beside the spec, never inside it.
+	docs := artifactDocs("art-abandoned", 9000)
+	f.artifactD = func(id string) (workload.Document, error) {
+		d, err := docs(id)
+		if err != nil {
+			return nil, err
+		}
+
+		spec, _ := d["spec"].(map[string]any)
+		delete(spec, "type")
+
+		d["type"] = "service"
+
+		return d, nil
+	}
+
+	install(t, f)
+
+	result, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]string{"guard", "sync", "build", "guard", "replace:art-abandoned", "await-rollout", "settle"},
+		tr.steps)
+	assert.Equal(t, ActionRolled, result.Action)
 }
 
 // An artifact's spec is fixed when it is created, so a draft left by an

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -774,6 +774,78 @@ func TestRun_LeftoverDraftIsReusedWhenThePlatformHoistsTheType(t *testing.T) {
 	assert.Equal(t, ActionRolled, result.Action)
 }
 
+// Normalising where the type lives is not enough on its own: the walk that
+// follows compares by exact equality, so a file spelling it "Service" against
+// a live "service", or a document carrying no type at all, each read as a
+// difference no deploy can settle. The leftover is refused, another draft is
+// minted, and the next attempt refuses that one too.
+func TestRun_LeftoverDraftIsReusedAcrossTypeSpellingAndSilence(t *testing.T) {
+	for name, live := range map[string]func(workload.Document){
+		"different spelling": func(d workload.Document) { d["type"] = "Service" },
+		"no type at all":     func(d workload.Document) { delete(d, "type") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			var tr track
+
+			f := builtRoll(&tr)
+			f.linked = func(string) bool { return true }
+			f.project = syncedProject("art-abandoned")
+			f.getArtifact = func(id string) (*workload.Artifact, error) {
+				return &workload.Artifact{ID: id, Status: workload.ArtifactStatusDraft}, nil
+			}
+			f.newArtifact = func(any) (*workload.Artifact, error) {
+				t.Fatal("the leftover says what the file says; a spelling is not a different kind")
+
+				return nil, nil
+			}
+
+			docs := artifactDocs("art-abandoned", 9000)
+			f.artifactD = func(id string) (workload.Document, error) {
+				d, err := docs(id)
+				if err != nil {
+					return nil, err
+				}
+
+				spec, _ := d["spec"].(map[string]any)
+				delete(spec, "type")
+				live(d)
+
+				return d, nil
+			}
+
+			install(t, f)
+
+			result, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+			require.NoError(t, err)
+			assert.Equal(t, ActionRolled, result.Action)
+		})
+	}
+}
+
+// A rollout that starts and then ends failed never promotes, so the previous
+// version keeps serving. Reporting "rolled" would name an outcome the workload
+// did not reach, on the one field a caller reads to find out what happened.
+func TestRun_FailedRolloutDoesNotReportThatItRolled(t *testing.T) {
+	var tr track
+
+	f := wiredRoll(&tr)
+	f.waitReplace = func(_ string, started *workload.Replacement, _, _ time.Duration,
+		_ func(*workload.Replacement),
+	) (*workload.Replacement, error) {
+		started.Status = workload.ReplacementStatusFailed
+
+		return started, errors.New("rollout failed")
+	}
+
+	install(t, f)
+
+	result, _, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "still running the version it was")
+	assert.Equal(t, ActionUnchanged, result.Action,
+		"the version serving did not change, so the run did not roll")
+}
+
 // An artifact's spec is fixed when it is created, so a draft left by an
 // attempt that read an older file describes that older file. Promoting it
 // would roll out a version the yaml no longer asks for and report the deploy

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/datarobot/cli/internal/drapi"
@@ -487,7 +488,7 @@ func deployable(live Live, workloadName string) error {
 // the timeout for a transition that is never coming. Interrupted can be
 // started.
 func startable(live Live, workloadName string) error {
-	if live.Status != workload.WorkloadStatusSuspended {
+	if !strings.EqualFold(live.Status, workload.WorkloadStatusSuspended) {
 		return nil
 	}
 
@@ -595,12 +596,14 @@ func start(live Live, result Result, opts Options) (Result, error) {
 }
 
 // startingStatus is what to report for a start nobody waited for. An
-// unrecognised status is passed through rather than overwritten.
+// unrecognised status is passed through rather than overwritten, and the
+// recognised ones are matched the way every other status comparison here
+// matches, which is without regard to case.
 func startingStatus(was string) string {
-	switch was {
-	case workload.WorkloadStatusStopped,
-		workload.WorkloadStatusSuspended,
-		workload.WorkloadStatusInterrupted:
+	switch {
+	case strings.EqualFold(was, workload.WorkloadStatusStopped),
+		strings.EqualFold(was, workload.WorkloadStatusSuspended),
+		strings.EqualFold(was, workload.WorkloadStatusInterrupted):
 		return workload.WorkloadStatusSubmitted
 
 	default:

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -48,7 +48,7 @@ var (
 	listBuildsFn       = workload.ListArtifactBuilds
 	getCredentialFn    = workload.GetCredential
 	findCredentialFn   = workload.FindCredentialNamed
-	guardReplacementFn = workload.GuardNoActiveReplacement
+	guardReplacementFn = workload.RefuseActiveReplacement
 	startReplacementFn = workload.StartReplacement
 	waitReplacementFn  = workload.WaitForReplacement
 	updateSettingsFn   = workload.UpdateWorkloadSettings
@@ -170,8 +170,13 @@ func Run(opts Options) (Result, error) {
 		Status:     plan.State.String(),
 		Endpoint:   live.Endpoint,
 		ArtifactID: live.ArtifactID,
-		Action:     plan.Action(),
-		Locked:     live.Locked,
+		// Action records what this run did, not what the plan wanted, so it
+		// starts at "nothing" and each path below sets its own once it has
+		// acted. Seeding it from the plan reported a mutation for every run
+		// that failed before attempting one, including the two returns just
+		// below this. What was wanted stays readable under plan.action.
+		Action: ActionUnchanged,
+		Locked: live.Locked,
 	}
 
 	if err := bindLocked(loaded, plan, &result); err != nil {
@@ -185,6 +190,10 @@ func Run(opts Options) (Result, error) {
 	noteUnusedForce(plan, opts)
 
 	if opts.DryRun {
+		// The one run whose action is the plan's: it stops here, so printing
+		// the plan is the whole of what it did.
+		result.Action = plan.Action()
+
 		return result, nil
 	}
 
@@ -219,7 +228,42 @@ func lockOnly(live Live, result Result, opts Options) (Result, error) {
 		return result, err
 	}
 
+	// A rollout in flight is about to move the workload off the artifact this
+	// would make permanent, and locking cannot be undone. deployable does not
+	// cover it: the workload reports itself running for the whole of a swap,
+	// so the only way to know is to ask.
+	if err := guardRollout(live.WorkloadID, "the artifact was left as it is"); err != nil {
+		return result, err
+	}
+
 	return lock(result, newReporter(opts.Stderr, opts.Spinner))
+}
+
+// guardRollout refuses to act while a swap is already under way, and gives a
+// failure to find out the operation it stopped.
+//
+// It asks the narrow question rather than the guarded one. The full guard
+// spends a second GET disambiguating the replacement route's 404 between
+// "nothing in flight" and "no such workload"; every caller here reaches this
+// through Look, which already read the workload, and deployable, which already
+// refused the states where it is gone. So the ambiguity is settled before the
+// question is asked, and paying for it again would put a redundant round trip
+// on the quiet path of every deploy.
+//
+// Only the second kind of error is wrapped. The refusal already names the
+// workload, what is in flight and the remedy, so prefixing it would put
+// "cannot tell whether" in front of a sentence that plainly knows. A
+// replacement route that answered 500, or timed out, says nothing at all
+// about the run it just stopped, and the reader is looking at a deploy rather
+// than at a route.
+func guardRollout(workloadID, consequence string) error {
+	err := guardReplacementFn(workloadID)
+	if err == nil || errors.Is(err, workload.ErrReplacementInFlight) {
+		return err
+	}
+
+	return fmt.Errorf("cannot tell whether workload %s already has a rollout in progress, so %s: %w",
+		workloadID, consequence, err)
 }
 
 // noteIgnoreFile passes on the note about a deprecated ignore filename.

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -415,6 +415,33 @@ func TestRun_LockWithNothingToDoStillLocks(t *testing.T) {
 	assert.True(t, result.Locked)
 }
 
+// The lock a `--lock` run takes on an empty plan lands on whatever Look read as
+// serving, and a rollout in flight is about to move the workload off exactly
+// that artifact. Locking cannot be undone, so a lost race would leave the
+// outgoing version permanent and the rollout unable to complete. deployable
+// cannot catch it: the workload reports itself running for the whole of a swap.
+func TestRun_LockWithNothingToDoWaitsForARolloutInFlight(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return doc(t, liveWorkloadJSON), nil },
+		artifactD: func(string) (workload.Document, error) { return draftArtifact(t), nil },
+		guard: func(workloadID string) error {
+			return fmt.Errorf("workload %s: %w (status switching)",
+				workloadID, workload.ErrReplacementInFlight)
+		},
+		lock: func(string) (*workload.Artifact, error) {
+			t.Fatal("locking is one-way, so it may not land on a version being rolled off")
+
+			return nil, nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	_, _, err := runIn(t, bound, Options{NonInteractive: true, Lock: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "a replacement is already in progress")
+}
+
 // The same run without the flag stays as cheap as it was. Locking is one-way,
 // so an empty plan must never take it on its own initiative.
 func TestRun_NothingToDoWithoutLockLocksNothing(t *testing.T) {
@@ -1343,9 +1370,11 @@ func TestRun_CreateBoundToAnUnreadableArtifactFails(t *testing.T) {
 		},
 	})
 
-	_, _, err := runIn(t, boundArtifactManifest, Options{NonInteractive: true})
+	result, _, err := runIn(t, boundArtifactManifest, Options{NonInteractive: true})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already locked")
+	assert.Equal(t, ActionUnchanged, result.Action,
+		"this fails before apply is reached, so the envelope must not report the create the plan wanted")
 }
 
 func TestRun_DryRunOnABuildTrackSucceeds(t *testing.T) {

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -453,6 +453,16 @@ func TestRun_NothingToDoWithoutLockLocksNothing(t *testing.T) {
 
 			return nil, nil
 		},
+		// Recorded rather than left to install's silent no-op. The guard is
+		// justified by not spending a round trip on the quiet path, and this is
+		// the quietest path there is: an empty plan that is not locking has
+		// nothing to guard, so a guard appearing here would be pure cost and
+		// the default fake would hide it.
+		guard: func(string) error {
+			t.Fatal("a run that changes nothing has no rollout to guard against")
+
+			return nil
+		},
 	})
 
 	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -1148,6 +1148,27 @@ func TestRun_UnchangedTreeWithAnImageSkipsTheBuild(t *testing.T) {
 	assert.Contains(t, stderr, "Image is up to date")
 }
 
+// The same skip, from a build the platform reported in lower case. hasImage
+// asks the question BuildSummaryFor asks, so it folds the way that does: left
+// exact, a completed build reads as no image at all and every deploy spends
+// minutes rebuilding one that is already sitting on the artifact.
+func TestRun_UnchangedTreeWithALowercaseCompletedBuildSkipsTheBuild(t *testing.T) {
+	var tr track
+
+	f := linkedAndSynced(&tr)
+	f.builds = func(string, int) ([]workload.Build, error) {
+		return []workload.Build{{ID: "bld-0", Status: "completed"}}, nil
+	}
+
+	install(t, f)
+
+	_, stderr, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"sync", "create-workload"}, tr.steps)
+	assert.Contains(t, stderr, "Image is up to date")
+}
+
 // The same run where the previous attempt never got as far as an image. The
 // question is asked of the platform rather than assumed, because assuming
 // either way is wrong half the time.

--- a/internal/workload/up/state.go
+++ b/internal/workload/up/state.go
@@ -14,7 +14,11 @@
 
 package up
 
-import "github.com/datarobot/cli/internal/workload"
+import (
+	"strings"
+
+	"github.com/datarobot/cli/internal/workload"
+)
 
 // State is the live workload reduced to the cases that change what `up` does
 // next. The platform has eleven statuses; only these distinctions matter to a
@@ -80,6 +84,13 @@ func (s State) String() string {
 
 // stateFor maps a platform status onto the branch `up` takes.
 //
+// The comparison folds case, as the build, artifact and replacement
+// classifiers do, because the platform does not agree with itself about the
+// casing of its status enums: its build statuses are upper case where these
+// are lower. Read exactly, a workload answering "RUNNING" would fall to the
+// default below and be reported as still settling, and every deploy onto it
+// would be refused as unsettled.
+//
 // Two of these are judgement calls rather than transcription. "unknown" is
 // treated as settling rather than as an error, because it is what the server
 // reports before it has decided anything and erroring on it would fail
@@ -87,19 +98,19 @@ func (s State) String() string {
 // rather than with errored, because it is a workload the platform took down
 // and will let you start again, not one that broke.
 func stateFor(status string) State {
-	switch status {
-	case workload.WorkloadStatusRunning:
+	switch {
+	case strings.EqualFold(status, workload.WorkloadStatusRunning):
 		return StateRunning
 
-	case workload.WorkloadStatusStopped,
-		workload.WorkloadStatusSuspended,
-		workload.WorkloadStatusInterrupted:
+	case strings.EqualFold(status, workload.WorkloadStatusStopped),
+		strings.EqualFold(status, workload.WorkloadStatusSuspended),
+		strings.EqualFold(status, workload.WorkloadStatusInterrupted):
 		return StateStopped
 
-	case workload.WorkloadStatusTerminated:
+	case strings.EqualFold(status, workload.WorkloadStatusTerminated):
 		return StateTerminated
 
-	case workload.WorkloadStatusErrored:
+	case strings.EqualFold(status, workload.WorkloadStatusErrored):
 		return StateErrored
 
 	default:

--- a/internal/workload/up/state_test.go
+++ b/internal/workload/up/state_test.go
@@ -97,3 +97,25 @@ func TestState_String(t *testing.T) {
 	assert.Equal(t, "errored", StateErrored.String())
 	assert.Equal(t, "unknown", State(99).String())
 }
+
+// The platform does not agree with itself about the casing of its status
+// enums. Read exactly, a workload answering "RUNNING" falls to the default and
+// is reported as still settling, so every deploy onto a healthy workload is
+// refused as unsettled.
+func TestStateFor_FoldsCase(t *testing.T) {
+	for _, c := range []struct {
+		status string
+		want   State
+	}{
+		{"RUNNING", StateRunning},
+		{"Running", StateRunning},
+		{"STOPPED", StateStopped},
+		{"Suspended", StateStopped},
+		{"INTERRUPTED", StateStopped},
+		{"TERMINATED", StateTerminated},
+		{"Errored", StateErrored},
+		{"LAUNCHING", StateSettling},
+	} {
+		assert.Equal(t, c.want, stateFor(c.status), "status %q", c.status)
+	}
+}

--- a/internal/workload/up/state_test.go
+++ b/internal/workload/up/state_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStateFor(t *testing.T) {
@@ -118,4 +119,24 @@ func TestStateFor_FoldsCase(t *testing.T) {
 	} {
 		assert.Equal(t, c.want, stateFor(c.status), "status %q", c.status)
 	}
+}
+
+// startable reads the same status stateFor just folded, so an upper-case
+// suspended must still be refused. Left exact it would be treated as startable
+// and polled until the timeout for a transition the platform never makes.
+func TestStartable_FoldsSuspended(t *testing.T) {
+	err := startable(Live{Status: "SUSPENDED"}, "my-app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "suspended")
+
+	require.NoError(t, startable(Live{Status: "STOPPED"}, "my-app"),
+		"stopped and interrupted can still be started")
+}
+
+// The status a detached start reports is mapped the same way.
+func TestStartingStatus_FoldsTheStatesItMaps(t *testing.T) {
+	assert.Equal(t, workload.WorkloadStatusSubmitted, startingStatus("STOPPED"))
+	assert.Equal(t, workload.WorkloadStatusSubmitted, startingStatus("Interrupted"))
+	assert.Equal(t, "something-new", startingStatus("something-new"),
+		"an unrecognised status is still passed through rather than overwritten")
 }

--- a/internal/workload/up/version.go
+++ b/internal/workload/up/version.go
@@ -23,6 +23,7 @@ import (
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/internal/workload/sync"
 	"github.com/datarobot/cli/internal/workload/wapi"
 )
@@ -380,15 +381,16 @@ func describes(loaded Loaded, artifactID string) bool {
 	// too.
 	delete(want, keyArtifactRepositoryID)
 
-	// Both sides are normalised so the type is compared once, beside the spec.
-	// The file may write it in either place; the platform hoists it and answers
-	// beside the spec. Comparing the blocks as they arrive made the type read
-	// as a field one side was missing, so no leftover ever described the file
-	// and every attempt minted another one: the pile reuse exists to prevent.
-	// Normalising both rather than assuming a shape means neither a file nor a
-	// route that puts it in the other place can reopen that.
-	hoistArtifactType(want)
-	hoistArtifactType(doc)
+	// The type is settled before the walk and taken out of both sides, because
+	// the walk cannot answer it correctly. It compares by exact equality, so a
+	// file saying "Service" against a live "service", or a document that
+	// carries no type at all, would each read as a difference no deploy can
+	// settle: the leftover is refused, another draft is minted, and the next
+	// attempt refuses that one too. It is the same question the plan asks, so
+	// it is asked the same way, folded and with only the live side defaulted.
+	if !sameArtifactTypeIn(want, doc) {
+		return false
+	}
 
 	// Both directions, which is the difference between this and measuring
 	// drift. Subset catches a value the file changed or added; Extra catches
@@ -397,6 +399,32 @@ func describes(loaded Loaded, artifactID string) bool {
 	// reused, and it is rolled out still carrying the variable that was
 	// deleted, which minting a fresh artifact would have dropped.
 	return len(Subset(want, doc)) == 0 && len(Extra(want, doc)) == 0
+}
+
+// sameArtifactTypeIn reports whether two artifact blocks name the same kind,
+// and takes the type out of both so the caller's walk never sees it.
+//
+// Placement is normalised first, since a file may write the type inside the
+// spec while the platform answers with it beside one. Then the comparison is
+// the plan's: folded, because the platform does not agree with itself about
+// the casing of its enums, and with only the live side defaulted, because an
+// artifact that states no type is a service while a file that states none has
+// no opinion and is owed no difference.
+func sameArtifactTypeIn(want, have map[string]any) bool {
+	hoistArtifactType(want)
+	hoistArtifactType(have)
+
+	wanted, _ := want[keyType].(string)
+	running, _ := have[keyType].(string)
+
+	delete(want, keyType)
+	delete(have, keyType)
+
+	if wanted == "" {
+		return true
+	}
+
+	return manifest.SameArtifactType(wanted, manifest.ArtifactTypeOrDefault(running))
 }
 
 // linkProject points the project at the new version, so the sync uploads into

--- a/internal/workload/up/version.go
+++ b/internal/workload/up/version.go
@@ -380,6 +380,16 @@ func describes(loaded Loaded, artifactID string) bool {
 	// too.
 	delete(want, keyArtifactRepositoryID)
 
+	// Both sides are normalised so the type is compared once, beside the spec.
+	// The file may write it in either place; the platform hoists it and answers
+	// beside the spec. Comparing the blocks as they arrive made the type read
+	// as a field one side was missing, so no leftover ever described the file
+	// and every attempt minted another one: the pile reuse exists to prevent.
+	// Normalising both rather than assuming a shape means neither a file nor a
+	// route that puts it in the other place can reopen that.
+	hoistArtifactType(want)
+	hoistArtifactType(doc)
+
 	// Both directions, which is the difference between this and measuring
 	// drift. Subset catches a value the file changed or added; Extra catches
 	// one it removed. Without the second, deleting an environment variable

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -104,25 +104,17 @@ func knownWorkloadStatuses() []string {
 // reason to bail. A workload that never leaves them surfaces via the timeout
 // rather than a spurious "settled" error on the first, still-stale poll.
 func IsTerminalWorkloadStatus(s string) bool {
-	switch s {
-	case WorkloadStatusRunning,
-		WorkloadStatusErrored,
-		WorkloadStatusTerminated:
-		return true
-	}
-
-	return false
+	return IsWorkloadErrorStatus(s) || strings.EqualFold(s, WorkloadStatusRunning)
 }
 
 // IsWorkloadErrorStatus reports whether s is a terminal failure a caller should
 // surface as an error rather than a settled state.
+//
+// Folded, like every other status comparison in this package: the platform
+// does not agree with itself about the casing of its enums, and a terminal
+// status read as non-terminal is a poll loop that runs to its timeout.
 func IsWorkloadErrorStatus(s string) bool {
-	switch s {
-	case WorkloadStatusErrored, WorkloadStatusTerminated:
-		return true
-	}
-
-	return false
+	return strings.EqualFold(s, WorkloadStatusErrored) || strings.EqualFold(s, WorkloadStatusTerminated)
 }
 
 // Workload is the projection of the server's workload document the CLI


### PR DESCRIPTION
## CHANGES

- The in-flight rollout guard was only on the roll. Added it to the runtime-only resize, and to `up --lock` on an empty plan, which otherwise took a one-way lock on the version a rollout was moving off.
- A manifest with `type` under `artifact.spec` made every `up` mint a version and roll, for ever: the platform keeps the type on the artifact and strips it from the spec, so it always read as missing. The draft-reuse check had the same bug and piled up drafts. Both now normalise before comparing.
- A guard refusal now reads differently from a route that could not answer, the refusal drops a blank artifact field, and it no longer re-fetches a workload the run already has.
- Build and workload status checks fold case, matching the artifact one.
- A run refused before it attempted anything no longer reports the plan's action as something it did, and a rollout that starts and then fails no longer reports that it rolled. Worth knowing that `reportable()` emits the envelope on failures too, so anything reading `action` for intent rather than outcome now sees `unchanged` there; `plan.action` still carries what was wanted.

## TESTING

On staging: the manifest that rolled on every run now prints "Already up to date", both guards refuse a live in-flight replacement, and neither over-refuses once it settles.

That run also settled an open question on the ticket: `PATCH /workloads/{id}/settings/` merges rather than replaces, so the runtime-merge layer the ticket planned is not needed.

## NOTES

`GuardNoActiveReplacement` has no production caller now that the deploy paths use the variant skipping the existence probe. Kept as the entry point for a command taking a workload id from a flag; happy to drop it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `up` deploy, lock, resize, and rollout guard behavior; mistakes could block deploys or allow queued swaps, though coverage is broad in unit tests.
> 
> **Overview**
> Fixes deploy loops and unsafe paths where the platform’s inconsistent status casing and artifact shape made `up` think work was always needed or let swaps proceed when they should not.
> 
> **Artifact type handling** hoists `type` out of `artifact.spec` before comparing manifest vs live (`hoistArtifactType` in load/plan/version, `liveArtifactType` in look). Spec diffs no longer treat a file-side type inside the spec as missing on the server; draft reuse uses the same normalization. Plan compares types with `ArtifactTypeOrDefault` on the live side so unstated live type reads as service and plan lines stay accurate.
> 
> **Replacement guarding** extends beyond roll: runtime-only retune and empty-plan `--lock` call `guardRollout`, which uses `RefuseActiveReplacement` (skips redundant workload existence GET after `Look`). Refusals wrap `ErrReplacementInFlight`; messages omit empty candidate artifact ids. Lookup failures get operation-specific “cannot tell whether…” wording distinct from in-flight refusals.
> 
> **Status classifiers** use case-insensitive checks for build terminal/error, replacement terminal/failed, and workload `stateFor`.
> 
> **Run result semantics** initialize `result.Action` to `unchanged` until apply succeeds (dry-run still reflects `plan.action`); early guard failures no longer report the planned action as done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7ea4c278b5395e3d3098dec94b5cae7514f1817. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
