### PR TITLE
[RAPTOR-19729] fix(workload): recovery never ends at the file

### DIFF
--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -700,9 +700,9 @@ func deployable(live Live, workloadName, dirFlag string) error {
 	switch live.State {
 	case StateTerminated:
 		return fmt.Errorf(
-			"workload %s is terminated, which cannot be undone, and it still holds its name and artifact. "+
-				"Remove it with 'dr workload delete %s%s', which also clears the binding in %s, then deploy again",
-			workloadName, live.WorkloadID, dirFlag, manifest.FileName)
+			"workload %s is terminated, which cannot be undone, and it still holds its name and artifact — "+
+				"%s, then deploy again",
+			workloadName, deleteRemedy(live.WorkloadID, dirFlag, true))
 
 	case StateErrored:
 		// The refusal carries its own exit. Ending at "check the logs" left
@@ -711,10 +711,8 @@ func deployable(live Live, workloadName, dirFlag string) error {
 		// name conflict below or throws away the code catalog with it.
 		return fmt.Errorf(
 			"workload %s is errored, so there is nothing safe to deploy onto. "+
-				"Check 'dr workload logs %s' first; a slow start can report errored and then recover. "+
-				"If it stays errored, remove it with 'dr workload delete %s%s', which also clears the "+
-				"binding in %s, and deploy again to recreate it under the same name",
-			workloadName, live.WorkloadID, live.WorkloadID, dirFlag, manifest.FileName)
+				"%sIf it stays errored, %s, and deploy again to recreate it under the same name",
+			workloadName, erroredCaveat(live.WorkloadID), deleteRemedy(live.WorkloadID, dirFlag, true))
 
 	case StateSettling:
 		// The backstop, not the answer. Every run waits a moving workload out
@@ -929,13 +927,20 @@ func nameTaken(createErr error, workloadName, path, dirFlag string) error {
 		// they just deleted. The advice is the one those refusals give:
 		// delete what holds the name.
 		if workload.IsWorkloadErrorStatus(existing[i].Status) {
+			// Errored gets the same hedge deployable's own refusal carries;
+			// terminated really is final, so it keeps the certainty.
+			caveat := ""
+			if !strings.EqualFold(existing[i].Status, workload.WorkloadStatusTerminated) {
+				caveat = erroredCaveat(existing[i].ID)
+			}
+
 			return fmt.Errorf(
 				"a workload named %s already exists (%s), is %s, and nothing was deployed onto it. "+
 					"A deploy cannot act on it, so binding to it would only move this refusal. "+
-					"If it is this project's dead workload, remove it with 'dr workload delete %s%s' "+
+					"%sIf it is this project's dead workload, %s "+
 					"and deploy again to recreate the name. If it is not, rename this one in %s: %w",
 				workloadName, existing[i].ID, strings.ToLower(existing[i].Status),
-				existing[i].ID, dirFlag, path, createErr)
+				caveat, deleteRemedy(existing[i].ID, dirFlag, false), path, createErr)
 		}
 
 		return fmt.Errorf(
@@ -947,6 +952,29 @@ func nameTaken(createErr error, workloadName, path, dirFlag string) error {
 	}
 
 	return createErr
+}
+
+// deleteRemedy is the recovery every dead-workload refusal spells out, one
+// implementation so the wording cannot drift between them. clearsBinding adds
+// what the delete does to the manifest, which is only true when this project
+// is bound to the workload being deleted — a create conflict has no binding
+// to clear.
+func deleteRemedy(workloadID, dirFlag string, clearsBinding bool) string {
+	remedy := fmt.Sprintf("remove it with 'dr workload delete %s%s'", workloadID, dirFlag)
+	if clearsBinding {
+		remedy += ", which also clears the binding in " + manifest.FileName
+	}
+
+	return remedy
+}
+
+// erroredCaveat is the hedge every message about an errored workload carries:
+// errored is the one dead-looking state that can still recover, so advising
+// its deletion with certainty would have a slow starter deleted mid-start.
+func erroredCaveat(workloadID string) string {
+	return fmt.Sprintf(
+		"Check 'dr workload logs %s' first; a slow start can report errored and then recover. ",
+		workloadID)
 }
 
 // conflictSearchLimit bounds the lookup behind a create conflict. Past this

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/datarobot/cli/internal/drapi"
@@ -704,10 +705,16 @@ func deployable(live Live, workloadName, dirFlag string) error {
 			workloadName, live.WorkloadID, dirFlag, manifest.FileName)
 
 	case StateErrored:
+		// The refusal carries its own exit. Ending at "check the logs" left
+		// recovery to folklore, and the folk remedy — hand-deleting the
+		// workloadId, or the whole state directory — either loops through the
+		// name conflict below or throws away the code catalog with it.
 		return fmt.Errorf(
 			"workload %s is errored, so there is nothing safe to deploy onto. "+
-				"Check 'dr workload logs' first; a slow start can report errored and then recover",
-			workloadName)
+				"Check 'dr workload logs %s' first; a slow start can report errored and then recover. "+
+				"If it stays errored, remove it with 'dr workload delete %s%s', which also clears the "+
+				"binding in %s, and deploy again to recreate it under the same name",
+			workloadName, live.WorkloadID, live.WorkloadID, dirFlag, manifest.FileName)
 
 	case StateSettling:
 		// The backstop, not the answer. Every run waits a moving workload out
