### PR TITLE
[-] chore: bump Go from 1.26.6 to 1.26.7

### DIFF
--- a/.github/documentation-style-spec.md
+++ b/.github/documentation-style-spec.md
@@ -262,7 +262,7 @@ Add periods to descriptions
 
 **Format**
 ```markdown
-✅ **Note:** The CLI requires Go 1.26.6 or later.
+✅ **Note:** The CLI requires Go 1.26.7 or later.
 
 ✅ **Important:** Never commit `.env` files to version control.
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: 1.26.6
+  go: 1.26.7
 linters:
   enable:
     - asasalint

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ If you would like to build and install from source, you can do so by following t
 
 #### Prerequisites
 
-- Go 1.26.6 or later (for building from source)
+- Go 1.26.7 or later (for building from source)
 - Git
 - [Task](https://taskfile.dev/) (for development and task running)
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -73,7 +73,7 @@ See [Building](building.md) for detailed workflow documentation.
 
 Before you begin development:
 
-- **Go 1.26.6 or later**&mdash;required for building the CLI.
+- **Go 1.26.7 or later**&mdash;required for building the CLI.
 - **Git**&mdash;version control.
 - **Task**&mdash;task runner for development commands.
 - **golangci-lint**&mdash;installed automatically via `task dev-init`.

--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -18,7 +18,7 @@ This guide outlines how to build, test, and develop with the DataRobot CLI.
 
 ### Prerequisites
 
-- [Go 1.26.6+](https://golang.org/dl/)
+- [Go 1.26.7+](https://golang.org/dl/)
 - Git version control
 - [Task](https://taskfile.dev/installation/) (The task runner)
 

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -6,7 +6,7 @@ This page outlines how to set up your development environment to build and devel
 
 ## Prerequisites
 
-- [Go 1.26.6](https://golang.org/dl/)
+- [Go 1.26.7](https://golang.org/dl/)
 - Git for version control
 - [Task](https://taskfile.dev/installation/) (A task runner)
 
@@ -60,7 +60,7 @@ The devcontainer's `postCreateCommand` runs `task bootstrap`, which verifies the
 
 #### Option B: Local setup (no container)
 
-If you prefer not to use a devcontainer, install the [prerequisites](#prerequisites) listed above (Go 1.26.6, Git, Task), then run:
+If you prefer not to use a devcontainer, install the [prerequisites](#prerequisites) listed above (Go 1.26.7, Git, Task), then run:
 
 ```bash
 task bootstrap

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datarobot/cli
 
-go 1.26.6
+go 1.26.7
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
Update go.mod, .golangci.yaml, and all docs to require Go 1.26.7.

The devcontainer auto-syncs via sync-go.sh (thanks @adamalpi!) and CI reads the version from go.mod

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and toolchain version pins only; no runtime or business-logic changes.
> 
> **Overview**
> Raises the required Go toolchain from **1.26.6** to **1.26.7** across the module and tooling config.
> 
> **`go.mod`** now declares `go 1.26.7`, and **`.golangci.yaml`** sets `run.go` to match so lint runs against the same version. User and contributor docs (**`README.md`**, **`docs/development/*`**, and the documentation style spec example) are updated so stated prerequisites stay aligned with the module. No application code changes; devcontainer Go pinning is expected to follow via `sync-go.sh`, and CI should continue to take the version from `go.mod`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2850a22d1b9829653b106ebbb86a38e5a8a3a326. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->