### PR TITLE
docs(review): add rules for editing user-owned files

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -8,6 +8,7 @@ Catch silent failures, resource leaks, data corruption, poor error handling, pla
 - **bugbot-errors.md** — Error wrapping, user-facing messages, error handling patterns
 - **bugbot-security.md** — Security boundaries, validation, threat models
 - **bugbot-validation.md** — Input validation, error messages, test coverage
+- **bugbot-user-files.md** — Editing files the user owns: comment preservation, round-trip symmetry
 
 ## Resource & Operations Rules
 

--- a/.cursor/bugbot-errors.md
+++ b/.cursor/bugbot-errors.md
@@ -19,3 +19,14 @@ When multiple errors can occur, document which error is returned and why.
 ## Avoid Cryptic Error Messages
 
 Error messages must explain what operation failed and why, not just return the system error.
+
+## One File State, One Message
+
+A file state both a read path and a write path can reject must produce one message from
+one shared sentinel — not two phrasings that differ by which path reached the file first.
+
+## Classification Errors Are Not User Messages
+
+An error whose only consumer is a boolean — file-type predicates, "is this ours" checks — must
+not be phrased as user guidance. Someone will later "align" it with a real message and put
+a remedy into a string nothing prints.

--- a/.cursor/bugbot-user-files.md
+++ b/.cursor/bugbot-user-files.md
@@ -1,0 +1,46 @@
+# Editing Files the User Owns
+
+Applies to code that writes back a file a human authored and keeps under version
+control — `.datarobot.yaml`, `.env`, and any project file the CLI edits in place
+rather than regenerating.
+
+## Re-emit, Do Not Regenerate
+
+In-place edits must re-emit the parsed node tree, never marshal a struct. Regenerating
+drops comments, unknown keys, and key order the user relies on.
+
+## CLI Annotation Dies With the CLI Key
+
+A marker the CLI wrote must be removed with the key it annotates, and user annotation
+must survive. Attach markers so they cannot outlive their key, and regenerate CLI help
+text from its source rather than parsing it back out of the file.
+
+## Removal Must Mirror Insertion
+
+Every node an insert moved, stole, or attached must be restored by the matching removal.
+Review the insert and the delete as one pair — an asymmetry is silent data loss in the
+user's file.
+
+## Preserve Line Endings
+
+A rewrite must give the file back the line endings it came with. Encoders that emit LF
+turn a one-key edit on a CRLF file into a whole-file diff.
+
+## Refuse Rather Than Damage
+
+A file the edit cannot put back soundly must be refused, with the remedy that fits that
+refusal: multi-document streams, repeated keys that disagree, an anchor the rest of the
+file aliases, or an edit that would leave the file unrecognizable. Do not append one
+generic remedy to every refusal.
+
+## Compare Through Aliases
+
+A value reachable through a YAML alias must be compared resolved, not as the raw node.
+The reader resolves it, so a raw comparison matches nothing and leaves the file unchanged
+while reporting success.
+
+## Match Only What You Wrote
+
+An edit conditioned on an id must verify that id inside the same parse that performs the
+edit. A separate read-then-write leaves a window for a concurrent command to rebind the
+file between the check and the write.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,7 @@ All PRs are reviewed against **bugbot rules** in [.cursor/BUGBOT.md](.cursor/BUG
 - **Error Handling** — Wrapping errors with context, user-facing messages, not silently ignoring errors
 - **Security** — Input validation, security boundaries, threat models
 - **Testing** — Race detector, error path coverage, test seams
+- **User Files** — In-place edits to `.datarobot.yaml` and `.env`: comment preservation, round-trip symmetry
 
 **Resource & Operations** (prevents hangs, leaks, platform bugs):
 
@@ -204,6 +205,7 @@ All PRs are reviewed against **bugbot rules** in [.cursor/BUGBOT.md](.cursor/BUG
 - **Commands**: Use `lipgloss/table` + `tui.TableBorderStyle`, consistent styling, test output formatting
 - **JSON output purity**: When `--output-format json` is set, stdout must contain only valid JSON. All deprecation warnings, logs, usage, and update hints go to stderr
 - **Platforms**: Add build tags, match signatures, test on target platforms
+- **User files**: Re-emit the parsed tree, never regenerate; CLI markers must die with the key they annotate; refuse a file you cannot put back soundly
 
 Refer to [.cursor/BUGBOT.md](.cursor/BUGBOT.md) for detailed rules and examples during PR review.
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -26,6 +26,7 @@ If you're new to developing the CLI, start here:
 - **[Plugins](plugins.md)**&mdash;develop and test CLI plugins, understand the plugin system architecture.
 - **[Remote plugins](remote-plugins.md)**&mdash;create and distribute remote plugins, plugin registry management.
 - **[Workload state directory validation](workload-wapi-validation.md)**&mdash;reference for `validator/v10` tags and cross-field rules for workload local state.
+- **[Editing user-owned files](editing-user-files.md)**&mdash;rules for in-place edits to `.datarobot.yaml` and `.env`: comment preservation, round-trip symmetry, and when a refusal beats a rewrite.
 - **[Releasing](releasing.md)**&mdash;release process, versioning strategy, and GoReleaser configuration.
 - **[Telemetry](telemetry.md)**&mdash;how usage analytics linked to your DataRobot user ID are collected, how to add events, and how to opt out.
 

--- a/docs/development/editing-user-files.md
+++ b/docs/development/editing-user-files.md
@@ -1,0 +1,101 @@
+# Editing user-owned files
+
+Most files the CLI writes are its own: `drconfig.yaml`, the state directory under
+`.datarobot/`, cached artifacts. Two are not. `.datarobot.yaml` and `.env` are authored by
+a human, committed, and reviewed &mdash; and the CLI still has to edit them in place.
+
+That makes every such write a round trip through someone else's file. This page collects
+the rules that fall out of it. The machine-readable form lives in
+[.cursor/bugbot-user-files.md](../../.cursor/bugbot-user-files.md).
+
+## The invariant
+
+> Give back everything you moved. Take nothing that was not yours.
+
+Both halves matter, and they are enforced in different places.
+
+## Re-emit, never regenerate
+
+Edits parse to a node tree, mutate it, and re-emit. They do not unmarshal into a struct
+and marshal it back, which would silently drop comments, unknown keys, and key order.
+
+`WriteWorkloadID` in `internal/workload/manifest/write.go` is the reference: it reads,
+parses to `yaml.Node`, runs the alias guard, mutates one key, and encodes the same tree.
+Its doc comment names it "the one edit the CLI makes to a file the user owns."
+
+## Annotation the CLI wrote dies with the key it wrote
+
+When the CLI adds `workloadId` it also adds a `# managed by the CLI` marker. That marker
+is attached as a **line comment on the key**, so removing the key removes the marker. No
+cleanup step has to remember it. The same holds for every generated key: `mapping()`
+attaches field comments as `LineComment`, never as free-floating text.
+
+Contrast with what the same function does to comments it did *not* write. Inserting
+`workloadId` at the top of the mapping steals the old first key's head comment, because a
+comment at the top of a file is a banner about the file rather than about whichever key
+happens to be first.
+
+That steal creates a debt. Any code that removes the binding has to hand the banner back
+to whatever key becomes first again. Review insert and remove as one pair: an asymmetry
+between them is not a cosmetic bug, it is data loss in a file the user committed.
+
+The `.env` builder meets the same invariant with a different mechanism, because it works on
+text rather than a node tree. `mergedDotenvChunks` in `internal/envbuilder/dotenv.go`
+splits the file into prompt-backed variables, user-provided variables, and everything
+else; CLI help comments are discarded on read and regenerated from `UserPrompt.HelpLines()`
+on write, while user comments are carried through untouched. Same invariant, different
+implementation. Do not try to unify them.
+
+## Refuse rather than damage
+
+Some files cannot be edited and put back soundly. Refuse them, each with the remedy that
+fits it:
+
+| Shape | Why it cannot be edited |
+| --- | --- |
+| More than one YAML document | Re-emitting moves comments between documents |
+| Repeated keys that disagree | Removing one silently promotes the other |
+| A value carrying an anchor the file aliases | Removing it strands the alias and the file never loads again |
+| The edit would leave no recognized key | The result is not a manifest, and the file still exists, so nothing falls back to setup |
+
+Do not append one generic remedy to all of them. "Remove that line" is correct advice for
+one of these and walks the user into a broken file for another.
+
+## Line endings
+
+YAML and JSON encoders emit LF. A CRLF file re-emitted unchanged lands in review as a
+whole-file diff, so a rewrite must restore the terminators the file came with. Convert
+back only a file that is *wholly* CRLF &mdash; guessing from one stray terminator is how a
+single CRLF line, or a CRLF inside a block scalar where it is content rather than a line
+ending, converts everything around it.
+
+## Compare through aliases, and match inside the edit
+
+Two rules that only look like details until they bite:
+
+- A value written as a YAML alias is resolved by the reader, so it is the value the project
+  actually deploys to. Comparisons must resolve too. Comparing the raw node reads the
+  anchor name, matches nothing, and leaves the file as stale as it found it while
+  reporting success.
+- An edit conditioned on an id must check that id inside the same parse that performs the
+  edit. Checking against a separate read leaves a window for a concurrent `dr workload up`
+  to write a fresh binding that the edit then removes without ever having looked at it.
+
+## Errors that are classifications, not messages
+
+Not every YAML validation error is user-facing, and the two must not be aligned.
+
+`PromptFileSchema.Validate` in `internal/envbuilder/schema.go` returns errors such as
+`document is empty` and `root must be a mapping (sections)`. Its only consumer is
+`isPromptFile`, a boolean: the errors are discarded, and non-conforming files are skipped
+silently so copier answer files and version manifests under `.datarobot/` do not raise
+anything. Those strings are a classification signal, not advice.
+
+The manifest's superficially identical refusal &mdash; `root must be a YAML mapping` in
+`WriteWorkloadID` &mdash; *is* printed, so it carries an explanation and a remedy, and the read
+and write paths that can both reject a file state should answer from one shared sentinel
+rather than two phrasings.
+
+Adding a remedy to the prompt-file strings would put user guidance into a string nothing
+prints, about a file the CLI deliberately ignores. Before aligning two error messages that
+read alike, check who consumes each one.


### PR DESCRIPTION
# RATIONALE

`.datarobot.yaml` and `.env` are the two files the CLI writes that it does not own. A
human authors them, commits them, and reviews the diff. Every edit the CLI makes to them
is a round trip through someone else's file, and the rules that fall out of that
constraint were spread across doc comments in two packages that solve the same problem in
different ways.

This came out of review on #822, which adds the first path that *removes* a key from
`.datarobot.yaml` rather than adding one. Reviewing it meant reconstructing the contract
from `setWorkloadID`'s comments each time. Writing it down once is cheaper, and gives
bugbot something to apply.

It also records a boundary that cost real review time. `PromptFileSchema.Validate` in
`internal/envbuilder/schema.go` returns `document is empty` and
`root must be a mapping (sections)`, which read like siblings of `WriteWorkloadID`'s
`root must be a YAML mapping`. They are not. The schema errors reach only `isPromptFile`,
a boolean — they are discarded, and non-conforming files are skipped silently so copier
answer files and version manifests under `.datarobot/` do not raise anything. Aligning
the two would put a remedy into a string nothing prints, about a file the CLI
deliberately ignores.

## CHANGES

- **`.cursor/bugbot-user-files.md`** (new) — seven rules for in-place edits to
  user-owned files: re-emit rather than regenerate, CLI annotation dies with the key it
  annotates, removal mirrors insertion, preserve line endings, refuse rather than damage,
  compare through aliases, match only what you wrote. Indexed under High-Risk in
  `.cursor/BUGBOT.md`.
- **`.cursor/bugbot-errors.md`** — two rules: one file state gets one message from one
  shared sentinel across read and write paths; an error whose only consumer is a boolean
  must not be phrased as user guidance.
- **`docs/development/editing-user-files.md`** (new) — the prose behind the rules,
  anchored on real code: `WriteWorkloadID` re-emitting the parsed tree, `setWorkloadID`
  attaching the CLI marker as a line comment so it dies with its key while the file
  banner it steals is a debt the removal path owes back, and `mergedDotenvChunks` meeting
  the same invariant on text rather than a node tree. Linked from the dev README.
- **`AGENTS.md`** — one review-category bullet and one quick-principle bullet.

Docs and rule files only. No Go changes, no behavior change.

## NOTES

Every symbol the doc cites is present on `main` today. The removal-side helpers from #822
(`editRoot`, `partition`, `matchLineEndings`, `ErrEmptyFile`) are deliberately **not**
cited — the sections covering removal and refusal are written as requirements the removal
path must meet rather than as descriptions of existing code. Once #822 merges those
become citable and the doc can name them; the rules hold either way.

## RELATED

- #822 — `dr workload delete` clearing the stale `workloadId`, the change this contract
  was reconstructed during.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and review-rule updates only; no application code or CLI behavior changes.
> 
> **Overview**
> Codifies how the CLI must treat **in-place edits** to `.datarobot.yaml` and `.env` — files humans own — so review and BugBot can enforce the contract instead of reconstructing it from scattered code comments.
> 
> Adds **`.cursor/bugbot-user-files.md`** (indexed as High-Risk in **BUGBOT.md**) with seven rules: re-emit parsed YAML trees instead of struct round-trips, tie CLI markers to the keys they annotate, mirror removal to insertion, preserve line endings, refuse unsafe shapes with specific remedies, resolve aliases when comparing values, and validate workload IDs in the same parse as the write.
> 
> Extends **`.cursor/bugbot-errors.md`** with *one file state, one shared sentinel* across read/write paths and a warning not to phrase boolean-only classification errors (e.g. prompt-file detection) as user-facing guidance.
> 
> Adds **`docs/development/editing-user-files.md`** (linked from the dev README) explaining the invariant and pointing at reference implementations like `WriteWorkloadID` and `mergedDotenvChunks`, plus parallel updates in **`AGENTS.md`**. **No runtime or Go behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49d0c653cb6aee01cd7759d7a4f6ababc0be9321. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->