### PR TITLE
[RAPTOR-19755] feat(workload): pull an existing workload's code before up deploys from an empty dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ docs/uv.lock
 *.vscode/
 *.claude/
 __pycache__/
+
+# Local smoke-test scaffolding (example workloads deployed by hand); kept out
+# of the repo so a `git add` never sweeps it into an unrelated change.
+/examples/

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/yuin/goldmark v1.8.2 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
-	golang.org/x/crypto v0.53.0 // indirect
+	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
-	golang.org/x/net v0.56.0 // indirect
+	golang.org/x/net v0.57.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -183,12 +183,12 @@ github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJ
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
-golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
-golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
+golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
+golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
-golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
-golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
+golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/workload/sync/download.go
+++ b/internal/workload/sync/download.go
@@ -23,15 +23,27 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/datarobot/cli/internal/drapi/filesapi"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/workload/fileops"
 )
 
-// downloadFiles pulls files in parallel up to DownloadConcurrency. Each
-// download streams to disk and computes SHA-256 in the same pass so
-// post-download verification is free. The first error closes done to
-// stop other workers from picking up the next file.
+// downloadFiles is the Engine-bound entry the sync pipeline uses; the reusable
+// work lives in DownloadFiles, which needs only a client and a destination.
 func downloadFiles(e *Engine, catalogID, versionID string, files []FileAction) error {
+	return DownloadFiles(e.files, e.projectDir, catalogID, versionID, files)
+}
+
+// DownloadFiles pulls files into dir in parallel up to DownloadConcurrency.
+// Each download streams to disk and computes SHA-256 in the same pass so
+// post-download verification is free. The first error closes done to stop
+// other workers from picking up the next file.
+//
+// It takes a client and a destination rather than an *Engine so callers
+// outside the sync pipeline can reuse it: the first-bind seed in
+// internal/workload/up pulls a workload's current code with the same
+// verified, partial-safe download the pipeline uses.
+func DownloadFiles(client filesapi.Client, dir, catalogID, versionID string, files []FileAction) error {
 	if len(files) == 0 {
 		return nil
 	}
@@ -65,7 +77,7 @@ func downloadFiles(e *Engine, catalogID, versionID string, files []FileAction) e
 
 			defer func() { <-sem }()
 
-			if err := downloadOne(e, catalogID, versionID, fa); err != nil {
+			if err := DownloadOne(client, dir, catalogID, versionID, fa); err != nil {
 				select {
 				case errCh <- err:
 					cancel()
@@ -85,9 +97,16 @@ func downloadFiles(e *Engine, catalogID, versionID string, files []FileAction) e
 	return nil
 }
 
-// downloadOne streams the remote file to disk, hashing as it writes.
-// Empty RemoteHash skips verification (e.g. synthesized EDIT_DEL_CONFLICT).
+// downloadOne is the Engine-bound entry; the reusable work lives in DownloadOne.
 func downloadOne(e *Engine, catalogID, versionID string, fa FileAction) error {
+	return DownloadOne(e.files, e.projectDir, catalogID, versionID, fa)
+}
+
+// DownloadOne streams the remote file into dir, hashing as it writes, and
+// removes the partial file on any failure so a half-written file is never left
+// on disk. Empty RemoteHash skips checksum verification (e.g. a synthesized
+// EDIT_DEL_CONFLICT, or a caller whose listing carries no hash).
+func DownloadOne(client filesapi.Client, dir, catalogID, versionID string, fa FileAction) error {
 	// phase5Execute already rejected unsafe server paths up front via
 	// validateServerPaths; re-check here so the per-call-site invariant
 	// survives future refactors that might bypass the phase entry point.
@@ -95,7 +114,7 @@ func downloadOne(e *Engine, catalogID, versionID string, fa FileAction) error {
 		return fmt.Errorf("server returned unsafe download path %q: %w", fa.Path, err)
 	}
 
-	dst := filepath.Join(e.projectDir, filepath.FromSlash(fa.Path))
+	dst := filepath.Join(dir, filepath.FromSlash(fa.Path))
 
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return fmt.Errorf("mkdir parent for %s: %w", fa.Path, err)
@@ -109,7 +128,7 @@ func downloadOne(e *Engine, catalogID, versionID string, fa FileAction) error {
 	h := sha256.New()
 	mw := io.MultiWriter(out, h)
 
-	_, n, err := e.files.DownloadFile(catalogID, versionID, fa.Path, mw)
+	_, n, err := client.DownloadFile(catalogID, versionID, fa.Path, mw)
 
 	closeErr := out.Close()
 

--- a/internal/workload/up/run.go
+++ b/internal/workload/up/run.go
@@ -555,6 +555,13 @@ func apply(loaded Loaded, live Live, plan Plan, result Result, opts Options) (Re
 		return result, err
 	}
 
+	// Pulled before anything is started or rolled, so a directory that turns
+	// out to hold the wrong thing is refused before the run has touched the
+	// workload.
+	if err := seedIfMinting(loaded, live, plan, opts); err != nil {
+		return result, err
+	}
+
 	report := newReporter(opts.Stderr, opts.Spinner)
 
 	// Everything that can refuse this run goes first, because a start is a

--- a/internal/workload/up/seed.go
+++ b/internal/workload/up/seed.go
@@ -1,0 +1,244 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/fileops"
+	"github.com/datarobot/cli/internal/workload/ignore"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/datarobot/cli/internal/workload/wapi"
+	"github.com/datarobot/cli/internal/workload/wizard"
+)
+
+// filesClientFn builds the client that pulls an existing workload's code. A
+// seam so tests can serve files without a network.
+var filesClientFn = filesapi.New
+
+// seedIfMinting pulls the workload's code when this run is one that pushes the
+// working tree. Only a version-minting run (a roll, or a create from source)
+// reads the tree; a retune, a start, or an unchanged run leaves it alone, and
+// none of them should read the live artifact or touch the directory.
+func seedIfMinting(loaded Loaded, live Live, plan Plan, opts Options) error {
+	if !plan.MintsVersion() {
+		return nil
+	}
+
+	return seedFromLiveArtifact(loaded, live, opts)
+}
+
+// seedFromLiveArtifact pulls a bound workload's current code into an empty
+// project directory before the deploy reads the working tree.
+//
+// Binding to an existing source-built workload has no download step: `config`
+// writes the live spec into the manifest, but never the code the artifact was
+// built from. So an `up` run from a directory that does not already hold that
+// code would roll a new version from whatever is there — an empty tree becomes
+// an empty artifact that fails the build with "cannot detect project runtime",
+// minutes later and after the workload has already been touched. This closes
+// that gap: when the directory is empty, the code is pulled down so the deploy
+// builds from the real thing; when it holds unrelated files, the run is
+// refused rather than allowed to replace the workload's code with them.
+//
+// It runs only for the one shape that needs it: a source-built workload, bound
+// and already existing, in a directory this CLI has not linked yet. Every
+// other run is left untouched.
+func seedFromLiveArtifact(loaded Loaded, live Live, opts Options) error {
+	if !seedApplies(loaded, live) {
+		return nil
+	}
+
+	codeRef, err := artifactCodeRef(live.ArtifactID)
+	if err != nil || codeRef == nil {
+		// A nil ref (no code catalog: a published image) is nothing to pull.
+		return err
+	}
+
+	files, err := filesClientFn().AllFiles(codeRef.CatalogID, codeRef.CatalogVersionID)
+	if err != nil {
+		return fmt.Errorf("cannot read the code of workload %s to pull it: %w", live.WorkloadID, err)
+	}
+
+	if !hasRealCode(files) {
+		// The workload's own artifact is empty too (only the ignore file, or
+		// nothing). There is nothing to seed, and the build guard elsewhere is
+		// what speaks to a runtime that cannot be detected.
+		return nil
+	}
+
+	return seedLocalDir(loaded, live, codeRef, files, opts)
+}
+
+// seedApplies reports whether this run is the one shape a pull is for: a
+// source-built workload, bound and already existing, in a directory the CLI
+// has not linked yet. A linked project is past first-bind and its incremental
+// sync knows its own base; a published image has no code to pull.
+func seedApplies(loaded Loaded, live Live) bool {
+	mode := loaded.Manifest.BuildMode()
+	if mode != manifest.BuildModeDockerfile && mode != manifest.BuildModeGenerated {
+		return false
+	}
+
+	return live.ArtifactID != "" && !projectLinkedFn(loaded.ProjectDir)
+}
+
+// seedLocalDir decides what to do about the project directory: leave a real
+// project as it is, pull into an empty one, or refuse one that holds files
+// that are not a recognised project and are not this workload's code.
+func seedLocalDir(
+	loaded Loaded,
+	live Live,
+	codeRef *workload.DatarobotCodeRef,
+	files map[string]filesapi.FileMeta,
+	opts Options,
+) error {
+	// A directory that already looks like a project is the normal case: the
+	// user has the code, and the deploy reads it as it always has.
+	if !wizard.Detect(loaded.ProjectDir).SuspectDir() {
+		return nil
+	}
+
+	empty, err := looksEmpty(loaded.ProjectDir)
+	if err != nil {
+		return err
+	}
+
+	if !empty {
+		// Files, but not a recognised project, and not linked to this
+		// workload. Rolling them would replace the workload's code with
+		// whatever this is; deploying its own code needs an empty directory to
+		// pull into, or the project root.
+		return fmt.Errorf(
+			"refusing to deploy: %s has files but no recognised project layout, and workload %s already has "+
+				"code this run would replace. Deploy from the project root, or start from an empty directory "+
+				"to pull the workload's current code first",
+			loaded.ProjectDir, name(loaded, live))
+	}
+
+	return pullCode(loaded.ProjectDir, codeRef, files, live, loaded, opts)
+}
+
+// artifactCodeRef reads the code catalog behind the artifact the workload is
+// running, nil when the artifact is built from a published image rather than
+// from source.
+func artifactCodeRef(artifactID string) (*workload.DatarobotCodeRef, error) {
+	artifact, err := getArtifactFn(artifactID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read artifact %s to pull its code: %w", artifactID, err)
+	}
+
+	return workload.ExtractCodeRef(*artifact), nil
+}
+
+// hasRealCode reports whether the file set is more than the CLI's own ignore
+// file. An artifact carrying only .drignore has no code worth pulling.
+func hasRealCode(files map[string]filesapi.FileMeta) bool {
+	for path := range files {
+		if path != ignore.FileName {
+			return true
+		}
+	}
+
+	return false
+}
+
+// looksEmpty reports whether the directory holds nothing but the files the CLI
+// writes itself: the state directory, the manifest, and the ignore file. Those
+// are the residue of an earlier bind or a failed run, not the user's code, so a
+// directory holding only them is still a directory to pull into.
+func looksEmpty(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, fmt.Errorf("cannot read %s: %w", dir, err)
+	}
+
+	for _, entry := range entries {
+		switch entry.Name() {
+		case wapi.RootDirName, manifest.FileName, ignore.FileName, ".git":
+			continue
+		default:
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// pullCode downloads every file of the workload's current version into the
+// project directory. The directory is empty (looksEmpty gated the call), so
+// the files are written in place rather than staged and swapped.
+func pullCode(
+	dir string,
+	codeRef *workload.DatarobotCodeRef,
+	files map[string]filesapi.FileMeta,
+	live Live,
+	loaded Loaded,
+	opts Options,
+) error {
+	client := filesClientFn()
+
+	paths := make([]string, 0, len(files))
+	for path := range files {
+		paths = append(paths, path)
+	}
+
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		if err := fileops.SafeRelPath(path); err != nil {
+			return fmt.Errorf("the workload's code names an unsafe path %q: %w", path, err)
+		}
+	}
+
+	for _, path := range paths {
+		if err := downloadInto(client, codeRef, dir, path); err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintf(opts.Stderr, "  Pulled %d file(s) from %s's current version into %s\n",
+		len(paths), name(loaded, live), dir)
+
+	return nil
+}
+
+// downloadInto writes one file of the version into dir, creating parents.
+func downloadInto(client filesapi.Client, codeRef *workload.DatarobotCodeRef, dir, path string) error {
+	dst := filepath.Join(dir, filepath.FromSlash(path))
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("cannot create the directory for %s: %w", path, err)
+	}
+
+	file, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("cannot create %s: %w", path, err)
+	}
+
+	defer func() { _ = file.Close() }()
+
+	if _, _, err := client.DownloadFile(codeRef.CatalogID, codeRef.CatalogVersionID, path, file); err != nil {
+		return errors.Join(fmt.Errorf("cannot download %s", path), err)
+	}
+
+	return nil
+}

--- a/internal/workload/up/seed.go
+++ b/internal/workload/up/seed.go
@@ -15,14 +15,8 @@
 package up
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"errors"
 	"fmt"
-	"hash"
-	"io"
 	"os"
-	"path/filepath"
 	"sort"
 
 	"github.com/datarobot/cli/internal/drapi/filesapi"
@@ -30,6 +24,7 @@ import (
 	"github.com/datarobot/cli/internal/workload/fileops"
 	"github.com/datarobot/cli/internal/workload/ignore"
 	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/datarobot/cli/internal/workload/sync"
 	"github.com/datarobot/cli/internal/workload/wapi"
 	"github.com/datarobot/cli/internal/workload/wizard"
 )
@@ -228,87 +223,22 @@ func pullCode(
 			fileops.FormatCaseCollisions(cs))
 	}
 
+	// The download itself is the sync pipeline's: it verifies each file against
+	// its catalog size and hash and removes the partial on any failure, so a
+	// half-written root marker never survives to make a retry skip seeding and
+	// build from a corrupt tree. Reused here rather than re-implemented.
+	actions := make([]sync.FileAction, 0, len(paths))
 	for _, path := range paths {
-		if err := downloadInto(client, codeRef, dir, path, files[path]); err != nil {
-			return err
-		}
+		meta := files[path]
+		actions = append(actions, sync.FileAction{Path: path, RemoteSize: meta.Size, RemoteHash: meta.Hash})
+	}
+
+	if err := sync.DownloadFiles(client, dir, codeRef.CatalogID, codeRef.CatalogVersionID, actions); err != nil {
+		return err
 	}
 
 	fmt.Fprintf(opts.Stderr, "  Pulled %d file(s) from %s's current version into %s\n",
 		len(paths), name(loaded, live), dir)
 
 	return nil
-}
-
-// downloadInto writes one file of the version into dir, creating parents, and
-// verifies it against the catalog's size and hash as it streams.
-//
-// A half-written file is removed on any failure rather than left on disk. The
-// pull writes in place (the directory was empty), so a partial survivor is not
-// staged away from the deploy: on a retry a truncated root marker (a cut-off
-// pyproject.toml) makes the directory look like a real project, seeding is
-// skipped, and the deploy builds from the corrupt tree — and a partial that is
-// not a marker refuses the next run with a message the user can only clear by
-// deleting files by hand. Verifying size and hash catches a silent truncation
-// the writer itself did not report. This mirrors the sync engine's downloadOne.
-func downloadInto(
-	client filesapi.Client,
-	codeRef *workload.DatarobotCodeRef,
-	dir, path string,
-	meta filesapi.FileMeta,
-) error {
-	dst := filepath.Join(dir, filepath.FromSlash(path))
-
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return fmt.Errorf("cannot create the directory for %s: %w", path, err)
-	}
-
-	file, err := os.Create(dst)
-	if err != nil {
-		return fmt.Errorf("cannot create %s: %w", path, err)
-	}
-
-	hasher := sha256.New()
-
-	_, n, downloadErr := client.DownloadFile(
-		codeRef.CatalogID, codeRef.CatalogVersionID, path, io.MultiWriter(file, hasher))
-
-	closeErr := file.Close()
-
-	if failure := verifyDownload(path, meta, n, hasher, downloadErr, closeErr); failure != nil {
-		_ = os.Remove(dst)
-
-		return failure
-	}
-
-	return nil
-}
-
-// verifyDownload reports the first thing wrong with a file that was just
-// written: the download or close itself, a byte count short of the catalog's,
-// or a checksum that does not match. nil means the file on disk is the file
-// the catalog holds. The caller removes the partial when this returns non-nil.
-func verifyDownload(
-	path string,
-	meta filesapi.FileMeta,
-	n int64,
-	hasher hash.Hash,
-	downloadErr, closeErr error,
-) error {
-	switch {
-	case downloadErr != nil:
-		return errors.Join(fmt.Errorf("cannot download %s", path), downloadErr)
-
-	case closeErr != nil:
-		return fmt.Errorf("cannot finish writing %s: %w", path, closeErr)
-
-	case meta.Size > 0 && n != meta.Size:
-		return fmt.Errorf("download of %s is %d bytes, expected %d", path, n, meta.Size)
-
-	case meta.Hash != "" && hex.EncodeToString(hasher.Sum(nil)) != meta.Hash:
-		return fmt.Errorf("download of %s does not match its expected checksum", path)
-
-	default:
-		return nil
-	}
 }

--- a/internal/workload/up/seed.go
+++ b/internal/workload/up/seed.go
@@ -17,6 +17,7 @@ package up
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/datarobot/cli/internal/drapi/filesapi"
@@ -85,13 +86,15 @@ func seedFromLiveArtifact(loaded Loaded, live Live, opts Options) error {
 
 	if !empty {
 		// Files, but not a recognised project, and not linked to this
-		// workload. Rolling them would replace the workload's code with
-		// whatever this is; deploying its own code needs an empty directory to
-		// pull into, or the project root.
+		// workload. Deploying would roll whatever is here onto the workload;
+		// pulling its own code instead needs an empty directory, or the
+		// project root. The message does not claim the workload has code to
+		// replace: that is not read on this path, and an artifact built from an
+		// empty tree has none.
 		return fmt.Errorf(
-			"refusing to deploy: %s has files but no recognised project layout, and workload %s already has "+
-				"code this run would replace. Deploy from the project root, or start from an empty directory "+
-				"to pull the workload's current code first",
+			"refusing to deploy: %s has files but no recognised project layout, so a deploy would roll "+
+				"whatever is here onto workload %s. Deploy from the project root, or start from an empty "+
+				"directory to pull the workload's current code first",
 			loaded.ProjectDir, name(loaded, live))
 	}
 
@@ -109,7 +112,9 @@ func pullLiveCode(loaded Loaded, live Live, opts Options) error {
 		return err
 	}
 
-	files, err := filesClientFn().AllFiles(codeRef.CatalogID, codeRef.CatalogVersionID)
+	client := filesClientFn()
+
+	files, err := client.AllFiles(codeRef.CatalogID, codeRef.CatalogVersionID)
 	if err != nil {
 		return fmt.Errorf("cannot read the code of workload %s to pull it: %w", live.WorkloadID, err)
 	}
@@ -121,7 +126,7 @@ func pullLiveCode(loaded Loaded, live Live, opts Options) error {
 		return nil
 	}
 
-	return pullCode(loaded.ProjectDir, codeRef, files, live, loaded, opts)
+	return pullCode(client, loaded.ProjectDir, codeRef, files, live, loaded, opts)
 }
 
 // seedApplies reports whether this run is the one shape a pull is for: a
@@ -185,8 +190,10 @@ func looksEmpty(dir string) (bool, error) {
 
 // pullCode downloads every file of the workload's current version into the
 // project directory. The directory is empty (looksEmpty gated the call), so
-// the files are written in place rather than staged and swapped.
+// the files are written in place; a pull that fails partway is reverted so the
+// directory is left as empty as it was found.
 func pullCode(
+	client filesapi.Client,
 	dir string,
 	codeRef *workload.DatarobotCodeRef,
 	files map[string]filesapi.FileMeta,
@@ -194,8 +201,6 @@ func pullCode(
 	loaded Loaded,
 	opts Options,
 ) error {
-	client := filesClientFn()
-
 	paths := make([]string, 0, len(files))
 	for path := range files {
 		paths = append(paths, path)
@@ -233,7 +238,21 @@ func pullCode(
 		actions = append(actions, sync.FileAction{Path: path, RemoteSize: meta.Size, RemoteHash: meta.Hash})
 	}
 
+	// The pull is parallel and stops on the first error, but the files that
+	// already landed stay on disk. Left there, a subset that happens to hold a
+	// root marker (pyproject.toml arrived, app.py did not) makes the next run's
+	// SuspectDir() false, so seeding is skipped and the deploy builds from an
+	// incomplete tree — the very thing this pull exists to prevent. The
+	// directory was empty before the pull, so a failure reverts it to empty and
+	// the retry pulls the whole set again rather than inheriting half of it.
+	before, err := topLevelNames(dir)
+	if err != nil {
+		return err
+	}
+
 	if err := sync.DownloadFiles(client, dir, codeRef.CatalogID, codeRef.CatalogVersionID, actions); err != nil {
+		revertPull(dir, before)
+
 		return err
 	}
 
@@ -241,4 +260,39 @@ func pullCode(
 		len(paths), name(loaded, live), dir)
 
 	return nil
+}
+
+// topLevelNames is the set of entries directly in dir, captured before a pull
+// so its leftovers can be told from what was already there.
+func topLevelNames(dir string) (map[string]struct{}, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read %s: %w", dir, err)
+	}
+
+	names := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		names[entry.Name()] = struct{}{}
+	}
+
+	return names, nil
+}
+
+// revertPull removes every top-level entry a failed pull added, returning the
+// directory to the state it had before. Best-effort: whatever it cannot remove
+// costs the user at most the manual deletion they faced before this existed,
+// and the pull's own error is what is reported.
+func revertPull(dir string, before map[string]struct{}) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		if _, kept := before[entry.Name()]; kept {
+			continue
+		}
+
+		_ = os.RemoveAll(filepath.Join(dir, entry.Name()))
+	}
 }

