### PR TITLE
fix(workload): stop an agent redraft forking its own lineage

### DIFF
--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -2123,6 +2123,46 @@ func TestRun_ReplacementForADivergedSpecJoinsTheSameLineage(t *testing.T) {
 	assert.Equal(t, "cat1", *tr.savedCfg.CatalogID)
 }
 
+// The same lineage question asked of an agent, which is what makes it a
+// regression test rather than a duplicate.
+//
+// The comparison that decides whether the linked draft still matches used to
+// normalise the live document in place, taking the type off it. The next line
+// read that type to pick the repository, found nothing, defaulted it to
+// service, and concluded the file had changed the artifact's kind. Every
+// redraft of an agent therefore started a new lineage instead of joining its
+// own, silently and permanently. Nothing caught it because every other fixture
+// here is a service, where the default happens to be the right answer.
+func TestRun_ReplacementForADivergedAgentJoinsTheSameLineage(t *testing.T) {
+	var tr track
+
+	f := divergedLink(wiredBuild(&tr), &tr)
+
+	inner := f.artifactD
+	f.artifactD = func(id string) (workload.Document, error) {
+		d, err := inner(id)
+		if err != nil {
+			return nil, err
+		}
+
+		d[keyType] = "agent"
+
+		return d, nil
+	}
+
+	install(t, f)
+
+	agent := strings.Replace(unboundDockerfileManifest, "type: service", "type: agent", 1)
+
+	_, _, err := runIn(t, agent, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	payload, ok := tr.artifactIn.(json.RawMessage)
+	require.True(t, ok, "the create has to have been given the artifact block")
+	assert.Contains(t, string(payload), "repo-1",
+		"an agent redraft joins its own lineage, exactly as a service does")
+}
+
 // The other half of that equivalence. The tree was already synced into the
 // artifact the file has since diverged from, so the sync onto its replacement
 // can find nothing to upload and the new version would go to the builder with

--- a/internal/workload/up/version.go
+++ b/internal/workload/up/version.go
@@ -384,6 +384,15 @@ func describes(loaded Loaded, artifactID string) bool {
 // it, or that needs the lock status off the same read, pays one round trip
 // instead of two to the same resource.
 func specMatches(loaded Loaded, doc workload.Document) (bool, error) {
+	// The comparison below normalises both sides in place, and the live side
+	// belongs to the caller. ensureArtifact hands the same document to
+	// redraftRepository immediately afterwards, which reads the type off it;
+	// left shared, this would take that type away, an agent would read as a
+	// service, and the replacement would open a new repository rather than
+	// joining the lineage it is a version of. A silent lineage fork on the
+	// recovery path is a poor price for one map allocation.
+	doc = detachedArtifact(doc)
+
 	payload, err := loaded.Compiled.ArtifactPayload()
 	if err != nil {
 		return false, err
@@ -426,6 +435,36 @@ func specMatches(loaded Loaded, doc workload.Document) (bool, error) {
 	// reused, and it is rolled out still carrying the variable that was
 	// deleted, which minting a fresh artifact would have dropped.
 	return len(Subset(want, doc)) == 0 && len(Extra(want, doc)) == 0, nil
+}
+
+// detachedArtifact is doc with the two maps the normalisation writes to copied,
+// so a caller's document survives being compared.
+//
+// It copies exactly what hoistArtifactType and sameArtifactTypeIn touch: the
+// top level, where the type is written and then removed, and the spec, where a
+// type written inside it is deleted from. Everything deeper is shared, which is
+// safe because nothing below reaches it, and a deep copy of a document that can
+// carry an entire container spec is not worth paying for a two-key edit.
+func detachedArtifact(doc workload.Document) workload.Document {
+	if doc == nil {
+		return nil
+	}
+
+	out := make(workload.Document, len(doc))
+	for k, v := range doc {
+		out[k] = v
+	}
+
+	if spec, ok := out[keySpec].(map[string]any); ok {
+		copied := make(map[string]any, len(spec))
+		for k, v := range spec {
+			copied[k] = v
+		}
+
+		out[keySpec] = copied
+	}
+
+	return out
 }
 
 // sameArtifactTypeIn reports whether two artifact blocks name the same kind,


### PR DESCRIPTION
# RATIONALE

Every redraft of an **agent** artifact silently forked its own lineage.

`specMatches` normalises both artifact blocks in place, because the walk that follows compares by exact equality and cannot answer the type question correctly. The live block it normalises belongs to the caller: `ensureArtifact` hands the same document to `redraftRepository` on the very next line, which reads the type off it. By then the type has been taken away, so an agent read as a service, the comparison against the file's `agent` failed, and the run concluded the file had changed the artifact's kind. That is a real reason to start a fresh repository, so the replacement opened one instead of joining the lineage it is the next version of.

Services were unaffected, since the default the missing type falls back to happens to be the right answer for them. Every fixture in this package is a service, which is why a green suite never saw it.

Found while reviewing the change stacked on top of this one; the fix is independent of it.

## CHANGES

- `internal/workload/up/version.go`: compare against a detached copy. It copies the two maps the normalisation writes to, the top level and the spec, and shares everything deeper, which nothing below reaches.
- A regression test with an agent artifact, which fails without the fix.