@@ -766,7 +773,7 @@ func create(
 	err := report.run("Creating workload", func() error {
 		wl, createErr := createWorkloadFn(payload)
 		if createErr != nil {
-			return nameTaken(createErr, result.Name, loaded.Path)
+			return nameTaken(createErr, result.Name, loaded.Path, dirFlagFor(loaded))
 		}
 
 		created = wl
@@ -897,7 +904,7 @@ func startingStatus(was string) string {
 //
 // So the run stops and hands the choice back, which costs one line in the
 // manifest in the case where adopting would have been right.
-func nameTaken(createErr error, workloadName, path string) error {
+func nameTaken(createErr error, workloadName, path, dirFlag string) error {
 	if !isConflict(createErr) || workloadName == "" {
 		return createErr
 	}
@@ -912,6 +919,23 @@ func nameTaken(createErr error, workloadName, path string) error {
 	for i := range existing {
 		if existing[i].Name != workloadName {
 			continue
+		}
+
+		// A workload a deploy cannot act on must not be recommended for
+		// binding. Advising 'set workloadId' against an errored or terminated
+		// holder sends the next run straight into that state's refusal — and
+		// for the user who cleared the binding by hand because their workload
+		// was stuck, it closes a loop: the 409 recommending the exact line
+		// they just deleted. The advice is the one those refusals give:
+		// delete what holds the name.
+		if workload.IsWorkloadErrorStatus(existing[i].Status) {
+			return fmt.Errorf(
+				"a workload named %s already exists (%s), is %s, and nothing was deployed onto it. "+
+					"A deploy cannot act on it, so binding to it would only move this refusal. "+
+					"If it is this project's dead workload, remove it with 'dr workload delete %s%s' "+
+					"and deploy again to recreate the name. If it is not, rename this one in %s: %w",
+				workloadName, existing[i].ID, strings.ToLower(existing[i].Status),
+				existing[i].ID, dirFlag, path, createErr)
 		}
 
 		return fmt.Errorf(

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -630,6 +630,58 @@ func TestRun_ConflictNamesTheWorkloadThatOwnsTheName(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
 }
 
+// The name-conflict refusal must not recommend the state it is refusing.
+// Told to bind to an errored holder, the next run walks into that state's own
+// refusal — and the user who hand-cleared the binding because their workload
+// was stuck is sent back to the exact line they deleted: a loop.
+func TestRun_ConflictWithADeadHolderAdvisesDeleteNotRebinding(t *testing.T) {
+	for _, status := range []string{workload.WorkloadStatusErrored, workload.WorkloadStatusTerminated} {
+		t.Run(status, func(t *testing.T) {
+			install(t, fakes{
+				create: func(any) (*workload.Workload, error) {
+					return nil, &drapi.HTTPError{StatusCode: http.StatusConflict}
+				},
+				list: func(int, []string, string) ([]workload.Workload, error) {
+					dead := *running("wl-dead")
+					dead.Status = status
+
+					return []workload.Workload{dead}, nil
+				},
+			})
+
+			_, _, err := runIn(t, unboundImageManifest, Options{NonInteractive: true})
+			require.Error(t, err)
+
+			assert.Contains(t, err.Error(), "dr workload delete wl-dead", "the exit is the delete")
+			assert.Contains(t, err.Error(), status, "say why binding is not offered")
+			assert.NotContains(t, err.Error(), "workloadId: wl-dead",
+				"binding advice against a dead holder is the loop this exists to break")
+		})
+	}
+}
+
+// The errored refusal carries its own exit. Ending at "check the logs" left
+// recovery to folklore: hand-deleting the workloadId loops through the name
+// conflict, and deleting the state directory throws the code catalog away
+// with it.
+func TestRun_ErroredRefusalNamesTheWayOut(t *testing.T) {
+	install(t, fakes{
+		workloadD: func(string) (workload.Document, error) {
+			return workload.Document{"id": "wl-1", "name": "my-app", "status": workload.WorkloadStatusErrored}, nil
+		},
+		artifactD: func(string) (workload.Document, error) { return nil, nil },
+	})
+
+	bound := "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" + unboundImageManifest
+
+	_, _, err := runIn(t, bound, Options{NonInteractive: true})
+	require.Error(t, err)
+
+	assert.Contains(t, err.Error(), "dr workload logs 68b0c1d2e3f4a5b6c7d8e9f0", "diagnosis first: it may recover")
+	assert.Contains(t, err.Error(), "dr workload delete 68b0c1d2e3f4a5b6c7d8e9f0", "and the exit when it does not")
+	assert.Contains(t, err.Error(), "clears the binding", "the delete owns the binding, so nobody hand-edits the file")
+}
+
 func TestRun_ConflictWithNoMatchKeepsTheOriginalError(t *testing.T) {
 	install(t, fakes{
 		create: func(any) (*workload.Workload, error) {

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -652,10 +652,19 @@ func TestRun_ConflictWithADeadHolderAdvisesDeleteNotRebinding(t *testing.T) {
 			_, _, err := runIn(t, unboundImageManifest, Options{NonInteractive: true})
 			require.Error(t, err)
 
-			assert.Contains(t, err.Error(), "dr workload delete wl-dead", "the exit is the delete")
+			assert.Contains(t, err.Error(), "dr workload delete wl-dead --dir ",
+				"the exit is the delete, carrying the flag that reaches this project")
 			assert.Contains(t, err.Error(), status, "say why binding is not offered")
 			assert.NotContains(t, err.Error(), "workloadId: wl-dead",
 				"binding advice against a dead holder is the loop this exists to break")
+
+			// Errored is the one dead-looking state that can recover, so it is
+			// hedged with diagnosis first; terminated really is final.
+			if status == workload.WorkloadStatusErrored {
+				assert.Contains(t, err.Error(), "dr workload logs wl-dead", "diagnosis before deletion")
+			} else {
+				assert.NotContains(t, err.Error(), "dr workload logs", "no hedge for a state that cannot recover")
+			}
 		})
 	}
 }


### PR DESCRIPTION
# RATIONALE

Recovering from a stuck workload required insider knowledge, and the CLI's own messages formed a loop. The errored refusal ended at "check the logs" with no way forward; the folk remedy — hand-deleting the `workloadId` line — sent the next `up` into a create, the create into a 409, and the 409's advice was to set the exact line just deleted. The other remedy in circulation, deleting the `.datarobot` state directory, only "works" because the wizard then lets a different name be picked — and it throws the code catalog and sync state away with it. The supported exit, `dr workload delete <id> --dir .` (which clears the binding too), was undiscoverable.

Ticket: [RAPTOR-19729](https://datarobot.atlassian.net/browse/RAPTOR-19729)

## CHANGES

- The **errored refusal carries its own exit**: check `dr workload logs <id>` first (a slow start can recover), and if it stays errored, `dr workload delete <id> --dir <path>` — which also clears the binding — then deploy again to recreate the name. The `--dir` suffix is computed the same way the terminated refusal already computes it, so the command is correct from any working directory.
- The **name-conflict (409) refusal reads the holder's status before advising**. Binding advice ("set `workloadId: <id>`") is only given for a workload a deploy can act on. An errored or terminated holder gets the delete advice instead — recommending the state being refused was what closed the loop.

Narrower than the ticket text because main has moved since it was filed: the terminated refusal already names the delete-with-binding-cleanup exit, and a missing workload now falls through to a clean re-create. This PR closes the two remaining holes — the errored dead end and the status-blind 409 — after which no `up` recovery path ends at "edit or delete the file".

Wording note: the advice prints `dr workload delete <id> --dir <path>`, which is correct today and stays correct after #843 (where the id becomes optional); once #843 lands, a follow-up could shorten the printed command.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CLI refusal messages and conflict-handling branches in `up`; no auth, API contracts, or deploy mutations beyond which error text is shown.
> 
> **Overview**
> **`dr workload up` error text now walks users through recovery** instead of stopping at “check the logs” or suggesting manifest edits that loop back into the same failure.
> 
> When deploy refuses an **errored** bound workload, the message now includes `dr workload logs <id>`, then—if it stays broken—`dr workload delete <id> --dir <path>` (same `--dir` suffix as the terminated case) so delete clears the manifest binding and redeploy can recreate the name.
> 
> On **create name conflict (409)**, `nameTaken` looks up the existing holder’s status. **Errored or terminated** holders get delete-and-redeploy guidance, not `workloadId` binding advice (which would only hit the same refusal again). Healthy holders still get the bind-to-existing-id path. Tests lock in both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e40bb89129b0e4a8f793465fc9956f85b4f031e7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->