--- a/internal/workload/up/seed.go
+++ b/internal/workload/up/seed.go
@@ -15,8 +15,12 @@
 package up
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"hash"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -67,53 +71,15 @@ func seedFromLiveArtifact(loaded Loaded, live Live, opts Options) error {
 		return nil
 	}
 
-	codeRef, err := artifactCodeRef(live.ArtifactID)
-	if err != nil || codeRef == nil {
-		// A nil ref (no code catalog: a published image) is nothing to pull.
-		return err
-	}
-
-	files, err := filesClientFn().AllFiles(codeRef.CatalogID, codeRef.CatalogVersionID)
-	if err != nil {
-		return fmt.Errorf("cannot read the code of workload %s to pull it: %w", live.WorkloadID, err)
-	}
-
-	if !hasRealCode(files) {
-		// The workload's own artifact is empty too (only the ignore file, or
-		// nothing). There is nothing to seed, and the build guard elsewhere is
-		// what speaks to a runtime that cannot be detected.
-		return nil
-	}
-
-	return seedLocalDir(loaded, live, codeRef, files, opts)
-}
-
-// seedApplies reports whether this run is the one shape a pull is for: a
-// source-built workload, bound and already existing, in a directory the CLI
-// has not linked yet. A linked project is past first-bind and its incremental
-// sync knows its own base; a published image has no code to pull.
-func seedApplies(loaded Loaded, live Live) bool {
-	mode := loaded.Manifest.BuildMode()
-	if mode != manifest.BuildModeDockerfile && mode != manifest.BuildModeGenerated {
-		return false
-	}
-
-	return live.ArtifactID != "" && !projectLinkedFn(loaded.ProjectDir)
-}
-
-// seedLocalDir decides what to do about the project directory: leave a real
-// project as it is, pull into an empty one, or refuse one that holds files
-// that are not a recognised project and are not this workload's code.
-func seedLocalDir(
-	loaded Loaded,
-	live Live,
-	codeRef *workload.DatarobotCodeRef,
-	files map[string]filesapi.FileMeta,
-	opts Options,
-) error {
-	// A directory that already looks like a project is the normal case: the
-	// user has the code, and the deploy reads it as it always has.
+	// The project directory decides whether a pull is even possible, and it
+	// needs no network to do it: a directory that already looks like a project
+	// is deployed as it is, and one that holds unrelated files is refused. Only
+	// an empty directory reaches for the live artifact, so the reads that
+	// resolve its code run after these gates rather than before — a transient
+	// files-API failure must not block a deploy that never needed seeding.
 	if !wizard.Detect(loaded.ProjectDir).SuspectDir() {
+		// A directory that already looks like a project is the normal case: the
+		// user has the code, and the deploy reads it as it always has.
 		return nil
 	}
 
@@ -134,7 +100,46 @@ func seedLocalDir(
 			loaded.ProjectDir, name(loaded, live))
 	}
 
