### PR TITLE
test(plugin): deflake the subprocess tests under load

### DIFF
--- a/internal/plugin/discover_test.go
+++ b/internal/plugin/discover_test.go
@@ -393,8 +393,13 @@ func (s *ManifestTestSuite) SetupTest() {
 	s.tempDir, err = os.MkdirTemp("", "plugin-manifest-test")
 	s.Require().NoError(err)
 
-	// Reset viper state for each test
+	// Reset viper state for each test, then raise the manifest timeout the
+	// way the other suites in this file do: these tests are about parsing
+	// and error paths, not about the deadline, and under a loaded full-suite
+	// run (or Windows CI) merely spawning the mock script can take longer
+	// than the 500ms production default.
 	viperx.Reset()
+	viperx.Set("plugin.manifest_timeout_ms", 5000)
 }
 
 func (s *ManifestTestSuite) TearDownTest() {
@@ -431,8 +436,10 @@ func (s *ManifestTestSuite) TestGetManifestNonExistent() {
 }
 
 func (s *ManifestTestSuite) TestGetManifestWithConfiguredTimeout() {
-	// Set a custom timeout via viper
-	viperx.Set("plugin.manifest_timeout_ms", 1000)
+	// A custom timeout via viper. The value only has to prove the configured
+	// branch is honored, so it is generous: a tight one races the process
+	// spawn under load, which is not what this test is about.
+	viperx.Set("plugin.manifest_timeout_ms", 15000)
 
 	path := createMockPlugin(s.T(), s.tempDir, "dr-test", validManifest)
 

--- a/internal/plugin/exec_test.go
+++ b/internal/plugin/exec_test.go
@@ -198,12 +198,17 @@ func TestExecutePluginContextCancellation(t *testing.T) {
 		t.Skip("SIGTERM handling is Unix-specific")
 	}
 
-	// Create a script that traps SIGTERM, writes a marker, and exits cleanly
+	// A script that traps SIGTERM, writes a marker, and exits cleanly. It
+	// also announces readiness: the trap has to be installed before the
+	// cancel fires, or the default handler kills the shell and the exit code
+	// asserts on the race rather than on the graceful path.
 	markerFile := filepath.Join(t.TempDir(), "sigterm-received")
+	readyFile := filepath.Join(t.TempDir(), "ready")
 	script := fmt.Sprintf(`#!/bin/sh
 trap 'touch %s; exit 55' TERM
+touch %s
 while true; do sleep 0.1; done
-`, markerFile)
+`, markerFile, readyFile)
 
 	scriptPath := filepath.Join(t.TempDir(), "trap-term.sh")
 	createScript(t, scriptPath, script)
@@ -216,8 +221,7 @@ while true; do sleep 0.1; done
 		done <- ExecutePlugin(ctx, PluginManifest{}, scriptPath, []string{}, nil)
 	}()
 
-	// Give the subprocess time to start and install its signal handler
-	time.Sleep(500 * time.Millisecond)
+	waitForFile(t, readyFile)
 
 	cancel()
 
@@ -240,11 +244,14 @@ func TestExecutePluginContextCancellationKillsUnresponsive(t *testing.T) {
 		t.Skip("SIGTERM handling is Unix-specific")
 	}
 
-	// Create a script that ignores SIGTERM entirely
-	script := `#!/bin/sh
+	// A script that ignores SIGTERM entirely, announcing readiness once the
+	// trap is installed so the cancel cannot race the shell's startup.
+	readyFile := filepath.Join(t.TempDir(), "ready")
+	script := fmt.Sprintf(`#!/bin/sh
 trap '' TERM
+touch %s
 while true; do sleep 0.1; done
-`
+`, readyFile)
 
 	scriptPath := filepath.Join(t.TempDir(), "ignore-term.sh")
 	createScript(t, scriptPath, script)
@@ -257,8 +264,7 @@ while true; do sleep 0.1; done
 		done <- ExecutePlugin(ctx, PluginManifest{}, scriptPath, []string{}, nil)
 	}()
 
-	// Give the subprocess time to start
-	time.Sleep(500 * time.Millisecond)
+	waitForFile(t, readyFile)
 
 	cancel()
 

--- a/internal/plugin/testhelpers_test.go
+++ b/internal/plugin/testhelpers_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -99,4 +100,23 @@ func createScript(t *testing.T, path, content string) {
 
 	err := os.WriteFile(path, []byte(content), 0o755)
 	require.NoError(t, err)
+}
+
+// waitForFile polls until path exists, failing the test after ten seconds.
+// It replaces the fixed sleeps the subprocess tests used to guess at shell
+// startup with, which a loaded machine routinely outran.
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+
+	deadline := time.Now().Add(10 * time.Second)
+
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("file %s did not appear within 10s", path)
 }


### PR DESCRIPTION
# RATIONALE

Three `internal/plugin` tests race their own subprocesses and lose under load — they blocked three unrelated CI/local runs today alone (`TestGetManifestValid` and `TestGetManifestWithConfiguredTimeout` on windows-latest and in local full-suite runs, `TestExecutePluginContextCancellation` locally). All three pass in isolation every time; only a loaded machine breaks them, which is what makes them flakes rather than failures.

## CHANGES

- The `ManifestTestSuite` now raises `plugin.manifest_timeout_ms` in `SetupTest`, the way every other suite in the file already does. Its tests are about parsing and error paths, not the deadline — but they ran mock plugins against the 500ms production default, and a loaded full-suite `-race` run (or Windows CI's slow process creation) can spend longer than that just spawning the shell.
- `TestGetManifestWithConfiguredTimeout` keeps proving the configured branch is honored, with a generous value instead of a 1000ms one that races the spawn.
- The two context-cancellation tests replace their blind `time.Sleep(500ms)` with a readiness handshake: the script touches a file once its SIGTERM trap is installed, and the test waits for the file before cancelling. Cancelled early, the default handler kills the shell and the assertion reads the race instead of the graceful-shutdown path it exists to test.

Verified: `go test ./internal/plugin/ -race -count=2` green, and a full `task test` sweep — the exact load condition that flaked all day — passes clean.

No production code changes; test-only.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No production code changes; only test timing and synchronization for plugin subprocess tests.
> 
> **Overview**
> **Test-only** changes to stop flaky `internal/plugin` failures when CI or full `-race` runs are slow to spawn mock shell scripts.
> 
> `ManifestTestSuite` now sets `plugin.manifest_timeout_ms` to **5000** in `SetupTest`, matching other discovery suites, so manifest parsing tests are not tripped by the **500ms** production default on Windows or under load. `TestGetManifestWithConfiguredTimeout` still exercises the configured-timeout path but uses a **15s** value so spawn latency does not race the assertion.
> 
> The two Unix context-cancellation tests drop fixed **500ms** sleeps in favor of a **readiness file** touched after the SIGTERM trap is installed, plus a shared **`waitForFile`** helper that polls up to 10s. Cancellation runs only after the subprocess is ready, so assertions target graceful SIGTERM handling instead of startup races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d172bfde9ec7ea71074e5070121a0b0665e9e8c6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->