### PR TITLE
[RAPTOR-19529] feat(workload): make the workload id optional with .datarobot.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Added
 
 - `dr workload status`, `dr workload get`, `dr workload endpoint` and `dr workload logs` now take the workload id as an optional argument. Left out, it is read from the `workloadId` in the nearest `.datarobot.yaml`, searched upward from the new `--dir` flag (the current directory by default), so the commands `dr workload up` points you at can be run as printed from the project it just deployed. A typed id still wins, and is used without reading any manifest. The workload that was picked is named on stderr, except under `--output-format json`, where anything on stderr would break `2>&1 | jq .`.
-- `dr workload stop`, `dr workload start` and `dr workload delete` take the workload id optionally too, on the same terms. Because they change something, a workload named by the manifest rather than by you is confirmed first; `--yes` (or `DATAROBOT_CLI_NON_INTERACTIVE=1`) skips the question, and a typed id is never questioned. `stop` and `start` gained `--yes` for this.
+- `dr workload stop`, `dr workload start` and `dr workload delete` take the workload id optionally too, on the same terms. Because they change something, a workload named by the manifest rather than by you is confirmed first; a typed id is never questioned. `--yes` skips the question, and `stop` and `start` gained that flag for this. `DATAROBOT_CLI_NON_INTERACTIVE=1` also skips it on `stop` and `start`, but not on a manifest-named `delete`: that variable is set once across a pipeline, and deleting something nobody named is not what it was set for.
 - `dr workload delete --dir <path>`: which project's manifest holds the binding to clear, matching the flag `up` and `config` already take.
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Added
 
+- `dr workload status`, `dr workload get`, `dr workload endpoint` and `dr workload logs` now take the workload id as an optional argument. Left out, it is read from the `workloadId` in the nearest `.datarobot.yaml`, searched upward from the new `--dir` flag (the current directory by default), so the commands `dr workload up` points you at can be run as printed from the project it just deployed. A typed id still wins, and is used without reading any manifest. The workload that was picked is named on stderr, except under `--output-format json`, where anything on stderr would break `2>&1 | jq .`.
+- `dr workload stop`, `dr workload start` and `dr workload delete` take the workload id optionally too, on the same terms. Because they change something, a workload named by the manifest rather than by you is confirmed first; `--yes` (or `DATAROBOT_CLI_NON_INTERACTIVE=1`) skips the question, and a typed id is never questioned. `stop` and `start` gained `--yes` for this.
 - `dr workload delete --dir <path>`: which project's manifest holds the binding to clear, matching the flag `up` and `config` already take.
 
 ## Fixed
@@ -17,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Changed
 
+- `dr workload up` no longer pastes the workload id into the commands it suggests running next. They are printed as they can be typed from the project it just deployed, carrying `--dir` when the deploy did. A run that failed after creating the workload names the id above them instead, because that is the one case where the manifest holds no binding for them to resolve.
 - `dr workload delete` now removes the `workloadId` it wrote from a `.datarobot.yaml` bound to the workload it deleted, so the next `dr workload up` is not pointed at something that no longer exists. Only a manifest naming that exact id is touched, the id is compared inside the same edit that removes it, and the artifact link under `.datarobot/` is left alone so the next deploy reuses the artifact; the command names that artifact and how to unlink from it. A workload that was already gone leaves the binding alone: a 404 means "not on this instance", which is not proof the binding is stale.
 - `dr workload up` now mints a new artifact when the one this project is linked to no longer says what `.datarobot.yaml` says. An artifact's spec is fixed when it is created, so reusing a diverged one deployed the frozen answer and reported success. A read that fails is not treated as a difference: the run stops and names the artifact it could not read, so a timeout never starts a new artifact lineage.
 - `dr workload up` now treats a binding that resolves to nothing as drift and creates a new workload, instead of refusing and asking for the id to be cleared by hand. The plan and the JSON envelope both name the id it could not find, so a run pointed at the wrong instance is visible rather than silent. A terminated workload is still refused, because it continues to exist and to hold its name and artifact; the message now names `dr workload delete`, which clears the way and the binding together.

--- a/cmd/workload/del/cmd.go
+++ b/cmd/workload/del/cmd.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/workload/internal/idargs"
 	"github.com/datarobot/cli/internal/auth"
-	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
@@ -100,7 +100,7 @@ Example:
 	idargs.AddYesFlag(cmd, "Skip the confirmation prompt.")
 
 	telemetry.TrackWith(cmd, func(cmd *cobra.Command, args []string) map[string]any {
-		yesFlag, _ := cmd.Flags().GetBool("yes")
+		yesFlag, _ := cmd.Flags().GetBool(cli.YesFlagName)
 
 		return map[string]any{
 			"workload_id":        idargs.TelemetryID(ref, args),
@@ -108,7 +108,7 @@ Example:
 			// The environment variable is only consent for a workload the user
 			// named, so reporting it unconditionally would say yes about the
 			// runs this command refuses for want of it.
-			"yes": yesFlag || (!ref.FromManifest() && viperx.GetBool("yes")),
+			"yes": yesFlag || (!ref.FromManifest() && cli.IsNonInteractive(cmd)),
 		}
 	})
 

--- a/cmd/workload/del/cmd.go
+++ b/cmd/workload/del/cmd.go
@@ -68,9 +68,6 @@ Example:
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Resolve first: it reads --dir and refuses a path that is not a
-			// directory, and a typo is worth catching while it still costs
-			// nothing, on this side of an irreversible call.
 			var err error
 
 			ref, err = idargs.Resolve(cmd, args)
@@ -78,13 +75,13 @@ Example:
 				return err
 			}
 
-			confirmed, err := confirmDelete(cmd, ref.ID)
+			confirmed, err := confirmDelete(cmd, ref)
 			if err != nil || !confirmed {
 				return err
 			}
 
 			if err := workload.DeleteWorkload(ref.ID); err != nil {
-				return handleDeleteError(err, ref.ID)
+				return handleDeleteError(err, ref)
 			}
 
 			fmt.Println(tui.BaseTextStyle.Render("Deleted workload: " + ref.ID))
@@ -96,37 +93,51 @@ Example:
 	}
 
 	idargs.AddDirFlag(cmd)
+	// Only here does --dir also decide which manifest gets its binding cleared,
+	// which is the whole reason a delete by typed id still takes the flag.
+	cmd.Flags().Lookup("dir").Usage += " Its binding to the deleted workload is cleared too."
+
 	idargs.AddYesFlag(cmd, "Skip the confirmation prompt.")
 
