### PR TITLE
[RAPTOR-18946] feat(workload): read build logs from OTEL, stream them under --wait

### DIFF
--- a/cmd/artifact/build/create/cmd.go
+++ b/cmd/artifact/build/create/cmd.go
@@ -17,6 +17,7 @@ package create
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/datarobot/cli/cmd/artifact/build/internal/buildargs"
 	"github.com/datarobot/cli/cmd/internal/pollflags"
@@ -41,10 +42,11 @@ The artifact-id argument is optional when run inside a directory linked
 via 'dr artifact code init': the id is read from .datarobot/workload/config.json.
 
 By default the command prints the new build IDs (one per line) and
-exits. With --wait it polls each build until it reaches a terminal
-status (COMPLETED, FAILED, or CANCELLED) and prints a summary with
-duration and resulting image_uri. On failure the tail of the build
-logs is dumped to stderr.
+exits. With --wait it follows each build to a terminal status
+(COMPLETED, FAILED, or CANCELLED), streaming the build's own log lines
+and status transitions to stderr while it waits, then prints a summary
+with duration and resulting image_uri. On failure the tail of the
+build logs is dumped to stderr.
 
 JSON output emits one document:
   - without --wait: the raw trigger response {"buildIds":[...]}.
@@ -141,7 +143,7 @@ func waitForAllBuilds(
 	for _, buildID := range buildIDs {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Waiting for build %s...\n", buildID)
 
-		build, werr := workload.WaitForBuild(artifactID, buildID, poll.Interval, poll.Timeout, nil)
+		build, werr := waitStreaming(cmd, artifactID, buildID, poll)
 		if werr != nil && firstWaitErr == nil {
 			firstWaitErr = werr
 		}
@@ -161,4 +163,42 @@ func waitForAllBuilds(
 	}
 
 	return summaries, firstWaitErr
+}
+
+// waitStreaming polls the build to its terminal status while printing its
+// own log lines and status transitions to stderr as they arrive, so a --wait
+// is a live transcript rather than a silent poll. Lines go to stderr like
+// every other progress message here: stdout stays the summary document.
+func waitStreaming(
+	cmd *cobra.Command,
+	artifactID, buildID string,
+	poll pollflags.Set,
+) (*workload.Build, error) {
+	out := cmd.ErrOrStderr()
+
+	tail := workload.NewBuildLogTail(artifactID, buildID,
+		func(e workload.WorkloadLogEntry) { fmt.Fprintln(out, "  "+workload.FormatBuildLogLine(e)) },
+		func(w string) { fmt.Fprintln(out, "  (log stream) "+w) })
+
+	// Narrate status transitions: the stages before the builder speaks are
+	// exactly the quiet ones where the user wonders if anything is happening.
+	// Terminal statuses are left to the summary.
+	lastStatus := ""
+
+	build, err := workload.WaitForBuild(artifactID, buildID, poll.Interval, poll.Timeout,
+		func(b *workload.Build) {
+			if b != nil && !workload.IsTerminalBuildStatus(b.Status) && !strings.EqualFold(b.Status, lastStatus) {
+				lastStatus = b.Status
+
+				fmt.Fprintln(out, "  "+workload.BuildStatusLine(b.Status))
+			}
+
+			tail.Poll()
+		})
+
+	// One more poll after the terminal status: ingestion lags the build, so
+	// the last lines routinely land after the wait has already ended.
+	tail.Poll()
+
+	return build, err
 }

--- a/cmd/artifact/build/logs/cmd.go
+++ b/cmd/artifact/build/logs/cmd.go
@@ -49,8 +49,10 @@ When invoked with one positional argument the artifact-id is read from
 .datarobot/workload/config.json in the current directory. When invoked with two, the
 first argument is the artifact-id and the second is the build-id.
 
-The server emits one structured JSON record per line; the default
-output drops records below INFO. Use --level debug to keep everything.
+Logs are read from the artifact's OTEL stream, narrowed to the one
+build — they outlive the build itself, unlike the deprecated per-build
+proxy this command used to call. The default output drops records
+below INFO. Use --level debug to keep everything.
 
 JSON output emits a single array document so the result can be piped
 to jq directly.

--- a/internal/workload/build.go
+++ b/internal/workload/build.go
@@ -15,13 +15,12 @@
 package workload
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -261,6 +260,13 @@ func TriggerArtifactBuild(artifactID string) (*BuildTriggerResponse, error) {
 
 // GetArtifactBuild fetches a single Build by id.
 func GetArtifactBuild(artifactID, buildID string) (*Build, error) {
+	return fetchArtifactBuild(artifactID, buildID, "build")
+}
+
+// fetchArtifactBuild is GetArtifactBuild with the caller choosing drapi's
+// per-request log label; the poll loop passes "" so its every-five-seconds
+// fetch line cannot interleave with a streamed build log.
+func fetchArtifactBuild(artifactID, buildID, reqInfo string) (*Build, error) {
 	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/builds/" + escapeID(buildID))
 	if err != nil {
 		return nil, err
@@ -268,7 +274,7 @@ func GetArtifactBuild(artifactID, buildID string) (*Build, error) {
 
 	var build Build
 
-	if err := drapi.GetJSON(url, "build", &build); err != nil {
+	if err := drapi.GetJSON(url, reqInfo, &build); err != nil {
 		return nil, err
 	}
 
@@ -318,54 +324,39 @@ func ListArtifactBuilds(artifactID string, limit int) ([]Build, error) {
 	return all, nil
 }
 
-// GetArtifactBuildLogs returns parsed log entries for a build. The endpoint
-// emits newline-delimited JSON; we tolerate malformed lines so a single bad
-// record cannot blank the whole tail. The original bytes for each line are
-// preserved in Raw so JSON output can pass them through unchanged.
+// GetArtifactBuildLogs returns a build's log lines, oldest first, read from
+// the artifact's OTEL stream filtered by external_build_id — the replacement
+// for the deprecated GET /artifacts/{id}/builds/{id}/logs proxy, whose
+// records only existed for as long as IBS retained the build. The OTEL
+// records are mapped onto the legacy BuildLogEntry shape so level filtering
+// and both renderers carry over; Raw holds the OTEL record itself, which is
+// what JSON output now passes through.
 func GetArtifactBuildLogs(artifactID, buildID string) ([]BuildLogEntry, error) {
-	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/builds/" + escapeID(buildID) + "/logs")
+	otel, err := fetchArtifactBuildLogs(artifactID, buildID, 0, "", "", "build logs")
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := drapi.Get(url, "build logs")
-	if err != nil {
-		return nil, err
-	}
+	// Newest first from the server; chronological for display, with the sort
+	// settling lines the collector ingested out of event order.
+	slices.Reverse(otel)
+	sortChronological(otel)
 
-	defer resp.Body.Close()
+	entries := make([]BuildLogEntry, 0, len(otel))
 
-	return parseBuildLogs(resp.Body)
-}
-
-func parseBuildLogs(r io.Reader) ([]BuildLogEntry, error) {
-	scanner := bufio.NewScanner(r)
-	// Each line can be a multi-KB structured log; bump the buffer past the
-	// 64KiB default to accommodate verbose entries without truncation.
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-
-	var entries []BuildLogEntry
-
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(strings.TrimSpace(string(line))) == 0 {
-			continue
+	for _, e := range otel {
+		raw, err := json.Marshal(e)
+		if err != nil {
+			raw = nil // the named fields still render; only passthrough is lost
 		}
 
-		var entry BuildLogEntry
-		if err := json.Unmarshal(line, &entry); err != nil {
-			// Skip malformed lines rather than fail the whole fetch;
-			// log payloads regularly include non-JSON tail lines from
-			// the underlying buildkit pipe.
-			continue
-		}
-
-		entry.Raw = append(json.RawMessage(nil), line...)
-		entries = append(entries, entry)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("read build logs: %w", err)
+		entries = append(entries, BuildLogEntry{
+			Asctime:   e.Timestamp,
+			Levelname: strings.ToUpper(e.Level),
+			Message:   e.Message,
+			BuildID:   buildID,
+			Raw:       raw,
+		})
 	}
 
 	return entries, nil
@@ -385,7 +376,7 @@ func WaitForBuild(
 	deadline := time.Now().Add(timeout)
 
 	for {
-		build, err := GetArtifactBuild(artifactID, buildID)
+		build, err := fetchArtifactBuild(artifactID, buildID, "")
 		if err != nil {
 			return nil, fmt.Errorf("poll build %s: %w", buildID, err)
 		}

--- a/internal/workload/build_logs.go
+++ b/internal/workload/build_logs.go
@@ -16,6 +16,7 @@ package workload
 
 import (
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/datarobot/cli/internal/drapi"
@@ -56,6 +57,36 @@ func fetchArtifactBuildLogs(artifactID, buildID string, maxEntries int, level, s
 	}
 
 	return drainLogPages(pageURL, maxEntries, reqInfo)
+}
+
+// FormatBuildLogLine renders one build log line for humans: the message alone
+// for routine output, a level marker for anything that deserves a glance —
+// an error scrolling past unmarked defeats the point of streaming. Styling is
+// the caller's business: a TTY colors what CI prints plain.
+func FormatBuildLogLine(e WorkloadLogEntry) string {
+	switch strings.ToLower(e.Level) {
+	case "", "info", "debug":
+		return e.Message
+	default:
+		return "[" + strings.ToUpper(e.Level) + "] " + e.Message
+	}
+}
+
+// BuildStatusLine narrates a build status for a stream, in words rather than
+// enum values for the stages every build passes through — the quiet ones
+// before the builder speaks are exactly where the user wonders whether
+// anything is happening.
+func BuildStatusLine(status string) string {
+	switch strings.ToUpper(status) {
+	case BuildStatusPending:
+		return "build accepted; waiting for a builder to pick it up"
+	case BuildStatusInProgress:
+		return "builder running"
+	case "BUILT":
+		return "image built; pushing it to the registry"
+	default:
+		return "build is " + strings.ToLower(status)
+	}
 }
 
 // buildLogHoldback is how long a line waits in the reorder buffer, measured

--- a/internal/workload/build_test.go
+++ b/internal/workload/build_test.go
@@ -143,46 +143,6 @@ func TestLastN(t *testing.T) {
 	})
 }
 
-func TestParseBuildLogs(t *testing.T) {
-	t.Run("valid JSONL passthrough", func(t *testing.T) {
-		body := `{"asctime":"2026-06-09 10:00:00","levelname":"INFO","name":"image-builder","message":"start","build_id":"b-1"}
-{"asctime":"2026-06-09 10:00:01","levelname":"DEBUG","name":"image-builder","message":"detail","build_id":"b-1"}
-`
-		entries, err := parseBuildLogs(strings.NewReader(body))
-		require.NoError(t, err)
-		require.Len(t, entries, 2)
-		assert.Equal(t, "INFO", entries[0].Levelname)
-		assert.Equal(t, "start", entries[0].Message)
-		assert.Equal(t, "b-1", entries[0].BuildID)
-		assert.NotEmpty(t, entries[0].Raw, "raw bytes preserved for passthrough")
-	})
-
-	t.Run("malformed lines are skipped", func(t *testing.T) {
-		body := `{"levelname":"INFO","message":"ok"}
-not-json-garbage
-{"levelname":"ERROR","message":"bad"}
-`
-		entries, err := parseBuildLogs(strings.NewReader(body))
-		require.NoError(t, err)
-		require.Len(t, entries, 2)
-		assert.Equal(t, "ok", entries[0].Message)
-		assert.Equal(t, "bad", entries[1].Message)
-	})
-
-	t.Run("empty body returns empty slice", func(t *testing.T) {
-		entries, err := parseBuildLogs(strings.NewReader(""))
-		require.NoError(t, err)
-		assert.Empty(t, entries)
-	})
-
-	t.Run("blank lines are skipped", func(t *testing.T) {
-		body := "\n\n{\"levelname\":\"INFO\",\"message\":\"x\"}\n\n"
-		entries, err := parseBuildLogs(strings.NewReader(body))
-		require.NoError(t, err)
-		assert.Len(t, entries, 1)
-	})
-}
-
 func TestBuildLogEntry_MarshalJSON_PassesThroughRaw(t *testing.T) {
 	entry := BuildLogEntry{
 		Asctime:   "later", // would disagree with Raw to prove passthrough wins
@@ -544,18 +504,22 @@ func TestListArtifactBuilds_InvalidLimit(t *testing.T) {
 	assert.Contains(t, err.Error(), "limit")
 }
 
-func TestGetArtifactBuildLogs_ParsesJSONL(t *testing.T) {
+func TestGetArtifactBuildLogs_ReadsTheOTELStream(t *testing.T) {
 	installSkipAuth(t)
 
-	body := `{"asctime":"2026-06-09 10:00:00","levelname":"INFO","name":"image-builder","message":"line-1","build_id":"b-1"}
-{"asctime":"2026-06-09 10:00:01","levelname":"DEBUG","name":"image-builder","message":"line-2","build_id":"b-1"}
-`
+	var gotPath string
+
+	var gotQuery map[string][]string
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/api/v2/artifacts/art-1/builds/b-1/logs", r.URL.Path)
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
 
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(body))
+		// Newest first, as the OTEL route answers.
+		fmt.Fprint(w, logsPage("",
+			logEntryDocAt("2026-06-09 10:00:01.000000+00:00", "DEBUG", "line-2"),
+			logEntryDocAt("2026-06-09 10:00:00.000000+00:00", "INFO", "line-1"),
+		))
 	}))
 
 	defer srv.Close()
@@ -565,8 +529,19 @@ func TestGetArtifactBuildLogs_ParsesJSONL(t *testing.T) {
 	entries, err := GetArtifactBuildLogs("art-1", "b-1")
 	require.NoError(t, err)
 	require.Len(t, entries, 2)
+
+	// The deprecated per-build proxy is gone: the artifact stream is read,
+	// narrowed to the one build via external_build_id.
+	assert.Equal(t, "/api/v2/otel/artifact/art-1/logs/", gotPath)
+	assert.Equal(t, []string{"external_build_id"}, gotQuery["searchKeys"])
+	assert.Equal(t, []string{"b-1"}, gotQuery["searchValues"])
+
+	// Chronological for display, mapped onto the legacy entry shape.
+	assert.Equal(t, "line-1", entries[0].Message)
 	assert.Equal(t, "INFO", entries[0].Levelname)
 	assert.Equal(t, "line-2", entries[1].Message)
+	assert.Equal(t, "b-1", entries[0].BuildID)
+	assert.NotEmpty(t, entries[0].Raw, "OTEL record preserved for JSON passthrough")
 }
 
 func TestWaitForBuild_TerminalCompletedReturnsNil(t *testing.T) {
@@ -728,13 +703,13 @@ func TestBuildSummaryFor_ReadsTheImageOffALowercaseCompleted(t *testing.T) {
 func TestBuildSummaryFor_FailureFetchesLogs(t *testing.T) {
 	installSkipAuth(t)
 
-	logBody := `{"levelname":"INFO","message":"start"}
-{"levelname":"ERROR","message":"boom"}
-`
-
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "/logs") {
-			_, _ = w.Write([]byte(logBody))
+		if strings.Contains(r.URL.Path, "/otel/artifact/") {
+			// Newest first, as the OTEL route answers.
+			fmt.Fprint(w, logsPage("",
+				logEntryDocAt("2026-06-09 10:00:01.000000+00:00", "ERROR", "boom"),
+				logEntryDocAt("2026-06-09 10:00:00.000000+00:00", "INFO", "start"),
+			))
 
 			return
 		}
@@ -812,7 +787,7 @@ func TestBuildSummaryFor_FailureLogFetch502(t *testing.T) {
 	installSkipAuth(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, "/logs") {
+		if strings.Contains(r.URL.Path, "/otel/artifact/") {
 			// Match the staging shape: 502 with a JSON detail body.
 			w.WriteHeader(http.StatusBadGateway)
 			_, _ = w.Write([]byte(`{"detail":"Failed to retrieve build logs"}`))

--- a/internal/workload/logs.go
+++ b/internal/workload/logs.go
@@ -41,8 +41,12 @@ const maxLogsPageSize = 1000
 // rather than skipped.
 const followLagAllowance = 10 * time.Second
 
-// followSeenCap bounds each follow dedup generation so memory stays bounded.
-const followSeenCap = 5000
+// followSeenCap bounds each follow dedup generation. It is a memory ceiling,
+// not the duplicate-suppression horizon: a since-mode follower prunes keys
+// that leave its fetch overlap, so live keys stay near the overlap's own
+// size and rotation never fires below a sustained ~800 lines/s. Only window
+// mode, which has no cursor to prune by, leans on the rotation itself.
+const followSeenCap = 50000
 
 // maxTransientPollErrors caps consecutive transient fetch failures a follow
 // tolerates before giving up; it resets on any successful poll.
@@ -420,10 +424,21 @@ func (f *logFollower) emit(entries []WorkloadLogEntry, hadSince bool) error {
 
 	f.advanceCursor(entries)
 
-	// An empty fetch seeds nothing: marking it seeded would pin a zero
-	// cursor, and the NEXT poll — the first with real lines — would be a
-	// window fetch capped at limit, gapping a producer that burst past it
-	// (a builder's opening seconds do exactly that).
+	// Forget only what the next fetch can no longer return: a since fetch
+	// starts at cursor-lag, so a key older than that is never offered again,
+	// while one inside the window must stay known however many lines came
+	// after it. Without this the dedup's rotation is a horizon a fast
+	// builder outruns, and the overlap prints twice.
+	if f.cursorUsable && !f.cursor.IsZero() {
+		f.dedup.prune(f.cursor.Add(-f.lag))
+	}
+
+	// Seeding waits for the first non-empty batch — not for the cursor's
+	// sake (an empty fetch leaves it zero, and the next poll is a window
+	// fetch either way) but for the gap warning above, which reads f.seeded
+	// as "the seed batch has already been shown". Armed by a leading empty
+	// poll, the first real batch filling the window would read as lines
+	// lost, when it is just the seed being as big as it was asked to be.
 	if len(entries) > 0 {
 		f.seeded = true
 	}
@@ -495,16 +510,25 @@ func logKey(e WorkloadLogEntry) string {
 	return e.Timestamp + "\x00" + e.Level + "\x00" + e.Message
 }
 
-// logDedup tracks emitted log lines, bounded by generational rotation: a
-// full current generation becomes prev (both consulted), so the last
-// genCap..2*genCap lines stay deduplicated.
+// logDedup tracks emitted log lines. Two bounds keep it honest. The caller
+// prunes keys older than what its next fetch can re-offer — the exact
+// invariant, because a key inside the fetch overlap has to stay known however
+// many lines arrived after it, or a fast builder's lines print twice off-TTY
+// where every duplicate is permanent. Generational rotation stays as the
+// memory ceiling for the callers where nothing prunes (window mode has no
+// cursor to prune by): the last genCap..2*genCap lines stay deduplicated.
 type logDedup struct {
-	cur, prev map[string]struct{}
+	cur, prev map[string]time.Time
 	genCap    int
+
+	// watermark is the newest parseable event time seen. A line whose own
+	// timestamp does not parse adopts it, so it ages out with its neighbors
+	// rather than living forever or dying at once.
+	watermark time.Time
 }
 
 func newLogDedup(genCap int) *logDedup {
-	return &logDedup{cur: make(map[string]struct{}), genCap: genCap}
+	return &logDedup{cur: make(map[string]time.Time), genCap: genCap}
 }
 
 // filterUnseen returns the entries whose key has not been seen, recording
@@ -525,13 +549,36 @@ func (d *logDedup) filterUnseen(entries []WorkloadLogEntry) []WorkloadLogEntry {
 
 		if len(d.cur) >= d.genCap {
 			d.prev = d.cur
-			d.cur = make(map[string]struct{}, d.genCap)
+			d.cur = make(map[string]time.Time, d.genCap)
 		}
 
-		d.cur[key] = struct{}{}
+		at, ok := parseLogTimestamp(e.Timestamp)
+		if ok && at.After(d.watermark) {
+			d.watermark = at
+		} else if !ok {
+			at = d.watermark
+		}
+
+		d.cur[key] = at
 
 		fresh = append(fresh, e)
 	}
 
 	return fresh
+}
+
+// prune forgets the keys no future fetch can re-offer: everything strictly
+// older than before, which the caller sets to its fetch floor (the cursor
+// minus its lag). Pruning is what keeps the generation cap a memory ceiling
+// rather than a duplicate-suppression horizon a fast producer can outrun:
+// kept ahead of the rotation, the live keys never reach genCap in the first
+// place.
+func (d *logDedup) prune(before time.Time) {
+	for _, generation := range []map[string]time.Time{d.cur, d.prev} {
+		for key, at := range generation {
+			if at.Before(before) {
+				delete(generation, key)
+			}
+		}
+	}
 }

--- a/internal/workload/logs_test.go
+++ b/internal/workload/logs_test.go
@@ -439,6 +439,112 @@ func TestLogDedup_RotationKeepsRecentMemory(t *testing.T) {
 	}
 }
 
+// Pruning forgets exactly what the next fetch can no longer return, and
+// nothing else: a key inside the overlap must survive however many lines
+// arrived after it, and one outside it is memory spent on nothing.
+func TestLogDedup_PruneForgetsWhatLeftTheOverlap(t *testing.T) {
+	at := func(offset time.Duration) string {
+		return time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC).Add(offset).Format(time.RFC3339Nano)
+	}
+
+	dedup := newLogDedup(100)
+
+	old := WorkloadLogEntry{Timestamp: at(0), Level: "INFO", Message: "old"}
+	recent := WorkloadLogEntry{Timestamp: at(90 * time.Second), Level: "INFO", Message: "recent"}
+
+	require.Len(t, dedup.filterUnseen([]WorkloadLogEntry{old, recent}), 2)
+
+	// The floor a 60s-lag fetch would use after the cursor reached "recent".
+	dedup.prune(mustParseLogTime(t, recent.Timestamp).Add(-60 * time.Second))
+
+	assert.Empty(t, dedup.filterUnseen([]WorkloadLogEntry{recent}),
+		"a key inside the overlap stays known")
+	assert.Len(t, dedup.filterUnseen([]WorkloadLogEntry{old}), 1,
+		"a key no fetch can re-offer is forgotten, which is the memory bound")
+}
+
+// The follower prunes its dedup to its own fetch floor after every emit, so
+// the generation cap is a ceiling for pathological rates rather than a
+// horizon an ordinary fast builder outruns.
+func TestFollower_PrunesTheDedupToItsFetchFloor(t *testing.T) {
+	at := func(offset time.Duration) string {
+		return time.Date(2026, 8, 26, 10, 0, 0, 0, time.UTC).Add(offset).Format(time.RFC3339Nano)
+	}
+
+	f, err := newLogFollower(
+		func(int, string, string, string) ([]WorkloadLogEntry, error) { return nil, nil },
+		10, "", time.Second,
+		func(WorkloadLogEntry) error { return nil },
+		func(string) {},
+	)
+	require.NoError(t, err)
+
+	f.lag = 60 * time.Second
+
+	old := WorkloadLogEntry{Timestamp: at(0), Level: "INFO", Message: "old"}
+	require.NoError(t, f.emit([]WorkloadLogEntry{old}, false))
+
+	// The cursor advances past this entry, putting "old" outside cursor-lag.
+	newest := WorkloadLogEntry{Timestamp: at(5 * time.Minute), Level: "INFO", Message: "new"}
+	require.NoError(t, f.emit([]WorkloadLogEntry{newest}, true))
+
+	assert.Len(t, f.dedup.filterUnseen([]WorkloadLogEntry{old}), 1,
+		"emit pruned the key that left the fetch overlap")
+	assert.Empty(t, f.dedup.filterUnseen([]WorkloadLogEntry{newest}),
+		"the key inside the overlap is still known")
+}
+
+// A leading empty poll must not arm the gap warning: the first real batch
+// filling the window is the seed being as big as it was asked to be, not
+// lines lost.
+func TestFollower_LeadingEmptyPollDoesNotArmTheGapWarning(t *testing.T) {
+	at := func(n int) string {
+		return time.Date(2026, 8, 26, 10, 0, n, 0, time.UTC).Format(time.RFC3339Nano)
+	}
+
+	var warns []string
+
+	f, err := newLogFollower(
+		func(int, string, string, string) ([]WorkloadLogEntry, error) { return nil, nil },
+		2, "", time.Second,
+		func(WorkloadLogEntry) error { return nil },
+		func(w string) { warns = append(warns, w) },
+	)
+	require.NoError(t, err)
+
+	// The empty first poll: seeds nothing, warns about nothing.
+	require.NoError(t, f.emit(nil, false))
+	assert.Empty(t, warns)
+
+	// The first real batch fills the whole window and is entirely fresh —
+	// the exact shape the gap warning looks for, and exactly what a seed is.
+	seed := []WorkloadLogEntry{
+		{Timestamp: at(1), Level: "INFO", Message: "a"},
+		{Timestamp: at(2), Level: "INFO", Message: "b"},
+	}
+	require.NoError(t, f.emit(seed, false))
+	assert.Empty(t, warns, "the seed batch is not a gap")
+
+	// The control: the same full-fresh window after the seed is a real gap.
+	burst := []WorkloadLogEntry{
+		{Timestamp: at(3), Level: "INFO", Message: "c"},
+		{Timestamp: at(4), Level: "INFO", Message: "d"},
+	}
+	require.NoError(t, f.emit(burst, false))
+	require.Len(t, warns, 1)
+	assert.Contains(t, warns[0], "possible gap")
+}
+
+// mustParseLogTime is parseLogTimestamp for fixtures the test itself wrote.
+func mustParseLogTime(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	at, ok := parseLogTimestamp(value)
+	require.True(t, ok)
+
+	return at
+}
+
 func TestFollowWorkloadLogs_StreamsWithTimeCursor(t *testing.T) {
 	installSkipAuth(t)
 

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -456,7 +456,7 @@ func buildImage(artifactID, attachTo string, opts Options, report *reporter) (st
 			if b != nil && !workload.IsTerminalBuildStatus(b.Status) && !strings.EqualFold(b.Status, lastStatus) {
 				lastStatus = b.Status
 
-				say(buildStatusLine(b.Status), tui.HintStyle)
+				say(workload.BuildStatusLine(b.Status), tui.HintStyle)
 			}
 
 			tail.Poll()
@@ -492,33 +492,19 @@ func buildImage(artifactID, attachTo string, opts Options, report *reporter) (st
 	return built.ID, err
 }
 
-// buildLogLine renders one streamed build log line with the style its level
-// deserves. The message alone, dimmed, is the line for routine output; a
-// non-info level is called out and colored, because an error scrolling past
-// dimmed and unmarked defeats the point of streaming.
+// buildLogLine renders one streamed build log line, colored by its level —
+// the wording is the shared formatter's, so `dr artifact build create --wait`
+// and this stream say the same thing; only the styling is this terminal's.
 func buildLogLine(e workload.WorkloadLogEntry) (string, lipgloss.Style) {
+	line := workload.FormatBuildLogLine(e)
+
 	switch strings.ToLower(e.Level) {
 	case "", "info", "debug":
-		return e.Message, tui.HintStyle
+		return line, tui.HintStyle
 	case "warn", "warning":
-		return "[" + strings.ToUpper(e.Level) + "] " + e.Message, tui.WarnStyle
+		return line, tui.WarnStyle
 	default:
-		return "[" + strings.ToUpper(e.Level) + "] " + e.Message, tui.ErrorStyle
-	}
-}
-
-// buildStatusLine narrates a build status for the stream, in words rather
-// than enum values for the two stages every build passes through.
-func buildStatusLine(status string) string {
-	switch strings.ToUpper(status) {
-	case workload.BuildStatusPending:
-		return "build accepted; waiting for a builder to pick it up"
-	case workload.BuildStatusInProgress:
-		return "builder running"
-	case "BUILT":
-		return "image built; pushing it to the registry"
-	default:
-		return "build is " + strings.ToLower(status)
+		return line, tui.ErrorStyle
 	}
 }
 

--- a/internal/workload/up/build_stream_test.go
+++ b/internal/workload/up/build_stream_test.go
@@ -157,6 +157,46 @@ func TestReporter_StreamStopsTheAnimatorWhenFnPanics(t *testing.T) {
 	assert.Equal(t, before, out.Len(), "a stopped animator writes nothing more")
 }
 
+// The region's row math assumes one line is one row. ansi.Truncate counts a
+// tab as zero columns while the terminal renders it, so a near-width line
+// carrying one wraps and every redraw after it is off by a row; a bare CR
+// sends the cursor to column 0 so the trailing \x1b[K blanks the row. Both
+// are rewritten before the width math sees them.
+func TestLiveRegion_SanitizesControlCharactersBeforeTheRowMath(t *testing.T) {
+	tests := map[string]struct{ in, want string }{
+		"tab becomes the columns it renders as": {"a\tb", "a    b"},
+		"bare CR is dropped":                    {"pull\rdone", "pulldone"},
+		"other C0 controls are dropped":         {"a\x07b\x08c", "abc"},
+		"escape survives for ANSI colors":       {"\x1b[31mred\x1b[0m", "\x1b[31mred\x1b[0m"},
+		"a clean line passes through":           {"step 1/4: FROM base", "step 1/4: FROM base"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.want, sanitizeRow(test.in))
+		})
+	}
+}
+
+// End to end: a tab inside a streamed line reaches the terminal as spaces,
+// never as a character the width math counted as zero.
+func TestReporter_StreamRendersTabsAsSpaces(t *testing.T) {
+	fixedClock(t, time.Second)
+	terminalOfSize(t, 40, 24)
+
+	var out bytes.Buffer
+
+	err := newReporter(&out, true).stream("Building the image", func(say func(string, lipgloss.Style)) error {
+		say("a\tb", tui.HintStyle)
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.NotContains(t, out.String(), "\t")
+	assert.Contains(t, out.String(), "a    b")
+}
+
 func TestReporter_StreamWindowNeverOutgrowsTheViewport(t *testing.T) {
 	fixedClock(t, time.Second)
 	// A viewport shorter than the default window: the region must shrink to

--- a/internal/workload/up/build_stream_test.go
+++ b/internal/workload/up/build_stream_test.go
@@ -88,10 +88,10 @@ func TestBuildLogLine_MarksAndColorsNonInfoLevels(t *testing.T) {
 }
 
 func TestBuildStatusLine_NarratesTheQuietStages(t *testing.T) {
-	assert.Equal(t, "build accepted; waiting for a builder to pick it up", buildStatusLine("PENDING"))
-	assert.Equal(t, "builder running", buildStatusLine("IN_PROGRESS"))
-	assert.Equal(t, "image built; pushing it to the registry", buildStatusLine("BUILT"))
-	assert.Equal(t, "build is cancelling", buildStatusLine("CANCELLING"))
+	assert.Equal(t, "build accepted; waiting for a builder to pick it up", workload.BuildStatusLine("PENDING"))
+	assert.Equal(t, "builder running", workload.BuildStatusLine("IN_PROGRESS"))
+	assert.Equal(t, "image built; pushing it to the registry", workload.BuildStatusLine("BUILT"))
+	assert.Equal(t, "build is cancelling", workload.BuildStatusLine("CANCELLING"))
 }
 
 // terminalOfSize fakes the stream's terminal for the test's lifetime.

--- a/internal/workload/up/phase.go
+++ b/internal/workload/up/phase.go
@@ -232,7 +232,7 @@ func (l *liveRegion) append(line string, style lipgloss.Style) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	line = ansi.Truncate(line, max(l.width-6, 8), "…")
+	line = ansi.Truncate(sanitizeRow(line), max(l.width-6, 8), "…")
 
 	l.tail = append(l.tail, "    "+style.Render(line))
 	if len(l.tail) > l.window {
@@ -248,6 +248,44 @@ func (l *liveRegion) append(line string, style lipgloss.Style) {
 	}
 
 	l.drawn = len(l.tail)
+}
+
+// sanitizeRow rewrites the control characters the region's row math cannot
+// survive. ansi.Truncate counts a tab as zero columns while the terminal
+// renders it, so a near-width line carrying one comes out wider than the
+// row and wraps, putting every redraw after it off by a row; a bare CR sends
+// the cursor back to column 0, so the \x1b[K meant for the line's tail
+// blanks the row instead. ESC stays: build output carries its own colors,
+// and Truncate counts those correctly.
+func sanitizeRow(line string) string {
+	if !strings.ContainsFunc(line, isRowControl) {
+		return line
+	}
+
+	var b strings.Builder
+
+	b.Grow(len(line))
+
+	for _, r := range line {
+		switch {
+		case r == '\t':
+			// The four columns a terminal gives an unlucky tab, in spaces
+			// the width math can count.
+			b.WriteString("    ")
+		case isRowControl(r):
+			// Dropped: nothing a one-row window can render.
+		default:
+			b.WriteRune(r)
+		}
+	}
+
+	return b.String()
+}
+
+// isRowControl reports a control character other than ESC, which is the one
+// with a legitimate job on a rendered row.
+func isRowControl(r rune) bool {
+	return (r < 0x20 || r == 0x7f) && r != '\x1b'
 }
 
 // repaintHeader rewrites the header row, drawn+1 rows above the cursor —


### PR DESCRIPTION
# RATIONALE

> Rebased onto main after #838 merged — the stack is flattened to two commits: the OTEL migration, plus the fixes for the review feedback #838 collected after its merge (dedup overlap capacity, control-character sanitizing in the live region, the seed guard's honest comment).

The per-build logs proxy (`GET /artifacts/{id}/builds/{id}/logs`) is being deprecated ([RAPTOR-18946](https://datarobot.atlassian.net/browse/RAPTOR-18946)): its records only exist while the build service retains the build, which is why a failed build so often answered "logs are not available" at exactly the moment logs were needed. This PR moves the CLI's last callers off that route onto the artifact's OTEL stream (narrowed per build via `external_build_id` — the same source #838 streams from), and upgrades `dr artifact build create --wait` from a silent poll into a live transcript.

## CHANGES

- `GetArtifactBuildLogs` reads the OTEL stream instead of the deprecated proxy; entries map onto the legacy `BuildLogEntry` shape so `dr artifact build logs`, its level filtering, and the failure tail in build summaries carry over. JSON output now passes through the OTEL record (`{timestamp, level, message}`) — a shape change for anyone parsing that output.
- `dr artifact build create --wait` streams the build's log lines and status transitions to stderr while waiting (same tail and wording as `up`'s stream); stdout still carries only the summary document. The per-poll `INFO Fetching build from …` line is gone — the poll fetch carries no request label.
- Log-line and status wording moved to shared `workload.FormatBuildLogLine` / `workload.BuildStatusLine`, so `up` and `build create --wait` say the same things; `up` keeps the coloring.
- No CLI caller remains on the deprecated route (the backend deprecation marking is the workload-api half of the ticket).
- Review feedback from #838, addressed here since the code now lives on this branch: the log dedup is kept as wide as the fetch overlap (keys are pruned once they leave the fetch floor, and the generation cap — now a memory ceiling only — rises to 50000, covering ~800 lines/s over the 60s lag where 5000 was outrun past ~83 lines/s); streamed lines are sanitized before the live region's width math (tabs render as the spaces they occupy, bare CR and other C0 controls are dropped, ESC survives for colors); and the empty-first-poll seed guard's comment now credits its real effect — keeping the gap warning quiet on a seed batch — rather than the gapping fix that `buildLogSeedLimit` actually made.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

## RELATED

- Stacked on: #838 (build-log streaming during `dr wl up`)
- Jira: [RAPTOR-18946](https://datarobot.atlassian.net/browse/RAPTOR-18946)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches build log retrieval to a new API and changes JSON log shape for scripted consumers; streaming and dedup changes affect high-volume build output but are covered by new tests.
> 
> **Overview**
> Moves artifact build logging off the deprecated per-build `/logs` proxy onto the artifact OTEL stream filtered by `external_build_id`, so logs remain available after the build service drops short-lived records.
> 
> **`GetArtifactBuildLogs`** (and `dr artifact build logs`) now read that OTEL route, sort chronologically, and map into the existing `BuildLogEntry` shape for text filtering and failure tails. **JSON output** for those entries now passthroughs the OTEL record (`timestamp`, `level`, `message`) instead of the old JSONL fields—a contract change for anyone parsing `--output-format json`.
> 
> **`dr artifact build create --wait`** streams a live transcript to stderr: human-readable status lines via shared **`workload.BuildStatusLine`**, log lines via **`BuildLogTail`** and **`FormatBuildLogLine`** (same wording as `dr workload up`). Stdout still holds only the summary; build status polls use a silent fetch label so progress lines do not interleave.
> 
> Follow-mode **dedup** prunes keys once they fall outside the fetch overlap (generation cap raised to 50k as a memory ceiling only), and seeding waits for the first non-empty batch so the “possible gap” warning does not fire on a normal seed. The **`up`** live region **sanitizes** tabs and other C0 controls before width math so streamed build output does not corrupt the sliding window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1a38e312ac0059dc63f0e3f810348514635e827. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->