### PR TITLE
[RAPTOR-19527] fix(workload): wait for the new version to serve

### DIFF
--- a/internal/workload/logs.go
+++ b/internal/workload/logs.go
@@ -48,8 +48,10 @@ const followLagAllowance = 10 * time.Second
 // mode, which has no cursor to prune by, leans on the rotation itself.
 const followSeenCap = 50000
 
-// maxTransientPollErrors caps consecutive transient fetch failures a follow
-// tolerates before giving up; it resets on any successful poll.
+// maxTransientPollErrors caps consecutive transient fetch failures a poll loop
+// tolerates before giving up; it resets on any successful poll. Shared by the
+// log follow and by pollWorkload, which want the same answer for the same
+// reason: both run long enough for a blip to land mid-wait.
 const maxTransientPollErrors = 5
 
 // sleepInterval waits for interval or ctx cancellation, returning false when

--- a/internal/workload/poll.go
+++ b/internal/workload/poll.go
@@ -1,0 +1,44 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+// transientBudget is the "forgive a blip, not an outage" policy the long waits
+// in this package share: count consecutive transient failures, reset on any
+// success, give up once the run exceeds maxTransientPollErrors.
+//
+// It exists because the policy was being re-derived at each call site, with the
+// comparisons already drifting apart, and because the waits that grew long
+// enough to need it are exactly the ones where a silent retry is indistinct
+// from a hang.
+type transientBudget struct {
+	spent int
+}
+
+// forgive reports whether err is worth looking past. A caller that gets false
+// should return the error.
+func (b *transientBudget) forgive(err error) bool {
+	if !isTransientPollError(err) || b.spent >= maxTransientPollErrors {
+		return false
+	}
+
+	b.spent++
+
+	return true
+}
+
+// reset forgets the run so far, and is called on any poll that worked.
+func (b *transientBudget) reset() {
+	b.spent = 0
+}

