### PR TITLE
[RAPTOR-19726] feat(workload): validate the project directory before the wizard asks

### DIFF
--- a/cmd/workload/config/cmd.go
+++ b/cmd/workload/config/cmd.go
@@ -284,7 +284,10 @@ func render(cmd *cobra.Command, f flags, format outputformat.OutputFormat, resul
 			warnLiterals(stderr, result.Draft.EnvVars)
 		}
 
-		fmt.Fprint(stderr, "\nNext: dr workload up\n")
+		// The wizard may have written the manifest into a directory the shell
+		// is not standing in; a bare `up` there would configure and deploy
+		// the wrong tree.
+		fmt.Fprintf(stderr, "\nNext: dr workload up%s\n", manifest.DirFlag(filepath.Dir(result.Path)))
 	}
 
 	// stdout carries the path and nothing else, so it can be piped.

--- a/cmd/workload/config/cmd_test.go
+++ b/cmd/workload/config/cmd_test.go
@@ -211,10 +211,10 @@ func TestCmd_JSONImpliesNonInteractive(t *testing.T) {
 	var ran bool
 
 	restoreFlow := wizard.SetInteractiveFlowForTest(
-		func(wizard.Options, wizard.Detected) ([]byte, manifest.Draft, error) {
+		func(wizard.Options, wizard.Detected) ([]byte, manifest.Draft, string, error) {
 			ran = true
 
-			return nil, manifest.Draft{}, errors.New("the wizard must not run")
+			return nil, manifest.Draft{}, "", errors.New("the wizard must not run")
 		})
 	defer restoreFlow()
 
@@ -238,10 +238,10 @@ func TestCmd_YesImpliesNonInteractive(t *testing.T) {
 	var ran bool
 
 	restoreFlow := wizard.SetInteractiveFlowForTest(
-		func(wizard.Options, wizard.Detected) ([]byte, manifest.Draft, error) {
+		func(wizard.Options, wizard.Detected) ([]byte, manifest.Draft, string, error) {
 			ran = true
 
-			return nil, manifest.Draft{}, errors.New("the wizard must not run")
+			return nil, manifest.Draft{}, "", errors.New("the wizard must not run")
 		})
 	defer restoreFlow()
 

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -489,8 +489,16 @@ func load(dir string, opts Options) (Loaded, error) {
 			"%w. Run 'dr workload config' to create one, then deploy", err)
 	}
 
-	if _, err := runWizardFn(wizard.Options{Dir: dir, Stderr: opts.Stderr}); err != nil {
+	setup, err := runWizardFn(wizard.Options{Dir: dir, Stderr: opts.Stderr})
+	if err != nil {
 		return Loaded{}, err
+	}
+
+	// The wizard's directory question may have moved the project, and the
+	// deploy has to follow the file it wrote: re-searching from where the
+	// command ran walks upward and cannot see a manifest one level down.
+	if setup.Path != "" {
+		return Load(filepath.Dir(setup.Path))
 	}
 
 	return Load(dir)

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -403,6 +403,42 @@ func TestRun_NoManifestOnATerminalRunsTheWizard(t *testing.T) {
 	assert.Equal(t, "wl-new", result.WorkloadID)
 }
 
+// TestRun_WizardRedirectIsFollowed: the wizard's directory question can move
+// the project into a subdirectory, and the deploy must follow the manifest it
+// wrote there — re-searching from where the command ran walks upward and
+// cannot see it.
+func TestRun_WizardRedirectIsFollowed(t *testing.T) {
+	dir := t.TempDir()
+	app := filepath.Join(dir, "web")
+	require.NoError(t, os.MkdirAll(app, 0o755))
+
+	var boundPath string
+
+	install(t, fakes{
+		wizard: func(wizard.Options) (wizard.Result, error) {
+			writeManifest(t, app, unboundImageManifest)
+
+			return wizard.Result{Path: manifest.Path(app)}, nil
+		},
+		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
+		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+			return running("wl-new"), nil
+		},
+		writeID: func(path, _ string) error {
+			boundPath = path
+
+			return nil
+		},
+	})
+
+	var stderr bytes.Buffer
+
+	result, err := Run(Options{Dir: dir, Stderr: &stderr})
+	require.NoError(t, err)
+	assert.Equal(t, "wl-new", result.WorkloadID)
+	assert.Equal(t, manifest.Path(app), boundPath, "the id lands in the manifest the wizard wrote")
+}
+
 func TestRun_DryRunAppliesNothing(t *testing.T) {
 	install(t, fakes{
 		create: func(any) (*workload.Workload, error) {

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/ignore"
+	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/internal/workload/sync"
 	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/datarobot/cli/internal/workload/wizard"
@@ -383,7 +384,10 @@ func TestRun_NoManifestOnATerminalRunsTheWizard(t *testing.T) {
 
 			writeManifest(t, dir, unboundImageManifest)
 
-			return wizard.Result{Path: opts.Dir}, nil
+			// Path is the manifest itself, as the real wizard reports it;
+			// load follows it, so a fake handing back the directory would
+			// send the deploy to the parent.
+			return wizard.Result{Path: manifest.Path(opts.Dir)}, nil
 		},
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
 		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {

--- a/internal/workload/wizard/detect.go
+++ b/internal/workload/wizard/detect.go
@@ -82,11 +82,96 @@ type Detected struct {
 	// but it must be reported: silence here reads as "there was nothing to
 	// import" and the missing variables surface as a runtime failure instead.
 	EnvErr error
+	// RootMarkers is which of the usual project files the directory itself
+	// carries. See SuspectDir for what an empty list means.
+	RootMarkers []string
+	// Candidates are immediate subdirectories that do carry project files,
+	// looked for only when the directory itself carries none: the offer the
+	// wrong-directory question makes instead of assuming ".".
+	Candidates []DirCandidate
+}
+
+// DirCandidate is a subdirectory that looks like a project root when the
+// directory setup ran from does not.
+type DirCandidate struct {
+	// Rel is the candidate relative to the checked directory.
+	Rel string
+	// Markers is which project files it carries, so the offer says why it is
+	// being offered rather than presenting a bare path.
+	Markers []string
+}
+
+// rootMarkers are the files a project root usually carries. The list is for
+// suspicion, not proof, in both directions: a directory with none can still
+// be a deployable project, which is why nothing here refuses.
+var rootMarkers = []string{
+	DockerfileName, "pyproject.toml", "uv.lock", "requirements.txt", "package.json", "go.mod", "setup.py",
+}
+
+// maxDirCandidates caps the offer. Past a handful the list stops being an
+// answer and --dir is the tool.
+const maxDirCandidates = 6
+
+// markersIn is which of the usual project files dir carries.
+func markersIn(dir string) []string {
+	var found []string
+
+	for _, marker := range rootMarkers {
+		if fsutil.FileExists(filepath.Join(dir, marker)) {
+			found = append(found, marker)
+		}
+	}
+
+	return found
+}
+
+// dirCandidates lists the immediate subdirectories carrying project files.
+// Hidden directories are never the project, and one already holding a
+// manifest is skipped too: it is entered with --dir, not set up afresh.
+func dirCandidates(dir string) []DirCandidate {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	var candidates []DirCandidate
+
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		sub := filepath.Join(dir, entry.Name())
+		if fsutil.FileExists(manifest.Path(sub)) {
+			continue
+		}
+
+		markers := markersIn(sub)
+		if len(markers) == 0 {
+			continue
+		}
+
+		candidates = append(candidates, DirCandidate{Rel: entry.Name(), Markers: markers})
+		if len(candidates) == maxDirCandidates {
+			break
+		}
+	}
+
+	return candidates
 }
 
 // HasEnvFile reports whether the project has a .env worth asking about.
 func (d Detected) HasEnvFile() bool {
 	return len(d.EnvVars) > 0
+}
+
+// SuspectDir reports that the directory carries none of the usual project
+// files, which is what running setup from the wrong place — the app's
+// parent, most often — looks like. It is a suspicion, never a verdict: a
+// valid project cannot be reliably recognized, so the absence only ever
+// produces a warning and an offer, not a refusal.
+func (d Detected) SuspectDir() bool {
+	return len(d.RootMarkers) == 0
 }
 
 // Plural picks the singular or plural word for count. Exported so the
@@ -112,6 +197,13 @@ func Detect(dir string) Detected {
 	}
 
 	detected.EnvVars, detected.EnvErr = envVars(filepath.Join(dir, EnvFileName))
+
+	detected.RootMarkers = markersIn(dir)
+	if detected.SuspectDir() {
+		// The subdirectory scan runs only when there is something to suspect:
+		// a directory that looks like a project needs no offer.
+		detected.Candidates = dirCandidates(dir)
+	}
 
 	if !detected.HasDockerfile {
 		return detected

--- a/internal/workload/wizard/detect.go
+++ b/internal/workload/wizard/detect.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/datarobot/cli/internal/fsutil"
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/joho/godotenv"
 )
@@ -89,6 +90,11 @@ type Detected struct {
 	// looked for only when the directory itself carries none: the offer the
 	// wrong-directory question makes instead of assuming ".".
 	Candidates []DirCandidate
+	// MoreCandidates reports that the candidate scan stopped early — at the
+	// offer cap or the entry budget — so the offer must say the list is not
+	// the whole answer: a project whose name sorts late would otherwise
+	// vanish without a trace, --dir unmentioned.
+	MoreCandidates bool
 }
 
 // DirCandidate is a subdirectory that looks like a project root when the
@@ -112,6 +118,13 @@ var rootMarkers = []string{
 // answer and --dir is the tool.
 const maxDirCandidates = 6
 
+// maxDirEntriesScanned caps the work, not just the offer: every entry
+// examined costs a manifest stat plus one per root marker, synchronously
+// before the wizard's first screen, and a directory with thousands of
+// entries (running setup from $HOME by mistake being the classic) must not
+// hang the wizard on stats.
+const maxDirEntriesScanned = 256
+
 // markersIn is which of the usual project files dir carries.
 func markersIn(dir string) []string {
 	var found []string
@@ -128,36 +141,81 @@ func markersIn(dir string) []string {
 // dirCandidates lists the immediate subdirectories carrying project files.
 // Hidden directories are never the project, and one already holding a
 // manifest is skipped too: it is entered with --dir, not set up afresh.
-func dirCandidates(dir string) []DirCandidate {
+// truncated reports that the scan stopped before the listing did, at either
+// cap, so a caller can say the offer is incomplete.
+//
+// The home directory is never scanned, same as repo.FindRepoRoot and
+// manifest.Locate stop there: everything under $HOME "carrying project
+// files" is not an offer, it is an inventory.
+func dirCandidates(dir string) (candidates []DirCandidate, truncated bool) {
+	if home, err := os.UserHomeDir(); err == nil && dir == home {
+		log.Debug("wizard: not scanning the home directory for project candidates")
+
+		return nil, false
+	}
+
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil
+		log.Debug("wizard: cannot list directory for project candidates", "dir", dir, "err", err)
+
+		return nil, false
 	}
 
-	var candidates []DirCandidate
+	for i, entry := range entries {
+		if i == maxDirEntriesScanned {
+			return candidates, true
+		}
 
-	for _, entry := range entries {
-		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+		candidate, ok := candidateFrom(dir, entry)
+		if !ok {
 			continue
 		}
 
-		sub := filepath.Join(dir, entry.Name())
-		if fsutil.FileExists(manifest.Path(sub)) {
-			continue
-		}
-
-		markers := markersIn(sub)
-		if len(markers) == 0 {
-			continue
-		}
-
-		candidates = append(candidates, DirCandidate{Rel: entry.Name(), Markers: markers})
 		if len(candidates) == maxDirCandidates {
-			break
+			return candidates, true
 		}
+
+		candidates = append(candidates, candidate)
 	}
 
-	return candidates
+	return candidates, false
+}
+
+// candidateFrom examines one directory entry and reports the candidate it
+// yields, if any.
+func candidateFrom(dir string, entry os.DirEntry) (DirCandidate, bool) {
+	if !isSubdirectory(dir, entry) || strings.HasPrefix(entry.Name(), ".") {
+		return DirCandidate{}, false
+	}
+
+	sub := filepath.Join(dir, entry.Name())
+	if fsutil.FileExists(manifest.Path(sub)) {
+		return DirCandidate{}, false
+	}
+
+	markers := markersIn(sub)
+	if len(markers) == 0 {
+		return DirCandidate{}, false
+	}
+
+	return DirCandidate{Rel: entry.Name(), Markers: markers}, true
+}
+
+// isSubdirectory reports whether entry is a directory, following one level of
+// symlink: DirEntry.IsDir reflects the entry's own on-disk type, so a project
+// reached through a symlink would otherwise be invisible to the offer.
+func isSubdirectory(dir string, entry os.DirEntry) bool {
+	if entry.IsDir() {
+		return true
+	}
+
+	if entry.Type()&os.ModeSymlink == 0 {
+		return false
+	}
+
+	info, err := os.Stat(filepath.Join(dir, entry.Name()))
+
+	return err == nil && info.IsDir()
 }
 
 // HasEnvFile reports whether the project has a .env worth asking about.
@@ -202,7 +260,10 @@ func Detect(dir string) Detected {
 	if detected.SuspectDir() {
 		// The subdirectory scan runs only when there is something to suspect:
 		// a directory that looks like a project needs no offer.
-		detected.Candidates = dirCandidates(dir)
+		detected.Candidates, detected.MoreCandidates = dirCandidates(dir)
+
+		log.Debug("wizard: directory carries no project markers",
+			"dir", dir, "candidates", len(detected.Candidates), "more", detected.MoreCandidates)
 	}
 
 	if !detected.HasDockerfile {

--- a/internal/workload/wizard/detect_test.go
+++ b/internal/workload/wizard/detect_test.go
@@ -222,3 +222,44 @@ func TestParseProblem_UnrecognizablePayloadYieldsNoLine(t *testing.T) {
 
 	assert.Equal(t, `unexpected character "-" in variable name`, parseProblem(err, "A=1\n"))
 }
+
+// A directory with none of the usual project files is suspect, and the offer
+// is its marker-bearing subdirectories: hidden ones are never the project,
+// empty ones say nothing, and one already holding a manifest is entered with
+// --dir rather than set up afresh.
+func TestDetect_SuspectDirOffersItsProjectLookingSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+
+	app := filepath.Join(dir, "my-app")
+	require.NoError(t, os.MkdirAll(app, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(app, "Dockerfile"), []byte("FROM scratch\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(app, "pyproject.toml"), []byte("[project]\n"), 0o644))
+
+	hidden := filepath.Join(dir, ".cache")
+	require.NoError(t, os.MkdirAll(hidden, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(hidden, "Dockerfile"), []byte("FROM scratch\n"), 0o644))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "docs"), 0o755))
+
+	configured := filepath.Join(dir, "configured")
+	require.NoError(t, os.MkdirAll(configured, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(configured, "go.mod"), []byte("module x\n"), 0o644))
+	require.NoError(t, os.WriteFile(manifest.Path(configured), []byte("name: x\n"), 0o644))
+
+	detected := Detect(dir)
+
+	assert.True(t, detected.SuspectDir())
+	require.Len(t, detected.Candidates, 1)
+	assert.Equal(t, "my-app", detected.Candidates[0].Rel)
+	assert.Equal(t, []string{"Dockerfile", "pyproject.toml"}, detected.Candidates[0].Markers)
+}
+
+// A directory carrying any project file is not suspect, and the subdirectory
+// scan never runs: a directory that looks like a project needs no offer.
+func TestDetect_MarkerBearingDirIsNotSuspect(t *testing.T) {
+	detected := Detect(writeDockerfile(t, t.TempDir(), "FROM scratch\n"))
+
+	assert.False(t, detected.SuspectDir())
+	assert.Contains(t, detected.RootMarkers, "Dockerfile")
+	assert.Empty(t, detected.Candidates)
+}

--- a/internal/workload/wizard/detect_test.go
+++ b/internal/workload/wizard/detect_test.go
@@ -16,6 +16,7 @@ package wizard
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -257,9 +258,72 @@ func TestDetect_SuspectDirOffersItsProjectLookingSubdirectories(t *testing.T) {
 // A directory carrying any project file is not suspect, and the subdirectory
 // scan never runs: a directory that looks like a project needs no offer.
 func TestDetect_MarkerBearingDirIsNotSuspect(t *testing.T) {
-	detected := Detect(writeDockerfile(t, t.TempDir(), "FROM scratch\n"))
+	dir := writeDockerfile(t, t.TempDir(), "FROM scratch\n")
+
+	// A subdirectory the scan would offer, so the empty Candidates below
+	// proves the scan was skipped rather than that there was nothing to find.
+	app := filepath.Join(dir, "nested-app")
+	require.NoError(t, os.MkdirAll(app, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(app, "package.json"), []byte("{}"), 0o644))
+
+	detected := Detect(dir)
 
 	assert.False(t, detected.SuspectDir())
 	assert.Contains(t, detected.RootMarkers, "Dockerfile")
 	assert.Empty(t, detected.Candidates)
+}
+
+// A project reached through a symlink is still an offer: the entry's own
+// on-disk type is a link, so the scan has to follow it one level to see the
+// directory behind it.
+func TestDetect_CandidateBehindSymlinkIsOffered(t *testing.T) {
+	target := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(target, "package.json"), []byte("{}"), 0o644))
+
+	dir := t.TempDir()
+	if err := os.Symlink(target, filepath.Join(dir, "linked-app")); err != nil {
+		t.Skipf("symlinks are not available here: %v", err)
+	}
+
+	detected := Detect(dir)
+
+	require.Len(t, detected.Candidates, 1)
+	assert.Equal(t, "linked-app", detected.Candidates[0].Rel)
+	assert.Equal(t, []string{"package.json"}, detected.Candidates[0].Markers)
+}
+
+// The home directory is never scanned: everything under it "carrying project
+// files" is an inventory, not an offer.
+func TestDetect_HomeDirectoryIsNeverScanned(t *testing.T) {
+	home := t.TempDir()
+	app := filepath.Join(home, "my-app")
+	require.NoError(t, os.MkdirAll(app, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(app, "go.mod"), []byte("module x\n"), 0o644))
+
+	t.Setenv("HOME", home)        // unix
+	t.Setenv("USERPROFILE", home) // windows
+
+	detected := Detect(home)
+
+	assert.True(t, detected.SuspectDir())
+	assert.Empty(t, detected.Candidates)
+	assert.False(t, detected.MoreCandidates)
+}
+
+// Past the offer cap the scan stops, and the flag is what lets the question
+// say the list is incomplete: a project whose name sorts late would
+// otherwise vanish without a trace.
+func TestDetect_TruncatedOfferReportsMoreCandidates(t *testing.T) {
+	dir := t.TempDir()
+
+	for i := range maxDirCandidates + 1 {
+		app := filepath.Join(dir, fmt.Sprintf("app-%d", i))
+		require.NoError(t, os.MkdirAll(app, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(app, "go.mod"), []byte("module x\n"), 0o644))
+	}
+
+	detected := Detect(dir)
+
+	assert.Len(t, detected.Candidates, maxDirCandidates)
+	assert.True(t, detected.MoreCandidates)
 }

--- a/internal/workload/wizard/interactive.go
+++ b/internal/workload/wizard/interactive.go
@@ -42,6 +42,19 @@ const execEnvPickLimit = 200
 // Every answer the flags did give survives, including the ones no screen asks
 // about (the runtime sizing) and the binding, which would otherwise be lost
 // and turn a bind into a create.
+// draftOrPartial is the draft the flags settle, falling back to the partial
+// draft when the flag set cannot be fully answered — interactively that is
+// not fatal, it is what the screens exist to resolve. One name for the step
+// newFlow and acceptDirectory both take, so the two cannot drift.
+func (a Answers) draftOrPartial(detected Detected) manifest.Draft {
+	draft, err := a.draft(detected)
+	if err != nil {
+		return a.partialDraft(detected)
+	}
+
+	return draft
+}
+
 func (a Answers) partialDraft(detected Detected) manifest.Draft {
 	kind := manifest.ArtifactTypeOrDefault(a.Type)
 

--- a/internal/workload/wizard/model.go
+++ b/internal/workload/wizard/model.go
@@ -57,6 +57,12 @@ const (
 type flow struct {
 	detected  Detected
 	workloads []workload.Workload
+	// offer is the Detected the directory question was built from, frozen at
+	// construction: acceptDirectory re-points detected at the chosen tree,
+	// and rebuilding the offer from that tree would make the question
+	// unanswerable a second time — Escape must find the original candidates,
+	// not the choice's own (empty) ones.
+	offer Detected
 	// pendingBind is a workload id a flag named, fetched by Init before the
 	// first screen so a flag-driven bind downloads the live spec exactly as
 	// the picker would.
@@ -174,19 +180,16 @@ type secretsStoredMsg struct {
 func newFlow(detected Detected, workloads []workload.Workload, answers Answers) flow {
 	f := flow{detected: detected, workloads: workloads, answers: answers, pendingBind: answers.WorkloadID}
 
-	draft, err := answers.draft(detected)
-	if err != nil {
-		// Interactively an unanswerable flag set is not fatal: the screens
-		// exist to answer exactly this. Everything the flags did settle is
-		// kept.
-		draft = answers.partialDraft(detected)
-	}
-
-	f.draft = draft
+	f.draft = answers.draftOrPartial(detected)
 	// A name passed as a flag is an answer the user gave, so the screen shows
 	// it as a value rather than re-offering the directory's suggestion.
 	f.nameGiven = answers.Name != ""
+
 	f.at = f.first(answers)
+	if f.at == screenDirectory {
+		f.offer = detected
+	}
+
 	f.enter(f.at)
 
 	// Only a flag the wizard cannot ask about is worth reporting on arrival.
@@ -196,7 +199,11 @@ func newFlow(detected Detected, workloads []workload.Workload, answers Answers) 
 	// about something the user has not been asked yet.
 	f.failed = answers.check()
 
-	if f.pendingBind != "" {
+	// A flag-named workload is fetched behind a loading view — but not while
+	// the directory question is on screen: the view would swallow every key
+	// and the question would never be seen (the fetch is deferred to the
+	// answer instead, see acceptDirectory and Init).
+	if f.pendingBind != "" && f.at != screenDirectory {
 		f.loading = "Reading workload " + f.pendingBind + "…"
 	}
 
@@ -239,6 +246,12 @@ func (f flow) firstQuestion(answers Answers) screen {
 
 func (f flow) Init() tea.Cmd {
 	if f.pendingBind == "" {
+		return nil
+	}
+
+	// The directory answer decides which tree the bound workload syncs from,
+	// so it comes first; acceptDirectory starts this fetch once it is given.
+	if f.at == screenDirectory {
 		return nil
 	}
 
@@ -694,23 +707,27 @@ func (f *flow) acceptKind() (tea.Cmd, error) {
 }
 
 // acceptDirectory re-reads the project from the directory chosen. This is
-// always the first screen, so no other answer exists yet and the draft is
-// rebuilt exactly the way newFlow built it — everything Detect suggests
-// (name, port, Dockerfile, .env) belonged to the old directory.
+// always the first screen, so no answer beyond this one exists yet and the
+// draft is rebuilt the way newFlow built it — everything Detect suggests
+// (name, port, Dockerfile, .env) belonged to the old directory. The env
+// table is dropped for the same reason: built once from the old tree, it
+// would otherwise write the old directory's variables into the new one's
+// manifest. f.offer stays untouched throughout, so Escape re-poses the
+// original question.
 func (f *flow) acceptDirectory() (tea.Cmd, error) {
-	chosen := f.choice.value()
-	if chosen == f.detected.Dir {
-		return nil, nil
+	if chosen := f.choice.value(); chosen != f.detected.Dir {
+		f.detected = Detect(chosen)
+		f.draft = f.answers.draftOrPartial(f.detected)
+		f.envTable = envTable{}
 	}
 
-	f.detected = Detect(chosen)
+	// A flag-named workload's fetch was deferred to here (see Init): the
+	// directory is settled, so the loading view no longer hides a question.
+	if f.pendingBind != "" {
+		f.loading = "Reading workload " + f.pendingBind + "…"
 
-	draft, err := f.answers.draft(f.detected)
-	if err != nil {
-		draft = f.answers.partialDraft(f.detected)
+		return fetchLiveCmd(f.pendingBind), nil
 	}
-
-	f.draft = draft
 
 	return nil, nil
 }

--- a/internal/workload/wizard/model.go
+++ b/internal/workload/wizard/model.go
@@ -45,6 +45,11 @@ const (
 	screenSettings
 	screenEnv
 	screenConfirm
+	// screenDirectory is conditional and first when shown: it exists only
+	// when the directory looks like the wrong place to run setup from and
+	// there are subdirectories to offer instead. Everything Detect suggests
+	// hangs off the answer, so nothing else may be asked before it.
+	screenDirectory
 )
 
 // flow is the wizard: one model for every screen, because the screens share
@@ -204,9 +209,21 @@ func defaultDraft(detected Detected) manifest.Draft {
 	return Answers{}.partialDraft(detected)
 }
 
-// first picks the opening screen. Binding is skipped when there is nothing to
-// bind to, or when a flag already said which workload this is.
+// first picks the opening screen. The directory question, when it exists,
+// comes before everything: a bound workload still syncs its code from here,
+// and every suggestion the other screens show was read from this directory.
 func (f flow) first(answers Answers) screen {
+	if f.detected.SuspectDir() && len(f.detected.Candidates) > 0 {
+		return screenDirectory
+	}
+
+	return f.firstQuestion(answers)
+}
+
+// firstQuestion picks the first ordinary screen. Binding is skipped when
+// there is nothing to bind to, or when a flag already said which workload
+// this is.
+func (f flow) firstQuestion(answers Answers) screen {
 	// A named workload is fetched by Init, and the kind screen is where the
 	// questions resume once it arrives.
 	if answers.WorkloadID != "" {
@@ -354,7 +371,7 @@ func (f flow) delegate(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		return f, nil
 
-	case screenKind, screenA2A, screenSource, screenEnv:
+	case screenKind, screenA2A, screenSource, screenEnv, screenDirectory:
 		if key, ok := msg.(tea.KeyMsg); ok {
 			f.updateSelection(key)
 		}
@@ -516,6 +533,10 @@ func (f flow) next() screen {
 // branch is the four answers that change where the flow goes next.
 func (f flow) branch() (screen, bool) {
 	switch f.at {
+	case screenDirectory:
+		// The flow restarts where it would have begun: the answer decided
+		// what every later screen suggests, not where the questions go.
+		return f.firstQuestion(f.answers), true
 	case screenBinding:
 		// A bound workload is already named.
 		return screenKind, f.live != nil
@@ -550,6 +571,7 @@ func (f flow) afterSource() (screen, bool) {
 // accepting maps each screen to what recording its answer means. Screens
 // absent from the table (the confirm screen) have nothing to record.
 var accepting = map[screen]func(*flow) (tea.Cmd, error){
+	screenDirectory:  (*flow).acceptDirectory,
 	screenBinding:    (*flow).acceptBinding,
 	screenName:       (*flow).acceptName,
 	screenKind:       (*flow).acceptKind,
@@ -667,6 +689,28 @@ func (f *flow) acceptKind() (tea.Cmd, error) {
 		f.draft.Type = kind
 		f.draft.A2AEnabled = false
 	}
+
+	return nil, nil
+}
+
+// acceptDirectory re-reads the project from the directory chosen. This is
+// always the first screen, so no other answer exists yet and the draft is
+// rebuilt exactly the way newFlow built it — everything Detect suggests
+// (name, port, Dockerfile, .env) belonged to the old directory.
+func (f *flow) acceptDirectory() (tea.Cmd, error) {
+	chosen := f.choice.value()
+	if chosen == f.detected.Dir {
+		return nil, nil
+	}
+
+	f.detected = Detect(chosen)
+
+	draft, err := f.answers.draft(f.detected)
+	if err != nil {
+		draft = f.answers.partialDraft(f.detected)
+	}
+
+	f.draft = draft
 
 	return nil, nil
 }
@@ -968,7 +1012,7 @@ func (f *flow) onEnter(at screen) tea.Cmd {
 		return focus
 
 	case screenBinding, screenName, screenKind, screenA2A, screenSource,
-		screenEntrypoint, screenImage, screenSettings, screenEnv:
+		screenEntrypoint, screenImage, screenSettings, screenEnv, screenDirectory:
 		// Everything these screens show is already in hand.
 		return focus
 	}

--- a/internal/workload/wizard/regression_test.go
+++ b/internal/workload/wizard/regression_test.go
@@ -1754,3 +1754,58 @@ func TestFlow_SuspectDirWithoutCandidatesAsksNothingExtra(t *testing.T) {
 
 	assert.Equal(t, screenName, model.at)
 }
+
+// Escape from the next screen has to find the original question: accepting a
+// candidate re-points detected at the chosen tree, and an offer rebuilt from
+// there would list that tree's own subdirectories instead.
+func TestFlow_DirectoryOfferSurvivesEscape(t *testing.T) {
+	model := newFlow(parentOfProject(t), nil, Answers{})
+	require.Equal(t, screenDirectory, model.at)
+
+	model = press(t, model, "enter")
+	require.Equal(t, screenName, model.at)
+
+	model = press(t, model, "esc")
+	require.Equal(t, screenDirectory, model.at)
+
+	options := model.directoryOptions()
+	require.Len(t, options, 2)
+	assert.Equal(t, "./my-app", options[0].label)
+}
+
+// Choosing another directory drops the env table along with the draft: built
+// from the old tree's .env, it would otherwise write the parent's variables
+// into the chosen project's manifest. Staying put keeps it, because nothing
+// it was built from has changed.
+func TestFlow_ChangingDirectoryDropsTheOldEnvTable(t *testing.T) {
+	stale := envTable{rows: []EnvVar{{Name: "PARENT_ONLY"}}}
+
+	model := newFlow(parentOfProject(t), nil, Answers{})
+	require.Equal(t, screenDirectory, model.at)
+
+	model.envTable = stale
+	model = press(t, model, "down", "enter") // stay put
+	assert.Len(t, model.envTable.rows, 1, "the same tree keeps its table")
+
+	model = press(t, model, "esc")
+	require.Equal(t, screenDirectory, model.at)
+
+	model = press(t, model, "enter") // take the candidate
+	assert.Empty(t, model.envTable.rows, "another tree starts from its own .env")
+}
+
+// A --workload-id bind must not hide the directory question behind the
+// loading view: the fetch waits for the answer, then starts.
+func TestFlow_BindWaitsForTheDirectoryAnswer(t *testing.T) {
+	model := newFlow(parentOfProject(t), nil, Answers{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"})
+	require.Equal(t, screenDirectory, model.at)
+	assert.Empty(t, model.loading, "the question must be visible")
+	assert.Nil(t, model.Init(), "the fetch waits for the directory answer")
+
+	updated, cmd := model.Update(keyMsg("enter"))
+	next, ok := updated.(flow)
+	require.True(t, ok)
+
+	assert.NotNil(t, cmd, "the deferred fetch starts once the directory is settled")
+	assert.NotEmpty(t, next.loading)
+}

--- a/internal/workload/wizard/regression_test.go
+++ b/internal/workload/wizard/regression_test.go
@@ -1413,7 +1413,7 @@ func TestFlow_ConfirmPreviewDoesNotOfferScrollingItDoesNotNeed(t *testing.T) {
 // open on it: the error would sit behind the loading view, the fetch would
 // run anyway, and arriving at the first screen would clear it.
 func TestRunInteractiveFlow_RejectsWorkloadIDWithName(t *testing.T) {
-	_, _, err := runInteractiveFlow(
+	_, _, _, err := runInteractiveFlow(
 		Options{Dir: t.TempDir(), Answers: Answers{WorkloadID: "68b0", Name: "my-app"}},
 		dockerfileProject(t))
 	require.Error(t, err)
@@ -1697,4 +1697,60 @@ func TestFlow_BoundEnvCountsOnlyWhatWasAdded(t *testing.T) {
 	// The running value stands: .env is the developer's copy and may be stale.
 	assert.Contains(t, string(model.content), "value: info")
 	assert.NotContains(t, string(model.content), "value: debug")
+}
+
+// parentOfProject is setup run from the wrong place: the directory itself
+// carries nothing, and the app sits one level down with a Dockerfile whose
+// EXPOSE the re-detection must pick up.
+func parentOfProject(t *testing.T) Detected {
+	t.Helper()
+
+	dir := t.TempDir()
+	app := filepath.Join(dir, "my-app")
+	require.NoError(t, os.MkdirAll(app, 0o755))
+	writeDockerfile(t, app, "FROM scratch\nEXPOSE 3000\n")
+
+	return Detect(dir)
+}
+
+// Run from a directory that looks wrong, the wizard's first question is the
+// directory itself — before the name, because every suggestion the other
+// screens show was read from it.
+func TestFlow_SuspectDirAsksForTheDirectoryFirst(t *testing.T) {
+	model := newFlow(parentOfProject(t), nil, Answers{})
+	require.Equal(t, screenDirectory, model.at)
+
+	// The cursor opens on the candidate — the likely intent — and choosing it
+	// re-reads everything from the chosen directory: the name suggestion and
+	// the EXPOSE port now belong to the app, not its parent.
+	model = press(t, model, "enter")
+	require.NoError(t, model.failed)
+	assert.Equal(t, screenName, model.at)
+	assert.Equal(t, "my-app", model.detected.Name)
+	assert.True(t, model.detected.HasDockerfile)
+	assert.Equal(t, 3000, model.draft.Port)
+	assert.False(t, model.detected.SuspectDir())
+}
+
+// Staying put is one keystroke past the offer, because the check is a
+// suspicion: a valid project cannot be reliably recognized, and being wrong
+// must be cheap.
+func TestFlow_SuspectDirCanBeKeptAnyway(t *testing.T) {
+	detected := parentOfProject(t)
+
+	model := newFlow(detected, nil, Answers{})
+	require.Equal(t, screenDirectory, model.at)
+
+	model = press(t, model, "down", "enter")
+	require.NoError(t, model.failed)
+	assert.Equal(t, screenName, model.at)
+	assert.Equal(t, detected.Dir, model.detected.Dir, "the directory setup ran from stands")
+}
+
+// A suspect directory with nothing to offer has no question to ask: an offer
+// needs candidates, and the headless warning covers the rest.
+func TestFlow_SuspectDirWithoutCandidatesAsksNothingExtra(t *testing.T) {
+	model := newFlow(Detect(t.TempDir()), nil, Answers{})
+
+	assert.Equal(t, screenName, model.at)
 }

--- a/internal/workload/wizard/run.go
+++ b/internal/workload/wizard/run.go
@@ -40,8 +40,10 @@ func SetStdinTerminalForTest(isTerminal bool) func() {
 }
 
 // SetInteractiveFlowForTest replaces the wizard itself, so a command-level
-// test can tell whether it would have run.
-func SetInteractiveFlowForTest(flow func(Options, Detected) ([]byte, manifest.Draft, error)) func() {
+// test can tell whether it would have run. The string is the project
+// directory the flow settled on, which is Detected.Dir unless the user chose
+// another on the directory screen.
+func SetInteractiveFlowForTest(flow func(Options, Detected) ([]byte, manifest.Draft, string, error)) func() {
 	original := runInteractiveFlowFn
 	runInteractiveFlowFn = flow
 
@@ -130,10 +132,16 @@ func Run(opts Options) (Result, error) {
 		warnUnreadEnvFile(opts.Stderr, detected)
 	}
 
-	content, draft, err := opts.resolve(detected)
+	content, draft, projectDir, err := opts.resolve(detected)
 	if err != nil {
 		return Result{}, err
 	}
+
+	// The interactive flow may have moved the project: everything from here
+	// on — the write, the validation's Dockerfile check, the reported path —
+	// belongs to the directory resolve settled on, which headless runs return
+	// unchanged.
+	path = manifest.Path(projectDir)
 
 	// A file that came from a running workload is judged as the platform's
 	// news, not as a bug in the wizard.
@@ -142,7 +150,7 @@ func Run(opts Options) (Result, error) {
 		author = authorLive
 	}
 
-	if err := checkRendered(content, dir, author); err != nil {
+	if err := checkRendered(content, projectDir, author); err != nil {
 		return Result{}, err
 	}
 
@@ -199,8 +207,10 @@ func existing(path string) (Result, error) {
 }
 
 // resolve produces the manifest bytes, from flags alone when nothing may
-// prompt and from the wizard otherwise.
-func (o Options) resolve(detected Detected) ([]byte, manifest.Draft, error) {
+// prompt and from the wizard otherwise. The directory it returns is where the
+// project actually is: Detected.Dir, unless the interactive flow's directory
+// screen chose another.
+func (o Options) resolve(detected Detected) ([]byte, manifest.Draft, string, error) {
 	if o.NonInteractive || !isStdinTerminalFn() {
 		return o.resolveHeadless(detected)
 	}
@@ -208,24 +218,56 @@ func (o Options) resolve(detected Detected) ([]byte, manifest.Draft, error) {
 	return runInteractiveFlowFn(o, detected)
 }
 
-func (o Options) resolveHeadless(detected Detected) ([]byte, manifest.Draft, error) {
+func (o Options) resolveHeadless(detected Detected) ([]byte, manifest.Draft, string, error) {
+	// Headless can warn but not offer: the check that interactively becomes
+	// the directory question is a line on stderr here, and never a refusal —
+	// a valid project cannot be reliably recognized, so a wrong guess has to
+	// cost nothing.
+	warnSuspectDir(o.Stderr, detected)
+
 	if o.Answers.WorkloadID != "" {
 		return o.resolveHeadlessBound(detected)
 	}
 
 	draft, err := o.Answers.draft(detected)
 	if err != nil {
-		return nil, manifest.Draft{}, err
+		return nil, manifest.Draft{}, "", err
 	}
 
 	draft.EnvVars = o.storeSecrets(draft.EnvVars, detected, draft.Name)
 
 	content, err := draft.Render()
 	if err != nil {
-		return nil, manifest.Draft{}, err
+		return nil, manifest.Draft{}, "", err
 	}
 
-	return content, draft, nil
+	return content, draft, detected.Dir, nil
+}
+
+// warnSuspectDir says when the directory looks like the wrong place to run
+// setup from — none of the usual project files — and names the subdirectories
+// that look right, because the fix is one --dir away and this is the last
+// moment before six questions and an artifact are spent on the wrong tree.
+func warnSuspectDir(w io.Writer, detected Detected) {
+	if !detected.SuspectDir() {
+		return
+	}
+
+	line := fmt.Sprintf("Warning: %s has none of the usual project files (Dockerfile, pyproject.toml, "+
+		"package.json, ...). If this is not the project root, everything here would be uploaded on deploy.",
+		detected.Dir)
+
+	if len(detected.Candidates) > 0 {
+		names := make([]string, 0, len(detected.Candidates))
+		for _, candidate := range detected.Candidates {
+			names = append(names, candidate.Rel)
+		}
+
+		line += fmt.Sprintf(" These look like project roots: %s — pass --dir to use one.",
+			strings.Join(names, ", "))
+	}
+
+	fmt.Fprintln(w, line)
 }
 
 // storeSecrets sends each secret to the credential store and reports what
@@ -251,19 +293,19 @@ func (o Options) storeSecrets(vars []manifest.EnvVar, detected Detected, workloa
 // resolveHeadlessBound binds to a live workload without prompting: the live
 // spec is downloaded and the flags are applied on top, so a headless bind is
 // the same operation the picker performs.
-func (o Options) resolveHeadlessBound(detected Detected) ([]byte, manifest.Draft, error) {
+func (o Options) resolveHeadlessBound(detected Detected) ([]byte, manifest.Draft, string, error) {
 	live, err := fetchLive(o.Answers.WorkloadID)
 	if err != nil {
-		return nil, manifest.Draft{}, err
+		return nil, manifest.Draft{}, "", err
 	}
 
 	if err := o.Answers.checkProbeEditable(live); err != nil {
-		return nil, manifest.Draft{}, err
+		return nil, manifest.Draft{}, "", err
 	}
 
 	draft, err := o.Answers.applyTo(live.Defaults(), detected)
 	if err != nil {
-		return nil, manifest.Draft{}, err
+		return nil, manifest.Draft{}, "", err
 	}
 
 	// A name the workload already declares keeps its running value, so it is
@@ -276,12 +318,12 @@ func (o Options) resolveHeadlessBound(detected Detected) ([]byte, manifest.Draft
 
 	applied, err := live.Apply(draft)
 	if err != nil {
-		return nil, manifest.Draft{}, err
+		return nil, manifest.Draft{}, "", err
 	}
 
 	content, err := applied.Render()
 	if err != nil {
-		return nil, manifest.Draft{}, err
+		return nil, manifest.Draft{}, "", err
 	}
 
 	// Read off the workload as it arrived, not off applied: the point is what
@@ -289,7 +331,7 @@ func (o Options) resolveHeadlessBound(detected Detected) ([]byte, manifest.Draft
 	// above has no file to warn about.
 	warnLiveSecretLiterals(o.Stderr, live)
 
-	return content, draft, nil
+	return content, draft, detected.Dir, nil
 }
 
 // applyTo layers the flags over defaults that already came from somewhere

--- a/internal/workload/wizard/run.go
+++ b/internal/workload/wizard/run.go
@@ -128,9 +128,7 @@ func Run(opts Options) (Result, error) {
 
 	detected := Detect(dir)
 
-	if !opts.Answers.SkipEnv {
-		warnUnreadEnvFile(opts.Stderr, detected)
-	}
+	opts.warnEnvFile(detected)
 
 	content, draft, projectDir, err := opts.resolve(detected)
 	if err != nil {
@@ -142,6 +140,14 @@ func Run(opts Options) (Result, error) {
 	// belongs to the directory resolve settled on, which headless runs return
 	// unchanged.
 	path = manifest.Path(projectDir)
+
+	// The chosen directory's own .env gets the same courtesy the starting
+	// one got above: a parse failure must not read as "there was nothing to
+	// import". The flow re-detected on the way, but only the warning's
+	// reader was lost — the TUI owned the terminal at the time.
+	if projectDir != dir {
+		opts.warnEnvFile(Detect(projectDir))
+	}
 
 	// A file that came from a running workload is judged as the platform's
 	// news, not as a bug in the wizard.
@@ -212,46 +218,54 @@ func existing(path string) (Result, error) {
 // screen chose another.
 func (o Options) resolve(detected Detected) ([]byte, manifest.Draft, string, error) {
 	if o.NonInteractive || !isStdinTerminalFn() {
-		return o.resolveHeadless(detected)
+		// Headless can warn but not offer: the check that interactively
+		// becomes the directory question is a line on stderr here, and never
+		// a refusal — a valid project cannot be reliably recognized, so a
+		// wrong guess has to cost nothing. Only the headless paths return
+		// detected.Dir unchanged, so the fourth value is settled right here.
+		o.warnSuspectDir(detected)
+
+		content, draft, err := o.resolveHeadless(detected)
+
+		return content, draft, detected.Dir, err
 	}
 
 	return runInteractiveFlowFn(o, detected)
 }
 
-func (o Options) resolveHeadless(detected Detected) ([]byte, manifest.Draft, string, error) {
-	// Headless can warn but not offer: the check that interactively becomes
-	// the directory question is a line on stderr here, and never a refusal —
-	// a valid project cannot be reliably recognized, so a wrong guess has to
-	// cost nothing.
-	warnSuspectDir(o.Stderr, detected)
-
+func (o Options) resolveHeadless(detected Detected) ([]byte, manifest.Draft, error) {
 	if o.Answers.WorkloadID != "" {
 		return o.resolveHeadlessBound(detected)
 	}
 
 	draft, err := o.Answers.draft(detected)
 	if err != nil {
-		return nil, manifest.Draft{}, "", err
+		return nil, manifest.Draft{}, err
 	}
 
 	draft.EnvVars = o.storeSecrets(draft.EnvVars, detected, draft.Name)
 
 	content, err := draft.Render()
 	if err != nil {
-		return nil, manifest.Draft{}, "", err
+		return nil, manifest.Draft{}, err
 	}
 
-	return content, draft, detected.Dir, nil
+	return content, draft, nil
 }
 
 // warnSuspectDir says when the directory looks like the wrong place to run
 // setup from — none of the usual project files — and names the subdirectories
 // that look right, because the fix is one --dir away and this is the last
 // moment before six questions and an artifact are spent on the wrong tree.
-func warnSuspectDir(w io.Writer, detected Detected) {
-	if !detected.SuspectDir() {
+//
+// An image-mode run is exempt: it never syncs local directory contents, so
+// "everything here would be uploaded" describes a risk that cannot happen.
+func (o Options) warnSuspectDir(detected Detected) {
+	if o.Stderr == nil || !detected.SuspectDir() || o.Answers.BuildMode == manifest.BuildModeImage {
 		return
 	}
+
+	w := o.Stderr
 
 	line := fmt.Sprintf("Warning: %s has none of the usual project files (Dockerfile, pyproject.toml, "+
 		"package.json, ...). If this is not the project root, everything here would be uploaded on deploy.",
@@ -263,8 +277,13 @@ func warnSuspectDir(w io.Writer, detected Detected) {
 			names = append(names, candidate.Rel)
 		}
 
-		line += fmt.Sprintf(" These look like project roots: %s — pass --dir to use one.",
-			strings.Join(names, ", "))
+		more := ""
+		if detected.MoreCandidates {
+			more = ", and more exist"
+		}
+
+		line += fmt.Sprintf(" These look like project roots: %s%s — pass --dir to use one.",
+			strings.Join(names, ", "), more)
 	}
 
 	fmt.Fprintln(w, line)
@@ -293,19 +312,19 @@ func (o Options) storeSecrets(vars []manifest.EnvVar, detected Detected, workloa
 // resolveHeadlessBound binds to a live workload without prompting: the live
 // spec is downloaded and the flags are applied on top, so a headless bind is
 // the same operation the picker performs.
-func (o Options) resolveHeadlessBound(detected Detected) ([]byte, manifest.Draft, string, error) {
+func (o Options) resolveHeadlessBound(detected Detected) ([]byte, manifest.Draft, error) {
 	live, err := fetchLive(o.Answers.WorkloadID)
 	if err != nil {
-		return nil, manifest.Draft{}, "", err
+		return nil, manifest.Draft{}, err
 	}
 
 	if err := o.Answers.checkProbeEditable(live); err != nil {
-		return nil, manifest.Draft{}, "", err
+		return nil, manifest.Draft{}, err
 	}
 
 	draft, err := o.Answers.applyTo(live.Defaults(), detected)
 	if err != nil {
-		return nil, manifest.Draft{}, "", err
+		return nil, manifest.Draft{}, err
 	}
 
 	// A name the workload already declares keeps its running value, so it is
@@ -318,12 +337,12 @@ func (o Options) resolveHeadlessBound(detected Detected) ([]byte, manifest.Draft
 
 	applied, err := live.Apply(draft)
 	if err != nil {
-		return nil, manifest.Draft{}, "", err
+		return nil, manifest.Draft{}, err
 	}
 
 	content, err := applied.Render()
 	if err != nil {
-		return nil, manifest.Draft{}, "", err
+		return nil, manifest.Draft{}, err
 	}
 
 	// Read off the workload as it arrived, not off applied: the point is what
@@ -331,7 +350,7 @@ func (o Options) resolveHeadlessBound(detected Detected) ([]byte, manifest.Draft
 	// above has no file to warn about.
 	warnLiveSecretLiterals(o.Stderr, live)
 
-	return content, draft, detected.Dir, nil
+	return content, draft, nil
 }
 
 // applyTo layers the flags over defaults that already came from somewhere
@@ -596,6 +615,16 @@ func warnShadowedManifest(stderr io.Writer, dir string) {
 	fmt.Fprintf(stderr,
 		"Warning: a manifest already exists at %s. Writing one in %s means a deploy from either directory reads a different file.\n",
 		found, dir)
+}
+
+// warnEnvFile is warnUnreadEnvFile behind the opt-out: --skip-env means the
+// user declined the import, so a failed read is not news either.
+func (o Options) warnEnvFile(detected Detected) {
+	if o.Answers.SkipEnv {
+		return
+	}
+
+	warnUnreadEnvFile(o.Stderr, detected)
 }
 
 // warnUnreadEnvFile says so when a .env is there but contributed nothing.

--- a/internal/workload/wizard/run_test.go
+++ b/internal/workload/wizard/run_test.go
@@ -630,16 +630,38 @@ func TestRun_HeadlessWarnsAboutASuspectDirectory(t *testing.T) {
 
 	var stderr bytes.Buffer
 
+	// Dockerfile mode syncs local code, which is what the warning is about —
+	// and a suspect directory genuinely has no Dockerfile, so the run then
+	// fails on its own terms. The warning must land first: it names the fix
+	// (--dir web) for the failure that follows.
 	_, err := Run(Options{
 		Dir: dir, NonInteractive: true, Stderr: &stderr,
-		Answers: Answers{Name: "my-app", BuildMode: manifest.BuildModeImage, Image: "registry/team/app:v1"},
+		Answers: Answers{Name: "my-app", BuildMode: manifest.BuildModeDockerfile},
 	})
-	require.NoError(t, err, "a suspicion never fails the run")
+	require.Error(t, err, "no Dockerfile here; the warning explains why")
 
 	warning := stderr.String()
 	assert.Contains(t, warning, "none of the usual project files")
 	assert.Contains(t, warning, "web", "the offer names what looks right")
 	assert.Contains(t, warning, "--dir", "and the flag that takes it")
+}
+
+// An image-mode run never syncs local directory contents, so the suspect-dir
+// warning would describe a risk that cannot happen — it stays quiet.
+func TestRun_HeadlessImageModeSkipsTheSuspectDirWarning(t *testing.T) {
+	dir := t.TempDir()
+	app := filepath.Join(dir, "web")
+	require.NoError(t, os.MkdirAll(app, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(app, "package.json"), []byte("{}"), 0o644))
+
+	var stderr bytes.Buffer
+
+	_, err := Run(Options{
+		Dir: dir, NonInteractive: true, Stderr: &stderr,
+		Answers: Answers{Name: "my-app", BuildMode: manifest.BuildModeImage, Image: "registry/team/app:v1"},
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, stderr.String(), "none of the usual project files")
 }
 
 // A directory that carries a project file gets no warning: the check is about

--- a/internal/workload/wizard/run_test.go
+++ b/internal/workload/wizard/run_test.go
@@ -390,8 +390,8 @@ func TestRun_BoundWorkloadWithoutAnArtifact(t *testing.T) {
 // Cancelling writes nothing and says so, so `config && up` stops here.
 func TestRun_CancelledWritesNothing(t *testing.T) {
 	original := runInteractiveFlowFn
-	runInteractiveFlowFn = func(Options, Detected) ([]byte, manifest.Draft, error) {
-		return nil, manifest.Draft{}, ErrCancelled
+	runInteractiveFlowFn = func(Options, Detected) ([]byte, manifest.Draft, string, error) {
+		return nil, manifest.Draft{}, "", ErrCancelled
 	}
 
 	t.Cleanup(func() { runInteractiveFlowFn = original })
@@ -412,10 +412,10 @@ func TestRun_CancelledWritesNothing(t *testing.T) {
 // Without a terminal nothing prompts, even when --yes was not passed.
 func TestRun_NoTerminalNeverPrompts(t *testing.T) {
 	originalFlow := runInteractiveFlowFn
-	runInteractiveFlowFn = func(Options, Detected) ([]byte, manifest.Draft, error) {
+	runInteractiveFlowFn = func(Options, Detected) ([]byte, manifest.Draft, string, error) {
 		t.Fatal("the wizard must not run without a terminal")
 
-		return nil, manifest.Draft{}, nil
+		return nil, manifest.Draft{}, "", nil
 	}
 
 	t.Cleanup(func() { runInteractiveFlowFn = originalFlow })
@@ -617,4 +617,76 @@ func TestRun_SkipEnvSilencesTheUnreadableEnvWarning(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Empty(t, stderr.String())
+}
+
+// Headless can warn but not offer: the directory check becomes a stderr line
+// naming the subdirectories that look right, and never a refusal — a valid
+// project cannot be reliably recognized, so a wrong guess must cost nothing.
+func TestRun_HeadlessWarnsAboutASuspectDirectory(t *testing.T) {
+	dir := t.TempDir()
+	app := filepath.Join(dir, "web")
+	require.NoError(t, os.MkdirAll(app, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(app, "package.json"), []byte("{}"), 0o644))
+
+	var stderr bytes.Buffer
+
+	_, err := Run(Options{
+		Dir: dir, NonInteractive: true, Stderr: &stderr,
+		Answers: Answers{Name: "my-app", BuildMode: manifest.BuildModeImage, Image: "registry/team/app:v1"},
+	})
+	require.NoError(t, err, "a suspicion never fails the run")
+
+	warning := stderr.String()
+	assert.Contains(t, warning, "none of the usual project files")
+	assert.Contains(t, warning, "web", "the offer names what looks right")
+	assert.Contains(t, warning, "--dir", "and the flag that takes it")
+}
+
+// A directory that carries a project file gets no warning: the check is about
+// the parent-of-the-app mistake, not about lecturing every project.
+func TestRun_HeadlessStaysQuietAboutAProjectRoot(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte("{}"), 0o644))
+
+	var stderr bytes.Buffer
+
+	_, err := Run(Options{
+		Dir: dir, NonInteractive: true, Stderr: &stderr,
+		Answers: Answers{Name: "my-app", BuildMode: manifest.BuildModeImage, Image: "registry/team/app:v1"},
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, stderr.String(), "usual project files")
+}
+
+// The manifest lands where the flow ended up. The interactive directory
+// question can move the project, and writing to the directory setup was
+// started from would put the file beside the app instead of inside it.
+func TestRun_WritesWhereTheFlowEndedUp(t *testing.T) {
+	parent := t.TempDir()
+	app := filepath.Join(parent, "app")
+	require.NoError(t, os.MkdirAll(app, 0o755))
+
+	restoreFlow := SetInteractiveFlowForTest(
+		func(Options, Detected) ([]byte, manifest.Draft, string, error) {
+			draft := defaultDraft(Detect(app))
+			draft.Name = "moved"
+			draft.Build = manifest.Build{Mode: manifest.BuildModeImage, ImageURI: "registry/team/app:v1"}
+
+			content, err := draft.Render()
+
+			return content, draft, app, err
+		})
+	defer restoreFlow()
+
+	restoreTerminal := SetStdinTerminalForTest(true)
+	defer restoreTerminal()
+
+	var stderr bytes.Buffer
+
+	result, err := Run(Options{Dir: parent, Stderr: &stderr})
+	require.NoError(t, err)
+
+	assert.Equal(t, manifest.Path(app), result.Path)
+	assert.FileExists(t, manifest.Path(app), "written where the flow chose")
+	assert.NoFileExists(t, manifest.Path(parent), "not where setup was started")
 }

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -59,7 +60,7 @@ const namePlaceholder = "my-app-name"
 // runInteractiveFlow asks the questions and returns the manifest the user
 // agreed to. The workload list is fetched up front because the first screen
 // depends on it: with nothing to bind to, there is no binding question.
-func runInteractiveFlow(opts Options, detected Detected) ([]byte, manifest.Draft, error) {
+func runInteractiveFlow(opts Options, detected Detected) ([]byte, manifest.Draft, string, error) {
 	// No screen can settle these, so they are not questions the wizard gets to
 	// ask. Started anyway, the error would sit behind the loading view while
 	// the fetch ran, and arriving at the first screen would clear it and drop
@@ -71,7 +72,7 @@ func runInteractiveFlow(opts Options, detected Detected) ([]byte, manifest.Draft
 	// never starts.
 	for _, check := range []func() error{opts.Answers.checkBinding, opts.Answers.checkProbeExclusive} {
 		if err := check(); err != nil {
-			return nil, manifest.Draft{}, err
+			return nil, manifest.Draft{}, "", err
 		}
 	}
 
@@ -80,7 +81,7 @@ func runInteractiveFlow(opts Options, detected Detected) ([]byte, manifest.Draft
 	if opts.Answers.WorkloadID == "" && opts.Answers.Name == "" {
 		fetched, err := listWorkloadsFn(workloadPickLimit, 0, nil, "")
 		if err != nil {
-			return nil, manifest.Draft{}, err
+			return nil, manifest.Draft{}, "", err
 		}
 
 		workloads = fetched
@@ -101,12 +102,12 @@ func runInteractiveFlow(opts Options, detected Detected) ([]byte, manifest.Draft
 	final, err := tui.Run(started,
 		tea.WithAltScreen(), tea.WithOutput(interactiveOutput(opts.Stderr)))
 	if err != nil {
-		return nil, manifest.Draft{}, err
+		return nil, manifest.Draft{}, "", err
 	}
 
 	finished, ok := tui.Unwrap(final).(flow)
 	if !ok {
-		return nil, manifest.Draft{}, ErrCancelled
+		return nil, manifest.Draft{}, "", ErrCancelled
 	}
 
 	// Printed here rather than from inside the flow: until tui.Run returns,
@@ -114,7 +115,11 @@ func runInteractiveFlow(opts Options, detected Detected) ([]byte, manifest.Draft
 	// underneath a full-screen redraw.
 	reportImport(opts.Stderr, finished.imports)
 
-	return finished.result()
+	content, draft, err := finished.result()
+
+	// The directory screen may have moved the project; the caller writes the
+	// manifest where the flow ended up, not where setup was started.
+	return content, draft, finished.detected.Dir, err
 }
 
 // interactiveOutput is where the wizard draws. bubbletea needs the real
@@ -139,7 +144,7 @@ func (f *flow) enter(at screen) {
 	case screenBinding, screenExecEnv:
 		f.enterPicker(at)
 
-	case screenKind, screenA2A, screenSource:
+	case screenKind, screenA2A, screenSource, screenDirectory:
 		f.enterChoice(at)
 		f.choice.liveValue = f.liveChoice(at)
 
@@ -189,14 +194,39 @@ func (f *flow) enterPicker(at screen) {
 		}
 
 	case screenName, screenKind, screenA2A, screenSource, screenEntrypoint,
-		screenImage, screenSettings, screenEnv, screenConfirm:
+		screenImage, screenSettings, screenEnv, screenConfirm, screenDirectory:
 		// Not lists.
 	}
+}
+
+// directoryOptions is the directory question's offer: the subdirectories
+// that look like project roots first — the likely intent, so the cursor
+// opens on the fix — and staying put last, because the check is a suspicion
+// and being wrong about it has to cost one keystroke.
+func (f flow) directoryOptions() []option {
+	options := make([]option, 0, len(f.detected.Candidates)+1)
+
+	for _, candidate := range f.detected.Candidates {
+		options = append(options, option{
+			value: filepath.Join(f.detected.Dir, candidate.Rel),
+			label: "./" + candidate.Rel,
+			note:  "has " + strings.Join(candidate.Markers, ", "),
+		})
+	}
+
+	return append(options, option{
+		value: f.detected.Dir,
+		label: "Use this directory anyway",
+		note:  "everything under it is uploaded on deploy",
+	})
 }
 
 // enterChoice prepares the menu screens.
 func (f *flow) enterChoice(at screen) {
 	switch at {
+	case screenDirectory:
+		f.choice = newChoice(f.directoryOptions(), "", "")
+
 	case screenKind:
 		f.choice = newChoice([]option{
 			{value: manifest.TypeService, label: "Service", note: "standard HTTP workload"},
@@ -255,7 +285,8 @@ func (f *flow) enterInputs(at screen) {
 		// screen has no tea.Cmd of its own to return it through.
 		f.focusCmd = f.applyFocus()
 
-	case screenBinding, screenExecEnv, screenKind, screenA2A, screenSource, screenEnv, screenConfirm:
+	case screenBinding, screenExecEnv, screenKind, screenA2A, screenSource, screenEnv,
+		screenConfirm, screenDirectory:
 		// No text entry.
 	}
 }
@@ -340,7 +371,7 @@ func (f flow) liveChoice(at screen) string {
 	case screenSource:
 		return live.Build.Mode
 	case screenBinding, screenName, screenExecEnv, screenEntrypoint,
-		screenImage, screenSettings, screenEnv, screenConfirm:
+		screenImage, screenSettings, screenEnv, screenConfirm, screenDirectory:
 		return ""
 	}
 
@@ -399,6 +430,11 @@ func (f flow) sourceConflictNote() string {
 // screen is shown, read before anything is answered.
 func (f flow) screenIntro() string {
 	switch f.at {
+	case screenDirectory:
+		return "Deploying uploads everything under the project directory and builds from it, so " +
+			"running setup from the wrong place — the app's parent, most often — fails minutes later, " +
+			"after the questions are answered. This is a suspicion, not a verdict: staying put is fine " +
+			"if this really is the project."
 	case screenName:
 		return ""
 	case screenKind:
@@ -434,7 +470,7 @@ func (f flow) screenNote() string {
 		return f.confirmNote()
 	case screenKind, screenSource, screenImage, screenExecEnv:
 		return f.boundScreenNote()
-	case screenName, screenA2A, screenEntrypoint:
+	case screenName, screenA2A, screenEntrypoint, screenDirectory:
 		return ""
 	}
 
@@ -455,7 +491,7 @@ func (f flow) boundScreenNote() string {
 	case screenImage:
 		return f.liveValuesNote()
 	case screenBinding, screenName, screenA2A, screenExecEnv,
-		screenEntrypoint, screenSettings, screenEnv, screenConfirm:
+		screenEntrypoint, screenSettings, screenEnv, screenConfirm, screenDirectory:
 		return ""
 	}
 
@@ -465,6 +501,7 @@ func (f flow) boundScreenNote() string {
 // questions is what each screen asks. Phrasing them in one place keeps the
 // wizard sounding like one voice rather than ten.
 var questions = map[screen]string{
+	screenDirectory:  "This directory has none of the usual project files. Deploy which one?",
 	screenBinding:    "Which workload should this repository deploy to?",
 	screenName:       "Name of your workload",
 	screenKind:       "What kind of workload is this?",
@@ -494,7 +531,7 @@ func (f flow) body() string {
 	case screenBinding, screenExecEnv:
 		return f.picker.view(f.width)
 
-	case screenKind, screenSource:
+	case screenKind, screenSource, screenDirectory:
 		return f.choice.view()
 
 	case screenEnv:

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -204,20 +204,28 @@ func (f *flow) enterPicker(at screen) {
 // opens on the fix — and staying put last, because the check is a suspicion
 // and being wrong about it has to cost one keystroke.
 func (f flow) directoryOptions() []option {
-	options := make([]option, 0, len(f.detected.Candidates)+1)
+	// Built from the frozen offer, never from f.detected: accepting a
+	// candidate re-points detected at the chosen tree, and Escape has to
+	// find the original question, not the choice's own view of itself.
+	options := make([]option, 0, len(f.offer.Candidates)+1)
 
-	for _, candidate := range f.detected.Candidates {
+	for _, candidate := range f.offer.Candidates {
 		options = append(options, option{
-			value: filepath.Join(f.detected.Dir, candidate.Rel),
+			value: filepath.Join(f.offer.Dir, candidate.Rel),
 			label: "./" + candidate.Rel,
 			note:  "has " + strings.Join(candidate.Markers, ", "),
 		})
 	}
 
+	stayNote := "everything under it is uploaded on deploy"
+	if f.offer.MoreCandidates {
+		stayNote += " · more candidates exist — pass --dir to name one"
+	}
+
 	return append(options, option{
-		value: f.detected.Dir,
+		value: f.offer.Dir,
 		label: "Use this directory anyway",
-		note:  "everything under it is uploaded on deploy",
+		note:  stayNote,
 	})
 }
 


### PR DESCRIPTION
# RATIONALE

Setup run from the wrong directory — the app's parent, most often — used to fail only at code-sync time, after six questions were answered and the artifact already existed. Nothing checked whether the directory looked like a project root; the only related check (the `pyproject.toml`/`uv.lock` one) lives in the sync engine, warn-only, and runs last. The check now happens before anything is asked, and — per the ticket's agreed direction — it **warns and offers, never fails**: a valid project cannot be reliably recognized, so a wrong suspicion has to cost one keystroke.

Ticket: [RAPTOR-19726](https://datarobot.atlassian.net/browse/RAPTOR-19726)

## CHANGES

- `Detect` now records which of the usual project files (Dockerfile, pyproject.toml, uv.lock, requirements.txt, package.json, go.mod, setup.py) the directory carries. When it carries none, it looks one level down for subdirectories that do — skipping hidden ones and ones already holding a manifest (those are entered with `--dir`, not set up afresh).
- **Interactive**: a suspect directory with candidates becomes the wizard's first question, ahead even of the binding — every suggestion the other screens show was read from the directory. The offer opens on the likeliest candidate ("./my-app — has Dockerfile, pyproject.toml"), "use this directory anyway" is one keystroke below, and choosing a candidate re-reads name, port, Dockerfile and .env from it. The manifest is then written where the flow ended up, and `up`'s wizard path follows the file it wrote instead of re-searching upward from where the command ran (which cannot see one level down).
- **Headless** (`--yes`, JSON, no terminal): a stderr warning naming the candidate directories and the `--dir` flag that takes them. Never a refusal, and silent for any directory that carries a project file.
- `wizard.SetInteractiveFlowForTest` gains a string return (the directory the flow settled on) — test-seam signature change, no production callers outside this repo.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which directory is detected, where the manifest is written, and how `up` loads after the wizard—directly affecting what code gets uploaded on deploy—but behavior is warn/offer only with broad test coverage.
> 
> **Overview**
> Setup and deploy used to assume the current directory was the project root, so running from a parent folder could waste the whole wizard and still sync the wrong tree. **This PR adds an early “wrong directory?” check that warns and offers a fix but never blocks.**
> 
> **Detection** now records usual root markers (Dockerfile, `pyproject.toml`, etc.). If the cwd has none, it scans immediate subdirectories (skipping hidden dirs and dirs that already have a manifest) and surfaces up to six candidates with the markers they carry.
> 
> **Interactive** runs show a new **directory screen first** when there are candidates—before binding or name—defaulting to the likeliest subfolder. Picking a subdirectory re-runs detection (name, port, Dockerfile, `.env`); staying put is one extra choice. The manifest is written under the directory the flow settled on, and **`dr workload up`** reloads from that manifest path after the inline wizard so deploy does not miss a manifest one level down.
> 
> **Headless** (`--yes`, JSON, no TTY) prints a stderr warning (and candidate names plus `--dir`) instead of prompting; runs still succeed. Test hooks like `SetInteractiveFlowForTest` now return the settled project directory as an extra string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4e202cf376db986488b79a0e333fb3961430689. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->