### PR TITLE
[RAPTOR-19602] fix(workload): stop a refused deploy announcing work it will not do

### DIFF
--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -33,6 +33,7 @@ import (
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
+	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/internal/workload/up"
 	"github.com/datarobot/cli/tui"
@@ -417,6 +418,16 @@ func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, resul
 	draft := draftIsServing(f, result, failed)
 
 	if f.dryRun {
+		// A dry run that failed says nothing of its own. The error explains
+		// itself, and the footer's calm "nothing was changed" sitting above it
+		// reads as a preview that went to plan; a refused deploy is exactly the
+		// case, since the plan it just printed is disclaimed rather than
+		// promised. draftIsServing already withholds the warning for the same
+		// reason, so there is nothing left to print here either.
+		if failed {
+			return nil
+		}
+
 		fmt.Fprintln(cmd.ErrOrStderr(), "\nDry run: nothing was changed.")
 		draftWarning(cmd.ErrOrStderr(), draft, true)
 
@@ -492,28 +503,63 @@ func draftWarning(w io.Writer, draft, planned bool) {
 }
 
 // nextSteps lists what to run against the workload this deploy just touched,
-// on stderr so the endpoint on stdout stays pipeable. Nothing is printed for a
-// run that produced no workload: a list of commands that need an id is no help
-// to someone who has not got one.
+// on stderr so the endpoint on stdout stays pipeable. Nothing is printed when
+// there is nothing worth running: see followUps.
+func nextSteps(w io.Writer, result up.Result, dir string, draft, failed bool) {
+	steps := followUps(result, dir, draft, failed)
+	if len(steps) == 0 {
+		return
+	}
+
+	fmt.Fprintf(w, "\n%s\n", tui.HintStyle.Render("Next:"))
+
+	for _, step := range steps {
+		fmt.Fprintf(w, "  %s  %s\n",
+			tui.InfoStyle.Render(step[0]), tui.HintStyle.Render(step[1]))
+	}
+}
+
+// followUps is what is worth running against this workload now, empty when
+// nothing is. A run that produced no workload is the first such case: a list of
+// commands that all name a workload is no help to someone who has not got one.
 //
 // The commands carry no id. A successful deploy leaves the manifest bound, so
 // they resolve from the project directory, and --dir carries a deploy that ran
 // somewhere else.
 //
-// A failed run is the exception, and takes the id instead. One of its shapes
-// is a workload created whose id could not be written back, where the binding
-// the bare commands need is exactly what is missing; printing them bare would
-// hand the reader three commands that cannot run. It is also what keeps
-// reportable's promise that a deploy which failed late is still findable.
+// A failed run is the exception, and takes the id instead. One of its shapes is
+// a workload created whose id could not be written back, where the binding the
+// bare commands need is exactly what is missing; printing them bare would hand
+// the reader commands that cannot run. It is also what keeps reportable's
+// promise that a deploy which failed late is still findable.
+//
+// A failed run also loses two of the lines, for the reason the endpoint's tick
+// is dropped on the same run. 'stop' is not a next step for a deploy that did
+// not land, and neither is --lock: a deploy onto a stopped workload starts it
+// before it rolls, so a run that fails after that really has put a draft on the
+// air, but locking a version this run could not finish is not the remedy for
+// it, and draftWarning names the command inline for anyone who decides
+// otherwise. --lock is in any case the one line that could not be made to name
+// the workload, since it takes no id, and on a failed run the manifest may hold
+// no binding for it to resolve. What survives is logs and status, which are the
+// right pair for an errored workload, a wait that timed out and a rollout that
+// never completed, and which carry the id that the errors naming those same
+// commands do not.
+//
+// A terminated workload gets nothing. None of the three mean anything against
+// something that is not coming back, and the refusal already names
+// 'dr workload delete', which is the only command that helps. Matched on the
+// status rather than through IsWorkloadErrorStatus, which also covers errored:
+// errored is exactly where logs and status earn their place.
 //
 // A draft deploy trades the stop line for --lock, and puts it first so it sits
 // directly under the warning that explains why it is there. Someone who wants
-// to switch a workload off goes looking for the command; someone whose
-// workload switches itself off does not know there is anything to look for,
-// and this list is the one place they will read either way.
-func nextSteps(w io.Writer, result up.Result, dir string, draft, failed bool) {
+// to switch a workload off goes looking for the command; someone whose workload
+// switches itself off does not know there is anything to look for, and this
+// list is the one place they will read either way.
+func followUps(result up.Result, dir string, draft, failed bool) [][2]string {
 	if result.WorkloadID == "" {
-		return
+		return nil
 	}
 
 	at := manifest.DirFlag(dir)
@@ -521,35 +567,32 @@ func nextSteps(w io.Writer, result up.Result, dir string, draft, failed bool) {
 		at = " " + result.WorkloadID
 	}
 
-	steps := [][2]string{
-		{"dr workload logs" + at, "View the container logs"},
-		{"dr workload status" + at, "Check the workload status"},
+	// No build-logs line on any of these paths. It needs an artifact id as well
+	// as a build id, and on a roll the two deliberately belong to different
+	// artifacts: BuildID is the candidate's, ArtifactID stays on the version
+	// still serving until the swap lands. Pairing them would send the reader to
+	// a 404 at exactly the moment they need the logs. The error from a failed
+	// build already names the right pair.
+	logs := [2]string{"dr workload logs" + at, "View the container logs"}
+	status := [2]string{"dr workload status" + at, "Check the workload status"}
+
+	if failed {
+		if strings.EqualFold(result.Status, workload.WorkloadStatusTerminated) {
+			return nil
+		}
+
+		return [][2]string{logs, status}
 	}
 
-	// --lock takes no id, so on a failed run it is the one line that cannot be
-	// made to name the workload. That is also the run where the manifest may
-	// hold no binding, which would make it create a second workload instead of
-	// locking this one, so it is left out rather than printed unrunnable.
-	if draft && !failed {
-		steps = append([][2]string{
-			{"dr workload up --lock" + manifest.DirFlag(dir), "Lock the artifact to make it permanent"},
-		}, steps...)
-	} else {
-		steps = append(steps,
-			[2]string{"dr workload stop" + at, "Stop the workload, retaining its version"})
+	if draft {
+		return [][2]string{
+			{"dr workload up --lock" + at, "Lock the artifact to make it permanent"},
+			logs, status,
+		}
 	}
 
-	// No build-logs line. It needs an artifact id as well as a build id, and
-	// on a roll the two deliberately belong to different artifacts: BuildID is
-	// the candidate's, ArtifactID stays on the version still serving until the
-	// swap lands. Pairing them would send the reader to a 404 at exactly the
-	// moment they need the logs. The error from a failed build already names
-	// the right pair.
-
-	fmt.Fprintf(w, "\n%s\n", tui.HintStyle.Render("Next:"))
-
-	for _, step := range steps {
-		fmt.Fprintf(w, "  %s  %s\n",
-			tui.InfoStyle.Render(step[0]), tui.HintStyle.Render(step[1]))
+	return [][2]string{
+		logs, status,
+		{"dr workload stop" + at, "Stop the workload, retaining its version"},
 	}
 }

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -385,6 +385,22 @@ func reportable(result up.Result) bool {
 // gets here: see bindLocked in internal/workload/up. Without it a promotion
 // of a locked artifact onto a fresh workload would be called temporary and
 // then advised to lock what is already locked.
+// terminated reports that the workload this run is about is not coming back.
+//
+// Status rather than Plan.State, and deliberately: the plan's state is what was
+// found before the run acted, so a deploy that started a workload which then
+// died reads as "stopped" there and as "terminated" here. Status is the last
+// thing known about the workload, which is the question both callers are
+// actually asking.
+//
+// The predicate lives in internal/workload rather than as a comparison here,
+// because the value being matched arrives by two routes -- the platform's own
+// status on a live read, and State.String() on a refusal -- and a literal in
+// this package would be relying on those two agreeing by coincidence.
+func terminated(result up.Result) bool {
+	return workload.IsTerminatedWorkloadStatus(result.Status)
+}
+
 func draftIsServing(f flags, result up.Result, failed bool) bool {
 	if f.lock || result.Locked {
 		return false
@@ -394,7 +410,14 @@ func draftIsServing(f flags, result up.Result, failed bool) bool {
 		// Action is what this run actually did, not what it wanted, so it says
 		// "started" only when the start went through. A run that failed before
 		// that changed nothing and has nothing to warn about.
-		return result.Action == up.ActionStarted
+		//
+		// Terminated is excluded even so. A workload that started and then
+		// reached the end of its life is running nothing, so the clock this
+		// warns about is not ticking and the remedy it names would be a lock on
+		// the artifact of something that is never coming back. followUps drops
+		// its whole list for the same state, and the two must agree: a warning
+		// with no follow-ups reads as advice the command forgot to give.
+		return result.Action == up.ActionStarted && !terminated(result)
 	}
 
 	return f.dryRun || result.WorkloadID != ""
@@ -548,9 +571,9 @@ func nextSteps(w io.Writer, result up.Result, dir string, draft, failed bool) {
 //
 // A terminated workload gets nothing. None of the three mean anything against
 // something that is not coming back, and the refusal already names
-// 'dr workload delete', which is the only command that helps. Matched on the
-// status rather than through IsWorkloadErrorStatus, which also covers errored:
-// errored is exactly where logs and status earn their place.
+// 'dr workload delete', which is the only command that helps. Asked through
+// terminated rather than through IsWorkloadErrorStatus, which also covers
+// errored: errored is exactly where logs and status earn their place.
 //
 // A draft deploy trades the stop line for --lock, and puts it first so it sits
 // directly under the warning that explains why it is there. Someone who wants
@@ -577,7 +600,7 @@ func followUps(result up.Result, dir string, draft, failed bool) [][2]string {
 	status := [2]string{"dr workload status" + at, "Check the workload status"}
 
 	if failed {
-		if strings.EqualFold(result.Status, workload.WorkloadStatusTerminated) {
+		if terminated(result) {
 			return nil
 		}
 

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -612,6 +612,113 @@ func TestCmd_UnchangedRunStillWarnsAboutTheDraft(t *testing.T) {
 	assert.Contains(t, stderr, draftHeadline)
 }
 
+// A refused --dry-run is a failure, and its footer would read as a preview
+// that went to plan. The plan block above it already says it is disclaimed and
+// the error below says why, so the line between them is the one thing on the
+// screen still describing an ordinary run.
+func TestCmd_FailedDryRunDropsTheFooter(t *testing.T) {
+	stubRun(t, refused("terminated"), errors.New("workload my-app is terminated"))
+
+	_, stderr, err := runCmd(t, "--dry-run")
+	require.Error(t, err)
+
+	assert.NotContains(t, stderr, "Dry run: nothing was changed.")
+	assert.False(t, draftWarned(stderr))
+}
+
+// refused is the result a deploy hands back when the live state turned it
+// away: the workload is real and reports where it stands, and nothing was done
+// to it.
+func refused(status string) up.Result {
+	result := deployed()
+	result.Status = status
+	result.Action = up.ActionUnchanged
+
+	return result
+}
+
+// TestCmd_TerminatedRefusalOffersNoFollowUps is half the reported bug. Three
+// commands were printed under the error, and not one of them applies to a
+// workload that is not coming back: 'stop' on a terminated workload is
+// meaningless, and the refusal already names the delete that clears the way.
+func TestCmd_TerminatedRefusalOffersNoFollowUps(t *testing.T) {
+	stubRun(t, refused("terminated"), errors.New("workload my-app is terminated"))
+
+	_, stderr, err := runCmd(t)
+	require.Error(t, err)
+
+	assert.NotContains(t, stderr, "Next:")
+	assert.NotContains(t, stderr, "dr workload stop")
+	assert.NotContains(t, stderr, "dr workload logs")
+}
+
+// An errored workload is the other half, and it goes the other way: reading the
+// logs is exactly what to do next, and the list is the only place the id is
+// attached to the command. What it loses is 'stop', which is not a next step
+// for a deploy that never landed.
+func TestCmd_ErroredRefusalKeepsLogsAndStatusButNotStop(t *testing.T) {
+	stubRun(t, refused("errored"), errors.New("workload my-app is errored"))
+
+	_, stderr, err := runCmd(t)
+	require.Error(t, err)
+
+	assert.Contains(t, stderr, "Next:")
+	assert.Contains(t, stderr, "dr workload logs 68b0c1d2e3f4a5b6c7d8e9f0")
+	assert.Contains(t, stderr, "dr workload status 68b0c1d2e3f4a5b6c7d8e9f0")
+	assert.NotContains(t, stderr, "dr workload stop")
+}
+
+// The rule is about the run having failed rather than about a refusal: a wait
+// that timed out, or a rollout that never completed, leaves a running workload
+// whose logs and status are the whole of what there is to look at.
+func TestCmd_AnyFailureKeepsLogsAndStatusButNotStop(t *testing.T) {
+	stubRun(t, deployed(), errors.New("timed out waiting"))
+
+	_, stderr, err := runCmd(t)
+	require.Error(t, err)
+
+	assert.Contains(t, stderr, "dr workload logs 68b0c1d2e3f4a5b6c7d8e9f0")
+	assert.Contains(t, stderr, "dr workload status 68b0c1d2e3f4a5b6c7d8e9f0")
+	assert.NotContains(t, stderr, "dr workload stop")
+	assert.NotContains(t, stderr, "dr workload up --lock",
+		"a failed run is not advised to lock what it did not deploy")
+}
+
+// A deploy onto a stopped workload starts it before it rolls, so a run that
+// fails after that has itself put a draft on the air: draftIsServing says so,
+// and the warning prints. The list still does not offer --lock, because locking
+// a version this run could not finish is not the remedy; the warning names the
+// command inline for anyone who decides otherwise.
+func TestCmd_FailureAfterAStartWarnsButOffersNoLock(t *testing.T) {
+	result := deployed()
+	result.Action = up.ActionStarted
+
+	stubRun(t, result, errors.New("rollout never completed"))
+
+	_, stderr, err := runCmd(t)
+	require.Error(t, err)
+
+	assert.True(t, draftWarned(stderr), "the run left a draft running and has to say so")
+	assert.Contains(t, stderr, "dr workload logs 68b0c1d2e3f4a5b6c7d8e9f0")
+	assert.Contains(t, stderr, "dr workload status 68b0c1d2e3f4a5b6c7d8e9f0")
+	assert.NotContains(t, stderr, "  dr workload up --lock  Lock the artifact")
+	assert.NotContains(t, stderr, "dr workload stop")
+}
+
+// A refusal still reports the workload it was refused by. Losing the id is how
+// a deploy becomes unfindable, and the endpoint is deliberately kept for the
+// same reason; only its success tick is dropped.
+func TestCmd_TerminatedRefusalStillReportsTheEndpoint(t *testing.T) {
+	stubRun(t, refused("terminated"), errors.New("workload my-app is terminated"))
+
+	stdout, stderr, err := runCmd(t)
+	require.Error(t, err)
+
+	assert.Equal(t, "https://app.datarobot.com/workloads/68b0/\n", stdout)
+	assert.Contains(t, stderr, "Workload endpoint:")
+	assert.NotContains(t, stderr, "✓ Workload endpoint:")
+}
+
 func TestCmd_IsRegisteredUnderWorkload(t *testing.T) {
 	cmd := Cmd()
 

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -572,6 +572,12 @@ func TestCmd_NoWorkloadSaysNothingAboutDrafts(t *testing.T) {
 	_, stderr, err := runCmd(t)
 	require.Error(t, err)
 	assert.False(t, draftWarned(stderr))
+
+	// The same run has no follow-ups either, and for its own reason: every
+	// command in the list needs an id, and this run never produced one. Pinned
+	// here because the guard that says so sits above the failed branch in
+	// followUps, where a later edit could reorder it out of the way.
+	assert.NotContains(t, stderr, "Next:")
 }
 
 // A failed deploy has one thing worth reading and it is the error. Telling
@@ -617,7 +623,7 @@ func TestCmd_UnchangedRunStillWarnsAboutTheDraft(t *testing.T) {
 // the error below says why, so the line between them is the one thing on the
 // screen still describing an ordinary run.
 func TestCmd_FailedDryRunDropsTheFooter(t *testing.T) {
-	stubRun(t, refused("terminated"), errors.New("workload my-app is terminated"))
+	stubRun(t, refused(up.StateTerminated), errors.New("workload my-app is terminated"))
 
 	_, stderr, err := runCmd(t, "--dry-run")
 	require.Error(t, err)
@@ -628,10 +634,12 @@ func TestCmd_FailedDryRunDropsTheFooter(t *testing.T) {
 
 // refused is the result a deploy hands back when the live state turned it
 // away: the workload is real and reports where it stands, and nothing was done
-// to it.
-func refused(status string) up.Result {
+// to it. Status and the plan's state agree here because a refusal sets the
+// first from the second, which is the shape the shell reads.
+func refused(state up.State) up.Result {
 	result := deployed()
-	result.Status = status
+	result.Status = state.String()
+	result.Plan.State = state
 	result.Action = up.ActionUnchanged
 
 	return result
@@ -642,7 +650,7 @@ func refused(status string) up.Result {
 // workload that is not coming back: 'stop' on a terminated workload is
 // meaningless, and the refusal already names the delete that clears the way.
 func TestCmd_TerminatedRefusalOffersNoFollowUps(t *testing.T) {
-	stubRun(t, refused("terminated"), errors.New("workload my-app is terminated"))
+	stubRun(t, refused(up.StateTerminated), errors.New("workload my-app is terminated"))
 
 	_, stderr, err := runCmd(t)
 	require.Error(t, err)
@@ -657,7 +665,7 @@ func TestCmd_TerminatedRefusalOffersNoFollowUps(t *testing.T) {
 // attached to the command. What it loses is 'stop', which is not a next step
 // for a deploy that never landed.
 func TestCmd_ErroredRefusalKeepsLogsAndStatusButNotStop(t *testing.T) {
-	stubRun(t, refused("errored"), errors.New("workload my-app is errored"))
+	stubRun(t, refused(up.StateErrored), errors.New("workload my-app is errored"))
 
 	_, stderr, err := runCmd(t)
 	require.Error(t, err)
@@ -705,11 +713,30 @@ func TestCmd_FailureAfterAStartWarnsButOffersNoLock(t *testing.T) {
 	assert.NotContains(t, stderr, "dr workload stop")
 }
 
+// A run that started a workload which then reached the end of its life warns
+// about nothing and offers nothing. The draft clock this would otherwise
+// mention is not ticking, because a terminated workload is running no artifact
+// at all, and the two halves of the footer have to agree: a warning above an
+// empty follow-up list reads as advice the command forgot to finish.
+func TestCmd_StartedThenTerminatedWarnsAboutNoDraft(t *testing.T) {
+	result := deployed()
+	result.Action = up.ActionStarted
+	result.Status = "terminated"
+
+	stubRun(t, result, errors.New("workload my-app finished as terminated"))
+
+	_, stderr, err := runCmd(t)
+	require.Error(t, err)
+
+	assert.False(t, draftWarned(stderr), "nothing is running, so nothing is on a clock")
+	assert.NotContains(t, stderr, "Next:")
+}
+
 // A refusal still reports the workload it was refused by. Losing the id is how
 // a deploy becomes unfindable, and the endpoint is deliberately kept for the
 // same reason; only its success tick is dropped.
 func TestCmd_TerminatedRefusalStillReportsTheEndpoint(t *testing.T) {
-	stubRun(t, refused("terminated"), errors.New("workload my-app is terminated"))
+	stubRun(t, refused(up.StateTerminated), errors.New("workload my-app is terminated"))
 
 	stdout, stderr, err := runCmd(t)
 	require.Error(t, err)

--- a/internal/workload/up/render.go
+++ b/internal/workload/up/render.go
@@ -38,6 +38,14 @@ type Summary struct {
 	// interrupted are one state to the deploy and three quite different things
 	// to a reader, and only one of them can actually be started.
 	Status string
+
+	// Refused marks a plan that is not going to be applied, because the live
+	// workload is in a state no deploy can land on. The block still prints:
+	// knowing what drift exists is useful even when nothing can be done about
+	// it yet, and a reader who has just been refused is usually about to ask
+	// exactly that. What changes is that it has to read as a description, where
+	// every other plan this command prints is an announcement.
+	Refused bool
 }
 
 // shortIDLen is how much of an id is enough to recognise it. The platform's
@@ -66,6 +74,8 @@ func Render(w io.Writer, s Summary, plan Plan) error {
 		b.WriteString(planTitleStyle.Render(head))
 		b.WriteString("\n")
 	}
+
+	writeRefusedNote(&b, s)
 
 	if plan.Empty() {
 		b.WriteString("\n" + settledVerdict(plan) + "\n")
@@ -104,6 +114,25 @@ func settledVerdict(plan Plan) string {
 	}
 
 	return tui.SuccessStyle.Render("✓ Already up to date")
+}
+
+// writeRefusedNote says that what follows is not going to happen.
+//
+// It goes above the changes rather than below them, because below is where the
+// error already is and the whole complaint is that the reader met the work
+// first and the refusal last.
+//
+// It says only that, in one line. The stateLine directly beneath it already
+// names what is wrong with the workload and the error directly below the block
+// already names the remedy, so a note that explained either would be the third
+// telling on one screen.
+func writeRefusedNote(b *strings.Builder, s Summary) {
+	if !s.Refused {
+		return
+	}
+
+	b.WriteString("\n  " + tui.HintStyle.Render(
+		"Nothing below will be applied; it is what differs, not what is about to happen.") + "\n")
 }
 
 // header names the workload being deployed onto and says what state it is in.

--- a/internal/workload/up/render_test.go
+++ b/internal/workload/up/render_test.go
@@ -110,6 +110,38 @@ func TestRender_TheThreeClasses(t *testing.T) {
 	assert.NotContains(t, out, "Already up to date")
 }
 
+// TestRender_RefusedPlanIsDescribedRatherThanAnnounced is the reported bug:
+// a state that cannot take a deploy still had its drift announced as work
+// about to happen, and the reader only found out on the last line. The block
+// survives, because knowing what differs is useful either way, but it is
+// introduced as a description.
+func TestRender_RefusedPlanIsDescribedRatherThanAnnounced(t *testing.T) {
+	plan := Plan{
+		State:    StateTerminated,
+		Artifact: []Change{{Path: "containerGroups[default].containers[primary].port", Have: 8080.0, Want: 9090.0}},
+	}
+
+	out := render(t, Summary{Name: "old-name", WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0", Refused: true}, plan)
+
+	assert.Contains(t, out, "old-name (68b0c1d2), terminated")
+	assert.Contains(t, out, "Nothing below will be applied")
+	assert.Contains(t, out, "+ artifact   new version, 1 spec change",
+		"the drift is still worth reading; only its framing changes")
+
+	note := strings.Index(out, "Nothing below will be applied")
+	change := strings.Index(out, "+ artifact")
+	assert.Less(t, note, change,
+		"the note has to precede the work it disclaims: below it is where the error already is")
+}
+
+// A plan that is going to be applied says nothing of the sort, which is the
+// whole of what makes the note mean anything.
+func TestRender_AppliedPlanCarriesNoRefusedNote(t *testing.T) {
+	out := render(t, appSummary, Plan{State: StateRunning, Code: builtCode(3)})
+
+	assert.NotContains(t, out, "Nothing below will be applied")
+}
+
 // TestRender_SingleRuntimeChangeSitsOnItsOwnLine: the common case is one
 // number moving, and pushing it onto a sub-line for consistency's sake would
 // cost a line to say nothing.

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -711,7 +711,7 @@ func announce(loaded Loaded, live Live, plan Plan, result Result, opts Options) 
 	var refused error
 
 	if !plan.Empty() {
-		refused = refusal(loaded, live, result.Name)
+		refused = refusal(loaded, live, result.Name, opts.DryRun)
 	}
 
 	summary := Summary{
@@ -736,22 +736,24 @@ func announce(loaded Loaded, live Live, plan Plan, result Result, opts Options) 
 // that is not going to be attempted, and the reader only finds that out on the
 // last line.
 //
-// Settling is deliberately not asked, though deployable refuses it. A moving
-// workload is waited out before the plan is built, so the run that ordinarily
-// reaches a plan still settling is a dry run, which does not wait and has
-// nothing to refuse: it previews where the deploy would land rather than acting
-// on where the workload is. Refusing it here would contradict the line printed
-// above the plan, which says a deploy would wait.
+// Settling is exempt on a dry run alone, which is the one asymmetry here.
 //
-// It is not the only way to get here, which is why this exempts the state
-// rather than the dry run. awaitSteady ends with a fresh Look, and a workload
-// that starts moving again between the wait landing and that read arrives here
-// settling on an ordinary deploy. That run is not previewing anything and does
-// have to be refused -- by deployable, at the point of action, which is the
-// backstop its settling branch is documented to be and the only place that can
-// tell a stale read from a live one.
-func refusal(loaded Loaded, live Live, workloadName string) error {
-	if live.State == StateSettling {
+// A moving workload is waited out before the plan is built, so a dry run is
+// what ordinarily reaches a plan still settling: it does not wait, and it has
+// nothing to refuse, because it previews where the deploy would land rather
+// than acting on where the workload is. Refusing it would contradict the line
+// printed directly above the plan, which says a deploy would wait.
+//
+// A real run reaching here settling is a different thing entirely. awaitSteady
+// ends with a fresh Look, so the workload was steady when the wait landed and
+// is moving again one call later. That run is not previewing anything, and
+// deployable refuses it moments afterwards regardless -- so leaving it out of
+// the question here bought nothing and cost the plan its disclaimer, which is
+// the whole defect this change exists to fix, in the one state the report named
+// alongside errored. deployable keeps its settling branch as the backstop for
+// everything that reaches the apply by another route.
+func refusal(loaded Loaded, live Live, workloadName string, dryRun bool) error {
+	if live.State == StateSettling && dryRun {
 		return nil
 	}
 

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -197,8 +197,7 @@ func Run(opts Options) (Result, error) {
 		return result, err
 	}
 
-	summary := Summary{Name: result.Name, WorkloadID: result.WorkloadID, Status: live.Status}
-	if err := Render(opts.Stderr, summary, plan); err != nil {
+	if err := announce(loaded, live, plan, result, opts); err != nil {
 		return result, err
 	}
 
@@ -554,6 +553,12 @@ func name(loaded Loaded, live Live) string {
 }
 
 // apply carries out the plan, or explains why it cannot.
+//
+// Most of the explaining happens earlier: Run refuses the states a deploy
+// cannot land on before it prints the plan, so a refusal no longer announces
+// work it will not attempt. deployable stays here as the backstop it always
+// was, and is the only thing that answers for a workload which was steady when
+// it was read and is moving again by the time it is acted on.
 func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Result, error) {
 	if err := deployable(live, result.Name, dirFlagFor(loaded)); err != nil {
 		return result, err
@@ -688,6 +693,61 @@ func credentialRefs(loaded Loaded, plan Plan) []manifest.CredentialRef {
 	}
 
 	return loaded.Compiled.CredentialRefs
+}
+
+// announce prints the plan and says whether the run may carry it out, which is
+// one act rather than two: whether the plan is going to be applied changes how
+// it has to be written, so the question is asked before anything is printed.
+//
+// A refusal and a stderr that will not take a write are returned the same way,
+// because Run answers both identically: the result so far, and the error.
+//
+// Only a plan with something in it is judged. An empty plan says what it found
+// rather than listing work, so there is no announcement to correct, and
+// refusing here would turn today's exit 0 into a failure for a run that was
+// never going to change anything. --lock is the one empty plan that still
+// mutates, and lockOnly asks the same question for itself.
+func announce(loaded Loaded, live Live, plan Plan, result Result, opts Options) error {
+	var refused error
+
+	if !plan.Empty() {
+		refused = refusal(loaded, live, result.Name)
+	}
+
+	summary := Summary{
+		Name:       result.Name,
+		WorkloadID: result.WorkloadID,
+		Status:     live.Status,
+		Refused:    refused != nil,
+	}
+
+	if err := Render(opts.Stderr, summary, plan); err != nil {
+		return err
+	}
+
+	return refused
+}
+
+// refusal is why the state this plan was built against cannot take it, and nil
+// when it can.
+//
+// It is asked before the plan is printed. `up`'s contract is that the plan is
+// what is about to happen, so a block of changes above a refusal announces work
+// that is not going to be attempted, and the reader only finds that out on the
+// last line.
+//
+// Settling is deliberately not asked, though deployable refuses it. A moving
+// workload is waited out before the plan is built, so the only run that reaches
+// a plan still settling is a dry run, which does not wait and has nothing to
+// refuse: it previews where the deploy would land rather than acting on where
+// the workload is. deployable keeps that branch as the backstop it is
+// documented to be, at the point of action.
+func refusal(loaded Loaded, live Live, workloadName string) error {
+	if live.State == StateSettling {
+		return nil
+	}
+
+	return deployable(live, workloadName, dirFlagFor(loaded))
 }
 
 // deployable refuses the live states that cannot take a deploy, one message

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -737,11 +737,19 @@ func announce(loaded Loaded, live Live, plan Plan, result Result, opts Options) 
 // last line.
 //
 // Settling is deliberately not asked, though deployable refuses it. A moving
-// workload is waited out before the plan is built, so the only run that reaches
-// a plan still settling is a dry run, which does not wait and has nothing to
-// refuse: it previews where the deploy would land rather than acting on where
-// the workload is. deployable keeps that branch as the backstop it is
-// documented to be, at the point of action.
+// workload is waited out before the plan is built, so the run that ordinarily
+// reaches a plan still settling is a dry run, which does not wait and has
+// nothing to refuse: it previews where the deploy would land rather than acting
+// on where the workload is. Refusing it here would contradict the line printed
+// above the plan, which says a deploy would wait.
+//
+// It is not the only way to get here, which is why this exempts the state
+// rather than the dry run. awaitSteady ends with a fresh Look, and a workload
+// that starts moving again between the wait landing and that read arrives here
+// settling on an ordinary deploy. That run is not previewing anything and does
+// have to be refused -- by deployable, at the point of action, which is the
+// backstop its settling branch is documented to be and the only place that can
+// tell a stale read from a live one.
 func refusal(loaded Loaded, live Live, workloadName string) error {
 	if live.State == StateSettling {
 		return nil

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -1281,9 +1281,9 @@ func TestRun_TerminatedWorkloadDoesNotAnnounceACreate(t *testing.T) {
 	assert.NotContains(t, stderr, "no longer exists", "it does still exist")
 }
 
-// terminatedLive is the live pair for a workload that has reached the end of
-// its life still holding its name and its artifact.
-func terminatedLive(t *testing.T, status string) fakes {
+// liveIn is the live pair for a workload the platform reports in status,
+// still holding its name and its artifact.
+func liveIn(t *testing.T, status string) fakes {
 	t.Helper()
 
 	return fakes{
@@ -1313,8 +1313,8 @@ func driftedManifest() string {
 // take a deploy is usually about to ask what the deploy would have been. What
 // changes is that the block says so before the reader gets to it.
 //
-// Both refusals are driven, because they differ in the remedy they name and in
-// what is worth running afterwards.
+// All three refusals are driven: they differ in the remedy they name, in what
+// is worth running afterwards, and in how they reach deployable at all.
 func TestRun_RefusedStateDescribesItsDriftRatherThanAnnouncingIt(t *testing.T) {
 	cases := []struct {
 		status string
@@ -1322,11 +1322,18 @@ func TestRun_RefusedStateDescribesItsDriftRatherThanAnnouncingIt(t *testing.T) {
 	}{
 		{workload.WorkloadStatusTerminated, "dr workload delete 68b0c1d2e3f4a5b6c7d8e9f0"},
 		{workload.WorkloadStatusErrored, "dr workload logs"},
+
+		// Suspended reaches the refusal by its own route, through
+		// deployable's stopped branch and into startable, and is the one
+		// refused status whose State is shared with a state that deploys
+		// perfectly well. A note that keyed off the state rather than the
+		// answer would go missing here and nowhere else.
+		{workload.WorkloadStatusSuspended, "suspended"},
 	}
 
 	for _, c := range cases {
 		t.Run(c.status, func(t *testing.T) {
-			install(t, terminatedLive(t, c.status))
+			install(t, liveIn(t, c.status))
 
 			_, stderr, err := runIn(t, driftedManifest(), Options{NonInteractive: true})
 			require.Error(t, err)
@@ -1365,7 +1372,7 @@ func TestRun_AnAppliedPlanIsStillAnnounced(t *testing.T) {
 // exit code. The plan is still printed, disclaimed, so the answer is not just
 // the refusal.
 func TestRun_RefusedDryRunIsAFailureNotAPreview(t *testing.T) {
-	install(t, terminatedLive(t, workload.WorkloadStatusTerminated))
+	install(t, liveIn(t, workload.WorkloadStatusTerminated))
 
 	result, stderr, err := runIn(t, driftedManifest(), Options{NonInteractive: true, DryRun: true})
 	require.Error(t, err)

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -1086,6 +1086,31 @@ func TestRun_DryRunOnASettlingWorkloadDoesNotWait(t *testing.T) {
 	assert.NotContains(t, stderr, "Already up to date")
 }
 
+// The settling exemption in refusal, guarded. A moving workload is waited out
+// before the plan is built, so the only run that reaches a plan still settling
+// is a dry run, which does not wait. Refusing that would contradict the note
+// printed two lines above it, which says a deploy would wait and plan against
+// where the workload lands. deployable keeps its settling branch for the point
+// of action; nothing may ask it here.
+func TestRun_DryRunOnASettlingWorkloadWithDriftIsStillAPreview(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			d := doc(t, liveWorkloadJSON)
+			d["status"] = workload.WorkloadStatusLaunching
+
+			return d, nil
+		},
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+	})
+
+	_, stderr, err := runIn(t, driftedManifest(), Options{NonInteractive: true, DryRun: true})
+	require.NoError(t, err, "a preview of a moving workload is early, not wrong")
+
+	assert.Contains(t, stderr, "plan against where it lands")
+	assert.Contains(t, stderr, "+ artifact")
+	assert.NotContains(t, stderr, "Nothing below will be applied")
+}
+
 // A workload that dies while the deploy is watching it must not be reported as
 // a success. The deploy now waits transitions out, so a workload that settles
 // into errored is one this run had a front-row seat to, and the file matching
@@ -1254,6 +1279,100 @@ func TestRun_TerminatedWorkloadDoesNotAnnounceACreate(t *testing.T) {
 
 	assert.NotContains(t, stderr, "will be created")
 	assert.NotContains(t, stderr, "no longer exists", "it does still exist")
+}
+
+// terminatedLive is the live pair for a workload that has reached the end of
+// its life still holding its name and its artifact.
+func terminatedLive(t *testing.T, status string) fakes {
+	t.Helper()
+
+	return fakes{
+		workloadD: func(string) (workload.Document, error) {
+			d := doc(t, liveWorkloadJSON)
+			d["status"] = status
+
+			return d, nil
+		},
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+	}
+}
+
+// driftedManifest is boundLiveManifest with one port moved, which is enough to
+// make the plan want a new version.
+func driftedManifest() string {
+	return "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" +
+		strings.Replace(boundLiveManifest, "port: 8000", "port: 9000", 1)
+}
+
+// TestRun_RefusedStateDescribesItsDriftRatherThanAnnouncingIt is the reported
+// bug. The plan was rendered before the apply path ever asked whether the state
+// could take one, so a refusal printed a full announcement of a rollout and
+// only disowned it on the last line.
+//
+// The drift itself stays: someone who has just been told the workload cannot
+// take a deploy is usually about to ask what the deploy would have been. What
+// changes is that the block says so before the reader gets to it.
+//
+// Both refusals are driven, because they differ in the remedy they name and in
+// what is worth running afterwards.
+func TestRun_RefusedStateDescribesItsDriftRatherThanAnnouncingIt(t *testing.T) {
+	cases := []struct {
+		status string
+		want   string
+	}{
+		{workload.WorkloadStatusTerminated, "dr workload delete 68b0c1d2e3f4a5b6c7d8e9f0"},
+		{workload.WorkloadStatusErrored, "dr workload logs"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.status, func(t *testing.T) {
+			install(t, terminatedLive(t, c.status))
+
+			_, stderr, err := runIn(t, driftedManifest(), Options{NonInteractive: true})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), c.want)
+
+			assert.Contains(t, stderr, "Nothing below will be applied")
+			assert.Contains(t, stderr, "+ artifact",
+				"the drift is still worth reading; only its framing changes")
+
+			note := strings.Index(stderr, "Nothing below will be applied")
+			change := strings.Index(stderr, "+ artifact")
+			require.Positive(t, change)
+			assert.Less(t, note, change, "the disclaimer has to come before the work it disclaims")
+		})
+	}
+}
+
+// A deploy that is going to happen says nothing about not happening, which is
+// the whole of what makes the note mean anything.
+func TestRun_AnAppliedPlanIsStillAnnounced(t *testing.T) {
+	install(t, fakes{
+		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return running("wl-new"), nil
+		},
+	})
+
+	_, stderr, err := runIn(t, unboundImageManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+	assert.NotContains(t, stderr, "Nothing below will be applied")
+}
+
+// A --dry-run onto a refused state is a failure rather than a preview. The
+// question the flag asks is "what would this deploy", and the honest answer is
+// that it would be turned away, which a CI job has to be able to see in the
+// exit code. The plan is still printed, disclaimed, so the answer is not just
+// the refusal.
+func TestRun_RefusedDryRunIsAFailureNotAPreview(t *testing.T) {
+	install(t, terminatedLive(t, workload.WorkloadStatusTerminated))
+
+	result, stderr, err := runIn(t, driftedManifest(), Options{NonInteractive: true, DryRun: true})
+	require.Error(t, err)
+
+	assert.Contains(t, stderr, "Nothing below will be applied")
+	assert.Contains(t, stderr, "+ artifact")
+	assert.Equal(t, ActionUnchanged, result.Action, "a refused run did nothing, including in a preview")
 }
 
 // track records what the build path did, in order, so a test can pin the

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -1111,6 +1111,44 @@ func TestRun_DryRunOnASettlingWorkloadWithDriftIsStillAPreview(t *testing.T) {
 	assert.NotContains(t, stderr, "Nothing below will be applied")
 }
 
+// The other half of the settling exemption, and the reason it is keyed on the
+// dry run rather than on the state.
+//
+// awaitSteady ends with a fresh Look, so a workload can be steady when the wait
+// lands and moving again one call later. That run is not a preview: deployable
+// refuses it at the point of action either way, so the plan printed above that
+// refusal has to carry the same disclaimer every other refused state gets.
+// Exempting the state wholesale left this one path announcing work it would not
+// do, which is the defect itself, in one of the two states the report named.
+func TestRun_SettlingOnTheReReadIsRefusedLikeAnyOtherState(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			d := doc(t, liveWorkloadJSON)
+			d["status"] = workload.WorkloadStatusProvisioning
+
+			return d, nil
+		},
+		artifactD: func(string) (workload.Document, error) { return doc(t, liveArtifactJSON), nil },
+		waitSteady: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			// Steady at the moment the wait lands; the Look that follows
+			// disagrees, which is the race this covers.
+			return &workload.Workload{ID: id, Status: workload.WorkloadStatusRunning}, nil
+		},
+	})
+
+	_, stderr, err := runIn(t, driftedManifest(), Options{NonInteractive: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a state a deploy can act on")
+
+	assert.Contains(t, stderr, "Nothing below will be applied",
+		"a real run refused for settling is refused like any other state")
+
+	note := strings.Index(stderr, "Nothing below will be applied")
+	change := strings.Index(stderr, "+ artifact")
+	require.Positive(t, change)
+	assert.Less(t, note, change)
+}
+
 // A workload that dies while the deploy is watching it must not be reported as
 // a success. The deploy now waits transitions out, so a workload that settles
 // into errored is one this run had a front-row seat to, and the file matching

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -130,6 +130,15 @@ func IsSuspendedWorkloadStatus(s string) bool {
 	return strings.EqualFold(s, WorkloadStatusSuspended)
 }
 
+// IsTerminatedWorkloadStatus reports the one status a workload never comes back
+// from. It is named here for the same reason IsSuspendedWorkloadStatus is: the
+// deploy and the shell that prints its result both have to single this status
+// out, they must not spell it differently, and the shell would otherwise be
+// comparing against a constant it reaches only through State.String().
+func IsTerminatedWorkloadStatus(s string) bool {
+	return strings.EqualFold(s, WorkloadStatusTerminated)
+}
+
 // IsStoppedWorkloadStatus reports whether s is one of the three ways a
 // workload can be switched off. They are grouped because a deploy treats them
 // alike, and named here because three files ask the same question: this one,

--- a/internal/workload/workload_test.go
+++ b/internal/workload/workload_test.go
@@ -688,6 +688,16 @@ func TestIsSuspendedWorkloadStatus(t *testing.T) {
 	}
 }
 
+func TestIsTerminatedWorkloadStatus(t *testing.T) {
+	assert.True(t, IsTerminatedWorkloadStatus(WorkloadStatusTerminated))
+	assert.True(t, IsTerminatedWorkloadStatus("TERMINATED"), "it folds like every other status")
+
+	for _, s := range []string{WorkloadStatusErrored, WorkloadStatusStopped, WorkloadStatusRunning} {
+		assert.False(t, IsTerminatedWorkloadStatus(s),
+			"%s is not the status a workload never comes back from", s)
+	}
+}
+
 func TestIsStoppedWorkloadStatus(t *testing.T) {
 	for _, s := range []string{WorkloadStatusStopped, WorkloadStatusSuspended, WorkloadStatusInterrupted} {
 		assert.True(t, IsStoppedWorkloadStatus(s), "%s is a way of being switched off", s)


### PR DESCRIPTION
# RATIONALE

[RAPTOR-19602](https://datarobot.atlassian.net/browse/RAPTOR-19602)

> Rebased onto #836. See **Rebase notes** at the bottom for what that changed.

When `up` refuses a live state it cannot deploy onto, it has already printed a full plan
of the work it is about to decline, and then prints three follow-up commands underneath
the error:

```
old-name (68b0term), terminated

  + artifact   new version, 2 spec changes
      containerGroups: [1 item(s)]
      type: service
  ~ runtime    containerGroups: [1 item(s)]

    Workload endpoint: https://…/68b0term0000000000000002/

Next:
  dr workload logs 68b0term…    what the container is saying
  dr workload status 68b0term…  whether it is healthy
  dr workload stop 68b0term…    switch it off, keeping the version
Error: workload old-name is terminated, which cannot be undone…
```

Two separate defects, both pre-existing:

1. `Run` rendered the plan before `apply` ever asked `deployable` whether the state could
   take one, so a refused state announced a rollout it was about to decline. #836 gave
   those states a `!` stateLine naming what is wrong with the workload, which helps, but
   the drift below it still reads as work about to happen and the refusal still arrives
   last.
2. `nextSteps` guarded only on `result.WorkloadID == ""`, so any refusal with an id got
   all three commands. The neighbouring endpoint tick already handles failure — *"a tick
   above an error reads as though both happened"* — and `nextSteps` never got the same
   treatment. `dr workload stop` on a terminated workload is meaningless.

The drift itself is not useless information, which is what made this a design question
rather than a bug to delete: someone who has just been refused is usually about to ask
what the deploy would have been. So the block stays and stops reading as an announcement.

## CHANGES

**The refusal is decided before the plan is printed** — `internal/workload/up/run.go`

`announce` asks `refusal` and hands the answer to `Render`. Only a non-empty plan is
judged; `--lock` on an empty one still asks for itself in `lockOnly`.

Settling is deliberately **not** asked. #836 waits a moving workload out before the plan
is built, so the only run that reaches a plan still settling is a dry run, which does not
wait — refusing it would contradict the note printed two lines above saying a deploy would
plan against where it lands. `deployable` keeps that branch as the backstop it is
documented to be, which is also why `apply` keeps its own call: it is now the only thing
answering for a workload that was steady when it was read and is moving again by the time
it is acted on.

**The plan says it is a description** — `internal/workload/up/render.go`

New `Summary.Refused` puts one line above the block. It says only that the rest will not
be applied: the `!` stateLine directly beneath already names what is wrong with the
workload, and the error below the block already names the remedy, so a note explaining
either would be the third telling on one screen.

```
gpt-oss-20b-vllm (68b0c1d2), terminated

  Nothing below will be applied; it is what differs, not what is about to happen.

  ! workload   terminated, and it still holds its name and artifact
  ~ lock       the running version is locked, so a new one is created and locked to match…
  + artifact   new version, 1 spec change
      containerGroups[default].containers[vllm-server].port: 8000 -> 9000
Error: workload gpt-oss-20b-vllm is terminated, which cannot be undone…
```

**The follow-ups suit the state** — `cmd/workload/up/cmd.go`

`nextSteps` splits into `followUps`:

| run | list |
| --- | --- |
| terminated refusal | nothing — none of the three apply, and the error already names `dr workload delete` |
| errored / timeout / failed roll | `logs`, `status` — right for all three, and the only place the id is attached to the command |
| success | unchanged: `logs`, `status`, and `stop` or `up --lock` |

`stop` is never offered on a failure: it is not a next step for a deploy that did not
land. Neither is `--lock` — since #836 a deploy onto a stopped workload starts it first,
so a run that fails after that really has put a draft on the air (`draftIsServing` says
so and the warning prints), but locking a version this run could not finish is not the
remedy for it, and `draftWarning` names the command inline for anyone who decides
otherwise.

The endpoint on a failed run is untouched, deliberately — losing the id and endpoint is
how a deploy becomes unfindable, and only its success tick is dropped.

## NOTES

One behaviour change beyond the report, intentional:

- **A refused `--dry-run` is now a failure rather than a preview.** The question the flag
  asks is "what would this deploy", and the honest answer is that it would be turned
  away, which a CI job has to be able to see in the exit code. The disclaimed plan is
  still printed, so the answer is not just the refusal. Its "Dry run: nothing was
  changed." footer is dropped on a failed run for the same reason the tick is: sitting
  above an error, it reads as a preview that went to plan.

A dry run onto a **settling** workload is untouched — still a preview, still exit 0, with
or without drift. There is a test pinning that, since it is the one thing the pre-flight
had to be taught not to do.

## TESTING

`task test` and `task lint` (GOOS=linux, darwin, windows) both clean.

New tests, driving terminated and errored separately at both layers since they differ in
which follow-ups make sense:

- `internal/workload/up`: `TestRun_RefusedStateDescribesItsDriftRatherThanAnnouncingIt`
  (both states; asserts the note precedes the change lines), `TestRun_AnAppliedPlanIsStillAnnounced`,
  `TestRun_RefusedDryRunIsAFailureNotAPreview`, and
  `TestRun_DryRunOnASettlingWorkloadWithDriftIsStillAPreview` guarding the settling
  exemption. `TestRender_RefusedPlanIsDescribedRatherThanAnnounced` and
  `TestRender_AppliedPlanCarriesNoRefusedNote` cover the renderer directly.
- `cmd/workload/up`: `TestCmd_TerminatedRefusalOffersNoFollowUps`,
  `TestCmd_ErroredRefusalKeepsLogsAndStatusButNotStop`,
  `TestCmd_AnyFailureKeepsLogsAndStatusButNotStop`,
  `TestCmd_FailureAfterAStartWarnsButOffersNoLock` (the #836 interaction),
  `TestCmd_TerminatedRefusalStillReportsTheEndpoint` (the endpoint must not regress),
  `TestCmd_FailedDryRunDropsTheFooter`.

## RELATED

- RAPTOR-19526 — found during its manual testing; `Run`'s render-then-apply order predates
  it, so this is pre-existing.
- RAPTOR-19686 (#836) — rebased onto it; overlapping surface, complementary fix.
- RAPTOR-19537 — making `up` legible to agents. A refusal that prints a plan plus three
  commands plus an error is exactly the shape that made an agent misread the command.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output and exit-code behavior for refused/failed `workload up` runs only; no auth, data, or deploy API contract changes beyond clearer pre-apply refusal messaging.
> 
> **Overview**
> Fixes misleading `dr workload up` output when a deploy is refused or fails: the plan no longer reads like work that will run, and the **Next:** hints match what actually helps.
> 
> **Plan framing** — Deployability is checked in `announce` before the plan is printed (via `refusal` / `deployable`, with settling still exempt for dry-run previews). When the workload cannot take the deploy, `Summary.Refused` adds a line above the drift: *Nothing below will be applied; it is what differs, not what is about to happen.*
> 
> **Command shell** — `nextSteps` now uses `followUps` with a `failed` flag: **terminated** refusals show no follow-ups; **failed** runs keep `logs` and `status` only (no `stop` or `--lock`); successful paths are unchanged. Failed **dry-run** skips the “Dry run: nothing was changed.” footer so it does not sit above the error. A refused **dry-run** now exits with error (CI can detect “would be turned away”) while still printing the disclaimed plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aab890468f2e128fed072217d5ef4f35bd2ad0f7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->