### PR TITLE
[RAPTOR-19762] feat(workload): highlight the selected picker row with a yellow bar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/jeandeaual/go-locale v0.0.0-20250612000132-0ef82f21eade
 	github.com/joho/godotenv v1.5.1
 	github.com/muesli/cancelreader v0.2.2
+	github.com/muesli/termenv v0.16.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.10.2
@@ -69,7 +70,6 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.4.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect

--- a/internal/telemetry/properties.go
+++ b/internal/telemetry/properties.go
@@ -15,7 +15,6 @@
 package telemetry
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"runtime"
@@ -98,7 +97,7 @@ func CollectCommonProperties() *CommonProperties {
 	}
 
 	// Retrieve account info (includes userID, orgID, tenantID)
-	result, err := retrieveAccountInfo(context.Background())
+	result, err := retrieveAccountInfo()
 	if err == nil {
 		props.UserID = &result.UID
 

--- a/internal/telemetry/userid.go
+++ b/internal/telemetry/userid.go
@@ -15,7 +15,6 @@
 package telemetry
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -84,7 +83,7 @@ type accountInfoResult struct {
 // GetAccountInfo fetches the DataRobot account info from GET /api/v2/account/info/.
 // It returns the full AccountInfo on success, or (*AccountInfo, error) on non-200 status,
 // empty uid, or network failure.
-func GetAccountInfo(_ context.Context) (*AccountInfo, error) {
+func GetAccountInfo() (*AccountInfo, error) {
 	url, err := config.GetEndpointURL("/api/v2/account/info/")
 	if err != nil {
 		return nil, err
@@ -92,7 +91,7 @@ func GetAccountInfo(_ context.Context) (*AccountInfo, error) {
 
 	var info AccountInfo
 
-	if err := drapi.GetJSON(url, "", &info); err != nil { //nolint:contextcheck // GetJSON does not yet accept context; ctx is reserved for future use
+	if err := drapi.GetJSON(url, "", &info); err != nil {
 		return nil, err
 	}
 
@@ -103,13 +102,13 @@ func GetAccountInfo(_ context.Context) (*AccountInfo, error) {
 	return &info, nil
 }
 
-func retrieveAccountInfo(ctx context.Context) (accountInfoResult, error) {
+func retrieveAccountInfo() (accountInfoResult, error) {
 	cached, hasMatchingCache := loadMatchingCache()
 	if hasMatchingCache && cached.isComplete() {
 		return cached.toResult(), nil
 	}
 
-	info, err := GetAccountInfo(ctx)
+	info, err := GetAccountInfo()
 	if err != nil {
 		log.Debugf("Failed to retrieve account info: %v", err)
 

--- a/internal/telemetry/userid_test.go
+++ b/internal/telemetry/userid_test.go
@@ -15,7 +15,6 @@
 package telemetry
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -58,7 +57,7 @@ func TestRetrieveAccountInfo_FreshAPI(t *testing.T) {
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 	viperx.Set(config.DataRobotAPIKey, "test-token")
 
-	result, err := retrieveAccountInfo(context.Background())
+	result, err := retrieveAccountInfo()
 
 	require.NoError(t, err)
 	assert.Equal(t, "fresh-uid", result.UID)
@@ -100,7 +99,7 @@ func TestRetrieveAccountInfo_FilePermissions(t *testing.T) {
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 	viperx.Set(config.DataRobotAPIKey, "test-token")
 
-	_, _ = retrieveAccountInfo(context.Background())
+	_, _ = retrieveAccountInfo()
 
 	cachePath := filepath.Join(tmpDir, "datarobot", userIDFileName)
 	info, err := os.Stat(cachePath)
@@ -146,7 +145,7 @@ func TestRetrieveAccountInfo_CacheHit(t *testing.T) {
 
 	require.NoError(t, err)
 
-	result, err := retrieveAccountInfo(context.Background())
+	result, err := retrieveAccountInfo()
 
 	require.NoError(t, err)
 	assert.Equal(t, "cached-uid-123", result.UID)
@@ -191,7 +190,7 @@ func TestRetrieveAccountInfo_CacheMiss_EndpointChanged(t *testing.T) {
 
 	require.NoError(t, err)
 
-	result, err := retrieveAccountInfo(context.Background())
+	result, err := retrieveAccountInfo()
 
 	require.NoError(t, err)
 	assert.Equal(t, "new-uid-456", result.UID)
@@ -236,7 +235,7 @@ func TestRetrieveAccountInfo_CacheMiss_TokenChanged(t *testing.T) {
 
 	require.NoError(t, err)
 
-	result, err := retrieveAccountInfo(context.Background())
+	result, err := retrieveAccountInfo()
 
 	require.NoError(t, err)
 	assert.Equal(t, "new-uid-789", result.UID)
@@ -260,7 +259,7 @@ func TestRetrieveAccountInfo_CacheMiss_NoFile(t *testing.T) {
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 
-	result, err := retrieveAccountInfo(context.Background())
+	result, err := retrieveAccountInfo()
 
 	require.NoError(t, err)
 	assert.Equal(t, "api-uid-000", result.UID)
@@ -294,7 +293,7 @@ func TestRetrieveAccountInfo_CacheMiss_CorruptJSON(t *testing.T) {
 
 	require.NoError(t, err)
 
-	result, err := retrieveAccountInfo(context.Background())
+	result, err := retrieveAccountInfo()
 
 	require.NoError(t, err)
 	assert.Equal(t, "recovery-uid", result.UID)
@@ -340,7 +339,7 @@ func TestRetrieveAccountInfo_TokenChange_UpdatesCache(t *testing.T) {
 
 	require.NoError(t, err)
 
-	result, err := retrieveAccountInfo(context.Background())
+	result, err := retrieveAccountInfo()
 
 	require.NoError(t, err)
 	assert.Equal(t, "new-token-uid", result.UID)
@@ -378,7 +377,7 @@ func TestRetrieveAccountInfo_APIFailureReturnsError(t *testing.T) {
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 
-	result, err := retrieveAccountInfo(context.Background())
+	result, err := retrieveAccountInfo()
 
 	require.Error(t, err)
 	assert.Empty(t, result.UID)
@@ -399,7 +398,7 @@ func TestGetAccountInfo_Success(t *testing.T) {
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 
-	info, err := GetAccountInfo(context.Background())
+	info, err := GetAccountInfo()
 	require.NoError(t, err)
 	assert.Equal(t, "account-uid-123", info.UID)
 	assert.Equal(t, "parakeet", info.OrgID)
@@ -418,7 +417,7 @@ func TestGetAccountInfo_Unauthorized(t *testing.T) {
 
 	viperx.Set(config.DataRobotURL, server.URL+"/api/v2")
 
-	info, err := GetAccountInfo(context.Background())
+	info, err := GetAccountInfo()
 	require.Error(t, err)
 	assert.Nil(t, info)
 }
@@ -462,7 +461,7 @@ func TestRetrieveAccountInfo_PartialCache_RefetchesAndUpgrades(t *testing.T) {
 
 	require.NoError(t, err)
 
-	result, err := retrieveAccountInfo(context.Background())
+	result, err := retrieveAccountInfo()
 
 	require.NoError(t, err)
 	assert.Equal(t, "cached-uid-123", result.UID)
@@ -529,7 +528,7 @@ func TestRetrieveAccountInfo_PartialCache_NetworkErrorReturnsUID(t *testing.T) {
 	require.NoError(t, err)
 
 	// Call should succeed and return the cached UID even though the API call fails.
-	result, err := retrieveAccountInfo(context.Background())
+	result, err := retrieveAccountInfo()
 
 	require.NoError(t, err)
 	assert.Equal(t, "cached-uid-123", result.UID)
@@ -583,7 +582,7 @@ func TestRetrieveAccountInfo_CompleteCache_NetworkErrorReturnsAllCachedFields(t 
 	require.NoError(t, err)
 
 	// Call should succeed and return all cached fields despite API call failure.
-	result, err := retrieveAccountInfo(context.Background())
+	result, err := retrieveAccountInfo()
 
 	require.NoError(t, err)
 	assert.Equal(t, "cached-uid-456", result.UID)
@@ -633,7 +632,7 @@ func TestRetrieveAccountInfo_StaleCache_NetworkErrorReturnsError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Call should fail because the stale cache does not match endpoint/token.
-	result, err := retrieveAccountInfo(context.Background())
+	result, err := retrieveAccountInfo()
 
 	require.Error(t, err)
 	assert.Empty(t, result.UID)

--- a/internal/workload/wizard/choice.go
+++ b/internal/workload/wizard/choice.go
@@ -126,7 +126,9 @@ func (c choice) view() string {
 		line := fmt.Sprintf("%d. %s", i+1, opt.label)
 
 		if i == c.selected {
-			b.WriteString(selectedStyle.Render("> " + line))
+			// The same cursor glyph the pickers use (table.go syncRows), so a
+			// selection reads the same across menus and lists.
+			b.WriteString(selectedStyle.Render("❯ " + line))
 		} else {
 			b.WriteString("  " + line)
 		}

--- a/internal/workload/wizard/choice.go
+++ b/internal/workload/wizard/choice.go
@@ -126,7 +126,7 @@ func (c choice) view() string {
 		line := fmt.Sprintf("%d. %s", i+1, opt.label)
 
 		if i == c.selected {
-			b.WriteString(tui.InfoStyle.Render("> " + line))
+			b.WriteString(selectedStyle.Render("> " + line))
 		} else {
 			b.WriteString("  " + line)
 		}
@@ -140,6 +140,9 @@ func (c choice) view() string {
 			b.WriteString(style.Render("   " + opt.note))
 		}
 
+		// A trailing green tag on the right, its own colour whatever the option
+		// is doing: green means "from the running workload" throughout the
+		// wizard's notes, and the tag is one more live-derived value.
 		if c.liveValue != "" && opt.value == c.liveValue {
 			b.WriteString(liveStyle.Render("   · in use"))
 		}

--- a/internal/workload/wizard/execenv_picker_test.go
+++ b/internal/workload/wizard/execenv_picker_test.go
@@ -15,9 +15,12 @@
 package wizard
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/datarobot/cli/internal/workload"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -65,10 +68,48 @@ func TestExecEnvPicker_TagsAndLiftsTheInUseEnvironment(t *testing.T) {
 
 	require.Len(t, picker.all, 2)
 	// Tagged and first; the tag rides on the last (ID) cell so it trails on the
-	// right. liveStyle.Render is plain text in a test's no-colour profile.
-	assert.Equal(t, []string{"Node", "javascript", "ee-2" + liveStyle.Render(inUseSuffix)}, picker.all[0].cells,
+	// right. It is plain text, not styled, because the cell flows through
+	// bubbles/table's ANSI-unaware column sizing and truncation.
+	assert.Equal(t, []string{"Node", "javascript", "ee-2" + inUseSuffix}, picker.all[0].cells,
 		"the in-use environment is tagged on the right and lifted first")
 	assert.Equal(t, []string{"Py 3.12", "python", "ee-1"}, picker.all[1].cells)
+}
+
+// The in-use tag rides a table cell, and bubbles/table sizes columns and
+// truncates cells with no awareness of ANSI: a styled tag would inflate the
+// measured width and, on a narrow terminal, be cut mid-escape, bleeding colour
+// across the row. So the cells must stay plain text even under a real colour
+// profile. The other picker tests run in the no-colour profile, where a stray
+// style renders as plain text and a regression would hide; this one forces
+// TrueColor so it cannot.
+func TestExecEnvPicker_InUseTagCarriesNoAnsiUnderColour(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	picker := newExecEnvPicker([]workload.ExecutionEnvironment{
+		{
+			ID: "ee-1", Name: "Py 3.12", ProgrammingLanguage: "python",
+			LatestSuccessfulVersion: &workload.EEVersion{ID: "v1"},
+		},
+		{
+			ID: "ee-2", Name: "Node", ProgrammingLanguage: "javascript",
+			LatestSuccessfulVersion: &workload.EEVersion{ID: "v2"},
+		},
+	}, "ee-2", 80, 40)
+
+	for _, row := range picker.all {
+		for _, cell := range row.cells {
+			assert.NotContains(t, cell, "\x1b", "picker cells must stay plain text, got %q", cell)
+		}
+	}
+
+	// The escape check is only meaningful if styling would otherwise emit one:
+	// prove the forced profile is live by rendering the tag's own style.
+	require.Contains(t, liveStyle.Render(inUseSuffix), "\x1b",
+		"the test must run under a colour profile for the assertion above to have teeth")
+	require.NotEmpty(t, strings.TrimSpace(inUseSuffix))
 }
 
 // A fresh setup has no bound workload, so nothing is tagged and the order is

--- a/internal/workload/wizard/execenv_picker_test.go
+++ b/internal/workload/wizard/execenv_picker_test.go
@@ -25,6 +25,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// forceColor makes lipgloss styles emit ANSI in a test that otherwise runs
+// under the no-colour profile, then restores the previous profile.
+//
+// It sets the profile on the default renderer in place rather than swapping the
+// renderer (the CLICOLOR_FORCE + SetDefaultRenderer trick): lipgloss pins each
+// style to the renderer that was default when NewStyle ran (Style{r: r}), so
+// the package-level styles here are bound to the default renderer built at init.
+// Only mutating that renderer's profile reaches them; replacing the global
+// default leaves them on the old renderer, whose profile earlier tests have
+// already cached as Ascii. Naming the profile needs termenv, hence the import.
+func forceColor(t *testing.T) {
+	t.Helper()
+
+	prev := lipgloss.ColorProfile()
+
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+}
+
 func TestExecEnvPicker_ShowsTheLanguageColumn(t *testing.T) {
 	picker := newExecEnvPicker([]workload.ExecutionEnvironment{
 		{
@@ -83,10 +102,7 @@ func TestExecEnvPicker_TagsAndLiftsTheInUseEnvironment(t *testing.T) {
 // style renders as plain text and a regression would hide; this one forces
 // TrueColor so it cannot.
 func TestExecEnvPicker_InUseTagCarriesNoAnsiUnderColour(t *testing.T) {
-	prev := lipgloss.ColorProfile()
-
-	lipgloss.SetColorProfile(termenv.TrueColor)
-	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+	forceColor(t)
 
 	picker := newExecEnvPicker([]workload.ExecutionEnvironment{
 		{

--- a/internal/workload/wizard/execenv_picker_test.go
+++ b/internal/workload/wizard/execenv_picker_test.go
@@ -36,7 +36,7 @@ func TestExecEnvPicker_ShowsTheLanguageColumn(t *testing.T) {
 			ID: "ee-3", Name: "R Lab", ProgrammingLanguage: "R",
 			LatestSuccessfulVersion: &workload.EEVersion{ID: "v3"},
 		},
-	}, 120, 40)
+	}, "", 120, 40)
 
 	require.Len(t, picker.all, 3)
 	assert.Equal(t, []string{"BASE IMAGE", "LANGUAGE", "ID"}, picker.headers)
@@ -46,4 +46,41 @@ func TestExecEnvPicker_ShowsTheLanguageColumn(t *testing.T) {
 	assert.Equal(t, []string{"Node", "—", "ee-2"}, picker.all[1].cells)
 	// The platform's own casing is kept: only the sort folds case.
 	assert.Equal(t, []string{"R Lab", "R", "ee-3"}, picker.all[2].cells)
+}
+
+// When bound to a workload, the environment it is built on is tagged "· in
+// use" and lifted to the top, so the long list opens on the option most
+// likely to be kept.
+func TestExecEnvPicker_TagsAndLiftsTheInUseEnvironment(t *testing.T) {
+	picker := newExecEnvPicker([]workload.ExecutionEnvironment{
+		{
+			ID: "ee-1", Name: "Py 3.12", ProgrammingLanguage: "python",
+			LatestSuccessfulVersion: &workload.EEVersion{ID: "v1"},
+		},
+		{
+			ID: "ee-2", Name: "Node", ProgrammingLanguage: "javascript",
+			LatestSuccessfulVersion: &workload.EEVersion{ID: "v2"},
+		},
+	}, "ee-2", 120, 40)
+
+	require.Len(t, picker.all, 2)
+	// Tagged and first; the tag rides on the last (ID) cell so it trails on the
+	// right. liveStyle.Render is plain text in a test's no-colour profile.
+	assert.Equal(t, []string{"Node", "javascript", "ee-2" + liveStyle.Render(inUseSuffix)}, picker.all[0].cells,
+		"the in-use environment is tagged on the right and lifted first")
+	assert.Equal(t, []string{"Py 3.12", "python", "ee-1"}, picker.all[1].cells)
+}
+
+// A fresh setup has no bound workload, so nothing is tagged and the order is
+// left as it came.
+func TestExecEnvPicker_TagsNothingWithoutABinding(t *testing.T) {
+	picker := newExecEnvPicker([]workload.ExecutionEnvironment{
+		{
+			ID: "ee-1", Name: "Py 3.12", ProgrammingLanguage: "python",
+			LatestSuccessfulVersion: &workload.EEVersion{ID: "v1"},
+		},
+	}, "", 120, 40)
+
+	require.Len(t, picker.all, 1)
+	assert.Equal(t, []string{"Py 3.12", "python", "ee-1"}, picker.all[0].cells)
 }

--- a/internal/workload/wizard/model.go
+++ b/internal/workload/wizard/model.go
@@ -1156,7 +1156,7 @@ func (f flow) execEnvsLoaded(msg execEnvsLoadedMsg) (tea.Model, tea.Cmd) {
 		f.failed = errors.New("no execution environments are available; go back and pick another image source")
 	default:
 		f.execEnvs = msg.environments
-		f.picker = newExecEnvPicker(msg.environments, f.width, f.height)
+		f.picker = newExecEnvPicker(msg.environments, f.liveExecEnvID(), f.width, f.height)
 	}
 
 	return f, nil

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -1205,14 +1205,15 @@ func newExecEnvPicker(environments []workload.ExecutionEnvironment, liveID strin
 		// the top: the list runs long, and the option most likely to be kept
 		// should not have to be scrolled for.
 		//
-		// The tag is green and on the last cell, matching the menus' live-value
-		// green and their trailing placement. Last is deliberate: a coloured
-		// cell resets colour where it ends, and only at the row's end does that
-		// reset land past everything, leaving the selection highlight on the
-		// rest of the row intact.
+		// The tag is plain text, not styled. It rides a table cell, and
+		// bubbles/table sizes columns and truncates cells by display width with
+		// no awareness of ANSI: a styled tag's escape bytes would inflate the
+		// column's measured width and, on a narrow terminal, be cut mid-escape,
+		// bleeding colour across the row. The green live-value tag stays on the
+		// menu screens, which render their own lines and never truncate.
 		if liveID != "" && ee.ID == liveID {
 			last := len(row.cells) - 1
-			row.cells[last] += liveStyle.Render(inUseSuffix)
+			row.cells[last] += inUseSuffix
 			inUse, haveInUse = row, true
 
 			continue

--- a/internal/workload/wizard/screens.go
+++ b/internal/workload/wizard/screens.go
@@ -183,7 +183,7 @@ func (f *flow) enterPicker(at screen) {
 		// the list again. On a first visit there is nothing yet, and emptying
 		// the shared table means a failed load cannot leave the previous
 		// screen's workload rows on display under a base-image heading.
-		f.picker = newExecEnvPicker(f.execEnvs, f.width, f.height)
+		f.picker = newExecEnvPicker(f.execEnvs, f.liveExecEnvID(), f.width, f.height)
 
 		if id := f.draft.Build.ExecutionEnvironmentID; id != "" {
 			f.picker.selectValue(func(v any) bool {
@@ -1175,8 +1175,17 @@ func newWorkloadPicker(workloads []workload.Workload, width, height int) rowTabl
 	return newRowTable([]string{"WORKLOAD", "STATUS", "UPDATED"}, rows, true, width, height)
 }
 
-func newExecEnvPicker(environments []workload.ExecutionEnvironment, width, height int) rowTable {
+// inUseSuffix tags the option a bound workload already uses, the same phrase
+// the menu screens append to their live option.
+const inUseSuffix = "  · in use"
+
+func newExecEnvPicker(environments []workload.ExecutionEnvironment, liveID string, width, height int) rowTable {
 	rows := make([]tableRow, 0, len(environments))
+
+	var (
+		inUse     tableRow
+		haveInUse bool
+	)
 
 	for _, ee := range environments {
 		// An environment with nothing built is not offered: picking it would
@@ -1187,13 +1196,46 @@ func newExecEnvPicker(environments []workload.ExecutionEnvironment, width, heigh
 			continue
 		}
 
-		rows = append(rows, tableRow{
+		row := tableRow{
 			cells: []string{ee.Name, languageLabel(ee.ProgrammingLanguage), ee.ID},
 			value: pickedEnv{id: ee.ID, versionID: ee.LatestSuccessfulVersion.ID},
-		})
+		}
+
+		// The one a bound workload is already built on is tagged and lifted to
+		// the top: the list runs long, and the option most likely to be kept
+		// should not have to be scrolled for.
+		//
+		// The tag is green and on the last cell, matching the menus' live-value
+		// green and their trailing placement. Last is deliberate: a coloured
+		// cell resets colour where it ends, and only at the row's end does that
+		// reset land past everything, leaving the selection highlight on the
+		// rest of the row intact.
+		if liveID != "" && ee.ID == liveID {
+			last := len(row.cells) - 1
+			row.cells[last] += liveStyle.Render(inUseSuffix)
+			inUse, haveInUse = row, true
+
+			continue
+		}
+
+		rows = append(rows, row)
+	}
+
+	if haveInUse {
+		rows = append([]tableRow{inUse}, rows...)
 	}
 
 	return newRowTable([]string{"BASE IMAGE", "LANGUAGE", "ID"}, rows, true, width, height)
+}
+
+// liveExecEnvID is the execution environment the bound workload is built on,
+// "" for a fresh setup. It marks the "in use" row in the base-image picker.
+func (f flow) liveExecEnvID() string {
+	if f.live == nil {
+		return ""
+	}
+
+	return f.live.Defaults().Build.ExecutionEnvironmentID
 }
 
 // languageLabel renders the language column: the platform's value as it came

--- a/internal/workload/wizard/style.go
+++ b/internal/workload/wizard/style.go
@@ -29,11 +29,15 @@ var (
 	// labelStyle names a field without competing with its value.
 	labelStyle = tui.HintStyle
 
-	// valueStyle is a value the user typed or accepted.
-	valueStyle = tui.BaseTextStyle
-
-	// selectedStyle marks the row or option under the cursor.
-	selectedStyle = tui.BaseTextStyle.Foreground(tui.TitleColor).Bold(true)
+	// selectedStyle marks whatever is under the cursor — a menu option, the
+	// advanced-options row, a picker row — in one yellow, so a selection reads
+	// the same wherever the wizard shows a list of things to choose between.
+	// The pickers show it only because their table cells are left uncoloured
+	// (see tableStyles): bubbles/table colours each cell before wrapping the
+	// row, and a coloured cell's reset codes would swallow this foreground.
+	selectedStyle = tui.BaseTextStyle.
+			Foreground(tui.GetAdaptiveColor(tui.DrYellow, tui.DrYellowDark)).
+			Bold(true)
 
 	// noteStyle is the sentence explaining the question. Italic so it reads as
 	// an aside rather than as another thing to answer.

--- a/internal/workload/wizard/style.go
+++ b/internal/workload/wizard/style.go
@@ -32,9 +32,13 @@ var (
 	// selectedStyle marks whatever is under the cursor — a menu option, the
 	// advanced-options row, a picker row — in one yellow, so a selection reads
 	// the same wherever the wizard shows a list of things to choose between.
-	// The pickers show it only because their table cells are left uncoloured
-	// (see tableStyles): bubbles/table colours each cell before wrapping the
-	// row, and a coloured cell's reset codes would swallow this foreground.
+	// Bold yellow foreground rather than the ticket's black-on-yellow bar: the
+	// filled bar was tried and read as heavy/ugly against the neutral rows, so
+	// the lighter yellow cue was kept. The pickers show it only because their
+	// table cells are left uncoloured (see tableStyles): bubbles/table colours
+	// each cell before wrapping the row, and a coloured cell's reset codes would
+	// swallow this foreground. The yellow adapts to the terminal background so
+	// the cue stays legible in both light and dark themes.
 	selectedStyle = tui.BaseTextStyle.
 			Foreground(tui.GetAdaptiveColor(tui.DrYellow, tui.DrYellowDark)).
 			Bold(true)

--- a/internal/workload/wizard/table.go
+++ b/internal/workload/wizard/table.go
@@ -152,10 +152,15 @@ func columnsFor(headers []string, rows []tableRow, width int) []table.Column {
 
 	columns[0].Width = 2
 
+	// Cells are measured by display width, not byte length: a multibyte name is
+	// as wide as it looks, not as wide as its UTF-8 encoding. This is also the
+	// width bubbles/table truncates against, so the two agree. Cells must stay
+	// plain text — an embedded ANSI escape would be counted here and cut
+	// mid-sequence by the table's truncation, which is not escape-aware.
 	for _, row := range rows {
 		for i, cell := range row.cells {
 			if i+1 < len(columns) {
-				columns[i+1].Width = max(columns[i+1].Width, min(len(cell), maxColumnWidth))
+				columns[i+1].Width = max(columns[i+1].Width, min(lipgloss.Width(cell), maxColumnWidth))
 			}
 		}
 	}

--- a/internal/workload/wizard/table.go
+++ b/internal/workload/wizard/table.go
@@ -121,10 +121,13 @@ func tableStyles() table.Styles {
 		BorderBottom(true).
 		Bold(true).
 		Padding(0, 1)
-	s.Cell = valueStyle.Padding(0, 1)
-	// No padding here: bubbles/table applies Selected to the whole row after
-	// the cells already carry theirs, so padding again shifts the highlighted
-	// row a column out of line with the rest.
+	// Cells carry no colour of their own. bubbles/table renders each cell and
+	// then wraps the cursor row in Selected; a cell that set its own foreground
+	// would emit a reset that swallows the selected row's colour, so the colour
+	// is left off here and the selected row is the only thing coloured.
+	s.Cell = lipgloss.NewStyle().Padding(0, 1)
+	// No padding on Selected: it wraps the already-padded row, so padding again
+	// would shift the highlighted row a column out of line with the rest.
 	s.Selected = selectedStyle
 
 	return s

--- a/internal/workload/wizard/table_test.go
+++ b/internal/workload/wizard/table_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -235,4 +236,22 @@ func TestColumnsFor_CapsAnOutlier(t *testing.T) {
 	assert.LessOrEqual(t, columns[1].Width, maxColumnWidth)
 	assert.Equal(t, len("67a554bbfef3a4ce2ab6700"), columns[2].Width,
 		"the id column keeps its natural width")
+}
+
+// columnsFor sizes by display width, not byte length. A cell carrying ANSI (as
+// a styled tag once did) or a multibyte name must be measured by what it shows,
+// not its raw bytes: bubbles/table truncates against display width and is not
+// escape-aware, so an over-measured column would let it cut a real escape
+// mid-sequence.
+func TestColumnsFor_SizesByDisplayWidthNotBytes(t *testing.T) {
+	plain := "ee-1  · in use"
+	styled := "\x1b[38;2;0;200;0m" + plain + "\x1b[0m"
+
+	columns := columnsFor([]string{"BASE IMAGE", "LANGUAGE", "ID"},
+		[]tableRow{{cells: []string{"Node", "javascript", styled}}}, 200)
+
+	id := columns[len(columns)-1]
+	assert.Equal(t, lipgloss.Width(plain), id.Width,
+		"the id column is sized to the visible width, not the escape-inflated byte length")
+	assert.Less(t, id.Width, len(styled), "byte length would have over-sized the column")
 }


### PR DESCRIPTION
# RATIONALE

In the `dr workload up` / `config` wizard, it was hard to see which option was selected. The list pickers (workload binding, base-image selection) marked the cursor row with only a `❯` — the colour cue that was meant to accompany it never showed, because `bubbles/table` colours each cell first and those cells' ANSI resets truncate any style wrapped around the finished row. And the "· in use" tag that marks a bound workload's current choice appeared on the menus but not in the base-image picker.

Ticket: [RAPTOR-19762](https://datarobot.atlassian.net/browse/RAPTOR-19762)

## CHANGES

- **One yellow selection everywhere.** Whatever is under the cursor — a menu option, the advanced-options row, a picker row — is now shown in the same **bold yellow text**, so a selection reads the same across every list the wizard offers. (Previously: menus cyan, pickers/advanced green, and the picker cue invisible.) The yellow uses `GetAdaptiveColor(DrYellow, DrYellowDark)`, so it adapts to the terminal background and stays legible in both **light and dark** themes.

> **Design note — deviation from the ticket.** The ticket describes the selected row as a *full-width black-on-yellow highlight bar*. We built the filled bar and it read as heavy/ugly against the neutral rows, so this PR keeps the lighter **bold-yellow foreground** cue instead. Same intent (an unmistakable, consistent selection colour), lighter treatment. The mechanism the ticket called out is still honoured: the picker's table cells are left uncoloured so the row-level style survives `bubbles/table`'s per-cell resets.
- **The pickers can show it** because their table cells are now left uncoloured; `bubbles/table` renders the cursor row's colour over plain cells cleanly instead of having it swallowed. Non-selected rows go neutral, the conventional look for a selection list.
- **`· in use` in the base-image picker.** The picker now tags the environment a bound workload is already built on and **lifts it to the top** — the list runs long, and the option most likely to be kept should not have to be scrolled for. The tag trails on the right, riding the last cell, and is **plain text**: it lives inside a `bubbles/table` cell, and the table sizes columns and truncates cells by display width with no awareness of ANSI, so a styled tag's escape bytes would inflate the measured column width and be cut mid-escape on a narrow terminal, bleeding colour across the row. The green live-value colour stays on the **menu screens**, which render their own lines and never truncate. Scoped to a bound run: a fresh setup has no live environment, so nothing is tagged and the order is left as it came.
- Removed the now-unused `valueStyle`; folded `selectedRowStyle` into `selectedStyle`.

Verified against the rendered escapes: a selected in-use picker row emits yellow across name/language/id under selection, with non-selected rows plain and no escape sequences embedded in any cell. A forced-TrueColor test guards that the picker cells stay plain text (the no-colour test profile is why an earlier styled tag slipped through), and `columnsFor` now measures display width so its sizing agrees with what the table truncates against.

## Review

Addressed AJ's review ([#857](https://github.com/datarobot-oss/cli/pull/857)):
- **P1** — the in-use tag was a styled string inside a table cell, breaking `columnsFor`'s `len(cell)` sizing and risking a mid-escape truncation by `bubbles/table` (green bleed) on an ~80-column terminal. Fixed by rendering the picker tag as plain text and measuring columns with `lipgloss.Width`; the green tag remains on the menu screens. Added a forced-colour regression test.
- **P3** — the menus rendered the cursor as ASCII `>` while the pickers use `❯`; unified on `❯`.

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)


