### PR TITLE
[CFX-7834] refactor(pipeline): validate count flags at parse time

### DIFF
--- a/cmd/pipeline/image/list/cmd.go
+++ b/cmd/pipeline/image/list/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -60,8 +61,8 @@ Example:
 
 	outputformat.AddFlag(cmd, &outputFormat)
 
-	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of images to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Pagination offset")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of images to return")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/image/list/cmd_test.go
+++ b/cmd/pipeline/image/list/cmd_test.go
@@ -47,3 +47,16 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
+
+func TestCmd_RejectsInvalidLimit(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any request.
+	err := runCmd(t, "--limit", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a positive integer")
+}
+
+func TestCmd_RejectsInvalidOffset(t *testing.T) {
+	err := runCmd(t, "--offset", "-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}

--- a/cmd/pipeline/input/list/cmd.go
+++ b/cmd/pipeline/input/list/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/datarobot/cli/cmd/internal/errmsg"
 	"github.com/datarobot/cli/cmd/pipeline/scopeflag"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -73,8 +74,8 @@ Example:
 
 	flags.Bind(cmd)
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of inputs to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Pagination offset")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of inputs to return")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/input/list/cmd_test.go
+++ b/cmd/pipeline/input/list/cmd_test.go
@@ -59,3 +59,16 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
+
+func TestCmd_RejectsInvalidLimit(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any request.
+	err := runCmd(t, "--pipeline", "p", "--limit", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a positive integer")
+}
+
+func TestCmd_RejectsInvalidOffset(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p", "--offset", "-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}

--- a/cmd/pipeline/list/cmd.go
+++ b/cmd/pipeline/list/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -68,8 +69,8 @@ Example:
 
 	cmd.Flags().StringVar(&mode, "mode", "", "Pipeline mode: draft or locked")
 	cmd.Flags().StringVar(&search, "search", "", "Filter pipelines by name substring")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
-	cmd.Flags().IntVar(&limit, "limit", 50, "Pagination limit (1-200)")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Pagination offset")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 50), "limit", "Pagination limit (1-200)")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/list/cmd_test.go
+++ b/cmd/pipeline/list/cmd_test.go
@@ -144,3 +144,28 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 		assert.NotNilf(t, flag, "expected --%s flag to be registered", name)
 	}
 }
+
+func TestCmd_RejectsInvalidLimit(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any request.
+	cmd := Cmd()
+	cmd.SetArgs([]string{"--limit", "0"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.PreRunE = nil
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a positive integer")
+}
+
+func TestCmd_RejectsInvalidOffset(t *testing.T) {
+	cmd := Cmd()
+	cmd.SetArgs([]string{"--offset", "-1"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.PreRunE = nil
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}

--- a/cmd/pipeline/run/list/cmd.go
+++ b/cmd/pipeline/run/list/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/datarobot/cli/cmd/internal/errmsg"
 	"github.com/datarobot/cli/cmd/pipeline/scopeflag"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -66,8 +67,8 @@ Example:
 
 	flags.Bind(cmd)
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of runs to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Pagination offset")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of runs to return")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/run/list/cmd_test.go
+++ b/cmd/pipeline/run/list/cmd_test.go
@@ -59,3 +59,16 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
+
+func TestCmd_RejectsInvalidLimit(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any request.
+	err := runCmd(t, "--pipeline", "p", "--limit", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a positive integer")
+}
+
+func TestCmd_RejectsInvalidOffset(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p", "--offset", "-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}

--- a/cmd/pipeline/run/task/logs/cmd.go
+++ b/cmd/pipeline/run/task/logs/cmd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/internal/errmsg"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -100,7 +101,7 @@ Example:
 	cmd.Flags().StringVar(&runID, "run", "", "Run (dispatch) ID")
 	_ = cmd.MarkFlagRequired("run")
 	cmd.Flags().StringVar(&stream, "stream", "", "Read durable S3 log: stdout or stderr")
-	cmd.Flags().IntVar(&tailLines, "tail", 0, "Limit to last N lines (live logs only)")
+	cmd.Flags().Var(countflags.NonNegativeInt(&tailLines, 0), "tail", "Limit to last N lines (live logs only)")
 	cmd.Flags().IntVar(&nodeID, "node-id", 0, "Select a specific fan-out invocation by its nodeId (from `task list`)")
 	cmd.Flags().StringVar(&verbosity, "verbosity", "", "Log verbosity: user (default) or all")
 

--- a/cmd/pipeline/run/task/logs/cmd_test.go
+++ b/cmd/pipeline/run/task/logs/cmd_test.go
@@ -70,3 +70,11 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
+
+func TestCmd_RejectsNegativeTail(t *testing.T) {
+	// --tail 0 stays valid (no limit); negatives die at parse time via
+	// countflags.NonNegativeInt, before any request is made.
+	err := runCmd(t, "--pipeline", "p-1", "--run", "d-1", "--tail", "-1", "1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}

--- a/cmd/pipeline/schedule/list/cmd.go
+++ b/cmd/pipeline/schedule/list/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -59,8 +60,8 @@ Example:
 
 	cmd.Flags().StringVar(&pipelineID, "pipeline", "", "Pipeline ID")
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of schedules to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Pagination offset")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of schedules to return")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/schedule/list/cmd_test.go
+++ b/cmd/pipeline/schedule/list/cmd_test.go
@@ -55,3 +55,16 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 
 	assert.Nil(t, cmd.Flags().Lookup("version"), "unexpected --version flag after removal")
 }
+
+func TestCmd_RejectsInvalidLimit(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any request.
+	err := runCmd(t, "--pipeline", "p", "--limit", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a positive integer")
+}
+
+func TestCmd_RejectsInvalidOffset(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p", "--offset", "-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}

--- a/cmd/pipeline/version/list/cmd.go
+++ b/cmd/pipeline/version/list/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -59,8 +60,8 @@ Example:
 
 	cmd.Flags().StringVar(&pipelineID, "pipeline", "", "Pipeline ID")
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of versions to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Pagination offset")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of versions to return")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/version/list/cmd_test.go
+++ b/cmd/pipeline/version/list/cmd_test.go
@@ -53,3 +53,16 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
+
+func TestCmd_RejectsInvalidLimit(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any request.
+	err := runCmd(t, "--pipeline", "p", "--limit", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a positive integer")
+}
+
+func TestCmd_RejectsInvalidOffset(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p", "--offset", "-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}


### PR DESCRIPTION
# RATIONALE
The pipeline list commands did no flag validation at all — the workload family validated, this family didn't, so the same mistake failed differently depending on which command ate it. The latent bugs this closes:

- **`--limit 0` (or negative) silently returned fewer rows than asked.** The old query builder omitted the `limit` param when it was `<= 0`, so the server's default page size applied: a script requesting 100 rows got the default, with no error and nothing in the output saying so.
- **A negative `--offset` silently restarted results from the beginning.** Same omission: the param was dropped, so every page request returned page 1. A paging loop with a computed offset that dipped negative re-fetched duplicate rows forever instead of failing.
- **`pipeline run task logs --tail -5` sent `tail_lines=-5` to the live-log endpoint.** The negative value was forwarded verbatim once the flag was set, producing a server-side failure mid-command — after authentication, deep past the point of feedback.
- **No parse-time gate for CI.** Any of the above burned a full auth + network round trip before surfacing; now cobra rejects them during flag parsing.

Migrating onto `internal/countflags` (from part 1, #858) makes the fix mechanical rather than per-command.

## CHANGES
- `--limit` -> `countflags.PositiveInt` on `dr pipeline list` (default 50) and `version/run/image/input/schedule list` (default 100).
- `--offset` -> `countflags.NonNegativeInt` (default 0) on all six list commands.
- `--tail` on `dr pipeline run task logs` -> `NonNegativeInt`, keeping 0 as "no limit".
- New invalid-limit/invalid-offset reject tests per list command and an invalid-`--tail` test, in the existing `runCmd` style.

## TESTING
`task lint` (all GOOS legs) and `task test` (race + coverage) pass.

## NOTES
Part 2/4 of a stacked review. Based on #858 (base = its branch), so this diff shows only the pipeline changes. Invalid values now error at parse time instead of reaching the API. (Result truncation for large limits is a separate fix, part 4 #861.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only flag validation and tests; behavior is stricter for invalid pagination/tail values with no changes to auth or server contracts beyond not sending bad query params.
> 
> **Overview**
> Pipeline **list** commands and **run task logs** now validate pagination and tail flags during Cobra parsing via `internal/countflags`, instead of plain `IntVar` flags that could reach the API with bad values.
> 
> **`--limit`** uses `PositiveInt` (rejects `0` and negatives) on `pipeline list`, and on image/input/run/schedule/version list commands with the same defaults as before. **`--offset`** uses `NonNegativeInt` on those list commands. **`pipeline run task logs --tail`** uses `NonNegativeInt` so negatives fail before auth/network; **`--tail 0`** remains “no limit.”
> 
> Each touched command gains tests that invalid `--limit`, `--offset`, or `--tail` fail at parse time with the expected error messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23c9407abb38a920ac22cd748be0a36d95781651. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->