### PR TITLE
[CFX-7822] refactor(drapi): typed, clamped timeouts; drop hand-rolled HTTP clients

### DIFF
--- a/docs/development/structure.md
+++ b/docs/development/structure.md
@@ -86,6 +86,10 @@ DataRobot API client implementation for:
 - API authentication
 - API endpoint communication
 
+See the package doc (`go doc ./internal/drapi`) for the timeout-override
+convention and the `HTTPError`/`errors.As` contract new commands should
+follow when wiring in a call.
+
 #### envbuilder/
 
 An environment configuration builder that:

--- a/internal/drapi/client.go
+++ b/internal/drapi/client.go
@@ -59,7 +59,28 @@ func getToken() (string, error) {
 
 // NewHTTPClient returns an *http.Client preconfigured with the given timeout.
 // Use this in place of constructing &http.Client{...} inline so timeouts and
-// future shared-transport tweaks live in one place.
+// future shared-transport tweaks live in one place. A non-positive timeout
+// (the zero value included, so an omitted variadic override falls through
+// cleanly) clamps to DefaultClientTimeout. Passing 0 straight to http.Client
+// would otherwise mean "no timeout" — silently unbounded, not "use the
+// default" — since that's how net/http itself reads a zero Timeout.
 func NewHTTPClient(timeout time.Duration) *http.Client {
+	if timeout <= 0 {
+		timeout = DefaultClientTimeout
+	}
+
 	return &http.Client{Timeout: timeout}
+}
+
+// Do sends req using a client built by NewHTTPClient(timeout). It exists for
+// callers that must build their own *http.Request — a multipart body, or a
+// caller with its own error-decoding shape — so they get the same
+// clamp-then-construct behavior as Get/Post/Patch/Delete without hand-rolling
+// NewHTTPClient(t).Do(req) themselves.
+func Do(req *http.Request, timeout time.Duration) (*http.Response, error) {
+	// req is caller-built, same as every other verb function's internally
+	// built request in this file — always against a DataRobot endpoint
+	// resolved via config.GetEndpointURL/drapi.EndpointURL, never arbitrary
+	// user- or network-supplied input, so this isn't an SSRF sink.
+	return NewHTTPClient(timeout).Do(req) //nolint:gosec // req comes from a caller-built DataRobot endpoint URL, not external input
 }

--- a/internal/drapi/client_test.go
+++ b/internal/drapi/client_test.go
@@ -63,9 +63,23 @@ func withSkipAuth(t *testing.T, value string) string {
 }
 
 func TestNewHTTPClient(t *testing.T) {
-	c := NewHTTPClient(7 * time.Second)
-	require.NotNil(t, c)
-	assert.Equal(t, 7*time.Second, c.Timeout)
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    time.Duration
+	}{
+		{name: "positive timeout passes through", timeout: 7 * time.Second, want: 7 * time.Second},
+		{name: "zero timeout clamps to default", timeout: 0, want: DefaultClientTimeout},
+		{name: "negative timeout clamps to default", timeout: -5 * time.Second, want: DefaultClientTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewHTTPClient(tt.timeout)
+			require.NotNil(t, c)
+			assert.Equal(t, tt.want, c.Timeout)
+		})
+	}
 }
 
 func TestDefaultClientTimeout(t *testing.T) {

--- a/internal/drapi/delete.go
+++ b/internal/drapi/delete.go
@@ -18,12 +18,21 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/log"
 )
 
