### PR TITLE
[RAPTOR-19725] feat(workload): sort the base-image picker by language, then name

### DIFF
--- a/internal/workload/execenv.go
+++ b/internal/workload/execenv.go
@@ -16,6 +16,7 @@ package workload
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/datarobot/cli/internal/config"
@@ -23,10 +24,12 @@ import (
 )
 
 // ExecutionEnvironment is the projection of the server's EE document the CLI
-// needs to build a generated-Dockerfile artifact spec.
+// needs to build a generated-Dockerfile artifact spec and to present the
+// base-image picker.
 type ExecutionEnvironment struct {
 	ID                      string     `json:"id"`
 	Name                    string     `json:"name"`
+	ProgrammingLanguage     string     `json:"programmingLanguage"`
 	LatestSuccessfulVersion *EEVersion `json:"latestSuccessfulVersion"`
 }
 
@@ -83,9 +86,17 @@ func ResolveExecutionEnvironment(nameOrID string) (id, versionID string, err err
 }
 
 // ListExecutionEnvironments returns up to limit environments that have a
-// version to build from, for the setup wizard's base-image picker. Ones with
-// no successful version are dropped rather than offered: picking one would
-// fail at build time with nothing the user could do about it.
+// version to build from, for the setup wizard's base-image picker, sorted so
+// the list reads as one: languages clustered (the catch-all "other" last, as
+// the least informative), names alphabetical within each. Ones with no
+// successful version are dropped rather than offered: picking one would fail
+// at build time with nothing the user could do about it.
+//
+// The whole listing is drained BEFORE sorting and trimming, deliberately:
+// the endpoint offers no server-side ordering, so trimming while paging
+// would keep whichever environments the server happened to list first and
+// silently drop the rest — an arbitrary subset masquerading as "the list".
+// Sorted first, the trim keeps a deterministic, explainable prefix.
 func ListExecutionEnvironments(limit int) ([]ExecutionEnvironment, error) {
 	if limit <= 0 {
 		return nil, fmt.Errorf("limit must be positive, got %d", limit)
@@ -96,7 +107,7 @@ func ListExecutionEnvironments(limit int) ([]ExecutionEnvironment, error) {
 		return nil, err
 	}
 
-	environments := make([]ExecutionEnvironment, 0, limit)
+	var environments []ExecutionEnvironment
 
 	for pages := 0; pageURL != ""; pages++ {
 		if pages >= maxExecEnvPages {
@@ -111,9 +122,7 @@ func ListExecutionEnvironments(limit int) ([]ExecutionEnvironment, error) {
 			return nil, err
 		}
 
-		if environments = appendBuildable(environments, list.Data, limit); len(environments) == limit {
-			return environments, nil
-		}
+		environments = appendBuildable(environments, list.Data)
 
 		next, err := nextPage(list.Next)
 		if err != nil {
@@ -123,24 +132,52 @@ func ListExecutionEnvironments(limit int) ([]ExecutionEnvironment, error) {
 		pageURL = next
 	}
 
+	sortExecutionEnvironments(environments)
+
+	if len(environments) > limit {
+		environments = environments[:limit]
+	}
+
 	return environments, nil
 }
 
-// appendBuildable adds the environments a build can target, stopping at limit.
-func appendBuildable(into, page []ExecutionEnvironment, limit int) []ExecutionEnvironment {
+// appendBuildable adds the environments a build can target.
+func appendBuildable(into, page []ExecutionEnvironment) []ExecutionEnvironment {
 	for _, ee := range page {
 		if ee.LatestSuccessfulVersion == nil {
 			continue
 		}
 
 		into = append(into, ee)
-
-		if len(into) == limit {
-			return into
-		}
 	}
 
 	return into
+}
+
+// sortExecutionEnvironments orders the picker's list: languages clustered
+// alphabetically with the catch-all "other" (and anything unlabeled) last,
+// names alphabetical within a language, all case-insensitively. Stable, so
+// same-named environments keep the server's relative order.
+func sortExecutionEnvironments(environments []ExecutionEnvironment) {
+	slices.SortStableFunc(environments, func(a, b ExecutionEnvironment) int {
+		if c := strings.Compare(languageSortKey(a.ProgrammingLanguage), languageSortKey(b.ProgrammingLanguage)); c != 0 {
+			return c
+		}
+
+		return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
+	})
+}
+
+// languageSortKey folds a language for grouping and banishes the catch-all to
+// the end: "other" is where the platform files everything it cannot name, so
+// it says the least and belongs after the languages that say something.
+func languageSortKey(language string) string {
+	lower := strings.ToLower(strings.TrimSpace(language))
+	if lower == "" || lower == "other" {
+		return "\x7f" // sorts after any letter
+	}
+
+	return lower
 }
 
 // nextPage validates a paging cursor, returning "" at the end of the listing.

--- a/internal/workload/execenv_test.go
+++ b/internal/workload/execenv_test.go
@@ -331,7 +331,7 @@ func TestListExecutionEnvironments_ClustersLanguagesWithOtherLast(t *testing.T) 
 		fmt.Fprintf(w, `{"data": [%s, %s, %s, %s, %s], "next": ""}`,
 			eeDocLang("ee-other", "AAA first by name alone", "other", "v1"),
 			eeDocLang("ee-none", "BBB unlabeled", "", "v2"),
-			eeDocLang("ee-r", "R Lab", "r", "v3"),
+			eeDocLang("ee-r", "R Lab", "R", "v3"),
 			eeDocLang("ee-java", "JVM", "java", "v4"),
 			eeDocLang("ee-py", "Py", "python", "v5"),
 		)
@@ -352,7 +352,8 @@ func TestListExecutionEnvironments_ClustersLanguagesWithOtherLast(t *testing.T) 
 
 	// java < python < r, then the catch-all and the unlabeled at the end by
 	// name — "other" is where the platform files what it cannot name, so it
-	// belongs after the languages that say something.
+	// belongs after the languages that say something. The capital "R" is the
+	// pin on the case folding: byte-sorted it would land ahead of java.
 	assert.Equal(t, []string{"ee-java", "ee-py", "ee-r", "ee-other", "ee-none"}, got)
 }
 

--- a/internal/workload/execenv_test.go
+++ b/internal/workload/execenv_test.go
@@ -25,6 +25,14 @@ import (
 )
 
 // eeDoc is one execution environment as the server serializes it.
+// eeDocLang is eeDoc with a programmingLanguage, for the sorting tests.
+func eeDocLang(id, name, language, versionID string) string {
+	return fmt.Sprintf(
+		`{"id": %q, "name": %q, "programmingLanguage": %q, "latestSuccessfulVersion": {"id": %q}}`,
+		id, name, language, versionID,
+	)
+}
+
 func eeDoc(id, name, versionID string) string {
 	if versionID == "" {
 		return fmt.Sprintf(`{"id": %q, "name": %q, "latestSuccessfulVersion": null}`, id, name)
@@ -269,7 +277,7 @@ func TestListExecutionEnvironments_SkipsVersionlessEnvironments(t *testing.T) {
 	assert.Equal(t, "ee-3", environments[1].ID)
 }
 
-func TestListExecutionEnvironments_StopsAtTheLimit(t *testing.T) {
+func TestListExecutionEnvironments_DrainsSortsAndTrimsDeterministically(t *testing.T) {
 	installSkipAuth(t)
 
 	// next is filled in once the server has an address; the handler only ever
@@ -280,11 +288,19 @@ func TestListExecutionEnvironments_StopsAtTheLimit(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		pages++
 
-		fmt.Fprintf(w, `{"data": [%s, %s], "next": %q}`,
-			eeDoc(fmt.Sprintf("ee-%da", pages), "A", "ver-a"),
-			eeDoc(fmt.Sprintf("ee-%db", pages), "B", "ver-b"),
-			next,
-		)
+		switch pages {
+		case 1:
+			fmt.Fprintf(w, `{"data": [%s, %s], "next": %q}`,
+				eeDocLang("ee-pyz", "Zephyr", "python", "v1"),
+				eeDocLang("ee-oth", "Aardvark", "other", "v2"),
+				next,
+			)
+		default:
+			fmt.Fprintf(w, `{"data": [%s, %s], "next": ""}`,
+				eeDocLang("ee-pya", "apex", "Python", "v3"),
+				eeDocLang("ee-r", "Stats", "r", "v4"),
+			)
+		}
 	}))
 
 	defer srv.Close()
@@ -296,8 +312,48 @@ func TestListExecutionEnvironments_StopsAtTheLimit(t *testing.T) {
 	environments, err := ListExecutionEnvironments(3)
 	require.NoError(t, err)
 
-	assert.Len(t, environments, 3)
-	assert.Equal(t, 2, pages, "paging stops as soon as the limit is reached")
+	// Every page is read BEFORE trimming: an unsorted early stop would keep
+	// whichever environments the server listed first, an arbitrary subset.
+	assert.Equal(t, 2, pages, "the whole listing is drained before sorting and trimming")
+
+	// Languages cluster (case-insensitively), names sort within a language,
+	// and the trim cuts the SORTED list — here dropping the catch-all
+	// "other" entry, the least informative group, not a random page-two row.
+	require.Len(t, environments, 3)
+	assert.Equal(t, []string{"ee-pya", "ee-pyz", "ee-r"},
+		[]string{environments[0].ID, environments[1].ID, environments[2].ID})
+}
+
+func TestListExecutionEnvironments_ClustersLanguagesWithOtherLast(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data": [%s, %s, %s, %s, %s], "next": ""}`,
+			eeDocLang("ee-other", "AAA first by name alone", "other", "v1"),
+			eeDocLang("ee-none", "BBB unlabeled", "", "v2"),
+			eeDocLang("ee-r", "R Lab", "r", "v3"),
+			eeDocLang("ee-java", "JVM", "java", "v4"),
+			eeDocLang("ee-py", "Py", "python", "v5"),
+		)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	environments, err := ListExecutionEnvironments(50)
+	require.NoError(t, err)
+	require.Len(t, environments, 5)
+
+	got := make([]string, 0, len(environments))
+	for _, ee := range environments {
+		got = append(got, ee.ID)
+	}
+
+	// java < python < r, then the catch-all and the unlabeled at the end by
+	// name — "other" is where the platform files what it cannot name, so it
+	// belongs after the languages that say something.
+	assert.Equal(t, []string{"ee-java", "ee-py", "ee-r", "ee-other", "ee-none"}, got)
 }
 
 func TestListExecutionEnvironments_ServerError(t *testing.T) {

--- a/internal/workload/wizard/execenv_picker_test.go
+++ b/internal/workload/wizard/execenv_picker_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecEnvPicker_ShowsTheLanguageColumn(t *testing.T) {
+	picker := newExecEnvPicker([]workload.ExecutionEnvironment{
+		{
+			ID: "ee-1", Name: "Py 3.12", ProgrammingLanguage: "python",
+			LatestSuccessfulVersion: &workload.EEVersion{ID: "v1"},
+		},
+		{
+			ID: "ee-2", Name: "Node", ProgrammingLanguage: "other",
+			LatestSuccessfulVersion: &workload.EEVersion{ID: "v2"},
+		},
+	}, 120, 40)
+
+	require.Len(t, picker.all, 2)
+	assert.Equal(t, []string{"BASE IMAGE", "LANGUAGE", "ID"}, picker.headers)
+	assert.Equal(t, []string{"Py 3.12", "python", "ee-1"}, picker.all[0].cells)
+	// "other" is where the platform files what it cannot name; as a column
+	// value it reads better as absence than as a category.
+	assert.Equal(t, []string{"Node", "—", "ee-2"}, picker.all[1].cells)
+}

--- a/internal/workload/wizard/execenv_picker_test.go
+++ b/internal/workload/wizard/execenv_picker_test.go
@@ -32,12 +32,18 @@ func TestExecEnvPicker_ShowsTheLanguageColumn(t *testing.T) {
 			ID: "ee-2", Name: "Node", ProgrammingLanguage: "other",
 			LatestSuccessfulVersion: &workload.EEVersion{ID: "v2"},
 		},
+		{
+			ID: "ee-3", Name: "R Lab", ProgrammingLanguage: "R",
+			LatestSuccessfulVersion: &workload.EEVersion{ID: "v3"},
+		},
 	}, 120, 40)
 
-	require.Len(t, picker.all, 2)
+	require.Len(t, picker.all, 3)
 	assert.Equal(t, []string{"BASE IMAGE", "LANGUAGE", "ID"}, picker.headers)
 	assert.Equal(t, []string{"Py 3.12", "python", "ee-1"}, picker.all[0].cells)
 	// "other" is where the platform files what it cannot name; as a column
 	// value it reads better as absence than as a category.
 	assert.Equal(t, []string{"Node", "—", "ee-2"}, picker.all[1].cells)
+	// The platform's own casing is kept: only the sort folds case.
+	assert.Equal(t, []string{"R Lab", "R", "ee-3"}, picker.all[2].cells)
 }

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -1143,12 +1143,24 @@ func newExecEnvPicker(environments []workload.ExecutionEnvironment, width, heigh
 		}
 
 		rows = append(rows, tableRow{
-			cells: []string{ee.Name, ee.ID},
+			cells: []string{ee.Name, languageLabel(ee.ProgrammingLanguage), ee.ID},
 			value: pickedEnv{id: ee.ID, versionID: ee.LatestSuccessfulVersion.ID},
 		})
 	}
 
-	return newRowTable([]string{"BASE IMAGE", "ID"}, rows, true, width, height)
+	return newRowTable([]string{"BASE IMAGE", "LANGUAGE", "ID"}, rows, true, width, height)
+}
+
+// languageLabel renders the language column: the platform's value as-is, and
+// a dash where it says "other" or nothing — a word that means "unlabeled"
+// reads better as absence than as a category.
+func languageLabel(language string) string {
+	lower := strings.ToLower(strings.TrimSpace(language))
+	if lower == "" || lower == "other" {
+		return "—"
+	}
+
+	return lower
 }
 
 // replicaValue leaves the field empty rather than showing a zero, which is

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -1151,16 +1151,17 @@ func newExecEnvPicker(environments []workload.ExecutionEnvironment, width, heigh
 	return newRowTable([]string{"BASE IMAGE", "LANGUAGE", "ID"}, rows, true, width, height)
 }
 
-// languageLabel renders the language column: the platform's value as-is, and
+// languageLabel renders the language column: the platform's value as it came
+// (only the sort folds case; a server that says "R" is shown saying "R"), and
 // a dash where it says "other" or nothing — a word that means "unlabeled"
 // reads better as absence than as a category.
 func languageLabel(language string) string {
-	lower := strings.ToLower(strings.TrimSpace(language))
-	if lower == "" || lower == "other" {
+	trimmed := strings.TrimSpace(language)
+	if lower := strings.ToLower(trimmed); lower == "" || lower == "other" {
 		return "—"
 	}
 
-	return lower
+	return trimmed
 }
 
 // replicaValue leaves the field empty rather than showing a zero, which is

--- a/internal/workload/wizard/table.go
+++ b/internal/workload/wizard/table.go
@@ -241,9 +241,15 @@ func (t *rowTable) update(msg tea.KeyMsg) bool {
 		// name like "Py 3.12" could not be typed. In a filterable table every
 		// printable character is filter input ("f" and "b" already are), and
 		// paging keeps pgup/pgdown.
-		t.filter += " "
+		//
+		// As a first keystroke it is swallowed like "/" above: a filter of
+		// one space is invisible on screen, and the esc that then seems to
+		// do nothing would be spent clearing it instead of going back.
+		if t.filter != "" {
+			t.filter += " "
 
-		t.apply()
+			t.apply()
+		}
 
 		return true
 	}

--- a/internal/workload/wizard/table.go
+++ b/internal/workload/wizard/table.go
@@ -234,6 +234,18 @@ func (t *rowTable) update(msg tea.KeyMsg) bool {
 		t.apply()
 
 		return true
+
+	case msg.Type == tea.KeySpace:
+		// Space arrives as its own key type, never inside KeyRunes, and the
+		// table underneath binds it to page-down — so without this case a
+		// name like "Py 3.12" could not be typed. In a filterable table every
+		// printable character is filter input ("f" and "b" already are), and
+		// paging keeps pgup/pgdown.
+		t.filter += " "
+
+		t.apply()
+
+		return true
 	}
 
 	return t.moveCursor(msg)

--- a/internal/workload/wizard/table_test.go
+++ b/internal/workload/wizard/table_test.go
@@ -158,6 +158,35 @@ func TestRowTable_Filter(t *testing.T) {
 	assert.False(t, table.clearFilter())
 }
 
+// Space reaches the filter like any other printable key. It arrives as its
+// own key type, never inside KeyRunes, and the table underneath binds it to
+// page-down — so before this was handled, a name like "Py 3.12" could not be
+// typed and the keystroke silently paged the list instead.
+func TestRowTable_FilterAcceptsSpaces(t *testing.T) {
+	rows := []tableRow{
+		{cells: []string{"Py 3.12", "a"}, value: 1},
+		{cells: []string{"Py 3.9", "b"}, value: 2},
+		{cells: []string{"Python-nospace", "c"}, value: 3},
+	}
+
+	table := newRowTable([]string{"NAME", "DETAIL"}, rows, true, 120, 44)
+
+	typeFilter(&table, "py")
+	assert.True(t, table.update(tea.KeyMsg{Type: tea.KeySpace}), "space is filter input, not paging")
+	typeFilter(&table, "3.1")
+
+	assert.Equal(t, "py 3.1", table.filter)
+	assert.Equal(t, 1, visibleRowCount(table.view(120)), "only 'Py 3.12' carries the spaced query")
+
+	// One backspace removes the space like any other character.
+	table.update(tea.KeyMsg{Type: tea.KeyBackspace})
+	table.update(tea.KeyMsg{Type: tea.KeyBackspace})
+	table.update(tea.KeyMsg{Type: tea.KeyBackspace})
+	table.update(tea.KeyMsg{Type: tea.KeyBackspace})
+	assert.Equal(t, "py", table.filter)
+	assert.Equal(t, 3, visibleRowCount(table.view(120)))
+}
+
 // A filter that matches nothing says so, rather than showing an empty frame.
 func TestRowTable_FilterMatchingNothing(t *testing.T) {
 	table := newRowTable([]string{"NAME", "DETAIL"}, fakeRows(3), true, 120, 44)

--- a/internal/workload/wizard/table_test.go
+++ b/internal/workload/wizard/table_test.go
@@ -171,6 +171,12 @@ func TestRowTable_FilterAcceptsSpaces(t *testing.T) {
 
 	table := newRowTable([]string{"NAME", "DETAIL"}, rows, true, 120, 44)
 
+	// A leading space is swallowed like "/": a filter of one space is
+	// invisible, and the esc that then seems to do nothing would be spent
+	// clearing it instead of going back.
+	assert.True(t, table.update(tea.KeyMsg{Type: tea.KeySpace}), "swallowed, not handed to paging")
+	assert.Empty(t, table.filter, "a space does not start a filter")
+
 	typeFilter(&table, "py")
 	assert.True(t, table.update(tea.KeyMsg{Type: tea.KeySpace}), "space is filter input, not paging")
 	typeFilter(&table, "3.1")


### PR DESCRIPTION
# RATIONALE

The wizard's base-image picker showed execution environments in whatever order the server returned them — and trimmed to the 200-item pick limit *while paging*, so what got dropped was whichever environments the server listed last: an arbitrary subset masquerading as "the list". The endpoint offers no server-side ordering to lean on (checked the monolith validators: `searchFor`/`useCases`/`isPublic` only), so the CLI has to make the list legible itself. Ticket: [RAPTOR-19725](https://datarobot.atlassian.net/browse/RAPTOR-19725).

## CHANGES

- `ListExecutionEnvironments` drains the whole listing (still bounded by the existing 100-page cap) before sorting and trimming: languages cluster alphabetically with the catch-all `other` (and anything unlabeled) last, names sort case-insensitively within a language, and the pick-limit trim now cuts a deterministic, explainable prefix instead of a random page boundary.
- The picker gains a LANGUAGE column so the grouping is visible; `other`/empty renders as a dash — a word that means "unlabeled" reads better as absence than as a category.
- `ExecutionEnvironment` carries `programmingLanguage` from the server document.
- Bug fix that surfaced while testing this: the picker's filter could not take a space. Space arrives as its own bubbletea key type (never inside `KeyRunes`), so it fell through to bubbles/table, which binds it to page-down — a name like "Py 3.12" could not be typed. In a filterable table every printable character is filter input (`f` and `b` already are), so space is too; paging keeps pgup/pgdown.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

## RELATED

- Jira: [RAPTOR-19725](https://datarobot.atlassian.net/browse/RAPTOR-19725)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Wizard listing and display only; no auth, deploy, or build-resolution logic changes beyond ordering and which rows appear when over the limit.
> 
> **Overview**
> The setup wizard’s **base-image picker** is easier to scan: execution environments are ordered by **programming language** (case-insensitive, with empty/`other` last), then **name**, instead of whatever order the API returned.
> 
> **`ListExecutionEnvironments`** now **pages through the full list** (still capped at 100 pages), **sorts**, then applies the pick limit. Trimming during paging is removed so the limit keeps a **deterministic prefix** of the sorted set rather than an arbitrary early page.
> 
> The picker adds a **LANGUAGE** column from `programmingLanguage` on the API document; unlabeled/`other` values show as **—**. Tests cover drain-then-trim behavior, sort order, and the new column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0622e08afe73811b2d867e01bd3a6f924b7ec72. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->