### PR TITLE
[RAPTOR-19686] feat(workload): deploy onto a settling or stopped workload in one run

### DIFF
--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -142,6 +142,12 @@ allocation, is applied in place instead. Nothing is built and no version is
 made, because what the workload runs has not changed. A deploy that moves both
 sends the sizing with the rollout, so the new version comes up with it.
 
+A workload that is not ready to be deployed onto is dealt with rather than
+refused. One still starting or stopping is waited out and then re-read, so the
+plan is built against where it landed. A stopped one is started and then
+reconciled in the same run, which is one command whether the file asks for a
+start alone or for a start and a new version.
+
 Examples:
   dr workload up
   dr workload up --dry-run
@@ -362,8 +368,13 @@ func reportable(result up.Result) bool {
 //
 // The three refusals, in order:
 //
-//   - A failed run says nothing. The error is what the reader needs, and
-//     "your broken deploy is also temporary" buries it.
+//   - A failed run says nothing, unless the failure came after it started the
+//     workload. The error is usually what the reader needs and "your broken
+//     deploy is also temporary" buries it; but a deploy onto a stopped
+//     workload starts it before it rolls, so a run that fails after that has
+//     itself put a draft on the air and started the eight hours. Saying
+//     nothing there leaves a workload running that the reader believes was
+//     never touched.
 //   - --lock says nothing, because the run is the remedy. This also covers a
 //     --lock whose lock failed, where the returned error names the artifact
 //     and explains the state better than a generic warning would.
@@ -379,8 +390,15 @@ func reportable(result up.Result) bool {
 // of a locked artifact onto a fresh workload would be called temporary and
 // then advised to lock what is already locked.
 func draftIsServing(f flags, result up.Result, failed bool) bool {
-	if failed || f.lock || result.Locked {
+	if f.lock || result.Locked {
 		return false
+	}
+
+	if failed {
+		// Action is what this run actually did, not what it wanted, so it says
+		// "started" only when the start went through. A run that failed before
+		// that changed nothing and has nothing to warn about.
+		return result.Action == up.ActionStarted
 	}
 
 	return f.dryRun || result.WorkloadID != ""

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -584,6 +584,21 @@ func TestCmd_FailedDeployDoesNotWarnAboutDrafts(t *testing.T) {
 	assert.False(t, draftWarned(stderr))
 }
 
+// The exception, and the reason it exists: a deploy onto a stopped workload
+// starts it before it rolls, so a run that fails after that has itself put a
+// draft on the air and started the eight hours. Saying nothing leaves a
+// workload running that the reader believes was never touched.
+func TestCmd_FailedDeployThatStartedTheWorkloadStillWarns(t *testing.T) {
+	result := deployed()
+	result.Action = up.ActionStarted
+
+	stubRun(t, result, errors.New("the rollout of workload wl-1 ended as failed"))
+
+	_, stderr, err := runCmd(t)
+	require.Error(t, err)
+	assert.True(t, draftWarned(stderr))
+}
+
 // A run that changed nothing still leaves a draft serving on the same clock.
 // "Already up to date" is not the same as "this will still be here tomorrow".
 func TestCmd_UnchangedRunStillWarnsAboutTheDraft(t *testing.T) {

--- a/internal/workload/up/plan.go
+++ b/internal/workload/up/plan.go
@@ -101,17 +101,45 @@ type Plan struct {
 	Locked bool
 }
 
-// Empty reports that the live state already matches the file. `up` prints
-// "Already up to date" and exits 0, having touched nothing.
+// Empty reports that the live state already matches the file and there is
+// nothing for the run to do about it. `up` prints "Already up to date" and
+// exits 0, having touched nothing.
 //
-// A stopped workload is never empty even when nothing differs: the user asked
-// to deploy, and a workload that is not running has not been deployed.
+// Matching the file is not sufficient, which is what actsOnState covers.
 func (p Plan) Empty() bool {
 	return !p.Creates &&
 		!p.Code.Changed() &&
 		len(p.Artifact) == 0 &&
 		len(p.Runtime) == 0 &&
-		p.State != StateStopped
+		!p.actsOnState()
+}
+
+// actsOnState reports the live states that give a run something to do even
+// when the file and the workload agree about every field.
+//
+// A stopped workload is the plain case: the user asked to deploy, and one that
+// is not running has not been deployed. The other two are about not lying. An
+// errored or terminated workload matches its file in exactly the way a crashed
+// process matches its source code, and the run that reaches them has to say so
+// rather than print a green tick: `up` announces what it found before it acts,
+// and "already up to date" over a header reading "errored" is the one summary
+// that sends the reader away.
+//
+// That mattered less when a deploy refused a moving workload outright. It
+// waits now, so a workload that dies while the deploy watches it is a case the
+// command deliberately observes, and reporting success for it would be a
+// success this run had a front-row seat to.
+func (p Plan) actsOnState() bool {
+	switch p.State {
+	case StateStopped, StateErrored, StateTerminated:
+		return true
+
+	case StateUnbound, StateMissing, StateSettling, StateRunning:
+		return false
+
+	default:
+		return false
+	}
 }
 
 // creates reports the states whose apply is a create rather than a reconcile.
@@ -176,6 +204,38 @@ func (p Plan) RollsArtifact() bool {
 // artifact exactly as it is.
 func (p Plan) MintsVersion() bool {
 	return p.Creates || p.RollsArtifact()
+}
+
+// OnlyStarts reports that starting the workload is the whole of what this run
+// does. It is asked twice on the stopped path, by the branch that decides
+// whether anything follows the start and by the start itself deciding whether
+// it may lock, and the two must not come to disagree: locking is one-way, so a
+// run that locked the version it was about to roll off could not take it back.
+func (p Plan) OnlyStarts() bool {
+	return p.Action() == ActionStarted
+}
+
+// Retunes reports that the sizing is the only thing this run changes: no
+// version is minted and the workload is updated where it stands. It is the
+// branch the apply takes, and it says nothing about whether the workload was
+// running when the run started, because by the time that branch is reached a
+// stopped one has been started.
+func (p Plan) Retunes() bool {
+	return !p.Creates && !p.RollsArtifact() && len(p.Runtime) > 0
+}
+
+// SendsNoEnvironment reports the one shape of deploy that resolves no
+// credential references, which is why the check that costs a round trip each
+// skips it: a resize sends the runtime block alone, so the artifact keeps every
+// variable it already has and a reference this deploy never touches must not be
+// able to refuse it.
+//
+// It is Retunes with one thing added rather than a second spelling of it. A
+// stopped workload whose file moved only its sizing is still started by the
+// run, and a start is when the container resolves its references from cold, so
+// that one verifies.
+func (p Plan) SendsNoEnvironment() bool {
+	return p.Retunes() && p.State != StateStopped
 }
 
 // Action names the outcome, for the summary line and the JSON envelope.

--- a/internal/workload/up/render.go
+++ b/internal/workload/up/render.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/tui"
 )
@@ -153,7 +154,7 @@ func lines(s Summary, plan Plan) []string {
 	// The plans whose reason to act is the state rather than a difference.
 	// Without a line the body is empty and the block reads as though nothing
 	// is about to happen, while the JSON beside it says otherwise.
-	if line := stateLine(plan.State); line != "" {
+	if line := stateLine(plan.State, s.Status); line != "" {
 		out = append(out, line)
 	}
 
@@ -168,17 +169,28 @@ func lines(s Summary, plan Plan) []string {
 	return out
 }
 
-// stateLine is what the live state alone puts in a plan, empty when the state
-// is not a reason to act by itself.
+// stateLine is what the live state puts in a plan, empty when the state is not
+// a reason to act by itself.
 //
-// The two that cannot be deployed onto get a line rather than being left to
+// The states that cannot be deployed onto get a line rather than being left to
 // the error below the block. A plan that renders as a bare header reads as a
 // run with nothing to do, which is the opposite of what a refusal is about to
 // say, and --dry-run never prints the error at all.
-func stateLine(state State) string {
+//
+// The status is needed as well as the state, for the one case where the
+// reduction is lossy in a way that changes what the run will do. Stopped,
+// suspended and interrupted are one state, and a start brings two of them back;
+// the platform ignores a start of a suspended workload, so promising one here
+// would preview an act the apply is about to refuse, and a dry run never gets
+// as far as the refusal.
+func stateLine(state State, status string) string {
 	switch state {
 	case StateStopped:
-		return entry("~", "workload", "started, having been stopped")
+		if workload.IsSuspendedWorkloadStatus(status) {
+			return entry("!", "workload", "suspended, which a deploy cannot undo")
+		}
+
+		return entry("~", "workload", "started, having been "+stoppedAs(status))
 
 	case StateErrored:
 		return entry("!", "workload", "errored, so there is nothing healthy to deploy onto")
@@ -192,6 +204,17 @@ func stateLine(state State) string {
 	default:
 		return ""
 	}
+}
+
+// stoppedAs is how the workload came to be switched off, for the line that says
+// it is about to be switched back on. Interrupted is not the same as stopped to
+// the person reading it, and the state they reduce to cannot tell them apart.
+func stoppedAs(status string) string {
+	if status == "" {
+		return "stopped"
+	}
+
+	return status
 }
 
 // createDetail names the workload about to be created. The plan is printed

--- a/internal/workload/up/render.go
+++ b/internal/workload/up/render.go
@@ -30,6 +30,13 @@ import (
 type Summary struct {
 	Name       string
 	WorkloadID string
+
+	// Status is the platform's own word for what the workload is doing. The
+	// header prints it rather than the State it reduces to, because the
+	// reduction is lossy in the one place it matters: stopped, suspended and
+	// interrupted are one state to the deploy and three quite different things
+	// to a reader, and only one of them can actually be started.
+	Status string
 }
 
 // shortIDLen is how much of an id is enough to recognise it. The platform's
@@ -60,7 +67,7 @@ func Render(w io.Writer, s Summary, plan Plan) error {
 	}
 
 	if plan.Empty() {
-		b.WriteString("\n" + tui.SuccessStyle.Render("✓ Already up to date") + "\n")
+		b.WriteString("\n" + settledVerdict(plan) + "\n")
 
 		_, err := io.WriteString(w, b.String())
 
@@ -79,6 +86,25 @@ func Render(w io.Writer, s Summary, plan Plan) error {
 	return err
 }
 
+// settledVerdict is what an empty plan means, which is not always that there
+// is nothing to do.
+//
+// A workload still moving is the exception, and it only reaches here on a dry
+// run, which does not wait. The plan for it was computed against a state that
+// is on its way somewhere else, so "already up to date" would be a claim the
+// run has no way to make: a workload halfway through stopping matches its file
+// until it finishes, at which point the deploy that follows starts it again.
+// Saying nothing differs, without saying it will differ, is how a preview comes
+// to read as the opposite of what the deploy will do.
+func settledVerdict(plan Plan) string {
+	if plan.State == StateSettling {
+		return tui.WarnStyle.Render("Nothing differs yet, but this workload is still settling") + "\n" +
+			tui.HintStyle.Render("  What a deploy does depends on where it lands, so it waits first.")
+	}
+
+	return tui.SuccessStyle.Render("✓ Already up to date")
+}
+
 // header names the workload being deployed onto and says what state it is in.
 //
 // There is nothing to head a plan with when no workload exists yet: naming a
@@ -95,7 +121,15 @@ func header(s Summary, plan Plan) string {
 		name = "workload"
 	}
 
-	return fmt.Sprintf("%s (%s), %s", name, shortID(s.WorkloadID), plan.State)
+	// The state is the fallback rather than the answer, for a caller that has
+	// no status to hand: every live read has one, and the plans built without a
+	// live workload never reach this line.
+	state := s.Status
+	if state == "" {
+		state = plan.State.String()
+	}
+
+	return fmt.Sprintf("%s (%s), %s", name, shortID(s.WorkloadID), state)
 }
 
 // shortID trims an id to something a person can compare at a glance.
@@ -116,12 +150,11 @@ func lines(s Summary, plan Plan) []string {
 		out = append(out, entry("+", "workload", createDetail(s, plan)))
 	}
 
-	// A stopped workload is the one plan whose reason to act is the state
-	// rather than a difference. Without a line for it the body is empty and
-	// the block reads as though nothing is about to happen, while the JSON
-	// beside it says the action is "started".
-	if plan.State == StateStopped {
-		out = append(out, entry("~", "workload", "started, having been stopped"))
+	// The plans whose reason to act is the state rather than a difference.
+	// Without a line the body is empty and the block reads as though nothing
+	// is about to happen, while the JSON beside it says otherwise.
+	if line := stateLine(plan.State); line != "" {
+		out = append(out, line)
 	}
 
 	if plan.Code.Changed() {
@@ -133,6 +166,32 @@ func lines(s Summary, plan Plan) []string {
 	out = append(out, runtimeLines(plan)...)
 
 	return out
+}
+
+// stateLine is what the live state alone puts in a plan, empty when the state
+// is not a reason to act by itself.
+//
+// The two that cannot be deployed onto get a line rather than being left to
+// the error below the block. A plan that renders as a bare header reads as a
+// run with nothing to do, which is the opposite of what a refusal is about to
+// say, and --dry-run never prints the error at all.
+func stateLine(state State) string {
+	switch state {
+	case StateStopped:
+		return entry("~", "workload", "started, having been stopped")
+
+	case StateErrored:
+		return entry("!", "workload", "errored, so there is nothing healthy to deploy onto")
+
+	case StateTerminated:
+		return entry("!", "workload", "terminated, and it still holds its name and artifact")
+
+	case StateUnbound, StateMissing, StateSettling, StateRunning:
+		return ""
+
+	default:
+		return ""
+	}
 }
 
 // createDetail names the workload about to be created. The plan is printed
@@ -277,8 +336,12 @@ func runtimeLines(plan Plan) []string {
 // entry formats one plan line: a marker, the class, and what happens to it.
 func entry(marker, class, detail string) string {
 	style := changeStyle
-	if marker == "+" {
+
+	switch marker {
+	case "+":
 		style = addStyle
+	case "!":
+		style = blockStyle
 	}
 
 	return fmt.Sprintf("  %s %s %s",
@@ -293,6 +356,10 @@ var (
 	planTitleStyle = lipgloss.NewStyle().Bold(true)
 	addStyle       = tui.SuccessStyle
 	changeStyle    = tui.WarnStyle
+
+	// A state the deploy cannot act on at all, which is neither an addition
+	// nor a change but the reason there will be neither.
+	blockStyle = tui.ErrorStyle
 )
 
 // details lists individual changes under their entry, capped, saying out loud

--- a/internal/workload/up/render_test.go
+++ b/internal/workload/up/render_test.go
@@ -35,6 +35,28 @@ func render(t *testing.T, s Summary, plan Plan) string {
 
 var appSummary = Summary{Name: "my-app", WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"}
 
+// The header carries the platform's own word rather than the state it reduces
+// to. Stopped, suspended and interrupted are one state to the deploy and three
+// different things to a reader, and only one of them can be started at all, so
+// a suspended workload announced as "stopped" is a header that contradicts the
+// refusal printed under it.
+func TestRender_HeaderCarriesTheLiveStatusNotTheReducedState(t *testing.T) {
+	out := render(t,
+		Summary{Name: "my-app", WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0", Status: "suspended"},
+		Plan{State: StateStopped})
+
+	assert.Contains(t, out, "my-app (68b0c1d2), suspended")
+	assert.NotContains(t, out, ", stopped")
+}
+
+// A summary with no status falls back to the state, which is what a plan built
+// without a live workload has.
+func TestRender_HeaderFallsBackToTheStateWithoutAStatus(t *testing.T) {
+	out := render(t, Summary{Name: "my-app", WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"}, Plan{State: StateStopped})
+
+	assert.Contains(t, out, "my-app (68b0c1d2), stopped")
+}
+
 func TestRender_Empty(t *testing.T) {
 	out := render(t, appSummary, Plan{State: StateRunning, Code: builtCode(0)})
 

--- a/internal/workload/up/render_test.go
+++ b/internal/workload/up/render_test.go
@@ -35,6 +35,36 @@ func render(t *testing.T, s Summary, plan Plan) string {
 
 var appSummary = Summary{Name: "my-app", WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"}
 
+// A suspended workload must not be previewed as about to start. The platform
+// ignores a start while it is in that state, so the apply refuses it, and a dry
+// run never gets as far as the refusal: the plan is the only thing the reader
+// sees. Stopped, suspended and interrupted reduce to one state, which is why
+// the line needs the status as well.
+func TestRender_SuspendedIsNotPreviewedAsAStart(t *testing.T) {
+	out := render(t,
+		Summary{Name: "my-app", WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0", Status: "suspended"},
+		Plan{State: StateStopped})
+
+	assert.Contains(t, out, "suspended, which a deploy cannot undo")
+	assert.NotContains(t, out, "started, having been")
+}
+
+// The two that can be started say which of them they were, because "stopped"
+// and "interrupted" are the same state to the deploy and not to the reader.
+func TestRender_AStartNamesWhatItIsStartingFrom(t *testing.T) {
+	for status, want := range map[string]string{
+		"stopped":     "started, having been stopped",
+		"interrupted": "started, having been interrupted",
+		"":            "started, having been stopped",
+	} {
+		out := render(t,
+			Summary{Name: "my-app", WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0", Status: status},
+			Plan{State: StateStopped})
+
+		assert.Contains(t, out, want, "status %q", status)
+	}
+}
+
 // The header carries the platform's own word rather than the state it reduces
 // to. Stopped, suspended and interrupted are one state to the deploy and three
 // different things to a reader, and only one of them can be started at all, so

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -31,9 +31,11 @@ import (
 // The order is not a preference. The guard comes first because a second
 // replacement POSTed while one is in flight queues another swap rather than
 // being refused, so the check that matters is the one immediately before the
-// call, and an early one saves a doomed run from creating anything. The
-// candidate is minted next, and the question of locking is put then, while
-// the answer still costs nothing.
+// call, and an early one saves a doomed run from creating anything.
+//
+// Whether a locked version may be rolled at all is settled by the caller,
+// before it. This can be reached with the workload already started, and a
+// question asked after that is one whose "no" has already changed something.
 //
 // The lock itself is last, inside replace, between the final guard and the
 // POST. The platform will not replace a locked artifact with a draft, so the
@@ -41,7 +43,7 @@ import (
 // locked for a rollout that is then refused can be neither unlocked nor
 // deleted. Taking the lock only once nothing is left that can say no is what
 // keeps a lost race from leaving one behind.
-func roll(loaded Loaded, live Live, plan Plan, result Result, opts Options, report *reporter) (Result, error) {
+func roll(loaded Loaded, live Live, plan Plan, lock bool, result Result, opts Options, report *reporter) (Result, error) {
 	if err := guardRollout(live.WorkloadID, "nothing was built or rolled out"); err != nil {
 		return result, err
 	}
@@ -60,13 +62,6 @@ func roll(loaded Loaded, live Live, plan Plan, result Result, opts Options, repo
 	// moves it when the rollout has actually promoted the new one. A failed
 	// swap leaves the old version running, so an envelope naming the
 	// candidate would send someone to read the wrong artifact.
-
-	// Asked now, locked later. Agreeing costs nothing that cannot be undone;
-	// the lock is taken inside replace, once the last guard has passed.
-	lock, err := confirmLock(live, result.Name, opts)
-	if err != nil {
-		return result, err
-	}
 
 	// A file that moved the sizing as well as the version rides both in on the
 	// same swap: the platform takes runtime alongside the artifact, so there is
@@ -161,6 +156,10 @@ func sameArtifactType(loaded Loaded, live Live) bool {
 // Only the question is asked here. The lock itself waits until immediately
 // before the swap, because locking is one-way and an artifact locked for a
 // rollout that never starts can be neither unlocked nor deleted.
+//
+// It is asked before the deploy touches anything, which is what lets the
+// refusal below tell the truth: nothing has happened yet, so the workload
+// really is still running what it was, and a stopped one is still stopped.
 func confirmLock(live Live, workloadName string, opts Options) (bool, error) {
 	if !live.Locked {
 		return false, nil
@@ -172,7 +171,11 @@ func confirmLock(live Live, workloadName string, opts Options) (bool, error) {
 	}
 
 	if !agreed {
-		return false, fmt.Errorf("cancelled: workload %s is still running the version it was", workloadName)
+		// Not "still running the version it was": the same question is asked of
+		// a stopped workload, which this run would have started, and telling
+		// someone their switched-off workload is still running is worse than
+		// saying less.
+		return false, fmt.Errorf("cancelled: nothing was deployed and workload %s is as it was", workloadName)
 	}
 
 	return true, nil

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -165,7 +165,7 @@ func confirmLock(live Live, workloadName string, opts Options) (bool, error) {
 		return false, nil
 	}
 
-	agreed, err := confirmRoll(workloadName, opts)
+	agreed, err := confirmRoll(live, workloadName, opts)
 	if err != nil {
 		return false, err
 	}
@@ -234,7 +234,7 @@ func lockedAlready(artifactID string) (bool, error) {
 // A run that cannot ask is refused rather than waved through. Being unable to
 // prompt is not the same as having been told to go ahead, and the difference
 // matters exactly once.
-func confirmRoll(workloadName string, opts Options) (bool, error) {
+func confirmRoll(live Live, workloadName string, opts Options) (bool, error) {
 	// Being able to ask settles it, ahead of any inference about whether
 	// anyone is there. NonInteractive is also true for --output json, which
 	// says how to format stdout rather than that production may be rolled
@@ -242,9 +242,10 @@ func confirmRoll(workloadName string, opts Options) (bool, error) {
 	// already in.
 	if opts.Confirm != nil {
 		return opts.Confirm(fmt.Sprintf(
-			"Workload %s is running a locked version, which means production.\n"+
+			"Workload %s is on a locked version, which means production.%s\n"+
 				"The new version will be locked too, and locking cannot be undone.\n"+
-				"Type the workload name to roll it, anything else to stop: ", workloadName), workloadName)
+				"Type the workload name to roll it, anything else to stop: ",
+			workloadName, alsoStarting(live)), workloadName)
 	}
 
 	if opts.NonInteractive {
@@ -254,6 +255,24 @@ func confirmRoll(workloadName string, opts Options) (bool, error) {
 	return false, errors.New(
 		"this rolls a locked, production version and there is no terminal to confirm on. " +
 			"Re-run with --yes to say so explicitly")
+}
+
+// alsoStarting is the clause the question needs when the workload is switched
+// off, and empty when it is not.
+//
+// The prompt used to open "is running a locked version", which was safe while a
+// stopped workload with drift was refused long before anyone was asked. It is
+// asked of one now, and telling somebody their switched-off workload is running
+// is exactly the wrong thing to say in the one prompt that guards production.
+// The version being locked is the fact that holds either way; that the run will
+// also switch the workload on is material to the answer, so it is said rather
+// than left to be discovered.
+func alsoStarting(live Live) string {
+	if live.State != StateStopped {
+		return ""
+	}
+
+	return " It is not running, and this deploy starts it."
 }
 
 // replace starts the rollout and follows it to the end. sizing is nil unless

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -18,10 +18,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/sync"
 	"github.com/datarobot/cli/internal/workload/wapi"
@@ -65,6 +67,34 @@ const (
         "name": "default",
         "containers": [
           {"name": "primary", "primary": true, "port": 8080, "imageUri": "registry/team/app:v1"}
+        ]
+      }
+    ]
+  }
+}`
+
+	// The same artifact with the credential reference already on it. A file
+	// that names the same reference therefore describes no artifact change, so
+	// a run that moves only the sizing really is a retune. Splicing the
+	// reference into the file alone would make it drift, and the run under test
+	// would quietly become a roll.
+	liveCredentialArtifactJSON = `{
+  "id": "68a0000000000000000000a1",
+  "name": "my-app-artifact",
+  "status": "draft",
+  "spec": {
+    "type": "service",
+    "containerGroups": [
+      {
+        "name": "default",
+        "containers": [
+          {
+            "name": "primary", "primary": true, "port": 8080, "imageUri": "registry/team/app:v1",
+            "environmentVars": [
+              {"source": "dr-credential", "name": "OPENAI_API_KEY",
+               "drCredentialId": "68b0cccc0000000000000003", "key": "apiToken"}
+            ]
+          }
         ]
       }
     ]
@@ -385,9 +415,11 @@ func TestRun_LockedProductionLeftAloneWhenTheAnswerIsNo(t *testing.T) {
 		Confirm: func(string, string) (bool, error) { return false, nil },
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "still running the version it was")
+	assert.Contains(t, err.Error(), "as it was")
 	assert.NotContains(t, tr.steps, "lock:art-2", "locking cannot be undone, so it must not happen on a no")
 	assert.NotContains(t, tr.steps, "replace:art-2")
+	assert.NotContains(t, tr.steps, "create-artifact",
+		"the question is put before anything is made, so a no leaves no draft behind")
 }
 
 // Being unable to ask is not the same as having been told to go ahead.
@@ -502,12 +534,189 @@ func TestRun_DetachedRollDoesNotWait(t *testing.T) {
 	assert.Contains(t, stderr, "not waiting")
 }
 
-// Rolling onto something that is not running is a different operation, and
-// guessing which half the user meant is worse than asking.
-func TestRun_StoppedWorkloadWithANewVersionSaysStartItFirst(t *testing.T) {
+// A stopped workload with a new version to roll is started first and then
+// rolled, in one run. It used to be refused, on the grounds that coming up on
+// the old version and then failing was the worst of both; the refusal was
+// worse, because it left the workload switched off and asked for two more
+// commands. From the start onwards this is the same deploy a running workload
+// gets, which is why the step list below is a roll's with a start in front.
+func TestRun_StoppedWorkloadWithANewVersionStartsThenRolls(t *testing.T) {
+	var tr track
+
+	f := stoppedRoll(&tr)
+
+	install(t, f)
+
+	result, stderr, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{
+		"guard", "start", "await-start", "guard", "create-artifact", "guard",
+		"replace:art-2", "await-rollout", "settle",
+	}, tr.steps, "the guard that can refuse comes before the start that mutates")
+	assert.Equal(t, ActionRolled, result.Action,
+		"rolling is the more significant of the two things this run did")
+	assert.Contains(t, stderr, "started, having been stopped")
+	assert.Contains(t, stderr, "artifact")
+}
+
+// The sizing half of the same rule: a stopped workload whose file moved only a
+// resource figure is started and then resized, rather than refused for asking
+// for more than a start.
+func TestRun_StoppedWorkloadWithASizingChangeStartsThenRetunes(t *testing.T) {
+	var tr track
+
+	f := stoppedRoll(&tr)
+	f.settings = func(id string, runtime json.RawMessage) (*workload.Replacement, error) {
+		tr.steps = append(tr.steps, "settings")
+		tr.rolledRuntime = runtime
+
+		return &workload.Replacement{ID: "rep-1", WorkloadID: id}, nil
+	}
+
+	install(t, f)
+
+	resized := strings.Replace(boundImageManifest, "replicaCount: 1", "replicaCount: 2", 1)
+
+	result, _, err := runIn(t, resized, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"guard", "start", "await-start", "guard", "settings", "await-rollout", "settle"},
+		tr.steps, "the guard that can refuse comes before the start that mutates")
+	assert.Equal(t, ActionUpdated, result.Action)
+}
+
+// A resize of a running workload deliberately skips the credential check, so
+// that a reference this deploy does not touch cannot refuse it. A stopped one
+// is not that run: it is started too, and a start is when the container
+// resolves its references from cold.
+//
+// The live artifact carries the reference as well as the file, which is what
+// makes this a retune. An earlier version of this test spliced the reference
+// into the file alone; that is artifact drift, so the run was a roll, the
+// settings seam was never called, and the rule the test is named for had no
+// coverage at all.
+func TestRun_StoppedRetuneStillVerifiesCredentials(t *testing.T) {
+	var (
+		tr      track
+		lookups int
+	)
+
+	f := stoppedRoll(&tr)
+	f.artifactD = func(string) (workload.Document, error) { return docOf(liveCredentialArtifactJSON), nil }
+	f.settings = func(id string, _ json.RawMessage) (*workload.Replacement, error) {
+		tr.steps = append(tr.steps, "settings")
+
+		return &workload.Replacement{ID: "rep-1", WorkloadID: id}, nil
+	}
+	f.cred = func(string) (*workload.Credential, error) {
+		lookups++
+
+		return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
+	}
+
+	install(t, f)
+
+	resized := strings.Replace(withCredential(boundImageManifest), "replicaCount: 1", "replicaCount: 2", 1)
+
+	_, _, err := runIn(t, resized, Options{NonInteractive: true})
+	require.Error(t, err)
+
+	assert.Equal(t, 1, lookups)
+	assert.Empty(t, tr.steps, "a bad reference stops the run before it starts anything")
+}
+
+// The pairing that gives the test above its meaning: the same manifest against
+// a running workload is the one case that may skip the check, because a resize
+// sends no environment and the artifact keeps every variable it has.
+func TestRun_RunningRetuneWithACredentialSkipsTheCheck(t *testing.T) {
 	var tr track
 
 	f := wiredRoll(&tr)
+	f.artifactD = func(string) (workload.Document, error) { return docOf(liveCredentialArtifactJSON), nil }
+	f.settings = func(id string, _ json.RawMessage) (*workload.Replacement, error) {
+		tr.steps = append(tr.steps, "settings")
+
+		return &workload.Replacement{ID: "rep-1", WorkloadID: id}, nil
+	}
+	f.cred = func(string) (*workload.Credential, error) {
+		t.Fatal("a settings update sends no environment, so a credential must not be able to refuse it")
+
+		return nil, nil
+	}
+
+	install(t, f)
+
+	resized := strings.Replace(withCredential(boundImageManifest), "replicaCount: 1", "replicaCount: 2", 1)
+
+	_, _, err := runIn(t, resized, Options{NonInteractive: true})
+	require.NoError(t, err)
+	assert.Contains(t, tr.steps, "settings")
+}
+
+// The lock is about the artifact left serving, so a run that starts a workload
+// only to roll it off that version must not lock what it is about to replace.
+// Locking cannot be undone, so this is not a tidiness point.
+func TestRun_StoppedRollLocksOnlyTheVersionItLeavesServing(t *testing.T) {
+	var tr track
+
+	install(t, stoppedRoll(&tr))
+
+	result, _, err := runIn(t, newImage(), Options{NonInteractive: true, Lock: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"lock:art-2"}, locks(tr.steps),
+		"one lock, on the version the run left running")
+	assert.True(t, result.Locked)
+}
+
+// --detach says not to wait for the deploy. The start is not the deploy: the
+// rollout cannot be requested against a workload that is not up yet, so the
+// wait happens and the run says why rather than blocking in silence.
+func TestRun_DetachedStoppedRollWaitsForTheStartOnly(t *testing.T) {
+	var tr track
+
+	install(t, stoppedRoll(&tr))
+
+	result, stderr, err := runIn(t, newImage(), Options{NonInteractive: true, Detach: true})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]string{"guard", "start", "await-start", "guard", "create-artifact", "guard", "replace:art-2"},
+		tr.steps)
+	assert.Equal(t, ActionRolled, result.Action)
+	assert.Contains(t, stderr, "--detach applies to the deploy")
+	assert.Contains(t, stderr, "not waiting")
+}
+
+// A credential id is a round trip each, and a stopped workload with drift
+// passes through both the branch that starts it and the one that rolls it.
+func TestRun_StoppedRollVerifiesCredentialsOnce(t *testing.T) {
+	var (
+		tr      track
+		lookups int
+	)
+
+	f := stoppedRoll(&tr)
+	f.cred = func(id string) (*workload.Credential, error) {
+		lookups++
+
+		return &workload.Credential{CredentialID: id}, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, withCredential(newImage()), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, lookups, "the same credential must not be looked up once per branch")
+}
+
+// stoppedRoll is wiredRoll against a workload that is switched off, with the
+// start wired so the order of the two halves is assertable.
+func stoppedRoll(tr *track) fakes {
+	f := wiredRoll(tr)
+
 	f.workloadD = func(string) (workload.Document, error) {
 		d := docOf(liveImageWorkloadJSON)
 		d["status"] = workload.WorkloadStatusStopped
@@ -515,12 +724,61 @@ func TestRun_StoppedWorkloadWithANewVersionSaysStartItFirst(t *testing.T) {
 		return d, nil
 	}
 
-	install(t, f)
+	f.start = func(id string) (*workload.WorkloadOperationResponse, error) {
+		tr.steps = append(tr.steps, "start")
 
-	_, _, err := runIn(t, newImage(), Options{NonInteractive: true})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "dr workload start")
-	assert.Empty(t, tr.steps)
+		return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
+	}
+
+	// The two waits are the same seam, so the label says which one this is:
+	// the first is the prerequisite start, the rest are the deploy settling.
+	settled := false
+	f.wait = func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		step := "await-start"
+		if settled {
+			step = "settle"
+		}
+
+		settled = true
+
+		tr.steps = append(tr.steps, step)
+
+		artifact := "68a0000000000000000000a1"
+		if step == "settle" {
+			artifact = "art-2"
+		}
+
+		return &workload.Workload{
+			ID: id, Name: "my-app", Status: workload.WorkloadStatusRunning,
+			ArtifactID: artifact, Endpoint: "https://app.datarobot.com/workloads/68b0/",
+		}, nil
+	}
+
+	return f
+}
+
+// withCredential hangs a stored-credential reference off the primary
+// container, which is the one thing in a manifest no local check can judge.
+func withCredential(file string) string {
+	return strings.Replace(file, "imageUri: registry/team/app:",
+		"environmentVars:\n"+
+			"              - name: OPENAI_API_KEY\n"+
+			"                value: dr-credential:68b0cccc0000000000000003/apiToken\n"+
+			"            imageUri: registry/team/app:", 1)
+}
+
+// locks picks the lock steps out of a track, so a test about how many locks a
+// run took does not have to restate every other step to say so.
+func locks(steps []string) []string {
+	var out []string
+
+	for _, step := range steps {
+		if strings.HasPrefix(step, "lock:") {
+			out = append(out, step)
+		}
+	}
+
+	return out
 }
 
 // builtRoll is a roll of a project whose image the platform builds, with

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -534,6 +534,60 @@ func TestRun_DetachedRollDoesNotWait(t *testing.T) {
 	assert.Contains(t, stderr, "not waiting")
 }
 
+// The production confirm is asked before anything is touched, which means it is
+// now asked of a workload that is switched off. It must not open by telling the
+// reader their workload is running: that is the one prompt where being wrong
+// about live state costs something, and the run is about to start it.
+func TestRun_LockedProductionPromptDoesNotClaimAStoppedWorkloadIsRunning(t *testing.T) {
+	var (
+		tr    track
+		asked string
+	)
+
+	f := lockedLive(stoppedRoll(&tr))
+
+	install(t, f)
+
+	_, _, err := runIn(t, newImage(), Options{
+		Confirm: func(question, _ string) (bool, error) {
+			asked = question
+
+			return false, nil
+		},
+	})
+	require.Error(t, err)
+
+	assert.NotContains(t, asked, "is running a locked version")
+	assert.Contains(t, asked, "is on a locked version")
+	assert.Contains(t, asked, "this deploy starts it",
+		"that the run also switches the workload on is material to the answer")
+	assert.Equal(t, []string{"guard"}, tr.steps,
+		"a no leaves the workload off and nothing minted; only the checks ahead of it ran")
+}
+
+// The same prompt against a running workload says nothing about starting,
+// because nothing is being started.
+func TestRun_LockedProductionPromptSaysNothingAboutStartingWhenItIsUp(t *testing.T) {
+	var (
+		tr    track
+		asked string
+	)
+
+	install(t, lockedLive(wiredRoll(&tr)))
+
+	_, _, err := runIn(t, newImage(), Options{
+		Confirm: func(question, _ string) (bool, error) {
+			asked = question
+
+			return false, nil
+		},
+	})
+	require.Error(t, err)
+
+	assert.Contains(t, asked, "is on a locked version")
+	assert.NotContains(t, asked, "starts it")
+}
+
 // A stopped workload with a new version to roll is started first and then
 // rolled, in one run. It used to be refused, on the grounds that coming up on
 // the old version and then failing was the worst of both; the refusal was

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -39,6 +39,7 @@ var (
 	runWizardFn        = wizard.Run
 	createWorkloadFn   = workload.CreateWorkload
 	waitWorkloadFn     = workload.WaitForWorkload
+	waitSteadyFn       = workload.WaitForSteadyWorkload
 	listWorkloadsFn    = workload.ListWorkloads
 	startWorkloadFn    = workload.StartWorkload
 	createArtifactFn   = workload.CreateArtifact
@@ -147,9 +148,13 @@ func Run(opts Options) (Result, error) {
 		return Result{}, err
 	}
 
-	live, err := Look(loaded.WorkloadID())
+	live, err := lookSettled(loaded.WorkloadID(), opts)
 	if err != nil {
-		return Result{}, err
+		// The binding travels with the failure. A run that dies before the plan
+		// exists still has to report which workload it was about: losing the id
+		// is how a deploy becomes unfindable, and it is the whole of what the
+		// JSON envelope can carry from here.
+		return Result{WorkloadID: loaded.WorkloadID()}, err
 	}
 
 	code, err := codeChangeFn(loaded, live)
@@ -188,7 +193,8 @@ func Run(opts Options) (Result, error) {
 		return result, err
 	}
 
-	if err := Render(opts.Stderr, Summary{Name: result.Name, WorkloadID: result.WorkloadID}, plan); err != nil {
+	summary := Summary{Name: result.Name, WorkloadID: result.WorkloadID, Status: live.Status}
+	if err := Render(opts.Stderr, summary, plan); err != nil {
 		return result, err
 	}
 
@@ -273,6 +279,119 @@ func guardRollout(workloadID, consequence string) error {
 
 	return fmt.Errorf("cannot tell whether workload %s already has a rollout in progress, so %s: %w",
 		workloadID, consequence, err)
+}
+
+// lookSettled is the live read a plan is built from: the workload as it is,
+// once it has stopped moving.
+func lookSettled(workloadID string, opts Options) (Live, error) {
+	found, err := Look(workloadID)
+	if err != nil {
+		return Live{}, err
+	}
+
+	return awaitSteady(found, opts)
+}
+
+// awaitSteady waits out a workload that is still moving, and hands back what
+// it settled into.
+//
+// It runs before the plan rather than as a refusal after it, which is the whole
+// change: a deploy arriving mid-transition is early rather than wrong, and
+// telling someone to run the same command again in a minute is work the command
+// can do itself. The state it waits for is a destination, not a healthy one, so
+// a workload that settles into errored or stopped goes on to the paths that know
+// what to do about those.
+//
+// It is the workload's own status that is waited on, which is narrower than it
+// sounds: a workload being replaced reports itself running for the whole of the
+// swap, so a rollout in flight is not something this can see. That case is
+// caught by guardRollout instead, off the replacement route.
+//
+// The workload is re-read afterwards rather than patched with the status the
+// wait ended on. The status is only half of what the plan is built from, and
+// the other half is the spec: reading one from before the transition and one
+// from after would compare a file against a snapshot that never existed.
+//
+// A dry run never waits, because blocking a preview for the poll timeout is the
+// opposite of what a preview is for. What it must not do is pretend it knows
+// the answer: the plan for a workload halfway through a transition depends on
+// where the transition lands, so the state travels on unchanged and Render
+// declines to call it up to date.
+func awaitSteady(live Live, opts Options) (Live, error) {
+	if live.State != StateSettling {
+		return live, nil
+	}
+
+	report := newReporter(opts.Stderr, opts.Spinner)
+
+	if opts.DryRun {
+		report.say("  %s\n", tui.HintStyle.Render(
+			"A deploy would wait for this to finish and plan against where it lands."))
+
+		return live, nil
+	}
+
+	// Said before the wait, not after it. Without a terminal there is no
+	// spinner and a phase prints nothing until it ends, so a CI log would
+	// otherwise show no output at all for as long as the transition takes,
+	// and the plan block that names the workload comes later still.
+	report.say("  %s\n", tui.HintStyle.Render(fmt.Sprintf(
+		"Workload %s is %s.", live.WorkloadID, live.Status)))
+
+	if opts.Detach {
+		// --detach is about not waiting for the deploy to serve. This wait is
+		// before the deploy: what to apply cannot be known until the workload
+		// stops moving. Saying so beats blocking in silence.
+		report.say("  %s\n", tui.HintStyle.Render(
+			"Waiting for it to settle before planning; --detach applies to the deploy."))
+	}
+
+	var settled *workload.Workload
+
+	err := report.run("Waiting for the workload to settle", func() error {
+		wl, waitErr := waitSteadyFn(live.WorkloadID, opts.PollInterval, opts.PollTimeout, nil)
+		settled = wl
+
+		return waitErr
+	})
+	if err != nil {
+		if failure := settleFailed(live, settled, err); failure != nil {
+			return live, failure
+		}
+
+		// The workload went away while this was waiting. That is drift, and
+		// the read below is what says so.
+	}
+
+	return Look(live.WorkloadID)
+}
+
+// settleFailed explains a wait that did not land, and tells a workload that
+// went away from one that is simply slow.
+//
+// A 404 is not a failure to settle. Look treats a workload the platform does
+// not have as drift and lets the deploy recreate it, and a workload deleted
+// while this was waiting deserves the same answer rather than a message
+// pointing at an id that no longer exists. Returning nil hands the run back to
+// the re-Look above, which reports StateMissing.
+//
+// Everything else names where the transition got to, which the wait returns
+// precisely so a caller can say it: "still stopping after 30m" is what decides
+// whether to wait longer or go and look at the platform, and the bare timeout
+// says neither.
+func settleFailed(live Live, settled *workload.Workload, err error) error {
+	if isNotFound(err) {
+		return nil
+	}
+
+	where := "did not finish settling"
+	if settled != nil && settled.Status != "" {
+		where = "was still " + settled.Status
+	}
+
+	return fmt.Errorf(
+		"workload %s %s, so nothing was deployed; check 'dr workload status %s': %w",
+		live.WorkloadID, where, live.WorkloadID, err)
 }
 
 // noteIgnoreFile passes on the note about a deprecated ignore filename.
@@ -428,54 +547,55 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 		return result, err
 	}
 
-	// Starting is checked before the roll refusal so that a stopped workload
-	// the file already agrees with gets deployed rather than turned away.
-	// When the file asks for more than a start, the refusal wins: bringing the
-	// workload up on the version it was stopped on would report a failure
-	// having already changed something, which is the worst of both.
-	if plan.Action() == ActionStarted {
-		// A start is when the container resolves its references, so a
-		// credential deleted while the workload was off would otherwise fail
-		// minutes later as a container that will not come up.
-		if err := verifyCredentials(loaded.Compiled.CredentialRefs, result.Name); err != nil {
-			return result, err
-		}
+	report := newReporter(opts.Stderr, opts.Spinner)
 
-		return start(live, result, opts)
-	}
-
-	// Everything below this changes a workload that is running: a rollout
-	// promotes onto something serving, and a settings change is followed by a
-	// wait for the workload to come back. Starting first and then applying the
-	// rest would bring the workload up on the version it was stopped on and
-	// report a failure afterwards, which is worse than refusing.
-	if live.State == StateStopped {
-		return result, fmt.Errorf(
-			"workload %s is stopped and the file asks for more than starting it. "+
-				"Start it with 'dr workload start %s' and deploy again, so the change lands on "+
-				"something that is running",
-			result.Name, live.WorkloadID)
-	}
-
-	// A runtime-only change sends no environment at all: the artifact keeps
-	// every variable it already has, so a credential this run does not touch
-	// must not be able to refuse a resize.
-	if !plan.Creates && !plan.RollsArtifact() {
-		return retune(loaded, result, opts, newReporter(opts.Stderr, opts.Spinner))
-	}
-
-	// Last check before the first mutation, and the only one that needs the
-	// network: a credential id is the one thing the local ledger cannot judge.
-	if err := verifyCredentials(loaded.Compiled.CredentialRefs, result.Name); err != nil {
+	// Everything that can refuse this run goes first, because a start is a
+	// mutation and the branch below performs one. The order used to be
+	// academic: a stopped workload with drift was turned away here, so nothing
+	// could refuse after something had already changed.
+	lock, err := beforeAnything(loaded, live, plan, result, opts)
+	if err != nil {
 		return result, err
 	}
 
-	report := newReporter(opts.Stderr, opts.Spinner)
+	// A stopped workload is started before anything else. Everything below
+	// changes a workload that has to be running to receive it: a rollout
+	// promotes onto something serving, and a settings change is followed by a
+	// wait for the workload to come back.
+	//
+	// This used to refuse whenever the file asked for more than a start, on the
+	// grounds that coming up on the version it was stopped on and then failing
+	// was the worst of both. It is not: the user asked for the workload to be
+	// up, so a failed roll that leaves it up on the old version is exactly what
+	// a failed roll against a running workload leaves behind, while the refusal
+	// left it switched off and told the reader to run two more commands.
+	//
+	// Starting first is also what keeps this one deploy rather than two. From
+	// the line below, a run against a stopped workload is indistinguishable
+	// from a run against a running one. live is deliberately not rewritten to
+	// say so: nothing below reads its state or status, and the fields that are
+	// read describe the artifact rather than the workload, so faking a refresh
+	// would advertise a consistency this value does not have.
+	if live.State == StateStopped {
+		result, err = startFirst(live, plan, result, opts, report)
+		if err != nil || plan.OnlyStarts() {
+			return result, err
+		}
+	}
+
+	// A runtime-only change is applied to the workload in place, with no new
+	// version minted. Asked through the plan rather than restated here, so the
+	// branch and the credential skip that mirrors it cannot drift apart: they
+	// are the same question, and answering it twice is how a roll comes to skip
+	// a check or a resize comes to fail one.
+	if plan.Retunes() {
+		return retune(loaded, result, opts, report)
+	}
 
 	// A workload that already exists is replaced rather than created: the
 	// endpoint has to survive, and something is serving on it meanwhile.
 	if plan.RollsArtifact() {
-		return roll(loaded, live, plan, result, opts, report)
+		return roll(loaded, live, plan, lock, result, opts, report)
 	}
 
 	// A published image is one POST. Anything the platform builds has to be
@@ -486,6 +606,76 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 	}
 
 	return create(loaded, loaded.Compiled.Payload, result, opts, report)
+}
+
+// beforeAnything runs every check that can still refuse, and settles the one
+// question that needs a person, so that nothing below can turn the run away
+// after it has already changed something. It reports whether the version this
+// run rolls has to be locked.
+//
+// The ordering matters now in a way it did not before. A stopped workload with
+// drift used to be refused outright, so the credential check, the in-flight
+// rollout guard and the locked-production confirm all sat comfortably after it.
+// Now the run starts the workload first, and a refusal that came later would
+// leave production switched on and serving traffic it was deliberately stopped
+// from serving, under a message saying nothing had changed.
+func beforeAnything(loaded Loaded, live Live, plan Plan, result Result, opts Options) (bool, error) {
+	// The only check here that needs the network for the file's own sake: a
+	// credential id is the one thing the local ledger cannot judge. It runs
+	// once rather than per branch: a stopped workload with drift now reaches
+	// both the start and the roll, each of which used to verify for itself,
+	// and the check is a round trip per reference.
+	if err := verifyCredentials(credentialRefs(loaded, plan), result.Name); err != nil {
+		return false, err
+	}
+
+	if !plan.RollsArtifact() && len(plan.Runtime) == 0 {
+		return false, nil
+	}
+
+	// A swap already in flight is about to move the workload somewhere this run
+	// has not planned for. roll and retune each guard immediately before their
+	// own call, which is the check that actually holds and which covers a
+	// workload that is already up; this one exists for the workload that is
+	// not, so a doomed run does not start something it is then going to refuse
+	// to deploy onto.
+	if live.State == StateStopped {
+		if err := guardRollout(live.WorkloadID, "the workload was left stopped"); err != nil {
+			return false, err
+		}
+	}
+
+	if !plan.RollsArtifact() {
+		return false, nil
+	}
+
+	// Asked before the first mutation rather than after the candidate is
+	// minted. Agreeing still costs nothing that cannot be undone, since the
+	// lock itself is taken immediately before the swap; declining now costs
+	// neither a draft nor a workload switched on to be rolled off again.
+	return confirmLock(live, result.Name, opts)
+}
+
+// credentialRefs is what this run has to verify before it mutates anything,
+// and nothing at all for a change that only moves the sizing of something
+// already running.
+//
+// That exception is the deliberate one: a runtime-only change sends no
+// environment at all, so the artifact keeps every variable it already has and a
+// credential this deploy does not touch must not be able to refuse a resize.
+//
+// A stopped workload is not covered by it, even when sizing is all its file
+// moved, because the run starts the workload as well. A start is when the
+// container resolves its references, so a credential deleted while the workload
+// was off would otherwise surface minutes later as a container that will not
+// come up. Every remaining run either builds a version out of the references or
+// starts a container that reads them, so it verifies.
+func credentialRefs(loaded Loaded, plan Plan) []manifest.CredentialRef {
+	if plan.SendsNoEnvironment() {
+		return nil
+	}
+
+	return loaded.Compiled.CredentialRefs
 }
 
 // deployable refuses the live states that cannot take a deploy, one message
@@ -504,7 +694,8 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 //
 // Stopped is not among them either. A stopped workload is one POST away from
 // being deployable, and `up` means "make the file true", which for something
-// that is not running means starting it.
+// that is not running means starting it, and then applying whatever else the
+// file asks for onto the workload that is now up.
 func deployable(live Live, workloadName, dirFlag string) error {
 	switch live.State {
 	case StateTerminated:
@@ -520,9 +711,15 @@ func deployable(live Live, workloadName, dirFlag string) error {
 			workloadName)
 
 	case StateSettling:
+		// The backstop, not the answer. Every run waits a moving workload out
+		// before the plan is built, so what reaches here is a workload that was
+		// steady when it was read and is moving again by the time it is acted
+		// on. The message describes rather than explains: this has no way to
+		// know which of the two reads was the stale one.
 		return fmt.Errorf(
-			"workload %s is still settling. Wait for it to finish, then deploy",
-			workloadName)
+			"workload %s is %s, which is not a state a deploy can act on. "+
+				"Check 'dr workload status %s', then deploy",
+			workloadName, live.Status, live.WorkloadID)
 
 	case StateUnbound, StateMissing, StateRunning:
 		return nil
@@ -604,38 +801,30 @@ func create(
 	return settle(created.ID, result, opts, report)
 }
 
-// start brings a stopped workload back up. It is the whole apply for a plan
-// that found nothing else to change: the file and the live spec already
-// agree, and the only thing standing between them and a served request is
-// that the workload is off.
+// startFirst brings a stopped workload up so the rest of the plan has
+// something to land on, and is the whole apply when starting is all the plan
+// asks for.
 //
 // Nothing is written back and nothing is compiled here, because nothing is
 // being changed. The workload keeps the artifact it was stopped on, which is
-// the version this run just confirmed the file still describes.
-func start(live Live, result Result, opts Options) (Result, error) {
-	report := newReporter(opts.Stderr, opts.Spinner)
-
-	var ack *workload.WorkloadOperationResponse
-
-	err := report.run("Starting workload", func() error {
-		response, startErr := startWorkloadFn(result.WorkloadID)
-		ack = response
-
-		return startErr
-	})
-	if err != nil {
-		return result, fmt.Errorf("cannot start workload %s: %w", result.WorkloadID, err)
-	}
-
-	// The only place the platform says it did nothing: a start it no-ops comes
-	// back 200 with a message saying so.
-	if ack != nil && ack.Status != "" {
-		report.say("  %s\n", ack.Status)
+// either the version this run just confirmed the file still describes, or the
+// one the roll below is about to replace.
+//
+// --detach is honoured only for a start that is the whole run. When more
+// follows, the wait is a prerequisite rather than the deploy: the rollout
+// cannot be requested against a workload that is not up yet, and it is the
+// rollout that --detach returns without waiting for. Saying so is better than
+// silently blocking, so the note goes out before the wait rather than after it.
+func startFirst(live Live, plan Plan, result Result, opts Options, report *reporter) (Result, error) {
+	if err := requestStart(result.WorkloadID, report); err != nil {
+		return result, err
 	}
 
 	result.Action = ActionStarted
 
-	if opts.Detach {
+	only := plan.OnlyStarts()
+
+	if opts.Detach && only {
 		// Without this the envelope reports "stopped" beside an action of
 		// "started", which reads as a run that did nothing.
 		result.Status = startingStatus(live.Status)
@@ -645,7 +834,41 @@ func start(live Live, result Result, opts Options) (Result, error) {
 		return result, nil
 	}
 
-	return settle(result.WorkloadID, result, opts, report)
+	if opts.Detach {
+		report.say("  Waiting for the start before deploying onto it; --detach applies to the deploy.\n")
+	}
+
+	// Only the run that ends here may lock: locking is about the artifact left
+	// serving, and a start that is about to be rolled off is not that.
+	if only {
+		return settle(result.WorkloadID, result, opts, report)
+	}
+
+	return awaitRunning(result.WorkloadID, result, opts, report)
+}
+
+// requestStart POSTs the start and passes on the one thing the platform says
+// about it.
+func requestStart(workloadID string, report *reporter) error {
+	var ack *workload.WorkloadOperationResponse
+
+	err := report.run("Starting workload", func() error {
+		response, startErr := startWorkloadFn(workloadID)
+		ack = response
+
+		return startErr
+	})
+	if err != nil {
+		return fmt.Errorf("cannot start workload %s: %w", workloadID, err)
+	}
+
+	// The only place the platform says it did nothing: a start it no-ops comes
+	// back 200 with a message saying so.
+	if ack != nil && ack.Status != "" {
+		report.say("  %s\n", ack.Status)
+	}
+
+	return nil
 }
 
 // startingStatus is what to report for a start nobody waited for. An
@@ -653,15 +876,11 @@ func start(live Live, result Result, opts Options) (Result, error) {
 // recognised ones are matched the way every other status comparison here
 // matches, which is without regard to case.
 func startingStatus(was string) string {
-	switch {
-	case strings.EqualFold(was, workload.WorkloadStatusStopped),
-		strings.EqualFold(was, workload.WorkloadStatusSuspended),
-		strings.EqualFold(was, workload.WorkloadStatusInterrupted):
+	if workload.IsStoppedWorkloadStatus(was) {
 		return workload.WorkloadStatusSubmitted
-
-	default:
-		return was
 	}
+
+	return was
 }
 
 // nameTaken turns a create conflict into an error naming what owns the name.
@@ -719,8 +938,25 @@ func isConflict(err error) bool {
 	return errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusConflict
 }
 
-// settle waits for the workload to come up and records where it landed.
+// settle waits for the workload to come up, records where it landed, and locks
+// the artifact serving when the run asked for that.
+//
+// It is the end of a run. A wait that happens partway through one, such as the
+// start a roll onto a stopped workload needs before it can begin, calls
+// awaitRunning instead: locking is about the artifact left serving, and an
+// artifact about to be rolled off is not it. Locking cannot be undone, so the
+// distinction is not a tidiness one.
 func settle(workloadID string, result Result, opts Options, report *reporter) (Result, error) {
+	result, err := awaitRunning(workloadID, result, opts, report)
+	if err != nil || !opts.Lock {
+		return result, err
+	}
+
+	return lock(result, report)
+}
+
+// awaitRunning waits for the workload to come up and records where it landed.
+func awaitRunning(workloadID string, result Result, opts Options, report *reporter) (Result, error) {
 	var final *workload.Workload
 
 	err := report.run("Waiting for the workload to run", func() error {
@@ -745,11 +981,7 @@ func settle(workloadID string, result Result, opts Options, report *reporter) (R
 			workloadID, result.Status, workloadID)
 	}
 
-	if !opts.Lock {
-		return result, nil
-	}
-
-	return lock(result, report)
+	return result, nil
 }
 
 // lock makes the live artifact permanent. It runs only after the workload is

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/datarobot/cli/internal/drapi"
@@ -737,7 +736,7 @@ func deployable(live Live, workloadName, dirFlag string) error {
 // the timeout for a transition that is never coming. Interrupted can be
 // started.
 func startable(live Live, workloadName string) error {
-	if !strings.EqualFold(live.Status, workload.WorkloadStatusSuspended) {
+	if !workload.IsSuspendedWorkloadStatus(live.Status) {
 		return nil
 	}
 

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -169,6 +169,7 @@ type fakes struct {
 	wizard         func(wizard.Options) (wizard.Result, error)
 	create         func(any) (*workload.Workload, error)
 	wait           func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
+	waitSteady     func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
 	list           func(int, []string, string) ([]workload.Workload, error)
 	start          func(string) (*workload.WorkloadOperationResponse, error)
 	lock           func(string) (*workload.Artifact, error)
@@ -221,6 +222,17 @@ func install(t *testing.T, f fakes) {
 
 		return nil, nil
 	})
+
+	// The same for the wait a settling workload triggers, which a fixture can
+	// reach without the test having asked for it.
+	force(t, &waitSteadyFn,
+		func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			t.Fatalf("the run waited on workload %s to settle, which this test did not wire", id)
+
+			return nil, nil
+		})
+
+	swap(t, &waitSteadyFn, f.waitSteady)
 
 	// The placeholder message looks a credential up by name. Left unwired it
 	// would list credentials from whatever tenant the developer is logged
@@ -700,13 +712,15 @@ func TestRun_LockIsNotAttemptedWhenTheWorkloadFailed(t *testing.T) {
 
 // TestRun_RefusesTheStatesThatCannotTakeADeploy checks each live state gets
 // its own message rather than a generic failure.
+//
+// The settling statuses are not among them any more: a workload still moving is
+// waited out before the plan is built, so it is deployed rather than refused.
 func TestRun_RefusesTheStatesThatCannotTakeADeploy(t *testing.T) {
 	cases := []struct {
 		status string
 		want   string
 	}{
 		{workload.WorkloadStatusErrored, "dr workload logs"},
-		{workload.WorkloadStatusProvisioning, "still settling"},
 	}
 
 	for _, c := range cases {
@@ -728,6 +742,227 @@ func TestRun_RefusesTheStatesThatCannotTakeADeploy(t *testing.T) {
 			_, _, err := runIn(t, bound, Options{NonInteractive: true})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), c.want)
+		})
+	}
+}
+
+// The reported dead end: a workload mid-transition used to be refused with
+// "wait for it to finish, then deploy", which is work the command can do
+// itself. It waits, re-reads, and deploys against where the workload landed.
+func TestRun_SettlingWorkloadIsWaitedOutAndThenDeployed(t *testing.T) {
+	var (
+		looks  int
+		waited string
+	)
+
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			looks++
+
+			d := stoppedWorkload(t)
+			if looks == 1 {
+				d["status"] = workload.WorkloadStatusProvisioning
+			}
+
+			return d, nil
+		},
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		waitSteady: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			waited = id
+
+			return &workload.Workload{ID: id, Status: workload.WorkloadStatusStopped}, nil
+		},
+		start: func(id string) (*workload.WorkloadOperationResponse, error) {
+			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
+		},
+		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			return running(id), nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	result, stderr, err := runIn(t, bound, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", waited)
+	assert.Equal(t, 2, looks, "the workload is re-read, because a transition can land somewhere new")
+	assert.Equal(t, ActionStarted, result.Action,
+		"the plan is built against where it settled, which here is stopped")
+	assert.Contains(t, stderr, "Waiting for the workload to settle")
+}
+
+// A workload still moving after the wait gave up has not been deployed onto.
+// The message names where it got to, because "still stopping after 30m" is what
+// decides whether to wait longer or go and look at the platform.
+func TestRun_SettlingThatNeverLandsStopsBeforeMutating(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			d := stoppedWorkload(t)
+			d["status"] = workload.WorkloadStatusStopping
+
+			return d, nil
+		},
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		waitSteady: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			return &workload.Workload{ID: id, Status: workload.WorkloadStatusStopping},
+				errors.New("timeout waiting for workload " + id + " after 30m0s")
+		},
+		create: func(any) (*workload.Workload, error) {
+			t.Fatal("a run that never got a settled state must not have deployed")
+
+			return nil, nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	result, _, err := runIn(t, bound, Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "was still stopping")
+	assert.Contains(t, err.Error(), "dr workload status 68b0c1d2e3f4a5b6c7d8e9f0")
+
+	// The binding survives the failure. Without it the command prints no JSON
+	// envelope at all, and losing the id is how a deploy becomes unfindable.
+	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", result.WorkloadID)
+}
+
+// A workload deleted while the deploy was waiting it out is drift, not a wait
+// that failed. Reporting "did not settle" against an id nothing answers to
+// would send the reader to a status command that 404s, when the answer `up`
+// already has for a workload that is gone is to create one.
+func TestRun_WorkloadDeletedDuringTheWaitIsRecreated(t *testing.T) {
+	var looks int
+
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			looks++
+			if looks > 1 {
+				return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
+			}
+
+			d := stoppedWorkload(t)
+			d["status"] = workload.WorkloadStatusStopping
+
+			return d, nil
+		},
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		waitSteady: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
+		},
+		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			return running(id), nil
+		},
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	result, _, err := runIn(t, bound, Options{NonInteractive: true})
+	require.NoError(t, err)
+	assert.Equal(t, ActionCreated, result.Action)
+}
+
+// --detach is about not waiting for the deploy to serve, and this wait is
+// before the deploy: what to apply cannot be known until the workload stops
+// moving. Blocking is right, blocking in silence is not.
+func TestRun_DetachedRunSaysWhyItIsWaitingToSettle(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) { return stoppedWorkload(t), nil },
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		waitSteady: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			return &workload.Workload{ID: id, Status: workload.WorkloadStatusStopped}, nil
+		},
+		start: func(id string) (*workload.WorkloadOperationResponse, error) {
+			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
+		},
+	})
+
+	// stoppedWorkload is read once as stopping so the wait fires, and the
+	// re-read is the stopped fixture the seam above already returns.
+	first := true
+
+	force(t, &getWorkloadDocFn, func(string) (workload.Document, error) {
+		d := stoppedWorkload(t)
+
+		if first {
+			first = false
+			d["status"] = workload.WorkloadStatusStopping
+		}
+
+		return d, nil
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	_, stderr, err := runIn(t, bound, Options{NonInteractive: true, Detach: true})
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "--detach applies to the deploy")
+}
+
+// A preview must not block for the poll timeout: it changes nothing, so the
+// honest answer is the plan as things stand plus a note that a deploy would
+// wait. The header carries the state, so nothing here reads as settled.
+func TestRun_DryRunOnASettlingWorkloadDoesNotWait(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			d := stoppedWorkload(t)
+			d["status"] = workload.WorkloadStatusLaunching
+
+			return d, nil
+		},
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+	result, stderr, err := runIn(t, bound, Options{NonInteractive: true, DryRun: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "plan against where it lands")
+	assert.Contains(t, stderr, "settling")
+	assert.Equal(t, "settling", result.Status)
+
+	// The trap this closes: nothing differs from the state as it stands, so the
+	// preview used to claim the deploy would do nothing, while the deploy that
+	// follows waits for the stop to land and then starts the workload.
+	assert.NotContains(t, stderr, "Already up to date")
+}
+
+// A workload that dies while the deploy is watching it must not be reported as
+// a success. The deploy now waits transitions out, so a workload that settles
+// into errored is one this run had a front-row seat to, and the file matching
+// it field for field is not a reason to print a green tick over the wreckage.
+func TestRun_SettlingIntoErroredIsNotReportedAsUpToDate(t *testing.T) {
+	for _, status := range []string{workload.WorkloadStatusErrored, workload.WorkloadStatusTerminated} {
+		t.Run(status, func(t *testing.T) {
+			var looks int
+
+			install(t, fakes{
+				workloadD: func(string) (workload.Document, error) {
+					looks++
+
+					d := doc(t, liveWorkloadJSON)
+					d["status"] = status
+
+					if looks == 1 {
+						d["status"] = workload.WorkloadStatusProvisioning
+					}
+
+					return d, nil
+				},
+				artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+				waitSteady: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+					return &workload.Workload{ID: id, Status: status}, nil
+				},
+			})
+
+			bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + boundLiveManifest
+
+			_, stderr, err := runIn(t, bound, Options{NonInteractive: true})
+			require.Error(t, err, "a broken workload is not a successful deploy")
+			assert.NotContains(t, stderr, "Already up to date")
+			assert.Contains(t, stderr, status, "the plan says what it found before the error explains it")
 		})
 	}
 }
@@ -1641,17 +1876,36 @@ func TestRun_StartsAStoppedWorkload(t *testing.T) {
 	assert.Contains(t, stderr, "Starting workload")
 }
 
-// A plan that asks for more than a start is refused whole. Starting the
-// workload first would bring it up on the version it was stopped on and then
-// report a failure, which leaves the user worse off than refusing did.
-func TestRun_StoppedWithDriftIsRefusedWithoutStarting(t *testing.T) {
+// The reported dead end: a stopped workload whose file asks for more than a
+// start used to be refused, with a remedy naming two more commands. It is one
+// run now, and the plan says both halves of it out loud.
+func TestRun_StoppedWithDriftStartsAndThenReconciles(t *testing.T) {
+	var order []string
+
 	install(t, fakes{
 		workloadD: func(string) (workload.Document, error) { return stoppedWorkload(t), nil },
 		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
-		start: func(string) (*workload.WorkloadOperationResponse, error) {
-			t.Fatal("a refused plan must not have started anything")
+		start: func(id string) (*workload.WorkloadOperationResponse, error) {
+			order = append(order, "start")
 
-			return nil, nil
+			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
+		},
+		settings: func(id string, _ json.RawMessage) (*workload.Replacement, error) {
+			order = append(order, "settings")
+
+			return &workload.Replacement{ID: "rep-1", WorkloadID: id}, nil
+		},
+		waitReplace: func(_ string, started *workload.Replacement, _, _ time.Duration,
+			_ func(*workload.Replacement),
+		) (*workload.Replacement, error) {
+			started.Status = workload.ReplacementStatusCompleted
+
+			return started, nil
+		},
+		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			order = append(order, "wait")
+
+			return running(id), nil
 		},
 	})
 
@@ -1660,10 +1914,14 @@ func TestRun_StoppedWithDriftIsRefusedWithoutStarting(t *testing.T) {
 	drifted := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" +
 		strings.Replace(boundLiveManifest, "cpu: 3", "cpu: 4", 1)
 
-	_, _, err := runIn(t, drifted, Options{NonInteractive: true})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "dr workload start")
-	assert.Contains(t, err.Error(), "more than starting it")
+	result, stderr, err := runIn(t, drifted, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"start", "wait", "settings", "wait"}, order,
+		"the workload has to be up before a settings change can land on it")
+	assert.Equal(t, ActionUpdated, result.Action)
+	assert.Contains(t, stderr, "started, having been stopped")
+	assert.Contains(t, stderr, "runtime")
 }
 
 func TestRun_StartFailureNamesTheWorkload(t *testing.T) {

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -2123,6 +2123,46 @@ func TestRun_ReplacementForADivergedSpecJoinsTheSameLineage(t *testing.T) {
 	assert.Equal(t, "cat1", *tr.savedCfg.CatalogID)
 }
 
+// The same lineage question asked of an agent, which is what makes it a
+// regression test rather than a duplicate.
+//
+// The comparison that decides whether the linked draft still matches used to
+// normalise the live document in place, taking the type off it. The next line
+// read that type to pick the repository, found nothing, defaulted it to
+// service, and concluded the file had changed the artifact's kind. Every
+// redraft of an agent therefore started a new lineage instead of joining its
+// own, silently and permanently. Nothing caught it because every other fixture
+// here is a service, where the default happens to be the right answer.
+func TestRun_ReplacementForADivergedAgentJoinsTheSameLineage(t *testing.T) {
+	var tr track
+
+	f := divergedLink(wiredBuild(&tr), &tr)
+
+	inner := f.artifactD
+	f.artifactD = func(id string) (workload.Document, error) {
+		d, err := inner(id)
+		if err != nil {
+			return nil, err
+		}
+
+		d[keyType] = "agent"
+
+		return d, nil
+	}
+
+	install(t, f)
+
+	agent := strings.Replace(unboundDockerfileManifest, "type: service", "type: agent", 1)
+
+	_, _, err := runIn(t, agent, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	payload, ok := tr.artifactIn.(json.RawMessage)
+	require.True(t, ok, "the create has to have been given the artifact block")
+	assert.Contains(t, string(payload), "repo-1",
+		"an agent redraft joins its own lineage, exactly as a service does")
+}
+
 // The other half of that equivalence. The tree was already synced into the
 // artifact the file has since diverged from, so the sync onto its replacement
 // can find nothing to upload and the new version would go to the builder with

--- a/internal/workload/up/state.go
+++ b/internal/workload/up/state.go
@@ -121,9 +121,7 @@ func stateFor(status string) State {
 	case strings.EqualFold(status, workload.WorkloadStatusRunning):
 		return StateRunning
 
-	case strings.EqualFold(status, workload.WorkloadStatusStopped),
-		strings.EqualFold(status, workload.WorkloadStatusSuspended),
-		strings.EqualFold(status, workload.WorkloadStatusInterrupted):
+	case workload.IsStoppedWorkloadStatus(status):
 		return StateStopped
 
 	case strings.EqualFold(status, workload.WorkloadStatusTerminated):

--- a/internal/workload/up/state_test.go
+++ b/internal/workload/up/state_test.go
@@ -15,9 +15,11 @@
 package up
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,24 +54,41 @@ func TestStateFor(t *testing.T) {
 // status silently becomes StateSettling, which is the safe answer but not
 // necessarily the right one, so the reminder is worth having.
 func TestStateFor_EveryPlatformStatusIsMapped(t *testing.T) {
-	known := []string{
-		workload.WorkloadStatusUnknown,
-		workload.WorkloadStatusSubmitted,
-		workload.WorkloadStatusProvisioning,
-		workload.WorkloadStatusLaunching,
-		workload.WorkloadStatusRunning,
-		workload.WorkloadStatusSuspended,
-		workload.WorkloadStatusInterrupted,
-		workload.WorkloadStatusStopping,
-		workload.WorkloadStatusStopped,
-		workload.WorkloadStatusErrored,
-		workload.WorkloadStatusTerminated,
-	}
+	assert.Len(t, platformStatuses, 11, "the platform's status enum changed; revisit stateFor")
 
-	assert.Len(t, known, 11, "the platform's status enum changed; revisit stateFor")
-
-	for _, status := range known {
+	for _, status := range platformStatuses {
 		assert.NotEmpty(t, stateFor(status).String(), "status %q maps to a nameless state", status)
+	}
+}
+
+// platformStatuses is every status the platform serialises, in one place so a
+// twelfth cannot be added to one test's copy and missed by another's. The
+// tripwire above is what makes that worth doing: it fails when the enum grows,
+// and it would be no use if the list it guards were not the list the other
+// tests range over.
+var platformStatuses = []string{
+	workload.WorkloadStatusUnknown,
+	workload.WorkloadStatusSubmitted,
+	workload.WorkloadStatusProvisioning,
+	workload.WorkloadStatusLaunching,
+	workload.WorkloadStatusRunning,
+	workload.WorkloadStatusSuspended,
+	workload.WorkloadStatusInterrupted,
+	workload.WorkloadStatusStopping,
+	workload.WorkloadStatusStopped,
+	workload.WorkloadStatusErrored,
+	workload.WorkloadStatusTerminated,
+}
+
+// Two packages classify the same eleven statuses and have to agree: stateFor
+// decides whether a deploy waits, and IsSteadyWorkloadStatus decides when that
+// wait ends. Drift between them is a deadlock rather than a wrong answer, since
+// the wait would end on a status the plan still calls unsettled, or never end
+// on one the plan is happy to deploy onto.
+func TestStateFor_AgreesWithTheSteadyPredicate(t *testing.T) {
+	for _, status := range append(slices.Clone(platformStatuses), "a-status-the-platform-added-later") {
+		assert.Equal(t, workload.IsSteadyWorkloadStatus(status), stateFor(status) != StateSettling,
+			"status %q is classified differently by stateFor and IsSteadyWorkloadStatus", status)
 	}
 }
 
@@ -118,6 +137,33 @@ func TestStateFor_FoldsCase(t *testing.T) {
 		{"LAUNCHING", StateSettling},
 	} {
 		assert.Equal(t, c.want, stateFor(c.status), "status %q", c.status)
+	}
+}
+
+// deployable's settling arm survives the wait: every run waits a moving
+// workload out before planning, so what reaches this is a workload that was
+// steady when it was read and is moving again by the time it is acted on. The
+// table test that used to cover it went away with the refusal, and an
+// uncovered refusal is one a later simplification can turn into a nil return
+// with the suite still green.
+func TestDeployable_RefusesAWorkloadThatStartedMovingAgain(t *testing.T) {
+	err := deployable(Live{
+		Live:   manifest.Live{WorkloadID: "wl-1"},
+		State:  StateSettling,
+		Status: workload.WorkloadStatusLaunching,
+	}, "my-app", "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), workload.WorkloadStatusLaunching,
+		"the message describes where it is rather than guessing how it got there")
+	assert.Contains(t, err.Error(), "dr workload status wl-1")
+}
+
+// The states a deploy can act on say nothing, which is what keeps the arm
+// above from being a catch-all.
+func TestDeployable_AcceptsTheStatesADeployCanActOn(t *testing.T) {
+	for _, state := range []State{StateUnbound, StateMissing, StateRunning} {
+		require.NoError(t, deployable(Live{State: state}, "my-app", ""), "state %s", state)
 	}
 }
 

--- a/internal/workload/up/version.go
+++ b/internal/workload/up/version.go
@@ -384,6 +384,15 @@ func describes(loaded Loaded, artifactID string) bool {
 // it, or that needs the lock status off the same read, pays one round trip
 // instead of two to the same resource.
 func specMatches(loaded Loaded, doc workload.Document) (bool, error) {
+	// The comparison below normalises both sides in place, and the live side
+	// belongs to the caller. ensureArtifact hands the same document to
+	// redraftRepository immediately afterwards, which reads the type off it;
+	// left shared, this would take that type away, an agent would read as a
+	// service, and the replacement would open a new repository rather than
+	// joining the lineage it is a version of. A silent lineage fork on the
+	// recovery path is a poor price for one map allocation.
+	doc = detachedArtifact(doc)
+
 	payload, err := loaded.Compiled.ArtifactPayload()
 	if err != nil {
 		return false, err
@@ -426,6 +435,36 @@ func specMatches(loaded Loaded, doc workload.Document) (bool, error) {
 	// reused, and it is rolled out still carrying the variable that was
 	// deleted, which minting a fresh artifact would have dropped.
 	return len(Subset(want, doc)) == 0 && len(Extra(want, doc)) == 0, nil
+}
+
+// detachedArtifact is doc with the two maps the normalisation writes to copied,
+// so a caller's document survives being compared.
+//
+// It copies exactly what hoistArtifactType and sameArtifactTypeIn touch: the
+// top level, where the type is written and then removed, and the spec, where a
+// type written inside it is deleted from. Everything deeper is shared, which is
+// safe because nothing below reaches it, and a deep copy of a document that can
+// carry an entire container spec is not worth paying for a two-key edit.
+func detachedArtifact(doc workload.Document) workload.Document {
+	if doc == nil {
+		return nil
+	}
+
+	out := make(workload.Document, len(doc))
+	for k, v := range doc {
+		out[k] = v
+	}
+
+	if spec, ok := out[keySpec].(map[string]any); ok {
+		copied := make(map[string]any, len(spec))
+		for k, v := range spec {
+			copied[k] = v
+		}
+
+		out[keySpec] = copied
+	}
+
+	return out
 }
 
 // sameArtifactTypeIn reports whether two artifact blocks name the same kind,

--- a/internal/workload/up/version.go
+++ b/internal/workload/up/version.go
@@ -416,7 +416,7 @@ func specMatches(loaded Loaded, doc workload.Document) (bool, error) {
 	// attempt refuses that one too. It is the same question the plan asks, so
 	// it is asked the same way, folded and with only the live side defaulted.
 	if !sameArtifactTypeIn(want, doc) {
-		return false
+		return false, nil
 	}
 
 	// Both directions, which is the difference between this and measuring

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -107,6 +107,34 @@ func IsTerminalWorkloadStatus(s string) bool {
 	return IsWorkloadErrorStatus(s) || strings.EqualFold(s, WorkloadStatusRunning)
 }
 
+// IsSteadyWorkloadStatus reports whether s is a status the platform will not
+// move away from on its own. It is the opposite question to
+// IsTerminalWorkloadStatus, which asks whether a workload on its way up has
+// arrived: this one asks whether it has stopped moving at all, so the states
+// that one deliberately keeps polling through (stopped, suspended,
+// interrupted) are answers here rather than steps on the way to one.
+//
+// Everything left over is the platform moving under its own power: submitted,
+// provisioning, launching, stopping, unknown, and whatever it adds later. An
+// unrecognised status therefore reads as still moving, which costs a wait and
+// never mistakes a transition for a destination.
+func IsSteadyWorkloadStatus(s string) bool {
+	return IsTerminalWorkloadStatus(s) || IsStoppedWorkloadStatus(s)
+}
+
+// IsStoppedWorkloadStatus reports whether s is one of the three ways a
+// workload can be switched off. They are grouped because a deploy treats them
+// alike, and named here because three files ask the same question: this one,
+// the deploy's own state reduction, and the status a detached start reports.
+//
+// Grouped, not equivalent. Only some of them can be started again, which is a
+// question for whoever is about to try rather than for this classification.
+func IsStoppedWorkloadStatus(s string) bool {
+	return strings.EqualFold(s, WorkloadStatusStopped) ||
+		strings.EqualFold(s, WorkloadStatusSuspended) ||
+		strings.EqualFold(s, WorkloadStatusInterrupted)
+}
+
 // IsWorkloadErrorStatus reports whether s is a terminal failure a caller should
 // surface as an error rather than a settled state.
 //
@@ -357,6 +385,57 @@ func WaitForWorkload(
 	interval, timeout time.Duration,
 	onTick func(*Workload),
 ) (*Workload, error) {
+	wl, err := pollWorkload(workloadID, interval, timeout, IsTerminalWorkloadStatus, onTick)
+	if err != nil || wl == nil {
+		return wl, err
+	}
+
+	if IsWorkloadErrorStatus(wl.Status) {
+		return wl, fmt.Errorf("workload %s ended with status %s; run 'dr workload logs %s' to inspect",
+			workloadID, wl.Status, workloadID)
+	}
+
+	return wl, nil
+}
+
+// WaitForSteadyWorkload polls until the workload stops moving under its own
+// power (see IsSteadyWorkloadStatus) or deadline expires. It is for a caller
+// that has to know where a transition landed before it can decide anything,
+// rather than one waiting for a workload it just started to come up.
+//
+// The difference from WaitForWorkload is the whole reason both exist. That one
+// polls through stopped, suspended and interrupted, because for a workload on
+// its way up they are steps rather than destinations; this one returns at them.
+// A `stopping` workload handed to WaitForWorkload runs to its timeout.
+//
+// Errored and terminated come back with a nil error. They are legitimate
+// answers to "has it stopped moving", so the verdict belongs to the caller
+// rather than here: the same "errored" is a destination to a caller asking
+// where a transition landed and a failure to one waiting for a workload it
+// just started. A caller that treats a nil error as "healthy" is reading this
+// as the wrong function; that is what WaitForWorkload is for.
+func WaitForSteadyWorkload(
+	workloadID string,
+	interval, timeout time.Duration,
+	onTick func(*Workload),
+) (*Workload, error) {
+	return pollWorkload(workloadID, interval, timeout, IsSteadyWorkloadStatus, onTick)
+}
+
+// pollWorkload is the loop both waits share. It errors only on a poll that
+// failed and on the deadline, so the verdict on a status the loop stopped at is
+// the caller's to pass: the same "errored" is a failure to one of them and an
+// answer to the other.
+//
+// The last-seen workload comes back with a timeout so a caller can still say
+// where it got to, and nothing at all comes back from a failed poll, since
+// there is no status to report.
+func pollWorkload(
+	workloadID string,
+	interval, timeout time.Duration,
+	stop func(string) bool,
+	onTick func(*Workload),
+) (*Workload, error) {
 	deadline := time.Now().Add(timeout)
 
 	for {
@@ -369,11 +448,7 @@ func WaitForWorkload(
 			onTick(wl)
 		}
 
-		if IsTerminalWorkloadStatus(wl.Status) {
-			if IsWorkloadErrorStatus(wl.Status) {
-				return wl, fmt.Errorf("workload %s ended with status %s; run 'dr workload logs %s' to inspect", workloadID, wl.Status, workloadID)
-			}
-
+		if stop(wl.Status) {
 			return wl, nil
 		}
 

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -122,6 +122,14 @@ func IsSteadyWorkloadStatus(s string) bool {
 	return IsTerminalWorkloadStatus(s) || IsStoppedWorkloadStatus(s)
 }
 
+// IsSuspendedWorkloadStatus reports the one switched-off status a start cannot
+// undo. The platform ignores a start while a workload is suspended, so both the
+// plan that says what a deploy will do and the apply that refuses to do it have
+// to single this status out, and they must not spell it differently.
+func IsSuspendedWorkloadStatus(s string) bool {
+	return strings.EqualFold(s, WorkloadStatusSuspended)
+}
+
 // IsStoppedWorkloadStatus reports whether s is one of the three ways a
 // workload can be switched off. They are grouped because a deploy treats them
 // alike, and named here because three files ask the same question: this one,

--- a/internal/workload/workload_test.go
+++ b/internal/workload/workload_test.go
@@ -584,6 +584,148 @@ func TestIsWorkloadErrorStatus(t *testing.T) {
 	}
 }
 
+func TestIsSteadyWorkloadStatus(t *testing.T) {
+	steady := []string{
+		WorkloadStatusRunning,
+		WorkloadStatusStopped,
+		WorkloadStatusSuspended,
+		WorkloadStatusInterrupted,
+		WorkloadStatusErrored,
+		WorkloadStatusTerminated,
+	}
+
+	moving := []string{
+		WorkloadStatusSubmitted,
+		WorkloadStatusProvisioning,
+		WorkloadStatusLaunching,
+		WorkloadStatusStopping,
+		WorkloadStatusUnknown,
+	}
+
+	for _, s := range steady {
+		assert.True(t, IsSteadyWorkloadStatus(s), "%s should be steady", s)
+		assert.True(t, IsSteadyWorkloadStatus(strings.ToUpper(s)), "%s should be steady whatever the casing", s)
+	}
+
+	for _, s := range moving {
+		assert.False(t, IsSteadyWorkloadStatus(s), "%s is the platform still moving", s)
+	}
+
+	assert.False(t, IsSteadyWorkloadStatus("something-added-later"),
+		"an unrecognised status costs a wait rather than mistaking a transition for a destination")
+}
+
+func TestIsStoppedWorkloadStatus(t *testing.T) {
+	for _, s := range []string{WorkloadStatusStopped, WorkloadStatusSuspended, WorkloadStatusInterrupted} {
+		assert.True(t, IsStoppedWorkloadStatus(s), "%s is a way of being switched off", s)
+		assert.True(t, IsStoppedWorkloadStatus(strings.ToUpper(s)), "%s folds like every other status", s)
+	}
+
+	for _, s := range []string{
+		WorkloadStatusRunning, WorkloadStatusErrored, WorkloadStatusTerminated,
+		WorkloadStatusStopping, WorkloadStatusProvisioning,
+	} {
+		assert.False(t, IsStoppedWorkloadStatus(s), "%s is not switched off", s)
+	}
+
+	assert.False(t, IsStoppedWorkloadStatus(WorkloadStatusStopping),
+		"stopping is the platform on its way there, which is a different answer")
+}
+
+// The pairing that justifies both waits existing: stopped is a destination to
+// one and a step on the way up to the other, so the same fixture ends one wait
+// and runs the other to its deadline.
+func TestWaitForSteadyWorkload_ReturnsAtStoppedWhereWaitForWorkloadWouldNot(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", WorkloadStatusStopped))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForSteadyWorkload("wl-1", time.Millisecond, time.Second, nil)
+	require.NoError(t, err)
+	assert.Equal(t, WorkloadStatusStopped, wl.Status)
+
+	_, err = WaitForWorkload("wl-1", 5*time.Millisecond, 25*time.Millisecond, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+}
+
+func TestWaitForSteadyWorkload_PollsUntilTheTransitionLands(t *testing.T) {
+	installSkipAuth(t)
+
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		page := atomic.AddInt32(&hits, 1)
+
+		status := WorkloadStatusStopping
+		if page >= 2 {
+			status = WorkloadStatusStopped
+		}
+
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", status))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	var ticks int
+
+	wl, err := WaitForSteadyWorkload("wl-1", time.Millisecond, time.Second, func(*Workload) {
+		ticks++
+	})
+	require.NoError(t, err)
+	assert.Equal(t, WorkloadStatusStopped, wl.Status)
+	assert.GreaterOrEqual(t, ticks, 2)
+}
+
+// Errored is an answer to "has it stopped moving", not a failure of the wait.
+// The caller decides what it means: a deploy recovers the workload, while a
+// wait for one it just started calls the same status a failure.
+func TestWaitForSteadyWorkload_ErroredIsAnAnswerNotAFailure(t *testing.T) {
+	installSkipAuth(t)
+
+	for _, status := range []string{WorkloadStatusErrored, WorkloadStatusTerminated} {
+		t.Run(status, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", status))
+			}))
+
+			defer srv.Close()
+
+			installEndpoint(t, srv.URL)
+
+			wl, err := WaitForSteadyWorkload("wl-1", time.Millisecond, time.Second, nil)
+			require.NoError(t, err)
+			assert.Equal(t, status, wl.Status)
+		})
+	}
+}
+
+func TestWaitForSteadyWorkload_TimeoutKeepsTheLastSeen(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, serverWorkloadDoc("wl-1", "a", WorkloadStatusLaunching))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForSteadyWorkload("wl-1", 5*time.Millisecond, 25*time.Millisecond, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+	require.NotNil(t, wl, "the caller can still say where it got to")
+	assert.Equal(t, WorkloadStatusLaunching, wl.Status)
+}
+
 func TestWaitForWorkload_RunningReturnsNil(t *testing.T) {
 	installSkipAuth(t)
 

--- a/internal/workload/workload_test.go
+++ b/internal/workload/workload_test.go
@@ -615,6 +615,16 @@ func TestIsSteadyWorkloadStatus(t *testing.T) {
 		"an unrecognised status costs a wait rather than mistaking a transition for a destination")
 }
 
+func TestIsSuspendedWorkloadStatus(t *testing.T) {
+	assert.True(t, IsSuspendedWorkloadStatus(WorkloadStatusSuspended))
+	assert.True(t, IsSuspendedWorkloadStatus("SUSPENDED"), "it folds like every other status")
+
+	for _, s := range []string{WorkloadStatusStopped, WorkloadStatusInterrupted, WorkloadStatusRunning} {
+		assert.False(t, IsSuspendedWorkloadStatus(s),
+			"%s is not the status a start cannot undo", s)
+	}
+}
+
 func TestIsStoppedWorkloadStatus(t *testing.T) {
 	for _, s := range []string{WorkloadStatusStopped, WorkloadStatusSuspended, WorkloadStatusInterrupted} {
 		assert.True(t, IsStoppedWorkloadStatus(s), "%s is a way of being switched off", s)


### PR DESCRIPTION
# RATIONALE

RAPTOR-19686. `dr workload up` refused three live states in a row, and each refusal named the command that led to the next one:

```
errored   -> "check 'dr workload logs' first"          (remedy: stop it)
settling  -> "wait for it to finish, then deploy"      (after the stop)
stopped   -> "start it with 'dr workload start' and deploy again"
```

The errored refusal is the perverse one: an empty plan never reaches it, so it only ever fired when the user already had the fix in hand.

Two of these states are dealt with here. A workload still moving is waited out and re-read, so the plan is built against where it landed rather than against a state that is about to change. A stopped one is started and then reconciled, which is one command whether the file asks for a start alone or for a start and a new version. Errored becomes deployable in the change that follows this one.

Reversing the stopped row is deliberate: it undoes a position amended into RAPTOR-18979 in August, which argued that coming up on the old version and then failing was the worst of both. It is not. The user asked for the workload to be up, so a failed roll that leaves it up on the old version is exactly what a failed roll against a running workload leaves behind, while the refusal left it switched off and asked for two more commands.

## CHANGES

**The two states.** `awaitSteady` waits before the plan is built and then re-reads, so the status and the spec come from one snapshot. A stopped workload is started first, and from that point the run is indistinguishable from one against a running workload.

**Ordering, which the start forces.** A start is a mutation, so everything that can still refuse moves ahead of it: the credential check, the in-flight rollout guard, and the question a locked production version has to answer. A "no" arriving after the workload had been switched on would be a refusal that had already changed something, under a message saying nothing had.

**A new wait primitive.** `WaitForSteadyWorkload` waits for a transition to land rather than for a workload to come up. That is the opposite question `WaitForWorkload` answers, and the reason a `stopping` workload handed to it polls to its timeout. Both now share one loop and layer their own verdict on top. A test pins the two status classifications together across the package boundary.

**The lock moved out of `settle`** into its own step, so a start that is about to be rolled off cannot lock the version it is about to replace. Locking is one way, so that distinction is not a tidiness one.

**Honesty fixes on the paths this opens.** An errored or terminated workload whose file matches no longer reports "Already up to date" and exit 0; a preview of a settling workload no longer claims nothing differs, since what the deploy does depends on where the transition lands; the plan header carries the platform's own status, so a suspended workload is not announced as stopped and then refused for being suspended; and the draft warning is no longer suppressed on a failed run that had itself started the workload and its eight hour clock.

## NOTES

Three API behaviours this design assumes are undocumented and want a staging run before the follow-up ships: whether a replacement, a stop and a settings PATCH are each accepted on an errored workload.

Known and deliberately left alone, rather than folded in here: `--poll-timeout` is a per wait budget across several waits, and this adds one more; the start's boot wait blocks an image build that needs nothing from the workload; and `WaitForWorkload`, `WaitForBuild` and `WaitForReplacement` are three copies of one poll loop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `workload up` deploy ordering and live-state handling (wait, start-then-roll), where mistakes could mutate production before refusing; coverage is broad in tests but behavior touches credentials, locking, and rollout guards.
> 
> **Overview**
> **`dr workload up` no longer bounces users through “wait, then deploy again” or “start, then deploy again”** for workloads that are still transitioning or stopped. Settling workloads are waited on and re-read before planning; stopped ones are started and then rolled/retuned in the same invocation.
> 
> The apply path is reordered so **refusals happen before any mutation**: credential verification, in-flight rollout guard, and locked-production confirmation run in `beforeAnything` ahead of `startFirst`. Locked-roll confirmation is no longer inside `roll`, so declining does not mint a draft artifact. **`confirmLock` cancellation messaging** is neutral (“as it was”) for stopped workloads.
> 
> **New workload polling**: `WaitForSteadyWorkload` / `IsSteadyWorkloadStatus` (shared `pollWorkload` with `WaitForWorkload`). Dry runs skip the settle wait but warn that a real deploy would wait; detached runs explain that `--detach` applies to the deploy, not the prerequisite settle/start waits.
> 
> **Plan/render/CLI honesty**: empty plans treat errored/terminated/stopped as actionable; settling dry-runs avoid “Already up to date”; headers show platform **status** (e.g. `suspended`); errored/terminated get plan lines. **Draft warnings** still appear when a failed run had already started the workload (`ActionStarted`). Credential checks are skipped only for **running** runtime-only retunes; stopped retunes still verify refs after start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0c122632450b9566bd6107fe42698af1cfbab1a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->