--- a/internal/workload/proton.go
+++ b/internal/workload/proton.go
@@ -1,0 +1,268 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/drapi"
+)
+
+// Proton statuses observed live during a rolling replacement. An unrecognised
+// one is not assumed to mean anything.
+const (
+	ProtonStatusRunning  = "running"
+	ProtonStatusDraining = "draining"
+)
+
+// ProtonRoleActive marks the generation the platform considers to be serving;
+// the others carry no role. Sharper than "which one is running", since a
+// candidate runs for a while before it is promoted.
+const ProtonRoleActive = "active"
+
+// maxProtonPages bounds the next-link walk. A workload has one generation most
+// of the time and two during a replacement, so anything approaching this is a
+// route that is not ending rather than a workload that is unusually busy.
+const maxProtonPages = 20
+
+// Proton is one generation of a workload's running containers: the thing that
+// answers the endpoint. A workload has one most of the time and two during a
+// rolling replacement, the outgoing one in "draining". It is the only place the
+// platform says whether the previous version has stopped serving.
+type Proton struct {
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	WorkloadID string    `json:"workloadId"`
+	ArtifactID string    `json:"artifactId"`
+	Status     string    `json:"status"`
+	Role       string    `json:"role"`
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+}
+
+type protonList struct {
+	Data       []Proton `json:"data"`
+	Count      int      `json:"count"`
+	TotalCount int      `json:"totalCount"`
+	Next       string   `json:"next"`
+}
+
+// IsDrainingProtonStatus reports whether s is a generation on its way out that
+// is still answering requests.
+func IsDrainingProtonStatus(s string) bool {
+	return strings.EqualFold(s, ProtonStatusDraining)
+}
+
+// IsRunningProtonStatus reports whether s is serving and not on its way out.
+func IsRunningProtonStatus(s string) bool {
+	return strings.EqualFold(s, ProtonStatusRunning)
+}
+
+// IsActiveProtonRole reports whether r marks the serving generation.
+func IsActiveProtonRole(r string) bool {
+	return strings.EqualFold(r, ProtonRoleActive)
+}
+
+// ListProtons fetches the generations currently attached to a workload.
+//
+// It follows next-links like every other list in this package. A page-one-only
+// read would be worse here than elsewhere: the generation being replaced is the
+// oldest, so a truncated page can omit exactly the draining proton the wait
+// exists to see, and the wait would settle early with no error to show for it.
+//
+// The walk is bounded. It runs inside a poll predicate, which sits downstream
+// of the deadline check, so a cursor that points back at itself would spin
+// past --poll-timeout with no way out. Every other list here is bounded by a
+// caller-supplied limit; this one has no limit to pass, so it counts pages.
+//
+// A body carrying no recognisable list is an error rather than an empty one.
+// Decoding into protonList succeeds for any JSON object, so a route that
+// answers a different shape would otherwise read as "no generations" and settle
+// the wait silently, which is the one failure mode that looks exactly like
+// success.
+func ListProtons(workloadID string) ([]Proton, error) {
+	pageURL, err := config.GetEndpointURL("/api/v2/workloads/" + escapeID(workloadID) + "/protons/")
+	if err != nil {
+		return nil, err
+	}
+
+	var all []Proton
+
+	for page := 0; pageURL != ""; page++ {
+		if page >= maxProtonPages {
+			return nil, fmt.Errorf(
+				"proton list for workload %s did not end after %d pages; refusing to follow more",
+				workloadID, maxProtonPages)
+		}
+
+		var list protonList
+
+		if err := drapi.GetJSON(pageURL, "protons", &list); err != nil {
+			return nil, err
+		}
+
+		if list.Data == nil && list.TotalCount == 0 && list.Count == 0 {
+			return nil, fmt.Errorf("proton list for workload %s carried no data field", workloadID)
+		}
+
+		all = append(all, list.Data...)
+
+		if list.Next == "" {
+			break
+		}
+
+		if err := drapi.AssertNextOnSameHost(list.Next); err != nil {
+			return nil, err
+		}
+
+		pageURL = list.Next
+	}
+
+	return all, nil
+}
+
+// protonsServing reports whether the generation the caller waits for is the one
+// answering, and the one it replaced has stopped.
+//
+// This is what the workload document cannot answer. Measured live: at t+110s it
+// names the NEW artifact, the old generation starts draining and the new one is
+// marked active, yet the endpoint answers with the old build until t+171s; the
+// old generation only leaves draining at t+530s.
+//
+// A predecessor blocks the wait while it is running or draining, which are the
+// two states in which it was observed still answering. Both matter: at t+27s
+// both generations were running and the endpoint was still on the old build.
+// Anything past those is treated as gone, because an outgoing generation sits
+// in stopping long after it stopped mattering and waiting for the list to empty
+// would hold a finished deploy open for minutes.
+//
+// Known limitation: a predecessor status this code has not seen is read as
+// gone. The alternative, blocking on anything unrecognised, trades a rare early
+// exit for a deploy that hangs to its timeout on a status the platform added.
+//
+// Without an artifact named, which is a resize, both generations share one and
+// draining is the only thing that tells them apart. An empty list settles that
+// case rather than blocking, so a cluster whose route answers differently does
+// not hang; with an artifact named it does not, since an empty list is also
+// what the gap between one generation being collected and the next appearing
+// looks like.
+func protonsServing(protons []Proton, want Serving) protonVerdict {
+	if len(protons) == 0 {
+		// An empty list is two things at once: a route with nothing to say,
+		// and the blink between one generation being collected and the next
+		// being listed. With an artifact named the second reading matters, so
+		// it is reported as unresolved rather than settled, and the caller
+		// gives it a bounded number of polls to resolve before accepting it.
+		return protonVerdict{Serving: want.ArtifactID == "", Empty: true}
+	}
+
+	if want.AwaitDrain && anyServingPredecessor(protons, want.ArtifactID) {
+		return protonVerdict{}
+	}
+
+	if want.ArtifactID == "" {
+		return protonVerdict{Serving: true}
+	}
+
+	// The platform's own answer, when it gives one.
+	if at := activeProtonIndex(protons); at >= 0 {
+		active := protons[at]
+
+		return protonVerdict{
+			Serving: active.ArtifactID == want.ArtifactID && IsRunningProtonStatus(active.Status),
+		}
+	}
+
+	// No role reported, so fall back to whether anything runs the version.
+	return protonVerdict{Serving: anyRunning(protons, want.ArtifactID)}
+}
+
+// protonVerdict is what the proton list said. Empty separates "the list is
+// there and the handover is not done" from "the list said nothing at all",
+// which are the same answer to the wait and different answers to how long it
+// is worth waiting.
+type protonVerdict struct {
+	Serving bool
+	Empty   bool
+}
+
+// anyServingPredecessor reports whether a generation other than the one being
+// waited for is still taking requests.
+//
+// Draining and running both count. Measured at t+27s of a rollout, both
+// generations were running and the endpoint was still on the old build, so
+// treating running as settled would return before the handover.
+//
+// The successor is identified by artifact when one is named, and otherwise by
+// the active role, which is what makes this work for a resize: a resize
+// replaces a workload with itself, so both generations carry the same artifact
+// and only the role separates them. On an install that reports no role, a
+// resize falls back to draining alone, since there is then nothing to tell a
+// predecessor from its replacement.
+func anyServingPredecessor(protons []Proton, wantArtifactID string) bool {
+	// By index, not by id. Identifying the successor by Proton.ID would treat
+	// every generation as the successor on any response that omits the field.
+	activeAt := activeProtonIndex(protons)
+
+	for i := range protons {
+		p := &protons[i]
+
+		if wantArtifactID != "" && p.ArtifactID == wantArtifactID {
+			continue
+		}
+
+		if i == activeAt {
+			continue
+		}
+
+		if IsDrainingProtonStatus(p.Status) {
+			return true
+		}
+
+		// Running only counts as a predecessor once something identifies the
+		// successor, or every generation would look like one.
+		if IsRunningProtonStatus(p.Status) && (wantArtifactID != "" || activeAt >= 0) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// activeProtonIndex is where the generation marked as serving sits, or -1 when
+// none is marked.
+func activeProtonIndex(protons []Proton) int {
+	for i := range protons {
+		if IsActiveProtonRole(protons[i].Role) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// anyRunning reports whether some generation runs wantArtifactID.
+func anyRunning(protons []Proton, wantArtifactID string) bool {
+	for i := range protons {
+		if protons[i].ArtifactID == wantArtifactID && IsRunningProtonStatus(protons[i].Status) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/workload/proton_test.go
+++ b/internal/workload/proton_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtonsServing(t *testing.T) {
+	running := func(a string) Proton { return Proton{ArtifactID: a, Status: ProtonStatusRunning} }
+	draining := func(a string) Proton { return Proton{ArtifactID: a, Status: ProtonStatusDraining} }
+	active := func(a string) Proton {
+		return Proton{ArtifactID: a, Status: ProtonStatusRunning, Role: ProtonRoleActive}
+	}
+	roll := func(a string) Serving { return Serving{ArtifactID: a, AwaitDrain: true} }
+
+	cases := []struct {
+		name    string
+		protons []Proton
+		want    Serving
+		serving bool
+	}{
+		{
+			// An empty list is also the blink between one generation being
+			// collected and the next being listed.
+			"an empty list does not confirm an artifact nobody is running",
+			nil, roll("art-2"), false,
+		},
+		{"an empty list settles a wait with nothing to look for", nil, Serving{}, true},
+		{"the new generation alone", []Proton{running("art-2")}, roll("art-2"), true},
+		{
+			"the previous generation still draining",
+			[]Proton{running("art-2"), draining("art-1")},
+			roll("art-2"), false,
+		},
+		{
+			// Measured at t+27s: both generations running, endpoint still on
+			// the old build. Draining is not the only way a predecessor serves.
+			"the previous generation still running",
+			[]Proton{active("art-2"), running("art-1")},
+			roll("art-2"), false,
+		},
+		{
+			// The endpoint has already moved on by the time an outgoing
+			// generation reaches stopping, and it sits there long after.
+			"a previous generation past draining does not hold the wait",
+			[]Proton{running("art-2"), {ArtifactID: "art-1", Status: "stopping"}},
+			roll("art-2"), true,
+		},
+		{
+			"drained away with nothing to replace it",
+			[]Proton{{ArtifactID: "art-1", Status: "stopping"}},
+			roll("art-2"), false,
+		},
+		{
+			"a resize waits out a drain it cannot tell apart by artifact",
+			[]Proton{running("art-1"), draining("art-1")},
+			Serving{AwaitDrain: true},
+			false,
+		},
+		{
+			// A create and a start replace no generation, so a leftover drain
+			// from an earlier rollout must not hold them up.
+			"a create ignores a draining generation entirely",
+			[]Proton{running("art-1"), draining("art-1")},
+			Serving{},
+			true,
+		},
+		{
+			// A candidate runs for a while before it is promoted.
+			"a running candidate is not a promoted one",
+			[]Proton{active("art-1"), running("art-2")},
+			roll("art-2"), false,
+		},
+		{
+			"promoted, and the role says so",
+			[]Proton{active("art-2"), {ArtifactID: "art-1", Status: "stopping"}},
+			roll("art-2"), true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.serving, protonsServing(c.protons, c.want).Serving)
+		})
+	}
+}
+
+func TestListProtons_ParsesTheList(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/workloads/wl-1/protons/", r.URL.Path)
+		fmt.Fprint(w, serverProtonList(
+			[2]string{"art-2", ProtonStatusRunning},
+			[2]string{"art-1", ProtonStatusDraining},
+		))
+	}))
+
+	protons, err := ListProtons("wl-1")
+	require.NoError(t, err)
+	require.Len(t, protons, 2)
+	assert.Equal(t, "art-2", protons[0].ArtifactID)
+	assert.Equal(t, ProtonStatusDraining, protons[1].Status)
+	assert.Equal(t, "wl-1", protons[0].WorkloadID)
+}
+
+// The generation being replaced is the oldest, so a page-one-only read can omit
+// exactly the draining proton the wait exists to see.
+func TestListProtons_FollowsNextLinks(t *testing.T) {
+	var srv *httptest.Server
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/workloads/wl-1/protons/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") == "2" {
+			fmt.Fprint(w, serverProtonList([2]string{"art-1", ProtonStatusDraining}))
+
+			return
+		}
+
+		fmt.Fprintf(w, `{"count":1,"totalCount":2,"next":%q,"data":[%s]}`,
+			srv.URL+"/api/v2/workloads/wl-1/protons/?page=2",
+			`{"id":"p1","artifactId":"art-2","status":"running"}`)
+	})
+
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	installSkipAuth(t)
+	installEndpoint(t, srv.URL)
+
+	protons, err := ListProtons("wl-1")
+	require.NoError(t, err)
+	require.Len(t, protons, 2)
+	assert.Equal(t, ProtonStatusDraining, protons[1].Status, "the second page carries the outgoing generation")
+}
+
+// Decoding into protonList succeeds for any JSON object, so a route answering a
+// different shape would read as "no generations" and settle the wait silently.
+func TestListProtons_RefusesABodyWithNoList(t *testing.T) {
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"protons":[{"id":"p1"}]}`)
+	}))
+
+	_, err := ListProtons("wl-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no data field")
+}
+
+// This walk runs inside a poll predicate, which sits downstream of the deadline
+// check, so a cursor that points at itself would spin past --poll-timeout with
+// no way out but Ctrl-C.
+func TestListProtons_RefusesAnEndlessCursor(t *testing.T) {
+	var srv *httptest.Server
+
+	var hits int32
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/workloads/wl-1/protons/", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		fmt.Fprintf(w, `{"count":1,"totalCount":9,"next":%q,"data":[%s]}`,
+			srv.URL+"/api/v2/workloads/wl-1/protons/",
+			`{"id":"p1","artifactId":"art-2","status":"running"}`)
+	})
+
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	installSkipAuth(t)
+	installEndpoint(t, srv.URL)
+
+	_, err := ListProtons("wl-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not end")
+	assert.LessOrEqual(t, atomic.LoadInt32(&hits), int32(maxProtonPages))
+}

--- a/internal/workload/replacement.go
+++ b/internal/workload/replacement.go
@@ -42,18 +42,10 @@ import (
 // WaitForReplacement reports the rollout as a success. That "errored" had to be
 // added at all is proof the vocabulary was incomplete once already.
 //
-// A roll no longer rests on this. The deploy confirms after the fact which
-// artifact the workload ended up running, so a rollout this file mistook for a
-// success is caught by the wait that follows it rather than reported as one.
-// See WaitForWorkload's wantArtifactID.
-//
-// A resize still does rest on it, and that is the limitation that remains.
-// Applying new sizing replaces the workload with itself on the artifact it is
-// already running, so there is no artifact change for anything downstream to
-// confirm, and the record's own status is the only account of how it went. The
-// only other candidate signal is the runtime block converging on what was sent,
-// which cannot be trusted without knowing how the platform normalises it:
-// guessing there would trade a rare false success for a routine false failure.
+// A roll no longer rests on this: the deploy confirms afterwards which artifact
+// the workload ended up running (see WaitForWorkload). A resize has no artifact
+// change to confirm, and is covered instead by that same wait refusing to
+// settle while a generation is still draining.
 const (
 	ReplacementStatusCompleted = "completed"
 	ReplacementStatusFailed    = "failed"
@@ -333,7 +325,10 @@ func confirmWorkloadExists(workloadID string) error {
 //   - the settled replacement and an error, when it failed, so the caller can
 //     still show what happened
 //   - the last-seen replacement and an error, on timeout, for the same reason
-//   - nil and an error, when a poll failed or nothing was ever active
+//   - the last-seen replacement and an error, when polling failed; that is the
+//     seed when nothing was ever observed, so its status is what StartReplacement
+//     answered rather than anything this wait saw
+//   - nil and an error, when nothing was ever active
 //
 // The two 404 cases mean opposite things, which is why this is not a plain
 // poll loop. Seen after a status, a 404 means the platform settled the
@@ -342,14 +337,10 @@ func confirmWorkloadExists(workloadID string) error {
 // fast rollout before the first poll landed; passing started is what lets the
 // wait tell those from each other.
 //
-// A 404 that arrives before any record has been watched has to earn its
-// meaning, because the first poll fires immediately after the POST that created
-// the record and a route that has not caught up yet answers exactly the same
-// way as one whose rollout is over. Believing it at once turned a swap that had
-// barely started into a wait that returned in no time at all, reporting a
-// rollout as finished while the endpoint went on serving the previous version
-// for as long as the swap really took. So an unwatched absence is counted
-// rather than acted on, and only a run of them settles the wait.
+// A 404 before any record has been watched has to earn its meaning: the first
+// poll fires immediately after the POST, and a route that has not caught up
+// answers exactly like one whose rollout is over, so it is counted rather than
+// acted on.
 //
 // A settled rollout does not guarantee a terminal Status on the way out. When
 // the record is collected before the first poll lands, the seed is the only
@@ -368,62 +359,85 @@ func WaitForReplacement(
 	}
 
 	deadline := time.Now().Add(timeout)
-
-	var (
-		lastSeen = started
-		watched  bool
-		absences int
-	)
+	wait := &replacementWait{workloadID: workloadID, lastSeen: started, onTick: onTick}
 
 	for {
-		replacement, err := GetActiveReplacement(workloadID)
-		if err != nil {
-			return nil, fmt.Errorf("poll replacement for workload %s: %w", workloadID, err)
-		}
-
-		switch {
-		case replacement != nil:
-			watched = true
-			absences = 0
-			lastSeen = replacement
-
-			if onTick != nil {
-				onTick(replacement)
-			}
-
-			if IsTerminalReplacementStatus(replacement.Status) {
-				return replacement, terminalReplacementErr(workloadID, replacement.Status)
-			}
-
-		default:
-			absences++
-
-			settled, done, err := absenceMeans(workloadID, lastSeen, watched, absences)
-			if done {
-				return settled, err
-			}
+		done, err := wait.step()
+		if done {
+			return wait.lastSeen, err
 		}
 
 		if time.Now().After(deadline) {
-			return lastSeen, fmt.Errorf("timeout waiting for replacement on workload %s after %s", workloadID, timeout)
+			return wait.lastSeen, timedOut(workloadID, timeout)
 		}
 
 		time.Sleep(interval)
 	}
 }
 
-// absenceMeans reads a 404 off the replacement route, which says three
-// different things depending on what the wait has seen before it.
-//
-// With nothing seen and nothing seeded, the caller asked to follow a rollout
-// that is not running: only reachable when started was nil, since lastSeen
-// begins as started, so this is the attach path. Gone after having been
-// watched is the platform collecting a rollout it has finished with, which is
-// the answer. Gone without ever having been watched is the ambiguous one, and
-// it settles the wait only once it has held for uncorroboratedAbsences polls.
-//
-// done reports whether the wait is over; when it is false the replacement is
-// nil and the caller polls again.
+// replacementWait is one wait's state, held together so the loop above stays a
+// loop and the decisions live in step.
+type replacementWait struct {
+	workloadID string
+	lastSeen   *Replacement
+	onTick     func(*Replacement)
+	watched    bool
+	absences   int
+	budget     transientBudget
+}
+
+// step polls once and reports whether the wait is over, with the error to
+// return when it is.
+func (w *replacementWait) step() (bool, error) {
+	replacement, err := GetActiveReplacement(w.workloadID)
+	if err != nil {
+		// A roll now spends minutes on this route, which is long enough for
+		// one 502 or one dropped connection to land between healthy polls, and
+		// failing there leaves the swap in flight with the deploy reporting
+		// failure.
+		if w.budget.forgive(err) {
+			return false, nil
+		}
+
+		return true, fmt.Errorf("poll replacement for workload %s: %w", w.workloadID, err)
+	}
+
+	w.budget.reset()
+
+	if replacement == nil {
+		w.absences++
+
+		settled, done, absenceErr := absenceMeans(w.workloadID, w.lastSeen, w.watched, w.absences)
+		w.lastSeen = settled
+
+		return done, absenceErr
+	}
+
+	w.watched = true
+	w.absences = 0
+	w.lastSeen = replacement
+
+	if w.onTick != nil {
+		w.onTick(replacement)
+	}
+
+	if !IsTerminalReplacementStatus(replacement.Status) {
+		return false, nil
+	}
+
+	return true, terminalReplacementErr(w.workloadID, replacement.Status)
+}
+
+// timedOut is the deadline error, spelled once because two paths reach it.
+func timedOut(workloadID string, timeout time.Duration) error {
+	return fmt.Errorf("timeout waiting for replacement on workload %s after %s", workloadID, timeout)
+}
+
+// absenceMeans reads a 404 off the replacement route, which says three things
+// depending on what the wait has seen: nothing seen and nothing seeded is the
+// attach path, gone after being watched is a finished rollout, and gone without
+// ever being watched settles only after uncorroboratedAbsences. done reports
+// whether the wait is over.
 func absenceMeans(workloadID string, lastSeen *Replacement, watched bool, absences int) (*Replacement, bool, error) {
 	switch {
 	case lastSeen == nil:
@@ -433,18 +447,13 @@ func absenceMeans(workloadID string, lastSeen *Replacement, watched bool, absenc
 		return lastSeen, true, nil
 
 	default:
-		return nil, false, nil
+		return lastSeen, false, nil
 	}
 }
 
 // uncorroboratedAbsences is how many consecutive 404s it takes to believe a
-// rollout the wait never watched is already over.
-//
-// One is not enough, because the first poll lands immediately after the POST
-// and cannot tell a record that is finished from one that is not readable yet.
-// The cost of asking again is a couple of poll intervals on the rare run whose
-// rollout really did settle that fast; the cost of not asking is a deploy that
-// reports success while the previous version is still serving.
+// rollout the wait never watched is over. One is not enough: the first lands
+// immediately after the POST, before the record is necessarily readable.
 const uncorroboratedAbsences = 3
 
 // defaultReplacementPollInterval keeps an exported poller from busy-spinning

--- a/internal/workload/replacement.go
+++ b/internal/workload/replacement.go
@@ -37,16 +37,23 @@ import (
 // IsTerminalReplacementStatus treats an unrecognised status as still in
 // progress rather than guessing, the same stance IsTerminalBuildStatus takes.
 //
-// Known limitation, and the reason that stance is not free. A failure status
-// the platform adds later would be classified as still in progress, and if
-// the record is then cleared, WaitForReplacement reports the rollout as a
-// success. That "errored" had to be added at all is proof the vocabulary was
-// incomplete once already. Closing the hole properly means confirming after
-// the fact which artifact the workload ended up running, which needs a
-// verified answer about how quickly the workload reflects a completed
-// replacement; guessing at that would trade a rare false success for a
-// routine false failure. Worth settling the first time a rollout is driven
-// against a live instance.
+// That stance is not free: a failure status the platform adds later would be
+// classified as still in progress, and if the record is then cleared,
+// WaitForReplacement reports the rollout as a success. That "errored" had to be
+// added at all is proof the vocabulary was incomplete once already.
+//
+// A roll no longer rests on this. The deploy confirms after the fact which
+// artifact the workload ended up running, so a rollout this file mistook for a
+// success is caught by the wait that follows it rather than reported as one.
+// See WaitForWorkload's wantArtifactID.
+//
+// A resize still does rest on it, and that is the limitation that remains.
+// Applying new sizing replaces the workload with itself on the artifact it is
+// already running, so there is no artifact change for anything downstream to
+// confirm, and the record's own status is the only account of how it went. The
+// only other candidate signal is the runtime block converging on what was sent,
+// which cannot be trusted without knowing how the platform normalises it:
+// guessing there would trade a rare false success for a routine false failure.
 const (
 	ReplacementStatusCompleted = "completed"
 	ReplacementStatusFailed    = "failed"
@@ -331,10 +338,18 @@ func confirmWorkloadExists(workloadID string) error {
 // The two 404 cases mean opposite things, which is why this is not a plain
 // poll loop. Seen after a status, a 404 means the platform settled the
 // rollout and collected the record, which is success. Seen before any status,
-// it means nothing was ever active. That second case used to be reported as
-// an error unconditionally, which was wrong whenever the platform settled a
-// fast rollout before the first poll landed: passing started lets the wait
-// tell "it finished before I looked" from "it was never there".
+// it means either that nothing was ever active or that the platform settled a
+// fast rollout before the first poll landed; passing started is what lets the
+// wait tell those from each other.
+//
+// A 404 that arrives before any record has been watched has to earn its
+// meaning, because the first poll fires immediately after the POST that created
+// the record and a route that has not caught up yet answers exactly the same
+// way as one whose rollout is over. Believing it at once turned a swap that had
+// barely started into a wait that returned in no time at all, reporting a
+// rollout as finished while the endpoint went on serving the previous version
+// for as long as the swap really took. So an unwatched absence is counted
+// rather than acted on, and only a run of them settles the wait.
 //
 // A settled rollout does not guarantee a terminal Status on the way out. When
 // the record is collected before the first poll lands, the seed is the only
@@ -353,7 +368,12 @@ func WaitForReplacement(
 	}
 
 	deadline := time.Now().Add(timeout)
-	lastSeen := started
+
+	var (
+		lastSeen = started
+		watched  bool
+		absences int
+	)
 
 	for {
 		replacement, err := GetActiveReplacement(workloadID)
@@ -361,34 +381,71 @@ func WaitForReplacement(
 			return nil, fmt.Errorf("poll replacement for workload %s: %w", workloadID, err)
 		}
 
-		if replacement == nil {
-			if lastSeen == nil {
-				// Only reachable when started was nil, since lastSeen begins
-				// as started: this is the attach path, and the caller asked
-				// to follow a rollout that is not running.
-				return nil, fmt.Errorf("no replacement is in flight for workload %s", workloadID)
+		switch {
+		case replacement != nil:
+			watched = true
+			absences = 0
+			lastSeen = replacement
+
+			if onTick != nil {
+				onTick(replacement)
 			}
 
-			return lastSeen, nil
-		}
+			if IsTerminalReplacementStatus(replacement.Status) {
+				return replacement, terminalReplacementErr(workloadID, replacement.Status)
+			}
 
-		lastSeen = replacement
+		default:
+			absences++
 
-		if onTick != nil {
-			onTick(replacement)
-		}
-
-		if IsTerminalReplacementStatus(replacement.Status) {
-			return replacement, terminalReplacementErr(workloadID, replacement.Status)
+			settled, done, err := absenceMeans(workloadID, lastSeen, watched, absences)
+			if done {
+				return settled, err
+			}
 		}
 
 		if time.Now().After(deadline) {
-			return replacement, fmt.Errorf("timeout waiting for replacement on workload %s after %s", workloadID, timeout)
+			return lastSeen, fmt.Errorf("timeout waiting for replacement on workload %s after %s", workloadID, timeout)
 		}
 
 		time.Sleep(interval)
 	}
 }
+
+// absenceMeans reads a 404 off the replacement route, which says three
+// different things depending on what the wait has seen before it.
+//
+// With nothing seen and nothing seeded, the caller asked to follow a rollout
+// that is not running: only reachable when started was nil, since lastSeen
+// begins as started, so this is the attach path. Gone after having been
+// watched is the platform collecting a rollout it has finished with, which is
+// the answer. Gone without ever having been watched is the ambiguous one, and
+// it settles the wait only once it has held for uncorroboratedAbsences polls.
+//
+// done reports whether the wait is over; when it is false the replacement is
+// nil and the caller polls again.
+func absenceMeans(workloadID string, lastSeen *Replacement, watched bool, absences int) (*Replacement, bool, error) {
+	switch {
+	case lastSeen == nil:
+		return nil, true, fmt.Errorf("no replacement is in flight for workload %s", workloadID)
+
+	case watched, absences >= uncorroboratedAbsences:
+		return lastSeen, true, nil
+
+	default:
+		return nil, false, nil
+	}
+}
+
+// uncorroboratedAbsences is how many consecutive 404s it takes to believe a
+// rollout the wait never watched is already over.
+//
+// One is not enough, because the first poll lands immediately after the POST
+// and cannot tell a record that is finished from one that is not readable yet.
+// The cost of asking again is a couple of poll intervals on the rare run whose
+// rollout really did settle that fast; the cost of not asking is a deploy that
+// reports success while the previous version is still serving.
+const uncorroboratedAbsences = 3
 
 // defaultReplacementPollInterval keeps an exported poller from busy-spinning
 // when handed a non-positive interval. The CLI's own flags cannot produce one

--- a/internal/workload/replacement_test.go
+++ b/internal/workload/replacement_test.go
@@ -523,8 +523,14 @@ func TestWaitForReplacement_NotFoundOnFirstPollIsError(t *testing.T) {
 // before rendering it. And onTick stays silent, because it reports poll
 // results and this wait had none, rather than replaying the seed as if it
 // were an observation.
+//
+// The absence has to hold across several polls before it counts, so this also
+// pins that a rollout which really is over still settles the wait.
 func TestWaitForReplacement_StartedSeedsTheWait(t *testing.T) {
+	var hits int32
+
 	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
 		notFound(w)
 	})
 
@@ -538,6 +544,40 @@ func TestWaitForReplacement_StartedSeedsTheWait(t *testing.T) {
 	assert.Equal(t, "art-2", replacement.ArtifactID)
 	assert.Equal(t, "submitted", replacement.Status,
 		"the seed comes back as it was; a nil error here does not mean the status is terminal")
+	assert.Equal(t, int32(uncorroboratedAbsences), atomic.LoadInt32(&hits),
+		"one 404 is not enough to conclude a rollout finished before the wait could see it")
+}
+
+// TestWaitForReplacement_UncorroboratedAbsenceWaitsForTheRecord is the cost of
+// the seed above, and the reason a lone 404 is no longer believed.
+//
+// The first poll fires immediately after the POST that created the record, so a
+// 404 there says equally "the rollout is over" and "the route has not caught up
+// yet". Taking it at face value ended the wait in no time at all, which let a
+// deploy report a swap as finished while it was still rolling and the endpoint
+// still answered with the previous build.
+func TestWaitForReplacement_UncorroboratedAbsenceWaitsForTheRecord(t *testing.T) {
+	var hits int32
+
+	serveReplacement(t, func(w http.ResponseWriter, _ *http.Request) {
+		switch atomic.AddInt32(&hits, 1) {
+		case 1:
+			notFound(w)
+		case 2:
+			fmt.Fprint(w, `{"candidateArtifactId":"art-2","status":"switching"}`)
+		default:
+			fmt.Fprint(w, `{"candidateArtifactId":"art-2","status":"completed"}`)
+		}
+	})
+
+	started := &Replacement{ArtifactID: "art-2", Status: "submitted"}
+
+	replacement, err := WaitForReplacement("wl-1", started, time.Millisecond, time.Second, nil)
+	require.NoError(t, err)
+	require.NotNil(t, replacement)
+	assert.Equal(t, ReplacementStatusCompleted, replacement.Status,
+		"a 404 one poll after the POST must not settle the wait before the record has appeared")
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&hits), int32(3))
 }
 
 // TestWaitForReplacement_NonTerminalClearedViaNotFoundIsSuccess is the other

--- a/internal/workload/replacement_test.go
+++ b/internal/workload/replacement_test.go
@@ -524,8 +524,8 @@ func TestWaitForReplacement_NotFoundOnFirstPollIsError(t *testing.T) {
 // results and this wait had none, rather than replaying the seed as if it
 // were an observation.
 //
-// The absence has to hold across several polls before it counts, so this also
-// pins that a rollout which really is over still settles the wait.
+// The absence has to hold across several polls, so this also pins that a
+// rollout which really is over still settles the wait.
 func TestWaitForReplacement_StartedSeedsTheWait(t *testing.T) {
 	var hits int32
 
@@ -549,13 +549,9 @@ func TestWaitForReplacement_StartedSeedsTheWait(t *testing.T) {
 }
 
 // TestWaitForReplacement_UncorroboratedAbsenceWaitsForTheRecord is the cost of
-// the seed above, and the reason a lone 404 is no longer believed.
-//
-// The first poll fires immediately after the POST that created the record, so a
-// 404 there says equally "the rollout is over" and "the route has not caught up
-// yet". Taking it at face value ended the wait in no time at all, which let a
-// deploy report a swap as finished while it was still rolling and the endpoint
-// still answered with the previous build.
+// the seed above. The first poll fires immediately after the POST, so a 404
+// there says equally "the rollout is over" and "the route has not caught up",
+// and taking it at face value ended the wait before the swap had begun.
 func TestWaitForReplacement_UncorroboratedAbsenceWaitsForTheRecord(t *testing.T) {
 	var hits int32
 

--- a/internal/workload/up/endpoint_check.go
+++ b/internal/workload/up/endpoint_check.go
@@ -68,7 +68,7 @@ var checkEndpointFn = func(url string) (int, error) {
 // judged for exactly that reason: a 404 at / is how a healthy API-only
 // framework answers, and only the person who wrote the app knows whether it
 // is fine.
-func verifyEndpoint(result Result, report *reporter) {
+func verifyEndpoint(result Result, unconfirmed string, report *reporter) {
 	if result.Endpoint == "" {
 		return
 	}
@@ -102,6 +102,18 @@ func verifyEndpoint(result Result, report *reporter) {
 
 	report.say("  %s\n", tui.HintStyle.Render(
 		"Endpoint check: an anonymous GET answered HTTP "+httpStatusLabel(status)+"."))
+
+	// Said only when the wait could not confirm the handover, and carrying the
+	// reason, because they are not the same problem: an install without the
+	// route is a platform fact, while a 403 is this token's own permissions.
+	// The GET above describes whatever answers now, and where the handover went
+	// unconfirmed "now" can be inside the window where the workload already
+	// names the new artifact and the endpoint is still on the old one.
+	if unconfirmed != "" {
+		report.say("    %s\n", tui.HintStyle.Render(
+			"The deploy could not tell whether the previous version has stopped answering, because "+
+				unconfirmed+". The line above may describe it."))
+	}
 }
 
 // httpStatusLabel renders "404 Not Found" rather than a bare number, because

--- a/internal/workload/up/endpoint_check_test.go
+++ b/internal/workload/up/endpoint_check_test.go
@@ -125,7 +125,7 @@ func TestRun_EndpointNotAnsweringDoesNotFailTheRun(t *testing.T) {
 	install(t, fakes{
 		create:  func(any) (*workload.Workload, error) { return running("wl-new"), nil },
 		writeID: func(string, string) error { return nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 		getArtifact: func(id string) (*workload.Artifact, error) {
@@ -147,7 +147,7 @@ func TestRun_ReportsTheEndpointAnswer(t *testing.T) {
 	install(t, fakes{
 		create:  func(any) (*workload.Workload, error) { return running("wl-new"), nil },
 		writeID: func(string, string) error { return nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 		getArtifact: func(id string) (*workload.Artifact, error) {

--- a/internal/workload/up/endpoint_check_test.go
+++ b/internal/workload/up/endpoint_check_test.go
@@ -38,7 +38,7 @@ func TestVerifyEndpoint_StatesTheStatusInWords(t *testing.T) {
 
 	var out bytes.Buffer
 
-	verifyEndpoint(Result{Endpoint: "https://x.example/w/", WorkloadID: "wl-1"}, newReporter(&out, false))
+	verifyEndpoint(Result{Endpoint: "https://x.example/w/", WorkloadID: "wl-1"}, "", newReporter(&out, false))
 
 	assert.Contains(t, out.String(), "404 Not Found")
 	assert.Contains(t, out.String(), "anonymous GET")
@@ -54,7 +54,7 @@ func TestVerifyEndpoint_SaysPlainlyWhenNothingAnswers(t *testing.T) {
 
 	var out bytes.Buffer
 
-	verifyEndpoint(Result{Endpoint: "https://x.example/w/", WorkloadID: "wl-1"}, newReporter(&out, false))
+	verifyEndpoint(Result{Endpoint: "https://x.example/w/", WorkloadID: "wl-1"}, "", newReporter(&out, false))
 
 	text := out.String()
 	assert.Contains(t, text, "did not answer")
@@ -74,7 +74,7 @@ func TestVerifyEndpoint_SkipsWithoutAnEndpoint(t *testing.T) {
 
 	var out bytes.Buffer
 
-	verifyEndpoint(Result{}, newReporter(&out, false))
+	verifyEndpoint(Result{}, "", newReporter(&out, false))
 	assert.Empty(t, out.String())
 }
 
@@ -125,7 +125,7 @@ func TestRun_EndpointNotAnsweringDoesNotFailTheRun(t *testing.T) {
 	install(t, fakes{
 		create:  func(any) (*workload.Workload, error) { return running("wl-new"), nil },
 		writeID: func(string, string) error { return nil },
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 		getArtifact: func(id string) (*workload.Artifact, error) {
@@ -147,7 +147,7 @@ func TestRun_ReportsTheEndpointAnswer(t *testing.T) {
 	install(t, fakes{
 		create:  func(any) (*workload.Workload, error) { return running("wl-new"), nil },
 		writeID: func(string, string) error { return nil },
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 		getArtifact: func(id string) (*workload.Artifact, error) {

--- a/internal/workload/up/retune.go
+++ b/internal/workload/up/retune.go
@@ -17,6 +17,7 @@ package up
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/datarobot/cli/internal/workload"
 )
@@ -93,13 +94,18 @@ func retune(loaded Loaded, result Result, opts Options, report *reporter) (Resul
 	// After the wait, for the reason a roll records it after its own: a
 	// settings replacement that ends failed leaves the workload on the sizing
 	// it had, so reporting an update would name something that did not happen.
+	waitFrom := time.Now()
+
 	if err := awaitResize(result.WorkloadID, started, opts, report); err != nil {
 		return result, err
 	}
 
 	result.Action = ActionUpdated
 
-	return settle(result.WorkloadID, "", result, opts, report)
+	// A resize changes no artifact, but it does replace a generation, so the
+	// wait still has to see the outgoing one stop answering.
+	return settle(result.WorkloadID, workload.Serving{AwaitDrain: true},
+		result, budgetLeft(opts, waitFrom), report)
 }
 
 // awaitResize follows the replacement a settings change starts. A failed one

--- a/internal/workload/up/retune.go
+++ b/internal/workload/up/retune.go
@@ -99,7 +99,7 @@ func retune(loaded Loaded, result Result, opts Options, report *reporter) (Resul
 
 	result.Action = ActionUpdated
 
-	return settle(result.WorkloadID, result, opts, report)
+	return settle(result.WorkloadID, "", result, opts, report)
 }
 
 // awaitResize follows the replacement a settings change starts. A failed one

--- a/internal/workload/up/retune_test.go
+++ b/internal/workload/up/retune_test.go
@@ -66,10 +66,9 @@ func wiredRetune(tr *track, sent *json.RawMessage) fakes {
 			return started, nil
 		},
 		// A resize changes no version, so it must not tell the wait to expect
-		// one: there is nothing for the workload to promote, and a wait given an
-		// artifact that is never going to move would run to its timeout.
-		wait: func(id, want string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
-			tr.steps = append(tr.steps, "settle:"+want)
+		// one: a wait on an artifact that never moves runs to its timeout.
+		wait: func(id string, want workload.Serving, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			tr.steps = append(tr.steps, servingLabel(want))
 
 			return &workload.Workload{
 				ID: id, Name: "gpt-oss-20b-vllm", Status: workload.WorkloadStatusRunning,
@@ -109,7 +108,7 @@ func TestRun_RuntimeOnlyChangeIsAppliedInPlace(t *testing.T) {
 	assert.Equal(t,
 		[]string{
 			"guard:68b0c1d2e3f4a5b6c7d8e9f0", "settings:68b0c1d2e3f4a5b6c7d8e9f0",
-			"await-resize", "settle:",
+			"await-resize", "settle:+drain",
 		}, tr.steps,
 		"the platform resizes by rolling a replacement, so that is what has to be guarded and followed")
 	assert.Equal(t, ActionUpdated, result.Action)
@@ -238,7 +237,7 @@ func TestRun_RetuneFailureNamesTheWorkload(t *testing.T) {
 	f.settings = func(string, json.RawMessage) (*workload.Replacement, error) {
 		return nil, errors.New("replicaCount and autoscaling are mutually exclusive")
 	}
-	f.wait = func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+	f.wait = func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 		t.Fatal("a settings call that failed changed nothing to wait for")
 
 		return nil, nil
@@ -270,7 +269,7 @@ func TestRun_RetuneReportsAReplacementThatFailed(t *testing.T) {
 
 		return started, errors.New("replacement ended as FAILED")
 	}
-	f.wait = func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+	f.wait = func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 		t.Fatal("a resize that failed leaves nothing to settle")
 
 		return nil, nil
@@ -379,7 +378,7 @@ func TestRun_RetuneWithLockLocksTheServingArtifact(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"guard:68b0c1d2e3f4a5b6c7d8e9f0", "settings:68b0c1d2e3f4a5b6c7d8e9f0",
-		"await-resize", "settle:", "lock:68a0000000000000000000a1",
+		"await-resize", "settle:+drain", "lock:68a0000000000000000000a1",
 	}, tr.steps, "the lock comes last, once the workload is serving again")
 	assert.True(t, result.Locked)
 }

--- a/internal/workload/up/retune_test.go
+++ b/internal/workload/up/retune_test.go
@@ -65,8 +65,11 @@ func wiredRetune(tr *track, sent *json.RawMessage) fakes {
 
 			return started, nil
 		},
-		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
-			tr.steps = append(tr.steps, "settle")
+		// A resize changes no version, so it must not tell the wait to expect
+		// one: there is nothing for the workload to promote, and a wait given an
+		// artifact that is never going to move would run to its timeout.
+		wait: func(id, want string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			tr.steps = append(tr.steps, "settle:"+want)
 
 			return &workload.Workload{
 				ID: id, Name: "gpt-oss-20b-vllm", Status: workload.WorkloadStatusRunning,
@@ -106,7 +109,7 @@ func TestRun_RuntimeOnlyChangeIsAppliedInPlace(t *testing.T) {
 	assert.Equal(t,
 		[]string{
 			"guard:68b0c1d2e3f4a5b6c7d8e9f0", "settings:68b0c1d2e3f4a5b6c7d8e9f0",
-			"await-resize", "settle",
+			"await-resize", "settle:",
 		}, tr.steps,
 		"the platform resizes by rolling a replacement, so that is what has to be guarded and followed")
 	assert.Equal(t, ActionUpdated, result.Action)
@@ -235,7 +238,7 @@ func TestRun_RetuneFailureNamesTheWorkload(t *testing.T) {
 	f.settings = func(string, json.RawMessage) (*workload.Replacement, error) {
 		return nil, errors.New("replicaCount and autoscaling are mutually exclusive")
 	}
-	f.wait = func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+	f.wait = func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 		t.Fatal("a settings call that failed changed nothing to wait for")
 
 		return nil, nil
@@ -267,7 +270,7 @@ func TestRun_RetuneReportsAReplacementThatFailed(t *testing.T) {
 
 		return started, errors.New("replacement ended as FAILED")
 	}
-	f.wait = func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+	f.wait = func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 		t.Fatal("a resize that failed leaves nothing to settle")
 
 		return nil, nil
@@ -293,7 +296,7 @@ func TestRun_DetachedRetuneDoesNotWait(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotContains(t, tr.steps, "await-resize")
-	assert.NotContains(t, tr.steps, "settle")
+	assert.NotContains(t, tr.steps, "settle:")
 	assert.Equal(t, ActionUpdated, result.Action)
 	// The status is the live one, because nobody looked again. A settings
 	// change leaves the workload running while the replacement swaps under
@@ -376,7 +379,7 @@ func TestRun_RetuneWithLockLocksTheServingArtifact(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"guard:68b0c1d2e3f4a5b6c7d8e9f0", "settings:68b0c1d2e3f4a5b6c7d8e9f0",
-		"await-resize", "settle", "lock:68a0000000000000000000a1",
+		"await-resize", "settle:", "lock:68a0000000000000000000a1",
 	}, tr.steps, "the lock comes last, once the workload is serving again")
 	assert.True(t, result.Locked)
 }

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -58,10 +58,11 @@ func roll(loaded Loaded, live Live, plan Plan, lock bool, result Result, opts Op
 		return result, err
 	}
 
-	// result.ArtifactID stays on the version that is serving, and settle
-	// moves it when the rollout has actually promoted the new one. A failed
-	// swap leaves the old version running, so an envelope naming the
-	// candidate would send someone to read the wrong artifact.
+	// result.ArtifactID stays on the version that is serving, and settle moves
+	// it once the rollout has actually promoted the new one, which it now waits
+	// to see rather than assuming. A failed swap leaves the old version
+	// running, so an envelope naming the candidate would send someone to read
+	// the wrong artifact.
 
 	// A file that moved the sizing as well as the version rides both in on the
 	// same swap: the platform takes runtime alongside the artifact, so there is
@@ -277,6 +278,11 @@ func alsoStarting(live Live) string {
 
 // replace starts the rollout and follows it to the end. sizing is nil unless
 // the runtime block changed too, in which case it travels with the swap.
+//
+// The candidate travels into settle as well as into the POST. Both waits that
+// follow report on a workload that never stops saying "running" for the whole
+// of a swap, so naming the artifact is the only thing that makes either of them
+// wait for this rollout rather than for the state it was already in.
 func replace(
 	workloadID string,
 	made version,
@@ -335,7 +341,7 @@ func replace(
 
 	result.Action = ActionRolled
 
-	return settle(workloadID, result, opts, report)
+	return settle(workloadID, made.ID, result, opts, report)
 }
 
 // awaitRollout waits for the swap itself, before the wait for the workload.

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
@@ -59,10 +60,9 @@ func roll(loaded Loaded, live Live, plan Plan, lock bool, result Result, opts Op
 	}
 
 	// result.ArtifactID stays on the version that is serving, and settle moves
-	// it once the rollout has actually promoted the new one, which it now waits
-	// to see rather than assuming. A failed swap leaves the old version
-	// running, so an envelope naming the candidate would send someone to read
-	// the wrong artifact.
+	// it once the rollout has promoted the new one, which it now waits to see
+	// rather than assuming. A failed swap leaves the old version running, so an
+	// envelope naming the candidate would point at the wrong artifact.
 
 	// A file that moved the sizing as well as the version rides both in on the
 	// same swap: the platform takes runtime alongside the artifact, so there is
@@ -279,10 +279,9 @@ func alsoStarting(live Live) string {
 // replace starts the rollout and follows it to the end. sizing is nil unless
 // the runtime block changed too, in which case it travels with the swap.
 //
-// The candidate travels into settle as well as into the POST. Both waits that
-// follow report on a workload that never stops saying "running" for the whole
-// of a swap, so naming the artifact is the only thing that makes either of them
-// wait for this rollout rather than for the state it was already in.
+// The candidate travels into settle as well as into the POST: the workload says
+// "running" throughout a swap, so naming the artifact is what makes the wait
+// that follows wait for this rollout rather than the state it was already in.
 func replace(
 	workloadID string,
 	made version,
@@ -335,13 +334,18 @@ func replace(
 	// that reported "rolled" would be naming an outcome the workload did not
 	// reach. What was attempted is still legible: the plan says what was
 	// wanted and the artifact and build ids say what was made.
+	// The two waits share one budget. Both can now run for minutes, and a
+	// --poll-timeout the user set is a bound on the deploy, not on each half.
+	waitFrom := time.Now()
+
 	if err := awaitRollout(workloadID, started, opts, report); err != nil {
 		return result, err
 	}
 
 	result.Action = ActionRolled
 
-	return settle(workloadID, made.ID, result, opts, report)
+	return settle(workloadID, workload.Serving{ArtifactID: made.ID, AwaitDrain: true},
+		result, budgetLeft(opts, waitFrom), report)
 }
 
 // awaitRollout waits for the swap itself, before the wait for the workload.

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -165,12 +165,16 @@ func wiredRoll(tr *track) fakes {
 
 			return started, nil
 		},
-		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
-			tr.steps = append(tr.steps, "settle")
+		// The artifact this fake is asked to wait for is recorded rather than
+		// ignored. Returning "art-2" while the production code never said which
+		// version it wanted is how a wait that settled on the old one read as a
+		// passing test.
+		wait: func(id, want string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			tr.steps = append(tr.steps, "settle:"+want)
 
 			return &workload.Workload{
 				ID: id, Name: "my-app", Status: workload.WorkloadStatusRunning,
-				ArtifactID: "art-2", Endpoint: "https://app.datarobot.com/workloads/68b0/",
+				ArtifactID: want, Endpoint: "https://app.datarobot.com/workloads/68b0/",
 			}, nil
 		},
 	})
@@ -206,7 +210,7 @@ func TestRun_RollsALiveWorkloadOntoANewVersion(t *testing.T) {
 	result, stderr, err := runIn(t, newImage(), Options{NonInteractive: true})
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"guard", "create-artifact", "guard", "replace:art-2", "await-rollout", "settle"}, tr.steps)
+	assert.Equal(t, []string{"guard", "create-artifact", "guard", "replace:art-2", "await-rollout", "settle:art-2"}, tr.steps)
 	assert.Equal(t, ActionRolled, result.Action)
 	assert.Equal(t, "art-2", result.ArtifactID)
 	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", result.WorkloadID, "a roll never makes a second workload")
@@ -234,7 +238,7 @@ func TestRun_RollUsesTheArtifactTheFileNames(t *testing.T) {
 	result, _, err := runIn(t, named, Options{NonInteractive: true})
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"guard", "guard", "replace:68b0bbbb0000000000000002", "await-rollout", "settle"}, tr.steps)
+	assert.Equal(t, []string{"guard", "guard", "replace:68b0bbbb0000000000000002", "await-rollout", "settle:68b0bbbb0000000000000002"}, tr.steps)
 	assert.Equal(t, ActionRolled, result.Action)
 }
 
@@ -299,7 +303,7 @@ func TestRun_LockedProductionRollsAfterTheNameIsTyped(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]string{"guard", "create-artifact", "guard", "lock:art-2", "replace:art-2", "await-rollout", "settle"},
+		[]string{"guard", "create-artifact", "guard", "lock:art-2", "replace:art-2", "await-rollout", "settle:art-2"},
 		tr.steps, "the successor is locked after the last guard and before the swap")
 	assert.Contains(t, asked, "production")
 	assert.Equal(t, "my-app", expect, "the name is what has to be typed")
@@ -336,7 +340,7 @@ func TestRun_LockedRollDoesNotRelockAnArtifactTheFileNamed(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"guard", "guard", "read:68b0bbbb0000000000000002",
-		"replace:68b0bbbb0000000000000002", "await-rollout", "settle",
+		"replace:68b0bbbb0000000000000002", "await-rollout", "settle:68b0bbbb0000000000000002",
 	}, tr.steps, "an artifact already locked is read, not locked again")
 	assert.True(t, result.Locked)
 }
@@ -365,7 +369,7 @@ func TestRun_LockedRollLocksANamedDraft(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"guard", "guard", "read:68b0bbbb0000000000000002", "lock:68b0bbbb0000000000000002",
-		"replace:68b0bbbb0000000000000002", "await-rollout", "settle",
+		"replace:68b0bbbb0000000000000002", "await-rollout", "settle:68b0bbbb0000000000000002",
 	}, tr.steps)
 	assert.True(t, result.Locked)
 }
@@ -491,6 +495,51 @@ func TestRun_LockFlagDoesNotLockTheVersionTwice(t *testing.T) {
 	assert.True(t, result.Locked)
 }
 
+// The lock a draft roll takes is the one settle was told to wait for, not
+// whatever the workload happened to be reporting when the wait returned.
+//
+// This is the sharpest consequence of a wait that could settle early. On a
+// draft workload --lock is not applied to the candidate before the swap, since
+// only a locked predecessor demands that; it is applied afterwards, to
+// result.ArtifactID, which is whatever the wait last saw. A wait that returned
+// on the version being rolled off therefore locked the wrong artifact, and
+// locking is one-way: the artifact this run was replacing is left permanent and
+// undeletable while the version actually serving stays a draft.
+func TestRun_DraftRollLocksTheVersionItRolledOnto(t *testing.T) {
+	var tr track
+
+	install(t, wiredRoll(&tr))
+
+	result, _, err := runIn(t, newImage(), Options{NonInteractive: true, Lock: true})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]string{
+			"guard", "create-artifact", "guard", "replace:art-2",
+			"await-rollout", "settle:art-2", "lock:art-2",
+		}, tr.steps,
+		"the lock follows the wait, so the wait is what decides which artifact becomes permanent")
+	assert.NotContains(t, tr.steps, "lock:68a0000000000000000000a1",
+		"locking the version being rolled off cannot be undone")
+	assert.Equal(t, "art-2", result.ArtifactID)
+	assert.True(t, result.Locked)
+}
+
+// The phase label is the line this bug was read from: a checkmark beside
+// "waiting for the workload to run" on a workload that never stopped running.
+func TestRun_RollSaysItIsWaitingForTheNewVersion(t *testing.T) {
+	var tr track
+
+	install(t, wiredRoll(&tr))
+
+	_, stderr, err := runIn(t, newImage(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, stderr, "Waiting for the new version to serve")
+	assert.NotContains(t, stderr, "Waiting for the workload to run",
+		"the workload was running before this deploy started; saying so proves nothing")
+}
+
 // A failed rollout leaves the old version serving, so reporting the workload
 // as healthy afterwards would be true and entirely misleading.
 func TestRun_FailedRolloutSaysTheOldVersionIsStillServing(t *testing.T) {
@@ -504,7 +553,7 @@ func TestRun_FailedRolloutSaysTheOldVersionIsStillServing(t *testing.T) {
 
 		return started, errors.New("replacement rep-1 ended with status failed")
 	}
-	f.wait = func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+	f.wait = func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 		t.Fatal("a failed rollout has nothing to settle")
 
 		return nil, nil
@@ -606,7 +655,7 @@ func TestRun_StoppedWorkloadWithANewVersionStartsThenRolls(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"guard", "start", "await-start", "guard", "create-artifact", "guard",
-		"replace:art-2", "await-rollout", "settle",
+		"replace:art-2", "await-rollout", "settle:art-2",
 	}, tr.steps, "the guard that can refuse comes before the start that mutates")
 	assert.Equal(t, ActionRolled, result.Action,
 		"rolling is the more significant of the two things this run did")
@@ -786,21 +835,28 @@ func stoppedRoll(tr *track) fakes {
 
 	// The two waits are the same seam, so the label says which one this is:
 	// the first is the prerequisite start, the rest are the deploy settling.
+	//
+	// The artifact each is told to expect rides along in the label. A start
+	// carries none, because it brings the workload up on the version it was
+	// stopped on; only the roll that follows names one, and a resize names none
+	// either, having changed no version.
 	settled := false
-	f.wait = func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+	f.wait = func(id, want string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 		step := "await-start"
+		artifact := "68a0000000000000000000a1"
+
 		if settled {
 			step = "settle"
+
+			if want != "" {
+				step += ":" + want
+				artifact = want
+			}
 		}
 
 		settled = true
 
 		tr.steps = append(tr.steps, step)
-
-		artifact := "68a0000000000000000000a1"
-		if step == "settle" {
-			artifact = "art-2"
-		}
 
 		return &workload.Workload{
 			ID: id, Name: "my-app", Status: workload.WorkloadStatusRunning,
@@ -946,7 +1002,7 @@ func TestRun_RollsABuiltProjectOntoAFreshlyBuiltVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]string{"guard", "create-artifact", "relink", "sync", "build", "guard", "replace:art-2", "await-rollout", "settle"},
+		[]string{"guard", "create-artifact", "relink", "sync", "build", "guard", "replace:art-2", "await-rollout", "settle:art-2"},
 		tr.steps)
 	assert.Equal(t, "art-2", tr.savedCfg.ArtifactID, "the sync has to land in the new version, not the live one")
 	assert.Equal(t, ActionRolled, result.Action)
@@ -974,7 +1030,7 @@ func TestRun_RollsABuiltProjectOffALockedVersion(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"guard", "create-artifact", "relink", "sync", "build",
-		"guard", "lock:art-2", "replace:art-2", "await-rollout", "settle",
+		"guard", "lock:art-2", "replace:art-2", "await-rollout", "settle:art-2",
 	}, tr.steps)
 	assert.Equal(t, "art-2", tr.savedCfg.ArtifactID, "the link has to leave the locked version behind")
 	assert.True(t, result.Locked, "a locked version is replaced by a locked one")
@@ -1028,7 +1084,7 @@ func TestRun_RollReusesTheVersionAnEarlierAttemptLeft(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]string{"guard", "sync", "build", "guard", "replace:art-abandoned", "await-rollout", "settle"},
+		[]string{"guard", "sync", "build", "guard", "replace:art-abandoned", "await-rollout", "settle:art-abandoned"},
 		tr.steps)
 	assert.Equal(t, ActionRolled, result.Action)
 	assert.Contains(t, stderr, "earlier attempt")
@@ -1081,7 +1137,7 @@ func TestRun_LeftoverDraftIsReusedWhenThePlatformHoistsTheType(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]string{"guard", "sync", "build", "guard", "replace:art-abandoned", "await-rollout", "settle"},
+		[]string{"guard", "sync", "build", "guard", "replace:art-abandoned", "await-rollout", "settle:art-abandoned"},
 		tr.steps)
 	assert.Equal(t, ActionRolled, result.Action)
 }
@@ -1308,7 +1364,7 @@ func TestRun_SpecOnlyRollCarriesTheCodeOver(t *testing.T) {
 	assert.Equal(t, []string{"art-2", "cat1", "ver1"}, tr.carried,
 		"a new version of the same code has to point at that code")
 	assert.Equal(t,
-		[]string{"guard", "create-artifact", "relink", "sync", "carry-code", "build", "guard", "replace:art-2", "await-rollout", "settle"},
+		[]string{"guard", "create-artifact", "relink", "sync", "carry-code", "build", "guard", "replace:art-2", "await-rollout", "settle:art-2"},
 		tr.steps)
 	assert.Equal(t, "bld-2", result.BuildID, "a version born without an image still needs one")
 }

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -166,15 +166,14 @@ func wiredRoll(tr *track) fakes {
 			return started, nil
 		},
 		// The artifact this fake is asked to wait for is recorded rather than
-		// ignored. Returning "art-2" while the production code never said which
-		// version it wanted is how a wait that settled on the old one read as a
-		// passing test.
-		wait: func(id, want string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
-			tr.steps = append(tr.steps, "settle:"+want)
+		// ignored: returning "art-2" unprompted is how a wait that settled on
+		// the old version read as a passing test.
+		wait: func(id string, want workload.Serving, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			tr.steps = append(tr.steps, servingLabel(want))
 
 			return &workload.Workload{
 				ID: id, Name: "my-app", Status: workload.WorkloadStatusRunning,
-				ArtifactID: want, Endpoint: "https://app.datarobot.com/workloads/68b0/",
+				ArtifactID: want.ArtifactID, Endpoint: "https://app.datarobot.com/workloads/68b0/",
 			}, nil
 		},
 	})
@@ -210,7 +209,7 @@ func TestRun_RollsALiveWorkloadOntoANewVersion(t *testing.T) {
 	result, stderr, err := runIn(t, newImage(), Options{NonInteractive: true})
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"guard", "create-artifact", "guard", "replace:art-2", "await-rollout", "settle:art-2"}, tr.steps)
+	assert.Equal(t, []string{"guard", "create-artifact", "guard", "replace:art-2", "await-rollout", "settle:art-2+drain"}, tr.steps)
 	assert.Equal(t, ActionRolled, result.Action)
 	assert.Equal(t, "art-2", result.ArtifactID)
 	assert.Equal(t, "68b0c1d2e3f4a5b6c7d8e9f0", result.WorkloadID, "a roll never makes a second workload")
@@ -238,7 +237,7 @@ func TestRun_RollUsesTheArtifactTheFileNames(t *testing.T) {
 	result, _, err := runIn(t, named, Options{NonInteractive: true})
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"guard", "guard", "replace:68b0bbbb0000000000000002", "await-rollout", "settle:68b0bbbb0000000000000002"}, tr.steps)
+	assert.Equal(t, []string{"guard", "guard", "replace:68b0bbbb0000000000000002", "await-rollout", "settle:68b0bbbb0000000000000002+drain"}, tr.steps)
 	assert.Equal(t, ActionRolled, result.Action)
 }
 
@@ -303,7 +302,7 @@ func TestRun_LockedProductionRollsAfterTheNameIsTyped(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]string{"guard", "create-artifact", "guard", "lock:art-2", "replace:art-2", "await-rollout", "settle:art-2"},
+		[]string{"guard", "create-artifact", "guard", "lock:art-2", "replace:art-2", "await-rollout", "settle:art-2+drain"},
 		tr.steps, "the successor is locked after the last guard and before the swap")
 	assert.Contains(t, asked, "production")
 	assert.Equal(t, "my-app", expect, "the name is what has to be typed")
@@ -340,7 +339,7 @@ func TestRun_LockedRollDoesNotRelockAnArtifactTheFileNamed(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"guard", "guard", "read:68b0bbbb0000000000000002",
-		"replace:68b0bbbb0000000000000002", "await-rollout", "settle:68b0bbbb0000000000000002",
+		"replace:68b0bbbb0000000000000002", "await-rollout", "settle:68b0bbbb0000000000000002+drain",
 	}, tr.steps, "an artifact already locked is read, not locked again")
 	assert.True(t, result.Locked)
 }
@@ -369,7 +368,7 @@ func TestRun_LockedRollLocksANamedDraft(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"guard", "guard", "read:68b0bbbb0000000000000002", "lock:68b0bbbb0000000000000002",
-		"replace:68b0bbbb0000000000000002", "await-rollout", "settle:68b0bbbb0000000000000002",
+		"replace:68b0bbbb0000000000000002", "await-rollout", "settle:68b0bbbb0000000000000002+drain",
 	}, tr.steps)
 	assert.True(t, result.Locked)
 }
@@ -495,38 +494,10 @@ func TestRun_LockFlagDoesNotLockTheVersionTwice(t *testing.T) {
 	assert.True(t, result.Locked)
 }
 
-// The lock a draft roll takes is the one settle was told to wait for, not
-// whatever the workload happened to be reporting when the wait returned.
-//
-// This is the sharpest consequence of a wait that could settle early. On a
-// draft workload --lock is not applied to the candidate before the swap, since
-// only a locked predecessor demands that; it is applied afterwards, to
-// result.ArtifactID, which is whatever the wait last saw. A wait that returned
-// on the version being rolled off therefore locked the wrong artifact, and
-// locking is one-way: the artifact this run was replacing is left permanent and
-// undeletable while the version actually serving stays a draft.
-func TestRun_DraftRollLocksTheVersionItRolledOnto(t *testing.T) {
-	var tr track
-
-	install(t, wiredRoll(&tr))
-
-	result, _, err := runIn(t, newImage(), Options{NonInteractive: true, Lock: true})
-	require.NoError(t, err)
-
-	assert.Equal(t,
-		[]string{
-			"guard", "create-artifact", "guard", "replace:art-2",
-			"await-rollout", "settle:art-2", "lock:art-2",
-		}, tr.steps,
-		"the lock follows the wait, so the wait is what decides which artifact becomes permanent")
-	assert.NotContains(t, tr.steps, "lock:68a0000000000000000000a1",
-		"locking the version being rolled off cannot be undone")
-	assert.Equal(t, "art-2", result.ArtifactID)
-	assert.True(t, result.Locked)
-}
-
-// The phase label is the line this bug was read from: a checkmark beside
-// "waiting for the workload to run" on a workload that never stopped running.
+// The roll label leans on result.ArtifactID still naming the outgoing version
+// at this point. That is true today by settle's ordering, but it is implicit:
+// a reorder that updated the envelope earlier would silently restore the
+// wording this change replaced.
 func TestRun_RollSaysItIsWaitingForTheNewVersion(t *testing.T) {
 	var tr track
 
@@ -538,6 +509,67 @@ func TestRun_RollSaysItIsWaitingForTheNewVersion(t *testing.T) {
 	assert.Contains(t, stderr, "Waiting for the new version to serve")
 	assert.NotContains(t, stderr, "Waiting for the workload to run",
 		"the workload was running before this deploy started; saying so proves nothing")
+}
+
+// Both waits a roll needs can now run for minutes, so --poll-timeout has to
+// bound the deploy rather than each half of it.
+func TestRun_TheTwoRollWaitsShareOnePollBudget(t *testing.T) {
+	var tr track
+
+	var settleTimeout time.Duration
+
+	f := wiredRoll(&tr)
+	f.waitReplace = func(_ string, started *workload.Replacement, _, _ time.Duration,
+		_ func(*workload.Replacement),
+	) (*workload.Replacement, error) {
+		tr.steps = append(tr.steps, "await-rollout")
+		started.Status = workload.ReplacementStatusCompleted
+
+		return started, nil
+	}
+	f.wait = func(id string, want workload.Serving, _, timeout time.Duration,
+		_ func(*workload.Workload),
+	) (*workload.Workload, error) {
+		settleTimeout = timeout
+
+		return &workload.Workload{
+			ID: id, Name: "my-app", Status: workload.WorkloadStatusRunning,
+			ArtifactID: want.ArtifactID,
+		}, nil
+	}
+
+	install(t, f)
+
+	_, _, err := runIn(t, newImage(), Options{NonInteractive: true, PollTimeout: 10 * time.Minute})
+	require.NoError(t, err)
+
+	assert.Positive(t, settleTimeout)
+	assert.LessOrEqual(t, settleTimeout, 10*time.Minute,
+		"the second wait may not start a fresh copy of the budget the first one was already spending")
+}
+
+// The sharpest consequence of a wait that could settle early. On a draft
+// workload --lock is applied after the swap, to result.ArtifactID, which is
+// whatever the wait last saw. A wait that returned on the version being rolled
+// off locked the wrong artifact, and locking is one-way.
+func TestRun_DraftRollLocksTheVersionItRolledOnto(t *testing.T) {
+	var tr track
+
+	install(t, wiredRoll(&tr))
+
+	result, _, err := runIn(t, newImage(), Options{NonInteractive: true, Lock: true})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		[]string{
+			"guard", "create-artifact", "guard", "replace:art-2",
+			"await-rollout", "settle:art-2+drain", "lock:art-2",
+		}, tr.steps,
+		"the lock follows the wait, so the wait is what decides which artifact becomes permanent")
+	assert.NotContains(t, tr.steps, "lock:68a0000000000000000000a1",
+		"locking the version being rolled off cannot be undone")
+	assert.Equal(t, "art-2", result.ArtifactID)
+	assert.True(t, result.Locked)
 }
 
 // A failed rollout leaves the old version serving, so reporting the workload
@@ -553,7 +585,7 @@ func TestRun_FailedRolloutSaysTheOldVersionIsStillServing(t *testing.T) {
 
 		return started, errors.New("replacement rep-1 ended with status failed")
 	}
-	f.wait = func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+	f.wait = func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 		t.Fatal("a failed rollout has nothing to settle")
 
 		return nil, nil
@@ -655,7 +687,7 @@ func TestRun_StoppedWorkloadWithANewVersionStartsThenRolls(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"guard", "start", "await-start", "guard", "create-artifact", "guard",
-		"replace:art-2", "await-rollout", "settle:art-2",
+		"replace:art-2", "await-rollout", "settle:art-2+drain",
 	}, tr.steps, "the guard that can refuse comes before the start that mutates")
 	assert.Equal(t, ActionRolled, result.Action,
 		"rolling is the more significant of the two things this run did")
@@ -684,7 +716,7 @@ func TestRun_StoppedWorkloadWithASizingChangeStartsThenRetunes(t *testing.T) {
 	result, _, err := runIn(t, resized, Options{NonInteractive: true})
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"guard", "start", "await-start", "guard", "settings", "await-rollout", "settle"},
+	assert.Equal(t, []string{"guard", "start", "await-start", "guard", "settings", "await-rollout", "settle:+drain"},
 		tr.steps, "the guard that can refuse comes before the start that mutates")
 	assert.Equal(t, ActionUpdated, result.Action)
 }
@@ -836,21 +868,18 @@ func stoppedRoll(tr *track) fakes {
 	// The two waits are the same seam, so the label says which one this is:
 	// the first is the prerequisite start, the rest are the deploy settling.
 	//
-	// The artifact each is told to expect rides along in the label. A start
-	// carries none, because it brings the workload up on the version it was
-	// stopped on; only the roll that follows names one, and a resize names none
-	// either, having changed no version.
+	// The artifact each is told to expect rides along in the label: a start
+	// carries none, only the roll that follows names one.
 	settled := false
-	f.wait = func(id, want string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+	f.wait = func(id string, want workload.Serving, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 		step := "await-start"
 		artifact := "68a0000000000000000000a1"
 
 		if settled {
-			step = "settle"
+			step = servingLabel(want)
 
-			if want != "" {
-				step += ":" + want
-				artifact = want
+			if want.ArtifactID != "" {
+				artifact = want.ArtifactID
 			}
 		}
 
@@ -1002,7 +1031,7 @@ func TestRun_RollsABuiltProjectOntoAFreshlyBuiltVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]string{"guard", "create-artifact", "relink", "sync", "build", "guard", "replace:art-2", "await-rollout", "settle:art-2"},
+		[]string{"guard", "create-artifact", "relink", "sync", "build", "guard", "replace:art-2", "await-rollout", "settle:art-2+drain"},
 		tr.steps)
 	assert.Equal(t, "art-2", tr.savedCfg.ArtifactID, "the sync has to land in the new version, not the live one")
 	assert.Equal(t, ActionRolled, result.Action)
@@ -1030,7 +1059,7 @@ func TestRun_RollsABuiltProjectOffALockedVersion(t *testing.T) {
 
 	assert.Equal(t, []string{
 		"guard", "create-artifact", "relink", "sync", "build",
-		"guard", "lock:art-2", "replace:art-2", "await-rollout", "settle:art-2",
+		"guard", "lock:art-2", "replace:art-2", "await-rollout", "settle:art-2+drain",
 	}, tr.steps)
 	assert.Equal(t, "art-2", tr.savedCfg.ArtifactID, "the link has to leave the locked version behind")
 	assert.True(t, result.Locked, "a locked version is replaced by a locked one")
@@ -1084,7 +1113,7 @@ func TestRun_RollReusesTheVersionAnEarlierAttemptLeft(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]string{"guard", "sync", "build", "guard", "replace:art-abandoned", "await-rollout", "settle:art-abandoned"},
+		[]string{"guard", "sync", "build", "guard", "replace:art-abandoned", "await-rollout", "settle:art-abandoned+drain"},
 		tr.steps)
 	assert.Equal(t, ActionRolled, result.Action)
 	assert.Contains(t, stderr, "earlier attempt")
@@ -1137,7 +1166,7 @@ func TestRun_LeftoverDraftIsReusedWhenThePlatformHoistsTheType(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t,
-		[]string{"guard", "sync", "build", "guard", "replace:art-abandoned", "await-rollout", "settle:art-abandoned"},
+		[]string{"guard", "sync", "build", "guard", "replace:art-abandoned", "await-rollout", "settle:art-abandoned+drain"},
 		tr.steps)
 	assert.Equal(t, ActionRolled, result.Action)
 }
@@ -1364,7 +1393,7 @@ func TestRun_SpecOnlyRollCarriesTheCodeOver(t *testing.T) {
 	assert.Equal(t, []string{"art-2", "cat1", "ver1"}, tr.carried,
 		"a new version of the same code has to point at that code")
 	assert.Equal(t,
-		[]string{"guard", "create-artifact", "relink", "sync", "carry-code", "build", "guard", "replace:art-2", "await-rollout", "settle:art-2"},
+		[]string{"guard", "create-artifact", "relink", "sync", "carry-code", "build", "guard", "replace:art-2", "await-rollout", "settle:art-2+drain"},
 		tr.steps)
 	assert.Equal(t, "bld-2", result.BuildID, "a version born without an image still needs one")
 }

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -797,7 +797,7 @@ func create(
 		return result, nil
 	}
 
-	return settle(created.ID, result, opts, report)
+	return settle(created.ID, "", result, opts, report)
 }
 
 // startFirst brings a stopped workload up so the rest of the plan has
@@ -840,10 +840,10 @@ func startFirst(live Live, plan Plan, result Result, opts Options, report *repor
 	// Only the run that ends here may lock: locking is about the artifact left
 	// serving, and a start that is about to be rolled off is not that.
 	if only {
-		return settle(result.WorkloadID, result, opts, report)
+		return settle(result.WorkloadID, "", result, opts, report)
 	}
 
-	return awaitRunning(result.WorkloadID, result, opts, report)
+	return awaitRunning(result.WorkloadID, "", result, opts, report)
 }
 
 // requestStart POSTs the start and passes on the one thing the platform says
@@ -945,8 +945,17 @@ func isConflict(err error) bool {
 // awaitRunning instead: locking is about the artifact left serving, and an
 // artifact about to be rolled off is not it. Locking cannot be undone, so the
 // distinction is not a tidiness one.
-func settle(workloadID string, result Result, opts Options, report *reporter) (Result, error) {
-	result, err := awaitRunning(workloadID, result, opts, report)
+//
+// wantArtifactID is what makes the lock safe as well as the report honest. lock
+// makes result.ArtifactID permanent, and that is whatever the wait last saw: a
+// wait that returned early would lock the artifact being rolled off, leaving it
+// undeletable while the version actually serving stays a draft.
+//
+// It is also what puts verifyEndpoint after the cutover rather than inside it.
+// Before this wait existed, a roll GETted the endpoint mid-swap and reported
+// the version being replaced.
+func settle(workloadID, wantArtifactID string, result Result, opts Options, report *reporter) (Result, error) {
+	result, err := awaitRunning(workloadID, wantArtifactID, result, opts, report)
 	if err != nil {
 		return result, err
 	}
@@ -964,11 +973,22 @@ func settle(workloadID string, result Result, opts Options, report *reporter) (R
 }
 
 // awaitRunning waits for the workload to come up and records where it landed.
-func awaitRunning(workloadID string, result Result, opts Options, report *reporter) (Result, error) {
+//
+// wantArtifactID is the artifact this run put there, and empty when the run
+// changed none: a create, a start and a resize all leave the running artifact
+// where it was. A roll names its candidate, because the workload reports
+// "running" for the whole of a swap and the status alone would settle the wait
+// before the new version had served anything.
+func awaitRunning(
+	workloadID, wantArtifactID string,
+	result Result,
+	opts Options,
+	report *reporter,
+) (Result, error) {
 	var final *workload.Workload
 
-	err := report.run("Waiting for the workload to run", func() error {
-		wl, waitErr := waitWorkloadFn(workloadID, opts.PollInterval, opts.PollTimeout, nil)
+	err := report.run(waitLabel(wantArtifactID, result), func() error {
+		wl, waitErr := waitWorkloadFn(workloadID, wantArtifactID, opts.PollInterval, opts.PollTimeout, nil)
 		final = wl
 
 		return waitErr
@@ -990,6 +1010,21 @@ func awaitRunning(workloadID string, result Result, opts Options, report *report
 	}
 
 	return result, nil
+}
+
+// waitLabel names what is actually being waited for.
+//
+// On a roll the workload never stopped running, so "waiting for the workload to
+// run" describes a wait that was over before it began, and printing it beside a
+// checkmark is how this bug read as a success. result.ArtifactID is still the
+// version that is serving at this point, so a want that differs from it is
+// precisely the roll case and nothing else.
+func waitLabel(wantArtifactID string, result Result) string {
+	if wantArtifactID != "" && wantArtifactID != result.ArtifactID {
+		return "Waiting for the new version to serve"
+	}
+
+	return "Waiting for the workload to run"
 }
 
 // lock makes the live artifact permanent. It runs only after the workload is

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/datarobot/cli/internal/drapi"
@@ -797,7 +798,7 @@ func create(
 		return result, nil
 	}
 
-	return settle(created.ID, "", result, opts, report)
+	return settle(created.ID, workload.Serving{}, result, opts, report)
 }
 
 // startFirst brings a stopped workload up so the rest of the plan has
@@ -840,10 +841,10 @@ func startFirst(live Live, plan Plan, result Result, opts Options, report *repor
 	// Only the run that ends here may lock: locking is about the artifact left
 	// serving, and a start that is about to be rolled off is not that.
 	if only {
-		return settle(result.WorkloadID, "", result, opts, report)
+		return settle(result.WorkloadID, workload.Serving{}, result, opts, report)
 	}
 
-	return awaitRunning(result.WorkloadID, "", result, opts, report)
+	return awaitRunning(result.WorkloadID, workload.Serving{}, result, opts, report)
 }
 
 // requestStart POSTs the start and passes on the one thing the platform says
@@ -946,16 +947,24 @@ func isConflict(err error) bool {
 // artifact about to be rolled off is not it. Locking cannot be undone, so the
 // distinction is not a tidiness one.
 //
-// wantArtifactID is what makes the lock safe as well as the report honest. lock
-// makes result.ArtifactID permanent, and that is whatever the wait last saw: a
-// wait that returned early would lock the artifact being rolled off, leaving it
+// want is what makes the lock safe as well as the report honest. lock makes
+// result.ArtifactID permanent, and that is whatever the wait last saw: a wait
+// that returned early would lock the artifact being rolled off, leaving it
 // undeletable while the version actually serving stays a draft.
 //
 // It is also what puts verifyEndpoint after the cutover rather than inside it.
 // Before this wait existed, a roll GETted the endpoint mid-swap and reported
 // the version being replaced.
-func settle(workloadID, wantArtifactID string, result Result, opts Options, report *reporter) (Result, error) {
-	result, err := awaitRunning(workloadID, wantArtifactID, result, opts, report)
+func settle(workloadID string, want workload.Serving, result Result, opts Options, report *reporter) (Result, error) {
+	// Whether the drain wait actually happened decides what the endpoint line
+	// below is allowed to claim. On an install without the proton route the
+	// wait rests on the artifact alone, and the artifact moves about a minute
+	// before the endpoint stops answering the old build, so a GET made there
+	// can describe the version being rolled off.
+	unconfirmed := ""
+	want.OnUnconfirmed = func(reason string) { unconfirmed = reason }
+
+	result, err := awaitRunning(workloadID, want, result, opts, report)
 	if err != nil {
 		return result, err
 	}
@@ -963,7 +972,7 @@ func settle(workloadID, wantArtifactID string, result Result, opts Options, repo
 	// One GET against the endpoint, reported and never fatal. Running means
 	// the container started; with no probe written by default, whether
 	// anything answers is a question nobody has asked yet.
-	verifyEndpoint(result, report)
+	verifyEndpoint(result, unconfirmed, report)
 
 	if !opts.Lock {
 		return result, nil
@@ -974,21 +983,24 @@ func settle(workloadID, wantArtifactID string, result Result, opts Options, repo
 
 // awaitRunning waits for the workload to come up and records where it landed.
 //
-// wantArtifactID is the artifact this run put there, and empty when the run
-// changed none: a create, a start and a resize all leave the running artifact
-// where it was. A roll names its candidate, because the workload reports
-// "running" for the whole of a swap and the status alone would settle the wait
-// before the new version had served anything.
+// want says what the wait has to see. A roll names its candidate and asks for
+// the drain, because the workload reports "running" for the whole of a swap and
+// the status alone would settle the wait too early; a resize asks for the drain
+// with no artifact to name; a create and a start ask for neither.
 func awaitRunning(
-	workloadID, wantArtifactID string,
+	workloadID string,
+	want workload.Serving,
 	result Result,
 	opts Options,
 	report *reporter,
 ) (Result, error) {
 	var final *workload.Workload
 
-	err := report.run(waitLabel(wantArtifactID, result), func() error {
-		wl, waitErr := waitWorkloadFn(workloadID, wantArtifactID, opts.PollInterval, opts.PollTimeout, nil)
+	label := waitLabel(want, result)
+
+	err := report.run(label, func() error {
+		wl, waitErr := waitWorkloadFn(workloadID, want, opts.PollInterval, opts.PollTimeout,
+			heartbeat(strings.ToLower(label), opts, report))
 		final = wl
 
 		return waitErr
@@ -1014,18 +1026,102 @@ func awaitRunning(
 
 // waitLabel names what is actually being waited for.
 //
-// On a roll the workload never stopped running, so "waiting for the workload to
-// run" describes a wait that was over before it began, and printing it beside a
-// checkmark is how this bug read as a success. result.ArtifactID is still the
-// version that is serving at this point, so a want that differs from it is
-// precisely the roll case and nothing else.
-func waitLabel(wantArtifactID string, result Result) string {
-	if wantArtifactID != "" && wantArtifactID != result.ArtifactID {
-		return "Waiting for the new version to serve"
+// A workload that never stopped running makes "waiting for the workload to run"
+// describe a wait that was over before it began, which is how this bug read as
+// a success. Both paths that replace a generation have that shape, so the label
+// keys on AwaitDrain rather than on the artifact: a resize waits out a drain
+// with no artifact to name, and would otherwise keep the wording the roll just
+// stopped using.
+//
+// result.ArtifactID still names the outgoing version at this point, by settle's
+// ordering, which is what tells a roll from a start onto the same version.
+func waitLabel(want workload.Serving, result Result) string {
+	if !want.AwaitDrain {
+		return "Waiting for the workload to run"
 	}
 
-	return "Waiting for the workload to run"
+	if want.ArtifactID == "" {
+		return "Waiting for the new settings to serve"
+	}
+
+	if want.ArtifactID == result.ArtifactID {
+		return "Waiting for the workload to run"
+	}
+
+	return "Waiting for the new version to serve"
 }
+
+// budgetLeft is opts with the poll timeout reduced by what a run has already
+// spent on it.
+//
+// A roll waits twice: once on the replacement, once on the handover. Each used
+// to take opts.PollTimeout in full, which was invisible while the second wait
+// returned on its first poll and is not now that it sits through a drain. A
+// --poll-timeout of ten minutes meant ten, not twenty, and a CI budget set
+// against the flag should still hold.
+//
+// A floor is kept so a first wait that used the whole budget still gives the
+// second one long enough to say something better than "timeout".
+func budgetLeft(opts Options, since time.Time) Options {
+	if opts.PollTimeout <= 0 {
+		return opts
+	}
+
+	left := opts.PollTimeout - time.Since(since)
+	if left < minPollBudget {
+		left = minPollBudget
+	}
+
+	opts.PollTimeout = left
+
+	return opts
+}
+
+// minPollBudget is what a wait gets when the one before it spent everything.
+const minPollBudget = 30 * time.Second
+
+// heartbeat prints a line every so often while a long wait runs, and nil when
+// there is a spinner to do that job.
+//
+// report.run prints nothing until a phase ends, so without this the longest
+// phase in the deploy emits no bytes at all: on a live rollout it sat for eight
+// and a half minutes, which from outside is indistinguishable from a hang.
+//
+// The line carries the phase name because it is printed before the checkmark it
+// belongs to. Read top to bottom, an unlabelled line sits under the previous
+// phase's tick and reads as belonging to that one.
+func heartbeat(label string, opts Options, report *reporter) func(*workload.Workload) {
+	if opts.Spinner || opts.PollInterval <= 0 {
+		return nil
+	}
+
+	every := int(heartbeatEvery / opts.PollInterval)
+	if every < 1 {
+		every = 1
+	}
+
+	started := phaseClock()
+	ticks := 0
+
+	return func(wl *workload.Workload) {
+		ticks++
+
+		if ticks%every != 0 {
+			return
+		}
+
+		// Elapsed, not the artifact. Naming the version being waited for reads
+		// as though it had arrived, which is the question this line exists to
+		// answer: the wait is progressing, not stuck.
+		report.say("    %s\n", tui.HintStyle.Render(fmt.Sprintf(
+			"%s, %s so far; the workload is %s",
+			label, phaseClock().Sub(started).Truncate(time.Second), wl.Status)))
+	}
+}
+
+// heartbeatEvery is how often a silent wait says it is still there. Long
+// enough not to bury a CI log, short enough that nobody reaches for Ctrl-C.
+const heartbeatEvery = 30 * time.Second
 
 // lock makes the live artifact permanent. It runs only after the workload is
 // serving, because locking is one-way: locking an artifact that never came up

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -168,7 +168,7 @@ runtime:
 type fakes struct {
 	wizard         func(wizard.Options) (wizard.Result, error)
 	create         func(any) (*workload.Workload, error)
-	wait           func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
+	wait           func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
 	waitSteady     func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
 	list           func(int, []string, string) ([]workload.Workload, error)
 	start          func(string) (*workload.WorkloadOperationResponse, error)
@@ -296,6 +296,17 @@ func install(t *testing.T, f fakes) {
 	swap(t, &updateSettingsFn, f.settings)
 }
 
+// servingLabel renders what a wait was asked to confirm, so a trace shows the
+// difference between a create (nothing), a resize (drain only) and a roll.
+func servingLabel(want workload.Serving) string {
+	label := "settle:" + want.ArtifactID
+	if want.AwaitDrain {
+		label += "+drain"
+	}
+
+	return label
+}
+
 // swap installs fake over the seam at target, and does nothing when the test
 // did not supply one. reflect is what makes that distinction possible: a nil
 // func in a type parameter is still a value, so there is no way to compare it
@@ -386,7 +397,7 @@ func TestRun_NoManifestOnATerminalRunsTheWizard(t *testing.T) {
 			return wizard.Result{Path: opts.Dir}, nil
 		},
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 	})
@@ -549,31 +560,6 @@ runtime:
           resourceAllocation: {cpu: 3, memory: 22GB, gpu: 1}
 `
 