+	return pullLiveCode(loaded, live, opts)
+}
+
+// pullLiveCode reads the live artifact's code catalog and pulls it into the
+// (already-confirmed-empty) project directory. It is reached only once the
+// local-directory gates have decided a pull is both possible and needed, so
+// the network reads it does are the reads no other run has to pay for.
+func pullLiveCode(loaded Loaded, live Live, opts Options) error {
+	codeRef, err := artifactCodeRef(live.ArtifactID)
+	if err != nil || codeRef == nil {
+		// A nil ref (no code catalog: a published image) is nothing to pull.
+		return err
+	}
+
+	files, err := filesClientFn().AllFiles(codeRef.CatalogID, codeRef.CatalogVersionID)
+	if err != nil {
+		return fmt.Errorf("cannot read the code of workload %s to pull it: %w", live.WorkloadID, err)
+	}
+
+	if !hasRealCode(files) {
+		// The workload's own artifact is empty too (only the ignore file, or
+		// nothing). There is nothing to seed, and the build guard elsewhere is
+		// what speaks to a runtime that cannot be detected.
+		return nil
+	}
+
 	return pullCode(loaded.ProjectDir, codeRef, files, live, loaded, opts)
+}
+
+// seedApplies reports whether this run is the one shape a pull is for: a
+// source-built workload, bound and already existing, in a directory the CLI
+// has not linked yet. A linked project is past first-bind and its incremental
+// sync knows its own base; a published image has no code to pull.
+func seedApplies(loaded Loaded, live Live) bool {
+	mode := loaded.Manifest.BuildMode()
+	if mode != manifest.BuildModeDockerfile && mode != manifest.BuildModeGenerated {
+		return false
+	}
+
+	return live.ArtifactID != "" && !projectLinkedFn(loaded.ProjectDir)
 }
 
 // artifactCodeRef reads the code catalog behind the artifact the workload is
