### PR TITLE
[RAPTOR-19728] fix(workload): no default readiness probe; verify the endpoint after deploy

### DIFF
--- a/cmd/workload/config/cmd.go
+++ b/cmd/workload/config/cmd.go
@@ -165,8 +165,9 @@ func addFlags(cmd *cobra.Command, f *flags) {
 
 	cmd.Flags().IntVar(&f.answers.Port, "port", 0, "Container port (default: the Dockerfile's EXPOSE, else 8080).")
 	cmd.Flags().StringVar(&f.answers.HealthPath, "health", "",
-		"Readiness path, e.g. /health. Without it no probe is written: a probe has to be written for the app "+
-			"it probes, and a wrong one stops a healthy deploy from ever going ready.")
+		"Readiness path, e.g. /health. A new manifest gets no probe without it: a probe has to be written "+
+			"for the app it probes, and a wrong one stops a healthy deploy from ever going ready. "+
+			"With --workload-id the bound workload's own probe is kept.")
 	// A flag of its own rather than an empty --health. Declining a probe is a
 	// different act from not mentioning one, and a flag that says so is both
 	// greppable in a CI script and impossible to type by accident.

--- a/cmd/workload/config/cmd.go
+++ b/cmd/workload/config/cmd.go
@@ -164,7 +164,9 @@ func addFlags(cmd *cobra.Command, f *flags) {
 	cmd.Flags().StringVar(&f.answers.Image, "image", "", "Published image URI. Required with --build-mode image.")
 
 	cmd.Flags().IntVar(&f.answers.Port, "port", 0, "Container port (default: the Dockerfile's EXPOSE, else 8080).")
-	cmd.Flags().StringVar(&f.answers.HealthPath, "health", "", "Readiness path (default /). Use --no-readiness-probe to write none.")
+	cmd.Flags().StringVar(&f.answers.HealthPath, "health", "",
+		"Readiness path, e.g. /health. Without it no probe is written: a probe has to be written for the app "+
+			"it probes, and a wrong one stops a healthy deploy from ever going ready.")
 	// A flag of its own rather than an empty --health. Declining a probe is a
 	// different act from not mentioning one, and a flag that says so is both
 	// greppable in a CI script and impossible to type by accident.

--- a/internal/workload/manifest/live.go
+++ b/internal/workload/manifest/live.go
@@ -122,7 +122,7 @@ func (l Live) Defaults() Draft {
 	}
 
 	// The health path is left empty when the container has no readiness probe,
-	// rather than falling back to DefaultHealthPath like everything else here.
+	// rather than falling back to a default like everything else here.
 	// A workload running without a probe has to arrive saying so: the screen
 	// shows the absence, and Apply can then read a path as the answer someone
 	// gave rather than as a default it must be careful not to attach.

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -90,6 +90,7 @@ const (
 	// deploy whose framework answers 404 there, minutes after the green tick
 	// and with nothing saying why. No probe by default, and the deploy's own
 	// endpoint check catches a container that answers nothing.
+
 	DefaultReplicas = 1
 	DefaultCPU      = 0.5
 	DefaultMemory   = "512MB"

--- a/internal/workload/manifest/write.go
+++ b/internal/workload/manifest/write.go
@@ -85,18 +85,14 @@ func ValidImportance(value string) bool {
 const (
 	DefaultImportance = "low"
 	DefaultPort       = 8080
-	// DefaultHealthPath is the root rather than /health because the probe has
-	// to pass on an application nobody wrote it for. Almost every HTTP service
-	// answers something at /, where /health is an endpoint the app has to have
-	// implemented; pointing a probe at one that does not exist is the most
-	// common first-deploy failure, and it presents as a deploy that never
-	// becomes ready rather than as a misconfigured probe. An app with a real
-	// health endpoint says so on the settings screen, and one that wants no
-	// probe at all clears the field.
-	DefaultHealthPath = "/"
-	DefaultReplicas   = 1
-	DefaultCPU        = 0.5
-	DefaultMemory     = "512MB"
+	// There is no default health path. A probe has to be written for the app
+	// it probes: any guessed path — / very much included — kills a healthy
+	// deploy whose framework answers 404 there, minutes after the green tick
+	// and with nothing saying why. No probe by default, and the deploy's own
+	// endpoint check catches a container that answers nothing.
+	DefaultReplicas = 1
+	DefaultCPU      = 0.5
+	DefaultMemory   = "512MB"
 
 	// GroupName and PrimaryContainerName appear in both halves of the file,
 	// which is how the sizing block is joined to the artifact block.

--- a/internal/workload/manifest/write_test.go
+++ b/internal/workload/manifest/write_test.go
@@ -27,7 +27,9 @@ import (
 )
 
 // serviceDraft is the Dockerfile happy path: what a user gets by pressing
-// Enter through every screen in a directory that has a Dockerfile.
+// Enter through every screen in a directory that has a Dockerfile, plus a
+// probe typed on the settings screen: no probe is written by default, and
+// this fixture is what pins the render of one that was asked for.
 func serviceDraft() Draft {
 	return Draft{
 		WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0",
@@ -35,7 +37,7 @@ func serviceDraft() Draft {
 		Type:       TypeService,
 		Build:      Build{Mode: BuildModeDockerfile},
 		Port:       DefaultPort,
-		HealthPath: DefaultHealthPath,
+		HealthPath: "/",
 		Runtime:    Runtime{Replicas: DefaultReplicas, CPU: DefaultCPU, Memory: DefaultMemory},
 	}
 }

--- a/internal/workload/up/endpoint_check.go
+++ b/internal/workload/up/endpoint_check.go
@@ -34,7 +34,17 @@ const endpointCheckTimeout = 10 * time.Second
 // access log, and a 401 or 403 proves something is serving as well as a 200
 // does.
 var checkEndpointFn = func(url string) (int, error) {
-	resp, err := drapi.NewHTTPClient(endpointCheckTimeout).Get(url)
+	client := drapi.NewHTTPClient(endpointCheckTimeout)
+
+	// The endpoint's own answer, never a hop beyond it: a gateway that 302s
+	// an anonymous GET to a login page would otherwise have this line report
+	// the login page's 200 for a container serving nothing, which is the one
+	// case the check exists to catch. A redirect is reported as the 3xx it is.
+	client.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	resp, err := client.Get(url)
 	if err != nil {
 		return 0, err
 	}
@@ -63,7 +73,22 @@ func verifyEndpoint(result Result, report *reporter) {
 		return
 	}
 
-	status, err := checkEndpointFn(result.Endpoint)
+	var (
+		status int
+		err    error
+	)
+
+	// Wrapped like every other wait in the package, because it can sit for
+	// the whole timeout: a check that blocks for ten seconds printing nothing
+	// reads as a hang. The closure returns nil whatever happened — the
+	// check-marked line says the GET was made, and the lines below say what
+	// it found; failing the run is the one thing this must never do.
+	_ = report.run("Checking the endpoint", func() error {
+		status, err = checkEndpointFn(result.Endpoint)
+
+		return nil
+	})
+
 	if err != nil {
 		report.say("  %s\n", tui.WarnStyle.Render("⚠ The endpoint did not answer a GET: "+err.Error()))
 		report.say("    %s\n", tui.HintStyle.Render(

--- a/internal/workload/up/endpoint_check.go
+++ b/internal/workload/up/endpoint_check.go
@@ -1,0 +1,91 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/tui"
+)
+
+// endpointCheckTimeout bounds the one GET the deploy ends with. The workload
+// just reported running, so an app that is up answers quickly; the allowance
+// is for one that is still booting, which the report then says.
+const endpointCheckTimeout = 10 * time.Second
+
+// checkEndpointFn performs the GET, swapped by tests. The request is
+// anonymous on purpose: the user's API token has no business in a container's
+// access log, and a 401 or 403 proves something is serving as well as a 200
+// does.
+var checkEndpointFn = func(url string) (int, error) {
+	resp, err := drapi.NewHTTPClient(endpointCheckTimeout).Get(url)
+	if err != nil {
+		return 0, err
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	return resp.StatusCode, nil
+}
+
+// verifyEndpoint GETs the endpoint once after the platform has said running,
+// and reports what came back. With no readiness probe written by default,
+// "running" only means the container started — nothing has checked that
+// anything answers on the endpoint, so without this line a deploy serving
+// nothing ends in a green tick and the discovery is left to whoever the URL
+// was shared with.
+//
+// It reports and never fails the run, whatever comes back. The probe default
+// was removed because a wrong guess about an app's routes kills a healthy
+// deploy; failing the deploy on the same guess here would be the same
+// mistake wearing a different line. The status code is stated rather than
+// judged for exactly that reason: a 404 at / is how a healthy API-only
+// framework answers, and only the person who wrote the app knows whether it
+// is fine.
+func verifyEndpoint(result Result, report *reporter) {
+	if result.Endpoint == "" {
+		return
+	}
+
+	status, err := checkEndpointFn(result.Endpoint)
+	if err != nil {
+		report.say("  %s\n", tui.WarnStyle.Render("⚠ The endpoint did not answer a GET: "+err.Error()))
+		report.say("    %s\n", tui.HintStyle.Render(
+			"The workload reports running, which only means the container started: it may still be booting, "+
+				"listening on a different port than the manifest names, or serving nothing."))
+		report.say("    %s\n", tui.HintStyle.Render(
+			"Check 'dr workload logs "+result.WorkloadID+"', then GET the endpoint again."))
+
+		return
+	}
+
+	report.say("  %s\n", tui.HintStyle.Render(
+		"Endpoint check: an anonymous GET answered HTTP "+httpStatusLabel(status)+"."))
+}
+
+// httpStatusLabel renders "404 Not Found" rather than a bare number, because
+// the reader of this line is deciding whether their app is fine and the words
+// carry more than the digits.
+func httpStatusLabel(status int) string {
+	if text := http.StatusText(status); text != "" {
+		return fmt.Sprintf("%d %s", status, text)
+	}
+
+	return strconv.Itoa(status)
+}

--- a/internal/workload/up/endpoint_check_test.go
+++ b/internal/workload/up/endpoint_check_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The status is stated, not judged: a 404 at / is how a healthy API-only
+// framework answers, and only the app's author knows whether that is fine.
+func TestVerifyEndpoint_StatesTheStatusInWords(t *testing.T) {
+	force(t, &checkEndpointFn, func(url string) (int, error) {
+		assert.Equal(t, "https://x.example/w/", url)
+
+		return http.StatusNotFound, nil
+	})
+
+	var out bytes.Buffer
+
+	verifyEndpoint(Result{Endpoint: "https://x.example/w/", WorkloadID: "wl-1"}, newReporter(&out, false))
+
+	assert.Contains(t, out.String(), "404 Not Found")
+	assert.Contains(t, out.String(), "anonymous GET")
+}
+
+// An endpoint that does not answer is the case this check exists for: with no
+// probe written by default, "running" only means the container started, and
+// this is the one line telling the user their green tick serves nothing yet.
+func TestVerifyEndpoint_SaysPlainlyWhenNothingAnswers(t *testing.T) {
+	force(t, &checkEndpointFn, func(string) (int, error) {
+		return 0, errors.New("dial tcp: connection refused")
+	})
+
+	var out bytes.Buffer
+
+	verifyEndpoint(Result{Endpoint: "https://x.example/w/", WorkloadID: "wl-1"}, newReporter(&out, false))
+
+	text := out.String()
+	assert.Contains(t, text, "did not answer")
+	assert.Contains(t, text, "connection refused")
+	assert.Contains(t, text, "only means the container started")
+	assert.Contains(t, text, "dr workload logs wl-1")
+}
+
+// No endpoint, nothing to check: a run that produced no URL has nothing whose
+// silence could surprise anyone.
+func TestVerifyEndpoint_SkipsWithoutAnEndpoint(t *testing.T) {
+	force(t, &checkEndpointFn, func(string) (int, error) {
+		t.Fatal("nothing may be fetched when there is no endpoint")
+
+		return 0, nil
+	})
+
+	var out bytes.Buffer
+
+	verifyEndpoint(Result{}, newReporter(&out, false))
+	assert.Empty(t, out.String())
+}
+
+// The real GET is anonymous. The user's API token has no business in a
+// container's access log, and a 401 proves something is serving as well as a
+// 200 does.
+func TestCheckEndpoint_SendsNoCredentials(t *testing.T) {
+	var gotAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	defer srv.Close()
+
+	status, err := checkEndpointFn(srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusTeapot, status)
+	assert.Empty(t, gotAuth, "the GET carries no credentials")
+}
+
+// A deploy whose endpoint answers nothing still succeeds. Failing it would be
+// the probe mistake again: a guess about the app's routes killing a deploy
+// the platform considers healthy.
+func TestRun_EndpointNotAnsweringDoesNotFailTheRun(t *testing.T) {
+	install(t, fakes{
+		create:  func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		writeID: func(string, string) error { return nil },
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return running("wl-new"), nil
+		},
+		getArtifact: func(id string) (*workload.Artifact, error) {
+			return &workload.Artifact{ID: id, Status: workload.ArtifactStatusLocked}, nil
+		},
+		checkEndpoint: func(string) (int, error) { return 0, errors.New("timeout awaiting headers") },
+	})
+
+	result, stderr, err := runIn(t, boundArtifactManifest, Options{NonInteractive: true})
+	require.NoError(t, err, "the check reports; it must never fail the deploy")
+	assert.Equal(t, "wl-new", result.WorkloadID)
+	assert.Contains(t, stderr, "did not answer")
+	assert.Contains(t, stderr, "dr workload logs wl-new")
+}
+
+// The happy path ends with the check's one line, so the transcript says what
+// the endpoint actually did rather than leaving the green tick to imply it.
+func TestRun_ReportsTheEndpointAnswer(t *testing.T) {
+	install(t, fakes{
+		create:  func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		writeID: func(string, string) error { return nil },
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return running("wl-new"), nil
+		},
+		getArtifact: func(id string) (*workload.Artifact, error) {
+			return &workload.Artifact{ID: id, Status: workload.ArtifactStatusLocked}, nil
+		},
+		checkEndpoint: func(string) (int, error) { return http.StatusOK, nil },
+	})
+
+	_, stderr, err := runIn(t, boundArtifactManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+	assert.Contains(t, stderr, "Endpoint check")
+	assert.Contains(t, stderr, "200 OK")
+}

--- a/internal/workload/up/endpoint_check_test.go
+++ b/internal/workload/up/endpoint_check_test.go
@@ -98,6 +98,26 @@ func TestCheckEndpoint_SendsNoCredentials(t *testing.T) {
 	assert.Empty(t, gotAuth, "the GET carries no credentials")
 }
 
+// A redirect is reported as the 3xx it is, never followed: a gateway that
+// 302s an anonymous GET to a login page would otherwise have the check
+// report the login page's 200 for a container serving nothing — the one
+// case the check exists to catch.
+func TestCheckEndpoint_ReportsTheRedirectItselfWithoutFollowing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/login" {
+			t.Fatal("the redirect must not be followed")
+		}
+
+		http.Redirect(w, r, "/login", http.StatusFound)
+	}))
+
+	defer srv.Close()
+
+	status, err := checkEndpointFn(srv.URL)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusFound, status)
+}
+
 // A deploy whose endpoint answers nothing still succeeds. Failing it would be
 // the probe mistake again: a guess about the app's routes killing a deploy
 // the platform considers healthy.

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -947,8 +947,17 @@ func isConflict(err error) bool {
 // distinction is not a tidiness one.
 func settle(workloadID string, result Result, opts Options, report *reporter) (Result, error) {
 	result, err := awaitRunning(workloadID, result, opts, report)
-	if err != nil || !opts.Lock {
+	if err != nil {
 		return result, err
+	}
+
+	// One GET against the endpoint, reported and never fatal. Running means
+	// the container started; with no probe written by default, whether
+	// anything answers is a question nobody has asked yet.
+	verifyEndpoint(result, report)
+
+	if !opts.Lock {
+		return result, nil
 	}
 
 	return lock(result, report)

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -194,6 +194,9 @@ type fakes struct {
 	waitBuild   func(string, string, time.Duration, time.Duration, func(*workload.Build)) (*workload.Build, error)
 	builds      func(string, int) ([]workload.Build, error)
 
+	// checkEndpoint is the one GET a deploy ends with.
+	checkEndpoint func(string) (int, error)
+
 	// The roll track: refuse to queue a second swap, start one, follow it.
 	guard       func(string) error
 	replace     func(string, string, json.RawMessage) (*workload.Replacement, error)
@@ -213,6 +216,11 @@ func install(t *testing.T, f fakes) {
 	// should not have to say so, and neither may touch a real project.
 	force(t, &writeWorkloadIDFn, func(string, string) error { return nil })
 	force(t, &codeChangeFn, func(Loaded, Live) (CodeChange, error) { return CodeChange{}, nil })
+
+	// The endpoint check would otherwise GET whatever URL the fixture
+	// carries, spending a real network timeout per test that reaches settle.
+	force(t, &checkEndpointFn, func(string) (int, error) { return http.StatusOK, nil })
+	swap(t, &checkEndpointFn, f.checkEndpoint)
 
 	// swap leaves a seam alone when the test supplied nothing, so without this
 	// a stopped fixture with no start fake POSTs to whatever tenant the

--- a/internal/workload/wizard/answers.go
+++ b/internal/workload/wizard/answers.go
@@ -254,14 +254,20 @@ func (a Answers) importance() string {
 	return strings.ToLower(strings.TrimSpace(a.Importance))
 }
 
-// healthPath is the path to probe: the flag, the documented default, or
-// nothing at all when the probe was declined.
+// healthPath is the path to probe: the flag's answer, or nothing at all.
+//
+// There is deliberately no default. A probe has to be written for the app it
+// probes: pointing one at / kills every API-only deploy whose framework 404s
+// there, and it presents as a workload that goes ERRORED minutes later with
+// nothing saying why. A wrong probe kills a healthy deploy, which is worse
+// than no probe — the deploy's own endpoint check is what catches a container
+// that answers nothing.
 func (a Answers) healthPath() string {
 	if a.NoProbe {
 		return ""
 	}
 
-	return orDefault(a.HealthPath, manifest.DefaultHealthPath)
+	return a.HealthPath
 }
 
 // The range a primary container's port may fall in. The floor is the

--- a/internal/workload/wizard/answers_test.go
+++ b/internal/workload/wizard/answers_test.go
@@ -133,7 +133,7 @@ func TestAnswers_DraftFromDetectionAlone(t *testing.T) {
 	assert.Equal(t, manifest.BuildModeDockerfile, draft.Build.Mode)
 	assert.Equal(t, detected.Name, draft.Name)
 	assert.Equal(t, 3000, draft.Port)
-	assert.Equal(t, manifest.DefaultHealthPath, draft.HealthPath)
+	assert.Empty(t, draft.HealthPath, "no probe by default: a guessed path kills API-only deploys that 404 at /")
 	assert.Equal(t, manifest.TypeService, draft.Type)
 	assert.Equal(t, manifest.DefaultImportance, draft.Importance)
 	assert.Equal(t, manifest.DefaultReplicas, draft.Runtime.Replicas)

--- a/internal/workload/wizard/regression_test.go
+++ b/internal/workload/wizard/regression_test.go
@@ -662,7 +662,8 @@ func TestFlow_HiddenFieldsKeepTheirValues(t *testing.T) {
 	assert.Contains(t, view, "1 replica")
 	assert.Contains(t, view, "0.5 cpu")
 	assert.Contains(t, view, "importance low")
-	assert.Contains(t, view, "Readiness: "+manifest.DefaultHealthPath+" on port 3000")
+	assert.Contains(t, view, "Readiness: no probe",
+		"nothing was typed into the health field, so no probe is written and the screen says so")
 }
 
 // Clearing the health path is how the screen declines the probe, and what
@@ -742,7 +743,7 @@ func TestFlow_HealthPathPlaceholderSaysNoProbe(t *testing.T) {
 
 	assert.Empty(t, model.inputs[fieldHealthPath].Value())
 	assert.Equal(t, healthPlaceholder, model.inputs[fieldHealthPath].Placeholder)
-	assert.NotContains(t, healthPlaceholder, manifest.DefaultHealthPath)
+	assert.NotContains(t, healthPlaceholder, "/", "the placeholder proposes no path")
 }
 
 // On the row, enter is the way to open it and the chord would be a second


### PR DESCRIPTION
# RATIONALE

Since RAPTOR-19535 the wizard defaulted the readiness probe to `/` — and moved the field behind advanced settings, making the guess invisible. API-only frameworks (FastAPI, Express, …) answer 404 at `/` unless a route is defined, so a **working container was turned ERRORED** roughly four minutes after the green tick, with nothing telling the user why. Hit independently twice, on the CLI's own FastAPI example and on a Node app. A wrong probe kills a healthy deploy; that is worse than no probe.

Ticket: [RAPTOR-19728](https://datarobot.atlassian.net/browse/RAPTOR-19728)

## CHANGES

- **No probe by default.** Nothing writes a readiness probe unless `--health <path>` or the settings screen says one. The wizard's health field starts empty (its placeholder already read "none: no readiness probe"); `--no-readiness-probe` keeps its distinct job of actively dropping a deployed probe when binding to a live workload.
- **Dropping the default alone would just move the surprise later** — with no probe, `running` only means the container started. So a deploy now ends with **one anonymous GET against the workload endpoint**, reported and never fatal: "Endpoint check: an anonymous GET answered HTTP 404 Not Found." when something answers, and a plain warning naming `dr workload logs <id>` when nothing does. The status is stated, not judged — a 404 at `/` is how a healthy API-only framework answers, and only the app's author knows whether that is fine.
- The GET is deliberately anonymous (the user's API token has no business in a container's access log; a 401 proves serving as well as a 200 does), runs on every path that ends settled (create, roll, start, retune), and is skipped on `--detach` and `--dry-run`, which never settle.

Docs note: the `config`/`up` doc sections live in #780, which is still open — the probe-default wording there should be reconciled by whichever merges second.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default deploy readiness behavior for new manifests and adds network I/O on every settling `up`, which affects first-deploy UX and rollout gating but avoids the prior silent probe failures.
> 
> **Overview**
> Fixes a regression where the wizard silently defaulted readiness probes to **`/`**, which breaks many API frameworks that 404 on the root and leaves deploys **ERRORED** long after a green tick.
> 
> **No probe unless you ask.** `DefaultHealthPath` is removed; manifests and wizard answers omit `readinessProbe` unless `--health <path>` or the settings screen supplies one. `--no-readiness-probe` still explicitly drops a probe when binding to a live workload. Flag help and confirm UI now say **“no probe”** when the health field is empty.
> 
> **Post-deploy sanity check.** After `dr workload up` waits for **running**, `settle` runs one **anonymous GET** on the workload URL (10s timeout), prints the HTTP status or a warning with `dr workload logs <id>`, and **never fails** the command—so a 404 at `/` is reported, not treated as a bad deploy.
> 
> Tests cover rendering without a probe, wizard defaults, endpoint messaging, and that a dead endpoint still exits 0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e446b588ffedb9fa49c59dedc0731da8191b823. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->