### PR TITLE
[RAPTOR-18978] feat(workload): stream build logs during the deploy

### DIFF
--- a/.devcontainer/sync-go.sh
+++ b/.devcontainer/sync-go.sh
@@ -11,7 +11,12 @@ set -euo pipefail
 GO_REQUIRED=$(grep '^go ' go.mod | awk '{print $2}')
 GO_INSTALLED=$(go version | awk '{print $3}' | sed 's/go//')
 
-if [ "$GO_REQUIRED" != "$GO_INSTALLED" ]; then
+# A newer toolchain satisfies an older go.mod directive, and the release
+# feed only lists current versions — a superseded patch release cannot be
+# fetched at all. So only ever upgrade forward.
+if [ "$(printf '%s\n%s\n' "$GO_REQUIRED" "$GO_INSTALLED" | sort -V | head -n1)" = "$GO_REQUIRED" ]; then
+    echo "Go $GO_INSTALLED satisfies go.mod's go $GO_REQUIRED"
+elif [ "$GO_REQUIRED" != "$GO_INSTALLED" ]; then
     echo "Go mismatch: need $GO_REQUIRED, have $GO_INSTALLED. Upgrading..."
     ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
     TARBALL="go${GO_REQUIRED}.linux-${ARCH}.tar.gz"

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/charmbracelet/harmonica v0.2.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/log v1.0.0
+	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/charmbracelet/x/exp/teatest v0.0.0-20250818131617-61d774aefe53
 	github.com/codeclysm/extract/v4 v4.0.0
 	github.com/denisbrodbeck/machineid v1.0.1
@@ -40,7 +41,6 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
-	github.com/charmbracelet/x/ansi v0.11.7 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20260622092256-25656177ba8e // indirect

--- a/internal/workload/build_logs.go
+++ b/internal/workload/build_logs.go
@@ -1,0 +1,120 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"time"
+
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// A build's logs live on the artifact-wide OTEL route
+// /api/v2/otel/artifact/{id}/logs/: an artifact accumulates every build it
+// ever ran, and the platform's own build id is internal, so searchKeys/
+// searchValues on external_build_id — the build id this CLI already holds
+// from the trigger response — is the only way to narrow the stream to one
+// build. The query keys are camelCase; their snake_case forms are rejected
+// with a 400.
+
+// buildLogSeedLimit is how many recent lines seed a build tail. A tail on a
+// freshly triggered build starts from an empty stream, so the seed only
+// matters when attaching to a build already in progress, where the recent
+// tail is the context the user needs.
+const buildLogSeedLimit = 200
+
+// fetchArtifactBuildLogs retrieves one build's log lines newest-first across
+// pages, by filtering the artifact's OTEL stream on external_build_id.
+func fetchArtifactBuildLogs(artifactID, buildID string, maxEntries int, level, since, reqInfo string) ([]WorkloadLogEntry, error) {
+	query := logsQueryParams(maxEntries, level, since)
+	query.Set("searchKeys", "external_build_id")
+	query.Set("searchValues", buildID)
+
+	pageURL, err := drapi.EndpointURL("/otel/artifact/"+escapeID(artifactID)+"/logs/", query)
+	if err != nil {
+		return nil, err
+	}
+
+	return drainLogPages(pageURL, maxEntries, reqInfo)
+}
+
+// BuildLogTail streams one build's log lines incrementally, driven by the
+// caller's own cadence (WaitForBuild's per-poll callback) rather than a
+// clock of its own. It is strictly progress feedback: no fetch failure is
+// ever surfaced as an error, because a build must not fail — or appear to —
+// over a hiccup in reading its logs. After too many consecutive failures the
+// tail disables itself, says so once through onWarn, and stays quiet.
+type BuildLogTail struct {
+	follower *logFollower
+	onWarn   func(string)
+	disabled bool
+}
+
+// NewBuildLogTail builds a tail for one build's lines. onLine receives each
+// unseen line in chronological order; onWarn (nil-safe) receives the one
+// notice given when the tail gives up.
+func NewBuildLogTail(artifactID, buildID string, onLine func(WorkloadLogEntry), onWarn func(string)) *BuildLogTail {
+	if onWarn == nil {
+		onWarn = func(string) {}
+	}
+
+	fetch := func(maxEntries int, level, since, reqInfo string) ([]WorkloadLogEntry, error) {
+		return fetchArtifactBuildLogs(artifactID, buildID, maxEntries, level, since, reqInfo)
+	}
+
+	// The interval passed here only satisfies the follower's validation; the
+	// caller's poll cadence is the real clock. Level stays the server default
+	// so the stream carries everything the builder said.
+	follower, err := newLogFollower(fetch, buildLogSeedLimit, "", time.Second,
+		func(e WorkloadLogEntry) error { onLine(e); return nil }, onWarn)
+	if err != nil {
+		// Unreachable with the constants above; a nil follower simply means
+		// the tail never emits, which is the contract's worst case anyway.
+		return &BuildLogTail{disabled: true, onWarn: onWarn}
+	}
+
+	return &BuildLogTail{follower: follower, onWarn: onWarn}
+}
+
+// Poll fetches once and emits any unseen lines. Call it from the build wait's
+// per-poll callback, and once more after the wait ends to catch lines
+// ingested between the terminal status and the last poll.
+func (t *BuildLogTail) Poll() {
+	if t.disabled {
+		return
+	}
+
+	entries, hadSince, err := t.follower.fetch()
+	if err != nil {
+		retryNow, ferr := t.follower.fetchFailure(err, hadSince)
+		if ferr != nil {
+			t.disabled = true
+			t.onWarn("build log streaming stopped; the build itself is unaffected: " + ferr.Error())
+
+			return
+		}
+
+		if retryNow {
+			t.Poll() // the follower dropped to window mode; re-fetch now
+
+			return
+		}
+
+		return
+	}
+
+	// onLine never returns an error (see NewBuildLogTail), so emit cannot
+	// fail; the return is the follower's contract, not this tail's.
+	_ = t.follower.emit(entries, hadSince)
+}