-// The other half of the label. A create really is waiting for the workload to
-// come up, and really does have only one version, so it names no artifact and
-// keeps the wording it had.
-func TestRun_CreateStillSaysItIsWaitingForTheWorkload(t *testing.T) {
-	var wanted string
-
-	install(t, fakes{
-		create: func(any) (*workload.Workload, error) {
-			return running("wl-new"), nil
-		},
-		writeID: func(string, string) error { return nil },
-		wait: func(_, want string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
-			wanted = want
-
-			return running("wl-new"), nil
-		},
-	})
-
-	_, stderr, err := runIn(t, unboundImageManifest, Options{NonInteractive: true})
-	require.NoError(t, err)
-
-	assert.Empty(t, wanted, "a create has nothing to promote, so it names no artifact to wait for")
-	assert.Contains(t, stderr, "Waiting for the workload to run")
-}
-
 func TestRun_CreatesFromAPublishedImage(t *testing.T) {
 	var (
 		payload              any
@@ -591,7 +577,7 @@ func TestRun_CreatesFromAPublishedImage(t *testing.T) {
 
 			return nil
 		},
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 	})
@@ -642,7 +628,7 @@ func TestRun_ConflictNamesTheWorkloadThatOwnsTheName(t *testing.T) {
 
 			return nil
 		},
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			t.Fatal("nothing was deployed, so there is nothing to wait for")
 
 			return nil, nil
