### PR TITLE
fix(bugbot): don't do JIRA in code, mk

### DIFF
--- a/.cursor/bugbot-package-design.md
+++ b/.cursor/bugbot-package-design.md
@@ -18,4 +18,5 @@ Document how functions fail, especially for streaming, long-running, and resourc
 
 ## Limitations and Future Work
 
-Intentional limitations must be tracked with JIRA tickets.
+Intentional limitations must be tracked with JIRA issues. However in package documentation or in the codebase,
+do NOT list issues by number. Just describe the limitation and the intended future work to address it.


### PR DESCRIPTION
From https://github.com/datarobot-oss/cli/pull/844#discussion_r3866636739

A coding review agent surmised that per these rules, because future work should be tracked in JIRA issues, those issue numbers should also be documented in the code.

That's a negative.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to internal BugBot rules; no runtime or product behavior is affected.
> 
> **Overview**
> Updates the **Limitations and Future Work** section in BugBot package-design guidance so intentional limits are still tracked in JIRA, but **package docs and code must not cite issue numbers**—only describe the limitation and planned follow-up.
> 
> This closes a review misread where agents inferred that “track in JIRA” meant embedding ticket IDs in documentation or the codebase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f52c7463540e862cc6b7e3f8926d4769b8e4c26c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->