### PR TITLE
Fixed confusing prompt

### DIFF
--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/datarobot/cli/tui"
 )
 
 // roll moves a live workload onto a new version of what the file describes.
@@ -245,7 +246,7 @@ func confirmRoll(live Live, workloadName string, opts Options) (bool, error) {
 			"Workload %s is on a locked version, which means production.%s\n"+
 				"The new version will be locked too, and locking cannot be undone.\n"+
 				"Type the workload name to roll it, anything else to stop: ",
-			workloadName, alsoStarting(live)), workloadName)
+			tui.WarnStyle.Render("`"+workloadName+"`"), alsoStarting(live)), workloadName)
 	}
 
 	if opts.NonInteractive {


### PR DESCRIPTION
# RATIONALE

I found it quite confusing to know what I should type here. This highlights it

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and terminal styling only in an interactive prompt; no rollout, locking, or confirmation logic changes.
> 
> **Overview**
> The locked-version rollout confirmation is easier to read because the workload name users must re-type is **visually emphasized** in the prompt text.
> 
> `confirmRoll` now passes the name through `tui.WarnStyle` with backticks around it in the “Workload … is on a locked version” message, instead of showing the plain string. Confirmation behavior is unchanged—the answer is still the exact workload name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c7f097d4d444862db5db7567ceb6b13c5fc0e90. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->