@@ -203,14 +208,28 @@ func pullCode(
 
 	sort.Strings(paths)
 
+	set := make(map[string]struct{}, len(paths))
+
 	for _, path := range paths {
 		if err := fileops.SafeRelPath(path); err != nil {
 			return fmt.Errorf("the workload's code names an unsafe path %q: %w", path, err)
 		}
+
+		set[path] = struct{}{}
+	}
+
+	// Two catalog keys that differ only by case (App.py vs app.py) map to one
+	// file on macOS and Windows, so writing them in turn would silently drop
+	// one and seed a tree that is missing code the build needs. Caught before
+	// any file is written, mirroring the check the sync engine makes.
+	if cs := fileops.DetectCaseCollisions(set); len(cs) > 0 {
+		return fmt.Errorf(
+			"the workload's code cannot be pulled onto this filesystem: %s",
+			fileops.FormatCaseCollisions(cs))
 	}
 
 	for _, path := range paths {
-		if err := downloadInto(client, codeRef, dir, path); err != nil {
+		if err := downloadInto(client, codeRef, dir, path, files[path]); err != nil {
 			return err
 		}
 	}
@@ -221,8 +240,23 @@ func pullCode(
 	return nil
 }
 
-// downloadInto writes one file of the version into dir, creating parents.
-func downloadInto(client filesapi.Client, codeRef *workload.DatarobotCodeRef, dir, path string) error {
+// downloadInto writes one file of the version into dir, creating parents, and
+// verifies it against the catalog's size and hash as it streams.
+//
+// A half-written file is removed on any failure rather than left on disk. The
+// pull writes in place (the directory was empty), so a partial survivor is not
+// staged away from the deploy: on a retry a truncated root marker (a cut-off
+// pyproject.toml) makes the directory look like a real project, seeding is
+// skipped, and the deploy builds from the corrupt tree — and a partial that is
+// not a marker refuses the next run with a message the user can only clear by
+// deleting files by hand. Verifying size and hash catches a silent truncation
+// the writer itself did not report. This mirrors the sync engine's downloadOne.
+func downloadInto(
+	client filesapi.Client,
+	codeRef *workload.DatarobotCodeRef,
+	dir, path string,
+	meta filesapi.FileMeta,
+) error {
 	dst := filepath.Join(dir, filepath.FromSlash(path))
 
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
@@ -234,11 +268,47 @@ func downloadInto(client filesapi.Client, codeRef *workload.DatarobotCodeRef, di
 		return fmt.Errorf("cannot create %s: %w", path, err)
 	}
 
-	defer func() { _ = file.Close() }()
+	hasher := sha256.New()
 
-	if _, _, err := client.DownloadFile(codeRef.CatalogID, codeRef.CatalogVersionID, path, file); err != nil {
-		return errors.Join(fmt.Errorf("cannot download %s", path), err)
+	_, n, downloadErr := client.DownloadFile(
+		codeRef.CatalogID, codeRef.CatalogVersionID, path, io.MultiWriter(file, hasher))
+
+	closeErr := file.Close()
+
+	if failure := verifyDownload(path, meta, n, hasher, downloadErr, closeErr); failure != nil {
+		_ = os.Remove(dst)
+
+		return failure
 	}
 
 	return nil
+}
+
+// verifyDownload reports the first thing wrong with a file that was just
+// written: the download or close itself, a byte count short of the catalog's,
+// or a checksum that does not match. nil means the file on disk is the file
+// the catalog holds. The caller removes the partial when this returns non-nil.
+func verifyDownload(
+	path string,
+	meta filesapi.FileMeta,
+	n int64,
+	hasher hash.Hash,
+	downloadErr, closeErr error,
+) error {
+	switch {
+	case downloadErr != nil:
+		return errors.Join(fmt.Errorf("cannot download %s", path), downloadErr)
+
+	case closeErr != nil:
+		return fmt.Errorf("cannot finish writing %s: %w", path, closeErr)
+
+	case meta.Size > 0 && n != meta.Size:
+		return fmt.Errorf("download of %s is %d bytes, expected %d", path, n, meta.Size)
+
+	case meta.Hash != "" && hex.EncodeToString(hasher.Sum(nil)) != meta.Hash:
+		return fmt.Errorf("download of %s does not match its expected checksum", path)
+
+	default:
+		return nil
+	}
 }

--- a/internal/workload/up/seed.go
+++ b/internal/workload/up/seed.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/datarobot/cli/internal/drapi/filesapi"
 	"github.com/datarobot/cli/internal/workload"
@@ -154,16 +155,37 @@ func artifactCodeRef(artifactID string) (*workload.DatarobotCodeRef, error) {
 	return workload.ExtractCodeRef(*artifact), nil
 }
 
-// hasRealCode reports whether the file set is more than the CLI's own ignore
-// file. An artifact carrying only .drignore has no code worth pulling.
+// hasRealCode reports whether the file set is more than CLI residue: the
+// project's ignore file, or tool state under .datarobot/. An artifact carrying
+// only those has no code worth pulling.
 func hasRealCode(files map[string]filesapi.FileMeta) bool {
 	for path := range files {
-		if path != ignore.FileName {
+		if !isCLIResidue(path) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// isCLIResidue reports whether a catalog path is the CLI's own residue rather
+// than project code: the ignore file (current or legacy) or anything under
+// .datarobot/. The sync only excludes .datarobot/workload, so a catalog can
+// capture sibling tool state such as .datarobot/cli/ — never code — which seed
+// must neither count as real code nor write locally, or the next `up` would see
+// a .datarobot it refuses as non-empty.
+func isCLIResidue(path string) bool {
+	return path == ignore.FileName ||
+		path == ignore.LegacyFileName ||
+		strings.HasPrefix(path, wapi.RootDirName+"/")
+}
+
+// underDatarobot reports whether a catalog path is tool state under
+// .datarobot/. Such state is filtered from the pull so seeding never writes it
+// into the fresh directory. The ignore files are not filtered — they are legit
+// project content the user wants pulled.
+func underDatarobot(path string) bool {
+	return strings.HasPrefix(path, wapi.RootDirName+"/")
 }
 
 // looksEmpty reports whether the directory holds nothing but the files the CLI
@@ -178,7 +200,7 @@ func looksEmpty(dir string) (bool, error) {
 
 	for _, entry := range entries {
 		switch entry.Name() {
-		case manifest.FileName, ignore.FileName, ".git":
+		case manifest.FileName, ignore.FileName, ignore.LegacyFileName, ".git":
 			continue
 		case wapi.RootDirName:
 			// A .datarobot directory is residue only when it holds nothing but
@@ -201,10 +223,16 @@ func looksEmpty(dir string) (bool, error) {
 }
 
 // datarobotHoldsOnlyWorkloadState reports whether a .datarobot directory
-// contains nothing but the workload sync state (wapi.StateDirName). That state
-// is this command's own residue and only it; anything else under .datarobot —
-// .datarobot/cli/ tool state, for one — is content the sync would upload, so
-// its presence means the directory is not empty to pull into.
+// contains nothing but the workload sync state (wapi.StateDirName). Anything
+// else under .datarobot — .datarobot/cli/ tool state, for one — is content the
+// sync would upload, so its presence means the directory is not empty to pull
+// into.
+//
+// In practice a .datarobot holding the workload state does not reach here at
+// all: that state is what projectLinkedFn (wapi.Exists) keys on, so seedApplies
+// has already skipped a linked project — the sync engine owns its base. The
+// tolerance is kept as defense in depth; the decision that matters on the live
+// path is refusing a .datarobot that carries non-workload state.
 func datarobotHoldsOnlyWorkloadState(datarobotDir string) (bool, error) {
 	entries, err := os.ReadDir(datarobotDir)
 	if err != nil {
@@ -234,7 +262,14 @@ func pullCode(
 	opts Options,
 ) error {
 	paths := make([]string, 0, len(files))
+
 	for path := range files {
+		// .datarobot/ tool state that leaked into the catalog is never written
+		// locally: seeding it would leave a .datarobot the next `up` refuses.
+		if underDatarobot(path) {
+			continue
+		}
+
 		paths = append(paths, path)
 	}
 

--- a/internal/workload/up/seed.go
+++ b/internal/workload/up/seed.go
@@ -178,9 +178,41 @@ func looksEmpty(dir string) (bool, error) {
 
 	for _, entry := range entries {
 		switch entry.Name() {
-		case wapi.RootDirName, manifest.FileName, ignore.FileName, ".git":
+		case manifest.FileName, ignore.FileName, ".git":
 			continue
+		case wapi.RootDirName:
+			// A .datarobot directory is residue only when it holds nothing but
+			// the workload state; sibling state like .datarobot/cli/ is real
+			// content the sync uploads, so a directory carrying it is not empty.
+			onlyState, err := datarobotHoldsOnlyWorkloadState(filepath.Join(dir, entry.Name()))
+			if err != nil {
+				return false, err
+			}
+
+			if !onlyState {
+				return false, nil
+			}
 		default:
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// datarobotHoldsOnlyWorkloadState reports whether a .datarobot directory
+// contains nothing but the workload sync state (wapi.StateDirName). That state
+// is this command's own residue and only it; anything else under .datarobot —
+// .datarobot/cli/ tool state, for one — is content the sync would upload, so
+// its presence means the directory is not empty to pull into.
+func datarobotHoldsOnlyWorkloadState(datarobotDir string) (bool, error) {
+	entries, err := os.ReadDir(datarobotDir)
+	if err != nil {
+		return false, fmt.Errorf("cannot read %s: %w", datarobotDir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.Name() != wapi.StateDirName {
 			return false, nil
 		}
 	}

--- a/internal/workload/up/seed_test.go
+++ b/internal/workload/up/seed_test.go
@@ -199,6 +199,42 @@ func TestSeed_RemovesAPartialFileWhenADownloadFails(t *testing.T) {
 		"a failed download must not leave a partial file a retry mistakes for a real project")
 }
 
+// A pull that fails partway must not leave the files that already landed on
+// disk: a subset holding a root marker would make the next run skip seeding and
+// build from an incomplete tree. The directory is reverted to what it held
+// before, so a retry pulls the whole set again.
+func TestSeed_RevertsAPartialPullOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".drignore"), []byte("__pycache__\n"), 0o644))
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		return artifactWithCode("cat-1", "ver-1"), nil
+	})
+	stubFiles(t, &fakeFiles{
+		files: map[string]filesapi.FileMeta{
+			"pyproject.toml": {},
+			"src/app.py":     {},
+		},
+		content: map[string]string{
+			"pyproject.toml": "[project]\nname = \"x\"\n",
+			"src/app.py":     "print('hi')\n",
+		},
+		failPaths: map[string]bool{"src/app.py": true},
+	})
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.Error(t, err)
+
+	// The marker that may have arrived before the failure is gone, and so is
+	// the directory the failed file lived under; only the pre-existing residue
+	// is left, so the next run sees an empty directory and pulls again.
+	assert.NoFileExists(t, filepath.Join(dir, "pyproject.toml"))
+	assert.NoDirExists(t, filepath.Join(dir, "src"))
+	assert.FileExists(t, filepath.Join(dir, ".drignore"), "pre-existing residue is left in place")
+}
+
 // A download whose bytes do not match the catalog's recorded size is a silent
 // truncation the writer did not report; it fails and leaves nothing behind.
 func TestSeed_RejectsASizeMismatch(t *testing.T) {

--- a/internal/workload/up/seed_test.go
+++ b/internal/workload/up/seed_test.go
@@ -1,0 +1,257 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package up
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/datarobot/cli/internal/drapi/filesapi"
+	"github.com/datarobot/cli/internal/workload"
+	"github.com/datarobot/cli/internal/workload/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A bound, source-built workload. workloadId makes it a bind rather than a
+// create, and source: generated makes it a build-from-code the pull applies to.
+const boundGeneratedManifest = `name: my-app
+workloadId: wl-1
+importance: low
+artifact:
+  name: my-app-artifact
+  spec:
+    type: service
+    containerGroups:
+      - name: default
+        containers:
+          - name: primary
+            primary: true
+            port: 8080
+            imageBuildConfig:
+              dockerfile:
+                source: generated
+                executionEnvironmentId: ee-1
+              entrypoint: ["uvicorn", "app:app"]
+runtime:
+  containerGroups:
+    - name: default
+      replicaCount: 1
+      containers:
+        - name: primary
+          resourceAllocation: {cpu: 0.5, memory: 512MB}
+`
+
+// fakeFiles serves a fixed file set. Only the two methods seed uses are
+// implemented; the embedded interface satisfies the rest and panics if the
+// code under test reaches for one, which would be a test worth failing.
+type fakeFiles struct {
+	filesapi.Client
+	files   map[string]filesapi.FileMeta
+	content map[string]string
+	pulled  []string
+}
+
+func (f *fakeFiles) AllFiles(string, string) (map[string]filesapi.FileMeta, error) {
+	return f.files, nil
+}
+
+func (f *fakeFiles) DownloadFile(_, _, path string, w io.Writer) (string, int64, error) {
+	f.pulled = append(f.pulled, path)
+
+	n, _ := io.WriteString(w, f.content[path])
+
+	return "", int64(n), nil
+}
+
+// loadedFrom builds a Loaded over dir from a manifest string.
+func loadedForSeed(t *testing.T, dir, manifestYAML string) Loaded {
+	t.Helper()
+
+	m, err := manifest.Parse([]byte(manifestYAML), dir)
+	require.NoError(t, err)
+
+	return Loaded{Path: filepath.Join(dir, manifest.FileName), ProjectDir: dir, Manifest: m}
+}
+
+// artifactWithCode is an artifact whose primary container is built from a code
+// catalog, which is what ExtractCodeRef reads.
+func artifactWithCode(catalog, version string) *workload.Artifact {
+	primary := true
+
+	return &workload.Artifact{
+		ID: "art-1",
+		Spec: workload.Spec{
+			ContainerGroups: []workload.ContainerGroup{{
+				Containers: []workload.Container{{
+					Primary: &primary,
+					ImageBuildConfig: &workload.ImageBuildConfig{
+						CodeRef: &workload.CodeRef{
+							Datarobot: &workload.DatarobotCodeRef{
+								CatalogID:        catalog,
+								CatalogVersionID: version,
+							},
+						},
+					},
+				}},
+			}},
+		},
+	}
+}
+
+// stubFiles installs a fake files client for the test's lifetime.
+func stubFiles(t *testing.T, fake *fakeFiles) {
+	t.Helper()
+
+	force(t, &filesClientFn, func() filesapi.Client { return fake })
+}
+
+// A bind into an empty directory pulls the workload's current code, so the
+// deploy that follows builds from the real thing instead of an empty tree. The
+// .drignore already sitting there (an earlier run wrote it) does not count as
+// content.
+func TestSeed_PullsCodeIntoAnEmptyBoundProject(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".drignore"), []byte("__pycache__\n"), 0o644))
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		return artifactWithCode("cat-1", "ver-1"), nil
+	})
+	stubFiles(t, &fakeFiles{
+		files: map[string]filesapi.FileMeta{
+			"app.py":         {},
+			"pyproject.toml": {},
+			".drignore":      {},
+		},
+		content: map[string]string{
+			"app.py":         "print('hi')\n",
+			"pyproject.toml": "[project]\nname = \"x\"\n",
+			".drignore":      "__pycache__\n",
+		},
+	})
+
+	var stderr bytes.Buffer
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: &stderr})
+	require.NoError(t, err)
+
+	assert.FileExists(t, filepath.Join(dir, "app.py"))
+	assert.FileExists(t, filepath.Join(dir, "pyproject.toml"))
+	assert.Contains(t, stderr.String(), "Pulled 3 file(s)")
+
+	got, err := os.ReadFile(filepath.Join(dir, "app.py"))
+	require.NoError(t, err)
+	assert.Equal(t, "print('hi')\n", string(got))
+}
+
+// A directory with files but no recognised project, not linked to the
+// workload, is refused rather than rolled: deploying it would replace the
+// workload's code with whatever this is.
+func TestSeed_RefusesANonEmptyUnlinkedDir(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("scratch"), 0o644))
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		return artifactWithCode("cat-1", "ver-1"), nil
+	})
+
+	fake := &fakeFiles{files: map[string]filesapi.FileMeta{"app.py": {}}}
+	stubFiles(t, fake)
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to deploy")
+	assert.Empty(t, fake.pulled, "nothing is downloaded when the run is refused")
+}
+
+// A directory that already looks like a project is the normal case: the user
+// has the code, and nothing is pulled over it.
+func TestSeed_SkipsWhenTheDirIsAlreadyAProject(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte("[project]\n"), 0o644))
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		return artifactWithCode("cat-1", "ver-1"), nil
+	})
+
+	fake := &fakeFiles{files: map[string]filesapi.FileMeta{"app.py": {}}}
+	stubFiles(t, fake)
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.NoError(t, err)
+	assert.Empty(t, fake.pulled, "a real project is deployed as-is, not overwritten")
+}
+
+// A published-image workload has no code catalog, so the artifact is never even
+// read for one.
+func TestSeed_SkipsAPublishedImageWorkload(t *testing.T) {
+	dir := t.TempDir()
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		t.Fatal("a published-image workload has no code to read")
+
+		return nil, nil
+	})
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, unboundImageManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.NoError(t, err)
+}
+
+// An artifact carrying only the ignore file has no code to pull, so an empty
+// directory is left empty and the build guard elsewhere speaks to it.
+func TestSeed_SkipsWhenTheArtifactHasNoRealCode(t *testing.T) {
+	dir := t.TempDir()
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		return artifactWithCode("cat-1", "ver-1"), nil
+	})
+
+	fake := &fakeFiles{files: map[string]filesapi.FileMeta{".drignore": {}}}
+	stubFiles(t, fake)
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.NoError(t, err)
+	assert.Empty(t, fake.pulled)
+}
+
+// A project already linked here is past first-bind; its incremental sync knows
+// its own base, and seeding would be wrong.
+func TestSeed_SkipsAnAlreadyLinkedProject(t *testing.T) {
+	dir := t.TempDir()
+
+	force(t, &projectLinkedFn, func(string) bool { return true })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		t.Fatal("a linked project is not re-seeded")
+
+		return nil, nil
+	})
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.NoError(t, err)
+}

