### PR TITLE
[RAPTOR-19719] feat(workload): retry build trigger on retry-safe statuses, surface API error detail

### DIFF
--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -32,6 +32,13 @@ type HTTPError struct {
 	StatusCode int
 	URL        string
 	Detail     string
+
+	// Body is up to 512 bytes of the error response, raw and uninterpreted.
+	// DataRobot's APIs do not agree on an error envelope (FastAPI services
+	// answer {"detail": ...}, the drflask Public API {"message": ...}, a
+	// proxy plain text), so drapi carries the bytes and a caller that knows
+	// its API's shape reads meaning into them — e.g. workload/apiclient.
+	Body []byte
 }
 
 // Error implements the error interface for HTTPError. Both shapes carry the

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -34,10 +34,12 @@ type HTTPError struct {
 	Detail     string
 }
 
-// Error implements the error interface for HTTPError.
+// Error implements the error interface for HTTPError. Both shapes carry the
+// URL: a message like "Internal server error" identifies nothing without the
+// endpoint it came from.
 func (e *HTTPError) Error() string {
 	if e.Detail != "" {
-		return fmt.Sprintf("HTTP %d %s: %s", e.StatusCode, http.StatusText(e.StatusCode), e.Detail)
+		return fmt.Sprintf("HTTP %d %s: %s (url: %s)", e.StatusCode, http.StatusText(e.StatusCode), e.Detail, e.URL)
 	}
 
 	return fmt.Sprintf("HTTP error: %d %s (url: %s)", e.StatusCode, http.StatusText(e.StatusCode), e.URL)

--- a/internal/drapi/helpers.go
+++ b/internal/drapi/helpers.go
@@ -15,7 +15,6 @@
 package drapi
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -45,49 +44,17 @@ func EndpointURL(path string, query url.Values) (string, error) {
 // up to 512 bytes of the response body for context. It always closes
 // resp.Body, so callers must not read it after calling this function.
 //
-// When the body is a FastAPI-style `{"detail": ...}` document, the detail is
-// lifted into HTTPError.Detail so the user reads the server's own sentence
-// instead of a raw JSON dump; anything else keeps the body= form, whose URL
-// is what makes an unstructured failure diagnosable.
+// The body is carried raw on HTTPError.Body, uninterpreted: drapi serves
+// every DataRobot API the CLI talks to, and they do not agree on an error
+// envelope, so reading meaning into the bytes is a caller's job (see
+// workload/apiclient for the Workload API's).
 func ErrFromResp(resp *http.Response, requestURL string) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-	if detail := ErrorDetail(body); detail != "" {
-		return &HTTPError{StatusCode: resp.StatusCode, URL: requestURL, Detail: detail}
-	}
-
 	if len(body) > 0 {
-		return fmt.Errorf("%w: body=%s", &HTTPError{StatusCode: resp.StatusCode, URL: requestURL}, body)
+		return fmt.Errorf("%w: body=%s", &HTTPError{StatusCode: resp.StatusCode, URL: requestURL, Body: body}, body)
 	}
 
 	return &HTTPError{StatusCode: resp.StatusCode, URL: requestURL}
-}
-
-// ErrorDetail pulls the "detail" field out of a FastAPI-style JSON error
-// body, or "" when the body is not such a document. Non-string details
-// (e.g. validation error arrays) are re-encoded as JSON rather than dropped:
-// they carry the field-level messages the caller needs.
-//
-// This is the one place that knows the server's error envelope; callers that
-// want a different fallback (e.g. the raw body) layer it on the "" return.
-func ErrorDetail(body []byte) string {
-	var payload struct {
-		Detail any `json:"detail"`
-	}
-
-	if err := json.Unmarshal(body, &payload); err != nil || payload.Detail == nil {
-		return ""
-	}
-
-	if detail, ok := payload.Detail.(string); ok {
-		return detail
-	}
-
-	encoded, err := json.Marshal(payload.Detail)
-	if err != nil {
-		return ""
-	}
-
-	return string(encoded)
 }

--- a/internal/drapi/helpers.go
+++ b/internal/drapi/helpers.go
@@ -15,6 +15,7 @@
 package drapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -43,13 +44,47 @@ func EndpointURL(path string, query url.Values) (string, error) {
 // ErrFromResp wraps a non-2xx *http.Response into a *HTTPError, capturing
 // up to 512 bytes of the response body for context. It always closes
 // resp.Body, so callers must not read it after calling this function.
+//
+// When the body is a FastAPI-style `{"detail": ...}` document, the detail is
+// lifted into HTTPError.Detail so the user reads the server's own sentence
+// instead of a raw JSON dump; anything else keeps the body= form, whose URL
+// is what makes an unstructured failure diagnosable.
 func ErrFromResp(resp *http.Response, requestURL string) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	if detail := errorDetail(body); detail != "" {
+		return &HTTPError{StatusCode: resp.StatusCode, URL: requestURL, Detail: detail}
+	}
+
 	if len(body) > 0 {
 		return fmt.Errorf("%w: body=%s", &HTTPError{StatusCode: resp.StatusCode, URL: requestURL}, body)
 	}
 
 	return &HTTPError{StatusCode: resp.StatusCode, URL: requestURL}
+}
+
+// errorDetail pulls the "detail" field out of a FastAPI-style JSON error
+// body, or "" when the body is not such a document. Non-string details
+// (e.g. validation error arrays) are re-encoded as JSON rather than dropped:
+// they carry the field-level messages the caller needs.
+func errorDetail(body []byte) string {
+	var payload struct {
+		Detail any `json:"detail"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil || payload.Detail == nil {
+		return ""
+	}
+
+	if detail, ok := payload.Detail.(string); ok {
+		return detail
+	}
+
+	encoded, err := json.Marshal(payload.Detail)
+	if err != nil {
+		return ""
+	}
+
+	return string(encoded)
 }

--- a/internal/drapi/helpers.go
+++ b/internal/drapi/helpers.go
@@ -53,7 +53,7 @@ func ErrFromResp(resp *http.Response, requestURL string) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-	if detail := errorDetail(body); detail != "" {
+	if detail := ErrorDetail(body); detail != "" {
 		return &HTTPError{StatusCode: resp.StatusCode, URL: requestURL, Detail: detail}
 	}
 
@@ -64,11 +64,14 @@ func ErrFromResp(resp *http.Response, requestURL string) error {
 	return &HTTPError{StatusCode: resp.StatusCode, URL: requestURL}
 }
 
-// errorDetail pulls the "detail" field out of a FastAPI-style JSON error
+// ErrorDetail pulls the "detail" field out of a FastAPI-style JSON error
 // body, or "" when the body is not such a document. Non-string details
 // (e.g. validation error arrays) are re-encoded as JSON rather than dropped:
 // they carry the field-level messages the caller needs.
-func errorDetail(body []byte) string {
+//
+// This is the one place that knows the server's error envelope; callers that
+// want a different fallback (e.g. the raw body) layer it on the "" return.
+func ErrorDetail(body []byte) string {
 	var payload struct {
 		Detail any `json:"detail"`
 	}

--- a/internal/drapi/helpers_test.go
+++ b/internal/drapi/helpers_test.go
@@ -64,7 +64,7 @@ func TestEndpointURL_PropagatesConfigError(t *testing.T) {
 	assert.Empty(t, got)
 }
 
-func TestErrFromResp_WithBody(t *testing.T) {
+func TestErrFromResp_LiftsFastAPIDetail(t *testing.T) {
 	resp := &http.Response{
 		StatusCode: http.StatusInternalServerError,
 		Body:       io.NopCloser(strings.NewReader(`{"detail":"boom"}`)),
@@ -72,12 +72,39 @@ func TestErrFromResp_WithBody(t *testing.T) {
 
 	err := ErrFromResp(resp, "https://example.test/api/v2/files/")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `body={"detail":"boom"}`)
+	// The server's own sentence, not a raw JSON dump.
+	assert.Contains(t, err.Error(), "boom")
+	assert.NotContains(t, err.Error(), "body=")
 
 	var httpErr *HTTPError
 
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
+	assert.Equal(t, "boom", httpErr.Detail)
+}
+
+func TestErrFromResp_NonStringDetailIsReencoded(t *testing.T) {
+	// FastAPI validation errors carry detail as an array; the field-level
+	// messages must survive into the error text.
+	resp := &http.Response{
+		StatusCode: http.StatusUnprocessableEntity,
+		Body:       io.NopCloser(strings.NewReader(`{"detail":[{"msg":"field required"}]}`)),
+	}
+
+	err := ErrFromResp(resp, "https://example.test/api/v2/files/")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "field required")
+}
+
+func TestErrFromResp_NonDetailBodyKeepsBodyForm(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Body:       io.NopCloser(strings.NewReader("upstream connect error")),
+	}
+
+	err := ErrFromResp(resp, "https://example.test/api/v2/files/")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "body=upstream connect error")
 }
 
 func TestErrFromResp_EmptyBody(t *testing.T) {

--- a/internal/drapi/helpers_test.go
+++ b/internal/drapi/helpers_test.go
@@ -64,7 +64,11 @@ func TestEndpointURL_PropagatesConfigError(t *testing.T) {
 	assert.Empty(t, got)
 }
 
-func TestErrFromResp_LiftsFastAPIDetail(t *testing.T) {
+// ErrFromResp interprets nothing: drapi serves APIs that disagree on their
+// error envelope, so even a well-formed FastAPI detail document stays a raw
+// body= dump here. Reading meaning into it is a caller's job (see
+// workload/apiclient).
+func TestErrFromResp_WithBody(t *testing.T) {
 	resp := &http.Response{
 		StatusCode: http.StatusInternalServerError,
 		Body:       io.NopCloser(strings.NewReader(`{"detail":"boom"}`)),
@@ -72,39 +76,15 @@ func TestErrFromResp_LiftsFastAPIDetail(t *testing.T) {
 
 	err := ErrFromResp(resp, "https://example.test/api/v2/files/")
 	require.Error(t, err)
-	// The server's own sentence, not a raw JSON dump.
-	assert.Contains(t, err.Error(), "boom")
-	assert.NotContains(t, err.Error(), "body=")
+	assert.Contains(t, err.Error(), `body={"detail":"boom"}`)
 
 	var httpErr *HTTPError
 
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
-	assert.Equal(t, "boom", httpErr.Detail)
-}
-
-func TestErrFromResp_NonStringDetailIsReencoded(t *testing.T) {
-	// FastAPI validation errors carry detail as an array; the field-level
-	// messages must survive into the error text.
-	resp := &http.Response{
-		StatusCode: http.StatusUnprocessableEntity,
-		Body:       io.NopCloser(strings.NewReader(`{"detail":[{"msg":"field required"}]}`)),
-	}
-
-	err := ErrFromResp(resp, "https://example.test/api/v2/files/")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "field required")
-}
-
-func TestErrFromResp_NonDetailBodyKeepsBodyForm(t *testing.T) {
-	resp := &http.Response{
-		StatusCode: http.StatusBadGateway,
-		Body:       io.NopCloser(strings.NewReader("upstream connect error")),
-	}
-
-	err := ErrFromResp(resp, "https://example.test/api/v2/files/")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "body=upstream connect error")
+	assert.Empty(t, httpErr.Detail, "drapi does not read the envelope")
+	assert.JSONEq(t, `{"detail":"boom"}`, string(httpErr.Body),
+		"the raw bytes ride the error so a caller that knows its API's envelope can")
 }
 
 func TestErrFromResp_EmptyBody(t *testing.T) {

--- a/internal/drapi/post.go
+++ b/internal/drapi/post.go
@@ -18,12 +18,22 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/log"
 )
 
-func Post(url, info string, body any) (*http.Response, error) {
+// Post sends body as JSON. timeoutSecs optionally overrides the default
+// client timeout, the same seam Get has: a caller whose endpoint does slow
+// synchronous work server-side (e.g. triggering an image build) must outlive
+// the server's own internal budget or it abandons answers already on the way.
+func Post(url, info string, body any, timeoutSecs ...int) (*http.Response, error) {
+	timeout := DefaultClientTimeout
+	if len(timeoutSecs) > 0 {
+		timeout = time.Duration(timeoutSecs[0]) * time.Second
+	}
+
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
@@ -52,7 +62,7 @@ func Post(url, info string, body any) (*http.Response, error) {
 		return nil, err
 	}
 
-	resp, err := NewHTTPClient(DefaultClientTimeout).Do(req)
+	resp, err := NewHTTPClient(timeout).Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +106,8 @@ func restoreRequestBody(req *http.Request) error {
 	return nil
 }
 
-func PostJSON(url, info string, body, v any) error {
-	resp, err := Post(url, info, body)
+func PostJSON(url, info string, body, v any, timeoutSecs ...int) error {
+	resp, err := Post(url, info, body, timeoutSecs...)
 	if err != nil {
 		return err
 	}

--- a/internal/drapi/post_test.go
+++ b/internal/drapi/post_test.go
@@ -91,8 +91,7 @@ func TestPost_NonSuccess(t *testing.T) {
 
 // Non-success response bodies must reach the caller so server validation
 // details (e.g. a FastAPI {"detail":[...]} envelope) survive in the error.
-// The detail is lifted out of its envelope, so the assertion is on the
-// field-level messages, not the verbatim body.
+// The body arrives verbatim: drapi does not read any API's envelope.
 func TestPost_NonSuccess_IncludesBody(t *testing.T) {
 	defer resetTokenForTest(t, "test-token")()
 
@@ -107,8 +106,7 @@ func TestPost_NonSuccess_IncludesBody(t *testing.T) {
 	resp, err := Post(server.URL, "", map[string]string{}) //nolint:bodyclose // resp is nil on error; Post closes it before returning
 	require.Error(t, err)
 	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), "Field required")
-	assert.Contains(t, err.Error(), "spec")
+	assert.Contains(t, err.Error(), validationBody)
 
 	var httpErr *HTTPError
 

--- a/internal/drapi/post_test.go
+++ b/internal/drapi/post_test.go
@@ -91,6 +91,8 @@ func TestPost_NonSuccess(t *testing.T) {
 
 // Non-success response bodies must reach the caller so server validation
 // details (e.g. a FastAPI {"detail":[...]} envelope) survive in the error.
+// The detail is lifted out of its envelope, so the assertion is on the
+// field-level messages, not the verbatim body.
 func TestPost_NonSuccess_IncludesBody(t *testing.T) {
 	defer resetTokenForTest(t, "test-token")()
 
@@ -105,7 +107,8 @@ func TestPost_NonSuccess_IncludesBody(t *testing.T) {
 	resp, err := Post(server.URL, "", map[string]string{}) //nolint:bodyclose // resp is nil on error; Post closes it before returning
 	require.Error(t, err)
 	assert.Nil(t, resp)
-	assert.Contains(t, err.Error(), validationBody)
+	assert.Contains(t, err.Error(), "Field required")
+	assert.Contains(t, err.Error(), "spec")
 
 	var httpErr *HTTPError
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -420,8 +420,25 @@ func buildMultipartBody(filePath string, fields map[string]string) (*bytes.Buffe
 // extractErrorDetail attempts to pull a "detail" string from a JSON error body
 // returned by FastAPI. Falls back to the raw body if the field is absent.
 func extractErrorDetail(body []byte) string {
-	if detail := drapi.ErrorDetail(body); detail != "" {
-		return detail
+	if len(body) == 0 {
+		return ""
+	}
+
+	var payload struct {
+		Detail any `json:"detail"`
+	}
+
+	err := json.Unmarshal(body, &payload)
+	if err == nil && payload.Detail != nil {
+		switch detail := payload.Detail.(type) {
+		case string:
+			return detail
+		default:
+			encoded, encErr := json.Marshal(detail)
+			if encErr == nil {
+				return string(encoded)
+			}
+		}
 	}
 
 	return string(body)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -420,25 +420,8 @@ func buildMultipartBody(filePath string, fields map[string]string) (*bytes.Buffe
 // extractErrorDetail attempts to pull a "detail" string from a JSON error body
 // returned by FastAPI. Falls back to the raw body if the field is absent.
 func extractErrorDetail(body []byte) string {
-	if len(body) == 0 {
-		return ""
-	}
-
-	var payload struct {
-		Detail any `json:"detail"`
-	}
-
-	err := json.Unmarshal(body, &payload)
-	if err == nil && payload.Detail != nil {
-		switch detail := payload.Detail.(type) {
-		case string:
-			return detail
-		default:
-			encoded, encErr := json.Marshal(detail)
-			if encErr == nil {
-				return string(encoded)
-			}
-		}
+	if detail := drapi.ErrorDetail(body); detail != "" {
+		return detail
 	}
 
 	return string(body)

--- a/internal/workload/apiclient/apiclient.go
+++ b/internal/workload/apiclient/apiclient.go
@@ -1,0 +1,87 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package apiclient is the Workload API's own client layer over drapi.
+//
+// drapi serves every DataRobot API the CLI talks to, and those APIs do not
+// agree on an error envelope: the Workload API and its sibling FastAPI
+// services answer {"detail": ...}, the drflask-based Public API answers
+// {"message": ...}, and a proxy in between answers plain text. drapi
+// therefore carries a failed response's body raw and uninterpreted, and this
+// package is where the Workload API's envelope is read into meaning. The
+// same split exists for pipelines, whose client layer is internal/pipeline.
+package apiclient
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// PostJSON is drapi.PostJSON with the Workload API's error envelope applied:
+// a failure whose body is a {"detail": ...} document is rewrapped so the
+// caller reads the server's own sentence instead of a raw JSON dump. Every
+// other error passes through untouched.
+func PostJSON(url, info string, body, v any, timeoutSecs ...int) error {
+	return LiftDetail(drapi.PostJSON(url, info, body, v, timeoutSecs...))
+}
+
+// LiftDetail applies the Workload API's error envelope to an error minted by
+// drapi. When the error is an HTTPError whose raw body carries a FastAPI
+// detail, the detail becomes the error's message; anything else — nil, a
+// non-HTTP error, a body in some other shape — is returned as it came.
+func LiftDetail(err error) error {
+	var httpErr *drapi.HTTPError
+	if !errors.As(err, &httpErr) {
+		return err
+	}
+
+	detail := ErrorDetail(httpErr.Body)
+	if detail == "" {
+		return err
+	}
+
+	return &drapi.HTTPError{
+		StatusCode: httpErr.StatusCode,
+		URL:        httpErr.URL,
+		Detail:     detail,
+		Body:       httpErr.Body,
+	}
+}
+
+// ErrorDetail pulls the "detail" field out of a FastAPI-style JSON error
+// body, or "" when the body is not such a document. Non-string details
+// (e.g. validation error arrays) are re-encoded as JSON rather than dropped:
+// they carry the field-level messages the caller needs.
+func ErrorDetail(body []byte) string {
+	var payload struct {
+		Detail any `json:"detail"`
+	}
+
+	if err := json.Unmarshal(body, &payload); err != nil || payload.Detail == nil {
+		return ""
+	}
+
+	if detail, ok := payload.Detail.(string); ok {
+		return detail
+	}
+
+	encoded, err := json.Marshal(payload.Detail)
+	if err != nil {
+		return ""
+	}
+
+	return string(encoded)
+}

--- a/internal/workload/apiclient/apiclient_test.go
+++ b/internal/workload/apiclient/apiclient_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiclient
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorDetail(t *testing.T) {
+	for name, c := range map[string]struct {
+		body string
+		want string
+	}{
+		"string detail":   {`{"detail":"boom"}`, "boom"},
+		"array detail":    {`{"detail":[{"msg":"field required"}]}`, `[{"msg":"field required"}]`},
+		"no detail field": {`{"message":"drflask says hi"}`, ""},
+		"not json":        {"<html>504 Gateway Time-out</html>", ""},
+		"empty":           {"", ""},
+		"null detail":     {`{"detail":null}`, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, c.want, ErrorDetail([]byte(c.body)))
+		})
+	}
+}
+
+// A detail-bearing failure reads as the server's own sentence, with the
+// endpoint kept: "Internal server error" identifies nothing without it.
+func TestLiftDetail_RewrapsAnEnvelopedError(t *testing.T) {
+	inner := &drapi.HTTPError{
+		StatusCode: http.StatusUnprocessableEntity,
+		URL:        "https://example.test/api/v2/artifacts/a-1/builds/",
+		Body:       []byte(`{"detail":"Artifact not found"}`),
+	}
+	err := LiftDetail(fmt.Errorf("%w: body=%s", inner, inner.Body))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Artifact not found")
+	assert.NotContains(t, err.Error(), "body=", "the raw dump is replaced by the sentence")
+	assert.Contains(t, err.Error(), "/api/v2/artifacts/a-1/builds/")
+
+	var httpErr *drapi.HTTPError
+
+	require.ErrorAs(t, err, &httpErr, "callers keep their errors.As status checks")
+	assert.Equal(t, http.StatusUnprocessableEntity, httpErr.StatusCode)
+	assert.Equal(t, "Artifact not found", httpErr.Detail)
+	assert.NotEmpty(t, httpErr.Body, "the raw bytes survive for callers that read them")
+}
+
+// Everything that is not an enveloped HTTP failure passes through untouched:
+// the lift adds meaning where it knows the shape and must not disturb
+// anything else.
+func TestLiftDetail_PassesEverythingElseThrough(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		require.NoError(t, LiftDetail(nil))
+	})
+
+	t.Run("non-HTTP error", func(t *testing.T) {
+		plain := errors.New("dial tcp: connection refused")
+		assert.Same(t, plain, LiftDetail(plain))
+	})
+
+	t.Run("HTTP error without an envelope", func(t *testing.T) {
+		proxy := &drapi.HTTPError{
+			StatusCode: http.StatusGatewayTimeout,
+			URL:        "https://example.test/api/v2/artifacts/a-1/builds/",
+			Body:       []byte("<html>504 Gateway Time-out</html>"),
+		}
+		wrapped := fmt.Errorf("%w: body=%s", proxy, proxy.Body)
+
+		assert.Same(t, wrapped, LiftDetail(wrapped), "a body drapi's caller cannot read stays as it came")
+	})
+}

--- a/internal/workload/build.go
+++ b/internal/workload/build.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -181,6 +182,31 @@ var triggerRetryDelays = []time.Duration{2 * time.Second, 5 * time.Second}
 // not spend wall-clock time.
 var triggerRetrySleep = time.Sleep
 
+// triggerTimeoutSecs must comfortably exceed the platform's own budget for
+// the trigger: workload-api waits up to 30s for its image build service to
+// accept the submission before answering. A client that hangs up at or under
+// that budget abandons an answer already on the way — including the 504 that
+// says a retry is safe. A var so tests can shrink it. Observed live on
+// staging: the default 30s client timeout expired mid-trigger and the deploy
+// died on "context deadline exceeded" with no way to tell what happened.
+var triggerTimeoutSecs = 60
+
+// explainTriggerTimeout wraps a client-side timeout — the one failure where
+// the CLI hung up rather than the platform answering — with what the user
+// needs to know: the outcome is unknown, and re-running is safe because a new
+// trigger supersedes any build the lost request may have started. Every other
+// error passes through untouched.
+func explainTriggerTimeout(err error) error {
+	if !os.IsTimeout(err) {
+		return err
+	}
+
+	return fmt.Errorf(
+		"the build trigger got no response within %ds; the platform may still have started the build. "+
+			"Re-running 'dr workload up' is safe: a new trigger supersedes any build this one started: %w",
+		triggerTimeoutSecs, err)
+}
+
 func isRetryableTriggerStatus(err error) bool {
 	var httpErr *drapi.HTTPError
 	if !errors.As(err, &httpErr) {
@@ -217,13 +243,13 @@ func TriggerArtifactBuild(artifactID string) (*BuildTriggerResponse, error) {
 	for attempt := 0; ; attempt++ {
 		var resp BuildTriggerResponse
 
-		err := drapi.PostJSON(url, "build", map[string]any{}, &resp)
+		err := drapi.PostJSON(url, "build", map[string]any{}, &resp, triggerTimeoutSecs)
 		if err == nil {
 			return &resp, nil
 		}
 
 		if attempt >= len(triggerRetryDelays) || !isRetryableTriggerStatus(err) {
-			return nil, err
+			return nil, explainTriggerTimeout(err)
 		}
 
 		log.Debug("build trigger got a retryable status; retrying",

--- a/internal/workload/build.go
+++ b/internal/workload/build.go
@@ -29,6 +29,7 @@ import (
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/workload/apiclient"
 )
 
 // Build statuses are server-side enum values (UPPERCASE). All five were
@@ -216,15 +217,15 @@ func isRetryableTriggerStatus(err error) bool {
 	// A 503 is safe to retry wherever it was minted: a gateway answers it
 	// before the request reaches the platform. A 504 is only safe when the
 	// PLATFORM answered it — its "nothing was recorded" guarantee comes with
-	// a JSON detail body, which is what fills Detail. A proxy's own 504
-	// (HTML/plain body, Detail empty) means the platform may still be
-	// processing and might yet record the build, so retrying risks a
-	// duplicate.
+	// a JSON detail body. A proxy's own 504 (HTML/plain body, no envelope)
+	// means the platform may still be processing and might yet record the
+	// build, so retrying risks a duplicate. The check reads the raw body
+	// rather than Detail, so it holds whatever layer shaped the error.
 	switch httpErr.StatusCode {
 	case http.StatusServiceUnavailable:
 		return true
 	case http.StatusGatewayTimeout:
-		return httpErr.Detail != ""
+		return apiclient.ErrorDetail(httpErr.Body) != ""
 	}
 
 	return false
@@ -243,7 +244,7 @@ func TriggerArtifactBuild(artifactID string) (*BuildTriggerResponse, error) {
 	for attempt := 0; ; attempt++ {
 		var resp BuildTriggerResponse
 
-		err := drapi.PostJSON(url, "build", map[string]any{}, &resp, triggerTimeoutSecs)
+		err := apiclient.PostJSON(url, "build", map[string]any{}, &resp, triggerTimeoutSecs)
 		if err == nil {
 			return &resp, nil
 		}

--- a/internal/workload/build.go
+++ b/internal/workload/build.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -168,23 +169,67 @@ func IsBuildErrorStatus(s string) bool {
 	return strings.EqualFold(s, BuildStatusFailed) || strings.EqualFold(s, BuildStatusCancelled)
 }
 
+// Trigger retries are keyed on exactly the two statuses the platform answers
+// with explicit safe-to-retry semantics: 503 (a dependency it needs is
+// temporarily down) and 504 (the build service did not confirm the submission
+// and nothing was recorded on the artifact). Any other status fails fast —
+// a plain 500 from an older server may have half-succeeded, where re-POSTing
+// risks a duplicate build.
+var triggerRetryDelays = []time.Duration{2 * time.Second, 5 * time.Second}
+
+// triggerRetrySleep is time.Sleep, replaced by tests so retry coverage does
+// not spend wall-clock time.
+var triggerRetrySleep = time.Sleep
+
+func isRetryableTriggerStatus(err error) bool {
+	var httpErr *drapi.HTTPError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+
+	// A 503 is safe to retry wherever it was minted: a gateway answers it
+	// before the request reaches the platform. A 504 is only safe when the
+	// PLATFORM answered it — its "nothing was recorded" guarantee comes with
+	// a JSON detail body, which is what fills Detail. A proxy's own 504
+	// (HTML/plain body, Detail empty) means the platform may still be
+	// processing and might yet record the build, so retrying risks a
+	// duplicate.
+	switch httpErr.StatusCode {
+	case http.StatusServiceUnavailable:
+		return true
+	case http.StatusGatewayTimeout:
+		return httpErr.Detail != ""
+	}
+
+	return false
+}
+
 // TriggerArtifactBuild POSTs an empty body to /artifacts/{id}/builds/ and
-// returns the trigger response. The defensive empty-slice check is in the
-// caller so the service layer remains a thin pass-through of the server
-// shape.
+// returns the trigger response, retrying the statuses the platform declares
+// safe to retry. The defensive empty-slice check is in the caller so the
+// service layer remains a thin pass-through of the server shape.
 func TriggerArtifactBuild(artifactID string) (*BuildTriggerResponse, error) {
 	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/builds/")
 	if err != nil {
 		return nil, err
 	}
 
-	var resp BuildTriggerResponse
+	for attempt := 0; ; attempt++ {
+		var resp BuildTriggerResponse
 
-	if err := drapi.PostJSON(url, "build", map[string]any{}, &resp); err != nil {
-		return nil, err
+		err := drapi.PostJSON(url, "build", map[string]any{}, &resp)
+		if err == nil {
+			return &resp, nil
+		}
+
+		if attempt >= len(triggerRetryDelays) || !isRetryableTriggerStatus(err) {
+			return nil, err
+		}
+
+		log.Debug("build trigger got a retryable status; retrying",
+			"artifact_id", artifactID, "attempt", attempt+1, "err", err)
+		triggerRetrySleep(triggerRetryDelays[attempt])
 	}
-
-	return &resp, nil
 }
 
 // GetArtifactBuild fetches a single Build by id.

--- a/internal/workload/build_test.go
+++ b/internal/workload/build_test.go
@@ -265,6 +265,128 @@ func TestTriggerArtifactBuild_PropagatesValidationError(t *testing.T) {
 	assert.Contains(t, err.Error(), "Artifact not found", "validation body must reach caller (0ae2527 regression)")
 }
 
+func TestTriggerArtifactBuild_RetriesGatewayTimeoutThenSucceeds(t *testing.T) {
+	installSkipAuth(t)
+
+	var slept []time.Duration
+
+	origSleep := triggerRetrySleep
+	triggerRetrySleep = func(d time.Duration) { slept = append(slept, d) }
+
+	t.Cleanup(func() { triggerRetrySleep = origSleep })
+
+	var calls int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusGatewayTimeout)
+			_, _ = w.Write([]byte(`{"detail":"The image build service did not confirm the build submission in time. No build was recorded on the artifact; it is safe to retry."}`))
+
+			return
+		}
+
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"buildIds":["b-1"]}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	resp, err := TriggerArtifactBuild("art-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"b-1"}, resp.BuildIDs)
+	assert.Equal(t, 2, calls)
+	assert.Equal(t, []time.Duration{2 * time.Second}, slept)
+}
+
+func TestTriggerArtifactBuild_DoesNotRetryProxy504(t *testing.T) {
+	// A 504 without a FastAPI detail body was minted by a proxy, not the
+	// platform — the platform may still be processing and might yet record
+	// the build, so retrying risks a duplicate.
+	installSkipAuth(t)
+
+	origSleep := triggerRetrySleep
+	triggerRetrySleep = func(time.Duration) { t.Fatal("must not sleep: a proxy 504 is not retryable") }
+
+	t.Cleanup(func() { triggerRetrySleep = origSleep })
+
+	var calls int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+
+		w.WriteHeader(http.StatusGatewayTimeout)
+		_, _ = w.Write([]byte("<html>504 Gateway Time-out</html>"))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := TriggerArtifactBuild("art-1")
+	require.Error(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestTriggerArtifactBuild_DoesNotRetryPlain500(t *testing.T) {
+	// A bare 500 has no safe-to-retry contract: an older server may have
+	// half-succeeded, and re-POSTing could start a duplicate build.
+	installSkipAuth(t)
+
+	origSleep := triggerRetrySleep
+	triggerRetrySleep = func(time.Duration) { t.Fatal("must not sleep: 500 is not retryable") }
+
+	t.Cleanup(func() { triggerRetrySleep = origSleep })
+
+	var calls int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"detail":"Internal server error"}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := TriggerArtifactBuild("art-1")
+	require.Error(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestTriggerArtifactBuild_GivesUpAfterRetryBudget(t *testing.T) {
+	installSkipAuth(t)
+
+	origSleep := triggerRetrySleep
+	triggerRetrySleep = func(time.Duration) {}
+
+	t.Cleanup(func() { triggerRetrySleep = origSleep })
+
+	var calls int
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"detail":"A DataRobot service needed to submit the build is temporarily unavailable, please retry in a few minutes."}`))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	_, err := TriggerArtifactBuild("art-1")
+	require.Error(t, err)
+	assert.Equal(t, 1+len(triggerRetryDelays), calls)
+	// The server's own sentence must reach the user, not a raw JSON dump.
+	assert.Contains(t, err.Error(), "temporarily unavailable")
+	assert.NotContains(t, err.Error(), `{"detail"`)
+}
+
 func TestGetArtifactBuild_Decodes(t *testing.T) {
 	installSkipAuth(t)
 

--- a/internal/workload/build_test.go
+++ b/internal/workload/build_test.go
@@ -358,6 +358,35 @@ func TestTriggerArtifactBuild_DoesNotRetryPlain500(t *testing.T) {
 	assert.Equal(t, 1, calls)
 }
 
+func TestTriggerArtifactBuild_ClientTimeoutSaysRerunIsSafe(t *testing.T) {
+	// When the CLI itself hangs up (no response at all), the outcome is
+	// unknown — no status code, no retry. The error must say re-running is
+	// safe rather than leaving a bare "context deadline exceeded".
+	installSkipAuth(t)
+
+	origTimeout := triggerTimeoutSecs
+	triggerTimeoutSecs = 1
+
+	t.Cleanup(func() { triggerTimeoutSecs = origTimeout })
+
+	release := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release // hold the response until the client has given up
+
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	t.Cleanup(func() { close(release); srv.Close() })
+
+	installEndpoint(t, srv.URL)
+
+	_, err := TriggerArtifactBuild("art-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Re-running 'dr workload up' is safe")
+	assert.Contains(t, err.Error(), "may still have started")
+}
+
 func TestTriggerArtifactBuild_GivesUpAfterRetryBudget(t *testing.T) {
 	installSkipAuth(t)
 

--- a/internal/workload/up/version_test.go
+++ b/internal/workload/up/version_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpecMatches_TypeMismatchIsNoMatchNotError(t *testing.T) {
+	loaded := loadedFrom(`{"artifact": {"name": "x", "type": "agent", "spec": {}}}`)
+	doc := workload.Document{"type": "service", "spec": map[string]any{}}
+
+	matches, err := specMatches(loaded, doc)
+
+	require.NoError(t, err, "a type mismatch is an ordinary no-match, not a fault")
+	assert.False(t, matches)
+}
+
+func TestSpecMatches_TypeComparisonFoldsCaseAndDefaultsLiveSide(t *testing.T) {
+	// A file saying "Service" against a live doc that states no type at all
+	// must match: the platform defaults an untyped artifact to service, and
+	// its enums disagree about casing.
+	loaded := loadedFrom(`{"artifact": {"name": "x", "type": "Service", "spec": {}}}`)
+	doc := workload.Document{"spec": map[string]any{}}
+
+	matches, err := specMatches(loaded, doc)
+
+	require.NoError(t, err)
+	assert.True(t, matches)
+}
+
+func TestSpecMatches_SpecDifferenceIsNoMatch(t *testing.T) {
+	loaded := loadedFrom(`{"artifact": {"name": "x", "type": "service", "spec": {"port": 8080}}}`)
+	doc := workload.Document{"type": "service", "spec": map[string]any{"port": float64(9090)}}
+
+	matches, err := specMatches(loaded, doc)
+
+	require.NoError(t, err)
+	assert.False(t, matches)
+}


### PR DESCRIPTION
# RATIONALE

When `dr wl up` (or `dr artifact build`) triggers an image build, one slow moment in the platform's build service used to kill the whole deploy after the code was already synced, with an opaque error:

```
Error: HTTP error: 500 Internal Server Error (url: ...): body={"detail":"Internal server error"}
```

The Workload API now answers that situation with an explicit contract ([RAPTOR-19719](https://datarobot.atlassian.net/browse/RAPTOR-19719), [datarobot/workload-api#1187](https://github.com/datarobot/workload-api/pull/1187)): a **504** guarantees nothing was recorded on the artifact and a retry is safe, and its existing **503** for dependency blips also says "please retry". This PR makes the CLI use that contract instead of failing the deploy, and makes every API error lead with the server's own explanation instead of a raw JSON dump.

## CHANGES

- `TriggerArtifactBuild` retries on exactly 503 and 504 (2s/5s backoff, three attempts total). A 504 is only retried when it carries the platform's JSON `detail` body — a proxy's own 504 (HTML/plain) means the platform may still be processing, where a re-POST could start a duplicate build. A plain 500 fails fast for the same reason.
- `drapi.ErrFromResp` now lifts FastAPI-style `{"detail": ...}` bodies into the (already existing, never populated) `HTTPError.Detail` field, so users read `HTTP 504 Gateway Timeout: ...it is safe to retry.` instead of a JSON blob. Validation-error arrays are re-encoded so field-level messages survive; non-JSON bodies keep the `body=` form with the URL.
- Tests for retry-then-succeed, no-retry-on-500, no-retry-on-proxy-504, retry-budget exhaustion, and the three `ErrFromResp` shapes; one existing assertion updated from verbatim-body to message-content.
- **Separate first commit: repairs `main`.** `specMatches` (`internal/workload/up/version.go:419`) was changed to return `(bool, error)` in the current `main` tip but one early `return false` was left behind, so the `up` package does not compile — every vet/test/build job has been failing on `main` and on any PR merged with it since. The fix returns `false, nil` (a type mismatch is an ordinary no-match, not an error).

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

## RELATED

- Backend contract this builds on: [datarobot/workload-api#1187](https://github.com/datarobot/workload-api/pull/1187)
- Jira: [RAPTOR-19719](https://datarobot.atlassian.net/browse/RAPTOR-19719)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787740712.249199 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Retry policy on build POSTs could duplicate builds if 504/503 classification is wrong; error parsing changes behavior for all drapi HTTP errors, not only builds.
> 
> **Overview**
> Makes artifact build triggers more resilient and API failures easier to read during `dr wl up` / `dr artifact build`.
> 
> **`TriggerArtifactBuild`** now retries up to three times (2s then 5s backoff) when the platform returns **503** or a **504** that includes a FastAPI JSON `detail` (the “safe to retry / nothing recorded” contract). It does **not** retry proxy HTML 504s, plain **500**s, or other statuses, to avoid duplicate builds when the server may have already accepted the POST.
> 
> **`drapi.ErrFromResp`** parses `{"detail": ...}` bodies into **`HTTPError.Detail`** so errors show the server message instead of `body={...}`; validation arrays are preserved as JSON, and non-JSON bodies still use the `body=` form.
> 
> Also fixes a **`specMatches`** compile break in `internal/workload/up/version.go` (`return false, nil` on artifact type mismatch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d039734844f421025e9bfd2734b932b6eab758. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->