@@ -683,7 +669,7 @@ func TestRun_ConflictWithNoMatchKeepsTheOriginalError(t *testing.T) {
 func TestRun_DetachSkipsTheWait(t *testing.T) {
 	install(t, fakes{
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			t.Fatal("--detach must not wait")
 
 			return nil, nil
@@ -703,7 +689,7 @@ func TestRun_LockHappensAfterTheWorkloadServes(t *testing.T) {
 
 	install(t, fakes{
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			order = append(order, "wait")
 
 			return running("wl-new"), nil
@@ -724,7 +710,7 @@ func TestRun_LockHappensAfterTheWorkloadServes(t *testing.T) {
 func TestRun_LockIsNotAttemptedWhenTheWorkloadFailed(t *testing.T) {
 	install(t, fakes{
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			errored := running("wl-new")
 			errored.Status = workload.WorkloadStatusErrored
 
@@ -808,7 +794,7 @@ func TestRun_SettlingWorkloadIsWaitedOutAndThenDeployed(t *testing.T) {
 		start: func(id string) (*workload.WorkloadOperationResponse, error) {
 			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
 		},
-		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id string, _ workload.Serving, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 	})
@@ -884,7 +870,7 @@ func TestRun_WorkloadDeletedDuringTheWaitIsRecreated(t *testing.T) {
 			return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
 		},
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id string, _ workload.Serving, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 	})
@@ -1016,7 +1002,7 @@ func TestRun_MissingWorkloadIsRecreated(t *testing.T) {
 
 			return nil
 		},
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 	})
@@ -1043,7 +1029,7 @@ func TestRun_MissingWorkloadNamesTheDeadBinding(t *testing.T) {
 		},
 		create:  func(any) (*workload.Workload, error) { return running("wl-new"), nil },
 		writeID: func(string, string) error { return nil },
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 	})
@@ -1189,7 +1175,7 @@ func wiredBuild(tr *track) fakes {
 
 			return running("wl-1"), nil
 		},
-		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id string, _ workload.Serving, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 	}
@@ -1553,7 +1539,7 @@ func TestRun_DetachStillWaitsForTheImage(t *testing.T) {
 	var tr track
 
 	f := wiredBuild(&tr)
-	f.wait = func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+	f.wait = func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 		t.Fatal("--detach does not wait for the workload")
 
 		return nil, nil
@@ -1732,7 +1718,7 @@ func TestRun_ForceBuildWithNothingToDoSaysSo(t *testing.T) {
 func TestRun_ForceBuildOnAPublishedImageSaysSo(t *testing.T) {
 	install(t, fakes{
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 		build: func(string) (*workload.BuildTriggerResponse, error) {
@@ -1777,7 +1763,7 @@ func TestRun_CreatesFromAnArtifactTheManifestNames(t *testing.T) {
 			return running("wl-new"), nil
 		},
 		writeID: func(string, string) error { return nil },
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 		getArtifact: func(id string) (*workload.Artifact, error) {
@@ -1803,7 +1789,7 @@ func TestRun_CreatesFromALockedArtifactReportsItLocked(t *testing.T) {
 	install(t, fakes{
 		create:  func(any) (*workload.Workload, error) { return running("wl-new"), nil },
 		writeID: func(string, string) error { return nil },
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 		getArtifact: func(id string) (*workload.Artifact, error) {
@@ -1888,7 +1874,7 @@ func TestRun_StartsAStoppedWorkload(t *testing.T) {
 
 			return &workload.WorkloadOperationResponse{WorkloadID: id, Status: "queued"}, nil
 		},
-		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id string, _ workload.Serving, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 		create: func(any) (*workload.Workload, error) {
@@ -1935,7 +1921,7 @@ func TestRun_StoppedWithDriftStartsAndThenReconciles(t *testing.T) {
 
 			return started, nil
 		},
-		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id string, _ workload.Serving, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			order = append(order, "wait")
 
 			return running(id), nil
@@ -1964,7 +1950,7 @@ func TestRun_StartFailureNamesTheWorkload(t *testing.T) {
 		start: func(string) (*workload.WorkloadOperationResponse, error) {
 			return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
 		},
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			t.Fatal("there is nothing to wait for when the start was refused")
 
 			return nil, nil
@@ -1985,7 +1971,7 @@ func TestRun_DetachedStartDoesNotWait(t *testing.T) {
 		start: func(id string) (*workload.WorkloadOperationResponse, error) {
 			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
 		},
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			t.Fatal("--detach returns as soon as the start is requested")
 
 			return nil, nil
@@ -2040,7 +2026,7 @@ func TestRun_InterruptedStartsLikeAnyStoppedWorkload(t *testing.T) {
 
 			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
 		},
-		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id string, _ workload.Serving, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 	})
@@ -2062,7 +2048,7 @@ func TestRun_StartAcknowledgementIsPrinted(t *testing.T) {
 		start: func(id string) (*workload.WorkloadOperationResponse, error) {
 			return &workload.WorkloadOperationResponse{WorkloadID: id, Status: "Proton is already running"}, nil
 		},
-		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id string, _ workload.Serving, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 	})
@@ -2083,7 +2069,7 @@ func TestRun_StartDoesNotRelockALockedArtifact(t *testing.T) {
 		start: func(id string) (*workload.WorkloadOperationResponse, error) {
 			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
 		},
-		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id string, _ workload.Serving, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 		lock: func(string) (*workload.Artifact, error) {
@@ -2126,7 +2112,7 @@ func TestRun_StartLocksAnUnlockedArtifactOnceItServes(t *testing.T) {
 
 			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
 		},
-		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id string, _ workload.Serving, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			order = append(order, "wait")
 
 			return running(id), nil
@@ -2267,7 +2253,7 @@ func TestRun_ResolvedCredentialDeploys(t *testing.T) {
 			return &workload.Credential{CredentialID: id, Name: "my-app/OPENAI_API_KEY"}, nil
 		},
 		create: func(any) (*workload.Workload, error) { return running("wl-1"), nil },
-		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-1"), nil
 		},
 	})

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -168,7 +168,7 @@ runtime:
 type fakes struct {
 	wizard         func(wizard.Options) (wizard.Result, error)
 	create         func(any) (*workload.Workload, error)
-	wait           func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
+	wait           func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
 	waitSteady     func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error)
 	list           func(int, []string, string) ([]workload.Workload, error)
 	start          func(string) (*workload.WorkloadOperationResponse, error)
@@ -386,7 +386,7 @@ func TestRun_NoManifestOnATerminalRunsTheWizard(t *testing.T) {
 			return wizard.Result{Path: opts.Dir}, nil
 		},
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 	})
@@ -549,6 +549,31 @@ runtime:
           resourceAllocation: {cpu: 3, memory: 22GB, gpu: 1}
 `
 
+// The other half of the label. A create really is waiting for the workload to
+// come up, and really does have only one version, so it names no artifact and
+// keeps the wording it had.
+func TestRun_CreateStillSaysItIsWaitingForTheWorkload(t *testing.T) {
+	var wanted string
+
+	install(t, fakes{
+		create: func(any) (*workload.Workload, error) {
+			return running("wl-new"), nil
+		},
+		writeID: func(string, string) error { return nil },
+		wait: func(_, want string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+			wanted = want
+
+			return running("wl-new"), nil
+		},
+	})
+
+	_, stderr, err := runIn(t, unboundImageManifest, Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Empty(t, wanted, "a create has nothing to promote, so it names no artifact to wait for")
+	assert.Contains(t, stderr, "Waiting for the workload to run")
+}
+
 func TestRun_CreatesFromAPublishedImage(t *testing.T) {
 	var (
 		payload              any
@@ -566,7 +591,7 @@ func TestRun_CreatesFromAPublishedImage(t *testing.T) {
 
 			return nil
 		},
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 	})
@@ -617,7 +642,7 @@ func TestRun_ConflictNamesTheWorkloadThatOwnsTheName(t *testing.T) {
 
 			return nil
 		},
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			t.Fatal("nothing was deployed, so there is nothing to wait for")
 
 			return nil, nil
@@ -658,7 +683,7 @@ func TestRun_ConflictWithNoMatchKeepsTheOriginalError(t *testing.T) {
 func TestRun_DetachSkipsTheWait(t *testing.T) {
 	install(t, fakes{
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			t.Fatal("--detach must not wait")
 
 			return nil, nil
@@ -678,7 +703,7 @@ func TestRun_LockHappensAfterTheWorkloadServes(t *testing.T) {
 
 	install(t, fakes{
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			order = append(order, "wait")
 
 			return running("wl-new"), nil
@@ -699,7 +724,7 @@ func TestRun_LockHappensAfterTheWorkloadServes(t *testing.T) {
 func TestRun_LockIsNotAttemptedWhenTheWorkloadFailed(t *testing.T) {
 	install(t, fakes{
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			errored := running("wl-new")
 			errored.Status = workload.WorkloadStatusErrored
 
@@ -783,7 +808,7 @@ func TestRun_SettlingWorkloadIsWaitedOutAndThenDeployed(t *testing.T) {
 		start: func(id string) (*workload.WorkloadOperationResponse, error) {
 			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
 		},
-		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 	})
@@ -859,7 +884,7 @@ func TestRun_WorkloadDeletedDuringTheWaitIsRecreated(t *testing.T) {
 			return nil, &drapi.HTTPError{StatusCode: http.StatusNotFound}
 		},
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 	})
@@ -991,7 +1016,7 @@ func TestRun_MissingWorkloadIsRecreated(t *testing.T) {
 
 			return nil
 		},
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 	})
@@ -1018,7 +1043,7 @@ func TestRun_MissingWorkloadNamesTheDeadBinding(t *testing.T) {
 		},
 		create:  func(any) (*workload.Workload, error) { return running("wl-new"), nil },
 		writeID: func(string, string) error { return nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 	})
@@ -1164,7 +1189,7 @@ func wiredBuild(tr *track) fakes {
 
 			return running("wl-1"), nil
 		},
-		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 	}
@@ -1528,7 +1553,7 @@ func TestRun_DetachStillWaitsForTheImage(t *testing.T) {
 	var tr track
 
 	f := wiredBuild(&tr)
-	f.wait = func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+	f.wait = func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 		t.Fatal("--detach does not wait for the workload")
 
 		return nil, nil
@@ -1707,7 +1732,7 @@ func TestRun_ForceBuildWithNothingToDoSaysSo(t *testing.T) {
 func TestRun_ForceBuildOnAPublishedImageSaysSo(t *testing.T) {
 	install(t, fakes{
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 		build: func(string) (*workload.BuildTriggerResponse, error) {
@@ -1752,7 +1777,7 @@ func TestRun_CreatesFromAnArtifactTheManifestNames(t *testing.T) {
 			return running("wl-new"), nil
 		},
 		writeID: func(string, string) error { return nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 		getArtifact: func(id string) (*workload.Artifact, error) {
@@ -1778,7 +1803,7 @@ func TestRun_CreatesFromALockedArtifactReportsItLocked(t *testing.T) {
 	install(t, fakes{
 		create:  func(any) (*workload.Workload, error) { return running("wl-new"), nil },
 		writeID: func(string, string) error { return nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 		getArtifact: func(id string) (*workload.Artifact, error) {
@@ -1863,7 +1888,7 @@ func TestRun_StartsAStoppedWorkload(t *testing.T) {
 
 			return &workload.WorkloadOperationResponse{WorkloadID: id, Status: "queued"}, nil
 		},
-		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 		create: func(any) (*workload.Workload, error) {
@@ -1910,7 +1935,7 @@ func TestRun_StoppedWithDriftStartsAndThenReconciles(t *testing.T) {
 
 			return started, nil
 		},
-		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			order = append(order, "wait")
 
 			return running(id), nil
@@ -1939,7 +1964,7 @@ func TestRun_StartFailureNamesTheWorkload(t *testing.T) {
 		start: func(string) (*workload.WorkloadOperationResponse, error) {
 			return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
 		},
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			t.Fatal("there is nothing to wait for when the start was refused")
 
 			return nil, nil
@@ -1960,7 +1985,7 @@ func TestRun_DetachedStartDoesNotWait(t *testing.T) {
 		start: func(id string) (*workload.WorkloadOperationResponse, error) {
 			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
 		},
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			t.Fatal("--detach returns as soon as the start is requested")
 
 			return nil, nil
@@ -2015,7 +2040,7 @@ func TestRun_InterruptedStartsLikeAnyStoppedWorkload(t *testing.T) {
 
 			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
 		},
-		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 	})
@@ -2037,7 +2062,7 @@ func TestRun_StartAcknowledgementIsPrinted(t *testing.T) {
 		start: func(id string) (*workload.WorkloadOperationResponse, error) {
 			return &workload.WorkloadOperationResponse{WorkloadID: id, Status: "Proton is already running"}, nil
 		},
-		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 	})
@@ -2058,7 +2083,7 @@ func TestRun_StartDoesNotRelockALockedArtifact(t *testing.T) {
 		start: func(id string) (*workload.WorkloadOperationResponse, error) {
 			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
 		},
-		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			return running(id), nil
 		},
 		lock: func(string) (*workload.Artifact, error) {
@@ -2101,7 +2126,7 @@ func TestRun_StartLocksAnUnlockedArtifactOnceItServes(t *testing.T) {
 
 			return &workload.WorkloadOperationResponse{WorkloadID: id}, nil
 		},
-		wait: func(id string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(id, _ string, _, _ time.Duration, _ func(*workload.Workload)) (*workload.Workload, error) {
 			order = append(order, "wait")
 
 			return running(id), nil
@@ -2242,7 +2267,7 @@ func TestRun_ResolvedCredentialDeploys(t *testing.T) {
 			return &workload.Credential{CredentialID: id, Name: "my-app/OPENAI_API_KEY"}, nil
 		},
 		create: func(any) (*workload.Workload, error) { return running("wl-1"), nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-1"), nil
 		},
 	})

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -378,24 +378,57 @@ func GetWorkload(workloadID string) (*Workload, error) {
 }
 
 // WaitForWorkload polls GetWorkload on interval until the workload reaches a
-// terminal status (see IsTerminalWorkloadStatus) or deadline expires. It
-// returns the final Workload in every non-poll-error case so callers can render
-// it:
-//   - running: success, nil error.
+// terminal status (see IsTerminalWorkloadStatus) while serving wantArtifactID,
+// or the deadline expires. It returns the final Workload in every
+// non-poll-error case so callers can render it:
+//   - running the wanted artifact: success, nil error.
 //   - errored/terminated: the final workload alongside a failure error.
 //   - timeout: the last-seen workload alongside a timeout error (this covers a
-//     workload stuck in a non-running steady state such as stopped).
+//     workload stuck in a non-running steady state such as stopped, and one
+//     that is running but has never promoted the version the caller put there).
+//
+// wantArtifactID is the artifact the caller expects to find serving, and empty
+// when it has no expectation. A create, a start and a resize all leave the
+// running artifact where it was, so there is nothing for them to name; a roll
+// is the case this exists for.
+//
+// Naming it is what makes the wait mean anything there. The platform applies a
+// roll by replacing the workload with itself, and the version already serving
+// keeps serving for the whole of the swap, so the workload reports "running"
+// from before the rollout starts until after it ends. Waiting on the status
+// alone therefore returns on the first poll, on the old version, having proved
+// nothing: the command exits reporting success while the endpoint still answers
+// with the previous build.
+//
+// Ids are compared exactly, unlike every status comparison in this package.
+// Those fold because the platform does not agree with itself about the casing
+// of its enums. An object id is not an enum, and folding one would only hide a
+// mismatch worth seeing.
 //
 // onTick may be nil and is invoked after each poll for debug-only observation,
 // mirroring WaitForBuild.
 func WaitForWorkload(
-	workloadID string,
+	workloadID, wantArtifactID string,
 	interval, timeout time.Duration,
 	onTick func(*Workload),
 ) (*Workload, error) {
-	wl, err := pollWorkload(workloadID, interval, timeout, IsTerminalWorkloadStatus, onTick)
-	if err != nil || wl == nil {
-		return wl, err
+	// The error term comes first, and is deliberately not guarded by the
+	// artifact check. An errored workload is still reporting whatever it was
+	// running, which is never the artifact a roll is waiting for, so requiring
+	// both would poll a dead workload to its timeout instead of failing on the
+	// first sight of it.
+	stop := func(wl *Workload) bool {
+		return IsWorkloadErrorStatus(wl.Status) ||
+			(IsTerminalWorkloadStatus(wl.Status) && serving(wl, wantArtifactID))
+	}
+
+	wl, err := pollWorkload(workloadID, interval, timeout, stop, onTick)
+	if err != nil {
+		return wl, unpromoted(workloadID, wl, wantArtifactID, err)
+	}
+
+	if wl == nil {
+		return wl, nil
 	}
 
 	if IsWorkloadErrorStatus(wl.Status) {
@@ -404,6 +437,32 @@ func WaitForWorkload(
 	}
 
 	return wl, nil
+}
+
+// serving reports whether wl is running the artifact the caller named.
+//
+// An empty want is not a hole in the check: it is a caller that changed no
+// artifact, for whom the status is the whole question.
+func serving(wl *Workload, wantArtifactID string) bool {
+	return wantArtifactID == "" || wl.ArtifactID == wantArtifactID
+}
+
+// unpromoted replaces a bare timeout with what actually went wrong when the
+// workload was there all along and simply never took the new version.
+//
+// "timeout waiting for workload X" sends the reader looking for something that
+// is not stuck. Naming both artifacts says the rollout is what did not land and
+// that the old version is still the one answering, which is the difference
+// between reading logs and re-running the deploy.
+func unpromoted(workloadID string, wl *Workload, wantArtifactID string, err error) error {
+	if wl == nil || serving(wl, wantArtifactID) {
+		return err
+	}
+
+	return fmt.Errorf(
+		"workload %s is %s but still serving artifact %s, not %s, so the rollout has not promoted "+
+			"the new version; check 'dr workload status %s': %w",
+		workloadID, wl.Status, wl.ArtifactID, wantArtifactID, workloadID, err)
 }
 
 // WaitForSteadyWorkload polls until the workload stops moving under its own
@@ -427,41 +486,68 @@ func WaitForSteadyWorkload(
 	interval, timeout time.Duration,
 	onTick func(*Workload),
 ) (*Workload, error) {
-	return pollWorkload(workloadID, interval, timeout, IsSteadyWorkloadStatus, onTick)
+	return pollWorkload(workloadID, interval, timeout, func(wl *Workload) bool {
+		return IsSteadyWorkloadStatus(wl.Status)
+	}, onTick)
 }
 
 // pollWorkload is the loop both waits share. It errors only on a poll that
-// failed and on the deadline, so the verdict on a status the loop stopped at is
-// the caller's to pass: the same "errored" is a failure to one of them and an
+// failed and on the deadline, so the verdict on a workload the loop stopped at
+// is the caller's to pass: the same "errored" is a failure to one of them and an
 // answer to the other.
 //
+// stop is handed the whole workload rather than its status because "has it
+// arrived" is not always a question about the status. A roll leaves the status
+// reading "running" from beginning to end, and the only thing that moves is
+// which artifact the workload names.
+//
 // The last-seen workload comes back with a timeout so a caller can still say
-// where it got to, and nothing at all comes back from a failed poll, since
-// there is no status to report.
+// where it got to, and nothing at all comes back from a failed poll, since a
+// wait that could not read the workload has no state to report.
+//
+// A transient failure is not a failed poll. These waits now run for as long as
+// a rollout takes, which is long enough for one 502 or one dropped connection
+// to land between two healthy polls, and failing a deploy that is going fine is
+// a worse answer than looking again. The allowance resets on every good poll,
+// so it forgives blips without ever forgiving an endpoint that has gone away.
 func pollWorkload(
 	workloadID string,
 	interval, timeout time.Duration,
-	stop func(string) bool,
+	stop func(*Workload) bool,
 	onTick func(*Workload),
 ) (*Workload, error) {
 	deadline := time.Now().Add(timeout)
 
+	var (
+		last      *Workload
+		transient int
+	)
+
 	for {
 		wl, err := GetWorkload(workloadID)
-		if err != nil {
+
+		switch {
+		case err == nil:
+			transient = 0
+			last = wl
+
+			if onTick != nil {
+				onTick(wl)
+			}
+
+			if stop(wl) {
+				return wl, nil
+			}
+
+		case isTransientPollError(err) && transient < maxTransientPollErrors:
+			transient++
+
+		default:
 			return nil, fmt.Errorf("poll workload %s: %w", workloadID, err)
 		}
 
-		if onTick != nil {
-			onTick(wl)
-		}
-
-		if stop(wl.Status) {
-			return wl, nil
-		}
-
 		if time.Now().After(deadline) {
-			return wl, fmt.Errorf("timeout waiting for workload %s after %s", workloadID, timeout)
+			return last, fmt.Errorf("timeout waiting for workload %s after %s", workloadID, timeout)
 		}
 
 		time.Sleep(interval)

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -377,58 +377,109 @@ func GetWorkload(workloadID string) (*Workload, error) {
 	return &workload, nil
 }
 
+// Serving is what a wait must see before it settles. The zero value asks only
+// that the workload be running, which is what a create and a start want: both
+// leave the running artifact where it was and neither replaces a generation.
+//
+// It is a struct rather than two arguments because the difference between the
+// three cases is not expressible in one string. A resize confirms no artifact
+// and still has to wait out a drain; a create confirms no artifact and must
+// not. Spelling that as an empty id made the two indistinguishable at the call
+// site and put a drain wait in front of every create.
+type Serving struct {
+	// ArtifactID is the version that must be the one answering, empty when
+	// the run changed none.
+	ArtifactID string
+
+	// AwaitDrain requires the generation being replaced to have stopped
+	// taking requests. A roll and a resize both replace one; a create and a
+	// start do not.
+	AwaitDrain bool
+
+	// OnUnconfirmed, if set, is called once with a short reason when the
+	// proton list cannot be read and the wait falls back to the artifact
+	// alone. A caller that reports on the endpoint afterwards should say so,
+	// because on that path the endpoint may still be answering from the
+	// version being replaced.
+	OnUnconfirmed func(reason string)
+}
+
 // WaitForWorkload polls GetWorkload on interval until the workload reaches a
-// terminal status (see IsTerminalWorkloadStatus) while serving wantArtifactID,
-// or the deadline expires. It returns the final Workload in every
-// non-poll-error case so callers can render it:
-//   - running the wanted artifact: success, nil error.
-//   - errored/terminated: the final workload alongside a failure error.
-//   - timeout: the last-seen workload alongside a timeout error (this covers a
-//     workload stuck in a non-running steady state such as stopped, and one
-//     that is running but has never promoted the version the caller put there).
+// terminal status (see IsTerminalWorkloadStatus) and satisfies want, or the
+// deadline expires. A timeout returns the last-seen workload so a caller can
+// say where it got to; errored and terminated come back as failures.
 //
-// wantArtifactID is the artifact the caller expects to find serving, and empty
-// when it has no expectation. A create, a start and a resize all leave the
-// running artifact where it was, so there is nothing for them to name; a roll
-// is the case this exists for.
+// A roll names its candidate, and needs to, because the platform rolls by
+// replacing the workload with itself and so reports "running" from before the
+// swap until after it, leaving a status-only wait to return on the first poll
+// having proved nothing. The artifact is not sufficient on its own either,
+// which is what protonsServing covers.
 //
-// Naming it is what makes the wait mean anything there. The platform applies a
-// roll by replacing the workload with itself, and the version already serving
-// keeps serving for the whole of the swap, so the workload reports "running"
-// from before the rollout starts until after it ends. Waiting on the status
-// alone therefore returns on the first poll, on the old version, having proved
-// nothing: the command exits reporting success while the endpoint still answers
-// with the previous build.
+// The proton list is corroboration, never the rollout itself, so no failure to
+// read it fails a deploy. A refusal falls back at once; anything else is given
+// a few polls to recover and then falls back too, because a deploy that has
+// built, promoted and started serving must not be reported as failed on
+// account of the second request that was only checking.
 //
-// Ids are compared exactly, unlike every status comparison in this package.
-// Those fold because the platform does not agree with itself about the casing
-// of its enums. An object id is not an enum, and folding one would only hide a
-// mismatch worth seeing.
-//
-// onTick may be nil and is invoked after each poll for debug-only observation,
-// mirroring WaitForBuild.
+// onTick may be nil and is invoked after each poll, mirroring WaitForBuild.
 func WaitForWorkload(
-	workloadID, wantArtifactID string,
+	workloadID string,
+	want Serving,
 	interval, timeout time.Duration,
 	onTick func(*Workload),
 ) (*Workload, error) {
-	// The error term comes first, and is deliberately not guarded by the
-	// artifact check. An errored workload is still reporting whatever it was
-	// running, which is never the artifact a roll is waiting for, so requiring
-	// both would poll a dead workload to its timeout instead of failing on the
-	// first sight of it.
+	var unreadable, empty int
+
+	// The error term is first and unguarded: an errored workload still reports
+	// whatever it was running, so requiring the artifact too would poll a dead
+	// workload to its timeout instead of failing on first sight.
 	stop := func(wl *Workload) bool {
-		return IsWorkloadErrorStatus(wl.Status) ||
-			(IsTerminalWorkloadStatus(wl.Status) && serving(wl, wantArtifactID))
+		if IsWorkloadErrorStatus(wl.Status) {
+			return true
+		}
+
+		// Only running reaches here, the error statuses having returned above.
+		if !IsTerminalWorkloadStatus(wl.Status) || !onWantedArtifact(wl, want.ArtifactID) {
+			return false
+		}
+
+		verdict, err := servingWanted(workloadID, want)
+		if err != nil {
+			unreadable++
+			if unreadable <= maxTransientPollErrors {
+				return false
+			}
+
+			degrade(want, "the container generations could not be read: "+err.Error())
+
+			return true
+		}
+
+		unreadable = 0
+
+		if !verdict.Empty {
+			empty = 0
+
+			return verdict.Serving
+		}
+
+		// An empty list that keeps coming back is a route with nothing to say
+		// rather than a handover in progress. Bounded the same way an
+		// unwatched replacement 404 is, and for the same reason: waiting
+		// forever on an absence turns a finished deploy into a timeout.
+		empty++
+		if empty < uncorroboratedAbsences {
+			return false
+		}
+
+		degrade(want, "this workload lists no container generations")
+
+		return true
 	}
 
 	wl, err := pollWorkload(workloadID, interval, timeout, stop, onTick)
 	if err != nil {
-		return wl, unpromoted(workloadID, wl, wantArtifactID, err)
-	}
-
-	if wl == nil {
-		return wl, nil
+		return wl, unpromoted(workloadID, wl, want, err)
 	}
 
 	if IsWorkloadErrorStatus(wl.Status) {
@@ -439,30 +490,108 @@ func WaitForWorkload(
 	return wl, nil
 }
 
-// serving reports whether wl is running the artifact the caller named.
-//
-// An empty want is not a hole in the check: it is a caller that changed no
-// artifact, for whom the status is the whole question.
-func serving(wl *Workload, wantArtifactID string) bool {
+// degrade tells the caller the handover went unconfirmed, once.
+func degrade(want Serving, reason string) {
+	if want.OnUnconfirmed != nil {
+		want.OnUnconfirmed(reason)
+	}
+}
+
+// onWantedArtifact reports whether wl names the artifact the caller named; an
+// empty want is a caller that changed none.
+func onWantedArtifact(wl *Workload, wantArtifactID string) bool {
 	return wantArtifactID == "" || wl.ArtifactID == wantArtifactID
 }
 
-// unpromoted replaces a bare timeout with what actually went wrong when the
-// workload was there all along and simply never took the new version.
+// servingWanted asks the proton list whether the previous generation has
+// stopped answering.
 //
-// "timeout waiting for workload X" sends the reader looking for something that
-// is not stuck. Naming both artifacts says the rollout is what did not land and
-// that the old version is still the one answering, which is the difference
-// between reading logs and re-running the deploy.
-func unpromoted(workloadID string, wl *Workload, wantArtifactID string, err error) error {
-	if wl == nil || serving(wl, wantArtifactID) {
+// A refusal is not a failure of the rollout. The route is absent on some
+// installs (404), a token that may deploy is not guaranteed to be allowed to
+// list protons (403), and a gateway that does not know the path can answer 405
+// or 422. None of those say anything went wrong, so they fall back to the
+// artifact check immediately. Everything else, including a body this code
+// cannot read, is returned for the caller to retry and then forgive.
+func servingWanted(workloadID string, want Serving) (protonVerdict, error) {
+	// A create and a start replace no generation and confirm no artifact, so
+	// there is nothing here for them to ask about and no reason to spend a
+	// request finding that out.
+	if want.ArtifactID == "" && !want.AwaitDrain {
+		return protonVerdict{Serving: true}, nil
+	}
+
+	protons, err := ListProtons(workloadID)
+	if err != nil {
+		if refusedRoute(err) {
+			degrade(want, "this install did not answer for container generations ("+err.Error()+")")
+
+			return protonVerdict{Serving: true}, nil
+		}
+
+		return protonVerdict{}, err
+	}
+
+	return protonsServing(protons, want), nil
+}
+
+// refusedRoute reports whether err is the route saying no in a way that will
+// not change on the next poll.
+func refusedRoute(err error) bool {
+	var httpErr *drapi.HTTPError
+
+	return errors.As(err, &httpErr) && httpErr.StatusCode >= 400 && httpErr.StatusCode < 500
+}
+
+// unpromoted says which way a rollout stalled, since a bare timeout sends the
+// reader looking for something that is not stuck.
+//
+// Only a deadline is decorated. A wait whose polls failed already carries the
+// failure, and inferring anything about a rollout from a workload read taken
+// seconds into it would be a guess dressed as a diagnosis.
+func unpromoted(workloadID string, wl *Workload, want Serving, err error) error {
+	var timedOut *waitTimeoutError
+
+	if wl == nil || !errors.As(err, &timedOut) {
 		return err
 	}
 
-	return fmt.Errorf(
-		"workload %s is %s but still serving artifact %s, not %s, so the rollout has not promoted "+
-			"the new version; check 'dr workload status %s': %w",
-		workloadID, wl.Status, wl.ArtifactID, wantArtifactID, workloadID, err)
+	if !onWantedArtifact(wl, want.ArtifactID) {
+		return fmt.Errorf(
+			"workload %s is %s but still serving artifact %s, not %s, so the rollout has not promoted "+
+				"the new version; check 'dr workload status %s': %w",
+			workloadID, wl.Status, wl.ArtifactID, want.ArtifactID, workloadID, err)
+	}
+
+	if reason := stalledOn(workloadID, want); reason != "" {
+		return fmt.Errorf("workload %s reports artifact %s, but %s; check 'dr workload status %s': %w",
+			workloadID, wl.ArtifactID, reason, workloadID, err)
+	}
+
+	return err
+}
+
+// stalledOn names what the proton list was still showing when the wait ran out,
+// or "" when it cannot say. The read is on the error path only and its own
+// failure is swallowed: this decorates a timeout already decided.
+func stalledOn(workloadID string, want Serving) string {
+	protons, err := ListProtons(workloadID)
+	if err != nil {
+		return ""
+	}
+
+	if len(protons) == 0 {
+		return "no container generations are listed for it"
+	}
+
+	if want.AwaitDrain && anyServingPredecessor(protons, want.ArtifactID) {
+		return "a previous version is still answering its endpoint, so the rollout has not finished"
+	}
+
+	if want.ArtifactID != "" && !anyRunning(protons, want.ArtifactID) {
+		return "nothing is running that version yet"
+	}
+
+	return ""
 }
 
 // WaitForSteadyWorkload polls until the workload stops moving under its own
@@ -491,44 +620,50 @@ func WaitForSteadyWorkload(
 	}, onTick)
 }
 
-// pollWorkload is the loop both waits share. It errors only on a poll that
-// failed and on the deadline, so the verdict on a workload the loop stopped at
-// is the caller's to pass: the same "errored" is a failure to one of them and an
-// answer to the other.
+// waitTimeoutError marks a wait that ran out of time, so a caller can tell it
+// from one whose polls failed and decorate only the first.
+type waitTimeoutError struct {
+	workloadID string
+	timeout    time.Duration
+}
+
+func (e *waitTimeoutError) Error() string {
+	return fmt.Sprintf("timeout waiting for workload %s after %s", e.workloadID, e.timeout)
+}
+
+// pollWorkload is the loop both waits share. It errors only on a failed poll
+// and on the deadline, leaving the verdict on where it stopped to the caller.
 //
-// stop is handed the whole workload rather than its status because "has it
-// arrived" is not always a question about the status. A roll leaves the status
-// reading "running" from beginning to end, and the only thing that moves is
-// which artifact the workload names.
+// stop takes the whole workload because "has it arrived" is not always about
+// the status: a roll leaves the status reading "running" throughout. It cannot
+// fail: confirming a rollout takes a second request, but a failure there is the
+// corroboration falling over rather than the deploy, so stop absorbs it and
+// this loop only ever reports on the workload read it names.
 //
-// The last-seen workload comes back with a timeout so a caller can still say
-// where it got to, and nothing at all comes back from a failed poll, since a
-// wait that could not read the workload has no state to report.
-//
-// A transient failure is not a failed poll. These waits now run for as long as
-// a rollout takes, which is long enough for one 502 or one dropped connection
-// to land between two healthy polls, and failing a deploy that is going fine is
-// a worse answer than looking again. The allowance resets on every good poll,
-// so it forgives blips without ever forgiving an endpoint that has gone away.
+// The last-seen workload comes back with every error that has one, so a caller
+// can still say what the workload was doing when the wait gave up.
 func pollWorkload(
 	workloadID string,
 	interval, timeout time.Duration,
 	stop func(*Workload) bool,
 	onTick func(*Workload),
 ) (*Workload, error) {
-	deadline := time.Now().Add(timeout)
+	if interval <= 0 {
+		interval = defaultWorkloadPollInterval
+	}
 
-	var (
-		last      *Workload
-		transient int
-	)
+	deadline := time.Now().Add(timeout)
+	budget := transientBudget{}
+
+	var last *Workload
 
 	for {
 		wl, err := GetWorkload(workloadID)
-
-		switch {
-		case err == nil:
-			transient = 0
+		if err != nil {
+			if !budget.forgive(err) {
+				return last, fmt.Errorf("poll workload %s: %w", workloadID, err)
+			}
+		} else {
 			last = wl
 
 			if onTick != nil {
@@ -539,20 +674,22 @@ func pollWorkload(
 				return wl, nil
 			}
 
-		case isTransientPollError(err) && transient < maxTransientPollErrors:
-			transient++
-
-		default:
-			return nil, fmt.Errorf("poll workload %s: %w", workloadID, err)
+			budget.reset()
 		}
 
 		if time.Now().After(deadline) {
-			return last, fmt.Errorf("timeout waiting for workload %s after %s", workloadID, timeout)
+			return last, &waitTimeoutError{workloadID: workloadID, timeout: timeout}
 		}
 
 		time.Sleep(interval)
 	}
 }
+
+// defaultWorkloadPollInterval keeps an exported poller from busy-spinning when
+// handed a non-positive interval, matching defaultReplacementPollInterval. The
+// CLI's own flags cannot produce one, but nothing in the signature says so, and
+// this loop now runs for as long as a rollout takes rather than a few polls.
+const defaultWorkloadPollInterval = 2 * time.Second
 
 type WorkloadList struct {
 	Data       []Workload `json:"data"`

--- a/internal/workload/workload_test.go
+++ b/internal/workload/workload_test.go
@@ -183,10 +183,8 @@ func serverWorkloadDoc(id, name, status string) string {
 	return serverWorkloadDocOn(id, name, status, "art-1")
 }
 
-// serverWorkloadDocOn is the same document with the running artifact named.
-// Which artifact a poll reports is the whole subject of the rollout waits, and
-// a fixture that always answers "art-1" is why the suite could not see a wait
-// settling on the version it was supposed to be replacing.
+// serverWorkloadDocOn names the running artifact. A fixture that always says
+// "art-1" is why the suite could not see a wait settle on the old version.
 func serverWorkloadDocOn(id, name, status, artifactID string) string {
 	return fmt.Sprintf(`{
 		"id": %q,
@@ -202,6 +200,55 @@ func serverWorkloadDocOn(id, name, status, artifactID string) string {
 		"permissions": ["CAN_DELETE"],
 		"runtime": {"containerGroups": []}
 	}`, id, name, status, artifactID, id)
+}
+
+// serverProtonList is the proton route's answer, one entry per generation.
+func serverProtonList(pairs ...[2]string) string {
+	entries := make([]string, 0, len(pairs))
+
+	for i, p := range pairs {
+		entries = append(entries, fmt.Sprintf(
+			`{"id":"proton-%d","name":"a","workloadId":"wl-1","artifactId":%q,"status":%q,`+
+				`"createdAt":"2026-06-10T08:00:00Z","updatedAt":"2026-06-10T08:05:00Z"}`,
+			i+1, p[0], p[1]))
+	}
+
+	return fmt.Sprintf(`{"count":%d,"totalCount":%d,"data":[%s]}`,
+		len(entries), len(entries), strings.Join(entries, ","))
+}
+
+// serveWorkloadAndProtons answers both routes the wait reads; an empty protons
+// body answers 404, as a cluster without the route does.
+func serveWorkloadAndProtons(t *testing.T, doc, protons func() string) {
+	t.Helper()
+
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/protons/") {
+			body := doc()
+			if body == "" {
+				w.WriteHeader(http.StatusBadGateway)
+
+				return
+			}
+
+			fmt.Fprint(w, body)
+
+			return
+		}
+
+		body := ""
+		if protons != nil {
+			body = protons()
+		}
+
+		if body == "" {
+			w.WriteHeader(http.StatusNotFound)
+
+			return
+		}
+
+		fmt.Fprint(w, body)
+	}))
 }
 
 func assertProjection(t *testing.T, w *Workload, id, name, status string) {
@@ -668,7 +715,7 @@ func TestWaitForSteadyWorkload_ReturnsAtStoppedWhereWaitForWorkloadWouldNot(t *t
 	require.NoError(t, err)
 	assert.Equal(t, WorkloadStatusStopped, wl.Status)
 
-	_, err = WaitForWorkload("wl-1", "", 5*time.Millisecond, 25*time.Millisecond, nil)
+	_, err = WaitForWorkload("wl-1", Serving{}, 5*time.Millisecond, 25*time.Millisecond, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timeout")
 }
@@ -766,7 +813,7 @@ func TestWaitForWorkload_RunningReturnsNil(t *testing.T) {
 
 	var ticks int
 
-	wl, err := WaitForWorkload("wl-1", "", time.Millisecond, time.Second, func(*Workload) {
+	wl, err := WaitForWorkload("wl-1", Serving{}, time.Millisecond, time.Second, func(*Workload) {
 		ticks++
 	})
 	require.NoError(t, err)
@@ -785,7 +832,7 @@ func TestWaitForWorkload_ErroredReturnsError(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	wl, err := WaitForWorkload("wl-1", "", time.Millisecond, time.Second, nil)
+	wl, err := WaitForWorkload("wl-1", Serving{}, time.Millisecond, time.Second, nil)
 	require.Error(t, err)
 	require.NotNil(t, wl, "errored returns final Workload alongside error")
 	assert.Equal(t, WorkloadStatusErrored, wl.Status)
@@ -814,7 +861,7 @@ func TestWaitForWorkload_PollsThroughStoppedUntilRunning(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	wl, err := WaitForWorkload("wl-1", "", time.Millisecond, time.Second, nil)
+	wl, err := WaitForWorkload("wl-1", Serving{}, time.Millisecond, time.Second, nil)
 	require.NoError(t, err)
 	assert.Equal(t, WorkloadStatusRunning, wl.Status)
 }
@@ -830,46 +877,103 @@ func TestWaitForWorkload_Timeout(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	_, err := WaitForWorkload("wl-1", "", 5*time.Millisecond, 25*time.Millisecond, nil)
+	_, err := WaitForWorkload("wl-1", Serving{}, 5*time.Millisecond, 25*time.Millisecond, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timeout")
 }
 
-// The regression test for a deploy that reported success while the endpoint
-// went on serving the previous build. A rolling swap leaves the workload
-// reporting "running" from beginning to end, so a wait that reads the status
-// alone settles on the first poll, on the version being replaced.
+// The regression test: a rolling swap leaves the workload reporting "running"
+// throughout, so a status-only wait settles at once, on the old version.
 func TestWaitForWorkload_KeepsPollingWhileTheOldArtifactServes(t *testing.T) {
-	installSkipAuth(t)
-
 	var hits int32
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// Running throughout, which is the whole difficulty: the only thing
-		// that moves is which artifact the workload names.
-		artifact := "art-1"
-		if atomic.AddInt32(&hits, 1) >= 3 {
-			artifact = "art-2"
-		}
+	serveWorkloadAndProtons(t,
+		func() string {
+			// Running throughout: the only thing that moves is the artifact.
+			artifact := "art-1"
+			if atomic.AddInt32(&hits, 1) >= 3 {
+				artifact = "art-2"
+			}
 
-		fmt.Fprint(w, serverWorkloadDocOn("wl-1", "a", WorkloadStatusRunning, artifact))
-	}))
+			return serverWorkloadDocOn("wl-1", "a", WorkloadStatusRunning, artifact)
+		},
+		func() string { return serverProtonList([2]string{"art-2", ProtonStatusRunning}) })
 
-	defer srv.Close()
-
-	installEndpoint(t, srv.URL)
-
-	wl, err := WaitForWorkload("wl-1", "art-2", time.Millisecond, time.Second, nil)
+	wl, err := WaitForWorkload("wl-1", Serving{ArtifactID: "art-2", AwaitDrain: true}, time.Millisecond, time.Second, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "art-2", wl.ArtifactID, "the wait must settle on the version it was told to wait for")
 	assert.GreaterOrEqual(t, atomic.LoadInt32(&hits), int32(3),
 		"returning while the old artifact was still serving is the bug")
 }
 
-// A workload that comes up and never takes the new version has not failed in
-// any way the status can express, so the timeout is the only place left to say
-// what happened. A bare "timeout waiting for workload" sends the reader looking
-// for something that is not stuck.
+// The measured shape of the bug: the workload names the new artifact while the
+// previous generation is still draining and still answering.
+func TestWaitForWorkload_WaitsOutTheDrainingGeneration(t *testing.T) {
+	var hits int32
+
+	serveWorkloadAndProtons(t,
+		// The workload has already moved on; it is not the thing that knows.
+		func() string { return serverWorkloadDocOn("wl-1", "a", WorkloadStatusRunning, "art-2") },
+		func() string {
+			if atomic.AddInt32(&hits, 1) < 3 {
+				return serverProtonList(
+					[2]string{"art-2", ProtonStatusRunning},
+					[2]string{"art-1", ProtonStatusDraining},
+				)
+			}
+
+			// The outgoing generation lingers in stopping long after the
+			// endpoint switched, so settling here keeps a finished deploy from
+			// being held open.
+			return serverProtonList(
+				[2]string{"art-2", ProtonStatusRunning},
+				[2]string{"art-1", "stopping"},
+			)
+		})
+
+	_, err := WaitForWorkload("wl-1", Serving{ArtifactID: "art-2", AwaitDrain: true}, time.Millisecond, time.Second, nil)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&hits), int32(3),
+		"the old generation was still answering the endpoint")
+}
+
+// A cluster that refuses the protons route must not fail every rollout on it.
+// The route is corroboration, not the rollout, and these deploys exited 0
+// before it was consulted at all.
+func TestWaitForWorkload_RefusedProtonRouteFallsBackToTheArtifact(t *testing.T) {
+	for _, code := range []int{
+		http.StatusNotFound, http.StatusForbidden,
+		http.StatusMethodNotAllowed, http.StatusUnprocessableEntity,
+	} {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			unconfirmed := 0
+
+			serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/protons/") {
+					w.WriteHeader(code)
+
+					return
+				}
+
+				fmt.Fprint(w, serverWorkloadDocOn("wl-1", "a", WorkloadStatusRunning, "art-2"))
+			}))
+
+			want := Serving{
+				ArtifactID:    "art-2",
+				AwaitDrain:    true,
+				OnUnconfirmed: func(string) { unconfirmed++ },
+			}
+
+			wl, err := WaitForWorkload("wl-1", want, time.Millisecond, time.Second, nil)
+			require.NoError(t, err)
+			assert.Equal(t, "art-2", wl.ArtifactID)
+			assert.Positive(t, unconfirmed, "the caller has to know the handover went unconfirmed")
+		})
+	}
+}
+
+// A workload that never takes the new version has not failed in any way the
+// status can express, so the timeout has to say so.
 func TestWaitForWorkload_TimesOutWhenTheNewArtifactNeverServes(t *testing.T) {
 	installSkipAuth(t)
 
@@ -881,7 +985,7 @@ func TestWaitForWorkload_TimesOutWhenTheNewArtifactNeverServes(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	wl, err := WaitForWorkload("wl-1", "art-2", 5*time.Millisecond, 25*time.Millisecond, nil)
+	wl, err := WaitForWorkload("wl-1", Serving{ArtifactID: "art-2", AwaitDrain: true}, 5*time.Millisecond, 25*time.Millisecond, nil)
 	require.Error(t, err)
 	require.NotNil(t, wl, "a timeout returns the last-seen workload so a caller can say where it got to")
 	assert.Contains(t, err.Error(), "art-1", "the error names the version still serving")
@@ -889,9 +993,8 @@ func TestWaitForWorkload_TimesOutWhenTheNewArtifactNeverServes(t *testing.T) {
 	assert.Contains(t, err.Error(), "timeout")
 }
 
-// An errored workload is still reporting whatever it was running, which is
-// never the artifact a roll is waiting for. Requiring both would poll a dead
-// workload to its timeout instead of failing on the first sight of it.
+// An errored workload still reports whatever it was running, so requiring the
+// artifact would poll a dead workload to its timeout.
 func TestWaitForWorkload_ErroredBeatsTheArtifactCheck(t *testing.T) {
 	installSkipAuth(t)
 
@@ -903,23 +1006,22 @@ func TestWaitForWorkload_ErroredBeatsTheArtifactCheck(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	wl, err := WaitForWorkload("wl-1", "art-2", time.Millisecond, time.Minute, nil)
+	wl, err := WaitForWorkload("wl-1", Serving{ArtifactID: "art-2", AwaitDrain: true}, time.Millisecond, time.Minute, nil)
 	require.Error(t, err)
 	require.NotNil(t, wl)
 	assert.Contains(t, err.Error(), WorkloadStatusErrored)
 	assert.NotContains(t, err.Error(), "timeout", "the failure is the answer, not something to wait out")
 }
 
-// These waits now run for as long as a rollout takes, which is long enough for
-// one bad response to land between two healthy polls.
-func TestWaitForWorkload_RidesOutATransientPollError(t *testing.T) {
-	installSkipAuth(t)
+// A rollout that has built, promoted and started serving must not be reported
+// as failed because the second request, the one that was only corroborating it,
+// fell over. The wait forgives a run of them and then says so.
+func TestWaitForWorkload_ForgivesAProtonRouteThatKeepsFailing(t *testing.T) {
+	reasons := 0
 
-	var hits int32
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if atomic.AddInt32(&hits, 1) == 1 {
-			w.WriteHeader(http.StatusBadGateway)
+	serveAPI(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/protons/") {
+			w.WriteHeader(http.StatusInternalServerError)
 
 			return
 		}
@@ -927,33 +1029,57 @@ func TestWaitForWorkload_RidesOutATransientPollError(t *testing.T) {
 		fmt.Fprint(w, serverWorkloadDocOn("wl-1", "a", WorkloadStatusRunning, "art-2"))
 	}))
 
-	defer srv.Close()
+	want := Serving{
+		ArtifactID:    "art-2",
+		AwaitDrain:    true,
+		OnUnconfirmed: func(string) { reasons++ },
+	}
 
-	installEndpoint(t, srv.URL)
-
-	wl, err := WaitForWorkload("wl-1", "art-2", time.Millisecond, time.Second, nil)
-	require.NoError(t, err, "a 502 between polls must not fail a deploy that is going fine")
+	wl, err := WaitForWorkload("wl-1", want, time.Millisecond, time.Minute, nil)
+	require.NoError(t, err, "the deploy itself was fine; only the corroborating read was not")
+	require.NotNil(t, wl)
 	assert.Equal(t, "art-2", wl.ArtifactID)
+	assert.Positive(t, reasons, "and the caller has to know it went unconfirmed")
 }
 
-// Forgiving a blip is not the same as forgiving an endpoint that has gone away.
-func TestWaitForWorkload_GivesUpOnANonTransientPollError(t *testing.T) {
-	installSkipAuth(t)
+// An empty list is both "this route has nothing to say" and "the drained
+// generation is collected and its replacement is not listed yet". Waiting
+// forever on the second reading turns a finished deploy into a timeout.
+func TestWaitForWorkload_SettlesOnAnEmptyProtonListThatPersists(t *testing.T) {
+	var polls int32
 
+	serveWorkloadAndProtons(t,
+		func() string { return serverWorkloadDocOn("wl-1", "a", WorkloadStatusRunning, "art-2") },
+		func() string {
+			atomic.AddInt32(&polls, 1)
+
+			return `{"count":0,"totalCount":0,"data":[]}`
+		})
+
+	want := Serving{ArtifactID: "art-2", AwaitDrain: true}
+
+	_, err := WaitForWorkload("wl-1", want, time.Millisecond, time.Minute, nil)
+	require.NoError(t, err, "an absence that never resolves must not run to the timeout")
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&polls), int32(uncorroboratedAbsences),
+		"but it is given a few polls to resolve first")
+}
+
+// These waits run for as long as a rollout takes, long enough for one bad
+// response to land between two healthy polls.
+func TestWaitForWorkload_RidesOutATransientPollError(t *testing.T) {
 	var hits int32
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&hits, 1)
-		w.WriteHeader(http.StatusNotFound)
-	}))
+	serveWorkloadAndProtons(t,
+		func() string {
+			if atomic.AddInt32(&hits, 1) == 1 {
+				return ""
+			}
 
-	defer srv.Close()
+			return serverWorkloadDocOn("wl-1", "a", WorkloadStatusRunning, "art-2")
+		},
+		func() string { return serverProtonList([2]string{"art-2", ProtonStatusRunning}) })
 
-	installEndpoint(t, srv.URL)
-
-	wl, err := WaitForWorkload("wl-1", "art-2", time.Millisecond, time.Minute, nil)
-	require.Error(t, err)
-	assert.Nil(t, wl, "a wait that could not read the workload has no state to report")
-	assert.Contains(t, err.Error(), "poll workload")
-	assert.Equal(t, int32(1), atomic.LoadInt32(&hits), "a 404 is an answer, not a blip to retry")
+	wl, err := WaitForWorkload("wl-1", Serving{ArtifactID: "art-2", AwaitDrain: true}, time.Millisecond, time.Second, nil)
+	require.NoError(t, err, "a 502 between polls must not fail a deploy that is going fine")
+	assert.Equal(t, "art-2", wl.ArtifactID)
 }

--- a/internal/workload/workload_test.go
+++ b/internal/workload/workload_test.go
@@ -180,20 +180,28 @@ func TestValidateWorkloadCreateRequest(t *testing.T) {
 // serverWorkloadDoc is a realistic workload document including server-side
 // extras the projection must ignore (owners, permissions, runtime).
 func serverWorkloadDoc(id, name, status string) string {
+	return serverWorkloadDocOn(id, name, status, "art-1")
+}
+
+// serverWorkloadDocOn is the same document with the running artifact named.
+// Which artifact a poll reports is the whole subject of the rollout waits, and
+// a fixture that always answers "art-1" is why the suite could not see a wait
+// settling on the version it was supposed to be replacing.
+func serverWorkloadDocOn(id, name, status, artifactID string) string {
 	return fmt.Sprintf(`{
 		"id": %q,
 		"name": %q,
 		"status": %q,
 		"type": "service",
 		"importance": "low",
-		"artifactId": "art-1",
+		"artifactId": %q,
 		"endpoint": "https://app.example.com/api/v2/endpoints/workloads/%s/",
 		"createdAt": "2026-06-10T08:00:00Z",
 		"updatedAt": "2026-06-10T08:05:00Z",
 		"owners": [{"id": "u-1", "email": "pii@example.com"}],
 		"permissions": ["CAN_DELETE"],
 		"runtime": {"containerGroups": []}
-	}`, id, name, status, id)
+	}`, id, name, status, artifactID, id)
 }
 
 func assertProjection(t *testing.T, w *Workload, id, name, status string) {
@@ -660,7 +668,7 @@ func TestWaitForSteadyWorkload_ReturnsAtStoppedWhereWaitForWorkloadWouldNot(t *t
 	require.NoError(t, err)
 	assert.Equal(t, WorkloadStatusStopped, wl.Status)
 
-	_, err = WaitForWorkload("wl-1", 5*time.Millisecond, 25*time.Millisecond, nil)
+	_, err = WaitForWorkload("wl-1", "", 5*time.Millisecond, 25*time.Millisecond, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timeout")
 }
@@ -758,7 +766,7 @@ func TestWaitForWorkload_RunningReturnsNil(t *testing.T) {
 
 	var ticks int
 
-	wl, err := WaitForWorkload("wl-1", time.Millisecond, time.Second, func(*Workload) {
+	wl, err := WaitForWorkload("wl-1", "", time.Millisecond, time.Second, func(*Workload) {
 		ticks++
 	})
 	require.NoError(t, err)
@@ -777,7 +785,7 @@ func TestWaitForWorkload_ErroredReturnsError(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	wl, err := WaitForWorkload("wl-1", time.Millisecond, time.Second, nil)
+	wl, err := WaitForWorkload("wl-1", "", time.Millisecond, time.Second, nil)
 	require.Error(t, err)
 	require.NotNil(t, wl, "errored returns final Workload alongside error")
 	assert.Equal(t, WorkloadStatusErrored, wl.Status)
@@ -806,7 +814,7 @@ func TestWaitForWorkload_PollsThroughStoppedUntilRunning(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	wl, err := WaitForWorkload("wl-1", time.Millisecond, time.Second, nil)
+	wl, err := WaitForWorkload("wl-1", "", time.Millisecond, time.Second, nil)
 	require.NoError(t, err)
 	assert.Equal(t, WorkloadStatusRunning, wl.Status)
 }
@@ -822,7 +830,130 @@ func TestWaitForWorkload_Timeout(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	_, err := WaitForWorkload("wl-1", 5*time.Millisecond, 25*time.Millisecond, nil)
+	_, err := WaitForWorkload("wl-1", "", 5*time.Millisecond, 25*time.Millisecond, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timeout")
+}
+
+// The regression test for a deploy that reported success while the endpoint
+// went on serving the previous build. A rolling swap leaves the workload
+// reporting "running" from beginning to end, so a wait that reads the status
+// alone settles on the first poll, on the version being replaced.
+func TestWaitForWorkload_KeepsPollingWhileTheOldArtifactServes(t *testing.T) {
+	installSkipAuth(t)
+
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Running throughout, which is the whole difficulty: the only thing
+		// that moves is which artifact the workload names.
+		artifact := "art-1"
+		if atomic.AddInt32(&hits, 1) >= 3 {
+			artifact = "art-2"
+		}
+
+		fmt.Fprint(w, serverWorkloadDocOn("wl-1", "a", WorkloadStatusRunning, artifact))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkload("wl-1", "art-2", time.Millisecond, time.Second, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "art-2", wl.ArtifactID, "the wait must settle on the version it was told to wait for")
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&hits), int32(3),
+		"returning while the old artifact was still serving is the bug")
+}
+
+// A workload that comes up and never takes the new version has not failed in
+// any way the status can express, so the timeout is the only place left to say
+// what happened. A bare "timeout waiting for workload" sends the reader looking
+// for something that is not stuck.
+func TestWaitForWorkload_TimesOutWhenTheNewArtifactNeverServes(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, serverWorkloadDocOn("wl-1", "a", WorkloadStatusRunning, "art-1"))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkload("wl-1", "art-2", 5*time.Millisecond, 25*time.Millisecond, nil)
+	require.Error(t, err)
+	require.NotNil(t, wl, "a timeout returns the last-seen workload so a caller can say where it got to")
+	assert.Contains(t, err.Error(), "art-1", "the error names the version still serving")
+	assert.Contains(t, err.Error(), "art-2", "and the one that never arrived")
+	assert.Contains(t, err.Error(), "timeout")
+}
+
+// An errored workload is still reporting whatever it was running, which is
+// never the artifact a roll is waiting for. Requiring both would poll a dead
+// workload to its timeout instead of failing on the first sight of it.
+func TestWaitForWorkload_ErroredBeatsTheArtifactCheck(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, serverWorkloadDocOn("wl-1", "a", WorkloadStatusErrored, "art-1"))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkload("wl-1", "art-2", time.Millisecond, time.Minute, nil)
+	require.Error(t, err)
+	require.NotNil(t, wl)
+	assert.Contains(t, err.Error(), WorkloadStatusErrored)
+	assert.NotContains(t, err.Error(), "timeout", "the failure is the answer, not something to wait out")
+}
+
+// These waits now run for as long as a rollout takes, which is long enough for
+// one bad response to land between two healthy polls.
+func TestWaitForWorkload_RidesOutATransientPollError(t *testing.T) {
+	installSkipAuth(t)
+
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&hits, 1) == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+
+			return
+		}
+
+		fmt.Fprint(w, serverWorkloadDocOn("wl-1", "a", WorkloadStatusRunning, "art-2"))
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkload("wl-1", "art-2", time.Millisecond, time.Second, nil)
+	require.NoError(t, err, "a 502 between polls must not fail a deploy that is going fine")
+	assert.Equal(t, "art-2", wl.ArtifactID)
+}
+
+// Forgiving a blip is not the same as forgiving an endpoint that has gone away.
+func TestWaitForWorkload_GivesUpOnANonTransientPollError(t *testing.T) {
+	installSkipAuth(t)
+
+	var hits int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	wl, err := WaitForWorkload("wl-1", "art-2", time.Millisecond, time.Minute, nil)
+	require.Error(t, err)
+	assert.Nil(t, wl, "a wait that could not read the workload has no state to report")
+	assert.Contains(t, err.Error(), "poll workload")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&hits), "a 404 is an answer, not a blip to retry")
 }


### PR DESCRIPTION
# RATIONALE

`dr workload up` printed a tick, exited 0, and the endpoint kept serving the previous build.

The wait asked only whether the workload was running, which is true from beginning to end of a rolling swap, so it returned on the first poll having proved nothing. Confirming the artifact is not enough either: the workload names the new one about a minute before the endpoint stops answering with the old build, and four minutes in one run. The proton list is the only place the platform says the outgoing generation has stopped taking requests.

## CHANGES

The wait takes a `Serving` struct saying what it must see, and settles only once the workload reports the artifact and the generation it replaced has stopped draining. A create and a start ask for neither and skip the extra request; a resize asks for the drain with no artifact to name.

Nothing about the proton route can fail a deploy: a refusal degrades at once, anything else is retried and then degrades, and the transcript says the handover went unconfirmed and why.

This also fixes `up --lock` making the wrong artifact permanent. On a draft workload the lock is applied after the wait, to whatever it last saw, so an early return locked the version being rolled off.

## NOTES

Rolls now take around eight minutes rather than thirty seconds. The endpoint switched at t+171s in one run and t+284s in another, and nothing in the API marks that moment, so the wait sits through the drain window. `--detach` still returns at once. RAPTOR-19347 and RAPTOR-19734 are the platform-side asks that would let this be quick as well as correct.

## TESTING

Against staging with real deployments: create, roll, resize, stop and start. The roll previously exited after 35s with the old build still serving, and now exits after 8m49s with the new build live. At t+43s of a roll both generations are running and the outgoing one still holds the active role, which is the window the predecessor check exists for.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core deploy wait semantics and duration (rolls block through drain); incorrect proton/artifact logic could hang or mis-report success, but behavior is heavily tested and missing protons degrades safely.
> 
> **Overview**
> Fixes **`dr workload up`** reporting success while the endpoint still serves the previous build during rolling swaps.
> 
> **`WaitForWorkload`** now accepts an optional **`wantArtifactID`**. Rolls pass the candidate artifact and only finish when the workload reports that artifact *and* **`GET /workloads/{id}/protons/`** shows no generation still **draining** (with artifact-only fallback if protons 404). Create, start, and resize pass an empty artifact and keep prior behavior. Timeouts distinguish “never promoted” vs “promoted but still draining”; **`pollWorkload`** retries transient poll errors like log follow.
> 
> **`workload up`** threads the candidate through **`settle`** / **`awaitRunning`** so **`--lock`** runs after the wait and locks the version actually serving, not the one being rolled off. Roll flows show **“Waiting for the new version to serve”** when appropriate.
> 
> **`WaitForReplacement`** requires **three** consecutive 404s before treating a seeded-but-never-seen rollout as settled, avoiding an early exit when the replacement record has not caught up right after POST.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34e8bd7173ec3a8bf6a7dcd59efc723e91bcdf39. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