--- a/internal/workload/up/seed_test.go
+++ b/internal/workload/up/seed_test.go
@@ -16,6 +16,7 @@ package up
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -62,9 +63,10 @@ runtime:
 // code under test reaches for one, which would be a test worth failing.
 type fakeFiles struct {
 	filesapi.Client
-	files   map[string]filesapi.FileMeta
-	content map[string]string
-	pulled  []string
+	files     map[string]filesapi.FileMeta
+	content   map[string]string
+	pulled    []string
+	failPaths map[string]bool
 }
 
 func (f *fakeFiles) AllFiles(string, string) (map[string]filesapi.FileMeta, error) {
@@ -74,7 +76,13 @@ func (f *fakeFiles) AllFiles(string, string) (map[string]filesapi.FileMeta, erro
 func (f *fakeFiles) DownloadFile(_, _, path string, w io.Writer) (string, int64, error) {
 	f.pulled = append(f.pulled, path)
 
+	// The bytes are written before the failure so the test exercises the
+	// partial-file-on-disk path, not a create that never wrote anything.
 	n, _ := io.WriteString(w, f.content[path])
+
+	if f.failPaths[path] {
+		return "", int64(n), errors.New("connection reset mid-stream")
+	}
 
 	return "", int64(n), nil
 }
@@ -159,6 +167,94 @@ func TestSeed_PullsCodeIntoAnEmptyBoundProject(t *testing.T) {
 	got, err := os.ReadFile(filepath.Join(dir, "app.py"))
 	require.NoError(t, err)
 	assert.Equal(t, "print('hi')\n", string(got))
+}
+
+// A download that fails mid-stream must not leave the partial file behind: on
+// a retry a truncated root marker would make the directory look like a real
+// project, seeding would be skipped, and the deploy would build from the
+// corrupt tree.
+func TestSeed_RemovesAPartialFileWhenADownloadFails(t *testing.T) {
+	dir := t.TempDir()
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		return artifactWithCode("cat-1", "ver-1"), nil
+	})
+	stubFiles(t, &fakeFiles{
+		files:     map[string]filesapi.FileMeta{"pyproject.toml": {}},
+		content:   map[string]string{"pyproject.toml": "[project]\nname = \"x\"\n"},
+		failPaths: map[string]bool{"pyproject.toml": true},
+	})
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.Error(t, err)
+	assert.NoFileExists(t, filepath.Join(dir, "pyproject.toml"),
+		"a failed download must not leave a partial file a retry mistakes for a real project")
+}
+
+// A download whose bytes do not match the catalog's recorded size is a silent
+// truncation the writer did not report; it fails and leaves nothing behind.
+func TestSeed_RejectsASizeMismatch(t *testing.T) {
+	dir := t.TempDir()
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		return artifactWithCode("cat-1", "ver-1"), nil
+	})
+	stubFiles(t, &fakeFiles{
+		files:   map[string]filesapi.FileMeta{"app.py": {Size: 999}},
+		content: map[string]string{"app.py": "print('hi')\n"},
+	})
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected 999")
+	assert.NoFileExists(t, filepath.Join(dir, "app.py"))
+}
+
+// Two catalog keys that differ only by case collapse to one file on a
+// case-insensitive filesystem, so the pull is refused before any file is
+// written rather than silently dropping one.
+func TestSeed_RefusesCaseCollidingCode(t *testing.T) {
+	dir := t.TempDir()
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		return artifactWithCode("cat-1", "ver-1"), nil
+	})
+
+	fake := &fakeFiles{files: map[string]filesapi.FileMeta{"App.py": {}, "app.py": {}}}
+	stubFiles(t, fake)
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "case-only path collisions")
+	assert.Empty(t, fake.pulled, "nothing is downloaded when the code cannot be laid down safely")
+}
+
+// A recognised-but-unlinked project needs no seeding, and must not be blocked
+// by a files-API call it never needed: the live artifact is not read at all.
+func TestSeed_DoesNotReadTheArtifactForARecognisedProject(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte("[project]\n"), 0o644))
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		t.Fatal("a recognised project needs no pull, so its code is never read")
+
+		return nil, nil
+	})
+
+	fake := &fakeFiles{}
+	stubFiles(t, fake)
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.NoError(t, err)
+	assert.Empty(t, fake.pulled)
 }
 
 // A directory with files but no recognised project, not linked to the

