### PR TITLE
[CFX-7834] refactor(task): validate --concurrency at parse time

### DIFF
--- a/cmd/task/run/cmd.go
+++ b/cmd/task/run/cmd.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/datarobot/cli/internal/cli"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/task"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -183,7 +184,7 @@ Examples:
 
 	cmd.Flags().StringVarP(&opts.Dir, "dir", "d", ".", "📁 Specify project directory (default: current directory)")
 	cmd.Flags().BoolVarP(&opts.taskOpts.Parallel, "parallel", "p", false, "⚡ Run multiple tasks simultaneously for faster execution")
-	cmd.Flags().IntVarP(&opts.taskOpts.Concurrency, "concurrency", "C", 2, "🔢 Number of concurrent tasks to run in parallel")
+	cmd.Flags().VarP(countflags.PositiveInt(&opts.taskOpts.Concurrency, 2), "concurrency", "C", "🔢 Number of concurrent tasks to run in parallel")
 	cmd.Flags().BoolVarP(&opts.taskOpts.WatchTask, "watch", "w", false, "👀 Watch files and re-run task on changes")
 	cmd.Flags().BoolVarP(&opts.taskOpts.AnswerYes, "yes", "y", false, "🚀 Skip confirmation prompts (useful for automation)")
 	cmd.Flags().BoolVarP(&opts.taskOpts.ExitCode, "exit-code", "x", false, "🔄 Pass through the exact exit code from task")

--- a/cmd/task/run/cmd_test.go
+++ b/cmd/task/run/cmd_test.go
@@ -153,6 +153,17 @@ func TestCmdReturnsErrNotInTemplateWhenDatarobotMissing(t *testing.T) {
 	require.ErrorIs(t, err, cli.ErrSilent)
 }
 
+func TestCmdRejectsNonPositiveConcurrency(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any task
+	// runner is looked up: zero concurrency would run nothing.
+	cmd := Cmd()
+	cmd.SetArgs([]string{"--concurrency", "0", "start"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be a positive integer")
+}
+
 // TestCmdStopsGeneratedTaskThatInvokesItself covers the recipe template's
 // `lint: [dr task run lint]` against a project with no committed root Taskfile.
 // Nothing sets DATAROBOT_CLI_TASK_RUN_FROM_ROOT on that path, so every


### PR DESCRIPTION
# RATIONALE
`dr task run --concurrency` forwarded any value verbatim as `-C <n>` to the task binary, and two of those values did the opposite of what a user would expect:

- **`--concurrency 0` meant unlimited parallelism, not "use the default 2".** go-task treats `-C 0` as "no concurrency limit", so passing 0 — a reasonable reading of "default" — unbounded the fan-out across every task in the graph. With recursive/root Taskfiles that is a quiet resource spike.
- **Negative values went straight through to the child binary** (`-C -1`), leaving its behavior undefined rather than ours.

Both now die at parse time via `internal/countflags.PositiveInt` (from #858): zero concurrency would run nothing, so it is rejected with the standard `invalid argument` message, before the task runner is even looked up.

## CHANGES
- `--concurrency` -> `countflags.PositiveInt` (default 2 unchanged).
- Reject test added in the existing command-test style.

## TESTING
`task lint` (all GOOS legs) and `task test` (race + coverage) pass.

## NOTES
Part 3/4 of a stacked review. Based on #859, so this diff shows only the task change.