-	telemetry.TrackWith(cmd, func(cmd *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWith(cmd, func(cmd *cobra.Command, args []string) map[string]any {
 		yesFlag, _ := cmd.Flags().GetBool("yes")
 
 		return map[string]any{
-			"workload_id":        ref.ID,
+			"workload_id":        idargs.TelemetryID(ref, args),
 			"workload_id_source": ref.Source,
-			"yes":                yesFlag || viperx.GetBool("yes"),
+			// The environment variable is only consent for a workload the user
+			// named, so reporting it unconditionally would say yes about the
+			// runs this command refuses for want of it.
+			"yes": yesFlag || (!ref.FromManifest() && viperx.GetBool("yes")),
 		}
 	})
 
 	return cmd
 }
 
-// confirmDelete returns (true, nil) when the deletion may proceed: either
-// --yes / DATAROBOT_CLI_NON_INTERACTIVE was given, or the user confirmed
-// interactively. A declined prompt is (false, nil) so the command exits 0
-// as a no-op.
-func confirmDelete(cmd *cobra.Command, workloadID string) (bool, error) {
-	confirmed, err := idargs.Confirm(cmd,
-		"Delete workload "+workloadID+"? This stops and removes a running workload. [y/N] ")
-	if err != nil {
-		return false, err
+// confirmDelete returns (true, nil) when the deletion may proceed: either it
+// was already answered, or the user confirmed interactively. A declined prompt
+// is (false, nil) so the command exits 0 as a no-op.
+//
+// A workload the manifest named rather than the user takes the explicit --yes
+// only. Delete is the one irreversible verb here, and the environment variable
+// that suppresses wizards in CI should not also stand as consent to remove
+// something nobody typed.
+func confirmDelete(cmd *cobra.Command, ref idargs.Ref) (bool, error) {
+	env := idargs.EnvMayConsent
+	if ref.FromManifest() {
+		env = idargs.EnvMayNotConsent
 	}
 
-	if !confirmed {
-		fmt.Println(tui.DimStyle.Render("Aborted."))
+	named := "workload " + ref.ID
+	if ref.FromManifest() {
+		// An id the reader never typed is nothing to compare against; the file
+		// that chose it is what makes the answer meaningful.
+		named += ", named by " + ref.DisplayPath()
 	}
 
-	return confirmed, nil
+	return idargs.Confirm(cmd,
+		"Delete "+named+"? This stops and removes a running workload. [y/N] ", env)
 }
 
 // handleDeleteError converts a 404 into a friendly informational message
@@ -141,16 +152,26 @@ func confirmDelete(cmd *cobra.Command, workloadID string) (bool, error) {
 // branch where nothing was actually deleted, would be the stronger claim made
 // on the weaker evidence. A binding that really is dead is cleared by the
 // deploy that recreates it.
-func handleDeleteError(err error, workloadID string) error {
+func handleDeleteError(err error, ref idargs.Ref) error {
 	var httpErr *drapi.HTTPError
 
 	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
-		fmt.Println(tui.DimStyle.Render("No workload found with id: " + workloadID))
+		// The manifest is named when it, rather than the user, chose the id:
+		// otherwise this reports an id the reader has never seen and gives
+		// them nowhere to look.
+		said := "No workload found with id: " + ref.ID
+		if ref.FromManifest() {
+			said += ", named by " + ref.DisplayPath()
+		}
+
+		fmt.Println(tui.DimStyle.Render(said))
 
 		return nil
 	}
 
-	return err
+	// Anything else keeps the provenance too, which is what turns a bare 403
+	// against an ambient id into something actionable.
+	return ref.Wrap(err)
 }
 
 // clearStaleBinding takes back the workloadId the CLI wrote into a manifest,
@@ -206,7 +227,8 @@ func clearStaleBinding(w io.Writer, dir, workloadID string) {
 	// Appending a single generic "remove that line" walked the user into the
 	// empty manifest the only-key refusal exists to prevent.
 	if err != nil {
-		fmt.Fprintln(w, tui.DimStyle.Render("Could not remove workloadId from "+path+": "+err.Error()))
+		fmt.Fprintln(w, tui.DimStyle.Render(
+			"Could not remove workloadId from "+idargs.DisplayPath(path)+": "+err.Error()))
 
 		return
 	}
@@ -216,7 +238,8 @@ func clearStaleBinding(w io.Writer, dir, workloadID string) {
 	}
 
 	fmt.Fprintln(w, tui.DimStyle.Render(
-		"Removed workloadId from "+path+"; the next 'dr workload up"+manifest.DirFlag(dir)+"' creates a new workload."))
+		"Removed workloadId from "+idargs.DisplayPath(path)+
+			"; the next 'dr workload up"+manifest.DirFlag(dir)+"' creates a new workload."))
 
 	noteLinkedArtifact(w, filepath.Dir(path))
 }

--- a/cmd/workload/del/cmd.go
+++ b/cmd/workload/del/cmd.go
@@ -24,13 +24,10 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"github.com/datarobot/cli/cmd/helpers"
+	"github.com/datarobot/cli/cmd/workload/internal/idargs"
 	"github.com/datarobot/cli/internal/auth"
-	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
-	"github.com/datarobot/cli/internal/fsutil"
-	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
@@ -40,8 +37,10 @@ import (
 )
 
 func Cmd() *cobra.Command {
+	var ref idargs.Ref
+
 	cmd := &cobra.Command{
-		Use:   "delete <workload-id>",
+		Use:   "delete [<workload-id>]",
 		Short: "Delete a workload.",
 		Long: `Delete a workload by id.
 
@@ -59,57 +58,53 @@ in a subdirectory is not visible from its parent.
 
 Without --yes the command asks for confirmation.
 
+` + idargs.HelpText + `
+
 Example:
+  dr workload delete
   dr workload delete 68b0c1d2e3f4a5b6c7d8e9f0
   dr workload delete 68b0c1d2e3f4a5b6c7d8e9f0 --yes`,
-		Args:         cobra.ExactArgs(1),
+		Args:         cobra.MaximumNArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			confirmed, err := confirmDelete(cmd, args[0])
+			// Resolve first: it reads --dir and refuses a path that is not a
+			// directory, and a typo is worth catching while it still costs
+			// nothing, on this side of an irreversible call.
+			var err error
+
+			ref, err = idargs.Resolve(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			confirmed, err := confirmDelete(cmd, ref.ID)
 			if err != nil || !confirmed {
 				return err
 			}
 
-			// Not discarded: a lookup failure means the flag was renamed or
-			// dropped, and the silent fallback is a search from the working
-			// directory, which is the behaviour --dir exists to replace.
-			dir, err := cmd.Flags().GetString("dir")
-			if err != nil {
-				return fmt.Errorf("cannot read --dir: %w", err)
+			if err := workload.DeleteWorkload(ref.ID); err != nil {
+				return handleDeleteError(err, ref.ID)
 			}
 
-			// Checked before the delete, not after: a typo is worth catching
-			// while it still costs nothing, and the cleanup that reports it
-			// runs on the far side of an irreversible call.
-			if dir != "" && !fsutil.DirExists(dir) {
-				return fmt.Errorf("--dir %s: %w", dir, manifest.ErrNotADirectory)
-			}
+			fmt.Println(tui.BaseTextStyle.Render("Deleted workload: " + ref.ID))
 
-			if err := workload.DeleteWorkload(args[0]); err != nil {
-				return handleDeleteError(err, args[0])
-			}
-
-			fmt.Println(tui.BaseTextStyle.Render("Deleted workload: " + args[0]))
-
-			clearStaleBinding(cmd.ErrOrStderr(), dir, args[0])
+			clearStaleBinding(cmd.ErrOrStderr(), ref.Dir, ref.ID)
 
 			return nil
 		},
 	}
 
-	cmd.Flags().BoolP(cli.YesFlagName, "y", false, "Skip the confirmation prompt.")
-	cmd.Flags().String("dir", "", "Project directory whose manifest holds the binding, searched upward from here.")
+	idargs.AddDirFlag(cmd)
+	idargs.AddYesFlag(cmd, "Skip the confirmation prompt.")
 
-	// Bind only the env var (DATAROBOT_CLI_NON_INTERACTIVE) to viper. The --yes
-	// flag itself is read directly from cmd.Flags() so an explicit --yes does
-	// not leak into viper.AllSettings() and persist to drconfig.yaml.
-	_ = viperx.BindEnv(cli.YesFlagName, "DATAROBOT_CLI_NON_INTERACTIVE")
+	telemetry.TrackWith(cmd, func(cmd *cobra.Command, _ []string) map[string]any {
+		yesFlag, _ := cmd.Flags().GetBool("yes")
 
-	telemetry.TrackWith(cmd, func(cmd *cobra.Command, args []string) map[string]any {
 		return map[string]any{
-			"workload_id": telemetry.FirstArg(args),
-			"yes":         cli.IsNonInteractive(cmd),
+			"workload_id":        ref.ID,
+			"workload_id_source": ref.Source,
+			"yes":                yesFlag || viperx.GetBool("yes"),
 		}
 	})
 
@@ -121,15 +116,7 @@ Example:
 // interactively. A declined prompt is (false, nil) so the command exits 0
 // as a no-op.
 func confirmDelete(cmd *cobra.Command, workloadID string) (bool, error) {
-	if cli.IsNonInteractive(cmd) {
-		return true, nil
-	}
-
-	if !reader.IsStdinTerminal() {
-		return false, errors.New("confirmation required: pass --yes (or set DATAROBOT_CLI_NON_INTERACTIVE=1) to delete without a prompt")
-	}
-
-	confirmed, err := helpers.Confirm(cmd.OutOrStdout(), cmd.InOrStdin(),
+	confirmed, err := idargs.Confirm(cmd,
 		"Delete workload "+workloadID+"? This stops and removes a running workload. [y/N] ")
 	if err != nil {
 		return false, err

--- a/cmd/workload/del/cmd_test.go
+++ b/cmd/workload/del/cmd_test.go
@@ -28,13 +28,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCmd_RequiresArg(t *testing.T) {
+func TestCmd_ArgIsOptional(t *testing.T) {
 	cmd := Cmd()
-	cmd.PreRunE = nil
-	cmd.SetArgs([]string{})
 
-	err := cmd.Execute()
-	require.Error(t, err)
+	require.NoError(t, cmd.Args(cmd, []string{"68b0c1d2e3f4a5b6c7d8e9f0"}))
+	require.NoError(t, cmd.Args(cmd, nil))
+	require.Error(t, cmd.Args(cmd, []string{"a", "b"}))
 }
 
 // In tests stdin is not a terminal, so without --yes the command must stop

--- a/cmd/workload/del/cmd_test.go
+++ b/cmd/workload/del/cmd_test.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/datarobot/cli/cmd/workload/internal/idargs"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/internal/workload/wapi"
@@ -78,7 +79,7 @@ func TestConfirmDelete_YesSources(t *testing.T) {
 				require.NoError(t, cmd.Flags().Set("yes", "true"))
 			}
 
-			confirmed, err := confirmDelete(cmd, "wl-1")
+			confirmed, err := confirmDelete(cmd, idargs.Ref{ID: "wl-1"})
 
 			if c.wantErr {
 				require.Error(t, err)
@@ -343,4 +344,26 @@ func TestCmd_RegistersDirFlag(t *testing.T) {
 
 	require.NotNil(t, flag, "RunE reads --dir by name; renaming it here fails nothing else")
 	assert.Equal(t, "string", flag.Value.Type())
+}
+
+// The rule this PR adds to the one irreversible verb: a workload the manifest
+// named takes the explicit --yes, and the environment variable that suppresses
+// wizards across a pipeline is not consent to remove it. Deleting the
+// FromManifest branch in confirmDelete makes the second case pass.
+func TestConfirmDelete_AmbientNeedsTheFlag(t *testing.T) {
+	t.Setenv(reader.NonInteractiveEnv, "1")
+
+	typed := idargs.Ref{ID: "wl-1", Source: idargs.WorkloadIDSourceExplicit}
+
+	confirmed, err := confirmDelete(Cmd(), typed)
+	require.NoError(t, err)
+	assert.True(t, confirmed, "an id the user typed is still answered by the env var")
+
+	ambient := idargs.Ref{ID: "wl-1", Source: idargs.WorkloadIDSourceManifest, Path: "/p/.datarobot.yaml"}
+
+	_, err = confirmDelete(Cmd(), ambient)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pass --yes to run")
+	assert.NotContains(t, err.Error(), reader.NonInteractiveEnv,
+		"the remedy must not name the variable it just refused")
 }

--- a/cmd/workload/endpoint/cmd.go
+++ b/cmd/workload/endpoint/cmd.go
@@ -78,9 +78,9 @@ Example:
 
 	idargs.AddDirFlag(cmd)
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
-			"workload_id":        ref.ID,
+			"workload_id":        idargs.TelemetryID(ref, args),
 			"workload_id_source": ref.Source,
 		}
 	})

--- a/cmd/workload/endpoint/cmd.go
+++ b/cmd/workload/endpoint/cmd.go
@@ -17,6 +17,7 @@ package endpoint
 import (
 	"fmt"
 
+	"github.com/datarobot/cli/cmd/workload/internal/idargs"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
@@ -24,8 +25,10 @@ import (
 )
 
 func Cmd() *cobra.Command {
+	var ref idargs.Ref
+
 	cmd := &cobra.Command{
-		Use:   "endpoint <workload-id>",
+		Use:   "endpoint [<workload-id>]",
 		Short: "Print a workload's endpoint URL.",
 		Long: `Print a workload's endpoint URL, and nothing else.
 
@@ -40,21 +43,31 @@ traffic once the workload is running. The command fails when the
 workload has no endpoint URL. For the full document (including the
 endpoint alongside status and metadata) use 'dr workload get'.
 
+` + idargs.HelpText + `
+
 Example:
+  dr workload endpoint
   dr workload endpoint 68b0c1d2e3f4a5b6c7d8e9f0`,
-		Args:         cobra.ExactArgs(1),
+		Args:         cobra.MaximumNArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
-		RunE: func(_ *cobra.Command, args []string) error {
-			wl, err := workload.GetWorkload(args[0])
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var err error
+
+			ref, err = idargs.Resolve(cmd, args)
 			if err != nil {
 				return err
+			}
+
+			wl, err := workload.GetWorkload(ref.ID)
+			if err != nil {
+				return ref.Wrap(err)
 			}
 
 			// Fail loudly rather than print an empty line: a script doing
 			// curl "$(dr workload endpoint ...)" must not curl "".
 			if wl.Endpoint == "" {
-				return fmt.Errorf("workload %s has no endpoint URL", args[0])
+				return fmt.Errorf("workload %s has no endpoint URL", ref.ID)
 			}
 
 			fmt.Println(wl.Endpoint)
@@ -63,9 +76,12 @@ Example:
 		},
 	}
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+	idargs.AddDirFlag(cmd)
+
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
-			"workload_id": telemetry.FirstArg(args),
+			"workload_id":        ref.ID,
+			"workload_id_source": ref.Source,
 		}
 	})
 

--- a/cmd/workload/endpoint/cmd_test.go
+++ b/cmd/workload/endpoint/cmd_test.go
@@ -21,12 +21,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCmd_RequiresArg(t *testing.T) {
+func TestCmd_ArgIsOptional(t *testing.T) {
+	// Args is called directly: with the id optional, cmd.Execute() would run
+	// PreRunE and start a real authentication flow.
 	cmd := Cmd()
-	cmd.SetArgs([]string{})
 
-	err := cmd.Execute()
-	require.Error(t, err)
+	require.NoError(t, cmd.Args(cmd, []string{"68b0c1d2e3f4a5b6c7d8e9f0"}))
+	require.NoError(t, cmd.Args(cmd, nil))
+	require.Error(t, cmd.Args(cmd, []string{"a", "b"}))
 }
 
 func TestCmd_HasNoOutputFormatFlag(t *testing.T) {

--- a/cmd/workload/get/cmd.go
+++ b/cmd/workload/get/cmd.go
@@ -75,9 +75,9 @@ Example:
 	outputformat.AddFlag(cmd, &outputFormat)
 	idargs.AddDirFlag(cmd)
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
-			"workload_id":        ref.ID,
+			"workload_id":        idargs.TelemetryID(ref, args),
 			"workload_id_source": ref.Source,
 			"output_format":      string(outputFormat),
 		}

--- a/cmd/workload/get/cmd.go
+++ b/cmd/workload/get/cmd.go
@@ -15,6 +15,7 @@
 package get
 
 import (
+	"github.com/datarobot/cli/cmd/workload/internal/idargs"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -25,8 +26,10 @@ import (
 func Cmd() *cobra.Command {
 	var outputFormat outputformat.OutputFormat
 
+	var ref idargs.Ref
+
 	cmd := &cobra.Command{
-		Use:   "get <workload-id>",
+		Use:   "get [<workload-id>]",
 		Short: "Display details of a workload.",
 		Long: `Display details of a single workload.
 
@@ -41,18 +44,28 @@ this command until the status is "running", then call the endpoint.
 
 By default, output is human-readable. Use --output-format json for machine-parseable output.
 
+` + idargs.HelpText + `
+
 Example:
+  dr workload get
   dr workload get 68b0c1d2e3f4a5b6c7d8e9f0
   dr workload get 68b0c1d2e3f4a5b6c7d8e9f0 --output-format json`,
-		Args:         cobra.ExactArgs(1),
+		Args:         cobra.MaximumNArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			wl, err := workload.GetWorkload(args[0])
+			var err error
+
+			ref, err = idargs.Resolve(cmd, args)
 			if err != nil {
 				return err
+			}
+
+			wl, err := workload.GetWorkload(ref.ID)
+			if err != nil {
+				return ref.Wrap(err)
 			}
 
 			return workload.RenderWorkload(outputFormat, *wl)
@@ -60,11 +73,13 @@ Example:
 	}
 
 	outputformat.AddFlag(cmd, &outputFormat)
+	idargs.AddDirFlag(cmd)
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
-			"workload_id":   telemetry.FirstArg(args),
-			"output_format": string(outputFormat),
+			"workload_id":        ref.ID,
+			"workload_id_source": ref.Source,
+			"output_format":      string(outputFormat),
 		}
 	})
 

--- a/cmd/workload/get/cmd_test.go
+++ b/cmd/workload/get/cmd_test.go
@@ -21,12 +21,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCmd_RequiresArg(t *testing.T) {
+func TestCmd_ArgIsOptional(t *testing.T) {
+	// Args is called directly: with the id optional, cmd.Execute() would run
+	// PreRunE and start a real authentication flow.
 	cmd := Cmd()
-	cmd.SetArgs([]string{})
 
-	err := cmd.Execute()
-	require.Error(t, err)
+	require.NoError(t, cmd.Args(cmd, []string{"68b0c1d2e3f4a5b6c7d8e9f0"}))
+	require.NoError(t, cmd.Args(cmd, nil))
+	require.Error(t, cmd.Args(cmd, []string{"a", "b"}))
 }
 
 func TestCmd_InvalidOutputFormat(t *testing.T) {

--- a/cmd/workload/internal/idargs/confirm.go
+++ b/cmd/workload/internal/idargs/confirm.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/datarobot/cli/cmd/helpers"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/tui"
@@ -32,9 +33,9 @@ import (
 // Only the environment variable is bound to viper: an explicit --yes read
 // through viper would land in AllSettings() and persist to drconfig.yaml.
 func AddYesFlag(cmd *cobra.Command, usage string) {
-	cmd.Flags().BoolP("yes", "y", false, usage)
+	cmd.Flags().BoolP(cli.YesFlagName, "y", false, usage)
 
-	_ = viperx.BindEnv("yes", reader.NonInteractiveEnv)
+	_ = viperx.BindEnv(cli.YesFlagName, reader.NonInteractiveEnv)
 }
 
 // EnvConsent says whether the non-interactive environment variable may stand
@@ -60,8 +61,15 @@ const (
 // `stop` and `start` ask only when the workload was named by a manifest rather
 // than by the user.
 func Confirm(cmd *cobra.Command, question string, env EnvConsent) (bool, error) {
-	yesFlag, _ := cmd.Flags().GetBool("yes")
-	if yesFlag || (bool(env) && declaredNonInteractive()) {
+	yesFlag, _ := cmd.Flags().GetBool(cli.YesFlagName)
+	if yesFlag {
+		return true, nil
+	}
+
+	// Past the flag, cli.IsNonInteractive is exactly "the environment says so",
+	// which is the half of automation consent an ambient delete refuses.
+	declared := cli.IsNonInteractive(cmd)
+	if declared && bool(env) {
 		return true, nil
 	}
 
@@ -84,7 +92,7 @@ func Confirm(cmd *cobra.Command, question string, env EnvConsent) (bool, error) 
 	// where it does not mean "yes". Reading it only as consent would leave the
 	// one case that refuses it, an ambient delete, blocking on a prompt nobody
 	// is there to answer.
-	if declaredNonInteractive() || !canAsk(cmd) {
+	if declared || !canAsk(cmd) {
 		return false, errors.New("confirmation required: " + remedy + " to run without a prompt")
 	}
 
@@ -130,15 +138,4 @@ func canAsk(cmd *cobra.Command) bool {
 	}
 
 	return term.IsTerminal(int(f.Fd())) //nolint:gosec // uintptr and int are same size on supported platforms
-}
-
-// declaredNonInteractive reports whether the run was declared non-interactive.
-//
-// Both sources are read. viper carries the repo's standard binding for the
-// flag's env var, and reader owns the variable itself and accepts every truthy
-// spelling of it; viper's cast takes only the ones strconv.ParseBool knows, so
-// DATAROBOT_CLI_NON_INTERACTIVE=yes reaches the spinner and the auth flow but
-// would not reach here on the binding alone.
-func declaredNonInteractive() bool {
-	return viperx.GetBool("yes") || reader.IsNonInteractive()
 }

--- a/cmd/workload/internal/idargs/confirm.go
+++ b/cmd/workload/internal/idargs/confirm.go
@@ -1,0 +1,65 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idargs
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/datarobot/cli/cmd/helpers"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/spf13/cobra"
+)
+
+// AddYesFlag registers --yes for the commands that ask before acting.
+//
+// Only the environment variable is bound to viper: an explicit --yes read
+// through viper would land in AllSettings() and persist to drconfig.yaml.
+func AddYesFlag(cmd *cobra.Command, usage string) {
+	cmd.Flags().BoolP("yes", "y", false, usage)
+
+	_ = viperx.BindEnv("yes", reader.NonInteractiveEnv)
+}
+
+// Confirm puts the question, unless --yes or the non-interactive environment
+// variable already answered it. A declined prompt is (false, nil) so the
+// caller can exit 0 as a no-op; no terminal is an error, because there is
+// nobody to ask.
+//
+// Whether to ask at all stays with the caller: `delete` always asks, while
+// `stop` and `start` ask only when the workload was named by a manifest rather
+// than by the user.
+func Confirm(cmd *cobra.Command, question string) (bool, error) {
+	yesFlag, _ := cmd.Flags().GetBool("yes")
+	if yesFlag || viperx.GetBool("yes") {
+		return true, nil
+	}
+
+	if !reader.IsStdinTerminal() {
+		return false, errors.New(
+			"confirmation required: pass --yes (or set " + reader.NonInteractiveEnv +
+				"=1) to run without a prompt")
+	}
+
+	return helpers.Confirm(cmd.OutOrStdout(), cmd.InOrStdin(), question)
+}
+
+// AmbientPrompt is the question a mutating command asks about a workload the
+// user did not name. It gives the manifest as well as the id, because an id
+// the reader has never seen is nothing to compare against.
+func AmbientPrompt(verb string, ref Ref) string {
+	return fmt.Sprintf("%s workload %s, named by %s? [y/N] ", verb, ref.ID, ref.Path)
+}

--- a/cmd/workload/internal/idargs/confirm.go
+++ b/cmd/workload/internal/idargs/confirm.go
@@ -17,11 +17,14 @@ package idargs
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/datarobot/cli/cmd/helpers"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // AddYesFlag registers --yes for the commands that ask before acting.
@@ -34,32 +37,108 @@ func AddYesFlag(cmd *cobra.Command, usage string) {
 	_ = viperx.BindEnv("yes", reader.NonInteractiveEnv)
 }
 
-// Confirm puts the question, unless --yes or the non-interactive environment
-// variable already answered it. A declined prompt is (false, nil) so the
-// caller can exit 0 as a no-op; no terminal is an error, because there is
-// nobody to ask.
+// EnvConsent says whether the non-interactive environment variable may stand
+// in for an answer.
+//
+// It may not when the target was named by a manifest rather than by the user
+// and the operation cannot be undone. That variable is set once in CI to keep
+// wizards from blocking a pipeline; letting it also mean "yes, delete whatever
+// the nearest manifest points at" turns a convenience into standing consent
+// for something nobody named. An explicit --yes is still accepted, because
+// that is typed for this command.
+type EnvConsent bool
+
+const (
+	EnvMayConsent    EnvConsent = true
+	EnvMayNotConsent EnvConsent = false
+)
+
+// Confirm puts the question, unless it has already been answered. A declined
+// prompt is (false, nil) so the caller can exit 0 as a no-op.
 //
 // Whether to ask at all stays with the caller: `delete` always asks, while
 // `stop` and `start` ask only when the workload was named by a manifest rather
 // than by the user.
-func Confirm(cmd *cobra.Command, question string) (bool, error) {
+func Confirm(cmd *cobra.Command, question string, env EnvConsent) (bool, error) {
 	yesFlag, _ := cmd.Flags().GetBool("yes")
-	if yesFlag || viperx.GetBool("yes") {
+	if yesFlag || (bool(env) && declaredNonInteractive()) {
 		return true, nil
 	}
 
-	if !reader.IsStdinTerminal() {
-		return false, errors.New(
-			"confirmation required: pass --yes (or set " + reader.NonInteractiveEnv +
-				"=1) to run without a prompt")
+	remedy := "pass --yes (or set " + reader.NonInteractiveEnv + "=1)"
+	if !env {
+		remedy = "pass --yes"
 	}
 
-	return helpers.Confirm(cmd.OutOrStdout(), cmd.InOrStdin(), question)
+	// A JSON run cannot be asked even on a terminal: the question would land
+	// in the document something is parsing, and IsStdinTerminal cannot see
+	// that, because it only watches stdin. `up` reaches the same conclusion
+	// for the same reason. Said separately from the no-terminal case so the
+	// reader learns which of the two is stopping them.
+	if emitsJSON(cmd) {
+		return false, errors.New(
+			"--output-format json cannot ask for confirmation: " + remedy + " to run without a prompt")
+	}
+
+	// Declaring the environment non-interactive has to mean "do not ask", even
+	// where it does not mean "yes". Reading it only as consent would leave the
+	// one case that refuses it, an ambient delete, blocking on a prompt nobody
+	// is there to answer.
+	if declaredNonInteractive() || !canAsk(cmd) {
+		return false, errors.New("confirmation required: " + remedy + " to run without a prompt")
+	}
+
+	// The question goes to stderr, not stdout: stdout is the acknowledgement
+	// these commands promise, or one JSON document, and a question printed
+	// into either breaks whatever is reading it.
+	confirmed, err := helpers.Confirm(cmd.ErrOrStderr(), cmd.InOrStdin(), question)
+	if err != nil || confirmed {
+		return confirmed, err
+	}
+
+	// Said once here rather than at three call sites, so a decline never looks
+	// like the command silently doing nothing.
+	fmt.Fprintln(cmd.ErrOrStderr(), tui.DimStyle.Render("Aborted."))
+
+	return false, nil
 }
 
 // AmbientPrompt is the question a mutating command asks about a workload the
 // user did not name. It gives the manifest as well as the id, because an id
 // the reader has never seen is nothing to compare against.
 func AmbientPrompt(verb string, ref Ref) string {
-	return fmt.Sprintf("%s workload %s, named by %s? [y/N] ", verb, ref.ID, ref.Path)
+	return fmt.Sprintf("%s workload %s, named by %s? [y/N] ", verb, ref.ID, shortPath(ref.Path))
+}
+
+// canAsk reports whether there is a terminal on both ends of the question.
+//
+// stdout is not consulted: the answer is read from stdin and the question is
+// written to stderr, and it is those two that have to be a terminal. Checking
+// stdin alone was enough while the question went to stdout; now that a
+// redirected stderr can swallow it, a prompt nobody can see is a prompt that
+// hangs.
+func canAsk(cmd *cobra.Command) bool {
+	if !reader.IsStdinTerminal() {
+		return false
+	}
+
+	f, ok := cmd.ErrOrStderr().(*os.File)
+	if !ok {
+		// Not a file at all, which in practice means a test buffer. The
+		// question is capturable, so it can be asked.
+		return true
+	}
+
+	return term.IsTerminal(int(f.Fd())) //nolint:gosec // uintptr and int are same size on supported platforms
+}
+
+// declaredNonInteractive reports whether the run was declared non-interactive.
+//
+// Both sources are read. viper carries the repo's standard binding for the
+// flag's env var, and reader owns the variable itself and accepts every truthy
+// spelling of it; viper's cast takes only the ones strconv.ParseBool knows, so
+// DATAROBOT_CLI_NON_INTERACTIVE=yes reaches the spinner and the auth flow but
+// would not reach here on the binding alone.
+func declaredNonInteractive() bool {
+	return viperx.GetBool("yes") || reader.IsNonInteractive()
 }

--- a/cmd/workload/internal/idargs/confirm_test.go
+++ b/cmd/workload/internal/idargs/confirm_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idargs
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// asking builds a command shaped like the mutating leaves: --yes, and a
+// --output-format of its own.
+func asking(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+
+	var format outputformat.OutputFormat
+
+	cmd := &cobra.Command{Use: "stop"}
+	AddYesFlag(cmd, "skip")
+	outputformat.AddFlag(cmd, &format)
+
+	var out, errOut bytes.Buffer
+
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+
+	return cmd, &out, &errOut
+}
+
+func TestConfirm(t *testing.T) {
+	t.Run("--yes answers it", func(t *testing.T) {
+		t.Setenv(reader.NonInteractiveEnv, "")
+
+		cmd, _, _ := asking(t)
+		require.NoError(t, cmd.Flags().Set("yes", "true"))
+
+		confirmed, err := Confirm(cmd, "go? [y/N] ", EnvMayConsent)
+		require.NoError(t, err)
+		assert.True(t, confirmed)
+	})
+
+	t.Run("the env var answers it, unless the caller says otherwise", func(t *testing.T) {
+		t.Setenv(reader.NonInteractiveEnv, "1")
+		t.Cleanup(viperx.Reset)
+
+		cmd, _, _ := asking(t)
+
+		confirmed, err := Confirm(cmd, "go? [y/N] ", EnvMayConsent)
+		require.NoError(t, err)
+		assert.True(t, confirmed)
+
+		// The rule that keeps a CI-wide env var from consenting to an
+		// irreversible delete of a workload nobody named.
+		_, err = Confirm(cmd, "go? [y/N] ", EnvMayNotConsent)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "pass --yes to run")
+		assert.NotContains(t, err.Error(), reader.NonInteractiveEnv)
+	})
+
+	// Declaring the run non-interactive has to mean "do not ask" even where it
+	// does not mean "yes", or the one case that refuses it blocks on a prompt
+	// nobody is there to answer.
+	t.Run("a declared non-interactive run is refused, never asked", func(t *testing.T) {
+		t.Setenv(reader.NonInteractiveEnv, "1")
+		t.Cleanup(viperx.Reset)
+
+		cmd, out, errOut := asking(t)
+
+		_, err := Confirm(cmd, "go? [y/N] ", EnvMayNotConsent)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "confirmation required")
+		assert.Empty(t, out.String()+errOut.String(), "no question may be put")
+	})
+
+	// viper's cast takes only what strconv.ParseBool knows; the variable's own
+	// reader accepts more, and the docs promise the variable, not the cast.
+	t.Run("every truthy spelling of the variable counts", func(t *testing.T) {
+		t.Setenv(reader.NonInteractiveEnv, "yes")
+		t.Cleanup(viperx.Reset)
+
+		cmd, _, _ := asking(t)
+
+		confirmed, err := Confirm(cmd, "go? [y/N] ", EnvMayConsent)
+		require.NoError(t, err)
+		assert.True(t, confirmed)
+	})
+
+	// The blocking bug: a question printed into a JSON run breaks whatever is
+	// parsing it, and stdin being a terminal says nothing about that.
+	t.Run("a JSON run is non-interactive", func(t *testing.T) {
+		t.Setenv(reader.NonInteractiveEnv, "")
+
+		cmd, out, errOut := asking(t)
+		require.NoError(t, cmd.Flags().Set("output-format", "json"))
+
+		_, err := Confirm(cmd, "go? [y/N] ", EnvMayConsent)
+		require.Error(t, err)
+
+		// Named rather than the generic refusal, so this proves the JSON check
+		// fired: under go test stdin is never a terminal, and the no-terminal
+		// branch would answer the same way whether or not the check existed.
+		assert.Contains(t, err.Error(), "--output-format json cannot ask")
+		assert.Empty(t, out.String(), "no question may reach stdout")
+		assert.Empty(t, errOut.String())
+	})
+}
+
+// announce keys off the command's own flag, not the inherited one: delete and
+// endpoint never render JSON, so a root --output-format must not cost them
+// their attribution.
+func TestAnnounce_IgnoresAnInheritedOutputFormat(t *testing.T) {
+	t.Cleanup(viperx.Reset)
+	viperx.Set("output-format", "json")
+
+	var errOut bytes.Buffer
+
+	cmd := &cobra.Command{Use: "delete"}
+	cmd.SetErr(&errOut)
+
+	announce(cmd, Ref{ID: boundID, Source: WorkloadIDSourceManifest, Path: "/p/.datarobot.yaml"})
+	assert.Contains(t, errOut.String(), boundID)
+
+	var format outputformat.OutputFormat
+
+	speaking := &cobra.Command{Use: "status"}
+	outputformat.AddFlag(speaking, &format)
+
+	var quiet bytes.Buffer
+
+	speaking.SetErr(&quiet)
+	announce(speaking, Ref{ID: boundID, Source: WorkloadIDSourceManifest, Path: "/p/.datarobot.yaml"})
+	assert.Empty(t, quiet.String(), "a command that does render JSON stays quiet")
+}

--- a/cmd/workload/internal/idargs/idargs.go
+++ b/cmd/workload/internal/idargs/idargs.go
@@ -1,0 +1,241 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package idargs centralizes the optional <workload-id> positional shared by
+// the dr workload leaves: each accepts the id or omits it, in which case the
+// workloadId bound in the nearest .datarobot.yaml is used. Keeping the arity,
+// the --dir flag and the help text in one place stops seven commands drifting
+// apart.
+//
+// It sits here rather than beside ResolveArtifactID in internal/workload
+// because that package cannot import internal/workload/manifest: the manifest
+// package's own tests import it back, and the cycle is only visible when the
+// tests build.
+package idargs
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/fsutil"
+	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/datarobot/cli/tui"
+	"github.com/spf13/cobra"
+)
+
+// HelpText is the paragraph every leaf appends to its Long, so one behaviour
+// is not explained seven ways.
+const HelpText = `The workload id is optional in a project directory: without it, the
+workloadId bound in the nearest .datarobot.yaml is used, searched upward
+from --dir (the current directory by default).`
+
+// AddDirFlag registers --dir. Paired with Resolve so a command cannot read the
+// flag without offering it.
+func AddDirFlag(cmd *cobra.Command) {
+	cmd.Flags().String("dir", "",
+		"Project directory whose .datarobot.yaml names the workload, searched upward from here.")
+}
+
+// Resolve returns the workload the command should act on, announcing one read
+// from a manifest on stderr.
+//
+// The notice is printed here rather than at each call site so seven commands
+// cannot each decide differently whether to say.
+func Resolve(cmd *cobra.Command, args []string) (Ref, error) {
+	dir, err := dirFlag(cmd)
+	if err != nil {
+		return Ref{}, err
+	}
+
+	ref, err := resolve(args, dir)
+	if err != nil {
+		return Ref{}, err
+	}
+
+	announce(cmd, ref)
+
+	return ref, nil
+}
+
+// announce names a workload the user did not, so an ambient target is never
+// silent. JSON runs stay quiet: stdout purity is only half the contract, and
+// `--output-format json 2>&1 | jq .` has to parse too.
+func announce(cmd *cobra.Command, ref Ref) {
+	if !ref.FromManifest() || outputformat.GetFormat(cmd) == outputformat.OutputFormatJSON {
+		return
+	}
+
+	fmt.Fprintln(cmd.ErrOrStderr(),
+		tui.DimStyle.Render("Using workload "+ref.ID+" from "+ref.Path))
+}
+
+// dirFlag reads --dir and defaults it to where the shell is standing.
+//
+// The lookup error is not discarded: it means the flag was renamed or dropped,
+// and the silent fallback is a search from the working directory, which is the
+// behaviour --dir exists to replace.
+func dirFlag(cmd *cobra.Command) (string, error) {
+	dir, err := cmd.Flags().GetString("dir")
+	if err != nil {
+		return "", fmt.Errorf("cannot read --dir: %w", err)
+	}
+
+	if dir != "" {
+		if !fsutil.DirExists(dir) {
+			return "", fmt.Errorf("--dir %s: %w", dir, manifest.ErrNotADirectory)
+		}
+
+		return dir, nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine the current directory: %w", err)
+	}
+
+	return cwd, nil
+}
+
+const (
+	WorkloadIDSourceExplicit = "explicit"
+	WorkloadIDSourceManifest = "manifest"
+)
+
+// Ref is the workload a command was pointed at, and how it was named.
+type Ref struct {
+	ID     string
+	Source string
+	// Path is the manifest the id came from, "" when the id was typed.
+	Path string
+	// Dir is where the search started, for the --dir a remedy has to carry.
+	Dir string
+}
+
+// FromManifest reports whether the id was read from a manifest rather than
+// typed by the user.
+func (r Ref) FromManifest() bool {
+	return r.Source == WorkloadIDSourceManifest
+}
+
+// resolve returns the workload to act on: the positional id when one was given,
+// otherwise the workloadId bound in the nearest .datarobot.yaml at or above
+// dir. It is the pure half, so it tests without a command or a writer.
+//
+// An explicit id is returned without touching the filesystem, so a manifest
+// that cannot be read is never a reason to refuse a command that was told
+// which workload it means.
+//
+// The manifest is parsed but deliberately not validated: the ledger has no
+// rule about workloadId, and logs is what you reach for when a project is
+// broken.
+func resolve(args []string, dir string) (Ref, error) {
+	if len(args) > 0 {
+		// Given-but-empty is an unset shell variable, not a request to fall
+		// back: acting on the manifest would target a workload the caller
+		// never named. Arity is the only thing that tells the two apart,
+		// because "" and absent are the same string.
+		id := strings.TrimSpace(args[0])
+		if id == "" {
+			return Ref{}, errors.New(
+				"the workload id is empty. Pass an id, or omit it to use " + manifest.FileName)
+		}
+
+		return Ref{ID: id, Source: WorkloadIDSourceExplicit, Dir: dir}, nil
+	}
+
+	path, err := manifest.Locate(dir)
+	if err != nil {
+		if errors.Is(err, manifest.ErrNotFound) {
+			// The sentinel leads rather than being nested: Locate says the same
+			// thing in the same words, and a reader should not be told twice.
+			// Where it looked is only worth naming when --dir sent it somewhere
+			// other than where the reader is standing.
+			where := "here or in any parent"
+			if at := shortPath(dir); at != "." {
+				where = "in " + at + " or any parent"
+			}
+
+			return Ref{}, fmt.Errorf("%w %s. Pass a workload id, or use --dir", manifest.ErrNotFound, where)
+		}
+
+		return Ref{}, err
+	}
+
+	m, err := manifest.Load(path)
+	if err != nil {
+		return Ref{}, fmt.Errorf("%w. Pass a workload id to skip reading it", err)
+	}
+
+	id := strings.TrimSpace(m.WorkloadID())
+	if id == "" {
+		return Ref{}, fmt.Errorf(
+			"%s names no workload yet. Run 'dr workload up%s', or pass an id",
+			shortPath(path), manifest.DirFlag(dir))
+	}
+
+	return Ref{ID: id, Source: WorkloadIDSourceManifest, Path: path, Dir: dir}, nil
+}
+
+// Wrap names the manifest behind a 404 or 403, which otherwise reports an id
+// the caller never saw and no file. Other errors, and every error against a
+// typed id, pass through untouched.
+func (r Ref) Wrap(err error) error {
+	if err == nil || !r.FromManifest() {
+		return err
+	}
+
+	var httpErr *drapi.HTTPError
+	if !errors.As(err, &httpErr) {
+		return err
+	}
+
+	if httpErr.StatusCode != http.StatusNotFound && httpErr.StatusCode != http.StatusForbidden {
+		return err
+	}
+
+	// A 404 means "not on this instance", which is not the same as gone: the
+	// same manifest read against the wrong endpoint, organisation or token
+	// answers exactly this way, so the remedy names both.
+	if httpErr.StatusCode == http.StatusForbidden {
+		return fmt.Errorf("no access to workload %s, named by %s", r.ID, shortPath(r.Path))
+	}
+
+	return fmt.Errorf(
+		"workload %s not found. %s names it; check the endpoint and organisation, or redeploy with 'dr workload up%s'",
+		r.ID, shortPath(r.Path), manifest.DirFlag(r.Dir))
+}
+
+// shortPath renders a path the way a reader would type it: relative when that
+// stays inside the working directory, absolute otherwise. Naming
+// /Users/me/some/long/project/.datarobot.yaml at someone standing in it spends
+// three lines saying "here".
+func shortPath(path string) string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return path
+	}
+
+	rel, err := filepath.Rel(cwd, path)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return path
+	}
+
+	return rel
+}

--- a/cmd/workload/internal/idargs/idargs.go
+++ b/cmd/workload/internal/idargs/idargs.go
@@ -35,6 +35,7 @@ import (
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/fsutil"
 	"github.com/datarobot/cli/internal/outputformat"
+	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/tui"
 	"github.com/spf13/cobra"
@@ -59,6 +60,11 @@ func AddDirFlag(cmd *cobra.Command) {
 // The notice is printed here rather than at each call site so seven commands
 // cannot each decide differently whether to say.
 func Resolve(cmd *cobra.Command, args []string) (Ref, error) {
+	// A --dir the user typed is always checked, even alongside an id that
+	// makes it redundant: a silently discarded flag is how a typo turns into
+	// "why did nothing change", and `up` and `delete` both refuse the same
+	// mistake. Only the search is skipped for a typed id, which is the part
+	// that would read a manifest.
 	dir, err := dirFlag(cmd)
 	if err != nil {
 		return Ref{}, err
@@ -78,12 +84,26 @@ func Resolve(cmd *cobra.Command, args []string) (Ref, error) {
 // silent. JSON runs stay quiet: stdout purity is only half the contract, and
 // `--output-format json 2>&1 | jq .` has to parse too.
 func announce(cmd *cobra.Command, ref Ref) {
-	if !ref.FromManifest() || outputformat.GetFormat(cmd) == outputformat.OutputFormatJSON {
+	if !ref.FromManifest() || emitsJSON(cmd) {
 		return
 	}
 
 	fmt.Fprintln(cmd.ErrOrStderr(),
-		tui.DimStyle.Render("Using workload "+ref.ID+" from "+ref.Path))
+		tui.DimStyle.Render("Using workload "+ref.ID+" from "+shortPath(ref.Path)))
+}
+
+// emitsJSON reports whether this command renders a JSON document.
+//
+// Keyed on the command's own flag rather than the effective value, because
+// --output-format is registered on the root as well: `delete` and `endpoint`
+// inherit a value they never act on, and staying quiet for it would cost them
+// their attribution to buy nothing.
+func emitsJSON(cmd *cobra.Command) bool {
+	if cmd.LocalFlags().Lookup("output-format") == nil {
+		return false
+	}
+
+	return outputformat.GetFormat(cmd) == outputformat.OutputFormatJSON
 }
 
 // dirFlag reads --dir and defaults it to where the shell is standing.
@@ -97,6 +117,17 @@ func dirFlag(cmd *cobra.Command) (string, error) {
 		return "", fmt.Errorf("cannot read --dir: %w", err)
 	}
 
+	return ProjectDir(dir)
+}
+
+// ProjectDir turns a --dir value into the directory to search, defaulting to
+// where the shell is standing.
+//
+// A flag naming something other than a directory is refused here rather than
+// left to the manifest search, which knows the path but not that a flag
+// supplied it. Shared with `up` because the two print this remedy at each
+// other, and answering one typo two ways is its own small confusion.
+func ProjectDir(dir string) (string, error) {
 	if dir != "" {
 		if !fsutil.DirExists(dir) {
 			return "", fmt.Errorf("--dir %s: %w", dir, manifest.ErrNotADirectory)
@@ -111,6 +142,19 @@ func dirFlag(cmd *cobra.Command) (string, error) {
 	}
 
 	return cwd, nil
+}
+
+// DisplayPath is Path as a reader would type it.
+func (r Ref) DisplayPath() string {
+	return DisplayPath(r.Path)
+}
+
+// DisplayPath renders any path the way the messages in this feature do, for a
+// caller that holds one without a Ref around it. One rendering, because two
+// lines of the same output naming the same file differently reads as two
+// files.
+func DisplayPath(path string) string {
+	return shortPath(path)
 }
 
 const (
@@ -214,12 +258,13 @@ func (r Ref) Wrap(err error) error {
 	// same manifest read against the wrong endpoint, organisation or token
 	// answers exactly this way, so the remedy names both.
 	if httpErr.StatusCode == http.StatusForbidden {
-		return fmt.Errorf("no access to workload %s, named by %s", r.ID, shortPath(r.Path))
+		return fmt.Errorf("no access to workload %s, named by %s: %w", r.ID, shortPath(r.Path), err)
 	}
 
 	return fmt.Errorf(
-		"workload %s not found. %s names it; check the endpoint and organisation, or redeploy with 'dr workload up%s'",
-		r.ID, shortPath(r.Path), manifest.DirFlag(r.Dir))
+		"workload %s is not on this instance; %s names it. Check the endpoint and organisation, "+
+			"or redeploy with 'dr workload up%s': %w",
+		r.ID, shortPath(r.Path), manifest.DirFlag(r.Dir), err)
 }
 
 // shortPath renders a path the way a reader would type it: relative when that
@@ -238,4 +283,15 @@ func shortPath(path string) string {
 	}
 
 	return rel
+}
+
+// TelemetryID is the workload id to report: the resolved one, falling back to
+// whatever was typed. RunE assigns the Ref, so a run that fails before it
+// (authentication, a bad flag) would otherwise report nothing at all.
+func TelemetryID(ref Ref, args []string) string {
+	if ref.ID != "" {
+		return ref.ID
+	}
+
+	return telemetry.FirstArg(args)
 }

--- a/cmd/workload/internal/idargs/idargs_test.go
+++ b/cmd/workload/internal/idargs/idargs_test.go
@@ -1,0 +1,164 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package idargs
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/testutil"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const boundID = "68b0c1d2e3f4a5b6c7d8e9f0"
+
+const boundManifest = `workloadId: ` + boundID + `
+name: my-app
+artifact:
+  name: my-app-artifact
+`
+
+// project makes a directory holding a manifest, with the manifest search
+// bounded to it so a stray .datarobot.yaml on the real filesystem cannot
+// answer for it. t.TempDir() sits outside $HOME, where Locate's stop condition
+// would never fire and the walk would run to the root.
+func project(t *testing.T, content string) string {
+	t.Helper()
+
+	home := t.TempDir()
+	testutil.SetTestHomeDir(t, home)
+
+	dir := filepath.Join(home, "proj")
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+
+	if content != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, manifest.FileName), []byte(content), 0o600))
+	}
+
+	return dir
+}
+
+func TestResolve(t *testing.T) {
+	t.Run("explicit id wins over a bound manifest", func(t *testing.T) {
+		dir := project(t, boundManifest)
+
+		ref, err := resolve([]string{"typed-id"}, dir)
+		require.NoError(t, err)
+		assert.Equal(t, "typed-id", ref.ID)
+		assert.False(t, ref.FromManifest())
+	})
+
+	t.Run("explicit id needs no manifest at all", func(t *testing.T) {
+		// Pins that an explicit id skips the search entirely: a foreign or
+		// broken manifest overhead must not fail a command that was told which
+		// workload it means.
+		ref, err := resolve([]string{"typed-id"}, project(t, ""))
+		require.NoError(t, err)
+		assert.Equal(t, "typed-id", ref.ID)
+	})
+
+	t.Run("a blank id is refused, not a fallback", func(t *testing.T) {
+		// "" is what an unset shell variable expands to and is the same string
+		// as no argument at all, so only arity separates them.
+		for _, blank := range []string{"", "   "} {
+			_, err := resolve([]string{blank}, project(t, boundManifest))
+			require.Error(t, err, "id %q", blank)
+			assert.Contains(t, err.Error(), "id is empty")
+		}
+	})
+
+	t.Run("a typed id is trimmed", func(t *testing.T) {
+		ref, err := resolve([]string{"  typed-id  "}, project(t, boundManifest))
+		require.NoError(t, err)
+		assert.Equal(t, "typed-id", ref.ID)
+	})
+
+	t.Run("reads the manifest in dir", func(t *testing.T) {
+		dir := project(t, boundManifest)
+
+		ref, err := resolve(nil, dir)
+		require.NoError(t, err)
+		assert.Equal(t, boundID, ref.ID)
+		assert.True(t, ref.FromManifest())
+		assert.Equal(t, filepath.Join(dir, manifest.FileName), ref.Path)
+	})
+
+	t.Run("reads a manifest in a parent directory", func(t *testing.T) {
+		dir := project(t, boundManifest)
+		nested := filepath.Join(dir, "svc", "internal")
+		require.NoError(t, os.MkdirAll(nested, 0o750))
+
+		ref, err := resolve(nil, nested)
+		require.NoError(t, err)
+		assert.Equal(t, boundID, ref.ID)
+	})
+
+	t.Run("no manifest names both remedies", func(t *testing.T) {
+		_, err := resolve(nil, project(t, ""))
+		require.Error(t, err)
+		require.ErrorIs(t, err, manifest.ErrNotFound)
+		assert.Contains(t, err.Error(), "Pass a workload id")
+	})
+
+	t.Run("an unbound manifest says to deploy, not to create a file", func(t *testing.T) {
+		_, err := resolve(nil, project(t, "name: my-app\n"))
+		require.Error(t, err)
+		require.NotErrorIs(t, err, manifest.ErrNotFound)
+		assert.Contains(t, err.Error(), "names no workload yet")
+	})
+}
+
+func TestRefWrap(t *testing.T) {
+	notFound := &drapi.HTTPError{StatusCode: http.StatusNotFound, URL: "u"}
+
+	t.Run("names the manifest behind a 404", func(t *testing.T) {
+		ref := Ref{ID: boundID, Source: WorkloadIDSourceManifest, Path: "/p/.datarobot.yaml"}
+
+		err := ref.Wrap(notFound)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "/p/.datarobot.yaml")
+		assert.Contains(t, err.Error(), "not found")
+
+		// The HTTP error is deliberately not chained: its "404 Not Found (url:
+		// ...)" tail is longer than the sentence explaining it, and nothing
+		// reads the status back off a command error.
+		assert.NotContains(t, err.Error(), "url:")
+	})
+
+	t.Run("a 403 does not claim the workload is missing", func(t *testing.T) {
+		ref := Ref{ID: boundID, Source: WorkloadIDSourceManifest, Path: "/p/.datarobot.yaml"}
+
+		err := ref.Wrap(&drapi.HTTPError{StatusCode: http.StatusForbidden, URL: "u"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no access")
+	})
+
+	t.Run("leaves a typed id alone", func(t *testing.T) {
+		ref := Ref{ID: boundID, Source: WorkloadIDSourceExplicit}
+		assert.Equal(t, notFound, ref.Wrap(notFound))
+	})
+
+	t.Run("passes other errors through", func(t *testing.T) {
+		other := errors.New("boom")
+		ref := Ref{ID: boundID, Source: WorkloadIDSourceManifest, Path: "/p"}
+		assert.Equal(t, other, ref.Wrap(other))
+	})
+}

--- a/cmd/workload/internal/idargs/idargs_test.go
+++ b/cmd/workload/internal/idargs/idargs_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/testutil"
 	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -135,12 +136,11 @@ func TestRefWrap(t *testing.T) {
 		err := ref.Wrap(notFound)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "/p/.datarobot.yaml")
-		assert.Contains(t, err.Error(), "not found")
+		assert.Contains(t, err.Error(), "not on this instance")
 
-		// The HTTP error is deliberately not chained: its "404 Not Found (url:
-		// ...)" tail is longer than the sentence explaining it, and nothing
-		// reads the status back off a command error.
-		assert.NotContains(t, err.Error(), "url:")
+		// The HTTPError stays in the chain, so a caller can still read the
+		// status back off it.
+		require.ErrorIs(t, err, notFound)
 	})
 
 	t.Run("a 403 does not claim the workload is missing", func(t *testing.T) {
@@ -161,4 +161,38 @@ func TestRefWrap(t *testing.T) {
 		ref := Ref{ID: boundID, Source: WorkloadIDSourceManifest, Path: "/p"}
 		assert.Equal(t, other, ref.Wrap(other))
 	})
+}
+
+// The explicit-id invariant through Resolve rather than resolve: a typed id
+// reads no manifest, even when --dir points somewhere that has none.
+func TestResolve_TypedIDReadsNoManifest(t *testing.T) {
+	empty := t.TempDir()
+	testutil.SetTestHomeDir(t, empty)
+
+	cmd := &cobra.Command{Use: "logs"}
+	AddDirFlag(cmd)
+	require.NoError(t, cmd.Flags().Set("dir", empty))
+
+	ref, err := Resolve(cmd, []string{"typed-id"})
+	require.NoError(t, err)
+	assert.Equal(t, "typed-id", ref.ID)
+	assert.False(t, ref.FromManifest())
+
+	// The same directory has nothing to answer with when there is no id.
+	_, err = Resolve(cmd, nil)
+	require.ErrorIs(t, err, manifest.ErrNotFound)
+}
+
+// A --dir the user typed is checked whether or not an id came with it: a flag
+// accepted and discarded is how a typo becomes "why did nothing change".
+func TestResolve_ChecksDirEvenWithATypedID(t *testing.T) {
+	cmd := &cobra.Command{Use: "logs"}
+	AddDirFlag(cmd)
+	require.NoError(t, cmd.Flags().Set("dir", filepath.Join(t.TempDir(), "gone")))
+
+	_, err := Resolve(cmd, []string{"typed-id"})
+	require.ErrorIs(t, err, manifest.ErrNotADirectory)
+
+	_, err = Resolve(cmd, nil)
+	require.ErrorIs(t, err, manifest.ErrNotADirectory)
 }

--- a/cmd/workload/logs/cmd.go
+++ b/cmd/workload/logs/cmd.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/datarobot/cli/cmd/internal/pollflags"
+	"github.com/datarobot/cli/cmd/workload/internal/idargs"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -33,6 +34,8 @@ const followPollInterval = 2 * time.Second
 func Cmd() *cobra.Command {
 	var outputFormat outputformat.OutputFormat
 
+	var ref idargs.Ref
+
 	var (
 		limit    int
 		level    string
@@ -41,7 +44,7 @@ func Cmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "logs <workload-id>",
+		Use:   "logs [<workload-id>]",
 		Short: "Show a workload's container logs.",
 		Long: `Show the application logs from a workload's running container(s).
 
@@ -59,13 +62,16 @@ per entry. Use --output-format json for machine-parseable output: a JSON
 array without --follow, or one JSON object per line (JSON Lines) with
 --follow.
 
+` + idargs.HelpText + `
+
 Example:
+  dr workload logs
   dr workload logs 68b0c1d2e3f4a5b6c7d8e9f0
   dr workload logs 68b0c1d2e3f4a5b6c7d8e9f0 --limit 500
   dr workload logs 68b0c1d2e3f4a5b6c7d8e9f0 --level error
   dr workload logs 68b0c1d2e3f4a5b6c7d8e9f0 --follow
   dr workload logs 68b0c1d2e3f4a5b6c7d8e9f0 --output-format json`,
-		Args:         cobra.ExactArgs(1),
+		Args:         cobra.MaximumNArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -80,21 +86,28 @@ Example:
 				return err
 			}
 
+			// After the flag checks, so a bad --limit is not reported as a
+			// missing manifest, and before anything reaches the network.
+			ref, err = idargs.Resolve(cmd, args)
+			if err != nil {
+				return err
+			}
+
 			if follow {
 				// Warnings go to stderr so stdout stays log lines only.
 				onWarn := func(msg string) {
 					fmt.Fprintln(cmd.ErrOrStderr(), "warning: "+msg)
 				}
 
-				return workload.FollowWorkloadLogs(cmd.Context(), args[0], limit, parsedLevel, interval,
+				return workload.FollowWorkloadLogs(cmd.Context(), ref.ID, limit, parsedLevel, interval,
 					func(e workload.WorkloadLogEntry) error {
 						return workload.RenderWorkloadLogLine(outputFormat, e)
 					}, onWarn)
 			}
 
-			entries, err := workload.GetWorkloadLogs(args[0], limit, parsedLevel)
+			entries, err := workload.GetWorkloadLogs(ref.ID, limit, parsedLevel)
 			if err != nil {
-				return err
+				return ref.Wrap(err)
 			}
 
 			return workload.RenderWorkloadLogs(outputFormat, entries)
@@ -102,6 +115,7 @@ Example:
 	}
 
 	outputformat.AddFlag(cmd, &outputFormat)
+	idargs.AddDirFlag(cmd)
 
 	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of recent log lines to return")
 	cmd.Flags().StringVar(&level, "level", "", "Minimum log level (debug, info, warn, warning, error, critical)")
@@ -110,15 +124,16 @@ Example:
 		"Interval between polls when --follow is set.")
 	_ = cmd.Flags().MarkHidden("poll-interval")
 
-	telemetry.TrackWith(cmd, func(c *cobra.Command, args []string) map[string]any {
+	telemetry.TrackWith(cmd, func(c *cobra.Command, _ []string) map[string]any {
 		limit, _ := c.Flags().GetInt("limit")
 
 		return map[string]any{
-			"workload_id":   telemetry.FirstArg(args),
-			"limit":         limit,
-			"level":         level,
-			"follow":        follow,
-			"output_format": string(outputFormat),
+			"workload_id":        ref.ID,
+			"workload_id_source": ref.Source,
+			"limit":              limit,
+			"level":              level,
+			"follow":             follow,
+			"output_format":      string(outputFormat),
 		}
 	})
 

--- a/cmd/workload/logs/cmd.go
+++ b/cmd/workload/logs/cmd.go
@@ -99,10 +99,10 @@ Example:
 					fmt.Fprintln(cmd.ErrOrStderr(), "warning: "+msg)
 				}
 
-				return workload.FollowWorkloadLogs(cmd.Context(), ref.ID, limit, parsedLevel, interval,
+				return ref.Wrap(workload.FollowWorkloadLogs(cmd.Context(), ref.ID, limit, parsedLevel, interval,
 					func(e workload.WorkloadLogEntry) error {
 						return workload.RenderWorkloadLogLine(outputFormat, e)
-					}, onWarn)
+					}, onWarn))
 			}
 
 			entries, err := workload.GetWorkloadLogs(ref.ID, limit, parsedLevel)
@@ -124,11 +124,11 @@ Example:
 		"Interval between polls when --follow is set.")
 	_ = cmd.Flags().MarkHidden("poll-interval")
 
-	telemetry.TrackWith(cmd, func(c *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWith(cmd, func(c *cobra.Command, args []string) map[string]any {
 		limit, _ := c.Flags().GetInt("limit")
 
 		return map[string]any{
-			"workload_id":        ref.ID,
+			"workload_id":        idargs.TelemetryID(ref, args),
 			"workload_id_source": ref.Source,
 			"limit":              limit,
 			"level":              level,

--- a/cmd/workload/logs/cmd_test.go
+++ b/cmd/workload/logs/cmd_test.go
@@ -21,12 +21,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCmd_RequiresArg(t *testing.T) {
+func TestCmd_ArgIsOptional(t *testing.T) {
+	// Args is called directly: with the id optional, cmd.Execute() would run
+	// PreRunE and start a real authentication flow.
 	cmd := Cmd()
-	cmd.SetArgs([]string{})
 
-	err := cmd.Execute()
-	require.Error(t, err)
+	require.NoError(t, cmd.Args(cmd, []string{"68b0c1d2e3f4a5b6c7d8e9f0"}))
+	require.NoError(t, cmd.Args(cmd, nil))
+	require.Error(t, cmd.Args(cmd, []string{"a", "b"}))
 }
 
 func TestCmd_InvalidOutputFormat(t *testing.T) {

--- a/cmd/workload/resolve_test.go
+++ b/cmd/workload/resolve_test.go
@@ -1,0 +1,139 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/testutil"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const wireID = "68b0c1d2e3f4a5b6c7d8e9f0"
+
+// TestUnboundID covers the whole feature end to end for every verb that takes
+// an id: the workloadId in .datarobot.yaml reaches the request URL, and the
+// notice naming it goes to the command's stderr rather than the process's.
+// The per-leaf tests only check arity, so this is what catches a leaf that
+// forgot to resolve.
+func TestUnboundID(t *testing.T) {
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+
+		seen = append(seen, r.Method+" "+r.URL.Path)
+		mu.Unlock()
+
+		// One body serves every verb: encoding/json ignores unknown fields, so
+		// this decodes as a workload, an operation response and a logs page.
+		fmt.Fprint(w, `{"id":"`+wireID+`","name":"my-app","status":"running",`+
+			`"endpoint":"https://app.example/","data":[]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	viperx.Set(config.DataRobotURL, srv.URL)
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+	viperx.Set(config.SkipAuthKey, true)
+
+	t.Cleanup(viperx.Reset)
+
+	home := t.TempDir()
+	testutil.SetTestHomeDir(t, home)
+
+	dir := filepath.Join(home, "proj")
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, manifest.FileName),
+		[]byte("workloadId: "+wireID+"\nname: my-app\n"), 0o600))
+	t.Chdir(dir)
+
+	for _, c := range []struct {
+		verb string
+		want string
+	}{
+		{"status", "GET /api/v2/workloads/" + wireID + "/"},
+		{"get", "GET /api/v2/workloads/" + wireID + "/"},
+		{"endpoint", "GET /api/v2/workloads/" + wireID + "/"},
+		{"logs", "GET /api/v2/otel/workload/" + wireID + "/logs/"},
+	} {
+		t.Run(c.verb, func(t *testing.T) {
+			mu.Lock()
+			seen = nil
+			mu.Unlock()
+
+			var stderr bytes.Buffer
+
+			cmd := Cmd()
+			cmd.SetArgs([]string{c.verb})
+			cmd.SetErr(&stderr)
+
+			require.NoError(t, cmd.Execute())
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			assert.Contains(t, seen, c.want)
+			assert.Contains(t, stderr.String(), wireID)
+			assert.Contains(t, stderr.String(), manifest.FileName)
+		})
+	}
+}
+
+// The notice is stderr chatter, and stderr chatter breaks
+// `--output-format json 2>&1 | jq .`.
+func TestUnboundID_SilentInJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"id":"`+wireID+`","name":"my-app","status":"running"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	viperx.Set(config.DataRobotURL, srv.URL)
+	viperx.Set(config.DataRobotAPIKey, "test-token")
+	viperx.Set(config.SkipAuthKey, true)
+
+	t.Cleanup(viperx.Reset)
+
+	home := t.TempDir()
+	testutil.SetTestHomeDir(t, home)
+
+	dir := filepath.Join(home, "proj")
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, manifest.FileName),
+		[]byte("workloadId: "+wireID+"\nname: my-app\n"), 0o600))
+	t.Chdir(dir)
+
+	var stderr bytes.Buffer
+
+	cmd := Cmd()
+	cmd.SetArgs([]string{"status", "--output-format", "json"})
+	cmd.SetErr(&stderr)
+
+	require.NoError(t, cmd.Execute())
+	assert.Empty(t, stderr.String())
+}

--- a/cmd/workload/resolve_test.go
+++ b/cmd/workload/resolve_test.go
@@ -34,11 +34,14 @@ import (
 
 const wireID = "68b0c1d2e3f4a5b6c7d8e9f0"
 
-// TestUnboundID covers the whole feature end to end for every verb that takes
-// an id: the workloadId in .datarobot.yaml reaches the request URL, and the
-// notice naming it goes to the command's stderr rather than the process's.
-// The per-leaf tests only check arity, so this is what catches a leaf that
-// forgot to resolve.
+// TestUnboundID covers the feature end to end for the verbs that take an id:
+// the workloadId in .datarobot.yaml reaches the request URL, and the notice
+// naming it goes to the command's stderr rather than the process's. The
+// per-leaf tests only check arity, so this is what catches a leaf that forgot
+// to resolve.
+//
+// `stop` is covered by its own confirmation test instead, because a stopped
+// workload is the state the others would then be read against.
 func TestUnboundID(t *testing.T) {
 	var (
 		mu   sync.Mutex
@@ -74,13 +77,16 @@ func TestUnboundID(t *testing.T) {
 	t.Chdir(dir)
 
 	for _, c := range []struct {
-		verb string
-		want string
+		verb  string
+		want  string
+		extra []string
 	}{
-		{"status", "GET /api/v2/workloads/" + wireID + "/"},
-		{"get", "GET /api/v2/workloads/" + wireID + "/"},
-		{"endpoint", "GET /api/v2/workloads/" + wireID + "/"},
-		{"logs", "GET /api/v2/otel/workload/" + wireID + "/logs/"},
+		{"status", "GET /api/v2/workloads/" + wireID + "/", nil},
+		{"get", "GET /api/v2/workloads/" + wireID + "/", nil},
+		{"endpoint", "GET /api/v2/workloads/" + wireID + "/", nil},
+		{"logs", "GET /api/v2/otel/workload/" + wireID + "/logs/", nil},
+		{"start", "POST /api/v2/workloads/" + wireID + "/start", []string{"--yes"}},
+		{"delete", "DELETE /api/v2/workloads/" + wireID + "/", []string{"--yes"}},
 	} {
 		t.Run(c.verb, func(t *testing.T) {
 			mu.Lock()
@@ -90,7 +96,9 @@ func TestUnboundID(t *testing.T) {
 			var stderr bytes.Buffer
 
 			cmd := Cmd()
-			cmd.SetArgs([]string{c.verb})
+			// The mutating verbs ask about a workload they were not given, so
+			// they are answered here; resolution is what this is testing.
+			cmd.SetArgs(append([]string{c.verb}, c.extra...))
 			cmd.SetErr(&stderr)
 
 			require.NoError(t, cmd.Execute())
@@ -99,6 +107,7 @@ func TestUnboundID(t *testing.T) {
 			defer mu.Unlock()
 
 			assert.Contains(t, seen, c.want)
+			restoreManifest(t, dir)
 			assert.Contains(t, stderr.String(), wireID)
 			assert.Contains(t, stderr.String(), manifest.FileName)
 		})
@@ -136,4 +145,13 @@ func TestUnboundID_SilentInJSON(t *testing.T) {
 
 	require.NoError(t, cmd.Execute())
 	assert.Empty(t, stderr.String())
+}
+
+// A successful delete takes the binding back out of the manifest, so the rows
+// after it would have nothing to resolve.
+func restoreManifest(t *testing.T, dir string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, manifest.FileName),
+		[]byte("workloadId: "+wireID+"\nname: my-app\n"), 0o600))
 }

--- a/cmd/workload/start/cmd.go
+++ b/cmd/workload/start/cmd.go
@@ -73,7 +73,7 @@ Example:
 
 			// Only an ambient target is confirmed: a typed id is the consent.
 			if ref.FromManifest() {
-				confirmed, err := idargs.Confirm(cmd, idargs.AmbientPrompt("Start", ref))
+				confirmed, err := idargs.Confirm(cmd, idargs.AmbientPrompt("Start", ref), idargs.EnvMayConsent)
 				if err != nil || !confirmed {
 					return err
 				}
@@ -102,9 +102,9 @@ Example:
 	idargs.AddDirFlag(cmd)
 	idargs.AddYesFlag(cmd, "Start a manifest-named workload without confirmation.")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
-			"workload_id":        ref.ID,
+			"workload_id":        idargs.TelemetryID(ref, args),
 			"workload_id_source": ref.Source,
 			"output_format":      string(outputFormat),
 		}

--- a/cmd/workload/start/cmd.go
+++ b/cmd/workload/start/cmd.go
@@ -17,6 +17,7 @@ package start
 import (
 	"fmt"
 
+	"github.com/datarobot/cli/cmd/workload/internal/idargs"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -27,8 +28,10 @@ import (
 func Cmd() *cobra.Command {
 	var outputFormat outputformat.OutputFormat
 
+	var ref idargs.Ref
+
 	cmd := &cobra.Command{
-		Use:   "start <workload-id>",
+		Use:   "start [<workload-id>]",
 		Short: "Start a stopped workload.",
 		Long: `Start a stopped workload.
 
@@ -46,18 +49,39 @@ The acknowledgement message is printed on stdout. Use
 By default, output is human-readable. Use --output-format json for the
 full acknowledgement document.
 
+` + idargs.HelpText + `
+
+A workload named by the manifest rather than by you is confirmed
+first; pass --yes to skip that.
+
 Example:
+  dr workload start
   dr workload start 68b0c1d2e3f4a5b6c7d8e9f0
   dr workload start 68b0c1d2e3f4a5b6c7d8e9f0 --output-format json`,
-		Args:         cobra.ExactArgs(1),
+		Args:         cobra.MaximumNArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			resp, err := workload.StartWorkload(args[0])
+			var err error
+
+			ref, err = idargs.Resolve(cmd, args)
 			if err != nil {
 				return err
+			}
+
+			// Only an ambient target is confirmed: a typed id is the consent.
+			if ref.FromManifest() {
+				confirmed, err := idargs.Confirm(cmd, idargs.AmbientPrompt("Start", ref))
+				if err != nil || !confirmed {
+					return err
+				}
+			}
+
+			resp, err := workload.StartWorkload(ref.ID)
+			if err != nil {
+				return ref.Wrap(err)
 			}
 
 			if err := workload.RenderWorkloadOperation(outputFormat, *resp); err != nil {
@@ -67,7 +91,7 @@ Example:
 			// The follow-up hint goes to stderr so script captures of stdout
 			// stay limited to the server's acknowledgement message.
 			if outputFormat == outputformat.OutputFormatText {
-				fmt.Fprintln(cmd.ErrOrStderr(), "Check progress with: dr workload status "+args[0])
+				fmt.Fprintln(cmd.ErrOrStderr(), "Check progress with: dr workload status "+ref.ID)
 			}
 
 			return nil
@@ -75,11 +99,14 @@ Example:
 	}
 
 	outputformat.AddFlag(cmd, &outputFormat)
+	idargs.AddDirFlag(cmd)
+	idargs.AddYesFlag(cmd, "Start a manifest-named workload without confirmation.")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
-			"workload_id":   telemetry.FirstArg(args),
-			"output_format": string(outputFormat),
+			"workload_id":        ref.ID,
+			"workload_id_source": ref.Source,
+			"output_format":      string(outputFormat),
 		}
 	})
 

--- a/cmd/workload/start/cmd_test.go
+++ b/cmd/workload/start/cmd_test.go
@@ -21,12 +21,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCmd_RequiresArg(t *testing.T) {
+func TestCmd_ArgIsOptional(t *testing.T) {
+	// Args is called directly: with the id optional, cmd.Execute() would run
+	// PreRunE and start a real authentication flow.
 	cmd := Cmd()
-	cmd.SetArgs([]string{})
 
-	err := cmd.Execute()
-	require.Error(t, err)
+	require.NoError(t, cmd.Args(cmd, []string{"68b0c1d2e3f4a5b6c7d8e9f0"}))
+	require.NoError(t, cmd.Args(cmd, nil))
+	require.Error(t, cmd.Args(cmd, []string{"a", "b"}))
 }
 
 func TestCmd_InvalidOutputFormat(t *testing.T) {

--- a/cmd/workload/status/cmd.go
+++ b/cmd/workload/status/cmd.go
@@ -73,9 +73,9 @@ Example:
 	outputformat.AddFlag(cmd, &outputFormat)
 	idargs.AddDirFlag(cmd)
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
-			"workload_id":        ref.ID,
+			"workload_id":        idargs.TelemetryID(ref, args),
 			"workload_id_source": ref.Source,
 			"output_format":      string(outputFormat),
 		}

--- a/cmd/workload/status/cmd.go
+++ b/cmd/workload/status/cmd.go
@@ -15,6 +15,7 @@
 package status
 
 import (
+	"github.com/datarobot/cli/cmd/workload/internal/idargs"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -25,8 +26,10 @@ import (
 func Cmd() *cobra.Command {
 	var outputFormat outputformat.OutputFormat
 
+	var ref idargs.Ref
+
 	cmd := &cobra.Command{
-		Use:   "status <workload-id>",
+		Use:   "status [<workload-id>]",
 		Short: "Show a workload's status.",
 		Long: `Show a workload's current status.
 
@@ -39,18 +42,28 @@ full document.
 
 JSON output emits one {"id", "status"} document.
 
+` + idargs.HelpText + `
+
 Example:
+  dr workload status
   dr workload status 68b0c1d2e3f4a5b6c7d8e9f0
   dr workload status 68b0c1d2e3f4a5b6c7d8e9f0 --output-format json`,
-		Args:         cobra.ExactArgs(1),
+		Args:         cobra.MaximumNArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			wl, err := workload.GetWorkload(args[0])
+			var err error
+
+			ref, err = idargs.Resolve(cmd, args)
 			if err != nil {
 				return err
+			}
+
+			wl, err := workload.GetWorkload(ref.ID)
+			if err != nil {
+				return ref.Wrap(err)
 			}
 
 			return workload.RenderWorkloadStatus(outputFormat, *wl)
@@ -58,11 +71,13 @@ Example:
 	}
 
 	outputformat.AddFlag(cmd, &outputFormat)
+	idargs.AddDirFlag(cmd)
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
-			"workload_id":   telemetry.FirstArg(args),
-			"output_format": string(outputFormat),
+			"workload_id":        ref.ID,
+			"workload_id_source": ref.Source,
+			"output_format":      string(outputFormat),
 		}
 	})
 

--- a/cmd/workload/status/cmd_test.go
+++ b/cmd/workload/status/cmd_test.go
@@ -21,12 +21,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCmd_RequiresArg(t *testing.T) {
+func TestCmd_ArgIsOptional(t *testing.T) {
+	// Args is called directly: with the id optional, cmd.Execute() would run
+	// PreRunE and start a real authentication flow.
 	cmd := Cmd()
-	cmd.SetArgs([]string{})
 
-	err := cmd.Execute()
-	require.Error(t, err)
+	require.NoError(t, cmd.Args(cmd, []string{"68b0c1d2e3f4a5b6c7d8e9f0"}))
+	require.NoError(t, cmd.Args(cmd, nil))
+	require.Error(t, cmd.Args(cmd, []string{"a", "b"}))
 }
 
 func TestCmd_InvalidOutputFormat(t *testing.T) {

--- a/cmd/workload/stop/cmd.go
+++ b/cmd/workload/stop/cmd.go
@@ -71,7 +71,7 @@ Example:
 
 			// Only an ambient target is confirmed: a typed id is the consent.
 			if ref.FromManifest() {
-				confirmed, err := idargs.Confirm(cmd, idargs.AmbientPrompt("Stop", ref))
+				confirmed, err := idargs.Confirm(cmd, idargs.AmbientPrompt("Stop", ref), idargs.EnvMayConsent)
 				if err != nil || !confirmed {
 					return err
 				}
@@ -100,9 +100,9 @@ Example:
 	idargs.AddDirFlag(cmd)
 	idargs.AddYesFlag(cmd, "Stop a manifest-named workload without confirmation.")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{
-			"workload_id":        ref.ID,
+			"workload_id":        idargs.TelemetryID(ref, args),
 			"workload_id_source": ref.Source,
 			"output_format":      string(outputFormat),
 		}

--- a/cmd/workload/stop/cmd.go
+++ b/cmd/workload/stop/cmd.go
@@ -17,6 +17,7 @@ package stop
 import (
 	"fmt"
 
+	"github.com/datarobot/cli/cmd/workload/internal/idargs"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -27,8 +28,10 @@ import (
 func Cmd() *cobra.Command {
 	var outputFormat outputformat.OutputFormat
 
+	var ref idargs.Ref
+
 	cmd := &cobra.Command{
-		Use:   "stop <workload-id>",
+		Use:   "stop [<workload-id>]",
 		Short: "Stop a workload.",
 		Long: `Stop a workload.
 
@@ -44,18 +47,39 @@ The acknowledgement message is printed on stdout. Use
 By default, output is human-readable. Use --output-format json for the
 full acknowledgement document.
 
+` + idargs.HelpText + `
+
+A workload named by the manifest rather than by you is confirmed
+first; pass --yes to skip that.
+
 Example:
+  dr workload stop
   dr workload stop 68b0c1d2e3f4a5b6c7d8e9f0
   dr workload stop 68b0c1d2e3f4a5b6c7d8e9f0 --output-format json`,
-		Args:         cobra.ExactArgs(1),
+		Args:         cobra.MaximumNArgs(1),
 		PreRunE:      auth.EnsureAuthenticatedE,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			resp, err := workload.StopWorkload(args[0])
+			var err error
+
+			ref, err = idargs.Resolve(cmd, args)
 			if err != nil {
 				return err
+			}
+
+			// Only an ambient target is confirmed: a typed id is the consent.
+			if ref.FromManifest() {
+				confirmed, err := idargs.Confirm(cmd, idargs.AmbientPrompt("Stop", ref))
+				if err != nil || !confirmed {
+					return err
+				}
+			}
+
+			resp, err := workload.StopWorkload(ref.ID)
+			if err != nil {
+				return ref.Wrap(err)
 			}
 
 			if err := workload.RenderWorkloadOperation(outputFormat, *resp); err != nil {
@@ -65,7 +89,7 @@ Example:
 			// The follow-up hint goes to stderr so script captures of stdout
 			// stay limited to the server's acknowledgement message.
 			if outputFormat == outputformat.OutputFormatText {
-				fmt.Fprintln(cmd.ErrOrStderr(), "Check progress with: dr workload status "+args[0])
+				fmt.Fprintln(cmd.ErrOrStderr(), "Check progress with: dr workload status "+ref.ID)
 			}
 
 			return nil
@@ -73,11 +97,14 @@ Example:
 	}
 
 	outputformat.AddFlag(cmd, &outputFormat)
+	idargs.AddDirFlag(cmd)
+	idargs.AddYesFlag(cmd, "Stop a manifest-named workload without confirmation.")
 
-	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
+	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{
-			"workload_id":   telemetry.FirstArg(args),
-			"output_format": string(outputFormat),
+			"workload_id":        ref.ID,
+			"workload_id_source": ref.Source,
+			"output_format":      string(outputFormat),
 		}
 	})
 

--- a/cmd/workload/stop/cmd_test.go
+++ b/cmd/workload/stop/cmd_test.go
@@ -21,12 +21,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCmd_RequiresArg(t *testing.T) {
+func TestCmd_ArgIsOptional(t *testing.T) {
+	// Args is called directly: with the id optional, cmd.Execute() would run
+	// PreRunE and start a real authentication flow.
 	cmd := Cmd()
-	cmd.SetArgs([]string{})
 
-	err := cmd.Execute()
-	require.Error(t, err)
+	require.NoError(t, cmd.Args(cmd, []string{"68b0c1d2e3f4a5b6c7d8e9f0"}))
+	require.NoError(t, cmd.Args(cmd, nil))
+	require.Error(t, cmd.Args(cmd, []string{"a", "b"}))
 }
 
 func TestCmd_InvalidOutputFormat(t *testing.T) {

--- a/cmd/workload/stop/confirm_test.go
+++ b/cmd/workload/stop/confirm_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stop
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/misc/reader"
+	"github.com/datarobot/cli/internal/testutil"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const boundID = "68b0c1d2e3f4a5b6c7d8e9f0"
+
+// A workload the user did not name is confirmed before it is stopped; one they
+// typed is not, because the id is the consent. Under go test stdin is never a
+// terminal, so an unanswered prompt surfaces as the non-interactive refusal.
+// `start` shares this code path.
+func TestCmd_ConfirmsOnlyAnAmbientWorkload(t *testing.T) {
+	for _, c := range []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "manifest-named waits to be asked", args: []string{}, wantErr: "confirmation required"},
+		{name: "--yes skips the question", args: []string{"--yes"}},
+		{name: "a typed id is never asked", args: []string{boundID}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv(reader.NonInteractiveEnv, "")
+
+			var (
+				mu     sync.Mutex
+				stops  int
+				server = func() *httptest.Server {
+					return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						mu.Lock()
+						stops++
+						mu.Unlock()
+
+						fmt.Fprint(w, `{"status":"stopping","workloadId":"`+boundID+`"}`)
+					}))
+				}()
+			)
+
+			t.Cleanup(server.Close)
+
+			viperx.Set(config.DataRobotURL, server.URL)
+			viperx.Set(config.DataRobotAPIKey, "test-token")
+			viperx.Set(config.SkipAuthKey, true)
+
+			t.Cleanup(viperx.Reset)
+
+			home := t.TempDir()
+			testutil.SetTestHomeDir(t, home)
+
+			dir := filepath.Join(home, "proj")
+			require.NoError(t, os.MkdirAll(dir, 0o750))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, manifest.FileName),
+				[]byte("workloadId: "+boundID+"\nname: my-app\n"), 0o600))
+			t.Chdir(dir)
+
+			cmd := Cmd()
+			cmd.SetArgs(c.args)
+
+			err := cmd.Execute()
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if c.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), c.wantErr)
+				assert.Zero(t, stops, "nothing may be stopped before the question is answered")
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, 1, stops)
+		})
+	}
+}

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -22,15 +22,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/datarobot/cli/cmd/internal/pollflags"
+	"github.com/datarobot/cli/cmd/workload/internal/idargs"
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config/viperx"
-	"github.com/datarobot/cli/internal/fsutil"
 	"github.com/datarobot/cli/internal/misc/reader"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -263,20 +262,7 @@ func run(cmd *cobra.Command, f flags, poll pollflags.Set, format outputformat.Ou
 // the two commands are printed at each other often enough that answering it
 // differently is its own small confusion.
 func resolveDir(dir string) (string, error) {
-	if dir != "" {
-		if !fsutil.DirExists(dir) {
-			return "", fmt.Errorf("--dir %s: %w", dir, manifest.ErrNotADirectory)
-		}
-
-		return dir, nil
-	}
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("cannot determine the current directory: %w", err)
-	}
-
-	return cwd, nil
+	return idargs.ProjectDir(dir)
 }
 
 // checkFlags refuses what the flags cannot mean.
@@ -506,11 +492,13 @@ func draftWarning(w io.Writer, draft, planned bool) {
 //
 // The commands carry no id. A successful deploy leaves the manifest bound, so
 // they resolve from the project directory, and --dir carries a deploy that ran
-// somewhere else. A failed run is the exception: one of its shapes is a
-// workload created whose id could not be written back, where the binding the
-// bare commands need is exactly what is missing, so the id is named above them
-// instead. That also keeps reportable's promise that a deploy which failed
-// late is still findable.
+// somewhere else.
+//
+// A failed run is the exception, and takes the id instead. One of its shapes
+// is a workload created whose id could not be written back, where the binding
+// the bare commands need is exactly what is missing; printing them bare would
+// hand the reader three commands that cannot run. It is also what keeps
+// reportable's promise that a deploy which failed late is still findable.
 //
 // A draft deploy trades the stop line for --lock, and puts it first so it sits
 // directly under the warning that explains why it is there. Someone who wants
@@ -523,9 +511,8 @@ func nextSteps(w io.Writer, result up.Result, dir string, draft, failed bool) {
 	}
 
 	at := manifest.DirFlag(dir)
-
 	if failed {
-		fmt.Fprintf(w, "\n%s\n", tui.HintStyle.Render("Workload: "+result.WorkloadID))
+		at = " " + result.WorkloadID
 	}
 
 	steps := [][2]string{
@@ -533,9 +520,13 @@ func nextSteps(w io.Writer, result up.Result, dir string, draft, failed bool) {
 		{"dr workload status" + at, "Check the workload status"},
 	}
 
-	if draft {
+	// --lock takes no id, so on a failed run it is the one line that cannot be
+	// made to name the workload. That is also the run where the manifest may
+	// hold no binding, which would make it create a second workload instead of
+	// locking this one, so it is left out rather than printed unrunnable.
+	if draft && !failed {
 		steps = append([][2]string{
-			{"dr workload up --lock" + at, "Lock the artifact to make it permanent"},
+			{"dr workload up --lock" + manifest.DirFlag(dir), "Lock the artifact to make it permanent"},
 		}, steps...)
 	} else {
 		steps = append(steps,

--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -449,7 +449,7 @@ func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, resul
 	}
 
 	draftWarning(cmd.ErrOrStderr(), draft, false)
-	nextSteps(cmd.ErrOrStderr(), result, draft)
+	nextSteps(cmd.ErrOrStderr(), result, f.dir, draft, failed)
 
 	return nil
 }
@@ -504,28 +504,42 @@ func draftWarning(w io.Writer, draft, planned bool) {
 // run that produced no workload: a list of commands that need an id is no help
 // to someone who has not got one.
 //
+// The commands carry no id. A successful deploy leaves the manifest bound, so
+// they resolve from the project directory, and --dir carries a deploy that ran
+// somewhere else. A failed run is the exception: one of its shapes is a
+// workload created whose id could not be written back, where the binding the
+// bare commands need is exactly what is missing, so the id is named above them
+// instead. That also keeps reportable's promise that a deploy which failed
+// late is still findable.
+//
 // A draft deploy trades the stop line for --lock, and puts it first so it sits
 // directly under the warning that explains why it is there. Someone who wants
 // to switch a workload off goes looking for the command; someone whose
 // workload switches itself off does not know there is anything to look for,
 // and this list is the one place they will read either way.
-func nextSteps(w io.Writer, result up.Result, draft bool) {
+func nextSteps(w io.Writer, result up.Result, dir string, draft, failed bool) {
 	if result.WorkloadID == "" {
 		return
 	}
 
+	at := manifest.DirFlag(dir)
+
+	if failed {
+		fmt.Fprintf(w, "\n%s\n", tui.HintStyle.Render("Workload: "+result.WorkloadID))
+	}
+
 	steps := [][2]string{
-		{"dr workload logs " + result.WorkloadID, "View the container logs"},
-		{"dr workload status " + result.WorkloadID, "Check the workload status"},
+		{"dr workload logs" + at, "View the container logs"},
+		{"dr workload status" + at, "Check the workload status"},
 	}
 
 	if draft {
 		steps = append([][2]string{
-			{"dr workload up --lock", "Lock the artifact to make it permanent"},
+			{"dr workload up --lock" + at, "Lock the artifact to make it permanent"},
 		}, steps...)
 	} else {
 		steps = append(steps,
-			[2]string{"dr workload stop " + result.WorkloadID, "Stop the workload, retaining its version"})
+			[2]string{"dr workload stop" + at, "Stop the workload, retaining its version"})
 	}
 
 	// No build-logs line. It needs an artifact id as well as a build id, and

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -661,3 +661,26 @@ func TestCmd_FailedRunStillNamesTheWorkload(t *testing.T) {
 
 	assert.Contains(t, stderr, "68b0c1d2e3f4a5b6c7d8e9f0")
 }
+
+// --lock takes no id, so on a failed run it cannot be made to name the
+// workload, and that is the run whose manifest may hold no binding. Printed
+// bare it would create a second workload instead of locking this one.
+func TestCmd_FailedDraftRunOmitsTheLockLine(t *testing.T) {
+	result := deployed()
+	result.Action = up.ActionStarted
+
+	stubRun(t, result, errors.New("id could not be written"))
+
+	_, stderr, err := runCmd(t)
+	require.Error(t, err)
+
+	_, next, found := strings.Cut(stderr, "Next:")
+	require.True(t, found)
+
+	// Scoped to the block: the draft warning above it names the same command
+	// as prose, and says the same thing on the successful runs where it is
+	// sound. This is about the copy-and-run list.
+	assert.NotContains(t, next, "--lock")
+	assert.Contains(t, next, "dr workload logs 68b0c1d2e3f4a5b6c7d8e9f0",
+		"the lines that can name the workload still do")
+}

--- a/cmd/workload/up/cmd_test.go
+++ b/cmd/workload/up/cmd_test.go
@@ -492,8 +492,8 @@ func TestCmd_DraftDeployTradesStopForLock(t *testing.T) {
 
 	assert.Contains(t, stderr, "dr workload up --lock")
 	assert.NotContains(t, stderr, "dr workload stop")
-	assert.Contains(t, stderr, "dr workload logs 68b0c1d2e3f4a5b6c7d8e9f0", "the other two lines stay")
-	assert.Contains(t, stderr, "dr workload status 68b0c1d2e3f4a5b6c7d8e9f0")
+	assert.Contains(t, stderr, "dr workload logs", "the other two lines stay")
+	assert.Contains(t, stderr, "dr workload status")
 }
 
 // A locked artifact is permanent, so there is nothing to warn about and the
@@ -509,7 +509,7 @@ func TestCmd_LockedDeploySaysNothingExtra(t *testing.T) {
 
 	assert.False(t, draftWarned(stderr))
 	assert.NotContains(t, stderr, "dr workload up --lock")
-	assert.Contains(t, stderr, "dr workload stop 68b0c1d2e3f4a5b6c7d8e9f0")
+	assert.Contains(t, stderr, "dr workload stop")
 }
 
 // A --lock run is the remedy, so telling it about drafts would be telling it
@@ -620,4 +620,44 @@ func TestCmd_IsRegisteredUnderWorkload(t *testing.T) {
 	assert.NotNil(t, cmd.Flags().Lookup("detach"))
 	assert.NotNil(t, cmd.Flags().Lookup("lock"))
 	assert.True(t, cmd.Flags().Lookup("poll-interval").Hidden)
+}
+
+// The commands are runnable as printed from the project that was just
+// deployed, which is the whole point of dropping the id from them.
+func TestCmd_NextStepsCarryNoID(t *testing.T) {
+	stubRun(t, deployed(), nil)
+
+	_, stderr, err := runCmd(t)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "dr workload logs  ")
+	assert.NotContains(t, stderr, "dr workload logs 68b0c1d2e3f4a5b6c7d8e9f0")
+}
+
+// A deploy that ran elsewhere needs the flag that reaches it, because the
+// manifest search only walks upward.
+func TestCmd_NextStepsCarryDirWhenTheDeployDid(t *testing.T) {
+	stubRun(t, deployed(), nil)
+
+	dir := t.TempDir()
+
+	_, stderr, err := runCmd(t, "--dir", dir)
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "dr workload logs --dir "+dir)
+	assert.Contains(t, stderr, "dr workload up --lock --dir "+dir,
+		"every line in the block has to run as printed, --lock included")
+}
+
+// The one shape where bare commands would not resolve: a workload was created
+// but its id could not be written back, so the manifest holds no binding. The
+// id is named instead, because a deploy that failed late still has to be
+// findable.
+func TestCmd_FailedRunStillNamesTheWorkload(t *testing.T) {
+	stubRun(t, deployed(), errors.New("id could not be written"))
+
+	_, stderr, err := runCmd(t)
+	require.Error(t, err)
+
+	assert.Contains(t, stderr, "68b0c1d2e3f4a5b6c7d8e9f0")
 }

--- a/docs/commands/workload.md
+++ b/docs/commands/workload.md
@@ -174,7 +174,7 @@ dr workload stop  <workload-id> [--output-format text|json]
 Print a workload's current status as a bare value (for example `running`), so it drops straight into scripts. An `errored` status is a valid answer, so the command still exits `0`. Use `dr workload get` for the full document.
 
 ```bash
-dr workload status <workload-id> [--output-format text|json]
+dr workload status [<workload-id>] [--dir <path>] [--output-format text|json]
 ```
 
 ### `endpoint`
@@ -187,12 +187,16 @@ curl "$(dr workload endpoint <workload-id>)health"
 
 The command fails when the workload has no endpoint URL yet.
 
+```bash
+dr workload endpoint [<workload-id>] [--dir <path>]
+```
+
 ### `logs`
 
 Show the application logs from a workload's containers. By default it prints the most recent `--limit` lines oldest-first, like `kubectl logs --tail`. Use `--level` to drop everything below a severity, and `--follow` (`-f`) to keep streaming new lines as they arrive (Ctrl-C to stop).
 
 ```bash
-dr workload logs <workload-id> [--limit N] [--level <level>] [--follow] [--output-format text|json]
+dr workload logs [<workload-id>] [--dir <path>] [--limit N] [--level <level>] [--follow] [--output-format text|json]
 ```
 
 **Flags:**
@@ -201,6 +205,24 @@ dr workload logs <workload-id> [--limit N] [--level <level>] [--follow] [--outpu
 - `--level <level>`: minimum level to show (`debug`, `info`, `warn`, `warning`, `error`, `critical`). Empty keeps every line.
 - `--follow`, `-f`: stream new lines as they arrive.
 - `--output-format <text|json>`: output format. Defaults to `text`. With `--follow`, JSON is emitted as one object per line (JSON Lines).
+
+## Working in a project directory
+
+Every command that takes a `<workload-id>` can leave it out inside a project that `dr workload up` has deployed. The id is read from the `workloadId` in the nearest `.datarobot.yaml`, searched upward from `--dir` (the current directory by default), and the command says on stderr which workload it picked:
+
+```bash
+cd my-app
+dr workload status          # instead of dr workload status 68b0c1d2e3f4a5b6c7d8e9f0
+dr workload logs --follow
+```
+
+A typed id always wins over the manifest. `--dir` is what reaches a project the current directory cannot see, because the search only walks upward:
+
+```bash
+dr workload logs --dir site   # the project deployed with 'dr workload up --dir site'
+```
+
+Because `stop`, `start` and `delete` change something, they ask for confirmation when the id came from a manifest rather than from you. Pass `--yes` (or set `DATAROBOT_CLI_NON_INTERACTIVE=1`) to skip the prompt in a script. A typed id is never prompted.
 
 ## Shared flags
 

--- a/docs/commands/workload.md
+++ b/docs/commands/workload.md
@@ -124,7 +124,7 @@ To define the artifact in the same call instead of referencing one, replace `art
 Show a single workload: name, status, endpoint, artifact, and timestamps.
 
 ```bash
-dr workload get <workload-id> [--output-format text|json]
+dr workload get [<workload-id>] [--dir <path>] [--output-format text|json]
 ```
 
 ### `list`
@@ -146,13 +146,13 @@ dr workload list [--status <status>] [--limit N] [--output-format text|json]
 Delete a workload by id. A running workload is stopped first and then removed. The artifact it was created from is not deleted. You are asked to confirm unless `--yes` is set.
 
 ```bash
-dr workload delete <workload-id> [--yes] [--dir <path>]
+dr workload delete [<workload-id>] [--dir <path>] [--yes]
 ```
 
 **Flags:**
 
-- `--yes`, `-y`: skip the confirmation prompt. Also honored via `DATAROBOT_CLI_NON_INTERACTIVE=1`.
-- `--dir <path>`: project directory whose manifest holds the binding, searched upward from there. Defaults to the current directory. Pass the same value you deployed with, since a manifest in a subdirectory is not visible from its parent.
+- `--yes`, `-y`: skip the confirmation prompt. `DATAROBOT_CLI_NON_INTERACTIVE=1` stands in for it only when you passed the workload id; a workload named by the manifest takes the explicit flag.
+- `--dir <path>`: project directory whose `.datarobot.yaml` names the workload, and holds the binding to clear, searched upward from there. Defaults to the current directory. Pass the same value you deployed with, since a manifest in a subdirectory is not visible from its parent.
 
 If the manifest found from `--dir` is bound to the workload just deleted, the `workloadId` line the CLI wrote is removed with it, so the next `dr workload up` creates a new workload instead of pointing at one that is gone. Only a manifest naming that exact id is touched. The artifact link under `.datarobot/` is left alone, because the artifact itself survives the deletion. The command names the artifact so the link is not left invisible, and names the state directory to remove if you want to unlink from it. These notes go to stderr, so stdout stays the command's result.
 
@@ -165,9 +165,11 @@ A workload that was already gone before the command ran is reported, and the bin
 Start a stopped workload, or stop a running one. Both are asynchronous: the server acknowledges the request and the workload transitions in the background. Each is a no-op if the workload is already in the target state.
 
 ```bash
-dr workload start <workload-id> [--output-format text|json]
-dr workload stop  <workload-id> [--output-format text|json]
+dr workload start [<workload-id>] [--dir <path>] [--yes] [--output-format text|json]
+dr workload stop  [<workload-id>] [--dir <path>] [--yes] [--output-format text|json]
 ```
+
+A workload named by the manifest rather than by you is confirmed first; `--yes` (or `DATAROBOT_CLI_NON_INTERACTIVE=1`) skips the question. A typed id is never questioned.
 
 ### `status`
 
@@ -222,7 +224,9 @@ A typed id always wins over the manifest. `--dir` is what reaches a project the 
 dr workload logs --dir site   # the project deployed with 'dr workload up --dir site'
 ```
 
-Because `stop`, `start` and `delete` change something, they ask for confirmation when the id came from a manifest rather than from you. Pass `--yes` (or set `DATAROBOT_CLI_NON_INTERACTIVE=1`) to skip the prompt in a script. A typed id is never prompted.
+Because `stop`, `start` and `delete` change something, they ask for confirmation when the id came from a manifest rather than from you. Pass `--yes` to skip the prompt in a script; a typed id is never prompted.
+
+`stop` and `start` also accept `DATAROBOT_CLI_NON_INTERACTIVE=1` in place of `--yes`. `delete` does not, when the workload came from a manifest: that variable is usually set once across a whole CI pipeline, and deleting something nobody named is not what it was set for. Pass `--yes` explicitly there.
 
 ## Shared flags
 

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -432,7 +432,7 @@ func TestRun_WizardRedirectIsFollowed(t *testing.T) {
 			return wizard.Result{Path: manifest.Path(app)}, nil
 		},
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 		writeID: func(path, _ string) error {


### PR DESCRIPTION
# RATIONALE

`dr workload up` ends by printing what to run next, with the workload id pasted into every line. Standing in the project directory that just deployed, you had to type that id back. The binding is already on disk, and `up` itself refuses `--workload-id` because the manifest is where that lives, but every other subcommand demanded it.

Closes RAPTOR-19529.

## CHANGES

The id is now optional on all seven subcommands that take one: `logs`, `status`, `stop`, `get`, `endpoint`, `start`, `delete`. Omitted, it is read from the `workloadId` in the nearest `.datarobot.yaml`, searched upward from a new `--dir` flag.

- A typed id still wins, and is used **without reading any manifest**, so a broken or foreign one nearby cannot fail a command that was told which workload it means.
- The workload picked for you is named on stderr, except under `--output-format json`, where anything on stderr would break `2>&1 | jq .`.
- `stop`, `start` and `delete` confirm a workload named by the manifest rather than by you; `--yes` skips it. A typed id is never questioned, because the id is the consent. `delete` keeps asking either way, as it already did.
- `up` no longer pastes the id into its Next block. The lines print as they can be typed, carrying `--dir` when the deploy did. A run that failed after creating the workload names the id above them, since that is the one case where the manifest holds no binding to resolve.

Resolution parses the manifest but never validates it: the ledger has no rule about `workloadId`, and `logs` is what you reach for when a project is broken.

Comments are deliberately terser than this package's usual style.

## TESTING

`task lint` clean on linux, darwin and windows; `go test -race -shuffle=on ./...` green.

Verified against staging with real deployments: full `up` → `stop` → `start` → `lock` → `delete` cycle; resolution from the project root, a subdirectory and the parent with `--dir`; JSON purity; a deploy onto a stopped workload to check against RAPTOR-19686; and the confirmation prompt driven through a real pty, where declining leaves the workload running and a typed id never prompts.

Staging caught two bugs the unit tests missed, both now fixed with regression tests: `dr workload status "$UNSET_VAR"` resolved from the manifest instead of failing loudly, and `up --lock` was the one Next-block line that would not run as printed under `--dir`.

## NOTES

`--yes` on `stop` and `start` is new surface. It only gates an interactive prompt that never fires in automation, so it should not affect the IaC equivalence PBMP-7947 asks for, but flagging it.

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787770597.313409 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad CLI behavior change across read and mutating workload commands; manifest-based targeting plus new stop/start confirmation paths could affect scripts and automation if `--dir` or cwd resolution is wrong, though explicit ids and `--yes` mitigate destructive mistakes.
> 
> **Overview**
> Workload subcommands can omit the positional **workload id** and resolve it from the nearest **`.datarobot.yaml`** (`workloadId`), walking upward from **`--dir`** (default: cwd). A new **`cmd/workload/internal/idargs`** package centralizes **`--dir`**, shared help text, **`Resolve`**, stderr “using workload …” (suppressed for **`--output-format json`**), and **`Ref.Wrap`** for clearer 404/403 when the id came from a manifest.
> 
> **`status`**, **`get`**, **`endpoint`**, and **`logs`** use this resolution; **`delete`**, **`stop`**, and **`start`** do too. **`stop`**/**`start`** add **`--yes`** and prompt only when the target was manifest-chosen (typed ids skip the extra prompt; **`delete`** still always confirms). Telemetry records **`workload_id_source`**.
> 
> **`dr workload up`** “Next” hints no longer embed the id—they print runnable commands (with **`--dir`** when deploy used it); failed runs that created a workload without writing the manifest still print the id explicitly.
> 
> Docs and tests cover optional arity, end-to-end manifest resolution, JSON stderr silence, and stop confirmation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c52fe5bf86474c991606cbb44d4e275765a007b7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->