--- a/internal/workload/up/seed_test.go
+++ b/internal/workload/up/seed_test.go
@@ -302,6 +302,54 @@ func TestSeed_DoesNotReadTheArtifactForARecognisedProject(t *testing.T) {
 // A directory with files but no recognised project, not linked to the
 // workload, is refused rather than rolled: deploying it would replace the
 // workload's code with whatever this is.
+// A directory whose only residue is the workload state config wrote
+// (.datarobot/workload) counts as empty and is pulled into. That state is this
+// command's own; nothing else is there to preserve.
+func TestSeed_PullsWhenOnlyWorkloadStateIsPresent(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".datarobot", "workload"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".datarobot", "workload", "config.json"), []byte("{}"), 0o644))
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		return artifactWithCode("cat-1", "ver-1"), nil
+	})
+	stubFiles(t, &fakeFiles{
+		files:   map[string]filesapi.FileMeta{"app.py": {}},
+		content: map[string]string{"app.py": "print('hi')\n"},
+	})
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(dir, "app.py"))
+}
+
+// Sibling state under .datarobot that is not the workload state — .datarobot/cli
+// tool state, which the sync uploads — means the directory is not empty: it is
+// refused rather than pulled over, and nothing is downloaded.
+func TestSeed_RefusesWhenDatarobotHoldsNonWorkloadState(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".datarobot", "cli"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, ".datarobot", "cli", "state.yaml"), []byte("k: v\n"), 0o644))
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		return artifactWithCode("cat-1", "ver-1"), nil
+	})
+
+	fake := &fakeFiles{files: map[string]filesapi.FileMeta{"app.py": {}}}
+	stubFiles(t, fake)
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to deploy")
+	assert.Empty(t, fake.pulled, "nothing is downloaded when the run is refused")
+}
+
 func TestSeed_RefusesANonEmptyUnlinkedDir(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("scratch"), 0o644))

