### PR TITLE
[RAPTOR-19519] fix(workload): stop rebuilding the image for runtime-only changes

### DIFF
--- a/cmd/workload/up/cmd.go
+++ b/cmd/workload/up/cmd.go
@@ -129,6 +129,12 @@ for an image first, so the first deploy of such a project takes as long as the
 build does. A build the deploy believes would produce the image already on the
 artifact is skipped; --force-build says otherwise.
 
+An environment variable, a port, a probe or a route is read when the container
+starts, so a deploy that changes only those keeps the image the running one has
+and takes seconds rather than minutes. Anything else builds: the code, the
+Dockerfile, the execution environment, a container or group added, a change of
+workload kind, a current version that was never built, and --force-build.
+
 Deploying onto a workload that already exists rolls it: a new version is made
 from the file and swapped in, the endpoint does not change, and the version
 already serving keeps serving until the new one is ready. When that version is

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -373,6 +373,45 @@ func CreateArtifact(payload any) (*Artifact, error) {
 	return &artifact, nil
 }
 
+// CloneArtifact copies an artifact into a new draft named name.
+func CloneArtifact(artifactID, name string) (*Artifact, error) {
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/clone")
+	if err != nil {
+		return nil, err
+	}
+
+	body := map[string]string{"name": name}
+
+	var artifact Artifact
+
+	if err := drapi.PostJSON(url, "artifact clone", body, &artifact); err != nil {
+		return nil, err
+	}
+
+	return &artifact, nil
+}
+
+// UpdateArtifactSpec writes a draft artifact's spec.
+//
+// containerGroups is replaced wholesale rather than merged key by key. The
+// platform re-injects what it owns on a build-from-source container, so a spec
+// that omits imageUri keeps the running image; codeRef is not re-injected,
+// which is why the copy path puts it back before writing.
+func UpdateArtifactSpec(artifactID string, spec json.RawMessage) error {
+	if len(spec) == 0 {
+		return errors.New("no artifact spec to update")
+	}
+
+	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/")
+	if err != nil {
+		return err
+	}
+
+	body := map[string]json.RawMessage{"spec": spec}
+
+	return drapi.PatchJSON(url, "artifact", body, nil)
+}
+
 func PatchArtifactCodeRef(artifactID, catalogID, catalogVersionID string) error {
 	url, err := config.GetEndpointURL("/api/v2/artifacts/" + escapeID(artifactID) + "/")
 	if err != nil {
@@ -394,6 +433,29 @@ func PatchArtifactCodeRef(artifactID, catalogID, catalogVersionID string) error 
 	return drapi.PatchJSON(url, "artifact", body, nil)
 }
 
+// SpecWithPrimaryCodeRef returns spec with the primary container pointed at the
+// catalog pair given. An update replaces a container wholesale, so the file's
+// spec alone would erase the reference.
+func SpecWithPrimaryCodeRef(spec json.RawMessage, catalogID, catalogVersionID string) (json.RawMessage, error) {
+	var decoded map[string]any
+
+	if err := json.Unmarshal(spec, &decoded); err != nil {
+		return nil, fmt.Errorf("cannot read the artifact spec: %w", err)
+	}
+
+	// The map is shared rather than copied, so its edits are marshalled back.
+	if err := setPrimaryCodeRefInRawArtifact(map[string]any{"spec": decoded}, catalogID, catalogVersionID); err != nil {
+		return nil, err
+	}
+
+	updated, err := json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert the artifact spec to JSON: %w", err)
+	}
+
+	return updated, nil
+}
+
 func setPrimaryCodeRefInRawArtifact(raw map[string]any, catalogID, catalogVersionID string) error {
 	spec, ok := raw["spec"].(map[string]any)
 	if !ok {
@@ -405,76 +467,140 @@ func setPrimaryCodeRefInRawArtifact(raw map[string]any, catalogID, catalogVersio
 		return errors.New("artifact: spec.containerGroups missing or empty")
 	}
 
-	codeRef := map[string]any{
-		"datarobot": map[string]any{
-			"catalogId":        catalogID,
-			"catalogVersionId": catalogVersionID,
-		},
+	container := primaryContainerInGroups(groups)
+	if container == nil {
+		return noPrimaryContainer(groups)
 	}
 
-	if found := assignToPrimaryContainer(groups, codeRef); found {
+	setImageBuildConfigCodeRef(container, map[string]any{
+		keyRawDatarobot: map[string]any{
+			keyRawCatalogID:        catalogID,
+			keyRawCatalogVersionID: catalogVersionID,
+		},
+	})
+
+	return nil
+}
+
+// noPrimaryContainer says why the search came back empty. Asked only after it
+// has failed: checking groups[0] first would refuse an artifact whose flagged
+// primary sits in a later group.
+func noPrimaryContainer(groups []any) error {
+	group, ok := groups[0].(map[string]any)
+	if !ok {
+		return errors.New("artifact: spec.containerGroups[0] missing or wrong type")
+	}
+
+	if len(containersOfGroup(group)) == 0 {
+		return errors.New("artifact: spec.containerGroups[0].containers missing or empty")
+	}
+
+	return errors.New("artifact: spec.containerGroups[0].containers[0] missing or wrong type")
+}
+
+// Keys along the code reference inside a decoded container, spelled once so
+// the reader and the writer below cannot drift apart.
+const (
+	keyRawImageBuildConfig = "imageBuildConfig"
+	keyRawCodeRef          = "codeRef"
+	keyRawDatarobot        = "datarobot"
+	keyRawCatalogID        = "catalogId"
+	keyRawCatalogVersionID = "catalogVersionId"
+)
+
+// CodeRefInContainer reads the catalog pair a decoded container points at, nil
+// when it names none. The read half of setPrimaryCodeRefInRawArtifact.
+func CodeRefInContainer(container map[string]any) *DatarobotCodeRef {
+	build, _ := container[keyRawImageBuildConfig].(map[string]any)
+	ref, _ := build[keyRawCodeRef].(map[string]any)
+
+	datarobot, ok := ref[keyRawDatarobot].(map[string]any)
+	if !ok {
 		return nil
 	}
 
-	// Mirror ExtractCodeRef's [0][0] fallback when no container is flagged primary.
-	return assignToFirstContainer(groups, codeRef)
+	catalogID, _ := datarobot[keyRawCatalogID].(string)
+	catalogVersionID, _ := datarobot[keyRawCatalogVersionID].(string)
+
+	return &DatarobotCodeRef{CatalogID: catalogID, CatalogVersionID: catalogVersionID}
 }
 
-func assignToPrimaryContainer(groups []any, codeRef map[string]any) bool {
+// PrimaryContainerInDocument is primaryContainer for an artifact still in the
+// shape the server sent it. Two readings of which container is primary
+// disagreeing is how a plan promises an image the run cannot find.
+func PrimaryContainerInDocument(raw map[string]any) map[string]any {
+	spec, ok := raw["spec"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	groups, ok := spec["containerGroups"].([]any)
+	if !ok {
+		return nil
+	}
+
+	return primaryContainerInGroups(groups)
+}
+
+// primaryContainerInGroups is primaryContainer's rule for a decoded document:
+// the container flagged "primary", else the first.
+func primaryContainerInGroups(groups []any) map[string]any {
+	if flagged := flaggedPrimaryContainer(groups); flagged != nil {
+		return flagged
+	}
+
+	return firstContainerInGroups(groups)
+}
+
+// flaggedPrimaryContainer is the container that claims to be primary, if any.
+func flaggedPrimaryContainer(groups []any) map[string]any {
 	for _, g := range groups {
 		group, ok := g.(map[string]any)
 		if !ok {
 			continue
 		}
 
-		containers, ok := group["containers"].([]any)
-		if !ok {
-			continue
-		}
-
-		for _, c := range containers {
-			container, ok := c.(map[string]any)
-			if !ok {
-				continue
-			}
-
-			if isPrimaryContainer(container) {
-				setImageBuildConfigCodeRef(container, codeRef)
-
-				return true
+		for _, c := range containersOfGroup(group) {
+			if container, ok := c.(map[string]any); ok && isPrimaryContainer(container) {
+				return container
 			}
 		}
 	}
-
-	return false
-}
-
-func assignToFirstContainer(groups []any, codeRef map[string]any) error {
-	firstGroup, ok := groups[0].(map[string]any)
-	if !ok {
-		return errors.New("artifact: spec.containerGroups[0] missing or wrong type")
-	}
-
-	containers, ok := firstGroup["containers"].([]any)
-	if !ok || len(containers) == 0 {
-		return errors.New("artifact: spec.containerGroups[0].containers missing or empty")
-	}
-
-	firstContainer, ok := containers[0].(map[string]any)
-	if !ok {
-		return errors.New("artifact: spec.containerGroups[0].containers[0] missing or wrong type")
-	}
-
-	setImageBuildConfigCodeRef(firstContainer, codeRef)
 
 	return nil
+}
+
+func firstContainerInGroups(groups []any) map[string]any {
+	if len(groups) == 0 {
+		return nil
+	}
+
+	group, ok := groups[0].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	containers := containersOfGroup(group)
+	if len(containers) == 0 {
+		return nil
+	}
+
+	first, _ := containers[0].(map[string]any)
+
+	return first
+}
+
+func containersOfGroup(group map[string]any) []any {
+	containers, _ := group["containers"].([]any)
+
+	return containers
 }
 
 // setImageBuildConfigCodeRef preserves any existing dockerfile config and
 // seeds a "provided" Dockerfile default when imageBuildConfig is absent
 // (server requires a dockerfile on the imageBuildConfig).
 func setImageBuildConfigCodeRef(container map[string]any, codeRef map[string]any) {
-	ibc, ok := container["imageBuildConfig"].(map[string]any)
+	ibc, ok := container[keyRawImageBuildConfig].(map[string]any)
 	if !ok || ibc == nil {
 		ibc = map[string]any{
 			"dockerfile": map[string]any{
@@ -483,8 +609,8 @@ func setImageBuildConfigCodeRef(container map[string]any, codeRef map[string]any
 		}
 	}
 
-	ibc["codeRef"] = codeRef
-	container["imageBuildConfig"] = ibc
+	ibc[keyRawCodeRef] = codeRef
+	container[keyRawImageBuildConfig] = ibc
 }
 
 func isPrimaryContainer(container map[string]any) bool {

--- a/internal/workload/artifact_test.go
+++ b/internal/workload/artifact_test.go
@@ -580,6 +580,30 @@ func TestSetPrimaryCodeRefInRawArtifact(t *testing.T) {
 		assert.Equal(t, "provided", ibc["dockerfile"].(map[string]any)["source"])
 	})
 
+	t.Run("FindsPrimaryPastAnEmptyFirstGroup", func(t *testing.T) {
+		// The flagged primary is in containerGroups[1] and groups[0] holds no
+		// containers, a shape PatchArtifactCodeRef sends on every code sync.
+		raw := map[string]any{
+			"spec": map[string]any{
+				"containerGroups": []any{
+					map[string]any{"containers": []any{}},
+					map[string]any{
+						"containers": []any{
+							map[string]any{"primary": true},
+						},
+					},
+				},
+			},
+		}
+
+		require.NoError(t, setPrimaryCodeRefInRawArtifact(raw, "cat-b", "ver-b"))
+
+		primary := raw["spec"].(map[string]any)["containerGroups"].([]any)[1].(map[string]any)["containers"].([]any)[0].(map[string]any)
+		dr := primary["imageBuildConfig"].(map[string]any)["codeRef"].(map[string]any)["datarobot"].(map[string]any)
+		assert.Equal(t, "cat-b", dr["catalogId"])
+		assert.Equal(t, "ver-b", dr["catalogVersionId"])
+	})
+
 	t.Run("FallsBackToFirstContainerWhenNoPrimary", func(t *testing.T) {
 		raw := map[string]any{
 			"spec": map[string]any{
@@ -636,6 +660,23 @@ func TestSetPrimaryCodeRefInRawArtifact(t *testing.T) {
 			"missing containerGroups",
 			map[string]any{"spec": map[string]any{}},
 			"containerGroups missing or empty",
+		},
+		{
+			"first group wrong type",
+			map[string]any{"spec": map[string]any{"containerGroups": []any{"not-a-map"}}},
+			"containerGroups[0] missing or wrong type",
+		},
+		{
+			"first group has no containers",
+			map[string]any{"spec": map[string]any{"containerGroups": []any{map[string]any{}}}},
+			"containerGroups[0].containers missing or empty",
+		},
+		{
+			"first container wrong type",
+			map[string]any{"spec": map[string]any{
+				"containerGroups": []any{map[string]any{"containers": []any{"not-a-map"}}},
+			}},
+			"containerGroups[0].containers[0] missing or wrong type",
 		},
 	}
 
@@ -701,6 +742,79 @@ func TestDeleteArtifact_409PropagatesAsHTTPError(t *testing.T) {
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusConflict, httpErr.StatusCode)
 	assert.Contains(t, err.Error(), "Delete the workload(s) first")
+}
+
+func TestCloneArtifact_PostsTheNameAndReturnsTheCopy(t *testing.T) {
+	installSkipAuth(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v2/artifacts/art-1/clone", r.URL.Path)
+
+		var body map[string]any
+
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, map[string]any{"name": "my-app-artifact"}, body)
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"art-2","name":"my-app-artifact","status":"draft","spec":{"containerGroups":[`+
+			`{"containers":[{"name":"primary","primary":true,"imageUri":"registry/app:sha-abc"}]}]}}`)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	artifact, err := CloneArtifact("art-1", "my-app-artifact")
+	require.NoError(t, err)
+	assert.Equal(t, "art-2", artifact.ID)
+	assert.Equal(t, ArtifactStatusDraft, artifact.Status)
+	assert.Equal(t, "registry/app:sha-abc", GetPrimaryContainerImageURI(*artifact),
+		"a copy keeps the image its source was built into, which is the whole reason to make one")
+}
+
+// The spec update sends the spec and nothing else. An empty one would be a
+// PATCH that changed nothing, which comes back 200 and looks like success, and
+// a locked artifact's refusal has to be tellable from anything else.
+func TestUpdateArtifactSpec(t *testing.T) {
+	installSkipAuth(t)
+
+	status := http.StatusOK
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			fmt.Fprint(w, `{"detail":"Cannot update artifact: artifact is locked"}`)
+
+			return
+		}
+
+		assert.Equal(t, http.MethodPatch, r.Method)
+		assert.Equal(t, "/api/v2/artifacts/art-2/", r.URL.Path)
+
+		var body map[string]any
+
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Len(t, body, 1)
+		assert.Contains(t, body, "spec")
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"art-2","status":"draft"}`)
+	}))
+
+	defer srv.Close()
+
+	installEndpoint(t, srv.URL)
+
+	spec := json.RawMessage(`{"containerGroups":[]}`)
+
+	require.NoError(t, UpdateArtifactSpec("art-2", spec))
+	require.Error(t, UpdateArtifactSpec("art-2", nil), "an empty spec never reaches the platform")
+
+	status = http.StatusForbidden
+
+	err := UpdateArtifactSpec("art-2", spec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "artifact is locked")
 }
 
 func TestLockArtifact_SendsStatusLocked(t *testing.T) {
@@ -1002,4 +1116,42 @@ func TestListArtifacts_ClampsPageSizeToServerMax(t *testing.T) {
 
 	_, err := ListArtifacts(250, 0, "")
 	require.NoError(t, err)
+}
+
+// CodeRefInContainer and setPrimaryCodeRefInRawArtifact walk one path. A
+// reader spelling it for itself answers "no code" for a container that has some.
+func TestCodeRefInContainer(t *testing.T) {
+	t.Run("ReadsWhatTheWriterWrote", func(t *testing.T) {
+		raw := map[string]any{
+			"spec": map[string]any{
+				"containerGroups": []any{
+					map[string]any{"containers": []any{map[string]any{"primary": true}}},
+				},
+			},
+		}
+
+		require.NoError(t, setPrimaryCodeRefInRawArtifact(raw, "cat-1", "ver-1"))
+
+		ref := CodeRefInContainer(PrimaryContainerInDocument(raw))
+		require.NotNil(t, ref)
+		assert.Equal(t, "cat-1", ref.CatalogID)
+		assert.Equal(t, "ver-1", ref.CatalogVersionID)
+	})
+
+	t.Run("AnswersNilForEveryShapeThatHasNone", func(t *testing.T) {
+		cases := map[string]map[string]any{
+			"no container at all": nil,
+			"no imageBuildConfig": {"name": "app"},
+			"no codeRef":          {"imageBuildConfig": map[string]any{"dockerfile": map[string]any{}}},
+			"codeRef with no datarobot": {
+				"imageBuildConfig": map[string]any{"codeRef": map[string]any{"git": map[string]any{}}},
+			},
+		}
+
+		for name, container := range cases {
+			t.Run(name, func(t *testing.T) {
+				assert.Nil(t, CodeRefInContainer(container))
+			})
+		}
+	})
 }

--- a/internal/workload/manifest/compile.go
+++ b/internal/workload/manifest/compile.go
@@ -66,6 +66,9 @@ type Compiled struct {
 	// A deploy reads it to know there is nothing to create: the version being
 	// rolled onto already exists.
 	ArtifactID string
+	// ArtifactName is what the inline block calls the artifact, "" when the
+	// file describes none. Lifted out so a caller need not decode the payload.
+	ArtifactName string
 	// CredentialRefs lists every credential the payload references.
 	CredentialRefs []CredentialRef
 }
@@ -88,6 +91,7 @@ func (m *Manifest) Compile() (*Compiled, error) {
 
 	workloadID := m.WorkloadID()
 	artifactID := topLevelString(m.root, keyArtifactID)
+	artifactName, _ := mapAt(doc, keyArtifact)[keyName].(string)
 
 	delete(doc, keyWorkloadID)
 	expandCredentialShorthand(doc)
@@ -101,6 +105,7 @@ func (m *Manifest) Compile() (*Compiled, error) {
 		Payload:        payload,
 		WorkloadID:     workloadID,
 		ArtifactID:     artifactID,
+		ArtifactName:   artifactName,
 		CredentialRefs: refs,
 	}, nil
 }
@@ -127,6 +132,33 @@ func (c *Compiled) ArtifactPayload() (json.RawMessage, error) {
 	raw, err := json.Marshal(artifact)
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert the %s block to JSON: %w", keyArtifact, err)
+	}
+
+	return raw, nil
+}
+
+// ArtifactSpecPayload is the spec inside the inline artifact block, which is
+// what an update takes: the block's own name and type are not an update's to
+// restate. A manifest bound by id has no block and says so.
+func (c *Compiled) ArtifactSpecPayload() (json.RawMessage, error) {
+	payload, err := c.decode()
+	if err != nil {
+		return nil, err
+	}
+
+	artifact, ok := payload[keyArtifact].(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("the manifest has no %s block to update from", keyArtifact)
+	}
+
+	spec, ok := artifact[keySpec]
+	if !ok {
+		return nil, fmt.Errorf("the manifest's %s block has no %s to update from", keyArtifact, keySpec)
+	}
+
+	raw, err := json.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert the %s block to JSON: %w", keySpec, err)
 	}
 
 	return raw, nil

--- a/internal/workload/manifest/compile_test.go
+++ b/internal/workload/manifest/compile_test.go
@@ -329,6 +329,41 @@ func TestArtifactPayload_NoBlockToCreate(t *testing.T) {
 	assert.Contains(t, err.Error(), "no artifact block")
 }
 
+// The spec on its own is what an update takes: the artifact already has a name
+// and a type, and the platform owns the type once it exists.
+func TestArtifactSpecPayload_IsTheSpecAlone(t *testing.T) {
+	m, err := Parse([]byte(buildManifest), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	payload, err := compiled.ArtifactSpecPayload()
+	require.NoError(t, err)
+
+	var spec map[string]any
+
+	require.NoError(t, json.Unmarshal(payload, &spec))
+	assert.Contains(t, spec, "containerGroups")
+	assert.NotContains(t, spec, "name", "the name is the artifact's, not its spec's")
+	assert.Equal(t, "my-app-artifact", compiled.ArtifactName, "which is lifted out for the copy to be named")
+}
+
+// A manifest bound by id describes no block, so there is nothing to lift.
+func TestCompile_ArtifactBoundByIDHasNoBlockToRead(t *testing.T) {
+	m, err := Parse([]byte("name: my-app\nartifactId: 68b0bbbb0000000000000002\n"), "")
+	require.NoError(t, err)
+
+	compiled, err := m.Compile()
+	require.NoError(t, err)
+
+	assert.Empty(t, compiled.ArtifactName)
+
+	_, err = compiled.ArtifactSpecPayload()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no artifact block")
+}
+
 // The mirror of ArtifactPayload: the sizing half on its own, with nothing in
 // it about what the workload runs.
 func TestRuntimePayload_IsTheBlockItself(t *testing.T) {

--- a/internal/workload/up/build.go
+++ b/internal/workload/up/build.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/internal/workload/sync"
@@ -66,11 +67,11 @@ func buildAndCreate(loaded Loaded, code CodeChange, result Result, opts Options,
 	// and died. Neither is distinguishable from the ordinary case by then: the
 	// link has already moved, so the only record of what happened is the
 	// catalog version in the project's own state, which is what this reads.
-	if err := inheritCode(loaded.ProjectDir, artifactID, synced, report); err != nil {
+	if err := inheritCode(loaded.ProjectDir, made, synced, report); err != nil {
 		return result, err
 	}
 
-	buildID, err := maybeBuild(artifactID, fresh, code, synced, opts, report)
+	buildID, err := maybeBuild(loaded.ProjectDir, made, code, synced, opts, report)
 
 	// Recorded before the error check: a failed build is still a build, and
 	// the caller's envelope should be able to name the one to go and read.
@@ -302,31 +303,21 @@ func syncCode(projectDir string, report *reporter) (*sync.Result, error) {
 // maybeBuild spends a build only when there is a reason to, and names the
 // build it ran so the caller can report it. An empty id means no build
 // happened, which is not the same as a build that produced nothing.
-//
-// A build is minutes, so skipping one that would produce the image already
-// sitting on the artifact is worth the two conditions it takes to be sure.
-// The reasons to build are: the artifact is new, so no image exists; the sync
-// moved something, so any image is now stale; or the user said to.
-//
-// Otherwise the tree matches what was synced and the only open question is
-// whether the previous run got as far as an image. That question is asked of
-// the platform rather than assumed, because the common way to arrive here is
-// a first deploy that failed after the sync.
 func maybeBuild(
-	artifactID string,
-	fresh bool,
+	projectDir string,
+	made version,
 	code CodeChange,
 	synced *sync.Result,
 	opts Options,
 	report *reporter,
 ) (string, error) {
-	if !fresh && !opts.ForceBuild && !changed(code, synced) {
-		builds, err := listBuildsFn(artifactID, buildHistoryLimit)
+	if !opts.ForceBuild && !changed(code, synced) {
+		built, builds, err := imageInHand(made)
 		if err != nil {
-			return "", fmt.Errorf("cannot tell whether artifact %s has been built: %w", artifactID, err)
+			return "", err
 		}
 
-		if hasImage(builds) {
+		if built {
 			report.say("  Image is up to date; no rebuild needed.\n")
 
 			return "", nil
@@ -341,11 +332,42 @@ func maybeBuild(
 		if running := runningBuild(builds, attachMaxAge(opts)); running != "" {
 			report.say("  A build of this code is already running; attaching to it (--force-build starts a new one).\n")
 
-			return buildImage(artifactID, running, opts, report)
+			return buildAndRecord(projectDir, made.ID, running, opts, report)
 		}
 	}
 
-	return buildImage(artifactID, "", opts, report)
+	return buildAndRecord(projectDir, made.ID, "", opts, report)
+}
+
+// imageInHand reports whether the candidate already has something to run, and
+// hands back the build history when it had to be fetched. Only a leftover
+// reaches the platform: a copy carries its image and a create has none.
+func imageInHand(made version) (bool, []workload.Build, error) {
+	if made.ImageURI != "" {
+		return true, nil, nil
+	}
+
+	if made.Fresh {
+		return false, nil, nil
+	}
+
+	builds, err := listBuildsFn(made.ID, buildHistoryLimit)
+	if err != nil {
+		return false, nil, fmt.Errorf("cannot tell whether artifact %s has been built: %w", made.ID, err)
+	}
+
+	return hasImage(builds), builds, nil
+}
+
+// buildAndRecord builds and notes what the image was made from, the one fact
+// nothing on the platform keeps.
+func buildAndRecord(projectDir, artifactID, attachTo string, opts Options, report *reporter) (string, error) {
+	buildID, err := buildImage(artifactID, attachTo, opts, report)
+	if err == nil && buildID != "" {
+		recordBuiltFn(projectDir)
+	}
+
+	return buildID, err
 }
 
 // runningBuild names the newest non-terminal build, "" when there is none
@@ -377,6 +399,27 @@ func attachMaxAge(opts Options) time.Duration {
 	return 30 * time.Minute
 }
 
+// recordBuiltVersion notes the code version the image was built from, which
+// nothing on the platform holds. Best effort: not writing it costs a build.
+func recordBuiltVersion(projectDir string) {
+	if !projectLinkedFn(projectDir) {
+		return
+	}
+
+	cfg, err := loadProjectFn(projectDir)
+	if err != nil || cfg.LastSyncedVersionID == nil {
+		return
+	}
+
+	built := *cfg.LastSyncedVersionID
+	cfg.LastBuiltVersionID = &built
+
+	if err := saveProjectFn(projectDir, cfg); err != nil {
+		log.Debug("cannot record the code version the image was built from",
+			"project_dir", projectDir, "err", err)
+	}
+}
+
 // changed reports whether anything moved. The sync's own count is preferred
 // over the plan's: the plan was computed before the upload and is a
 // prediction, while the result is what happened.
@@ -389,13 +432,9 @@ func changed(code CodeChange, synced *sync.Result) bool {
 }
 
 // hasImage reports whether the artifact has ever built successfully. Any
-// completed build answers it, without regard to which is newest: this is only
-// asked when the working tree matches what was last synced, so a build that
-// completed at all built the code about to be deployed.
-//
-// The exception is code pushed by `dr artifact code sync` between deploys,
-// which leaves a completed build of the previous version and a tree that
-// looks unchanged to `up`. That is what --force-build is for.
+// completed build answers it, whichever is newest: this is only asked when the
+// working tree matches what was last synced. Code pushed by `dr artifact code
+// sync` between deploys is the exception, answered by CodeChange.ImageStale.
 func hasImage(builds []workload.Build) bool {
 	for _, build := range builds {
 		if workload.IsBuildCompleted(build.Status) {

--- a/internal/workload/up/build_stream_test.go
+++ b/internal/workload/up/build_stream_test.go
@@ -254,7 +254,7 @@ func TestMaybeBuild_AttachesToRunningBuildWhenCodeUnchanged(t *testing.T) {
 
 	var out bytes.Buffer
 
-	buildID, err := maybeBuild("art-1", false, CodeChange{}, unchangedSync(), Options{}, newReporter(&out, false))
+	buildID, err := maybeBuild(t.TempDir(), version{ID: "art-1"}, CodeChange{}, unchangedSync(), Options{}, newReporter(&out, false))
 	require.NoError(t, err)
 	assert.Equal(t, "bld-running", buildID)
 	assert.Equal(t, "bld-running", waited)
@@ -291,7 +291,7 @@ func TestMaybeBuild_TriggersInsteadOfAttachingToAWedgedBuild(t *testing.T) {
 
 	var out bytes.Buffer
 
-	buildID, err := maybeBuild("art-1", false, CodeChange{}, unchangedSync(), Options{}, newReporter(&out, false))
+	buildID, err := maybeBuild(t.TempDir(), version{ID: "art-1"}, CodeChange{}, unchangedSync(), Options{}, newReporter(&out, false))
 	require.NoError(t, err)
 	assert.True(t, triggered, "a wedged build must be superseded, not attached to")
 	assert.Equal(t, "bld-new", buildID)
@@ -322,7 +322,7 @@ func TestMaybeBuild_TriggersDespiteRunningBuildWhenCodeChanged(t *testing.T) {
 
 	var out bytes.Buffer
 
-	buildID, err := maybeBuild("art-1", false, CodeChange{}, &sync.Result{UploadedCount: 1}, Options{}, newReporter(&out, false))
+	buildID, err := maybeBuild(t.TempDir(), version{ID: "art-1"}, CodeChange{}, &sync.Result{UploadedCount: 1}, Options{}, newReporter(&out, false))
 	require.NoError(t, err)
 	assert.True(t, triggered)
 	assert.Equal(t, "bld-new", buildID)

--- a/internal/workload/up/build_test.go
+++ b/internal/workload/up/build_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/wapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Two of the three answers cost nothing: a copy carries its image, and a create
+// cannot have one. Only a leftover is a real question, and a history that
+// cannot be read is not an answer: "no image" would spend a build on a guess,
+// "has one" would promote an artifact with nothing to run.
+func TestImageInHand(t *testing.T) {
+	leftover := version{ID: "art-abandoned"}
+
+	cases := []struct {
+		name    string
+		made    version
+		builds  []workload.Build
+		readErr error
+		asks    bool
+		want    bool
+	}{
+		{
+			name: "a carried image answers itself", want: true,
+			made: version{ID: "art-2", Fresh: true, HasCode: true, ImageURI: "registry/app:sha"},
+		},
+		{name: "so does a version created moments ago", made: version{ID: "art-2", Fresh: true}},
+		{
+			name: "a leftover with a completed build has one", made: leftover, asks: true, want: true,
+			builds: []workload.Build{{Status: workload.BuildStatusCompleted}},
+		},
+		{name: "a leftover with none does not", made: leftover, asks: true},
+		{
+			name: "a history that cannot be read is an error", made: leftover, asks: true,
+			readErr: errors.New("gateway timeout"),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			asked := false
+
+			force(t, &listBuildsFn, func(string, int) ([]workload.Build, error) {
+				asked = true
+
+				return c.builds, c.readErr
+			})
+
+			got, builds, err := imageInHand(c.made)
+			assert.Equal(t, c.asks, asked, "only a leftover is worth a round trip")
+
+			if c.readErr != nil {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), c.made.ID)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, c.want, got)
+			assert.Equal(t, c.builds != nil, builds != nil, "the history comes back only when fetched")
+		})
+	}
+}
+
+// `dr artifact code sync` moves the code an artifact points at without touching
+// the working tree, and nothing on the platform records what built an image.
+// Everything it cannot establish is stale, the only answer safe to be wrong
+// about: the alternative deploys an image nothing vouches for.
+func TestImageStale(t *testing.T) {
+	cases := []struct {
+		name    string
+		linked  bool
+		loadErr error
+		built   *string
+		live    string
+		want    bool
+	}{
+		{name: "the recorded build made the code the artifact points at", linked: true, built: ptr("ver1"), live: "ver1"},
+		{name: "the code has moved on since that build", linked: true, built: ptr("ver0"), live: "ver1", want: true},
+		{name: "no build recorded, so nothing vouches for the image", linked: true, live: "ver1", want: true},
+		{name: "the running version points at no code at all", linked: true, built: ptr("ver1"), want: true},
+		{name: "the project is not linked, so there is no record to read", built: ptr("ver1"), live: "ver1", want: true},
+		{
+			name: "the record cannot be read", linked: true, built: ptr("ver1"), live: "ver1",
+			loadErr: errors.New("permission denied"), want: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			force(t, &projectLinkedFn, func(string) bool { return c.linked })
+			force(t, &loadProjectFn, func(string) (wapi.Config, error) {
+				return wapi.Config{ArtifactID: "art-1", LastBuiltVersionID: c.built}, c.loadErr
+			})
+
+			assert.Equal(t, c.want, imageStale("/project", Live{CodeVersionID: c.live}))
+		})
+	}
+}
+
+// The record is what the next deploy compares against. A write that fails costs
+// that deploy a build, so it must not fail this one, and the two states with
+// nothing to record must not write: an id no build was made from reads as
+// licence to skip one.
+func TestRecordBuiltVersion(t *testing.T) {
+	synced := "ver-2"
+
+	cases := []struct {
+		name     string
+		linked   bool
+		synced   *string
+		writeErr error
+		want     string
+	}{
+		{name: "the version synced is the version built", linked: true, synced: &synced, want: "ver-2"},
+		{
+			name: "a write that fails is still attempted", linked: true, synced: &synced,
+			writeErr: errors.New("read-only"), want: "ver-2",
+		},
+		{name: "the project is not linked, so there is nowhere to write"},
+		{name: "nothing has been synced, so no version was built", linked: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var saved *wapi.Config
+
+			force(t, &projectLinkedFn, func(string) bool { return c.linked })
+			force(t, &loadProjectFn, func(string) (wapi.Config, error) {
+				return wapi.Config{ArtifactID: "art-1", LastSyncedVersionID: c.synced}, nil
+			})
+			force(t, &saveProjectFn, func(_ string, cfg wapi.Config) error {
+				saved = &cfg
+
+				return c.writeErr
+			})
+
+			require.NotPanics(t, func() { recordBuiltVersion("/project") })
+
+			if c.want == "" {
+				assert.Nil(t, saved, "nothing to record is nothing to write")
+
+				return
+			}
+
+			require.NotNil(t, saved)
+			require.NotNil(t, saved.LastBuiltVersionID)
+			assert.Equal(t, c.want, *saved.LastBuiltVersionID)
+		})
+	}
+}
+
+func ptr(v string) *string { return &v }

--- a/internal/workload/up/diff.go
+++ b/internal/workload/up/diff.go
@@ -31,7 +31,15 @@ type Change struct {
 	// Path is where the field sits, in the file's own spelling, with
 	// name-keyed lists addressed by name rather than by index:
 	// artifact.spec.containerGroups[default].containers[primary].port.
+	// Built to be read by a person: names go in verbatim, so one carrying a
+	// dot or a bracket parses as something else. Keys is the same location in
+	// the form code should ask about.
 	Path string
+
+	// Keys is Path as the segments the walk descended through, each name-keyed
+	// element contributing its name: {containerGroups, default, containers,
+	// primary, port}. A rebuild is decided from these.
+	Keys []string
 
 	// Want is the value the manifest asks for.
 	Want any
@@ -69,38 +77,40 @@ func (c Change) String() string {
 func Subset(want, have map[string]any) []Change {
 	var changes []Change
 
-	walk("", want, have, true, &changes)
+	walk("", nil, want, have, true, &changes)
 
 	return changes
 }
 
 // walk compares one node. present says whether have was actually there, so a
 // key holding an explicit null is not confused with a key that is missing.
-func walk(path string, want, have any, present bool, out *[]Change) {
+// path and keys are threaded together so neither can be rebuilt from the
+// other after the fact.
+func walk(path string, keys []string, want, have any, present bool, out *[]Change) {
 	if !present {
-		*out = append(*out, Change{Path: path, Want: want, Absent: true})
+		*out = append(*out, Change{Path: path, Keys: keys, Want: want, Absent: true})
 
 		return
 	}
 
 	switch w := want.(type) {
 	case map[string]any:
-		walkMap(path, w, have, out)
+		walkMap(path, keys, w, have, out)
 	case []any:
-		walkList(path, w, have, out)
+		walkList(path, keys, w, have, out)
 	default:
 		if !equalAt(path, want, have) {
-			*out = append(*out, Change{Path: path, Want: want, Have: have})
+			*out = append(*out, Change{Path: path, Keys: keys, Want: want, Have: have})
 		}
 	}
 }
 
 // walkMap recurses into an object, in key order so the plan reads the same
 // way twice.
-func walkMap(path string, want map[string]any, have any, out *[]Change) {
+func walkMap(path string, keys []string, want map[string]any, have any, out *[]Change) {
 	h, ok := have.(map[string]any)
 	if !ok {
-		*out = append(*out, Change{Path: path, Want: want, Have: have})
+		*out = append(*out, Change{Path: path, Keys: keys, Want: want, Have: have})
 
 		return
 	}
@@ -108,7 +118,7 @@ func walkMap(path string, want map[string]any, have any, out *[]Change) {
 	for _, key := range slices.Sorted(maps.Keys(want)) {
 		hv, present := h[key]
 
-		walk(join(path, key), want[key], hv, present, out)
+		walk(join(path, key), descend(keys, key), want[key], hv, present, out)
 	}
 }
 
@@ -119,17 +129,17 @@ func walkMap(path string, want map[string]any, have any, out *[]Change) {
 // resourceBundles of plain strings or an autoscaling policy with no name to
 // key on, is compared whole, because a partial match of an unkeyed list
 // means nothing.
-func walkList(path string, want []any, have any, out *[]Change) {
+func walkList(path string, keys []string, want []any, have any, out *[]Change) {
 	h, ok := have.([]any)
 	if !ok {
-		*out = append(*out, Change{Path: path, Want: want, Have: have})
+		*out = append(*out, Change{Path: path, Keys: keys, Want: want, Have: have})
 
 		return
 	}
 
 	if !nameKeyed(want) {
 		if !equal(want, h) {
-			*out = append(*out, Change{Path: path, Want: want, Have: h})
+			*out = append(*out, Change{Path: path, Keys: keys, Want: want, Have: h})
 		}
 
 		return
@@ -141,16 +151,23 @@ func walkList(path string, want []any, have any, out *[]Change) {
 		element, _ := item.(map[string]any)
 		name, _ := element["name"].(string)
 		at := fmt.Sprintf("%s[%s]", path, name)
+		below := descend(keys, name)
 
 		counterpart, found := live[name]
 		if !found {
-			*out = append(*out, Change{Path: at, Want: element, Absent: true})
+			*out = append(*out, Change{Path: at, Keys: below, Want: element, Absent: true})
 
 			continue
 		}
 
-		walkMap(at, element, counterpart, out)
+		walkMap(at, below, element, counterpart, out)
 	}
+}
+
+// descend is keys with one more segment, always in storage of its own:
+// appending in place would let two siblings share a backing array.
+func descend(keys []string, key string) []string {
+	return append(slices.Clone(keys), key)
 }
 
 // nameKeyed reports whether every element is an object carrying a non-empty

--- a/internal/workload/up/diff_test.go
+++ b/internal/workload/up/diff_test.go
@@ -458,3 +458,26 @@ func TestSubset_OnlyMemoryComparesAcrossTypes(t *testing.T) {
 
 	assert.Len(t, Subset(want, have), 1, "a port written as a string is still a difference")
 }
+
+// Siblings must not share a backing array: appending in place would have the
+// second overwrite the first's last segment, so a changed port would read as a
+// changed environment variable.
+func TestSubset_SiblingKeysDoNotShareStorage(t *testing.T) {
+	spec := func(port, cpu float64) map[string]any {
+		return map[string]any{"containerGroups": []any{map[string]any{
+			"name":       "default",
+			"containers": []any{map[string]any{"name": "primary", "port": port, "cpu": cpu}},
+		}}}
+	}
+
+	changes := Subset(spec(9000, 2), spec(8000, 1))
+	require.Len(t, changes, 2)
+
+	last := map[string]bool{}
+	for _, c := range changes {
+		last[c.Keys[len(c.Keys)-1]] = true
+	}
+
+	assert.Equal(t, map[string]bool{"port": true, "cpu": true}, last,
+		"each sibling keeps its own last segment")
+}

--- a/internal/workload/up/doc.go
+++ b/internal/workload/up/doc.go
@@ -66,6 +66,11 @@
 // minting a version and promoting it leaves a draft nothing points at, and
 // the next run continues with it rather than adding another to the pile.
 //
+// A build is the expensive part, and most of what a file can change is not an
+// input to one: environment, port, probes and routes are read when a container
+// starts, so the version carrying them is a copy of the one now serving with
+// the file's spec written over it. Everything else still builds.
+//
 // Locking is one-way, and it is the rule both deploy shapes have to obey the
 // same way: a locked artifact can take neither new code nor a new image, so
 // the next version of a locked thing is a new artifact rather than a change to

--- a/internal/workload/up/look.go
+++ b/internal/workload/up/look.go
@@ -42,6 +42,23 @@ const (
 	keySpec       = "spec"
 	keyType       = "type"
 
+	// Keys inside the artifact spec: the running image, and how the plan
+	// recognizes a changed field as one container's.
+	keyContainerGroups = "containerGroups"
+	keyContainers      = "containers"
+	keyImageURI        = "imageUri"
+
+	// The fields a container reads when it starts, which the plan's runtime
+	// allow-list is made of. manifest/keys.go spells the ones it renders; the
+	// duplication is deliberate, since this side reads the platform's spec.
+	keyA2AEnabled      = "a2aEnabled"
+	keyEnvironmentVars = "environmentVars"
+	keyLivenessProbe   = "livenessProbe"
+	keyPort            = "port"
+	keyReadinessProbe  = "readinessProbe"
+	keyRoutes          = "routes"
+	keyStartupProbe    = "startupProbe"
+
 	// keyArtifactRepositoryID is the repository an artifact belongs to. The
 	// platform assigns it, so it is read here and never written to the file;
 	// a create that sends it back is what makes successive versions land in
@@ -99,6 +116,12 @@ type Live struct {
 	// artifact means production, and its successor has to be locked too
 	// before the platform will accept a replacement.
 	Locked bool
+
+	// ImageURI is the image the running version was built into, read off the
+	// raw document because Spec has it stripped as a build output.
+	ImageURI string
+
+	CodeVersionID string
 }
 
 // liveArtifactType reads the discriminator off the artifact document, falling
@@ -173,6 +196,10 @@ func Look(workloadID string) (Live, error) {
 		return Live{}, err
 	}
 
+	// Walked once for both fields below: two walks that could disagree about
+	// which container is primary is how a plan promises a missing image.
+	primary := workload.PrimaryContainerInDocument(artifactDoc)
+
 	return Live{
 		Live:                 live,
 		State:                stateFor(status),
@@ -182,7 +209,26 @@ func Look(workloadID string) (Live, error) {
 		ArtifactRepositoryID: artifactDoc.String(keyArtifactRepositoryID),
 		Endpoint:             workloadDoc.String(keyEndpoint),
 		Locked:               isLocked(artifactDoc.String(keyStatus)),
+		ImageURI:             containerImageURI(primary),
+		CodeVersionID:        containerCodeVersionID(primary),
 	}, nil
+}
+
+// containerCodeVersionID reads the catalog version a container points at,
+// which is what an inherited image is measured against.
+func containerCodeVersionID(container map[string]any) string {
+	ref := workload.CodeRefInContainer(container)
+	if ref == nil {
+		return ""
+	}
+
+	return ref.CatalogVersionID
+}
+
+func containerImageURI(container map[string]any) string {
+	uri, _ := container[keyImageURI].(string)
+
+	return uri
 }
 
 // artifactFor reads the artifact a workload runs. A workload without one is

--- a/internal/workload/up/look_test.go
+++ b/internal/workload/up/look_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/datarobot/cli/internal/drapi"
@@ -149,8 +150,52 @@ func TestLook_ReadsBothDocuments(t *testing.T) {
 	assert.Equal(t, "gpt-oss-20b-vllm-artifact", live.ArtifactName)
 	assert.Equal(t, "https://app.datarobot.com/workloads/68b0/", live.Endpoint)
 	assert.True(t, live.Locked)
+	assert.Equal(t, "registry.internal/built-by-the-server:sha-abc123", live.ImageURI)
+	assert.Equal(t, "ver1", live.CodeVersionID,
+		"the code the running image was built from is what staleness is measured against")
 	assert.NotEmpty(t, live.Spec)
 	assert.NotEmpty(t, live.Runtime)
+}
+
+// Both fields are read off the primary container, and the sidecar beside it
+// carries an image of its own that a runtime-only deploy must not inherit.
+func TestLook_ReadsTheImageAndCodeOffThePrimaryContainer(t *testing.T) {
+	// The flagged primary is not the first, so a walk falling through to
+	// [0][0] would answer with the sidecar for both.
+	reordered := strings.Replace(liveArtifactJSON,
+		`          {
+            "name": "vllm-server",`,
+		`          {"name": "metrics-bridge", "imageUri": "registry/vllm-metrics-bridge:v1"},
+          {
+            "name": "vllm-server",`, 1)
+	reordered = strings.Replace(reordered,
+		`,
+          {"name": "metrics-bridge", "imageUri": "registry/vllm-metrics-bridge:v1"}
+        ]`, `
+        ]`, 1)
+
+	stubLive(t, liveWorkloadJSON, reordered)
+
+	live, err := Look("68b0c1d2e3f4a5b6c7d8e9f0")
+	require.NoError(t, err)
+
+	assert.Equal(t, "registry.internal/built-by-the-server:sha-abc123", live.ImageURI)
+	assert.Equal(t, "ver1", live.CodeVersionID)
+}
+
+// An artifact the platform builds nothing for has no code reference to read,
+// and imageStale reads it, so a wrong key path skips every staleness check.
+func TestLook_NoCodeReferenceReadsAsNone(t *testing.T) {
+	stubLive(t, liveWorkloadJSON, strings.Replace(liveArtifactJSON,
+		`,
+              "codeRef": {"datarobot": {"catalogId": "cat1", "catalogVersionId": "ver1"}}`, "", 1))
+
+	live, err := Look("68b0c1d2e3f4a5b6c7d8e9f0")
+	require.NoError(t, err)
+
+	assert.Empty(t, live.CodeVersionID)
+	assert.Equal(t, "registry.internal/built-by-the-server:sha-abc123", live.ImageURI,
+		"the image is still there; it is the code that is not")
 }
 
 // TestLook_StripsBuildOutputsFromTheSpec is the property that keeps a

--- a/internal/workload/up/plan.go
+++ b/internal/workload/up/plan.go
@@ -14,7 +14,11 @@
 
 package up
 
-import "github.com/datarobot/cli/internal/workload/manifest"
+import (
+	"slices"
+
+	"github.com/datarobot/cli/internal/workload/manifest"
+)
 
 // Actions are what a run will do, and what the JSON envelope reports. A run
 // does exactly one of them, so when several could apply the most significant
@@ -50,6 +54,10 @@ type CodeChange struct {
 	// only part of a run that a --dry-run does, so carrying it here is what
 	// lets the preview mention it at all.
 	IgnoreNotice string
+
+	// ImageStale reports that the running image was built from code the
+	// artifact has since moved past, which `dr artifact code sync` does.
+	ImageStale bool
 
 	// LinkLocked reports that the artifact this project pushes into can no
 	// longer take code. The deploy answers by minting one that can and moving
@@ -92,6 +100,10 @@ type Plan struct {
 	Code     CodeChange
 	Artifact []Change
 	Runtime  []Change
+
+	// InheritsImage reports that the new version can take the running image.
+	// What the plan intends, not a promise; the envelope is corrected after.
+	InheritsImage bool
 
 	// Locked reports that the version now serving is immutable. Its successor
 	// has to be locked too before the platform will take it, so a deploy onto
@@ -197,6 +209,65 @@ func (p Plan) RollsArtifact() bool {
 	return !p.Creates && (p.Code.Changed() || len(p.Artifact) > 0)
 }
 
+// RebuildsImage reports whether anything this run changes is an input to the
+// image. runtimeFields are read when the container starts; everything else is
+// a rebuild, where being wrong the other way promotes a version with no image.
+func (p Plan) RebuildsImage() bool {
+	if p.Code.Changed() || p.Code.ImageStale {
+		return true
+	}
+
+	for _, change := range p.Artifact {
+		if !runtimeOnly(change.Keys) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// runtimeFields are the fields inside a container this release knows are read
+// when it starts. An allow-list, so a field the platform grows later does not
+// silently inherit a stale image.
+var runtimeFields = []string{
+	keyEnvironmentVars,
+	keyLivenessProbe,
+	keyPort,
+	keyReadinessProbe,
+	keyRoutes,
+	keyStartupProbe,
+}
+
+// specRuntimeFields is runtimeFields for the fields directly under the spec,
+// kept apart because the two sit at different depths.
+var specRuntimeFields = []string{keyA2AEnabled}
+
+// runtimeOnly reports whether a change names something a container reads at
+// start, from the walk's key segments rather than the rendered path.
+func runtimeOnly(keys []string) bool {
+	// A field directly under the spec, not in any container.
+	if len(keys) == 1 {
+		return slices.Contains(specRuntimeFields, keys[0])
+	}
+
+	for i := 0; i+2 < len(keys); i++ {
+		// The group's name sits between the two, which makes this a container
+		// group's list rather than a "containers" elsewhere.
+		if keys[i] != keyContainerGroups || keys[i+2] != keyContainers {
+			continue
+		}
+
+		// keys[i+3] is the container's name, so the field follows it.
+		if i+4 >= len(keys) {
+			return false
+		}
+
+		return slices.Contains(runtimeFields, keys[i+4])
+	}
+
+	return false
+}
+
 // MintsVersion reports whether this run will produce a new artifact. Only a
 // run that does can lock one, so it is what decides whether the plan says
 // anything about locking: a change that moves the sizing alone is applied in
@@ -259,8 +330,9 @@ func (p Plan) Action() string {
 // code is passed in rather than computed here so this package never acquires
 // the project lock the sync engine holds between plan and execute, and so the
 // tests never touch a filesystem. The caller runs the sync engine's own plan
-// and hands over the count.
-func Build(loaded Loaded, live Live, code CodeChange) (Plan, error) {
+// and hands over the count. opts arrives the same way, because whether the
+// image can be inherited depends on --force-build as well as on the file.
+func Build(loaded Loaded, live Live, code CodeChange, opts Options) (Plan, error) {
 	plan := Plan{
 		State:           live.State,
 		Creates:         creates(live.State),
@@ -296,6 +368,7 @@ func Build(loaded Loaded, live Live, code CodeChange) (Plan, error) {
 	if bound := loaded.Compiled.ArtifactID; bound != "" && bound != live.ArtifactID {
 		plan.Artifact = append(plan.Artifact, Change{
 			Path: keyArtifactID,
+			Keys: []string{keyArtifactID},
 			Have: live.ArtifactID,
 			Want: bound,
 		})
@@ -335,10 +408,14 @@ func Build(loaded Loaded, live Live, code CodeChange) (Plan, error) {
 		!manifest.SameArtifactType(kind, running) {
 		plan.Artifact = append(plan.Artifact, Change{
 			Path: keyArtifactType,
+			Keys: []string{keyArtifactType},
 			Have: running,
 			Want: kind,
 		})
 	}
+
+	// Last: every drift has to be in hand before RebuildsImage can answer.
+	plan.InheritsImage = inheritsImage(live, plan, opts, kind, loaded.Compiled.ArtifactName)
 
 	return plan, nil
 }

--- a/internal/workload/up/plan_test.go
+++ b/internal/workload/up/plan_test.go
@@ -16,6 +16,8 @@ package up
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/datarobot/cli/internal/workload/manifest"
@@ -23,8 +25,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// loadedFrom builds a Loaded around a compiled payload, which is the only
-// part of it Build reads.
+// loadedFrom builds a Loaded around a compiled payload. The parse tree is nil
+// on purpose: Build reads the file through the payload alone.
 func loadedFrom(payload string) Loaded {
 	return Loaded{Compiled: &manifest.Compiled{Payload: json.RawMessage(payload)}}
 }
@@ -113,12 +115,101 @@ func TestPlan_RollsArtifact(t *testing.T) {
 		{"spec differs", Plan{Artifact: []Change{{Path: "port"}}}, true},
 		{"sizing alone never mints a version", Plan{Runtime: []Change{{Path: "replicaCount"}}}, false},
 		{"a creation is not a roll", Plan{Creates: true, Code: builtCode(2)}, false},
+		{
+			// A rendered path would cut at the name's bracket and read "b]".
+			"a container name holding a bracket cannot steer the answer",
+			Plan{Artifact: []Change{{
+				Path: "containerGroups[default].containers[a]b].imageUri",
+				Keys: []string{keyContainerGroups, "default", keyContainers, "a]b", "imageUri"},
+			}}},
+			true,
+		},
 		{"nothing differs", Plan{Code: builtCode(0)}, false},
 	}
 
 	for _, c := range cases {
 		assert.Equal(t, c.want, c.plan.RollsArtifact(), c.name)
 	}
+}
+
+func TestPlan_RebuildsImage(t *testing.T) {
+	// A container name holding a bracket: a rendered path would cut at it and
+	// read "b]" as the field, which is in no allow-list.
+	bracketed := Change{
+		Path: "containerGroups[default].containers[a]b].imageUri",
+		Keys: []string{keyContainerGroups, "default", keyContainers, "a]b", "imageUri"},
+	}
+
+	cases := []struct {
+		name string
+		plan Plan
+		want bool
+	}{
+		{"changed code is a new image", Plan{Code: builtCode(2)}, true},
+		{"nothing differs", Plan{Code: builtCode(0)}, false},
+		{
+			"an environment variable is read at start",
+			Plan{Artifact: []Change{inPrimary("environmentVars", "LOG_LEVEL", "value")}},
+			false,
+		},
+		// The wizard's agent card flag sits under the spec, not a container.
+		{
+			"a spec-level field the CLI writes is read at start too",
+			Plan{Artifact: []Change{{Path: "a2aEnabled", Keys: []string{"a2aEnabled"}}}},
+			false,
+		},
+		{
+			"the dockerfile is what a build reads",
+			Plan{Artifact: []Change{inPrimary("imageBuildConfig", "dockerfile", "source")}},
+			true,
+		},
+		{"and the image itself", Plan{Artifact: []Change{inPrimary("imageUri")}}, true},
+		{
+			"a field this release has never heard of is a build input until it is known not to be",
+			Plan{Artifact: []Change{inPrimary("buildArgs", "VERSION")}},
+			true,
+		},
+		{
+			"a whole container added is not a change to how one runs",
+			Plan{Artifact: []Change{absent(inContainer("sidecar"))}},
+			true,
+		},
+		{
+			"a change of kind starts a lineage with nothing to inherit from",
+			Plan{Artifact: []Change{{Path: keyArtifactType, Keys: []string{keyArtifactType}}}},
+			true,
+		},
+		{
+			"a container name holding a bracket cannot steer the answer",
+			Plan{Artifact: []Change{bracketed}},
+			true,
+		},
+	}
+
+	for _, c := range cases {
+		assert.Equal(t, c.want, c.plan.RebuildsImage(), c.name)
+	}
+}
+
+func inPrimary(field ...string) Change {
+	return inContainer("primary", field...)
+}
+
+func inContainer(name string, field ...string) Change {
+	keys := append([]string{keyContainerGroups, "default", keyContainers, name}, field...)
+
+	path := fmt.Sprintf("containerGroups[default].containers[%s]", name)
+	if len(field) > 0 {
+		path += "." + strings.Join(field, ".")
+	}
+
+	return Change{Path: path, Keys: keys}
+}
+
+func absent(change Change) Change {
+	change.Absent = true
+
+	return change
 }
 
 // TestPlan_ActionPicksTheMostSignificant pins the priority order that the
@@ -204,6 +295,7 @@ func TestBuild_MatchingLiveStateIsEmpty(t *testing.T) {
 		loadedFrom(planPayload),
 		liveFrom(t, StateRunning, planLiveSpec, planLiveRuntime),
 		builtCode(0),
+		Options{},
 	)
 	require.NoError(t, err)
 
@@ -233,6 +325,7 @@ func TestBuild_SplitsDriftIntoItsTwoHalves(t *testing.T) {
 		loadedFrom(drifted),
 		liveFrom(t, StateRunning, planLiveSpec, planLiveRuntime),
 		builtCode(0),
+		Options{},
 	)
 	require.NoError(t, err)
 
@@ -258,7 +351,7 @@ func TestBuild_BoundToAnotherArtifactIsARoll(t *testing.T) {
 	live := liveFrom(t, StateRunning, "", planLiveRuntime)
 	live.ArtifactID = "68a0000000000000000000a1"
 
-	plan, err := Build(loaded, live, builtCode(0))
+	plan, err := Build(loaded, live, builtCode(0), Options{})
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"artifactId"}, paths(plan.Artifact))
@@ -277,7 +370,7 @@ func TestBuild_BoundToTheRunningArtifactIsEmpty(t *testing.T) {
 	live := liveFrom(t, StateRunning, "", planLiveRuntime)
 	live.ArtifactID = "68a0000000000000000000a1"
 
-	plan, err := Build(loaded, live, builtCode(0))
+	plan, err := Build(loaded, live, builtCode(0), Options{})
 	require.NoError(t, err)
 
 	assert.Empty(t, plan.Artifact)
@@ -304,6 +397,7 @@ func TestBuild_RuntimeOnlyDriftDoesNotRoll(t *testing.T) {
 		loadedFrom(resized),
 		liveFrom(t, StateRunning, planLiveSpec, planLiveRuntime),
 		builtCode(0),
+		Options{},
 	)
 	require.NoError(t, err)
 
@@ -319,6 +413,7 @@ func TestBuild_UnboundDoesNotDiff(t *testing.T) {
 		loadedFrom(planPayload),
 		Live{State: StateUnbound},
 		CodeChange{Applies: true, FirstDeploy: true},
+		Options{},
 	)
 	require.NoError(t, err)
 
@@ -340,6 +435,7 @@ func TestBuild_MissingWorkloadPlansACreate(t *testing.T) {
 		loadedFrom(planPayload),
 		Live{Live: manifest.Live{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"}, State: StateMissing},
 		builtCode(0),
+		Options{},
 	)
 	require.NoError(t, err)
 
@@ -358,6 +454,7 @@ func TestBuild_MissingWorkloadKeepsTheDeadID(t *testing.T) {
 		loadedFrom(planPayload),
 		Live{Live: manifest.Live{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"}, State: StateMissing},
 		builtCode(0),
+		Options{},
 	)
 	require.NoError(t, err)
 
@@ -373,6 +470,7 @@ func TestBuild_TerminatedWorkloadIsNotACreate(t *testing.T) {
 		loadedFrom(planPayload),
 		Live{Live: manifest.Live{WorkloadID: "68b0c1d2e3f4a5b6c7d8e9f0"}, State: StateTerminated},
 		builtCode(0),
+		Options{},
 	)
 	require.NoError(t, err)
 
@@ -383,7 +481,7 @@ func TestBuild_TerminatedWorkloadIsNotACreate(t *testing.T) {
 // TestBuild_FirstDeployHasNoPriorBinding: a create only names an id when it is
 // replacing a binding, so an unbound manifest must not print one.
 func TestBuild_FirstDeployHasNoPriorBinding(t *testing.T) {
-	plan, err := Build(loadedFrom(planPayload), Live{State: StateUnbound}, builtCode(0))
+	plan, err := Build(loadedFrom(planPayload), Live{State: StateUnbound}, builtCode(0), Options{})
 	require.NoError(t, err)
 
 	assert.True(t, plan.Creates)
@@ -395,6 +493,7 @@ func TestBuild_CarriesCodeAndStateThrough(t *testing.T) {
 		loadedFrom(planPayload),
 		liveFrom(t, StateStopped, planLiveSpec, planLiveRuntime),
 		builtCode(7),
+		Options{},
 	)
 	require.NoError(t, err)
 
@@ -404,7 +503,7 @@ func TestBuild_CarriesCodeAndStateThrough(t *testing.T) {
 }
 
 func TestBuild_BadPayloadIsReported(t *testing.T) {
-	_, err := Build(loadedFrom("{not json"), Live{State: StateRunning}, builtCode(0))
+	_, err := Build(loadedFrom("{not json"), Live{State: StateRunning}, builtCode(0), Options{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "compiled manifest")
 }
@@ -426,7 +525,7 @@ func TestBuild_TypeInsideTheSpecIsNotPerpetualDrift(t *testing.T) {
 	live := liveFrom(t, StateRunning, "", planLiveRuntime)
 	live.ArtifactType = "service"
 
-	plan, err := Build(loaded, live, builtCode(0))
+	plan, err := Build(loaded, live, builtCode(0), Options{})
 	require.NoError(t, err)
 
 	assert.Empty(t, paths(plan.Artifact), "the file and the workload agree about the type")
@@ -447,7 +546,7 @@ func TestBuild_TypeChangeInsideTheSpecIsStillARoll(t *testing.T) {
 	live := liveFrom(t, StateRunning, "", planLiveRuntime)
 	live.ArtifactType = "service"
 
-	plan, err := Build(loaded, live, builtCode(0))
+	plan, err := Build(loaded, live, builtCode(0), Options{})
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"artifact.type"}, paths(plan.Artifact))
@@ -467,7 +566,7 @@ func TestBuild_TypeBesideTheSpecWinsOverTypeWithinIt(t *testing.T) {
 	live := liveFrom(t, StateRunning, "", planLiveRuntime)
 	live.ArtifactType = "agent"
 
-	plan, err := Build(loaded, live, builtCode(0))
+	plan, err := Build(loaded, live, builtCode(0), Options{})
 	require.NoError(t, err)
 
 	assert.Empty(t, paths(plan.Artifact), "the type beside the spec is the one that counts")
@@ -487,7 +586,7 @@ func TestBuild_TypeChangeAgainstAnUnstatedLiveTypeReadsAsService(t *testing.T) {
 	live := liveFrom(t, StateRunning, "", planLiveRuntime)
 	live.ArtifactType = ""
 
-	plan, err := Build(loaded, live, builtCode(0))
+	plan, err := Build(loaded, live, builtCode(0), Options{})
 	require.NoError(t, err)
 
 	require.Len(t, plan.Artifact, 1)
@@ -509,7 +608,7 @@ func TestBuild_LiveArtifactWithNoStatedTypeIsAService(t *testing.T) {
 	live := liveFrom(t, StateRunning, "", planLiveRuntime)
 	live.ArtifactType = ""
 
-	plan, err := Build(loaded, live, builtCode(0))
+	plan, err := Build(loaded, live, builtCode(0), Options{})
 	require.NoError(t, err)
 
 	assert.Empty(t, paths(plan.Artifact))
@@ -530,7 +629,7 @@ func TestBuild_ArtifactTypeChangeIsARoll(t *testing.T) {
 	live := liveFrom(t, StateRunning, "", planLiveRuntime)
 	live.ArtifactType = "service"
 
-	plan, err := Build(loaded, live, builtCode(0))
+	plan, err := Build(loaded, live, builtCode(0), Options{})
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"artifact.type"}, paths(plan.Artifact))
@@ -551,7 +650,7 @@ func TestBuild_MatchingArtifactTypeIsEmpty(t *testing.T) {
 	live := liveFrom(t, StateRunning, "", planLiveRuntime)
 	live.ArtifactType = "agent"
 
-	plan, err := Build(loaded, live, builtCode(0))
+	plan, err := Build(loaded, live, builtCode(0), Options{})
 	require.NoError(t, err)
 
 	assert.Empty(t, plan.Artifact)
@@ -574,7 +673,7 @@ func TestBuild_ArtifactTypeSpellingIsNotAChange(t *testing.T) {
 	live := liveFrom(t, StateRunning, "", planLiveRuntime)
 	live.ArtifactType = "service"
 
-	plan, err := Build(loaded, live, builtCode(0))
+	plan, err := Build(loaded, live, builtCode(0), Options{})
 	require.NoError(t, err)
 
 	assert.Empty(t, plan.Artifact)
@@ -595,7 +694,7 @@ func TestBuild_NoTypeInTheFileIsNotDrift(t *testing.T) {
 	live := liveFrom(t, StateRunning, "", planLiveRuntime)
 	live.ArtifactType = "agent"
 
-	plan, err := Build(loaded, live, builtCode(0))
+	plan, err := Build(loaded, live, builtCode(0), Options{})
 	require.NoError(t, err)
 
 	assert.Empty(t, plan.Artifact)

--- a/internal/workload/up/render.go
+++ b/internal/workload/up/render.go
@@ -325,6 +325,9 @@ func lockLines(plan Plan) []string {
 // artifactLines describes the new immutable version, when there is one. Code
 // and spec both produce one, and they are reported as a single entry because
 // they are a single act: one version, built and rolled once.
+//
+// A version that keeps the running image says so: --dry-run is the whole of the
+// review a deploy gets.
 func artifactLines(plan Plan) []string {
 	if !plan.RollsArtifact() {
 		return nil
@@ -334,6 +337,10 @@ func artifactLines(plan Plan) []string {
 	if len(plan.Artifact) > 0 {
 		reason = fmt.Sprintf("new version, %d spec %s",
 			len(plan.Artifact), plural(len(plan.Artifact), "change", "changes"))
+	}
+
+	if plan.InheritsImage {
+		reason += "; keeps the running image, so no rebuild"
 	}
 
 	return append([]string{entry("+", "artifact", reason)}, details(plan.Artifact)...)
@@ -458,6 +465,11 @@ type PlanJSON struct {
 	// legitimate first deploy.
 	PriorWorkloadID string `json:"priorWorkloadId"`
 
+	// KeepsImage reports that the version this run mints runs the image the
+	// current one runs, so no build happens. Intent under --dry-run, and what
+	// happened after a real run.
+	KeepsImage bool `json:"keepsImage"`
+
 	Code     CodeJSON `json:"code"`
 	Artifact []string `json:"artifact"`
 	Runtime  []string `json:"runtime"`
@@ -492,6 +504,9 @@ func (p Plan) JSON() PlanJSON {
 		Creates:         p.Creates,
 		Locked:          p.Locked && mints,
 		PriorWorkloadID: p.PriorWorkloadID,
+
+		// Already gated on there being a version to mint.
+		KeepsImage: p.InheritsImage,
 		Code: CodeJSON{
 			Applies:     p.Code.Applies,
 			Changed:     p.Code.Changed(),

--- a/internal/workload/up/render_test.go
+++ b/internal/workload/up/render_test.go
@@ -190,6 +190,19 @@ func TestRender_ArtifactFromCodeAloneSaysWhy(t *testing.T) {
 	assert.Contains(t, out, "+ artifact   rebuilt from the synced code")
 }
 
+// A deploy that keeps the running image takes seconds where one that rebuilds
+// takes minutes, and --dry-run is the whole of the review a deploy gets.
+func TestRender_ArtifactSaysWhetherTheImageIsKept(t *testing.T) {
+	change := Change{Path: "containerGroups[default].containers[primary].environmentVars[LOG_LEVEL]", Absent: true}
+
+	kept := render(t, appSummary, Plan{State: StateRunning, InheritsImage: true, Artifact: []Change{change}})
+	assert.Contains(t, kept, "new version, 1 spec change; keeps the running image, so no rebuild")
+
+	building := render(t, appSummary, Plan{State: StateRunning, Artifact: []Change{change}})
+	assert.Contains(t, building, "new version, 1 spec change")
+	assert.NotContains(t, building, "no rebuild", "a deploy about to build says nothing about keeping an image")
+}
+
 // TestRender_NeverPrintsEnvironmentVariableValues is the one hard rule in
 // here. A literal can be a secret someone pasted in plaintext, and a plan
 // that echoed it would put it in scrollback and CI logs.

--- a/internal/workload/up/roll.go
+++ b/internal/workload/up/roll.go
@@ -50,11 +50,16 @@ func roll(loaded Loaded, live Live, plan Plan, lock bool, result Result, opts Op
 		return result, err
 	}
 
-	made, err := candidateArtifact(loaded, live, plan.Code, opts, report)
+	made, err := candidateArtifact(loaded, live, plan, opts, report)
 
 	// Recorded before the error check: a failed build is still a build, and
 	// the caller's envelope should be able to name the one to go and read.
 	result.BuildID = made.BuildID
+
+	// By here it is known rather than predicted: a leftover taken ahead of a
+	// copy, a platform with no copy endpoint and a tree that moved between the
+	// plan and the sync all reach this line having built anyway.
+	result.Plan.InheritsImage = plan.InheritsImage && err == nil && made.BuildID == ""
 
 	if err != nil {
 		return result, err
@@ -90,7 +95,7 @@ func roll(loaded Loaded, live Live, plan Plan, lock bool, result Result, opts Op
 func candidateArtifact(
 	loaded Loaded,
 	live Live,
-	code CodeChange,
+	plan Plan,
 	opts Options,
 	report *reporter,
 ) (version, error) {
@@ -100,8 +105,11 @@ func candidateArtifact(
 
 	repository := sameRepository(loaded, live)
 
-	if mode := loaded.Manifest.BuildMode(); mode == manifest.BuildModeDockerfile || mode == manifest.BuildModeGenerated {
-		return buildVersion(loaded, live, code, repository, opts, report)
+	// The same reading the plan used, rather than a second one off the parse
+	// tree: two answers to "does the platform build this image" coming apart is
+	// how a plan describes a deploy that does not happen.
+	if plan.Code.Applies {
+		return buildVersion(loaded, live, plan, repository, opts, report)
 	}
 
 	return createVersion(loaded, repository, labelNewVersion, report)
@@ -191,8 +199,8 @@ func confirmLock(live Live, workloadName string, opts Options) (bool, error) {
 // its say, so a lock taken here is one the run is committed to using.
 func matchLock(made version, report *reporter) (bool, error) {
 	// A candidate the file named, or one left by an earlier attempt, may
-	// already be locked, and locking twice is not a no-op at the platform.
-	// One created by this run is always a draft.
+	// already be locked, and locking twice answers 403. A create and a copy are
+	// both drafts, so only a leftover has to be asked about.
 	if !made.Fresh {
 		already, lockedErr := lockedAlready(made.ID)
 		if lockedErr != nil {

--- a/internal/workload/up/roll_test.go
+++ b/internal/workload/up/roll_test.go
@@ -19,12 +19,14 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
 	"github.com/datarobot/cli/internal/workload/sync"
 	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/stretchr/testify/assert"
@@ -920,12 +922,15 @@ func locks(steps []string) []string {
 	return out
 }
 
-// builtRoll is a roll of a project whose image the platform builds, with
-// every step wired to succeed. The live artifact is made a draft: the lock
-// ceremony has its own tests above, and leaving it locked would put a
-// confirmation in the middle of every assertion about the build.
+// builtRoll is a roll of a project whose image the platform builds and whose
+// code has changed, every step wired to succeed. The live artifact is a draft
+// so no lock confirmation lands among the build assertions.
 func builtRoll(tr *track) fakes {
 	f := wiredRoll(tr)
+
+	f.code = func(Loaded, Live) (CodeChange, error) {
+		return CodeChange{Applies: true, Files: 2}, nil
+	}
 
 	f.workloadD = func(string) (workload.Document, error) { return docOf(liveWorkloadJSON), nil }
 	f.artifactD = func(string) (workload.Document, error) {
@@ -1374,10 +1379,9 @@ func TestRun_RollDoesNotReuseALockedLeftover(t *testing.T) {
 	assert.Contains(t, tr.steps, "replace:art-2")
 }
 
-// A spec-only roll moves a port or a probe and leaves the working tree alone,
-// so the sync mints no version and patches nothing. Without this the new
-// artifact would go to the builder with no code reference at all.
-func TestRun_SpecOnlyRollCarriesTheCodeOver(t *testing.T) {
+// A roll whose sync uploads nothing leaves the new version with no code of its
+// own, and the plan's file count is only a prediction.
+func TestRun_RollWithNothingToUploadCarriesTheCodeOver(t *testing.T) {
 	var tr track
 
 	f := builtRoll(&tr)
@@ -1392,16 +1396,15 @@ func TestRun_SpecOnlyRollCarriesTheCodeOver(t *testing.T) {
 
 	assert.Equal(t, []string{"art-2", "cat1", "ver1"}, tr.carried,
 		"a new version of the same code has to point at that code")
-	assert.Equal(t,
-		[]string{"guard", "create-artifact", "relink", "sync", "carry-code", "build", "guard", "replace:art-2", "await-rollout", "settle:art-2+drain"},
-		tr.steps)
+	assert.Equal(t, []string{
+		"guard", "create-artifact", "relink", "sync", "carry-code", "build",
+		"guard", "replace:art-2", "await-rollout", "settle:art-2+drain",
+	}, tr.steps)
 	assert.Equal(t, "bld-2", result.BuildID, "a version born without an image still needs one")
 }
 
-// Nothing to upload and nothing recorded to inherit means there would be
-// nothing to build, which is worth saying before a builder is asked to
-// produce an image from an empty artifact.
-func TestRun_SpecOnlyRollWithNoCodeToCarryStopsBeforeTheBuild(t *testing.T) {
+// A version with no code must not reach the builder, nor be promoted.
+func TestRun_RollWithNoCodeToCarryStopsBeforeTheBuild(t *testing.T) {
 	var tr track
 
 	f := builtRoll(&tr)
@@ -1418,7 +1421,7 @@ func TestRun_SpecOnlyRollWithNoCodeToCarryStopsBeforeTheBuild(t *testing.T) {
 	assert.Contains(t, err.Error(), "art-2")
 	assert.Contains(t, err.Error(), "nothing to build")
 	assert.NotContains(t, tr.steps, "build")
-	assert.NotContains(t, tr.steps, "replace:art-2", "a version with no code must not be promoted")
+	assert.NotContains(t, tr.steps, "replace:art-2")
 }
 
 // The version exists and only the local record of it failed to write. The
@@ -1467,4 +1470,460 @@ func TestRun_FailedBuildOnARollLeavesTheOldVersionServing(t *testing.T) {
 	assert.NotContains(t, tr.steps, "replace:art-2")
 	assert.Equal(t, "68a0000000000000000000a1", result.ArtifactID,
 		"the envelope names what is serving, which is still the old version")
+}
+
+// copiedArtifact is what a clone comes back as: its source's image and code.
+// The build rows stayed on the source.
+func copiedArtifact() *workload.Artifact {
+	primary := true
+
+	return &workload.Artifact{
+		ID:     "art-2",
+		Status: workload.ArtifactStatusDraft,
+		Spec: workload.Spec{
+			ContainerGroups: []workload.ContainerGroup{{
+				Containers: []workload.Container{{
+					Name:     "vllm-server",
+					Primary:  &primary,
+					ImageURI: "registry.internal/built-by-the-server:sha-abc123",
+					ImageBuildConfig: &workload.ImageBuildConfig{
+						CodeRef: &workload.CodeRef{
+							Datarobot: &workload.DatarobotCodeRef{CatalogID: "cat1", CatalogVersionID: "ver1"},
+						},
+					},
+				}},
+			}},
+		},
+	}
+}
+
+func copyStep(tr *track, copied *workload.Artifact) func(string, string) (*workload.Artifact, error) {
+	return func(sourceID, name string) (*workload.Artifact, error) {
+		tr.steps = append(tr.steps, "copy:"+sourceID)
+		tr.copiedAs = name
+		copied.Name = name
+
+		return copied, nil
+	}
+}
+
+func updateSpecStep(tr *track) func(string, json.RawMessage) error {
+	return func(artifactID string, spec json.RawMessage) error {
+		tr.steps = append(tr.steps, "update-spec:"+artifactID)
+		tr.updatedSpec = spec
+
+		return nil
+	}
+}
+
+// readBackStep answers the read after the write the way the platform does: the
+// written spec with the server-owned image put back. Anything that is not the
+// copy is the version now serving.
+func readBackStep(tr *track, copied *workload.Artifact, live func() workload.Document) func(string) (workload.Document, error) {
+	return func(id string) (workload.Document, error) {
+		if id != copied.ID || tr.updatedSpec == nil {
+			return live(), nil
+		}
+
+		var spec map[string]any
+
+		if err := json.Unmarshal(tr.updatedSpec, &spec); err != nil {
+			return nil, err
+		}
+
+		doc := workload.Document{"id": copied.ID, "status": copied.Status, "spec": spec}
+
+		if uri := workload.GetPrimaryContainerImageURI(*copied); uri != "" {
+			workload.PrimaryContainerInDocument(doc)["imageUri"] = uri
+		}
+
+		return doc, nil
+	}
+}
+
+func draftLiveArtifact() workload.Document {
+	d := docOf(liveArtifactJSON)
+	d["status"] = workload.ArtifactStatusDraft
+
+	return d
+}
+
+func runtimeOnlyRoll(tr *track) fakes {
+	return runtimeOnlyRollOf(tr, copiedArtifact())
+}
+
+func runtimeOnlyRollOf(tr *track, copied *workload.Artifact) fakes {
+	f := builtRoll(tr)
+
+	f.code = func(Loaded, Live) (CodeChange, error) { return CodeChange{Applies: true}, nil }
+	f.sync = emptySync(tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("68a0000000000000000000a1")
+	f.copyArtifact = copyStep(tr, copied)
+	f.artifactD = readBackStep(tr, copied, draftLiveArtifact)
+	f.updateSpec = updateSpecStep(tr)
+	f.deleteArtifact = func(id string) error {
+		tr.steps = append(tr.steps, "delete:"+id)
+
+		return nil
+	}
+
+	return f
+}
+
+func envDrift() string {
+	return "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" +
+		strings.Replace(boundLiveManifest,
+			"            port: 8000\n",
+			"            port: 8000\n"+
+				"            environmentVars:\n"+
+				"              - name: LOG_LEVEL\n"+
+				"                value: debug\n", 1)
+}
+
+func buildDrift() string {
+	return "workloadId: 68b0c1d2e3f4a5b6c7d8e9f0\n" +
+		strings.Replace(boundLiveManifest,
+			"                source: provided\n",
+			"                source: generated\n"+
+				"                executionEnvironmentId: 6890000000000000000000e1\n"+
+				"                executionEnvironmentVersionId: 6890000000000000000000e2\n"+
+				"                entrypoint: [\"python\", \"app.py\"]\n", 1)
+}
+
+// The deploy this whole path exists for. The copy's code reference has to
+// survive the write, since the manifest states none.
+// Production is the same deploy plus the lock, and is where the saving is worth
+// most: the platform checks image provenance across the tenant, precisely so a
+// copy can still be locked.
+func TestRun_RuntimeOnlyRollCopiesTheRunningVersion(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		live  func() workload.Document
+		steps []string
+	}{
+		{
+			name:  "a draft is replaced by a draft",
+			live:  draftLiveArtifact,
+			steps: []string{"guard", "replace:art-2", "await-rollout", "settle:art-2+drain"},
+		},
+		{
+			name:  "a locked one is replaced by a locked one",
+			live:  func() workload.Document { return docOf(liveArtifactJSON) },
+			steps: []string{"guard", "lock:art-2", "replace:art-2", "await-rollout", "settle:art-2+drain"},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var tr track
+
+			f := runtimeOnlyRoll(&tr)
+			f.artifactD = readBackStep(&tr, copiedArtifact(), c.live)
+
+			install(t, f)
+
+			result, _, err := runIn(t, envDrift(), Options{NonInteractive: true})
+			require.NoError(t, err)
+
+			assert.Equal(t, append([]string{
+				"guard", "copy:68a0000000000000000000a1", "update-spec:art-2", "relink", "sync",
+			}, c.steps...), tr.steps)
+			assert.Empty(t, result.BuildID, "a version that inherits an image has none to build")
+			assert.Equal(t, ActionRolled, result.Action)
+			assert.Equal(t, "art-2", tr.savedCfg.ArtifactID, "the project pushes to the version it made")
+			assert.Equal(t, "gpt-oss-20b-vllm-artifact", tr.copiedAs)
+
+			spec := string(tr.updatedSpec)
+			assert.Contains(t, spec, "LOG_LEVEL", "the change that started the run has to land")
+			assert.Contains(t, spec, `"catalogId":"cat1"`, "and must not cost the copy its code reference")
+			assert.Contains(t, spec, `"catalogVersionId":"ver1"`)
+		})
+	}
+}
+
+// The four ways a roll still pays for a build.
+func TestRun_RollsThatStillBuild(t *testing.T) {
+	noImage := func(f *fakes) {
+		f.artifactD = func(string) (workload.Document, error) {
+			d := docOf(liveArtifactJSON)
+			d["status"] = workload.ArtifactStatusDraft
+
+			delete(primaryOf(d), "imageUri")
+
+			return d, nil
+		}
+	}
+
+	stale := func(f *fakes) {
+		f.code = func(Loaded, Live) (CodeChange, error) {
+			return CodeChange{Applies: true, ImageStale: true}, nil
+		}
+	}
+
+	cases := []struct {
+		name     string
+		manifest string
+		force    bool
+		tweak    func(*fakes)
+	}{
+		{name: "the dockerfile changed", manifest: buildDrift()},
+		{name: "--force-build asked for one", manifest: envDrift(), force: true},
+		{name: "the running version has no image", manifest: envDrift(), tweak: noImage},
+		{name: "the code has moved past the running image", manifest: envDrift(), tweak: stale},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var tr track
+
+			f := runtimeOnlyRoll(&tr)
+			if c.tweak != nil {
+				c.tweak(&f)
+			}
+
+			install(t, f)
+
+			result, _, err := runIn(t, c.manifest, Options{NonInteractive: true, ForceBuild: c.force})
+			require.NoError(t, err)
+
+			assert.NotContains(t, tr.steps, "copy:68a0000000000000000000a1")
+			assert.Contains(t, tr.steps, "create-artifact")
+			assert.Equal(t, "bld-2", result.BuildID)
+		})
+	}
+}
+
+// The ways a copy goes wrong. Every one ends in the deploy that creates and
+// builds, so none fails a deploy that used to work. A copy that exists is
+// taken away first, unless it cannot be, where the run stops and names it.
+func TestRun_CopiesThatGoWrong(t *testing.T) {
+	refuse := func(status int) func(*fakes, *track, *workload.Artifact) {
+		return func(f *fakes, tr *track, _ *workload.Artifact) {
+			f.copyArtifact = func(id, _ string) (*workload.Artifact, error) {
+				tr.steps = append(tr.steps, "copy:"+id)
+
+				return nil, &drapi.HTTPError{StatusCode: status}
+			}
+		}
+	}
+
+	writeAnswers := func(err error) func(*fakes, *track, *workload.Artifact) {
+		return func(f *fakes, _ *track, _ *workload.Artifact) {
+			f.updateSpec = func(string, json.RawMessage) error { return err }
+		}
+	}
+
+	fellBack := []string{"create-artifact", "build"}
+	tookBack := []string{"delete:art-2", "create-artifact", "build"}
+
+	cases := []struct {
+		name       string
+		breaks     func(*fakes, *track, *workload.Artifact)
+		wantErr    string
+		wantSteps  []string
+		wantAbsent []string
+		wantBuild  string
+	}{
+		// 404 is a platform with no copy endpoint and 500 is one that broke.
+		// Neither left anything behind, so both take the fallback.
+		{
+			name: "the copy never happens", breaks: refuse(http.StatusNotFound),
+			wantSteps: fellBack, wantBuild: "bld-2",
+		},
+		{
+			name: "the write is refused", breaks: writeAnswers(&drapi.HTTPError{StatusCode: http.StatusNotFound}),
+			wantSteps: tookBack, wantBuild: "bld-2",
+		},
+		// Accepted, and the copy still does not say what the file says.
+		{
+			name: "the write lands nowhere", breaks: writeAnswers(nil),
+			wantSteps: tookBack, wantBuild: "bld-2",
+		},
+		{
+			// An artifact cannot be moved between repositories, so a copy that
+			// landed in one of its own would fork the version history for good.
+			name: "the copy lands in another repository",
+			breaks: func(f *fakes, _ *track, copied *workload.Artifact) {
+				copied.ArtifactRepositoryID = "repo-other"
+				f.artifactD = func(string) (workload.Document, error) {
+					d := draftLiveArtifact()
+					d["artifactRepositoryId"] = "repo-1"
+
+					return d, nil
+				}
+			},
+			wantSteps: tookBack, wantAbsent: []string{"update-spec:art-2"}, wantBuild: "bld-2",
+		},
+		{
+			name: "the write costs the copy its image",
+			breaks: func(f *fakes, tr *track, copied *workload.Artifact) {
+				f.updateSpec = func(id string, spec json.RawMessage) error {
+					tr.steps = append(tr.steps, "update-spec:"+id)
+					tr.updatedSpec = spec
+					copied.Spec.ContainerGroups[0].Containers[0].ImageURI = ""
+
+					return nil
+				}
+			},
+			wantSteps: []string{"build", "replace:art-2"}, wantBuild: "bld-2",
+		},
+		{
+			name: "the copy cannot be taken away either: its id is the only record",
+			breaks: func(f *fakes, _ *track, _ *workload.Artifact) {
+				f.updateSpec = func(string, json.RawMessage) error { return errors.New("spec rejected") }
+				f.deleteArtifact = func(string) error { return errors.New("still referenced") }
+			},
+			wantErr:    "left behind",
+			wantAbsent: []string{"create-artifact", "replace:art-2"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var tr track
+
+			copied := copiedArtifact()
+			f := runtimeOnlyRollOf(&tr, copied)
+			c.breaks(&f, &tr, copied)
+
+			install(t, f)
+
+			result, _, err := runIn(t, envDrift(), Options{NonInteractive: true})
+
+			if c.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), c.wantErr)
+				assert.Contains(t, err.Error(), manifest.FileName,
+					"a copy that cannot be made to match names the file it was measured against")
+			} else {
+				require.NoError(t, err)
+			}
+
+			for _, step := range c.wantSteps {
+				assert.Contains(t, tr.steps, step)
+			}
+
+			for _, step := range c.wantAbsent {
+				assert.NotContains(t, tr.steps, step)
+			}
+
+			assert.Equal(t, c.wantBuild, result.BuildID)
+			assert.False(t, result.Plan.JSON().KeepsImage, "no run that built or failed kept an image")
+		})
+	}
+}
+
+func TestInheritsImage_ArtifactType(t *testing.T) {
+	// The rest of inheritsImage's conditions are covered end to end by
+	// TestRun_RollsThatStillBuild. Only the type comparison is here, because it
+	// is the one the plan and the copy path came to answer differently.
+	plan := Plan{
+		Code: CodeChange{Applies: true},
+		Artifact: []Change{{Keys: []string{
+			keyContainerGroups, "default", keyContainers, "app", keyEnvironmentVars,
+		}}},
+	}
+	live := Live{ArtifactID: "art-1", ImageURI: "img", ArtifactType: "agent"}
+
+	for kind, want := range map[string]bool{
+		"":        true, // a file stating no type has no opinion
+		"agent":   true,
+		"Agent":   true, // the platform disagrees with itself about casing
+		"service": false,
+	} {
+		t.Run("file says "+kind, func(t *testing.T) {
+			assert.Equal(t, want, inheritsImage(live, plan, Options{}, kind, "an-artifact"))
+		})
+	}
+}
+
+// The record the next deploy reads is written by the build that made it, and
+// nothing else. A build that stopped recording would leave every later
+// runtime-only deploy inheriting an image with nothing to measure.
+func TestRun_RecordingWhatABuildWasMadeFrom(t *testing.T) {
+	cases := []struct {
+		name   string
+		copies bool
+		fails  bool
+		want   int
+	}{
+		{name: "a build that succeeds records it", want: 1},
+		{name: "a build that fails records nothing", fails: true},
+		{name: "a deploy that skips the build records nothing", copies: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var (
+				tr       track
+				recorded []string
+			)
+
+			file, f := builtDrift(), builtRoll(&tr)
+			if c.copies {
+				file, f = envDrift(), runtimeOnlyRoll(&tr)
+			}
+
+			f.linked = func(string) bool { return true }
+			f.project = syncedProject("68a0000000000000000000a1")
+			f.recordBuilt = func(dir string) { recorded = append(recorded, dir) }
+
+			if c.fails {
+				f.waitBuild = func(_, id string, _, _ time.Duration, _ func(*workload.Build)) (*workload.Build, error) {
+					return &workload.Build{ID: id, Status: workload.BuildStatusFailed},
+						fmt.Errorf("build %s ended with status %s", id, workload.BuildStatusFailed)
+				}
+			}
+
+			install(t, f)
+
+			_, _, err := runIn(t, file, Options{NonInteractive: true})
+			assert.Equal(t, c.fails, err != nil)
+			assert.Equal(t, !c.copies, slices.Contains(tr.steps, "build"))
+			assert.Len(t, recorded, c.want, "the record names the code an image was built from")
+		})
+	}
+}
+
+// A leftover carrying a code reference of its own is still re-anchored at the
+// code the project last synced, since `dr artifact create` and an abandoned
+// attempt both point at code older than the last sync. Only a leftover that
+// kept the running image is left alone.
+func TestRun_ALeftoverWithItsOwnCodeIsStillReAnchored(t *testing.T) {
+	var tr track
+
+	f := builtRoll(&tr)
+	f.code = func(Loaded, Live) (CodeChange, error) { return CodeChange{Applies: true}, nil }
+	f.sync = emptySync(&tr)
+	f.linked = func(string) bool { return true }
+	f.project = syncedProject("art-abandoned")
+	f.getArtifact = func(id string) (*workload.Artifact, error) {
+		primary := true
+
+		return &workload.Artifact{
+			ID:     id,
+			Status: workload.ArtifactStatusDraft,
+			Spec: workload.Spec{ContainerGroups: []workload.ContainerGroup{{
+				Containers: []workload.Container{{
+					Primary: &primary,
+					ImageBuildConfig: &workload.ImageBuildConfig{
+						CodeRef: &workload.CodeRef{
+							Datarobot: &workload.DatarobotCodeRef{CatalogID: "cat1", CatalogVersionID: "ver0"},
+						},
+					},
+				}},
+			}}},
+		}, nil
+	}
+	f.artifactD = artifactDocs("art-abandoned", 9000)
+
+	install(t, f)
+
+	_, _, err := runIn(t, builtDrift(), Options{NonInteractive: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, tr.steps, "carry-code",
+		"a reference older than the last sync is not the code this deploy is for")
+	assert.Contains(t, tr.steps, "build")
+	assert.Equal(t, []string{"art-abandoned", "cat1", "ver1"}, tr.carried,
+		"the version the project last synced is what it is pointed at")
 }

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -36,32 +36,36 @@ import (
 
 // Test seams. The deploy is mostly network, and the tests are not.
 var (
-	runWizardFn        = wizard.Run
-	createWorkloadFn   = workload.CreateWorkload
-	waitWorkloadFn     = workload.WaitForWorkload
-	waitSteadyFn       = workload.WaitForSteadyWorkload
-	listWorkloadsFn    = workload.ListWorkloads
-	startWorkloadFn    = workload.StartWorkload
-	createArtifactFn   = workload.CreateArtifact
-	getArtifactFn      = workload.GetArtifact
-	lockArtifactFn     = workload.LockArtifact
-	triggerBuildFn     = workload.TriggerArtifactBuild
-	waitBuildFn        = workload.WaitForBuild
-	listBuildsFn       = workload.ListArtifactBuilds
-	getCredentialFn    = workload.GetCredential
-	findCredentialFn   = workload.FindCredentialNamed
-	guardReplacementFn = workload.RefuseActiveReplacement
-	startReplacementFn = workload.StartReplacement
-	waitReplacementFn  = workload.WaitForReplacement
-	updateSettingsFn   = workload.UpdateWorkloadSettings
-	writeWorkloadIDFn  = manifest.WriteWorkloadID
-	codeChangeFn       = defaultCodeChange
-	projectLinkedFn    = wapi.Exists
-	loadProjectFn      = wapi.LoadConfig
-	initProjectFn      = wapi.Initialize
-	saveProjectFn      = wapi.SaveConfig
-	patchCodeRefFn     = workload.PatchArtifactCodeRef
-	syncProjectFn      = defaultSync
+	runWizardFn          = wizard.Run
+	createWorkloadFn     = workload.CreateWorkload
+	waitWorkloadFn       = workload.WaitForWorkload
+	waitSteadyFn         = workload.WaitForSteadyWorkload
+	listWorkloadsFn      = workload.ListWorkloads
+	startWorkloadFn      = workload.StartWorkload
+	createArtifactFn     = workload.CreateArtifact
+	copyArtifactFn       = workload.CloneArtifact
+	deleteArtifactFn     = workload.DeleteArtifact
+	recordBuiltFn        = recordBuiltVersion
+	updateArtifactSpecFn = workload.UpdateArtifactSpec
+	getArtifactFn        = workload.GetArtifact
+	lockArtifactFn       = workload.LockArtifact
+	triggerBuildFn       = workload.TriggerArtifactBuild
+	waitBuildFn          = workload.WaitForBuild
+	listBuildsFn         = workload.ListArtifactBuilds
+	getCredentialFn      = workload.GetCredential
+	findCredentialFn     = workload.FindCredentialNamed
+	guardReplacementFn   = workload.RefuseActiveReplacement
+	startReplacementFn   = workload.StartReplacement
+	waitReplacementFn    = workload.WaitForReplacement
+	updateSettingsFn     = workload.UpdateWorkloadSettings
+	writeWorkloadIDFn    = manifest.WriteWorkloadID
+	codeChangeFn         = defaultCodeChange
+	projectLinkedFn      = wapi.Exists
+	loadProjectFn        = wapi.LoadConfig
+	initProjectFn        = wapi.Initialize
+	saveProjectFn        = wapi.SaveConfig
+	patchCodeRefFn       = workload.PatchArtifactCodeRef
+	syncProjectFn        = defaultSync
 )
 
 // Options is everything a run needs from its caller.
@@ -164,7 +168,7 @@ func Run(opts Options) (Result, error) {
 
 	noteIgnoreFile(code, opts)
 
-	plan, err := Build(loaded, live, code)
+	plan, err := Build(loaded, live, code, opts)
 	if err != nil {
 		return Result{}, err
 	}
@@ -1224,7 +1228,7 @@ func lock(result Result, report *reporter) (Result, error) {
 // a sync: the count it produces is what tells the deploy to mint a new version
 // and roll onto it. A refusal here would refuse that deploy, which is the only
 // way past a lock.
-func defaultCodeChange(loaded Loaded, _ Live) (change CodeChange, err error) {
+func defaultCodeChange(loaded Loaded, live Live) (change CodeChange, err error) {
 	mode := loaded.Manifest.BuildMode()
 	if mode != manifest.BuildModeDockerfile && mode != manifest.BuildModeGenerated {
 		// A published image has no code to sync, and a file bound by artifact
@@ -1266,11 +1270,37 @@ func defaultCodeChange(loaded Loaded, _ Live) (change CodeChange, err error) {
 		Applies:      true,
 		Files:        len(plan.Uploads) + len(plan.Deletes),
 		IgnoreNotice: notice,
+		ImageStale:   imageStale(loaded.ProjectDir, live),
 		// The engine says so rather than this asking a second time: it fetched
 		// the artifact to build the plan, and a locked one is the reason it
 		// left a notice at all.
 		LinkLocked: engine.LockedNotice() != "",
 	}, nil
+}
+
+// imageStale reports that the running version's image was built from code the
+// artifact has since been pointed away from. `dr artifact code sync` moves what
+// the artifact claims without touching the working tree, so a deploy changing
+// only an environment variable would otherwise inherit an image built before
+// that sync and report success.
+//
+// Every answer it cannot establish is stale. The record is absent for every
+// project until its next build, and saying "not stale" there would put exactly
+// those runs on the fast path unchecked, where nothing would ever write the
+// record that ends it. Saying "stale" costs one build, and then it opens.
+func imageStale(projectDir string, live Live) bool {
+	if !projectLinkedFn(projectDir) {
+		return true
+	}
+
+	cfg, err := loadProjectFn(projectDir)
+	if err != nil || cfg.LastBuiltVersionID == nil {
+		return true
+	}
+
+	// No code reference on the running version is the same unknown from the
+	// other side: nothing says the image matches it.
+	return live.CodeVersionID == "" || *cfg.LastBuiltVersionID != live.CodeVersionID
 }
 
 // ignoreFileNotice is the deprecation line for this project, empty when there

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -185,15 +185,23 @@ type fakes struct {
 	// code, turn it into an image.
 	newArtifact func(any) (*workload.Artifact, error)
 	getArtifact func(string) (*workload.Artifact, error)
-	linked      func(string) bool
-	project     func(string) (wapi.Config, error)
-	link        func(string, wapi.InitOptions) error
-	save        func(string, wapi.Config) error
-	codeRef     func(string, string, string) error
-	sync        func(string) (*sync.Result, error)
-	build       func(string) (*workload.BuildTriggerResponse, error)
-	waitBuild   func(string, string, time.Duration, time.Duration, func(*workload.Build)) (*workload.Build, error)
-	builds      func(string, int) ([]workload.Build, error)
+
+	// The copy track: a runtime-only change is made from the version now
+	// serving and written over, rather than created and built.
+	copyArtifact   func(string, string) (*workload.Artifact, error)
+	updateSpec     func(string, json.RawMessage) error
+	deleteArtifact func(string) error
+	recordBuilt    func(string)
+
+	linked    func(string) bool
+	project   func(string) (wapi.Config, error)
+	link      func(string, wapi.InitOptions) error
+	save      func(string, wapi.Config) error
+	codeRef   func(string, string, string) error
+	sync      func(string) (*sync.Result, error)
+	build     func(string) (*workload.BuildTriggerResponse, error)
+	waitBuild func(string, string, time.Duration, time.Duration, func(*workload.Build)) (*workload.Build, error)
+	builds    func(string, int) ([]workload.Build, error)
 
 	// checkEndpoint is the one GET a deploy ends with.
 	checkEndpoint func(string) (int, error)
@@ -276,8 +284,35 @@ func install(t *testing.T, f fakes) {
 		return nil, nil
 	})
 
+	force(t, &copyArtifactFn, func(id, _ string) (*workload.Artifact, error) {
+		t.Fatalf("the run copied artifact %s, which this test did not wire", id)
+
+		return nil, nil
+	})
+	force(t, &updateArtifactSpecFn, func(id string, _ json.RawMessage) error {
+		t.Fatalf("the run rewrote the spec of artifact %s, which this test did not wire", id)
+
+		return nil
+	})
+	force(t, &deleteArtifactFn, func(id string) error {
+		t.Fatalf("the run deleted artifact %s, which this test did not wire", id)
+
+		return nil
+	})
+
+	force(t, &recordBuiltFn, func(string) {})
+
+	// A leftover with no image sends the run to the build history, so a test
+	// that wired none would ask whatever tenant is logged in. Empty builds,
+	// which is the track those tests were written against.
+	force(t, &listBuildsFn, func(string, int) ([]workload.Build, error) { return nil, nil })
+
 	swap(t, &createArtifactFn, f.newArtifact)
 	swap(t, &getArtifactFn, f.getArtifact)
+	swap(t, &copyArtifactFn, f.copyArtifact)
+	swap(t, &updateArtifactSpecFn, f.updateSpec)
+	swap(t, &deleteArtifactFn, f.deleteArtifact)
+	swap(t, &recordBuiltFn, f.recordBuilt)
 	swap(t, &projectLinkedFn, f.linked)
 	swap(t, &loadProjectFn, f.project)
 	swap(t, &initProjectFn, f.link)
@@ -432,7 +467,7 @@ func TestRun_WizardRedirectIsFollowed(t *testing.T) {
 			return wizard.Result{Path: manifest.Path(app)}, nil
 		},
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 		writeID: func(path, _ string) error {
@@ -1238,6 +1273,9 @@ type track struct {
 	// rolledRuntime is the sizing that travelled with the swap, nil when the
 	// deploy changed only the version.
 	rolledRuntime json.RawMessage
+
+	copiedAs    string
+	updatedSpec json.RawMessage
 }
 
 // wiredBuild is a build path where every step works, over the track that
@@ -2655,4 +2693,44 @@ func TestRun_ArtifactCreatedWithoutAnIDIsRefusedBeforeLinking(t *testing.T) {
 	_, _, err := runIn(t, unboundDockerfileManifest, Options{NonInteractive: true})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reported no id")
+}
+
+// The roll decides whether to build from plan.Code.Applies rather than reading
+// the file again, so the two must answer alike for every file.
+func TestDefaultCodeChange_AppliesMatchesTheFilesBuildMode(t *testing.T) {
+	generated := strings.Replace(unboundDockerfileManifest,
+		"                source: provided\n",
+		"                source: generated\n"+
+			"                executionEnvironmentId: 6890000000000000000000e1\n"+
+			"                executionEnvironmentVersionId: 6890000000000000000000e2\n"+
+			"                entrypoint: [\"python\", \"app.py\"]\n", 1)
+
+	cases := []struct {
+		name string
+		file string
+	}{
+		{name: "a dockerfile the platform builds", file: unboundDockerfileManifest},
+		{name: "an image the platform generates", file: generated},
+		{name: "an image someone else published", file: unboundImageManifest},
+		{name: "a manifest bound to an artifact by id", file: boundArtifactManifest},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeManifest(t, dir, c.file)
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte("FROM scratch\n"), 0o644))
+
+			loaded, err := load(dir, Options{NonInteractive: true})
+			require.NoError(t, err)
+
+			mode := loaded.Manifest.BuildMode()
+			builds := mode == manifest.BuildModeDockerfile || mode == manifest.BuildModeGenerated
+
+			code, err := defaultCodeChange(loaded, Live{})
+			require.NoError(t, err)
+			assert.Equal(t, builds, code.Applies,
+				"the plan's answer and the file's have to be the same answer (build mode %q)", mode)
+		})
+	}
 }

--- a/internal/workload/up/version.go
+++ b/internal/workload/up/version.go
@@ -39,13 +39,16 @@ type version struct {
 	// was left behind.
 	ID string
 
-	// Fresh reports that this run created it, which means it is certainly a
-	// draft and certainly has no image yet.
 	Fresh bool
 
 	// BuildID names the image build this run ran, "" when it ran none. A
 	// failed build sets it: it is the way to the logs.
 	BuildID string
+
+	ImageURI string
+
+	// HasCode reports that it points at the code its image was built from.
+	HasCode bool
 }
 
 // buildVersion produces the version a built project rolls onto: a new
@@ -63,12 +66,12 @@ type version struct {
 func buildVersion(
 	loaded Loaded,
 	live Live,
-	code CodeChange,
+	plan Plan,
 	repositoryID string,
 	opts Options,
 	report *reporter,
 ) (version, error) {
-	made, err := versionArtifact(loaded, live, repositoryID, report)
+	made, err := versionArtifact(loaded, live, plan, repositoryID, report)
 	if err != nil {
 		return made, err
 	}
@@ -82,30 +85,193 @@ func buildVersion(
 		return made, err
 	}
 
-	if err := inheritCode(loaded.ProjectDir, made.ID, synced, report); err != nil {
+	if err := inheritCode(loaded.ProjectDir, made, synced, report); err != nil {
 		return made, err
 	}
 
-	// A version minted here has no image whatever the working tree says, so
-	// Fresh is what stops maybeBuild from skipping the build and promoting an
-	// artifact with nothing to run. One picked up from an earlier attempt may
-	// already have its image, and that is the skip worth having.
-	buildID, err := maybeBuild(made.ID, made.Fresh, code, synced, opts, report)
+	buildID, err := maybeBuild(loaded.ProjectDir, made, plan.Code, synced, opts, report)
 	made.BuildID = buildID
 
 	return made, err
 }
 
-// versionArtifact returns the artifact to fill and build, reusing the one an
-// earlier attempt left behind rather than adding to a pile of drafts.
-func versionArtifact(loaded Loaded, live Live, repositoryID string, report *reporter) (version, error) {
-	if id, ok := abandoned(loaded, live, repositoryID); ok {
-		report.say("  Continuing with artifact %s from an earlier attempt.\n", id)
+func versionArtifact(
+	loaded Loaded,
+	live Live,
+	plan Plan,
+	repositoryID string,
+	report *reporter,
+) (version, error) {
+	if made, ok := abandoned(loaded, live, plan, repositoryID); ok {
+		report.say("  Continuing with artifact %s from an earlier attempt.\n", made.ID)
 
-		return version{ID: id}, nil
+		return made, nil
+	}
+
+	if plan.InheritsImage {
+		made, err := copiedVersion(loaded, live, report)
+		if err == nil {
+			return made, nil
+		}
+
+		// A copy still standing stops the fallback: creating past it would
+		// strand an artifact nothing points at. Every other failure left
+		// nothing behind, so the deploy that builds is taken.
+		if made.ID != "" {
+			return made, err
+		}
+
+		log.Debug("the running version could not be copied; creating the new one instead", "err", err)
+		report.say("  The running version could not be copied (%v), so the new version is built after all.\n", err)
 	}
 
 	return createVersion(loaded, repositoryID, labelNewVersion, report)
+}
+
+// inheritsImage reports whether this run may copy the running version rather
+// than create one, which decides whether it spends a build.
+//
+// The running image is the whole of the evidence: a build-from-source
+// container has its imageUri stripped at create and written back only once a
+// build completes. A build row would answer wrong the moment that version is
+// itself a copy, since a copy keeps the image and leaves the rows behind.
+func inheritsImage(live Live, plan Plan, opts Options, kind, artifactName string) bool {
+	return plan.RollsArtifact() &&
+		plan.Code.Applies &&
+		!opts.ForceBuild &&
+		!plan.RebuildsImage() &&
+		live.ImageURI != "" &&
+		artifactName != "" &&
+		sameArtifactTypeAs(kind, live.ArtifactType)
+}
+
+// copiedVersion is the version a runtime-only change rolls onto: a copy of the
+// running one, written over with what the file says and read back, since an
+// update replaces a container wholesale.
+func copiedVersion(loaded Loaded, live Live, report *reporter) (version, error) {
+	var made version
+
+	err := report.run(labelCopiedVersion, func() error {
+		spec, specErr := loaded.Compiled.ArtifactSpecPayload()
+		if specErr != nil {
+			return specErr
+		}
+
+		copied, cloneErr := copyArtifactFn(live.ArtifactID, loaded.Compiled.ArtifactName)
+		if cloneErr != nil {
+			return cloneErr
+		}
+
+		// Recorded before the update, so a failure below can name it.
+		made = version{ID: copied.ID, Fresh: true}
+
+		if err := sameLineage(copied, live); err != nil {
+			return err
+		}
+
+		spec, specErr = keepCodeRef(spec, copied)
+		if specErr != nil {
+			return specErr
+		}
+
+		if updateErr := updateArtifactSpecFn(copied.ID, spec); updateErr != nil {
+			return updateErr
+		}
+
+		hasCode, imageURI, matches := carried(loaded, copied.ID)
+		if !matches {
+			// Accepted and still not what the file says: promoting it would
+			// report a deploy that changed nothing.
+			return errors.New("the copy does not say what " + manifest.FileName + " asks for")
+		}
+
+		made.HasCode, made.ImageURI = hasCode, imageURI
+
+		return nil
+	})
+	if err != nil && made.ID != "" {
+		return discardCopy(made, live.ArtifactID, err)
+	}
+
+	return made, err
+}
+
+// sameLineage refuses a copy the platform put somewhere other than where the
+// running version lives: an artifact cannot be moved once it exists, so
+// promoting one from elsewhere forks the version history permanently. A copy
+// stating no repository is not refused, only one that disagrees.
+func sameLineage(copied *workload.Artifact, live Live) error {
+	if live.ArtifactRepositoryID == "" || copied.ArtifactRepositoryID == "" {
+		return nil
+	}
+
+	if copied.ArtifactRepositoryID == live.ArtifactRepositoryID {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"the copy landed in artifact repository %s rather than %s, which the running version cannot leave",
+		copied.ArtifactRepositoryID, live.ArtifactRepositoryID)
+}
+
+// discardCopy takes back a copy this run cannot use: nothing points at it, so
+// leaving it costs one artifact per failed attempt. The version it returns
+// says whether anything is still standing.
+func discardCopy(made version, sourceID string, cause error) (version, error) {
+	if err := deleteArtifactFn(made.ID); err != nil {
+		log.Debug("cannot remove the unusable copy", "artifact_id", made.ID, "err", err)
+
+		return made, fmt.Errorf(
+			"artifact %s was copied from %s, could not be made to match %s, and could not be removed, "+
+				"so it is left behind: %w",
+			made.ID, sourceID, manifest.FileName, cause)
+	}
+
+	return version{}, fmt.Errorf(
+		"the copy of artifact %s could not be made to match %s: %w",
+		sourceID, manifest.FileName, cause)
+}
+
+// carried reports what the artifact has once the write is done: code, image,
+// and whether it says what the file asks for. A read that fails answers no to
+// the first two and yes to the third, which is the safe way round.
+func carried(loaded Loaded, artifactID string) (hasCode bool, imageURI string, matches bool) {
+	doc, err := getArtifactDocFn(artifactID)
+	if err != nil {
+		log.Debug("cannot read back the copied artifact; treating it as carrying nothing",
+			"artifact_id", artifactID, "err", err)
+
+		return false, "", true
+	}
+
+	container := workload.PrimaryContainerInDocument(doc)
+	uri, _ := container[keyImageURI].(string)
+
+	matched, err := specMatches(loaded, doc)
+	if err != nil {
+		log.Debug("cannot tell whether the copy took the change", "artifact_id", artifactID, "err", err)
+
+		matched = true
+	}
+
+	return workload.CodeRefInContainer(container) != nil, uri, matched
+}
+
+// keepCodeRef puts the copy's own code reference into the spec about to be
+// written over it. The manifest states none, so the file's spec alone would
+// take it away, and the platform refuses a container that says how to build
+// itself but not from what. Nothing else puts it back: this deploy never builds.
+func keepCodeRef(spec json.RawMessage, copied *workload.Artifact) (json.RawMessage, error) {
+	if copied == nil {
+		return spec, nil
+	}
+
+	ref := workload.ExtractCodeRef(*copied)
+	if ref == nil {
+		return spec, nil
+	}
+
+	return workload.SpecWithPrimaryCodeRef(spec, ref.CatalogID, ref.CatalogVersionID)
 }
 
 // The two things a create can be. A project's first artifact is not a new
@@ -114,6 +280,8 @@ func versionArtifact(loaded Loaded, live Live, repositoryID string, report *repo
 const (
 	labelFirstArtifact = "Creating the artifact"
 	labelNewVersion    = "Creating the new version"
+
+	labelCopiedVersion = "Copying the running version"
 )
 
 // createVersion mints an artifact from the file's artifact block, into
@@ -306,30 +474,54 @@ func withoutRepository(payload json.RawMessage) (json.RawMessage, error) {
 // `dr artifact create` makes, both of which sit in a repository of their own.
 // Minting a fresh version costs the stray draft that reuse exists to avoid;
 // reusing costs the lineage, permanently.
-func abandoned(loaded Loaded, live Live, repositoryID string) (string, bool) {
+func abandoned(loaded Loaded, live Live, plan Plan, repositoryID string) (version, bool) {
 	if !projectLinkedFn(loaded.ProjectDir) {
-		return "", false
+		return version{}, false
 	}
 
 	cfg, err := loadProjectFn(loaded.ProjectDir)
 	if err != nil || cfg.ArtifactID == "" || cfg.ArtifactID == live.ArtifactID {
-		return "", false
+		return version{}, false
 	}
 
 	artifact, err := getArtifactFn(cfg.ArtifactID)
 	if err != nil || artifact.IsLocked() {
-		return "", false
+		return version{}, false
 	}
 
 	if !joinable(artifact, repositoryID) {
-		return "", false
+		return version{}, false
 	}
 
 	if !describes(loaded, cfg.ArtifactID) {
-		return "", false
+		return version{}, false
 	}
 
-	return cfg.ArtifactID, true
+	// A leftover keeps its code reference only when it also keeps the image
+	// that reference was built into.
+	image := inheritedImage(artifact, live, plan)
+
+	return version{
+		ID:       cfg.ArtifactID,
+		HasCode:  image != "",
+		ImageURI: image,
+	}, true
+}
+
+// inheritedImage is the leftover's image when it is the one the version now
+// serving runs, and "" otherwise. The plan decides first: without it, a
+// leftover minted before the dockerfile changed would skip the build.
+func inheritedImage(draft *workload.Artifact, live Live, plan Plan) string {
+	if !plan.InheritsImage {
+		return ""
+	}
+
+	uri := workload.GetPrimaryContainerImageURI(*draft)
+	if uri == "" || uri != live.ImageURI {
+		return ""
+	}
+
+	return uri
 }
 
 // joinable reports whether promoting this draft would leave the workload in
@@ -486,6 +678,17 @@ func sameArtifactTypeIn(want, have map[string]any) bool {
 	delete(want, keyType)
 	delete(have, keyType)
 
+	return sameArtifactTypeAs(wanted, running)
+}
+
+// sameArtifactTypeAs compares the kind a file states against the kind a
+// workload runs. Folded, because the platform disagrees with itself about the
+// casing of its enums, and with only the live side defaulted, because a file
+// stating no type has no opinion. One function rather than the same three
+// lines twice, which is how the plan and the copy path came apart for an agent
+// whose file leaves it out. Deliberately not sameRepository's question, which
+// is what kind of thing is about to be created, so both sides default there.
+func sameArtifactTypeAs(wanted, running string) bool {
 	if wanted == "" {
 		return true
 	}
@@ -567,7 +770,17 @@ func relinkFailure(artifactID, projectDir string, err error) error {
 // code reference at all, and the roll would promote something that cannot
 // start. Pointing it at the version last synced is what makes "a new version
 // of the same code" true.
-func inheritCode(projectDir, artifactID string, synced *sync.Result, report *reporter) error {
+//
+// A version already carrying the code its image was built from is left
+// pointing there: re-anchoring it at whatever the project last synced would
+// claim code the image was never built from. Anything else is re-anchored,
+// including a leftover with a reference of its own, since `dr artifact create`
+// and an abandoned attempt both point at code older than the last sync.
+func inheritCode(projectDir string, made version, synced *sync.Result, report *reporter) error {
+	if made.HasCode {
+		return nil
+	}
+
 	// A sync that moved anything has already pointed the artifact at what it
 	// produced, so only one that found nothing to do leaves a version with no
 	// code of its own. Minting a version is the usual proof of that, but not
@@ -588,15 +801,15 @@ func inheritCode(projectDir, artifactID string, synced *sync.Result, report *rep
 		return fmt.Errorf(
 			"artifact %s has no code and the working tree had nothing to upload, so there would be "+
 				"nothing to build. Check that %s holds the project's source",
-			artifactID, projectDir)
+			made.ID, projectDir)
 	}
 
 	err = report.run("Carrying the code over", func() error {
-		return patchCodeRefFn(artifactID, catalog, lastVersion)
+		return patchCodeRefFn(made.ID, catalog, lastVersion)
 	})
 	if err != nil {
 		return fmt.Errorf("cannot point artifact %s at the code it should build (%s): %w",
-			artifactID, lastVersion, err)
+			made.ID, lastVersion, err)
 	}
 
 	return nil

--- a/internal/workload/wapi/config.go
+++ b/internal/workload/wapi/config.go
@@ -30,11 +30,16 @@ import (
 // CatalogID and LastSyncedVersionID use pointer semantics so that an empty
 // value round-trips as JSON null rather than "".
 type Config struct {
-	ArtifactID          string    `json:"artifactId" validate:"required,dr_id"`
-	CatalogID           *string   `json:"catalogId" validate:"omitempty,dr_nonempty_ptr,dr_id"`
-	LastSyncedVersionID *string   `json:"lastSyncedVersionId" validate:"omitempty,dr_nonempty_ptr,dr_id"`
-	CreatedAt           time.Time `json:"createdAt" validate:"required"`
-	CLIVersion          string    `json:"cliVersion" validate:"required"`
+	ArtifactID          string  `json:"artifactId" validate:"required,dr_id"`
+	CatalogID           *string `json:"catalogId" validate:"omitempty,dr_nonempty_ptr,dr_id"`
+	LastSyncedVersionID *string `json:"lastSyncedVersionId" validate:"omitempty,dr_nonempty_ptr,dr_id"`
+
+	// LastBuiltVersionID is the code version the last image was built from, nil
+	// when none has been recorded. Nothing on the platform holds it, so without
+	// it a deploy that inherits an image cannot tell whether the code moved.
+	LastBuiltVersionID *string   `json:"lastBuiltVersionId" validate:"omitempty,dr_nonempty_ptr,dr_id"`
+	CreatedAt          time.Time `json:"createdAt" validate:"required"`
+	CLIVersion         string    `json:"cliVersion" validate:"required"`
 }
 
 // LoadConfig reads and parses the project's config.json. Returns ErrNotInitialized if


### PR DESCRIPTION
# RATIONALE

Changing an environment variable on a workload retriggered a full image build. Env vars are runtime configuration: the container reads them when it starts, so the change wants a restart, not a new image.

The rebuild was ours rather than the server's. Any artifact spec edit made the run a roll, a roll minted a fresh artifact, and a fresh artifact has no image, so it always built. A port, a probe or a route cost a build the same way.

## CHANGES

A version that changes only fields a container reads at start is now copied from the one now serving, inheriting its image, the code it was built into and its repository, with the file's spec written over the copy. Everything else still builds. An env-var deploy goes from about 45 seconds to about 25, with no build at all, and the same holds for locked production and for a workload that was stopped.

Three calls worth arguing about.

The runtime fields are an allow-list rather than a list of build inputs to exclude. The compiler passes keys it does not recognize straight through, so a field the platform grows after this release ships would read as runtime under a deny-list, inherit a stale image and deploy clean. Under an allow-list it reads as a rebuild, which costs a build and is always survivable.

Project state gains `lastBuiltVersionId`. Nothing on the platform records which code an image was built from: a build row does not name its catalog pair, and an artifact's build pointer is cleared both by a re-sync and by being copied, so the two cannot be told apart. Without it, `dr artifact code sync` between deploys would let a later env-var change inherit an image built from the code before that sync and report success. Absent, which it is for every existing project until its next build, the deploy behaves as it did before.

A copy inherits artifact-spec fields the file never mentions instead of dropping them as a create would. That is the one-directional contract `Subset` already implements, but it is now a difference between the two tracks.

Verified against staging across twenty scenarios, including locked production, a stopped workload, an out-of-band `dr artifact code sync`, `--detach`, `--force-build`, a service-to-agent type change and a manifest bound by artifact id.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core roll/deploy path (artifact minting, build skipping, and production/locked behavior) with new platform API dependencies; mitigated by conservative runtime allow-list, read-back validation, and broad integration tests.
> 
> **Overview**
> **`dr workload up` no longer triggers a full image build when a roll only changes runtime configuration** (environment variables, ports, probes, routes, and similar fields read at container start). Those deploys **clone the running artifact**, **PATCH the manifest spec onto the copy** (preserving image and code reference), and **roll without calling the builder**.
> 
> The deploy planner gains **`RebuildsImage` / `InheritsImage`** using an **allow-list of runtime fields** and structured **`Change.Keys`** so rebuild vs copy is not inferred from rendered paths. **`Look`** now surfaces the live **image URI** and **catalog version**; project **`lastBuiltVersionId`** records which code the last successful build used so env-only rolls still rebuild after **`dr artifact code sync`**. New workload API helpers **`CloneArtifact`**, **`UpdateArtifactSpec`**, and **`SpecWithPrimaryCodeRef`** support the copy path, with **fallback to create-and-build** when clone is unsupported or the copy cannot be updated. Plans and JSON output expose **`keepsImage`** / dry-run messaging when no rebuild is expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dc420d513dccd67dd27908b06cf107d1c772feb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->