-func Delete(url, info string, body any) (*http.Response, error) {
+// Delete sends body as JSON via HTTP DELETE. timeout optionally overrides
+// DefaultClientTimeout, the same seam Get/Post/Patch have. Omitted, or ≤0,
+// falls back to DefaultClientTimeout (see NewHTTPClient).
+func Delete(url, info string, body any, timeout ...time.Duration) (*http.Response, error) {
+	var t time.Duration
+	if len(timeout) > 0 {
+		t = timeout[0]
+	}
+
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
@@ -50,7 +59,7 @@ func Delete(url, info string, body any) (*http.Response, error) {
 		return nil, err
 	}
 
-	resp, err := NewHTTPClient(DefaultClientTimeout).Do(req)
+	resp, err := NewHTTPClient(t).Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -70,8 +79,9 @@ func isDeleteSuccess(code int) bool {
 	return code == http.StatusOK || code == http.StatusAccepted || code == http.StatusNoContent
 }
 
-func DeleteJSON(url, info string, body, v any) error {
-	resp, err := Delete(url, info, body)
+// DeleteJSON is Delete with the response body decoded into v. timeout forwards to Delete.
+func DeleteJSON(url, info string, body, v any, timeout ...time.Duration) error {
+	resp, err := Delete(url, info, body, timeout...)
 	if err != nil {
 		return err
 	}

--- a/internal/drapi/doc.go
+++ b/internal/drapi/doc.go
@@ -1,0 +1,64 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package drapi is the CLI's shared HTTP client for every DataRobot API it
+// talks to: the Public API, the Workload API, and their sibling FastAPI
+// services. A new command that needs to call one of those APIs should build
+// on this package rather than constructing its own *http.Client.
+//
+// # Verbs
+//
+// Get, Post, Patch, and Delete each send one request and return the raw
+// *http.Response; GetJSON, PostJSON, PatchJSON, and DeleteJSON additionally
+// decode a JSON response body into a caller-supplied value. Post, Patch, and
+// Delete marshal their body argument as JSON — none of the four support
+// multipart/form-data; a caller that needs to upload a file builds its own
+// *http.Request (see internal/pipeline's doMultipart) and sends it with Do.
+//
+// # Timeouts
+//
+// Every verb function takes an optional trailing time.Duration override:
+//
+//	drapi.Get(url, "info")                   // DefaultClientTimeout (30s)
+//	drapi.Get(url, "info", 5*time.Second)     // 5s
+//
+// Omitting the argument, or passing a value ≤0, falls back to
+// DefaultClientTimeout — the same clamp NewHTTPClient applies, so a caller
+// that computes a timeout dynamically (e.g. from a config value that could
+// legitimately be zero) never has to guard it themselves. A caller that
+// builds its own request should call Do(req, timeout) rather than
+// NewHTTPClient(timeout).Do(req) directly, for the same reason.
+//
+// # Errors
+//
+// A non-2xx response comes back as *HTTPError, which callers unpack with
+// errors.As to read StatusCode:
+//
+//	var httpErr *drapi.HTTPError
+//	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+//		...
+//	}
+//
+// DataRobot's APIs don't agree on an error envelope (FastAPI services answer
+// {"detail": ...}, the drflask Public API {"message": ...}, a proxy in
+// between plain text), so HTTPError carries the response body raw and
+// uninterpreted on Body rather than guessing at a shape. HTTPError.Detail
+// exists for a caller that has already parsed a message out of Body — it's
+// best-effort and caller-populated, not something drapi itself fills in.
+// Branch decisions on StatusCode, which the server always sets; use Detail
+// for display only. See internal/workload/apiclient for the pattern to
+// follow when an API's envelope needs that parsing: it reads Body into a
+// Detail-bearing HTTPError while keeping the result unpackable with the same
+// errors.As(err, &httpErr) callers already use everywhere else.
+package drapi

--- a/internal/drapi/filesapi/allfiles.go
+++ b/internal/drapi/filesapi/allfiles.go
@@ -84,7 +84,7 @@ func (c *httpClient) DownloadFile(catalogID, versionID, path string, w io.Writer
 		return "", 0, fmt.Errorf("build download url: %w", err)
 	}
 
-	resp, err := drapi.Get(requestURL, "file", int(downloadHTTPTimeout.Seconds()))
+	resp, err := drapi.Get(requestURL, "file", downloadHTTPTimeout)
 	if err != nil {
 		return "", 0, fmt.Errorf("download %s: %w", path, err)
 	}

--- a/internal/drapi/get.go
+++ b/internal/drapi/get.go
@@ -31,7 +31,15 @@ import (
 type HTTPError struct {
 	StatusCode int
 	URL        string
-	Detail     string
+
+	// Detail is a best-effort, caller-parsed human-readable message (see
+	// workload/apiclient.LiftDetail) — not a structural guarantee. It comes
+	// back empty for reasons that have nothing to do with whether the
+	// request actually failed: the API's envelope shape, a proxy in the
+	// middle, a truncated body, even the caller's locale. Branch decisions
+	// on StatusCode, which the server always sets; use Detail for display
+	// only.
+	Detail string
 
 	// Body is up to 512 bytes of the error response, raw and uninterpreted.
 	// DataRobot's APIs do not agree on an error envelope (FastAPI services
@@ -86,10 +94,12 @@ func resolveToken() (string, error) {
 	return config.GetAPIKey(context.Background())
 }
 
-func Get(url, info string, timeoutSecs ...int) (*http.Response, error) {
-	timeout := DefaultClientTimeout
-	if len(timeoutSecs) > 0 {
-		timeout = time.Duration(timeoutSecs[0]) * time.Second
+// Get sends a GET request. timeout optionally overrides DefaultClientTimeout;
+// omitted, or ≤0, falls back to it (see NewHTTPClient).
+func Get(url, info string, timeout ...time.Duration) (*http.Response, error) {
+	var t time.Duration
+	if len(timeout) > 0 {
+		t = timeout[0]
 	}
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -107,7 +117,7 @@ func Get(url, info string, timeoutSecs ...int) (*http.Response, error) {
 
 	log.Debug("Request Info: \n" + config.RedactedReqInfo(req))
 
-	resp, err := NewHTTPClient(timeout).Do(req)
+	resp, err := NewHTTPClient(t).Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -121,8 +131,9 @@ func Get(url, info string, timeoutSecs ...int) (*http.Response, error) {
 	return resp, err
 }
 
-func GetJSON(url, info string, v any, timeoutSecs ...int) error {
-	resp, err := Get(url, info, timeoutSecs...)
+// GetJSON is Get with the response body decoded into v. timeout forwards to Get.
+func GetJSON(url, info string, v any, timeout ...time.Duration) error {
+	resp, err := Get(url, info, timeout...)
 	if err != nil {
 		return err
 	}

--- a/internal/drapi/patch.go
+++ b/internal/drapi/patch.go
@@ -18,12 +18,21 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/log"
 )
 
-func Patch(url, info string, body any) (*http.Response, error) {
+// Patch sends body as JSON via HTTP PATCH. timeout optionally overrides
+// DefaultClientTimeout, the same seam Get/Post have. Omitted, or ≤0, falls
+// back to DefaultClientTimeout (see NewHTTPClient).
+func Patch(url, info string, body any, timeout ...time.Duration) (*http.Response, error) {
+	var t time.Duration
+	if len(timeout) > 0 {
+		t = timeout[0]
+	}
+
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
@@ -50,7 +59,7 @@ func Patch(url, info string, body any) (*http.Response, error) {
 		return nil, err
 	}
 
-	resp, err := NewHTTPClient(DefaultClientTimeout).Do(req)
+	resp, err := NewHTTPClient(t).Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -73,8 +82,9 @@ func isPatchSuccess(code int) bool {
 	return code == http.StatusOK || code == http.StatusAccepted || code == http.StatusNoContent
 }
 
-func PatchJSON(url, info string, body, v any) error {
-	resp, err := Patch(url, info, body)
+// PatchJSON is Patch with the response body decoded into v. timeout forwards to Patch.
+func PatchJSON(url, info string, body, v any, timeout ...time.Duration) error {
+	resp, err := Patch(url, info, body, timeout...)
 	if err != nil {
 		return err
 	}

--- a/internal/drapi/post.go
+++ b/internal/drapi/post.go
@@ -24,14 +24,15 @@ import (
 	"github.com/datarobot/cli/internal/log"
 )
 
-// Post sends body as JSON. timeoutSecs optionally overrides the default
-// client timeout, the same seam Get has: a caller whose endpoint does slow
-// synchronous work server-side (e.g. triggering an image build) must outlive
-// the server's own internal budget or it abandons answers already on the way.
-func Post(url, info string, body any, timeoutSecs ...int) (*http.Response, error) {
-	timeout := DefaultClientTimeout
-	if len(timeoutSecs) > 0 {
-		timeout = time.Duration(timeoutSecs[0]) * time.Second
+// Post sends body as JSON. timeout optionally overrides DefaultClientTimeout,
+// the same seam Get has: a caller whose endpoint does slow synchronous work
+// server-side (e.g. triggering an image build) must outlive the server's own
+// internal budget or it abandons answers already on the way. Omitted, or ≤0,
+// falls back to DefaultClientTimeout (see NewHTTPClient).
+func Post(url, info string, body any, timeout ...time.Duration) (*http.Response, error) {
+	var t time.Duration
+	if len(timeout) > 0 {
+		t = timeout[0]
 	}
 
 	payload, err := json.Marshal(body)
@@ -62,7 +63,7 @@ func Post(url, info string, body any, timeoutSecs ...int) (*http.Response, error
 		return nil, err
 	}
 
-	resp, err := NewHTTPClient(timeout).Do(req)
+	resp, err := NewHTTPClient(t).Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -106,8 +107,9 @@ func restoreRequestBody(req *http.Request) error {
 	return nil
 }
 
-func PostJSON(url, info string, body, v any, timeoutSecs ...int) error {
-	resp, err := Post(url, info, body, timeoutSecs...)
+// PostJSON is Post with the response body decoded into v. timeout forwards to Post.
+func PostJSON(url, info string, body, v any, timeout ...time.Duration) error {
+	resp, err := Post(url, info, body, timeout...)
 	if err != nil {
 		return err
 	}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -311,9 +311,7 @@ func doMultipart(method, endpoint, filePath string, fields map[string]string, in
 		log.Debug("Request Info: \n" + config.RedactedReqInfo(req))
 	}
 
-	client := drapi.NewHTTPClient(uploadTimeout)
-
-	resp, err := client.Do(req)
+	resp, err := drapi.Do(req, uploadTimeout)
 	if err != nil {
 		return fmt.Errorf("request %s: %w", endpoint, err)
 	}

--- a/internal/pipeline/transport.go
+++ b/internal/pipeline/transport.go
@@ -57,9 +57,7 @@ func doJSON(method, endpoint string, body any, info string, out any) error {
 		log.Debug("Request Info: \n" + config.RedactedReqInfo(req))
 	}
 
-	client := drapi.NewHTTPClient(jsonTimeout)
-
-	resp, err := client.Do(req)
+	resp, err := drapi.Do(req, jsonTimeout)
 	if err != nil {
 		return fmt.Errorf("request %s: %w", endpoint, err)
 	}
@@ -144,9 +142,7 @@ func doDelete(endpoint, info string) error {
 		log.Debug("Request Info: \n" + config.RedactedReqInfo(req))
 	}
 
-	client := drapi.NewHTTPClient(jsonTimeout)
-
-	resp, err := client.Do(req)
+	resp, err := drapi.Do(req, jsonTimeout)
 	if err != nil {
 		return fmt.Errorf("request %s: %w", endpoint, err)
 	}

--- a/internal/workload/apiclient/apiclient.go
+++ b/internal/workload/apiclient/apiclient.go
@@ -21,11 +21,21 @@
 // therefore carries a failed response's body raw and uninterpreted, and this
 // package is where the Workload API's envelope is read into meaning. The
 // same split exists for pipelines, whose client layer is internal/pipeline.
+//
+// Contract: every exported function here must keep returning something
+// errors.As can unpack into *drapi.HTTPError — the original error unchanged,
+// %w-wrapped, or (as LiftDetail's detail-found branch does) a fresh
+// *drapi.HTTPError carrying the same StatusCode/URL. At least 32 call sites
+// across cmd/pipeline, cmd/artifact, cmd/workload, cmd/dotenv,
+// internal/workload, and internal/pipeline depend on errors.As(err, &httpErr)
+// succeeding to read StatusCode. Breaking that chain is silent: no compile
+// error, no red test — every one of those checks just starts returning false.
 package apiclient
 
 import (
 	"encoding/json"
 	"errors"
+	"time"
 
 	"github.com/datarobot/cli/internal/drapi"
 )
@@ -33,9 +43,9 @@ import (
 // PostJSON is drapi.PostJSON with the Workload API's error envelope applied:
 // a failure whose body is a {"detail": ...} document is rewrapped so the
 // caller reads the server's own sentence instead of a raw JSON dump. Every
-// other error passes through untouched.
-func PostJSON(url, info string, body, v any, timeoutSecs ...int) error {
-	return LiftDetail(drapi.PostJSON(url, info, body, v, timeoutSecs...))
+// other error passes through untouched. timeout forwards to drapi.PostJSON.
+func PostJSON(url, info string, body, v any, timeout ...time.Duration) error {
+	return LiftDetail(drapi.PostJSON(url, info, body, v, timeout...))
 }
 
 // LiftDetail applies the Workload API's error envelope to an error minted by

--- a/internal/workload/build.go
+++ b/internal/workload/build.go
@@ -183,14 +183,14 @@ var triggerRetryDelays = []time.Duration{2 * time.Second, 5 * time.Second}
 // not spend wall-clock time.
 var triggerRetrySleep = time.Sleep
 
-// triggerTimeoutSecs must comfortably exceed the platform's own budget for
+// triggerTimeout must comfortably exceed the platform's own budget for
 // the trigger: workload-api waits up to 30s for its image build service to
 // accept the submission before answering. A client that hangs up at or under
 // that budget abandons an answer already on the way — including the 504 that
 // says a retry is safe. A var so tests can shrink it. Observed live on
 // staging: the default 30s client timeout expired mid-trigger and the deploy
 // died on "context deadline exceeded" with no way to tell what happened.
-var triggerTimeoutSecs = 60
+var triggerTimeout = 60 * time.Second
 
 // explainTriggerTimeout wraps a client-side timeout — the one failure where
 // the CLI hung up rather than the platform answering — with what the user
@@ -203,9 +203,9 @@ func explainTriggerTimeout(err error) error {
 	}
 
 	return fmt.Errorf(
-		"the build trigger got no response within %ds; the platform may still have started the build. "+
+		"the build trigger got no response within %s; the platform may still have started the build. "+
 			"Re-running 'dr workload up' is safe: a new trigger supersedes any build this one started: %w",
-		triggerTimeoutSecs, err)
+		triggerTimeout, err)
 }
 
 func isRetryableTriggerStatus(err error) bool {
@@ -244,7 +244,7 @@ func TriggerArtifactBuild(artifactID string) (*BuildTriggerResponse, error) {
 	for attempt := 0; ; attempt++ {
 		var resp BuildTriggerResponse
 
-		err := apiclient.PostJSON(url, "build", map[string]any{}, &resp, triggerTimeoutSecs)
+		err := apiclient.PostJSON(url, "build", map[string]any{}, &resp, triggerTimeout)
 		if err == nil {
 			return &resp, nil
 		}

--- a/internal/workload/build_test.go
+++ b/internal/workload/build_test.go
@@ -364,10 +364,10 @@ func TestTriggerArtifactBuild_ClientTimeoutSaysRerunIsSafe(t *testing.T) {
 	// safe rather than leaving a bare "context deadline exceeded".
 	installSkipAuth(t)
 
-	origTimeout := triggerTimeoutSecs
-	triggerTimeoutSecs = 1
+	origTimeout := triggerTimeout
+	triggerTimeout = time.Millisecond
 
-	t.Cleanup(func() { triggerTimeoutSecs = origTimeout })
+	t.Cleanup(func() { triggerTimeout = origTimeout })
 
 	release := make(chan struct{})
 


### PR DESCRIPTION
# RATIONALE

`internal/drapi`'s four verb functions disagreed on timeouts: `Get`/`Post` accepted an unclamped `timeoutSecs ...int` override (a negative value silently meant "no timeout" — `net/http` reads a zero/negative `http.Client.Timeout` as unbounded, not "use the default"), while `Patch`/`Delete` had no override at all and were hardcoded to `DefaultClientTimeout`. That asymmetry is why `internal/pipeline` hand-rolled `NewHTTPClient(t).Do(req)` in three places instead of calling drapi's verbs.

Separately, the `*drapi.HTTPError`/`errors.As` contract that 32 call sites across the repo depend on wasn't written down anywhere — a future refactor could silently break every one of them (no compile error, no red test).

## CHANGES

- `NewHTTPClient` now clamps a non-positive timeout to `DefaultClientTimeout` in one place, instead of every caller needing to guard it.
- `Get`/`Post`/`Patch`/`Delete` (and their `*JSON` variants) all take the same optional `timeout ...time.Duration` override. Retyping `Get`/`Post`'s existing `timeoutSecs ...int` forced 2 call-site updates (`filesapi/allfiles.go`, `workload/apiclient.PostJSON`'s wrapper + its one caller in `build.go`); `Patch`/`Delete` gaining the param is additive and touches nothing else.
- New `drapi.Do(req, timeout)` helper for callers that must build their own `*http.Request` (multipart uploads). `pipeline.go`'s `doMultipart` and `transport.go`'s `doJSON`/`doDelete` now call it instead of hand-rolling `NewHTTPClient(t).Do(req)` three times over.
- `internal/workload/apiclient`'s package doc states the `HTTPError`/`errors.As` contract explicitly, with the real call-site count (32, not the 14 originally assumed — verified by grep).
- `HTTPError.Detail` gets a warning comment: it's best-effort and caller-parsed, not a structural guarantee. Branch decisions on `StatusCode`.
- `internal/drapi` gets its first package doc (`doc.go`) covering the verb functions, the timeout convention, and the error contract; `docs/development/structure.md` now points at it.

No behavior change for existing callers beyond the 2 forced updates above and the timeout-clamp fix (a caller that previously passed 0/negative now gets `DefaultClientTimeout` instead of an unbounded client).

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.

## RELATED

- Jira: [CFX-7822](https://datarobot.atlassian.net/browse/CFX-7822)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787786321.063689 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared HTTP client behavior and public signatures change across drapi and pipeline/workload paths; the timeout clamp fixes a footgun but alters edge-case behavior for zero/negative overrides.
> 
> **Overview**
> Standardizes how the shared **drapi** HTTP layer handles timeouts and documents the error-handling contract contributors should follow.
> 
> **`NewHTTPClient`** now treats omitted or non-positive timeouts as **`DefaultClientTimeout`** (30s), fixing the case where zero meant an unbounded client in `net/http`. **`Get`/`Post`/`Patch`/`Delete`** and their **`*JSON`** helpers all accept the same optional **`timeout ...time.Duration`** override (replacing **`timeoutSecs ...int`** on Get/Post). **`Patch`/`Delete`** gain overrides without changing default behavior when omitted.
> 
> Adds **`drapi.Do(req, timeout)`** for custom requests (e.g. multipart); **`internal/pipeline`** uses it instead of **`NewHTTPClient(...).Do`**. New **`internal/drapi/doc.go`** plus **`workload/apiclient`** and **`HTTPError.Detail`** docs spell out timeout usage and the **`*HTTPError` / `errors.As`** pattern; **`docs/development/structure.md`** points to the package doc.
> 
> Call-site updates: file download passes a **`time.Duration`**; artifact build trigger uses **`triggerTimeout`** as **`60 * time.Second`** (test adjusted). Callers that previously passed **0** or negative seconds now get the default timeout instead of no limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ce157499b96053346b1ace744a7f3eeccb192aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->