--- a/internal/workload/up/seed_test.go
+++ b/internal/workload/up/seed_test.go
@@ -302,14 +302,34 @@ func TestSeed_DoesNotReadTheArtifactForARecognisedProject(t *testing.T) {
 // A directory with files but no recognised project, not linked to the
 // workload, is refused rather than rolled: deploying it would replace the
 // workload's code with whatever this is.
-// A directory whose only residue is the workload state config wrote
-// (.datarobot/workload) counts as empty and is pulled into. That state is this
-// command's own; nothing else is there to preserve.
-func TestSeed_PullsWhenOnlyWorkloadStateIsPresent(t *testing.T) {
+// A directory that already holds workload sync state (.datarobot/workload) is
+// linked, so the real projectLinkedFn (wapi.Exists) makes seedApplies skip it —
+// the sync engine owns a linked project's base. projectLinkedFn is left
+// unstubbed here so the check runs against the directory on disk, not a stub.
+func TestSeed_SkipsWhenWorkloadStateExistsOnDisk(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".datarobot", "workload"), 0o755))
-	require.NoError(t, os.WriteFile(
-		filepath.Join(dir, ".datarobot", "workload", "config.json"), []byte("{}"), 0o644))
+
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		t.Fatal("a linked project is not seeded, so its artifact is never read")
+
+		return nil, nil
+	})
+
+	fake := &fakeFiles{}
+	stubFiles(t, fake)
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.NoError(t, err)
+	assert.Empty(t, fake.pulled, "a linked project is left to the sync engine")
+}
+
+// A directory whose only residue is a pre-rename .wapiignore is as empty as one
+// with a .drignore, so it is pulled into rather than wrongly refused.
+func TestSeed_PullsWhenOnlyLegacyIgnoreIsPresent(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".wapiignore"), []byte("__pycache__\n"), 0o644))
 
 	force(t, &projectLinkedFn, func(string) bool { return false })
 	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
