### PR TITLE
[CFX-7834] refactor(cmd): validate count flags at parse time via countflags

### DIFF
--- a/cmd/artifact/build/list/cmd.go
+++ b/cmd/artifact/build/list/cmd.go
@@ -15,10 +15,9 @@
 package list
 
 import (
-	"fmt"
-
 	"github.com/datarobot/cli/cmd/artifact/build/internal/buildargs"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
@@ -49,10 +48,6 @@ Examples:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			if limit <= 0 {
-				return fmt.Errorf("invalid --limit %d: must be positive", limit)
-			}
-
 			artifactID, err := buildargs.ResolveOptional(args)
 			if err != nil {
 				return err
@@ -69,7 +64,7 @@ Examples:
 
 	outputformat.AddFlag(cmd, &outputFormat)
 
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of builds to return.")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of builds to return.")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{

--- a/cmd/artifact/build/list/cmd_test.go
+++ b/cmd/artifact/build/list/cmd_test.go
@@ -28,7 +28,7 @@ func TestCmd_InvalidLimit(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "limit")
+	assert.Contains(t, err.Error(), "must be a positive integer")
 }
 
 func TestCmd_InvalidOutputFormat(t *testing.T) {

--- a/cmd/artifact/code/versions/cmd.go
+++ b/cmd/artifact/code/versions/cmd.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/drapi/filesapi"
 	"github.com/datarobot/cli/internal/outputformat"
@@ -52,7 +53,10 @@ func Cmd() *cobra.Command {
 }
 
 func cmdWithDeps(deps Deps) *cobra.Command {
-	var outputFormat outputformat.OutputFormat
+	var (
+		outputFormat outputformat.OutputFormat
+		limit        int
+	)
 
 	c := &cobra.Command{
 		Use:          "versions",
@@ -87,7 +91,7 @@ Example:
 	outputformat.AddFlag(c, &outputFormat)
 
 	c.Flags().String("dir", "", "Project directory (default: current directory).")
-	c.Flags().Int("limit", 100, "Maximum number of versions to return.")
+	c.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of versions to return.")
 
 	telemetry.TrackWith(c, func(cmd *cobra.Command, _ []string) map[string]any {
 		limit, _ := cmd.Flags().GetInt("limit")
@@ -104,10 +108,6 @@ Example:
 func runVersions(cmd *cobra.Command, outputFormat outputformat.OutputFormat, deps Deps) error {
 	dirFlag, _ := cmd.Flags().GetString("dir")
 	limit, _ := cmd.Flags().GetInt("limit")
-
-	if limit <= 0 {
-		return fmt.Errorf("invalid --limit %d: must be positive", limit)
-	}
 
 	absDir, err := resolveProjectDir(dirFlag)
 	if err != nil {

--- a/cmd/artifact/code/versions/cmd_test.go
+++ b/cmd/artifact/code/versions/cmd_test.go
@@ -267,12 +267,12 @@ func TestVersions_NonPositiveLimitRejected(t *testing.T) {
 			dir := initLinkedDir(t, "cat-1", "")
 
 			cmd, _ := newTestCmd(t, dir, Deps{})
-			require.NoError(t, cmd.Flags().Set("limit", val))
 
-			err := cmd.Execute()
+			// Rejected at parse time by countflags.PositiveInt, before any
+			// request is made, so only the Set error needs asserting.
+			err := cmd.Flags().Set("limit", val)
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "invalid --limit "+val)
-			assert.Contains(t, err.Error(), "must be positive")
+			assert.Contains(t, err.Error(), "must be a positive integer")
 		})
 	}
 }

--- a/cmd/artifact/list/cmd.go
+++ b/cmd/artifact/list/cmd.go
@@ -15,9 +15,8 @@
 package list
 
 import (
-	"fmt"
-
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
@@ -56,14 +55,6 @@ Example:
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			if limit <= 0 {
-				return fmt.Errorf("invalid --limit %d: must be positive", limit)
-			}
-
-			if offset < 0 {
-				return fmt.Errorf("invalid --offset %d: must be non-negative", offset)
-			}
-
 			artifacts, err := workload.ListArtifacts(limit, offset, status)
 			if err != nil {
 				return err
@@ -76,8 +67,8 @@ Example:
 	outputformat.AddFlag(cmd, &outputFormat)
 
 	workload.AddStatusFlag(cmd, &status)
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of artifacts to return")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Number of artifacts to skip before returning results")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of artifacts to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Number of artifacts to skip before returning results")
 
 	telemetry.TrackWith(cmd, func(c *cobra.Command, _ []string) map[string]any {
 		limit, _ := c.Flags().GetInt("limit")

--- a/cmd/artifact/list/cmd_test.go
+++ b/cmd/artifact/list/cmd_test.go
@@ -49,7 +49,7 @@ func TestCmd_InvalidLimit(t *testing.T) {
 
 		err := cmd.Execute()
 		require.Error(t, err, "limit %s", v)
-		assert.Contains(t, err.Error(), "must be positive")
+		assert.Contains(t, err.Error(), "must be a positive integer")
 	}
 }
 
@@ -60,5 +60,5 @@ func TestCmd_InvalidOffset(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must be non-negative")
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
 }

--- a/cmd/workload/list/cmd.go
+++ b/cmd/workload/list/cmd.go
@@ -16,10 +16,10 @@ package list
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
@@ -68,14 +68,6 @@ Example:
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			if limit <= 0 {
-				return fmt.Errorf("invalid --limit %d: must be positive", limit)
-			}
-
-			if offset < 0 {
-				return fmt.Errorf("invalid --offset %d: must be non-negative", offset)
-			}
-
 			// A blank --enclave would silently drop the filter and list
 			// everything, the opposite of what the flag asked for.
 			if cmd.Flags().Changed("enclave") && strings.TrimSpace(enclave) == "" {
@@ -98,8 +90,8 @@ Example:
 
 	outputformat.AddFlag(cmd, &outputFormat)
 
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of workloads to return")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Number of workloads to skip before returning results")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of workloads to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Number of workloads to skip before returning results")
 	cmd.Flags().StringSliceVar(&statuses, "status", nil,
 		"Filter by status (repeatable, also accepts comma-separated values; e.g. running, errored)")
 	cmd.Flags().StringVar(&enclave, "enclave", "",

--- a/cmd/workload/list/cmd_test.go
+++ b/cmd/workload/list/cmd_test.go
@@ -37,7 +37,7 @@ func TestCmd_InvalidLimit(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid --limit")
+	assert.Contains(t, err.Error(), "must be a positive integer")
 }
 
 func TestCmd_InvalidStatus(t *testing.T) {
@@ -67,7 +67,7 @@ func TestCmd_InvalidOffset(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must be non-negative")
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
 }
 
 func TestCmd_BlankEnclave(t *testing.T) {

--- a/cmd/workload/logs/cmd.go
+++ b/cmd/workload/logs/cmd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/datarobot/cli/cmd/internal/pollflags"
 	"github.com/datarobot/cli/cmd/workload/internal/idargs"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
@@ -77,10 +78,6 @@ Example:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			if limit <= 0 {
-				return fmt.Errorf("invalid --limit %d: must be positive", limit)
-			}
-
 			parsedLevel, err := workload.ParseLogLevel(level)
 			if err != nil {
 				return err
@@ -117,7 +114,7 @@ Example:
 	outputformat.AddFlag(cmd, &outputFormat)
 	idargs.AddDirFlag(cmd)
 
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of recent log lines to return")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of recent log lines to return")
 	cmd.Flags().StringVar(&level, "level", "", "Minimum log level (debug, info, warn, warning, error, critical)")
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Stream new log lines as they arrive (Ctrl-C to stop).")
 	cmd.Flags().Var(pollflags.PositiveDuration(&interval, followPollInterval), "poll-interval",

--- a/cmd/workload/logs/cmd.go
+++ b/cmd/workload/logs/cmd.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/internal/pollflags"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
@@ -71,10 +72,6 @@ Example:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			if limit <= 0 {
-				return fmt.Errorf("invalid --limit %d: must be positive", limit)
-			}
-
 			parsedLevel, err := workload.ParseLogLevel(level)
 			if err != nil {
 				return err
@@ -103,7 +100,7 @@ Example:
 
 	outputformat.AddFlag(cmd, &outputFormat)
 
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of recent log lines to return")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of recent log lines to return")
 	cmd.Flags().StringVar(&level, "level", "", "Minimum log level (debug, info, warn, warning, error, critical)")
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Stream new log lines as they arrive (Ctrl-C to stop).")
 	cmd.Flags().Var(pollflags.PositiveDuration(&interval, followPollInterval), "poll-interval",

--- a/cmd/workload/logs/cmd_test.go
+++ b/cmd/workload/logs/cmd_test.go
@@ -46,7 +46,7 @@ func TestCmd_RejectsNonPositiveLimit(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid --limit 0")
+	assert.Contains(t, err.Error(), "must be a positive integer")
 }
 
 func TestCmd_ParsesFollowFlag(t *testing.T) {

--- a/cmd/workload/logs/cmd_test.go
+++ b/cmd/workload/logs/cmd_test.go
@@ -48,7 +48,7 @@ func TestCmd_RejectsNonPositiveLimit(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid --limit 0")
+	assert.Contains(t, err.Error(), "must be a positive integer")
 }
 
 func TestCmd_ParsesFollowFlag(t *testing.T) {

--- a/docs/development/flags.md
+++ b/docs/development/flags.md
@@ -7,6 +7,7 @@ This guide covers best practices for defining and managing **command-line flags*
 ## Table of contents
 
 - [Define flags clearly](#define-flags-clearly)
+- [Count flags (parse-time validation)](#count-flags-parse-time-validation)
 - [Global output-format pattern](#global-output-format-pattern)
 - [Universal flags (forwarded to plugins)](#universal-flags-forwarded-to-plugins)
 - [Mark flag groups](#mark-flag-groups)
@@ -41,6 +42,40 @@ func Cmd() *cobra.Command {
     return cmd
 }
 ```
+
+## Count flags (parse-time validation)
+
+Flags that carry a count — `--limit`, `--offset`, `--tail`, `--concurrency` —
+register through `internal/countflags` so out-of-range values are rejected
+while the flags are parsed, before the command runs:
+
+```go
+import "github.com/datarobot/cli/internal/countflags"
+
+cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of workloads to return")
+cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Number of workloads to skip before returning results")
+```
+
+- `PositiveInt` rejects zero and negative values. Use it for page sizes: a
+  limit of 0 would fetch nothing and read as an empty result instead of an
+  error.
+- `NonNegativeInt` allows zero (meaningful as "from the start" or "no limit")
+  and rejects negatives.
+- Both bind a caller-owned `int`; read the resolved value from your variable
+  as with `IntVar`, and `Flags().GetInt(...)` (used by telemetry closures)
+  keeps working.
+- Do **not** use them where 0 means "unset, use a default" (for example
+  `workload config --port`), or for selectors like `--node-id`.
+
+Invalid input fails at parse time with cobra's standard wrapping:
+
+```
+Error: invalid argument "0" for "--limit" flag: must be a positive integer
+```
+
+so `RunE` stays free of flag-shape checks. Keep library-level argument
+validation in `internal/...` as defense in depth for non-CLI callers. The
+pattern follows `cmd/internal/pollflags`, which does the same for durations.
 
 ## Global output-format pattern
 

--- a/internal/countflags/countflags.go
+++ b/internal/countflags/countflags.go
@@ -24,6 +24,7 @@ package countflags
 
 import (
 	"errors"
+	"math"
 	"strconv"
 
 	"github.com/spf13/pflag"
@@ -57,13 +58,18 @@ func NonNegativeInt(p *int, value int) pflag.Value {
 
 // Set parses s with the same base-0, 64-bit semantics as pflag's built-in
 // int flag, so the only behavior change versus IntVar is the bound check.
+// The parsed int64 is also checked against the platform int maximum before
+// narrowing: int is 32-bit on some architectures, and an unchecked
+// conversion would silently truncate (CodeQL incorrect-conversion-between-
+// integer-types). On 64-bit builds the upper bound is unreachable and only
+// documents intent.
 func (v *boundedIntValue) Set(s string) error {
 	parsed, err := strconv.ParseInt(s, 0, 64)
 	if err != nil {
 		return err
 	}
 
-	if parsed < int64(v.min) {
+	if parsed < int64(v.min) || parsed > math.MaxInt {
 		return errors.New(v.msg)
 	}
 

--- a/internal/countflags/countflags.go
+++ b/internal/countflags/countflags.go
@@ -1,0 +1,82 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package countflags provides pflag.Value constructors for count-like int
+// flags (--limit, --offset, --tail, --concurrency) that reject out-of-range
+// values at parse time, so invalid input dies in flag parsing with cobra's
+// standard "invalid argument" message instead of surfacing from deep inside
+// a command's RunE. Commands bind their own int and keep reading it directly;
+// Flags().GetInt keeps working because the value reports type "int".
+//
+// The registration pattern mirrors cmd/internal/pollflags.
+package countflags
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/spf13/pflag"
+)
+
+// boundedIntValue is an int flag value that rejects anything Set parses to
+// below min. min is inclusive: PositiveInt registers 1, NonNegativeInt 0.
+type boundedIntValue struct {
+	p   *int
+	min int
+	msg string
+}
+
+// PositiveInt returns an int flag value with value as the default, for count
+// flags that must be at least 1. A page size of 0 would fetch nothing and
+// read as an empty result rather than an error, so zero is rejected too.
+func PositiveInt(p *int, value int) pflag.Value {
+	*p = value
+
+	return &boundedIntValue{p: p, min: 1, msg: "must be a positive integer"}
+}
+
+// NonNegativeInt returns an int flag value with value as the default, for
+// count flags where 0 is meaningful ("from the start", "no limit") but
+// negative values are not.
+func NonNegativeInt(p *int, value int) pflag.Value {
+	*p = value
+
+	return &boundedIntValue{p: p, min: 0, msg: "must be a non-negative integer"}
+}
+
+// Set parses s with the same base-0, 64-bit semantics as pflag's built-in
+// int flag, so the only behavior change versus IntVar is the bound check.
+func (v *boundedIntValue) Set(s string) error {
+	parsed, err := strconv.ParseInt(s, 0, 64)
+	if err != nil {
+		return err
+	}
+
+	if parsed < int64(v.min) {
+		return errors.New(v.msg)
+	}
+
+	*v.p = int(parsed)
+
+	return nil
+}
+
+func (v *boundedIntValue) String() string {
+	return strconv.Itoa(*v.p)
+}
+
+// Type reports "int" so pflag's GetInt conversion path is unchanged.
+func (v *boundedIntValue) Type() string {
+	return "int"
+}

--- a/internal/countflags/countflags_test.go
+++ b/internal/countflags/countflags_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package countflags
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPositiveInt_AppliesDefault(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var limit int
+
+	cmd.Flags().Var(PositiveInt(&limit, 100), "limit", "usage")
+
+	require.NoError(t, cmd.ParseFlags(nil))
+	assert.Equal(t, 100, limit)
+}
+
+func TestPositiveInt_ParsesValidValues(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var limit int
+
+	cmd.Flags().Var(PositiveInt(&limit, 100), "limit", "usage")
+
+	require.NoError(t, cmd.ParseFlags([]string{"--limit", "10"}))
+	assert.Equal(t, 10, limit)
+}
+
+func TestPositiveInt_RejectsNonPositiveValues(t *testing.T) {
+	for _, args := range [][]string{{"--limit", "0"}, {"--limit", "-1"}} {
+		cmd := &cobra.Command{}
+
+		var limit int
+
+		cmd.Flags().Var(PositiveInt(&limit, 100), "limit", "usage")
+
+		// A page size of 0 would fetch nothing and read as an empty result
+		// rather than an error, so it is rejected at parse time.
+		err := cmd.ParseFlags(args)
+		require.Errorf(t, err, "args %v", args)
+		assert.Contains(t, err.Error(), "must be a positive integer")
+	}
+}
+
+func TestPositiveInt_RejectsGarbage(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var limit int
+
+	cmd.Flags().Var(PositiveInt(&limit, 100), "limit", "usage")
+
+	// Non-numeric input keeps pflag's underlying strconv error.
+	err := cmd.ParseFlags([]string{"--limit", "abc"})
+	require.Error(t, err)
+}
+
+func TestNonNegativeInt_AllowsZero(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var offset int
+
+	cmd.Flags().Var(NonNegativeInt(&offset, 0), "offset", "usage")
+
+	// Zero is meaningful for offset-style flags ("from the start"), unlike
+	// page sizes, so only negatives are rejected.
+	require.NoError(t, cmd.ParseFlags([]string{"--offset", "0"}))
+	assert.Equal(t, 0, offset)
+}
+
+func TestNonNegativeInt_RejectsNegativeValues(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var offset int
+
+	cmd.Flags().Var(NonNegativeInt(&offset, 0), "offset", "usage")
+
+	err := cmd.ParseFlags([]string{"--offset", "-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}
+
+// TestGetIntRoundTrip pins the contract telemetry closures rely on: the
+// custom value reports type "int", so Flags().GetInt converts via String()
+// instead of failing with a flag-type mismatch.
+func TestGetIntRoundTrip(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var limit int
+
+	cmd.Flags().Var(PositiveInt(&limit, 100), "limit", "usage")
+
+	require.NoError(t, cmd.ParseFlags([]string{"--limit", "7"}))
+
+	got, err := cmd.Flags().GetInt("limit")
+	require.NoError(t, err)
+	assert.Equal(t, 7, got)
+}

--- a/internal/countflags/countflags_test.go
+++ b/internal/countflags/countflags_test.go
@@ -72,6 +72,19 @@ func TestPositiveInt_RejectsGarbage(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestPositiveInt_RejectsOutOfRangeValues(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var limit int
+
+	cmd.Flags().Var(PositiveInt(&limit, 100), "limit", "usage")
+
+	// Beyond the int64 range strconv.ParseInt itself reports "value out of
+	// range"; nothing is truncated or silently clamped.
+	err := cmd.ParseFlags([]string{"--limit", "99999999999999999999"})
+	require.Error(t, err)
+}
+
 func TestNonNegativeInt_AllowsZero(t *testing.T) {
 	cmd := &cobra.Command{}
 


### PR DESCRIPTION
# RATIONALE
Deferred from the RAPTOR-19349 review ([CFX-7834](https://datarobot.atlassian.net/browse/CFX-7834)): the `--limit`/`--offset` flags validated inside each command's `RunE`, moving validation from parse time to runtime. A shared `pflag.Value` rejects out-of-range values while flags are parsed, drops the boilerplate from `RunE`, and centralizes the messages.

This started as just "validate count flags at parse time" (deferred from the RAPTOR-19349 review of PR #784), but I realized there are a lot more wins by scope creeping. Consistent validation is the smallest part of what the stack buys:

- **`--limit` meant two different things in one CLI.** The workload family treated it as "total rows I want" and walked next-links to get there; the pipeline family sent it as a single request's page size and returned whatever that page held — anything beyond the server's page ceiling was silently truncated. Scripts consuming JSON output had no way to tell a complete result from a truncated one. After this stack, `--limit N` means N rows or an error, everywhere.

- **Invalid flags used to be expensive to learn about.** A negative `--limit` got past parsing, through authentication, into a live API call, and came back as a server 422 — or didn't fail at all (the pipeline family did zero checks). Rejection now happens during flag parsing: no network, no token use, deterministic exit for CI.

- **Deduplicating the walk surfaced latent drift.** Three hand-copied pagination loops had already diverged — the builds endpoint sent the unclamped `--limit` as its per-request page size while its siblings clamp to the server's 100 ceiling. One generic `paginate.Walk` (host-checked next links included) makes the next list endpoint correct by construction instead of correct by copy-paste, and `docs/development/flags.md` makes the flag pattern the default rather than tribal knowledge.

I used a PR stack so that Workload, Compute Services, and CLI Maintainers can all review their own slice sin parallel.

## CHANGES
- New `internal/countflags`: `PositiveInt` (rejects 0 and negatives) and `NonNegativeInt` (allows 0, rejects negatives) constructors returning `pflag.Value`, following the `cmd/internal/pollflags` pattern. `Type()` reports `"int"`, so existing `Flags().GetInt` reads in telemetry closures are unchanged (verified against pflag v1.0.9's conversion path).
- Migrated to `PositiveInt` for `--limit` (default 100) and `NonNegativeInt` for `--offset` (default 0), deleting the runtime checks: `dr workload list`, `dr workload logs`, `dr artifact list`, `dr artifact build list`, `dr artifact code versions`.
- Invalid input now fails at parse time: `invalid argument "0" for "--limit" flag: must be a positive integer` (was `invalid --limit 0: must be positive` after the command started).
- Test assertions updated to the parse-time messages; the `artifact code versions` invalid-limit case now asserts the `Flags().Set` error. New `countflags` unit tests mirror `pollflags_test.go`.
- Documented the pattern in `docs/development/flags.md`.

## TESTING
`task lint` (all GOOS legs) and `task test` (race + coverage) pass.

## NOTES
Part 1/4 of a stacked review, opened as separate drafts so teams can review in parallel without blocking:
- Part 2 (pipeline count flags): base = this branch
- Part 3 (task `--concurrency`): stacks on part 2
- Part 4 (list pagination unification): stacks on part 3

Deliberately excluded: `workload config --port/--replicas` (0 = "use default") and selector flags like `--node-id`. Library-level checks in `internal/workload` stay as defense in depth for non-CLI callers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only flag parsing and validation refactor with no changes to auth, APIs, or data handling; behavior for valid flags stays the same.
> 
> **Overview**
> Introduces **`internal/countflags`** (`PositiveInt` / `NonNegativeInt`) so `--limit` and `--offset` are bounded during flag parsing, following the same approach as `pollflags` for durations.
> 
> **Workload and artifact list commands** (`dr workload list`, `dr workload logs`, `dr artifact list`, `dr artifact build list`, `dr artifact code versions`) now register count flags through `countflags` instead of `IntVar`, and the duplicated `RunE` checks for non-positive limits or negative offsets are removed. Invalid values fail earlier with Cobra’s wrapped parse error (e.g. `must be a positive integer`) rather than custom `invalid --limit` errors after auth or API work would have started.
> 
> **Tests and docs** are updated for the new messages and parse-time behavior; `docs/development/flags.md` documents when to use each helper and when not to (e.g. flags where `0` means “use default”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f54523bffb4f29ab20e8d12d72e4ad531dd9f00. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->