--- a/internal/workload/build_logs.go
+++ b/internal/workload/build_logs.go
@@ -31,8 +31,9 @@ import (
 // buildLogSeedLimit is how many recent lines seed a build tail. A tail on a
 // freshly triggered build starts from an empty stream, so the seed only
 // matters when attaching to a build already in progress, where the recent
-// tail is the context the user needs.
-const buildLogSeedLimit = 200
+// tail is the context the user needs — a couple of live-window's worth, not
+// the whole history the renderer would immediately slide past.
+const buildLogSeedLimit = 40
 
 // fetchArtifactBuildLogs retrieves one build's log lines newest-first across
 // pages, by filtering the artifact's OTEL stream on external_build_id.
@@ -75,7 +76,8 @@ func NewBuildLogTail(artifactID, buildID string, onLine func(WorkloadLogEntry), 
 
 	// The interval passed here only satisfies the follower's validation; the
 	// caller's poll cadence is the real clock. Level stays the server default
-	// so the stream carries everything the builder said.
+	// (debug) deliberately: dim noise costs a glance, a failure detail the
+	// builder only said at debug costs a debugging session.
 	follower, err := newLogFollower(fetch, buildLogSeedLimit, "", time.Second,
 		func(e WorkloadLogEntry) error { onLine(e); return nil }, onWarn)
 	if err != nil {

--- a/internal/workload/build_logs.go
+++ b/internal/workload/build_logs.go
@@ -28,12 +28,19 @@ import (
 // build. The query keys are camelCase; their snake_case forms are rejected
 // with a 400.
 
-// buildLogSeedLimit is how many recent lines seed a build tail. A tail on a
-// freshly triggered build starts from an empty stream, so the seed only
-// matters when attaching to a build already in progress, where the recent
-// tail is the context the user needs — a couple of live-window's worth, not
-// the whole history the renderer would immediately slide past.
-const buildLogSeedLimit = 40
+// buildLogSeedLimit is how many lines a window-mode fetch may carry: the
+// server's own page cap, because a builder can burst hundreds of lines in
+// one poll interval and anything smaller gaps the opening of the build.
+// Once the first non-empty batch seeds the time cursor, fetches are
+// since-based and unbounded, so this only governs the first batch and an
+// attach's seed.
+const buildLogSeedLimit = maxLogsPageSize
+
+// buildLogLagAllowance is the build tail's cursor lag. Build-log ingestion
+// trails the builder by 20-40s (measured on staging), far past the runtime
+// follower's default; a line ingested later than the lag window is skipped
+// forever, so the window errs wide and the dedup absorbs the overlap.
+const buildLogLagAllowance = 60 * time.Second
 
 // fetchArtifactBuildLogs retrieves one build's log lines newest-first across
 // pages, by filtering the artifact's OTEL stream on external_build_id.
@@ -80,6 +87,10 @@ func NewBuildLogTail(artifactID, buildID string, onLine func(WorkloadLogEntry), 
 	// builder only said at debug costs a debugging session.
 	follower, err := newLogFollower(fetch, buildLogSeedLimit, "", time.Second,
 		func(e WorkloadLogEntry) error { onLine(e); return nil }, onWarn)
+	if err == nil {
+		follower.lag = buildLogLagAllowance
+	}
+
 	if err != nil {
 		// Unreachable with the constants above; a nil follower simply means
 		// the tail never emits, which is the contract's worst case anyway.

--- a/internal/workload/build_logs.go
+++ b/internal/workload/build_logs.go
@@ -15,6 +15,7 @@
 package workload
 
 import (
+	"slices"
 	"time"
 
 	"github.com/datarobot/cli/internal/drapi"
@@ -57,16 +58,43 @@ func fetchArtifactBuildLogs(artifactID, buildID string, maxEntries int, level, s
 	return drainLogPages(pageURL, maxEntries, reqInfo)
 }
 
+// buildLogHoldback is how long a line waits in the reorder buffer, measured
+// against the newest event time seen. OTEL ingestion delivers lines seconds
+// out of order across polls; holding each line back lets a late sibling slot
+// in ahead of it, at the cost of the stream trailing the builder by this
+// much. Finish drains the buffer regardless, so nothing is ever withheld
+// past the build's end.
+const buildLogHoldback = 10 * time.Second
+
 // BuildLogTail streams one build's log lines incrementally, driven by the
 // caller's own cadence (WaitForBuild's per-poll callback) rather than a
-// clock of its own. It is strictly progress feedback: no fetch failure is
-// ever surfaced as an error, because a build must not fail — or appear to —
-// over a hiccup in reading its logs. After too many consecutive failures the
-// tail disables itself, says so once through onWarn, and stays quiet.
+// clock of its own. Lines pass through a holdback reorder buffer so
+// late-ingested lines print in event order rather than arrival order.
+//
+// It is strictly progress feedback: no fetch failure is ever surfaced as an
+// error, because a build must not fail — or appear to — over a hiccup in
+// reading its logs. After too many consecutive failures the tail disables
+// itself, says so once through onWarn, and stays quiet.
 type BuildLogTail struct {
 	follower *logFollower
+	onLine   func(WorkloadLogEntry)
 	onWarn   func(string)
 	disabled bool
+
+	// The reorder buffer: lines sorted by event time (arrival order breaking
+	// ties), flushed once they age past the newest-seen event time minus the
+	// holdback.
+	pending []bufferedLogLine
+	seq     int
+	newest  time.Time
+}
+
+// bufferedLogLine is one held-back line: its parsed event time and an
+// arrival sequence number that keeps equal or unparseable timestamps stable.
+type bufferedLogLine struct {
+	at    time.Time
+	seq   int
+	entry WorkloadLogEntry
 }
 
 // NewBuildLogTail builds a tail for one build's lines. onLine receives each
@@ -85,19 +113,75 @@ func NewBuildLogTail(artifactID, buildID string, onLine func(WorkloadLogEntry), 
 	// caller's poll cadence is the real clock. Level stays the server default
 	// (debug) deliberately: dim noise costs a glance, a failure detail the
 	// builder only said at debug costs a debugging session.
-	follower, err := newLogFollower(fetch, buildLogSeedLimit, "", time.Second,
-		func(e WorkloadLogEntry) error { onLine(e); return nil }, onWarn)
-	if err == nil {
-		follower.lag = buildLogLagAllowance
-	}
+	tail := &BuildLogTail{onLine: onLine, onWarn: onWarn}
 
+	follower, err := newLogFollower(fetch, buildLogSeedLimit, "", time.Second,
+		func(e WorkloadLogEntry) error { tail.buffer(e); return nil }, onWarn)
 	if err != nil {
 		// Unreachable with the constants above; a nil follower simply means
 		// the tail never emits, which is the contract's worst case anyway.
-		return &BuildLogTail{disabled: true, onWarn: onWarn}
+		tail.disabled = true
+
+		return tail
 	}
 
-	return &BuildLogTail{follower: follower, onWarn: onWarn}
+	follower.lag = buildLogLagAllowance
+	tail.follower = follower
+
+	return tail
+}
+
+// buffer inserts one line into the reorder buffer and advances the
+// event-time watermark. Unparseable timestamps adopt the current watermark,
+// so they flush with their neighbors instead of jamming the buffer.
+func (t *BuildLogTail) buffer(e WorkloadLogEntry) {
+	at, ok := parseLogTimestamp(e.Timestamp)
+	if !ok {
+		at = t.newest
+	}
+
+	if at.After(t.newest) {
+		t.newest = at
+	}
+
+	t.pending = append(t.pending, bufferedLogLine{at: at, seq: t.seq, entry: e})
+	t.seq++
+}
+
+// flush emits buffered lines in event order: everything when all is set,
+// otherwise only lines older than the holdback watermark, so a late sibling
+// still to arrive can slot in ahead of what remains held.
+func (t *BuildLogTail) flush(all bool) {
+	slices.SortStableFunc(t.pending, func(a, b bufferedLogLine) int {
+		if c := a.at.Compare(b.at); c != 0 {
+			return c
+		}
+
+		return a.seq - b.seq
+	})
+
+	watermark := t.newest.Add(-buildLogHoldback)
+
+	kept := t.pending[:0]
+
+	for _, line := range t.pending {
+		if all || !line.at.After(watermark) {
+			t.onLine(line.entry)
+		} else {
+			kept = append(kept, line)
+		}
+	}
+
+	t.pending = kept
+}
+
+// Finish performs the final catch-up poll and drains the reorder buffer.
+// Call it once after the build wait ends: ingestion lags the build, so the
+// last lines routinely land after the terminal status, and nothing may stay
+// withheld once the stream is over.
+func (t *BuildLogTail) Finish() {
+	t.Poll()
+	t.flush(true)
 }
 
 // Poll fetches once and emits any unseen lines. Call it from the build wait's
@@ -127,7 +211,9 @@ func (t *BuildLogTail) Poll() {
 		return
 	}
 
-	// onLine never returns an error (see NewBuildLogTail), so emit cannot
+	// buffer never returns an error (see NewBuildLogTail), so emit cannot
 	// fail; the return is the follower's contract, not this tail's.
 	_ = t.follower.emit(entries, hadSince)
+
+	t.flush(false)
 }

--- a/internal/workload/build_logs_test.go
+++ b/internal/workload/build_logs_test.go
@@ -89,9 +89,52 @@ func TestBuildLogTail_EmitsOnlyUnseenLinesAcrossPolls(t *testing.T) {
 
 	tail.Poll()
 	tail.Poll()
+	tail.flush(true) // drain the holdback buffer without another fetch
 
 	assert.Equal(t, []string{"a", "b", "c"}, lines)
 	assert.Equal(t, 2, calls)
+}
+
+func TestBuildLogTail_HoldbackReordersLateLines(t *testing.T) {
+	installSkipAuth(t)
+
+	calls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+
+		switch calls {
+		case 1:
+			// The newer line arrives first...
+			fmt.Fprint(w, logsPage("",
+				logEntryDocAt("2026-06-11 14:04:16.000000+00:00", "INFO", "later"),
+			))
+		default:
+			// ...its older sibling only in the NEXT poll, the ingestion
+			// pattern that used to print "later" before "earlier".
+			fmt.Fprint(w, logsPage("",
+				logEntryDocAt("2026-06-11 14:04:16.000000+00:00", "INFO", "later"),
+				logEntryDocAt("2026-06-11 14:04:15.000000+00:00", "INFO", "earlier"),
+			))
+		}
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	var lines []string
+
+	tail := NewBuildLogTail("art-1", "bld-1", func(e WorkloadLogEntry) {
+		lines = append(lines, e.Message)
+	}, nil)
+
+	tail.Poll()
+	tail.Poll()
+	tail.flush(true)
+
+	// The holdback let the late older line slot in ahead.
+	assert.Equal(t, []string{"earlier", "later"}, lines)
 }
 
 func TestBuildLogTail_EmptyFirstPollDoesNotPinAZeroCursor(t *testing.T) {
@@ -131,6 +174,7 @@ func TestBuildLogTail_EmptyFirstPollDoesNotPinAZeroCursor(t *testing.T) {
 	tail.Poll() // empty: must NOT seed
 	tail.Poll() // first real batch: window fetch, seeds the cursor
 	tail.Poll() // since-based, trailing by the build tail's own lag
+	tail.flush(true)
 
 	assert.Equal(t, []string{"a", "b"}, lines)
 	require.Len(t, startTimes, 3)

--- a/internal/workload/build_logs_test.go
+++ b/internal/workload/build_logs_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchArtifactBuildLogs_FiltersOnExternalBuildID(t *testing.T) {
+	installSkipAuth(t)
+
+	var gotPath string
+
+	var gotQuery map[string][]string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
+
+		fmt.Fprint(w, logsPage("", logEntryDocAt("2026-06-11 14:04:14.084208+00:00", "INFO", "step 1")))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	entries, err := fetchArtifactBuildLogs("art-1", "bld-1", 10, "", "", "")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "step 1", entries[0].Message)
+
+	assert.Equal(t, "/api/v2/otel/artifact/art-1/logs/", gotPath)
+	// camelCase is load-bearing: the snake_case forms are rejected with 400.
+	assert.Equal(t, []string{"external_build_id"}, gotQuery["searchKeys"])
+	assert.Equal(t, []string{"bld-1"}, gotQuery["searchValues"])
+}
+
+func TestBuildLogTail_EmitsOnlyUnseenLinesAcrossPolls(t *testing.T) {
+	installSkipAuth(t)
+
+	calls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+
+		switch calls {
+		case 1:
+			fmt.Fprint(w, logsPage("",
+				logEntryDocAt("2026-06-11 14:04:15.000001+00:00", "INFO", "b"),
+				logEntryDocAt("2026-06-11 14:04:14.084208+00:00", "INFO", "a"),
+			))
+		default:
+			// The overlap line b re-serves within the lag allowance; only c is new.
+			fmt.Fprint(w, logsPage("",
+				logEntryDocAt("2026-06-11 14:04:16.000001+00:00", "INFO", "c"),
+				logEntryDocAt("2026-06-11 14:04:15.000001+00:00", "INFO", "b"),
+			))
+		}
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	var lines []string
+
+	tail := NewBuildLogTail("art-1", "bld-1", func(e WorkloadLogEntry) {
+		lines = append(lines, e.Message)
+	}, nil)
+
+	tail.Poll()
+	tail.Poll()
+
+	assert.Equal(t, []string{"a", "b", "c"}, lines)
+	assert.Equal(t, 2, calls)
+}
+
+func TestBuildLogTail_DisablesAfterSustainedFailuresWithoutErroring(t *testing.T) {
+	installSkipAuth(t)
+
+	calls := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	var warns []string
+
+	tail := NewBuildLogTail("art-1", "bld-1", func(WorkloadLogEntry) {
+		t.Fatal("no line should be emitted from a failing stream")
+	}, func(w string) { warns = append(warns, w) })
+
+	// One more poll than the transient budget: the last one must be a no-op.
+	for range maxTransientPollErrors + 2 {
+		tail.Poll()
+	}
+
+	assert.True(t, tail.disabled)
+	assert.Equal(t, maxTransientPollErrors+1, calls, "a disabled tail must stop fetching")
+	// Exactly one user-visible notice that streaming gave up, at the end.
+	require.NotEmpty(t, warns)
+	assert.Contains(t, warns[len(warns)-1], "the build itself is unaffected")
+}

--- a/internal/workload/build_logs_test.go
+++ b/internal/workload/build_logs_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -91,6 +92,56 @@ func TestBuildLogTail_EmitsOnlyUnseenLinesAcrossPolls(t *testing.T) {
 
 	assert.Equal(t, []string{"a", "b", "c"}, lines)
 	assert.Equal(t, 2, calls)
+}
+
+func TestBuildLogTail_EmptyFirstPollDoesNotPinAZeroCursor(t *testing.T) {
+	installSkipAuth(t)
+
+	calls := 0
+
+	var startTimes []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+
+		startTimes = append(startTimes, r.URL.Query().Get("startTime"))
+
+		switch calls {
+		case 1:
+			// The stream is empty right after the trigger.
+			fmt.Fprint(w, logsPage(""))
+		default:
+			fmt.Fprint(w, logsPage("",
+				logEntryDocAt("2026-06-11 14:04:15.000001+00:00", "INFO", "b"),
+				logEntryDocAt("2026-06-11 14:04:14.084208+00:00", "INFO", "a"),
+			))
+		}
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	var lines []string
+
+	tail := NewBuildLogTail("art-1", "bld-1", func(e WorkloadLogEntry) {
+		lines = append(lines, e.Message)
+	}, nil)
+
+	tail.Poll() // empty: must NOT seed
+	tail.Poll() // first real batch: window fetch, seeds the cursor
+	tail.Poll() // since-based, trailing by the build tail's own lag
+
+	assert.Equal(t, []string{"a", "b"}, lines)
+	require.Len(t, startTimes, 3)
+	// The empty poll and the first real batch are window fetches...
+	assert.Empty(t, startTimes[0])
+	assert.Empty(t, startTimes[1])
+	// ...and the third trails the newest timestamp by the build lag, not the
+	// runtime follower's default.
+	newest, ok := parseLogTimestamp("2026-06-11 14:04:15.000001+00:00")
+	require.True(t, ok)
+	assert.Equal(t, newest.Add(-buildLogLagAllowance).UTC().Format(time.RFC3339Nano), startTimes[2])
 }
 
 func TestBuildLogTail_DisablesAfterSustainedFailuresWithoutErroring(t *testing.T) {

--- a/internal/workload/logs.go
+++ b/internal/workload/logs.go
@@ -175,6 +175,13 @@ func fetchWorkloadLogs(workloadID string, maxEntries int, level, since, reqInfo 
 		return nil, err
 	}
 
+	return drainLogPages(pageURL, maxEntries, reqInfo)
+}
+
+// drainLogPages walks an OTEL logs route's pagination from pageURL,
+// newest-first, applying the same page-overlap dedup and maxEntries cap for
+// every log source.
+func drainLogPages(pageURL string, maxEntries int, reqInfo string) ([]WorkloadLogEntry, error) {
 	var all []WorkloadLogEntry
 
 	priorPages := make(map[string]struct{})
@@ -212,6 +219,11 @@ func fetchWorkloadLogs(workloadID string, maxEntries int, level, since, reqInfo 
 	return all, nil
 }
 
+// logsFetchFn retrieves one poll's worth of log lines newest-first. It is the
+// seam that lets the follower stream any OTEL log source: the workload stream
+// and a build's filtered artifact stream differ only in this function.
+type logsFetchFn func(maxEntries int, level, since, reqInfo string) ([]WorkloadLogEntry, error)
+
 // FollowWorkloadLogs streams a workload's log lines until ctx is cancelled
 // (Ctrl-C ends it cleanly with nil) or a terminal fetch error occurs. It
 // seeds with the most recent limit lines, then polls for newer ones, falling
@@ -230,13 +242,17 @@ func FollowWorkloadLogs(
 	onLine func(WorkloadLogEntry) error,
 	onWarn func(string),
 ) error {
-	f, err := newLogFollower(workloadID, limit, level, interval, onLine, onWarn)
+	fetch := func(maxEntries int, lvl, since, reqInfo string) ([]WorkloadLogEntry, error) { //nolint:contextcheck // drapi does not yet accept context; ctx gates the inter-poll sleeps
+		return fetchWorkloadLogs(workloadID, maxEntries, lvl, since, reqInfo)
+	}
+
+	f, err := newLogFollower(fetch, limit, level, interval, onLine, onWarn)
 	if err != nil {
 		return err
 	}
 
 	for {
-		entries, hadSince, err := f.fetch() //nolint:contextcheck // drapi does not yet accept context; ctx gates the inter-poll sleeps
+		entries, hadSince, err := f.fetch()
 		if err != nil {
 			retryNow, ferr := f.fetchFailure(err, hadSince)
 			if ferr != nil {
@@ -266,11 +282,11 @@ func FollowWorkloadLogs(
 
 // logFollower holds one follow stream's state between polls.
 type logFollower struct {
-	workloadID string
-	limit      int
-	level      string
-	onLine     func(WorkloadLogEntry) error
-	onWarn     func(string)
+	fetchFn logsFetchFn
+	limit   int
+	level   string
+	onLine  func(WorkloadLogEntry) error
+	onWarn  func(string)
 
 	dedup           *logDedup
 	cursor          time.Time // newest parsed timestamp; zero means window mode
@@ -280,13 +296,17 @@ type logFollower struct {
 }
 
 func newLogFollower(
-	workloadID string,
+	fetchFn logsFetchFn,
 	limit int,
 	level string,
 	interval time.Duration,
 	onLine func(WorkloadLogEntry) error,
 	onWarn func(string),
 ) (*logFollower, error) {
+	if fetchFn == nil {
+		return nil, errors.New("fetchFn is required")
+	}
+
 	if limit <= 0 {
 		return nil, fmt.Errorf("invalid limit %d: must be positive", limit)
 	}
@@ -304,7 +324,7 @@ func newLogFollower(
 	}
 
 	return &logFollower{
-		workloadID:   workloadID,
+		fetchFn:      fetchFn,
 		limit:        limit,
 		level:        level,
 		onLine:       onLine,
@@ -327,8 +347,8 @@ func (f *logFollower) fetch() (entries []WorkloadLogEntry, hadSince bool, err er
 	}
 
 	// Empty reqInfo silences drapi's per-request "Fetching ..." log so the
-	// follow stream stays just the workload's log lines.
-	entries, err = fetchWorkloadLogs(f.workloadID, maxEntries, f.level, since, "")
+	// follow stream stays just the source's log lines.
+	entries, err = f.fetchFn(maxEntries, f.level, since, "")
 
 	return entries, since != "", err
 }
@@ -352,7 +372,7 @@ func (f *logFollower) fetchFailure(err error, hadSince bool) (retryNow bool, _ e
 	f.transientErrors++
 
 	if f.transientErrors > maxTransientPollErrors {
-		return false, fmt.Errorf("fetch workload logs: %d consecutive transient errors, last: %w", f.transientErrors, err)
+		return false, fmt.Errorf("fetch logs: %d consecutive transient errors, last: %w", f.transientErrors, err)
 	}
 
 	f.onWarn(fmt.Sprintf("transient error fetching logs, retrying: %v", err))

--- a/internal/workload/logs.go
+++ b/internal/workload/logs.go
@@ -295,6 +295,11 @@ type logFollower struct {
 	// but not on every stream this follower serves).
 	gapHint string
 
+	// lag is how far behind the newest-seen timestamp the cursor trails, so
+	// late-ingested lines are caught by the dedup overlap rather than
+	// skipped. Callers whose source ingests slowly (build logs) widen it.
+	lag time.Duration
+
 	dedup           *logDedup
 	cursor          time.Time // newest parsed timestamp; zero means window mode
 	cursorUsable    bool      // false once the server rejects the startTime filter
@@ -338,6 +343,7 @@ func newLogFollower(
 		onWarn:       onWarn,
 		dedup:        newLogDedup(followSeenCap),
 		cursorUsable: true,
+		lag:          followLagAllowance,
 	}, nil
 }
 
@@ -349,7 +355,7 @@ func (f *logFollower) fetch() (entries []WorkloadLogEntry, hadSince bool, err er
 	maxEntries := f.limit
 
 	if f.seeded && f.cursorUsable && !f.cursor.IsZero() {
-		since = f.cursor.Add(-followLagAllowance).UTC().Format(time.RFC3339Nano)
+		since = f.cursor.Add(-f.lag).UTC().Format(time.RFC3339Nano)
 		maxEntries = 0
 	}
 
@@ -412,13 +418,15 @@ func (f *logFollower) emit(entries []WorkloadLogEntry, hadSince bool) error {
 		}
 	}
 
-	for _, e := range entries {
-		if t, ok := parseLogTimestamp(e.Timestamp); ok && t.After(f.cursor) {
-			f.cursor = t
-		}
-	}
+	f.advanceCursor(entries)
 
-	f.seeded = true
+	// An empty fetch seeds nothing: marking it seeded would pin a zero
+	// cursor, and the NEXT poll — the first with real lines — would be a
+	// window fetch capped at limit, gapping a producer that burst past it
+	// (a builder's opening seconds do exactly that).
+	if len(entries) > 0 {
+		f.seeded = true
+	}
 
 	return nil
 }
@@ -438,6 +446,15 @@ func sortChronological(entries []WorkloadLogEntry) {
 
 		return ta.Compare(tb)
 	})
+}
+
+// advanceCursor moves the cursor past the newest parseable timestamp.
+func (f *logFollower) advanceCursor(entries []WorkloadLogEntry) {
+	for _, e := range entries {
+		if t, ok := parseLogTimestamp(e.Timestamp); ok && t.After(f.cursor) {
+			f.cursor = t
+		}
+	}
 }
 
 // isFilterRejectedError reports whether the server rejected the query params

--- a/internal/workload/logs.go
+++ b/internal/workload/logs.go
@@ -251,6 +251,8 @@ func FollowWorkloadLogs(
 		return err
 	}
 
+	f.gapHint = " (re-run with a larger --limit)"
+
 	for {
 		entries, hadSince, err := f.fetch()
 		if err != nil {
@@ -287,6 +289,11 @@ type logFollower struct {
 	level   string
 	onLine  func(WorkloadLogEntry) error
 	onWarn  func(string)
+
+	// gapHint is appended to the possible-gap warning; it names the remedy,
+	// which only the caller knows (a --limit flag exists on `workload logs`
+	// but not on every stream this follower serves).
+	gapHint string
 
 	dedup           *logDedup
 	cursor          time.Time // newest parsed timestamp; zero means window mode
@@ -385,15 +392,18 @@ func (f *logFollower) fetchFailure(err error, hadSince bool) (retryNow bool, _ e
 func (f *logFollower) emit(entries []WorkloadLogEntry, hadSince bool) error {
 	f.transientErrors = 0
 
-	// Newest first from the server; chronological for display.
+	// Newest first from the server; chronological for display. The reverse
+	// gets the bulk order right; the sort settles lines the collector
+	// ingested out of event order.
 	slices.Reverse(entries)
+	sortChronological(entries)
 
 	fresh := f.dedup.filterUnseen(entries)
 
 	// A full window with zero overlap means >limit lines arrived since the
 	// last poll and the excess is unfetchable.
 	if f.seeded && !hadSince && len(entries) == f.limit && len(fresh) == len(entries) {
-		f.onWarn(fmt.Sprintf("possible gap: more than %d new lines arrived since the last poll and some may have been skipped (re-run with a larger --limit)", f.limit))
+		f.onWarn(fmt.Sprintf("possible gap: more than %d new lines arrived since the last poll and some may have been skipped%s", f.limit, f.gapHint))
 	}
 
 	for _, e := range fresh {
@@ -411,6 +421,23 @@ func (f *logFollower) emit(entries []WorkloadLogEntry, hadSince bool) error {
 	f.seeded = true
 
 	return nil
+}
+
+// sortChronological stable-sorts entries by their parsed timestamps, settling
+// lines the collector ingested out of event order (a build's "#1 DONE"
+// arriving before its "#1 [internal] load"). Unparseable timestamps stay
+// where the server put them.
+func sortChronological(entries []WorkloadLogEntry) {
+	slices.SortStableFunc(entries, func(a, b WorkloadLogEntry) int {
+		ta, aok := parseLogTimestamp(a.Timestamp)
+		tb, bok := parseLogTimestamp(b.Timestamp)
+
+		if !aok || !bok {
+			return 0
+		}
+
+		return ta.Compare(tb)
+	})
 }
 
 // isFilterRejectedError reports whether the server rejected the query params

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/internal/workload/sync"
@@ -411,13 +410,20 @@ func buildImage(artifactID, attachTo string, opts Options, report *reporter) (st
 			buildID = triggered
 		}
 
+		// The line below is the phase's heartbeat: the trigger above can
+		// legitimately take minutes against a slow platform, and the first
+		// log line lags the build by however long ingestion takes, so without
+		// it the header sits alone and reads as a hang.
+		say("following build " + buildID + "; its first log lines can take a minute to arrive")
+
 		// The tail is progress feedback only: it never errors, and after
 		// sustained fetch failures it says so once and goes quiet, while the
-		// build wait carries on. Warnings go to the debug log rather than the
-		// stream, where they would read as the build's own output.
+		// build wait carries on. Its notices go into the stream marked as the
+		// CLI's own — silence here is indistinguishable from a hang, which is
+		// worse than one meta line among the build's output.
 		tail := workload.NewBuildLogTail(artifactID, buildID,
 			func(e workload.WorkloadLogEntry) { say(buildLogLine(e)) },
-			func(w string) { log.Debug("build log tail", "msg", w) })
+			func(w string) { say("(log stream) " + w) })
 
 		// WaitForBuild hands the build back alongside its error when the
 		// build ends badly or the wait runs out, so the id is taken from it

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -19,10 +19,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/internal/workload/sync"
 	"github.com/datarobot/cli/internal/workload/wapi"
+	"github.com/datarobot/cli/tui"
 )
 
 // buildAndCreate is the first deploy of a project whose image the platform
@@ -399,7 +401,7 @@ const buildHistoryLimit = 20
 func buildImage(artifactID, attachTo string, opts Options, report *reporter) (string, error) {
 	var built *workload.Build
 
-	err := report.stream("Building the image", func(say func(string)) error {
+	err := report.stream("Building the image", func(say func(string, lipgloss.Style)) error {
 		buildID := attachTo
 		if buildID == "" {
 			triggered, triggerErr := triggerBuild(artifactID)
@@ -414,7 +416,7 @@ func buildImage(artifactID, attachTo string, opts Options, report *reporter) (st
 		// legitimately take minutes against a slow platform, and the first
 		// log line lags the build by however long ingestion takes, so without
 		// it the header sits alone and reads as a hang.
-		say("following build " + buildID + "; its first log lines can take a minute to arrive")
+		say("following build "+buildID+"; its first log lines can take a minute to arrive", tui.HintStyle)
 
 		// The tail is progress feedback only: it never errors, and after
 		// sustained fetch failures it says so once and goes quiet, while the
@@ -422,14 +424,29 @@ func buildImage(artifactID, attachTo string, opts Options, report *reporter) (st
 		// CLI's own — silence here is indistinguishable from a hang, which is
 		// worse than one meta line among the build's output.
 		tail := workload.NewBuildLogTail(artifactID, buildID,
-			func(e workload.WorkloadLogEntry) { say(buildLogLine(e)) },
-			func(w string) { say("(log stream) " + w) })
+			func(e workload.WorkloadLogEntry) { line, style := buildLogLine(e); say(line, style) },
+			func(w string) { say("(log stream) "+w, tui.WarnStyle) })
+
+		// Each status transition is narrated, because the stages before the
+		// builder speaks — accepted, waiting for a builder — are exactly the
+		// quiet ones where the user wonders whether anything is happening.
+		// Terminal statuses are left to the phase's own ending.
+		lastStatus := ""
+
+		onTick := func(b *workload.Build) {
+			if b != nil && !workload.IsTerminalBuildStatus(b.Status) && !strings.EqualFold(b.Status, lastStatus) {
+				lastStatus = b.Status
+
+				say(buildStatusLine(b.Status), tui.HintStyle)
+			}
+
+			tail.Poll()
+		}
 
 		// WaitForBuild hands the build back alongside its error when the
 		// build ends badly or the wait runs out, so the id is taken from it
 		// before the error is looked at: it is the only way to the logs.
-		b, waitErr := waitBuildFn(artifactID, buildID, opts.PollInterval, opts.PollTimeout,
-			func(*workload.Build) { tail.Poll() })
+		b, waitErr := waitBuildFn(artifactID, buildID, opts.PollInterval, opts.PollTimeout, onTick)
 		built = b
 
 		// One more poll after the terminal status: ingestion lags the build,
@@ -456,15 +473,31 @@ func buildImage(artifactID, attachTo string, opts Options, report *reporter) (st
 	return built.ID, err
 }
 
-// buildLogLine renders one streamed build log line. The message alone is the
-// line for routine output; a non-info level is called out, because an error
-// scrolling past dimmed and unmarked defeats the point of streaming.
-func buildLogLine(e workload.WorkloadLogEntry) string {
+// buildLogLine renders one streamed build log line with the style its level
+// deserves. The message alone, dimmed, is the line for routine output; a
+// non-info level is called out and colored, because an error scrolling past
+// dimmed and unmarked defeats the point of streaming.
+func buildLogLine(e workload.WorkloadLogEntry) (string, lipgloss.Style) {
 	switch strings.ToLower(e.Level) {
 	case "", "info", "debug":
-		return e.Message
+		return e.Message, tui.HintStyle
+	case "warn", "warning":
+		return "[" + strings.ToUpper(e.Level) + "] " + e.Message, tui.WarnStyle
 	default:
-		return "[" + strings.ToUpper(e.Level) + "] " + e.Message
+		return "[" + strings.ToUpper(e.Level) + "] " + e.Message, tui.ErrorStyle
+	}
+}
+
+// buildStatusLine narrates a build status for the stream, in words rather
+// than enum values for the two stages every build passes through.
+func buildStatusLine(status string) string {
+	switch strings.ToUpper(status) {
+	case workload.BuildStatusPending:
+		return "build accepted; waiting for a builder to pick it up"
+	case workload.BuildStatusInProgress:
+		return "builder running"
+	default:
+		return "build is " + strings.ToLower(status)
 	}
 }
 

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -496,6 +496,8 @@ func buildStatusLine(status string) string {
 		return "build accepted; waiting for a builder to pick it up"
 	case workload.BuildStatusInProgress:
 		return "builder running"
+	case "BUILT":
+		return "image built; pushing it to the registry"
 	default:
 		return "build is " + strings.ToLower(status)
 	}

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -17,7 +17,9 @@ package up
 import (
 	"errors"
 	"fmt"
+	"strings"
 
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/internal/workload/sync"
@@ -317,19 +319,42 @@ func maybeBuild(
 	report *reporter,
 ) (string, error) {
 	if !fresh && !opts.ForceBuild && !changed(code, synced) {
-		built, err := hasImage(artifactID)
+		builds, err := listBuildsFn(artifactID, buildHistoryLimit)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("cannot tell whether artifact %s has been built: %w", artifactID, err)
 		}
 
-		if built {
+		if hasImage(builds) {
 			report.say("  Image is up to date; no rebuild needed.\n")
 
 			return "", nil
 		}
+
+		// The tree matches what was synced and no image exists yet — if a
+		// build of that code is already running (a previous up triggered it
+		// and died, or another terminal is mid-deploy), attach to it instead
+		// of starting a second one. Only safe on this path: when the code
+		// changed, a running build is building the old tree, and a fresh
+		// trigger — which supersedes it server-side — is the correct move.
+		if running := runningBuild(builds); running != "" {
+			report.say("  A build of this code is already running; attaching to it.\n")
+
+			return buildImage(artifactID, running, opts, report)
+		}
 	}
 
-	return buildImage(artifactID, opts, report)
+	return buildImage(artifactID, "", opts, report)
+}
+
+// runningBuild names the newest non-terminal build, "" when there is none
+// (the caller then just triggers, which is the pre-attach behavior and
+// always safe).
+func runningBuild(builds []workload.Build) string {
+	if len(builds) == 0 || workload.IsTerminalBuildStatus(builds[0].Status) {
+		return ""
+	}
+
+	return builds[0].ID
 }
 
 // changed reports whether anything moved. The sync's own count is preferred
@@ -351,43 +376,59 @@ func changed(code CodeChange, synced *sync.Result) bool {
 // The exception is code pushed by `dr artifact code sync` between deploys,
 // which leaves a completed build of the previous version and a tree that
 // looks unchanged to `up`. That is what --force-build is for.
-func hasImage(artifactID string) (bool, error) {
-	builds, err := listBuildsFn(artifactID, buildHistoryLimit)
-	if err != nil {
-		return false, fmt.Errorf("cannot tell whether artifact %s has been built: %w", artifactID, err)
-	}
-
+func hasImage(builds []workload.Build) bool {
 	for _, build := range builds {
 		if workload.IsBuildCompleted(build.Status) {
-			return true, nil
+			return true
 		}
 	}
 
-	return false, nil
+	return false
 }
 
 // buildHistoryLimit bounds the look back for a completed build. A handful of
 // attempts is all a deploy can have made; past that the answer is no.
 const buildHistoryLimit = 20
 
-// buildImage builds the artifact's image and waits for it. The wait is not
-// optional even under --detach: a workload created against an artifact with
-// no image would come up unable to start, and --detach promises not to wait
-// for the workload, not to deploy something that cannot run.
-func buildImage(artifactID string, opts Options, report *reporter) (string, error) {
+// buildImage builds the artifact's image and waits for it, streaming the
+// build's own log lines beneath the phase header while it runs. attachTo, when
+// set, is an already-running build to follow instead of triggering a new one.
+//
+// The wait is not optional even under --detach: a workload created against an
+// artifact with no image would come up unable to start, and --detach promises
+// not to wait for the workload, not to deploy something that cannot run.
+func buildImage(artifactID, attachTo string, opts Options, report *reporter) (string, error) {
 	var built *workload.Build
 
-	err := report.run("Building the image", func() error {
-		buildID, triggerErr := triggerBuild(artifactID)
-		if triggerErr != nil {
-			return triggerErr
+	err := report.stream("Building the image", func(say func(string)) error {
+		buildID := attachTo
+		if buildID == "" {
+			triggered, triggerErr := triggerBuild(artifactID)
+			if triggerErr != nil {
+				return triggerErr
+			}
+
+			buildID = triggered
 		}
+
+		// The tail is progress feedback only: it never errors, and after
+		// sustained fetch failures it says so once and goes quiet, while the
+		// build wait carries on. Warnings go to the debug log rather than the
+		// stream, where they would read as the build's own output.
+		tail := workload.NewBuildLogTail(artifactID, buildID,
+			func(e workload.WorkloadLogEntry) { say(buildLogLine(e)) },
+			func(w string) { log.Debug("build log tail", "msg", w) })
 
 		// WaitForBuild hands the build back alongside its error when the
 		// build ends badly or the wait runs out, so the id is taken from it
 		// before the error is looked at: it is the only way to the logs.
-		b, waitErr := waitBuildFn(artifactID, buildID, opts.PollInterval, opts.PollTimeout, nil)
+		b, waitErr := waitBuildFn(artifactID, buildID, opts.PollInterval, opts.PollTimeout,
+			func(*workload.Build) { tail.Poll() })
 		built = b
+
+		// One more poll after the terminal status: ingestion lags the build,
+		// so the last lines routinely land after the wait has already ended.
+		tail.Poll()
 
 		return waitErr
 	})
@@ -407,6 +448,18 @@ func buildImage(artifactID string, opts Options, report *reporter) (string, erro
 	// A build still running when the wait expires keeps its id too: it is
 	// what the user needs to follow it to the end.
 	return built.ID, err
+}
+
+// buildLogLine renders one streamed build log line. The message alone is the
+// line for routine output; a non-info level is called out, because an error
+// scrolling past dimmed and unmarked defeats the point of streaming.
+func buildLogLine(e workload.WorkloadLogEntry) string {
+	switch strings.ToLower(e.Level) {
+	case "", "info", "debug":
+		return e.Message
+	default:
+		return "[" + strings.ToUpper(e.Level) + "] " + e.Message
+	}
 }
 
 // triggerBuild starts one build and names it. The endpoint answers with a

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/datarobot/cli/internal/workload"
@@ -337,8 +338,8 @@ func maybeBuild(
 		// of starting a second one. Only safe on this path: when the code
 		// changed, a running build is building the old tree, and a fresh
 		// trigger — which supersedes it server-side — is the correct move.
-		if running := runningBuild(builds); running != "" {
-			report.say("  A build of this code is already running; attaching to it.\n")
+		if running := runningBuild(builds, attachMaxAge(opts)); running != "" {
+			report.say("  A build of this code is already running; attaching to it (--force-build starts a new one).\n")
 
 			return buildImage(artifactID, running, opts, report)
 		}
@@ -350,12 +351,30 @@ func maybeBuild(
 // runningBuild names the newest non-terminal build, "" when there is none
 // (the caller then just triggers, which is the pre-attach behavior and
 // always safe).
-func runningBuild(builds []workload.Build) string {
+func runningBuild(builds []workload.Build, maxAge time.Duration) string {
 	if len(builds) == 0 || workload.IsTerminalBuildStatus(builds[0].Status) {
 		return ""
 	}
 
+	// A non-terminal build older than a wait would ever tolerate is wedged —
+	// an orphaned trigger or a lost reconcile — not running. Attaching would
+	// wait the whole timeout on a build that can never finish; triggering
+	// supersedes it server-side, which is also the cleanup.
+	if !builds[0].CreatedAt.IsZero() && phaseClock().Sub(builds[0].CreatedAt) > maxAge {
+		return ""
+	}
+
 	return builds[0].ID
+}
+
+// attachMaxAge is how old a running build may be and still be worth attaching
+// to: the poll timeout, because a healthy build finishes within one wait.
+func attachMaxAge(opts Options) time.Duration {
+	if opts.PollTimeout > 0 {
+		return opts.PollTimeout
+	}
+
+	return 30 * time.Minute
 }
 
 // changed reports whether anything moved. The sync's own count is preferred

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -468,9 +468,9 @@ func buildImage(artifactID, attachTo string, opts Options, report *reporter) (st
 		b, waitErr := waitBuildFn(artifactID, buildID, opts.PollInterval, opts.PollTimeout, onTick)
 		built = b
 
-		// One more poll after the terminal status: ingestion lags the build,
-		// so the last lines routinely land after the wait has already ended.
-		tail.Poll()
+		// The final catch-up: ingestion lags the build, so the last lines
+		// routinely land after the wait, and the reorder buffer must drain.
+		tail.Finish()
 
 		return waitErr
 	})

--- a/internal/workload/up/build_stream_test.go
+++ b/internal/workload/up/build_stream_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReporter_StreamPrintsHeaderLinesAndCheckmark(t *testing.T) {
+	fixedClock(t, 2*time.Second)
+
+	var out bytes.Buffer
+
+	err := newReporter(&out, false).stream("Building the image", func(say func(string)) error {
+		say("step 1/4: FROM base")
+		say("step 2/4: COPY . .")
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	text := out.String()
+	assert.Contains(t, text, "Building the image\n")
+	assert.Contains(t, text, "step 1/4: FROM base")
+	assert.Contains(t, text, "step 2/4: COPY . .")
+	assert.Contains(t, text, "✓ Building the image (2s)")
+
+	// Header before lines, lines before checkmark.
+	header := bytes.Index(out.Bytes(), []byte("Building the image"))
+	line := bytes.Index(out.Bytes(), []byte("step 1/4"))
+	check := bytes.Index(out.Bytes(), []byte("✓"))
+
+	assert.Less(t, header, line)
+	assert.Less(t, line, check)
+}
+
+func TestReporter_StreamFailurePrintsNoCheckmark(t *testing.T) {
+	fixedClock(t, time.Second)
+
+	var out bytes.Buffer
+
+	err := newReporter(&out, false).stream("Building the image", func(say func(string)) error {
+		say("step 1/4: FROM base")
+
+		return errors.New("boom")
+	})
+	require.Error(t, err)
+	assert.NotContains(t, out.String(), "✓")
+	// The streamed lines stay: they are the context for the error.
+	assert.Contains(t, out.String(), "step 1/4: FROM base")
+}
+
+func TestBuildLogLine_MarksNonInfoLevels(t *testing.T) {
+	assert.Equal(t, "pulling layer",
+		buildLogLine(workload.WorkloadLogEntry{Level: "INFO", Message: "pulling layer"}))
+	assert.Equal(t, "cache key",
+		buildLogLine(workload.WorkloadLogEntry{Level: "debug", Message: "cache key"}))
+	assert.Equal(t, "[ERROR] no space left on device",
+		buildLogLine(workload.WorkloadLogEntry{Level: "error", Message: "no space left on device"}))
+	assert.Equal(t, "[WARNING] deprecated base image",
+		buildLogLine(workload.WorkloadLogEntry{Level: "warning", Message: "deprecated base image"}))
+}
+
+// unchangedSync is a sync result that moved nothing, which is the only state
+// the attach path is reachable from.
+func unchangedSync() *sync.Result { return &sync.Result{} }
+
+func TestMaybeBuild_AttachesToRunningBuildWhenCodeUnchanged(t *testing.T) {
+	fixedClock(t, time.Second)
+
+	// Newest build is still running and nothing has ever completed: the code
+	// on the artifact is being built right now, so a second trigger would be
+	// a duplicate.
+	force(t, &listBuildsFn, func(string, int) ([]workload.Build, error) {
+		return []workload.Build{{ID: "bld-running", Status: "IN_PROGRESS"}}, nil
+	})
+	force(t, &triggerBuildFn, func(string) (*workload.BuildTriggerResponse, error) {
+		t.Fatal("attach must not trigger a second build")
+
+		return nil, nil
+	})
+
+	var waited string
+
+	force(t, &waitBuildFn, func(_, id string, _, _ time.Duration, onTick func(*workload.Build)) (*workload.Build, error) {
+		waited = id
+
+		if onTick != nil {
+			onTick(&workload.Build{ID: id, Status: "IN_PROGRESS"})
+		}
+
+		return &workload.Build{ID: id, Status: "COMPLETED"}, nil
+	})
+
+	var out bytes.Buffer
+
+	buildID, err := maybeBuild("art-1", false, CodeChange{}, unchangedSync(), Options{}, newReporter(&out, false))
+	require.NoError(t, err)
+	assert.Equal(t, "bld-running", buildID)
+	assert.Equal(t, "bld-running", waited)
+	assert.Contains(t, out.String(), "already running; attaching")
+}
+
+func TestMaybeBuild_TriggersDespiteRunningBuildWhenCodeChanged(t *testing.T) {
+	fixedClock(t, time.Second)
+
+	// A running build of the OLD tree must not be attached to: the fresh
+	// trigger supersedes it server-side and builds what was just synced.
+	force(t, &listBuildsFn, func(string, int) ([]workload.Build, error) {
+		t.Fatal("changed code must not consult the build list")
+
+		return nil, nil
+	})
+
+	triggered := false
+
+	force(t, &triggerBuildFn, func(string) (*workload.BuildTriggerResponse, error) {
+		triggered = true
+
+		return &workload.BuildTriggerResponse{BuildIDs: []string{"bld-new"}}, nil
+	})
+	force(t, &waitBuildFn, func(_, id string, _, _ time.Duration, _ func(*workload.Build)) (*workload.Build, error) {
+		return &workload.Build{ID: id, Status: "COMPLETED"}, nil
+	})
+
+	var out bytes.Buffer
+
+	buildID, err := maybeBuild("art-1", false, CodeChange{}, &sync.Result{UploadedCount: 1}, Options{}, newReporter(&out, false))
+	require.NoError(t, err)
+	assert.True(t, triggered)
+	assert.Equal(t, "bld-new", buildID)
+}

--- a/internal/workload/up/build_stream_test.go
+++ b/internal/workload/up/build_stream_test.go
@@ -20,8 +20,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/datarobot/cli/tui"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,9 +33,9 @@ func TestReporter_StreamPrintsHeaderLinesAndCheckmark(t *testing.T) {
 
 	var out bytes.Buffer
 
-	err := newReporter(&out, false).stream("Building the image", func(say func(string)) error {
-		say("step 1/4: FROM base")
-		say("step 2/4: COPY . .")
+	err := newReporter(&out, false).stream("Building the image", func(say func(string, lipgloss.Style)) error {
+		say("step 1/4: FROM base", tui.HintStyle)
+		say("step 2/4: COPY . .", tui.HintStyle)
 
 		return nil
 	})
@@ -59,8 +61,8 @@ func TestReporter_StreamFailurePrintsNoCheckmark(t *testing.T) {
 
 	var out bytes.Buffer
 
-	err := newReporter(&out, false).stream("Building the image", func(say func(string)) error {
-		say("step 1/4: FROM base")
+	err := newReporter(&out, false).stream("Building the image", func(say func(string, lipgloss.Style)) error {
+		say("step 1/4: FROM base", tui.HintStyle)
 
 		return errors.New("boom")
 	})
@@ -70,15 +72,53 @@ func TestReporter_StreamFailurePrintsNoCheckmark(t *testing.T) {
 	assert.Contains(t, out.String(), "step 1/4: FROM base")
 }
 
-func TestBuildLogLine_MarksNonInfoLevels(t *testing.T) {
-	assert.Equal(t, "pulling layer",
-		buildLogLine(workload.WorkloadLogEntry{Level: "INFO", Message: "pulling layer"}))
-	assert.Equal(t, "cache key",
-		buildLogLine(workload.WorkloadLogEntry{Level: "debug", Message: "cache key"}))
-	assert.Equal(t, "[ERROR] no space left on device",
-		buildLogLine(workload.WorkloadLogEntry{Level: "error", Message: "no space left on device"}))
-	assert.Equal(t, "[WARNING] deprecated base image",
-		buildLogLine(workload.WorkloadLogEntry{Level: "warning", Message: "deprecated base image"}))
+func TestBuildLogLine_MarksAndColorsNonInfoLevels(t *testing.T) {
+	line, style := buildLogLine(workload.WorkloadLogEntry{Level: "INFO", Message: "pulling layer"})
+	assert.Equal(t, "pulling layer", line)
+	assert.Equal(t, tui.HintStyle, style)
+
+	line, style = buildLogLine(workload.WorkloadLogEntry{Level: "error", Message: "no space left on device"})
+	assert.Equal(t, "[ERROR] no space left on device", line)
+	assert.Equal(t, tui.ErrorStyle, style)
+
+	line, style = buildLogLine(workload.WorkloadLogEntry{Level: "warning", Message: "deprecated base image"})
+	assert.Equal(t, "[WARNING] deprecated base image", line)
+	assert.Equal(t, tui.WarnStyle, style)
+}
+
+func TestBuildStatusLine_NarratesTheQuietStages(t *testing.T) {
+	assert.Equal(t, "build accepted; waiting for a builder to pick it up", buildStatusLine("PENDING"))
+	assert.Equal(t, "builder running", buildStatusLine("IN_PROGRESS"))
+	assert.Equal(t, "build is cancelling", buildStatusLine("CANCELLING"))
+}
+
+func TestReporter_StreamCollapsesOnSuccessOnTerminal(t *testing.T) {
+	fixedClock(t, 2*time.Second)
+
+	prev := streamWidth
+	streamWidth = func() int { return 30 }
+
+	t.Cleanup(func() { streamWidth = prev })
+
+	var out bytes.Buffer
+
+	// spinner=true marks out as the user's terminal, which is what arms
+	// truncation and the erase.
+	err := newReporter(&out, true).stream("Building the image", func(say func(string, lipgloss.Style)) error {
+		say("short line", tui.HintStyle)
+		say("a very long line that cannot possibly fit in thirty columns", tui.HintStyle)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	text := out.String()
+	// The long line was truncated to one row.
+	assert.Contains(t, text, "…")
+	assert.NotContains(t, text, "thirty columns")
+	// Two stream rows plus the header are erased, then the checkmark prints.
+	assert.Contains(t, text, "\x1b[3A\x1b[0J")
+	assert.Contains(t, text, "✓ Building the image (2s)")
 }
 
 // unchangedSync is a sync result that moved nothing, which is the only state
@@ -122,6 +162,8 @@ func TestMaybeBuild_AttachesToRunningBuildWhenCodeUnchanged(t *testing.T) {
 	// The heartbeat line: the phase must say something before the first log
 	// line arrives, or a slow start reads as a hang.
 	assert.Contains(t, out.String(), "following build bld-running")
+	// The status transition the stub's onTick delivered is narrated.
+	assert.Contains(t, out.String(), "builder running")
 }
 
 func TestMaybeBuild_TriggersDespiteRunningBuildWhenCodeChanged(t *testing.T) {

--- a/internal/workload/up/build_stream_test.go
+++ b/internal/workload/up/build_stream_test.go
@@ -17,6 +17,7 @@ package up
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -89,21 +90,28 @@ func TestBuildLogLine_MarksAndColorsNonInfoLevels(t *testing.T) {
 func TestBuildStatusLine_NarratesTheQuietStages(t *testing.T) {
 	assert.Equal(t, "build accepted; waiting for a builder to pick it up", buildStatusLine("PENDING"))
 	assert.Equal(t, "builder running", buildStatusLine("IN_PROGRESS"))
+	assert.Equal(t, "image built; pushing it to the registry", buildStatusLine("BUILT"))
 	assert.Equal(t, "build is cancelling", buildStatusLine("CANCELLING"))
+}
+
+// terminalOfSize fakes the stream's terminal for the test's lifetime.
+func terminalOfSize(t *testing.T, width, height int) {
+	t.Helper()
+
+	prev := streamSize
+	streamSize = func() (int, int) { return width, height }
+
+	t.Cleanup(func() { streamSize = prev })
 }
 
 func TestReporter_StreamCollapsesOnSuccessOnTerminal(t *testing.T) {
 	fixedClock(t, 2*time.Second)
-
-	prev := streamWidth
-	streamWidth = func() int { return 30 }
-
-	t.Cleanup(func() { streamWidth = prev })
+	terminalOfSize(t, 30, 24)
 
 	var out bytes.Buffer
 
 	// spinner=true marks out as the user's terminal, which is what arms
-	// truncation and the erase.
+	// truncation, the sliding window, and the erase.
 	err := newReporter(&out, true).stream("Building the image", func(say func(string, lipgloss.Style)) error {
 		say("short line", tui.HintStyle)
 		say("a very long line that cannot possibly fit in thirty columns", tui.HintStyle)
@@ -116,9 +124,33 @@ func TestReporter_StreamCollapsesOnSuccessOnTerminal(t *testing.T) {
 	// The long line was truncated to one row.
 	assert.Contains(t, text, "…")
 	assert.NotContains(t, text, "thirty columns")
-	// Two stream rows plus the header are erased, then the checkmark prints.
+	// Two window rows plus the header are erased, then the checkmark prints.
 	assert.Contains(t, text, "\x1b[3A\x1b[0J")
 	assert.Contains(t, text, "✓ Building the image (2s)")
+}
+
+func TestReporter_StreamWindowNeverOutgrowsTheViewport(t *testing.T) {
+	fixedClock(t, time.Second)
+	// A viewport shorter than the default window: the region must shrink to
+	// fit, or the cursor could not reach back over it (it cannot move above
+	// the viewport, and scrolled rows would survive in scrollback).
+	terminalOfSize(t, 40, 6)
+
+	var out bytes.Buffer
+
+	err := newReporter(&out, true).stream("Building the image", func(say func(string, lipgloss.Style)) error {
+		for i := range 20 {
+			say(fmt.Sprintf("line %d", i), tui.HintStyle)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	// height-4 = 2 window rows, plus the header: the final erase is 3 rows.
+	assert.Contains(t, out.String(), "\x1b[3A\x1b[0J")
+	// The redraws never move the cursor further up than the window is tall.
+	assert.NotContains(t, out.String(), "\x1b[4A")
 }
 
 // unchangedSync is a sync result that moved nothing, which is the only state

--- a/internal/workload/up/build_stream_test.go
+++ b/internal/workload/up/build_stream_test.go
@@ -226,6 +226,38 @@ func TestMaybeBuild_AttachesToRunningBuildWhenCodeUnchanged(t *testing.T) {
 	assert.Contains(t, out.String(), "builder running")
 }
 
+func TestMaybeBuild_TriggersInsteadOfAttachingToAWedgedBuild(t *testing.T) {
+	fixedClock(t, time.Second)
+
+	// A non-terminal build older than any wait would tolerate is wedged (an
+	// orphaned trigger, a lost reconcile), not running: attaching would wait
+	// the whole timeout on it, while a fresh trigger supersedes it.
+	stale := time.Date(2026, time.August, 12, 9, 0, 0, 0, time.UTC) // 3h before fixedClock's base
+
+	force(t, &listBuildsFn, func(string, int) ([]workload.Build, error) {
+		return []workload.Build{{ID: "bld-wedged", Status: "IN_PROGRESS", CreatedAt: stale}}, nil
+	})
+
+	triggered := false
+
+	force(t, &triggerBuildFn, func(string) (*workload.BuildTriggerResponse, error) {
+		triggered = true
+
+		return &workload.BuildTriggerResponse{BuildIDs: []string{"bld-new"}}, nil
+	})
+	force(t, &waitBuildFn, func(_, id string, _, _ time.Duration, _ func(*workload.Build)) (*workload.Build, error) {
+		return &workload.Build{ID: id, Status: "COMPLETED"}, nil
+	})
+
+	var out bytes.Buffer
+
+	buildID, err := maybeBuild("art-1", false, CodeChange{}, unchangedSync(), Options{}, newReporter(&out, false))
+	require.NoError(t, err)
+	assert.True(t, triggered, "a wedged build must be superseded, not attached to")
+	assert.Equal(t, "bld-new", buildID)
+	assert.NotContains(t, out.String(), "attaching")
+}
+
 func TestMaybeBuild_TriggersDespiteRunningBuildWhenCodeChanged(t *testing.T) {
 	fixedClock(t, time.Second)
 

--- a/internal/workload/up/build_stream_test.go
+++ b/internal/workload/up/build_stream_test.go
@@ -129,6 +129,34 @@ func TestReporter_StreamCollapsesOnSuccessOnTerminal(t *testing.T) {
 	assert.Contains(t, text, "✓ Building the image (2s)")
 }
 
+// A panic inside fn unwinds through stream. The deferred halt has to stop the
+// animator on the way out, or its ticker keeps writing escape codes to the
+// terminal until the process dies.
+func TestReporter_StreamStopsTheAnimatorWhenFnPanics(t *testing.T) {
+	terminalOfSize(t, 30, 24)
+
+	var out bytes.Buffer
+
+	panicked := func() (p any) {
+		defer func() { p = recover() }()
+
+		_ = newReporter(&out, true).stream("Building the image", func(func(string, lipgloss.Style)) error {
+			panic("boom")
+		})
+
+		return nil
+	}()
+	require.Equal(t, "boom", panicked, "the panic must still propagate; stream only cleans up")
+
+	// The deferred halt ran before the panic reached us, so the animator is
+	// stopped and the buffer may no longer move. A tick is 100ms; if one were
+	// still alive, this window would catch it repainting the header.
+	before := out.Len()
+
+	time.Sleep(250 * time.Millisecond)
+	assert.Equal(t, before, out.Len(), "a stopped animator writes nothing more")
+}
+
 func TestReporter_StreamWindowNeverOutgrowsTheViewport(t *testing.T) {
 	fixedClock(t, time.Second)
 	// A viewport shorter than the default window: the region must shrink to

--- a/internal/workload/up/build_stream_test.go
+++ b/internal/workload/up/build_stream_test.go
@@ -119,6 +119,9 @@ func TestMaybeBuild_AttachesToRunningBuildWhenCodeUnchanged(t *testing.T) {
 	assert.Equal(t, "bld-running", buildID)
 	assert.Equal(t, "bld-running", waited)
 	assert.Contains(t, out.String(), "already running; attaching")
+	// The heartbeat line: the phase must say something before the first log
+	// line arrives, or a slow start reads as a hang.
+	assert.Contains(t, out.String(), "following build bld-running")
 }
 
 func TestMaybeBuild_TriggersDespiteRunningBuildWhenCodeChanged(t *testing.T) {

--- a/internal/workload/up/phase.go
+++ b/internal/workload/up/phase.go
@@ -70,6 +70,34 @@ func (r *reporter) work(label string, fn func() error) error {
 	return fn()
 }
 
+// stream executes one phase whose progress arrives as text lines rather than
+// a spinner. The label prints first as a header, fn's lines print dimmed and
+// indented beneath it as they arrive, and the check-marked line with the
+// elapsed time prints after — so the spinner and the stream never fight over
+// the terminal (no spinner runs at all during a streamed phase). On a plain
+// writer (no TTY, JSON mode) the same lines print undecorated, which is how
+// CI logs stay readable.
+//
+// A failure prints nothing extra, exactly like run: the error carries the
+// story, and the lines already streamed are the context.
+func (r *reporter) stream(label string, fn func(say func(line string)) error) error {
+	started := phaseClock()
+
+	fmt.Fprintf(r.out, "  %s %s\n", tui.HintStyle.Render("⠿"), label)
+
+	say := func(line string) {
+		fmt.Fprintf(r.out, "    %s\n", tui.HintStyle.Render(line))
+	}
+
+	if err := fn(say); err != nil {
+		return err
+	}
+
+	r.done(label, phaseClock().Sub(started))
+
+	return nil
+}
+
 // done prints the completed phase. Durations are truncated to a tenth of a
 // second: a deploy is measured in minutes and the extra digits are noise.
 func (r *reporter) done(label string, elapsed time.Duration) {

--- a/internal/workload/up/phase.go
+++ b/internal/workload/up/phase.go
@@ -17,9 +17,14 @@ package up
 import (
 	"fmt"
 	"io"
+	"os"
+	"strings"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/datarobot/cli/tui"
+	"golang.org/x/term"
 )
 
 // phaseClock is the time source, swapped by tests so a check-marked line's
@@ -74,28 +79,66 @@ func (r *reporter) work(label string, fn func() error) error {
 // a spinner. The label prints first as a header, fn's lines print dimmed and
 // indented beneath it as they arrive, and the check-marked line with the
 // elapsed time prints after — so the spinner and the stream never fight over
-// the terminal (no spinner runs at all during a streamed phase). On a plain
-// writer (no TTY, JSON mode) the same lines print undecorated, which is how
-// CI logs stay readable.
+// the terminal (no spinner runs at all during a streamed phase).
 //
-// A failure prints nothing extra, exactly like run: the error carries the
-// story, and the lines already streamed are the context.
-func (r *reporter) stream(label string, fn func(say func(line string)) error) error {
+// On the terminal, every line is truncated to the width so it occupies
+// exactly one row, and a phase that SUCCEEDS erases its stream — header
+// included — leaving only the check-marked line, so a deploy's final
+// transcript stays clean. One row per line is what makes the erase count
+// exact; a resize mid-phase can still rewrap history, which at worst strands
+// a few lines. A failed phase keeps every line: they are the context for the
+// error. On a plain writer (no TTY, JSON mode) nothing is truncated or
+// erased, which is how CI logs stay complete.
+func (r *reporter) stream(label string, fn func(say func(line string, style lipgloss.Style)) error) error {
 	started := phaseClock()
 
 	fmt.Fprintf(r.out, "  %s %s\n", tui.HintStyle.Render("⠿"), label)
 
-	say := func(line string) {
-		fmt.Fprintf(r.out, "    %s\n", tui.HintStyle.Render(line))
+	// r.spinner is the "out is the terminal the user is watching" flag; a
+	// width is only meaningful, and erasing only safe, on that terminal.
+	width := 0
+	if r.spinner {
+		width = streamWidth()
+	}
+
+	rows := 0
+	say := func(line string, style lipgloss.Style) {
+		// A message with newlines would break the one-row-per-line math.
+		for _, part := range strings.Split(line, "\n") {
+			if width > 0 {
+				part = ansi.Truncate(part, max(width-6, 8), "…")
+			}
+
+			fmt.Fprintf(r.out, "    %s\n", style.Render(part))
+
+			rows++
+		}
 	}
 
 	if err := fn(say); err != nil {
 		return err
 	}
 
+	if width > 0 {
+		// Cursor up over the stream and its header, clear to the end of the
+		// screen; the check-marked line below replaces them.
+		fmt.Fprintf(r.out, "\x1b[%dA\x1b[0J", rows+1)
+	}
+
 	r.done(label, phaseClock().Sub(started))
 
 	return nil
+}
+
+// streamWidth returns the width of the terminal the stream renders on, 0 when
+// there is none. A var so tests can exercise the terminal path without one.
+var streamWidth = func() int {
+	w, _, err := term.GetSize(int(os.Stderr.Fd()))
+	if err != nil || w <= 0 {
+		return 0
+	}
+
+	return w
 }
 
 // done prints the completed phase. Durations are truncated to a tenth of a

--- a/internal/workload/up/phase.go
+++ b/internal/workload/up/phase.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
@@ -75,11 +76,16 @@ func (r *reporter) work(label string, fn func() error) error {
 	return fn()
 }
 
+// streamSpinnerFrames are spinner.Dot's frames, so a streamed phase's header
+// animates exactly like the spinner every other phase shows.
+var streamSpinnerFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
+
 // stream executes one phase whose progress arrives as text lines rather than
-// a spinner. The label prints first as a header, fn's lines print dimmed and
-// indented beneath it as they arrive, and the check-marked line with the
-// elapsed time prints after — so the spinner and the stream never fight over
-// the terminal (no spinner runs at all during a streamed phase).
+// a spinner. The label prints first as a header — animated in place on the
+// terminal, so it moves like every other phase's spinner — fn's lines print
+// styled and indented beneath it as they arrive, and the check-marked line
+// with the elapsed time prints after. The animation repaints only the header
+// row, never the cursor's own line, so it cannot fight with the stream.
 //
 // On the terminal, every line is truncated to the width so it occupies
 // exactly one row, and a phase that SUCCEEDS erases its stream — header
@@ -95,14 +101,41 @@ func (r *reporter) stream(label string, fn func(say func(line string, style lipg
 	fmt.Fprintf(r.out, "  %s %s\n", tui.HintStyle.Render("⠿"), label)
 
 	// r.spinner is the "out is the terminal the user is watching" flag; a
-	// width is only meaningful, and erasing only safe, on that terminal.
+	// width is only meaningful, and cursor games only safe, on that terminal.
 	width := 0
 	if r.spinner {
 		width = streamWidth()
 	}
 
+	var mu sync.Mutex
+
 	rows := 0
+
+	// repaintHeader rewrites the header row, which sits rows+1 rows above the
+	// cursor — exact because every streamed line occupies one row. The caller
+	// holds mu.
+	repaintHeader := func(glyph string) {
+		fmt.Fprintf(r.out, "\x1b[%dA\r  %s %s\x1b[K\x1b[%dB\r", rows+1, glyph, label, rows+1)
+	}
+
+	stop := make(chan struct{})
+
+	var animator sync.WaitGroup
+
+	if width > 0 {
+		animator.Add(1)
+
+		go func() {
+			defer animator.Done()
+
+			animateStreamHeader(stop, &mu, repaintHeader)
+		}()
+	}
+
 	say := func(line string, style lipgloss.Style) {
+		mu.Lock()
+		defer mu.Unlock()
+
 		// A message with newlines would break the one-row-per-line math.
 		for _, part := range strings.Split(line, "\n") {
 			if width > 0 {
@@ -115,7 +148,20 @@ func (r *reporter) stream(label string, fn func(say func(line string, style lipg
 		}
 	}
 
-	if err := fn(say); err != nil {
+	err := fn(say)
+
+	if width > 0 {
+		close(stop)
+		animator.Wait()
+	}
+
+	if err != nil {
+		// A dead animation frame must not outlive the phase; the static
+		// glyph says "this phase stopped here" above the kept lines.
+		if width > 0 {
+			repaintHeader(tui.HintStyle.Render("⠿"))
+		}
+
 		return err
 	}
 
@@ -128,6 +174,28 @@ func (r *reporter) stream(label string, fn func(say func(line string, style lipg
 	r.done(label, phaseClock().Sub(started))
 
 	return nil
+}
+
+// animateStreamHeader cycles the header glyph until stop closes, locking mu
+// around each repaint so frames never interleave with streamed lines.
+func animateStreamHeader(stop <-chan struct{}, mu *sync.Mutex, repaint func(glyph string)) {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	frame := 0
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			mu.Lock()
+			repaint(tui.InfoStyle.Render(streamSpinnerFrames[frame%len(streamSpinnerFrames)]))
+			mu.Unlock()
+
+			frame++
+		}
+	}
 }
 
 // streamWidth returns the width of the terminal the stream renders on, 0 when

--- a/internal/workload/up/phase.go
+++ b/internal/workload/up/phase.go
@@ -83,8 +83,9 @@ func (r *reporter) work(label string, fn func() error) error {
 var streamSpinnerFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
 
 // streamWindowRows caps the live region at header + this many lines: tall
-// enough to read progress, small enough to redraw cheaply and fit a viewport.
-const streamWindowRows = 10
+// enough to follow a build's parallel steps, small enough to redraw cheaply
+// and fit a viewport (shorter terminals shrink it further).
+const streamWindowRows = 20
 
 // stream executes one phase whose progress arrives as text lines rather than
 // a spinner. The label prints first as a header — animated in place on the

--- a/internal/workload/up/phase.go
+++ b/internal/workload/up/phase.go
@@ -80,95 +80,84 @@ func (r *reporter) work(label string, fn func() error) error {
 // animates exactly like the spinner every other phase shows.
 var streamSpinnerFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
 
+// streamWindowRows caps the live region at header + this many lines: tall
+// enough to read progress, small enough to redraw cheaply and fit a viewport.
+const streamWindowRows = 10
+
 // stream executes one phase whose progress arrives as text lines rather than
 // a spinner. The label prints first as a header — animated in place on the
-// terminal, so it moves like every other phase's spinner — fn's lines print
-// styled and indented beneath it as they arrive, and the check-marked line
-// with the elapsed time prints after. The animation repaints only the header
-// row, never the cursor's own line, so it cannot fight with the stream.
+// terminal, so it moves like every other phase's spinner — and fn's lines
+// render beneath it as they arrive, with the check-marked line and elapsed
+// time printing after.
 //
-// On the terminal, every line is truncated to the width so it occupies
-// exactly one row, and a phase that SUCCEEDS erases its stream — header
-// included — leaving only the check-marked line, so a deploy's final
-// transcript stays clean. One row per line is what makes the erase count
-// exact; a resize mid-phase can still rewrap history, which at worst strands
-// a few lines. A failed phase keeps every line: they are the context for the
-// error. On a plain writer (no TTY, JSON mode) nothing is truncated or
-// erased, which is how CI logs stay complete.
+// On the terminal, the lines live in a fixed-height sliding window (the way
+// docker buildx renders): only the newest lines stay on screen, each
+// truncated to the width so it occupies exactly one row, and every new line
+// redraws the region in place. Nothing ever scrolls, which is what makes the
+// two cursor tricks safe — the cursor cannot move above the viewport, so a
+// region taller than the screen could neither be animated nor erased, and
+// scrolled-away rows would survive in scrollback where no escape code
+// reaches. A phase that SUCCEEDS erases the window — header included —
+// leaving only the check-marked line, so the deploy's final transcript stays
+// clean. A failed phase keeps the window's tail: the freshest context for
+// the error, with the full log a command away. On a plain writer (no TTY,
+// JSON mode) every line prints permanently, which is how CI logs stay
+// complete.
 func (r *reporter) stream(label string, fn func(say func(line string, style lipgloss.Style)) error) error {
 	started := phaseClock()
 
 	fmt.Fprintf(r.out, "  %s %s\n", tui.HintStyle.Render("⠿"), label)
 
 	// r.spinner is the "out is the terminal the user is watching" flag; a
-	// width is only meaningful, and cursor games only safe, on that terminal.
-	width := 0
+	// live region is only safe on that terminal, so anywhere else lines just
+	// print permanently.
+	var region *liveRegion
 	if r.spinner {
-		width = streamWidth()
-	}
-
-	var mu sync.Mutex
-
-	rows := 0
-
-	// repaintHeader rewrites the header row, which sits rows+1 rows above the
-	// cursor — exact because every streamed line occupies one row. The caller
-	// holds mu.
-	repaintHeader := func(glyph string) {
-		fmt.Fprintf(r.out, "\x1b[%dA\r  %s %s\x1b[K\x1b[%dB\r", rows+1, glyph, label, rows+1)
+		region = newLiveRegion(r.out, label)
 	}
 
 	stop := make(chan struct{})
 
 	var animator sync.WaitGroup
 
-	if width > 0 {
+	if region != nil {
 		animator.Add(1)
 
 		go func() {
 			defer animator.Done()
 
-			animateStreamHeader(stop, &mu, repaintHeader)
+			animateStreamHeader(stop, region)
 		}()
 	}
 
 	say := func(line string, style lipgloss.Style) {
-		mu.Lock()
-		defer mu.Unlock()
-
 		// A message with newlines would break the one-row-per-line math.
 		for _, part := range strings.Split(line, "\n") {
-			if width > 0 {
-				part = ansi.Truncate(part, max(width-6, 8), "…")
+			if region == nil {
+				fmt.Fprintf(r.out, "    %s\n", style.Render(part))
+			} else {
+				region.append(part, style)
 			}
-
-			fmt.Fprintf(r.out, "    %s\n", style.Render(part))
-
-			rows++
 		}
 	}
 
 	err := fn(say)
 
-	if width > 0 {
+	if region != nil {
 		close(stop)
 		animator.Wait()
 	}
 
 	if err != nil {
-		// A dead animation frame must not outlive the phase; the static
-		// glyph says "this phase stopped here" above the kept lines.
-		if width > 0 {
-			repaintHeader(tui.HintStyle.Render("⠿"))
+		if region != nil {
+			region.finishFailure()
 		}
 
 		return err
 	}
 
-	if width > 0 {
-		// Cursor up over the stream and its header, clear to the end of the
-		// screen; the check-marked line below replaces them.
-		fmt.Fprintf(r.out, "\x1b[%dA\x1b[0J", rows+1)
+	if region != nil {
+		region.finishSuccess()
 	}
 
 	r.done(label, phaseClock().Sub(started))
@@ -176,9 +165,89 @@ func (r *reporter) stream(label string, fn func(say func(line string, style lipg
 	return nil
 }
 
-// animateStreamHeader cycles the header glyph until stop closes, locking mu
-// around each repaint so frames never interleave with streamed lines.
-func animateStreamHeader(stop <-chan struct{}, mu *sync.Mutex, repaint func(glyph string)) {
+// liveRegion is the fixed-height window a streamed phase renders into: the
+// header row plus up to window lines, redrawn in place so nothing ever
+// scrolls. All methods lock internally; the animator and the stream share it.
+type liveRegion struct {
+	out    io.Writer
+	label  string
+	width  int
+	window int
+
+	mu    sync.Mutex
+	tail  []string // rendered lines on screen, newest last
+	drawn int      // rows currently on screen below the header
+}
+
+// newLiveRegion sizes a region for the terminal, nil when there is none. The
+// window must fit the viewport with the header and a little slack: the cursor
+// cannot move above the viewport, so a taller region could neither be redrawn
+// nor erased, and scrolled-away rows would survive in scrollback.
+func newLiveRegion(out io.Writer, label string) *liveRegion {
+	width, height := streamSize()
+	if width <= 0 {
+		return nil
+	}
+
+	return &liveRegion{
+		out:    out,
+		label:  label,
+		width:  width,
+		window: min(streamWindowRows, max(height-4, 1)),
+	}
+}
+
+// append truncates the line to one row, slides the window, and repaints it.
+func (l *liveRegion) append(line string, style lipgloss.Style) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	line = ansi.Truncate(line, max(l.width-6, 8), "…")
+
+	l.tail = append(l.tail, "    "+style.Render(line))
+	if len(l.tail) > l.window {
+		l.tail = l.tail[len(l.tail)-l.window:]
+	}
+
+	if l.drawn > 0 {
+		fmt.Fprintf(l.out, "\x1b[%dA", l.drawn)
+	}
+
+	for _, row := range l.tail {
+		fmt.Fprintf(l.out, "\r%s\x1b[K\n", row)
+	}
+
+	l.drawn = len(l.tail)
+}
+
+// repaintHeader rewrites the header row, drawn+1 rows above the cursor —
+// exact because the window's lines each occupy one row.
+func (l *liveRegion) repaintHeader(glyph string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	fmt.Fprintf(l.out, "\x1b[%dA\r  %s %s\x1b[K\x1b[%dB\r", l.drawn+1, glyph, l.label, l.drawn+1)
+}
+
+// finishSuccess erases the window and its header; the caller's check-marked
+// line replaces them.
+func (l *liveRegion) finishSuccess() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	fmt.Fprintf(l.out, "\x1b[%dA\x1b[0J", l.drawn+1)
+}
+
+// finishFailure repaints the header static, so a dead animation frame does
+// not outlive the phase above the kept tail — the freshest context for the
+// error, with the full log a command away.
+func (l *liveRegion) finishFailure() {
+	l.repaintHeader(tui.HintStyle.Render("⠿"))
+}
+
+// animateStreamHeader cycles the region's header glyph until stop closes; the
+// region's own lock keeps frames from interleaving with streamed lines.
+func animateStreamHeader(stop <-chan struct{}, region *liveRegion) {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -189,24 +258,23 @@ func animateStreamHeader(stop <-chan struct{}, mu *sync.Mutex, repaint func(glyp
 		case <-stop:
 			return
 		case <-ticker.C:
-			mu.Lock()
-			repaint(tui.InfoStyle.Render(streamSpinnerFrames[frame%len(streamSpinnerFrames)]))
-			mu.Unlock()
+			region.repaintHeader(tui.InfoStyle.Render(streamSpinnerFrames[frame%len(streamSpinnerFrames)]))
 
 			frame++
 		}
 	}
 }
 
-// streamWidth returns the width of the terminal the stream renders on, 0 when
-// there is none. A var so tests can exercise the terminal path without one.
-var streamWidth = func() int {
-	w, _, err := term.GetSize(int(os.Stderr.Fd()))
-	if err != nil || w <= 0 {
-		return 0
+// streamSize returns the (width, height) of the terminal the stream renders
+// on, zeros when there is none. A var so tests can exercise the terminal path
+// without one.
+var streamSize = func() (int, int) {
+	w, h, err := term.GetSize(int(os.Stderr.Fd()))
+	if err != nil || w <= 0 || h <= 0 {
+		return 0, 0
 	}
 
-	return w
+	return w, h
 }
 
 // done prints the completed phase. Durations are truncated to a tenth of a

--- a/internal/workload/up/phase.go
+++ b/internal/workload/up/phase.go
@@ -68,9 +68,11 @@ func (r *reporter) run(label string, fn func() error) error {
 }
 
 // work performs the phase, with a spinner when there is a terminal to spin on.
+// The two-space prefix keeps the animated glyph in the column where stream's
+// ⠿ header and done's ✓ sit.
 func (r *reporter) work(label string, fn func() error) error {
 	if r.spinner {
-		return tui.RunWithSpinner(label, fn)
+		return tui.RunWithSpinnerPrefix("  ", label, fn)
 	}
 
 	return fn()

--- a/internal/workload/up/phase.go
+++ b/internal/workload/up/phase.go
@@ -154,8 +154,8 @@ func (r *reporter) stream(label string, fn func(say func(line string, style lipg
 			// deploy down mid-build. Recovered into the debug log rather
 			// than swallowed, so it stays findable.
 			defer func() {
-				if r := recover(); r != nil {
-					log.Debug("stream header animator panicked", "panic", r)
+				if rec := recover(); rec != nil {
+					log.Debug("stream header animator panicked", "panic", rec)
 				}
 			}()
 

--- a/internal/workload/up/phase.go
+++ b/internal/workload/up/phase.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/tui"
 	"golang.org/x/term"
 )
@@ -121,13 +122,42 @@ func (r *reporter) stream(label string, fn func(say func(line string, style lipg
 
 	stop := make(chan struct{})
 
-	var animator sync.WaitGroup
+	var (
+		animator sync.WaitGroup
+		haltOnce sync.Once
+	)
+
+	// halt stops the animation exactly once. It is deferred so a panic inside
+	// fn cannot unwind past a still-ticking animator, and also called inline
+	// on both exits, because finishSuccess and finishFailure repaint rows the
+	// animator writes to and must not race it.
+	halt := func() {
+		if region == nil {
+			return
+		}
+
+		haltOnce.Do(func() {
+			close(stop)
+			animator.Wait()
+		})
+	}
+
+	defer halt()
 
 	if region != nil {
 		animator.Add(1)
 
 		go func() {
 			defer animator.Done()
+
+			// The animation is cosmetic; a panic here must not take the
+			// deploy down mid-build. Recovered into the debug log rather
+			// than swallowed, so it stays findable.
+			defer func() {
+				if r := recover(); r != nil {
+					log.Debug("stream header animator panicked", "panic", r)
+				}
+			}()
 
 			animateStreamHeader(stop, region)
 		}()
@@ -146,10 +176,7 @@ func (r *reporter) stream(label string, fn func(say func(line string, style lipg
 
 	err := fn(say)
 
-	if region != nil {
-		close(stop)
-		animator.Wait()
-	}
+	halt()
 
 	if err != nil {
 		if region != nil {

--- a/tui/spinner.go
+++ b/tui/spinner.go
@@ -25,6 +25,7 @@ import (
 type spinnerModel struct {
 	spinner Loading
 	label   string
+	prefix  string
 	fn      func() error
 	done    bool
 }
@@ -60,18 +61,30 @@ func (m spinnerModel) View() string {
 		return ""
 	}
 
-	return InfoStyle.Render(m.spinner.View()+" ") + m.label + "\n"
+	// The Dot frames carry their own trailing space, so nothing more goes
+	// between glyph and label: one column, the same gap the glyph-led lines
+	// around a spinner (a phase list's "✓ label") leave.
+	return m.prefix + InfoStyle.Render(m.spinner.View()) + m.label + "\n"
 }
 
 // RunWithSpinner runs fn in the background while showing an animated spinner
 // with the given label. Returns the error from fn, if any.
 func RunWithSpinner(label string, fn func() error) error {
+	return RunWithSpinnerPrefix("", label, fn)
+}
+
+// RunWithSpinnerPrefix is RunWithSpinner with a fixed prefix ahead of the
+// glyph on every frame, including the non-interactive fallback line. The
+// glyph leads the line, so a caller aligning the spinner under other
+// glyph-led output (a phase list's "  ✓ label") has to hand the indent in
+// here; an indent on the label could never move the glyph.
+func RunWithSpinnerPrefix(prefix, label string, fn func() error) error {
 	if !reader.IsStdinTerminal() {
 		return fn()
 	}
 
 	if reader.IsNonInteractive() {
-		fmt.Fprintln(os.Stderr, InfoStyle.Render("• ")+label)
+		fmt.Fprintln(os.Stderr, prefix+InfoStyle.Render("• ")+label)
 
 		return fn()
 	}
@@ -81,6 +94,7 @@ func RunWithSpinner(label string, fn func() error) error {
 	m := spinnerModel{
 		spinner: NewLoading(),
 		label:   label,
+		prefix:  prefix,
 		fn: func() error {
 			fnErr = fn()
 

--- a/tui/spinner_test.go
+++ b/tui/spinner_test.go
@@ -16,6 +16,7 @@ package tui
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -134,6 +135,41 @@ func TestRunWithSpinner_LabelRendered(t *testing.T) {
 	view := m.View()
 
 	assert.Contains(t, view, "my special label")
+}
+
+// The prefix exists so a spinner can sit in an indented block: the glyph
+// leads the line, so only a prefix ahead of it can move it into the column
+// where the surrounding "  ✓ label" lines put theirs.
+func TestSpinnerModel_ViewLeadsWithThePrefix(t *testing.T) {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = InfoStyle
+
+	m := spinnerModel{
+		spinner: Loading{Spinner: s},
+		label:   "Loading…",
+		prefix:  "  ",
+	}
+
+	view := m.View()
+
+	assert.True(t, strings.HasPrefix(view, "  "), "the prefix must come before the glyph")
+	assert.Contains(t, view, "Loading…")
+}
+
+// One column between glyph and label, not two: the Dot frames carry their own
+// trailing space, and a second one would push the label out of line with the
+// text of the "✓ label" rows rendered around the spinner.
+func TestSpinnerModel_ViewLeavesOneColumnAfterTheGlyph(t *testing.T) {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+
+	m := spinnerModel{
+		spinner: Loading{Spinner: s},
+		label:   "Loading…",
+	}
+
+	assert.NotContains(t, m.View(), "  Loading…", "exactly the frame's own space separates glyph and label")
 }
 
 func TestSpinnerModel_InitReturnsBatch(t *testing.T) {


### PR DESCRIPTION
# RATIONALE

The build is the longest phase of `dr workload up` — routinely minutes — and it rendered as a single spinner line: no sign of whether a builder had even picked the job up, and a failure told you nothing until you went hunting with `dr artifact build logs`. This PR streams the build's own log lines beneath the phase header while it runs, the way docker buildx does, so a deploy's slowest phase is also its most legible one.

Ticket: [RAPTOR-18978](https://datarobot.atlassian.net/browse/RAPTOR-18978)

## CHANGES

- The build phase renders into a fixed-height live window (header + up to 20 rows) that never scrolls: the newest lines slide through, success collapses the window to the usual check-marked line so the final transcript stays clean, and failure keeps the tail as the freshest context for the error.
- Build log lines come from the artifact's OTEL logs route filtered by `external_build_id`. A poll-driven `BuildLogTail` rides `WaitForBuild`'s own cadence (no clock or goroutine of its own), never fails a build over a log-fetch hiccup, and after sustained fetch failures says so once and goes quiet.
- Status transitions are narrated in words (accepted → builder running → pushing), log levels are colored so an error cannot scroll past dimmed, and a heartbeat line covers the gap between trigger and first ingested log line.
- When the tree is unchanged and a build of that code is already running (a previous `up` died, or another terminal is mid-deploy), `up` attaches to it instead of triggering a duplicate.
- The running spinner is aligned with the rest of the phase list: it now sits in the same column as the `⠿`/`✓` glyphs, and the accidental double space after the glyph is gone for every spinner caller.
- Off the terminal (CI, `--output-format json`) every line prints permanently on stderr, so logs stay complete and stdout stays pure.
- Stream fidelity against real OTEL ingestion (found by dogfooding on staging): an empty first poll no longer pins a zero cursor (which used to gap the build's opening behind a 40-line window), the window-mode fetch grew to the server's page size, the cursor lag widened to 60s because build-log ingestion trails the builder by 20–40s, and a 10s holdback reorder buffer lets late-ingested lines slot in ahead of newer ones already fetched — `Finish()` drains it after the wait so nothing is withheld past the build's end. Residual interleave across `#N` steps is buildkit's genuine parallelism, as `docker buildx --progress=plain` shows it.
- The attach path refuses a non-terminal build older than the poll timeout: that build is wedged (orphaned trigger, lost reconcile), and attaching would wait the whole timeout on something that can never finish; the attach message names `--force-build` as the manual escape.

- Heads-up on a repo-wide cosmetic change: the spinner's glyph→label gap goes from two spaces to one for every `RunWithSpinner` call site (the Dot frames carry their own trailing space), aligning the in-flight glyph with the `✓`/`⠿` column.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787754696.818549 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core `up` build/wait path (attach-vs-trigger, streamed TTY redraw) and adds OTEL log polling, though log streaming is isolated from build success and is covered by new tests.
> 
> **Overview**
> **`dr workload up`** now shows live build output during the image phase instead of a single spinner line. The build step uses a new **`reporter.stream`** path with a docker buildx-style fixed-height TTY window (animated header, sliding tail, success collapses to the usual ✓ line; failures keep the last lines). Off-TTY/CI, every line is written permanently to stderr.
> 
> Build lines are pulled from the artifact OTEL logs API filtered by **`external_build_id`** via **`BuildLogTail`**, which polls on **`WaitForBuild`**’s cadence, dedupes like workload log follow, and never fails the deploy on log fetch errors (warn once and stop streaming).
> 
> **`maybeBuild`** can **attach to an in-flight build** when the tree is unchanged and no image exists yet, avoiding duplicate triggers; changed code still triggers a fresh build. Status transitions and log levels are narrated/styled; spinners align with other phase glyphs via **`RunWithSpinnerPrefix`**.
> 
> Shared log pagination is factored into **`drainLogPages`**; **`logFollower`** now takes a **`logsFetchFn`** so workload follow and build tail share the same follower.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 874fc89ef777902713a6a27063badba260cce2ae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