@@ -324,6 +344,57 @@ func TestSeed_PullsWhenOnlyWorkloadStateIsPresent(t *testing.T) {
 		Options{Stderr: io.Discard})
 	require.NoError(t, err)
 	assert.FileExists(t, filepath.Join(dir, "app.py"))
+}
+
+// .datarobot/ tool state that leaked into the catalog is never written locally,
+// so seeding cannot leave a .datarobot the next `up` would refuse. Real code
+// alongside it is still pulled.
+func TestSeed_DoesNotPullDatarobotToolStateFromCatalog(t *testing.T) {
+	dir := t.TempDir()
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		return artifactWithCode("cat-1", "ver-1"), nil
+	})
+	stubFiles(t, &fakeFiles{
+		files: map[string]filesapi.FileMeta{
+			"app.py":                    {},
+			".datarobot/cli/state.yaml": {},
+		},
+		content: map[string]string{
+			"app.py":                    "print('hi')\n",
+			".datarobot/cli/state.yaml": "k: v\n",
+		},
+	})
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(dir, "app.py"))
+	assert.NoDirExists(t, filepath.Join(dir, ".datarobot", "cli"),
+		"tool state from the catalog must not be seeded into the fresh directory")
+}
+
+// A catalog carrying nothing but CLI residue — the ignore file and .datarobot/
+// tool state — has no code worth pulling, so an empty directory is left empty.
+func TestSeed_SkipsWhenCatalogIsOnlyCLIResidue(t *testing.T) {
+	dir := t.TempDir()
+
+	force(t, &projectLinkedFn, func(string) bool { return false })
+	force(t, &getArtifactFn, func(string) (*workload.Artifact, error) {
+		return artifactWithCode("cat-1", "ver-1"), nil
+	})
+
+	fake := &fakeFiles{files: map[string]filesapi.FileMeta{
+		".drignore":                 {},
+		".datarobot/cli/state.yaml": {},
+	}}
+	stubFiles(t, fake)
+
+	err := seedFromLiveArtifact(loadedForSeed(t, dir, boundGeneratedManifest), Live{ArtifactID: "art-1"},
+		Options{Stderr: io.Discard})
+	require.NoError(t, err)
+	assert.Empty(t, fake.pulled, "a catalog of only residue has no real code to pull")
 }
 
 // Sibling state under .datarobot that is not the workload state — .datarobot/cli

--- a/internal/workload/up/seed_test.go
+++ b/internal/workload/up/seed_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/datarobot/cli/internal/drapi/filesapi"
@@ -65,8 +66,11 @@ type fakeFiles struct {
 	filesapi.Client
 	files     map[string]filesapi.FileMeta
 	content   map[string]string
-	pulled    []string
 	failPaths map[string]bool
+
+	// The reused sync downloader pulls in parallel, so pulled is guarded.
+	mu     sync.Mutex
+	pulled []string
 }
 
 func (f *fakeFiles) AllFiles(string, string) (map[string]filesapi.FileMeta, error) {
@@ -74,7 +78,9 @@ func (f *fakeFiles) AllFiles(string, string) (map[string]filesapi.FileMeta, erro
 }
 
 func (f *fakeFiles) DownloadFile(_, _, path string, w io.Writer) (string, int64, error) {
+	f.mu.Lock()
 	f.pulled = append(f.pulled, path)
+	f.mu.Unlock()
 
 	// The bytes are written before the failure so the test exercises the
 	// partial-file-on-disk path, not a create that never wrote anything.


### PR DESCRIPTION
# RATIONALE

Binding to an existing source-built workload has no download step. `dr workload config` writes the live spec into `.datarobot.yaml`, but never the *code* the artifact was built from — so `dr workload up` from a directory that doesn't already hold that code rolls a new version from whatever *is* there. An empty directory becomes an empty artifact that fails the build with "cannot detect project runtime", minutes in and after the workload has already been started. Found live (RAPTOR-19755): a deploy synced a single `.drignore` and 422'd at build time.

Ticket: [RAPTOR-19755](https://datarobot.atlassian.net/browse/RAPTOR-19755)

## CHANGES

- On a version-minting `up` (a roll, or a create from source — `plan.MintsVersion()`), and only then, `up` looks at the project directory before it reads the working tree:
  - **Empty directory** bound to a workload whose current artifact has code → **pull that code down** into the directory, so the deploy builds from the real thing instead of an empty tree.
  - **Already looks like a project** (has recognised markers) → untouched; the deploy reads it as it always has.
  - **Files, but no recognised project and not linked** → **refused**, naming the fix, rather than allowed to overwrite the workload's code with whatever is there.
- Retune, start-only, and unchanged runs never reach this — they don't push the tree, so they don't read the live artifact or touch the directory.
- Reuses the existing `filesapi` download + `ExtractCodeRef`; no new API surface.

## Scope / follow-up

Pull-only for now. After a pull, the immediately-following deploy rebuilds an identical version once (the working tree matches what's already running). Seeding the sync base to skip that redundant rebuild is a deliberate follow-up — it means reaching into the sync engine's three-way state, which is not worth perturbing in the same change. Not done here: an `up`-level integration test that drives a full source *roll* — the roll fixtures are all published-image based, and the seed logic itself is covered by six unit tests over the decision tree, with the `MintsVersion` gate proven by the existing roll/retune suite passing unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core `up` apply path and writes to the project directory from remote code before deploy; mistakes could block deploys or pull the wrong tree, though scope is narrow and failures happen before workload mutation.
> 
> **Overview**
> Fixes **RAPTOR-19755**: binding with `dr workload config` only writes the manifest, so `dr workload up` from an empty or wrong directory could mint a version from that tree and fail late (or overwrite live code).
> 
> On **version-minting** runs only (`plan.MintsVersion()`), `apply` now calls **`seedIfMinting`** before starts, rolls, or other mutations. For **source-built**, **bound**, **unlinked** projects it resolves the live artifact’s code catalog via existing `filesapi` / `ExtractCodeRef`, then either **downloads** into a directory that looks empty (CLI residue like `.datarobot.yaml` / `.drignore` still counts as empty), **leaves** a directory that already looks like a real project, or **refuses** with a clear error when unrelated files would replace the workload’s code. Retune, start-only, published-image, linked, and artifact-without-code cases are no-ops.
> 
> Adds **`seed.go`** and six unit tests over that decision tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60374aac3e4bfa5b1d1739dbe8b4f6d359a7318d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->