### PR TITLE
[CFX-7945] refactor(api): unify next-link pagination behind internal/paginate

### DIFF
--- a/cmd/artifact/build/list/cmd.go
+++ b/cmd/artifact/build/list/cmd.go
@@ -15,10 +15,9 @@
 package list
 
 import (
-	"fmt"
-
 	"github.com/datarobot/cli/cmd/artifact/build/internal/buildargs"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
@@ -49,10 +48,6 @@ Examples:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			if limit <= 0 {
-				return fmt.Errorf("invalid --limit %d: must be positive", limit)
-			}
-
 			artifactID, err := buildargs.ResolveOptional(args)
 			if err != nil {
 				return err
@@ -69,7 +64,7 @@ Examples:
 
 	outputformat.AddFlag(cmd, &outputFormat)
 
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of builds to return.")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of builds to return.")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, args []string) map[string]any {
 		return map[string]any{

--- a/cmd/artifact/build/list/cmd_test.go
+++ b/cmd/artifact/build/list/cmd_test.go
@@ -28,7 +28,7 @@ func TestCmd_InvalidLimit(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "limit")
+	assert.Contains(t, err.Error(), "must be a positive integer")
 }
 
 func TestCmd_InvalidOutputFormat(t *testing.T) {

--- a/cmd/artifact/code/versions/cmd.go
+++ b/cmd/artifact/code/versions/cmd.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/artifact/code/internal/format"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/drapi/filesapi"
 	"github.com/datarobot/cli/internal/outputformat"
@@ -52,7 +53,10 @@ func Cmd() *cobra.Command {
 }
 
 func cmdWithDeps(deps Deps) *cobra.Command {
-	var outputFormat outputformat.OutputFormat
+	var (
+		outputFormat outputformat.OutputFormat
+		limit        int
+	)
 
 	c := &cobra.Command{
 		Use:          "versions",
@@ -87,7 +91,7 @@ Example:
 	outputformat.AddFlag(c, &outputFormat)
 
 	c.Flags().String("dir", "", "Project directory (default: current directory).")
-	c.Flags().Int("limit", 100, "Maximum number of versions to return.")
+	c.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of versions to return.")
 
 	telemetry.TrackWith(c, func(cmd *cobra.Command, _ []string) map[string]any {
 		limit, _ := cmd.Flags().GetInt("limit")
@@ -104,10 +108,6 @@ Example:
 func runVersions(cmd *cobra.Command, outputFormat outputformat.OutputFormat, deps Deps) error {
 	dirFlag, _ := cmd.Flags().GetString("dir")
 	limit, _ := cmd.Flags().GetInt("limit")
-
-	if limit <= 0 {
-		return fmt.Errorf("invalid --limit %d: must be positive", limit)
-	}
 
 	absDir, err := resolveProjectDir(dirFlag)
 	if err != nil {

--- a/cmd/artifact/code/versions/cmd_test.go
+++ b/cmd/artifact/code/versions/cmd_test.go
@@ -267,12 +267,12 @@ func TestVersions_NonPositiveLimitRejected(t *testing.T) {
 			dir := initLinkedDir(t, "cat-1", "")
 
 			cmd, _ := newTestCmd(t, dir, Deps{})
-			require.NoError(t, cmd.Flags().Set("limit", val))
 
-			err := cmd.Execute()
+			// Rejected at parse time by countflags.PositiveInt, before any
+			// request is made, so only the Set error needs asserting.
+			err := cmd.Flags().Set("limit", val)
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), "invalid --limit "+val)
-			assert.Contains(t, err.Error(), "must be positive")
+			assert.Contains(t, err.Error(), "must be a positive integer")
 		})
 	}
 }

--- a/cmd/artifact/list/cmd.go
+++ b/cmd/artifact/list/cmd.go
@@ -15,9 +15,8 @@
 package list
 
 import (
-	"fmt"
-
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
@@ -56,14 +55,6 @@ Example:
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			if limit <= 0 {
-				return fmt.Errorf("invalid --limit %d: must be positive", limit)
-			}
-
-			if offset < 0 {
-				return fmt.Errorf("invalid --offset %d: must be non-negative", offset)
-			}
-
 			artifacts, err := workload.ListArtifacts(limit, offset, status)
 			if err != nil {
 				return err
@@ -76,8 +67,8 @@ Example:
 	outputformat.AddFlag(cmd, &outputFormat)
 
 	workload.AddStatusFlag(cmd, &status)
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of artifacts to return")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Number of artifacts to skip before returning results")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of artifacts to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Number of artifacts to skip before returning results")
 
 	telemetry.TrackWith(cmd, func(c *cobra.Command, _ []string) map[string]any {
 		limit, _ := c.Flags().GetInt("limit")

--- a/cmd/artifact/list/cmd_test.go
+++ b/cmd/artifact/list/cmd_test.go
@@ -49,7 +49,7 @@ func TestCmd_InvalidLimit(t *testing.T) {
 
 		err := cmd.Execute()
 		require.Error(t, err, "limit %s", v)
-		assert.Contains(t, err.Error(), "must be positive")
+		assert.Contains(t, err.Error(), "must be a positive integer")
 	}
 }
 
@@ -60,5 +60,5 @@ func TestCmd_InvalidOffset(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must be non-negative")
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
 }

--- a/cmd/pipeline/image/list/cmd.go
+++ b/cmd/pipeline/image/list/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -60,8 +61,8 @@ Example:
 
 	outputformat.AddFlag(cmd, &outputFormat)
 
-	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of images to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Pagination offset")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of images to return")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/image/list/cmd_test.go
+++ b/cmd/pipeline/image/list/cmd_test.go
@@ -47,3 +47,16 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
+
+func TestCmd_RejectsInvalidLimit(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any request.
+	err := runCmd(t, "--limit", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a positive integer")
+}
+
+func TestCmd_RejectsInvalidOffset(t *testing.T) {
+	err := runCmd(t, "--offset", "-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}

--- a/cmd/pipeline/input/list/cmd.go
+++ b/cmd/pipeline/input/list/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/datarobot/cli/cmd/internal/errmsg"
 	"github.com/datarobot/cli/cmd/pipeline/scopeflag"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -73,8 +74,8 @@ Example:
 
 	flags.Bind(cmd)
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of inputs to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Pagination offset")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of inputs to return")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/input/list/cmd_test.go
+++ b/cmd/pipeline/input/list/cmd_test.go
@@ -59,3 +59,16 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
+
+func TestCmd_RejectsInvalidLimit(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any request.
+	err := runCmd(t, "--pipeline", "p", "--limit", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a positive integer")
+}
+
+func TestCmd_RejectsInvalidOffset(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p", "--offset", "-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}

--- a/cmd/pipeline/list/cmd.go
+++ b/cmd/pipeline/list/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -68,8 +69,8 @@ Example:
 
 	cmd.Flags().StringVar(&mode, "mode", "", "Pipeline mode: draft or locked")
 	cmd.Flags().StringVar(&search, "search", "", "Filter pipelines by name substring")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
-	cmd.Flags().IntVar(&limit, "limit", 50, "Pagination limit (1-200)")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Pagination offset")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 50), "limit", "Pagination limit (1-200)")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/list/cmd_test.go
+++ b/cmd/pipeline/list/cmd_test.go
@@ -144,3 +144,28 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 		assert.NotNilf(t, flag, "expected --%s flag to be registered", name)
 	}
 }
+
+func TestCmd_RejectsInvalidLimit(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any request.
+	cmd := Cmd()
+	cmd.SetArgs([]string{"--limit", "0"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.PreRunE = nil
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a positive integer")
+}
+
+func TestCmd_RejectsInvalidOffset(t *testing.T) {
+	cmd := Cmd()
+	cmd.SetArgs([]string{"--offset", "-1"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.PreRunE = nil
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}

--- a/cmd/pipeline/run/list/cmd.go
+++ b/cmd/pipeline/run/list/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/datarobot/cli/cmd/internal/errmsg"
 	"github.com/datarobot/cli/cmd/pipeline/scopeflag"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -66,8 +67,8 @@ Example:
 
 	flags.Bind(cmd)
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of runs to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Pagination offset")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of runs to return")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/run/list/cmd_test.go
+++ b/cmd/pipeline/run/list/cmd_test.go
@@ -59,3 +59,16 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
+
+func TestCmd_RejectsInvalidLimit(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any request.
+	err := runCmd(t, "--pipeline", "p", "--limit", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a positive integer")
+}
+
+func TestCmd_RejectsInvalidOffset(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p", "--offset", "-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}

--- a/cmd/pipeline/run/task/logs/cmd.go
+++ b/cmd/pipeline/run/task/logs/cmd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/internal/errmsg"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -100,7 +101,7 @@ Example:
 	cmd.Flags().StringVar(&runID, "run", "", "Run (dispatch) ID")
 	_ = cmd.MarkFlagRequired("run")
 	cmd.Flags().StringVar(&stream, "stream", "", "Read durable S3 log: stdout or stderr")
-	cmd.Flags().IntVar(&tailLines, "tail", 0, "Limit to last N lines (live logs only)")
+	cmd.Flags().Var(countflags.NonNegativeInt(&tailLines, 0), "tail", "Limit to last N lines (live logs only)")
 	cmd.Flags().IntVar(&nodeID, "node-id", 0, "Select a specific fan-out invocation by its nodeId (from `task list`)")
 	cmd.Flags().StringVar(&verbosity, "verbosity", "", "Log verbosity: user (default) or all")
 

--- a/cmd/pipeline/run/task/logs/cmd_test.go
+++ b/cmd/pipeline/run/task/logs/cmd_test.go
@@ -70,3 +70,11 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
+
+func TestCmd_RejectsNegativeTail(t *testing.T) {
+	// --tail 0 stays valid (no limit); negatives die at parse time via
+	// countflags.NonNegativeInt, before any request is made.
+	err := runCmd(t, "--pipeline", "p-1", "--run", "d-1", "--tail", "-1", "1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}

--- a/cmd/pipeline/schedule/list/cmd.go
+++ b/cmd/pipeline/schedule/list/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -59,8 +60,8 @@ Example:
 
 	cmd.Flags().StringVar(&pipelineID, "pipeline", "", "Pipeline ID")
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of schedules to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Pagination offset")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of schedules to return")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/schedule/list/cmd_test.go
+++ b/cmd/pipeline/schedule/list/cmd_test.go
@@ -55,3 +55,16 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 
 	assert.Nil(t, cmd.Flags().Lookup("version"), "unexpected --version flag after removal")
 }
+
+func TestCmd_RejectsInvalidLimit(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any request.
+	err := runCmd(t, "--pipeline", "p", "--limit", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a positive integer")
+}
+
+func TestCmd_RejectsInvalidOffset(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p", "--offset", "-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}

--- a/cmd/pipeline/version/list/cmd.go
+++ b/cmd/pipeline/version/list/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/pipeline"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -59,8 +60,8 @@ Example:
 
 	cmd.Flags().StringVar(&pipelineID, "pipeline", "", "Pipeline ID")
 	_ = cmd.MarkFlagRequired("pipeline")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Pagination offset")
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of versions to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Pagination offset")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of versions to return")
 
 	telemetry.TrackWith(cmd, func(_ *cobra.Command, _ []string) map[string]any {
 		return map[string]any{

--- a/cmd/pipeline/version/list/cmd_test.go
+++ b/cmd/pipeline/version/list/cmd_test.go
@@ -53,3 +53,16 @@ func TestCmd_HasExpectedFlags(t *testing.T) {
 		assert.NotNilf(t, cmd.Flags().Lookup(name), "expected --%s flag", name)
 	}
 }
+
+func TestCmd_RejectsInvalidLimit(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any request.
+	err := runCmd(t, "--pipeline", "p", "--limit", "0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a positive integer")
+}
+
+func TestCmd_RejectsInvalidOffset(t *testing.T) {
+	err := runCmd(t, "--pipeline", "p", "--offset", "-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}

--- a/cmd/task/run/cmd.go
+++ b/cmd/task/run/cmd.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/datarobot/cli/internal/cli"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/task"
 	"github.com/datarobot/cli/internal/telemetry"
@@ -183,7 +184,7 @@ Examples:
 
 	cmd.Flags().StringVarP(&opts.Dir, "dir", "d", ".", "📁 Specify project directory (default: current directory)")
 	cmd.Flags().BoolVarP(&opts.taskOpts.Parallel, "parallel", "p", false, "⚡ Run multiple tasks simultaneously for faster execution")
-	cmd.Flags().IntVarP(&opts.taskOpts.Concurrency, "concurrency", "C", 2, "🔢 Number of concurrent tasks to run in parallel")
+	cmd.Flags().VarP(countflags.PositiveInt(&opts.taskOpts.Concurrency, 2), "concurrency", "C", "🔢 Number of concurrent tasks to run in parallel")
 	cmd.Flags().BoolVarP(&opts.taskOpts.WatchTask, "watch", "w", false, "👀 Watch files and re-run task on changes")
 	cmd.Flags().BoolVarP(&opts.taskOpts.AnswerYes, "yes", "y", false, "🚀 Skip confirmation prompts (useful for automation)")
 	cmd.Flags().BoolVarP(&opts.taskOpts.ExitCode, "exit-code", "x", false, "🔄 Pass through the exact exit code from task")

--- a/cmd/task/run/cmd_test.go
+++ b/cmd/task/run/cmd_test.go
@@ -153,6 +153,17 @@ func TestCmdReturnsErrNotInTemplateWhenDatarobotMissing(t *testing.T) {
 	require.ErrorIs(t, err, cli.ErrSilent)
 }
 
+func TestCmdRejectsNonPositiveConcurrency(t *testing.T) {
+	// Rejected at parse time by countflags.PositiveInt, before any task
+	// runner is looked up: zero concurrency would run nothing.
+	cmd := Cmd()
+	cmd.SetArgs([]string{"--concurrency", "0", "start"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be a positive integer")
+}
+
 // TestCmdStopsGeneratedTaskThatInvokesItself covers the recipe template's
 // `lint: [dr task run lint]` against a project with no committed root Taskfile.
 // Nothing sets DATAROBOT_CLI_TASK_RUN_FROM_ROOT on that path, so every

--- a/cmd/workload/list/cmd.go
+++ b/cmd/workload/list/cmd.go
@@ -16,10 +16,10 @@ package list
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
@@ -68,14 +68,6 @@ Example:
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			if limit <= 0 {
-				return fmt.Errorf("invalid --limit %d: must be positive", limit)
-			}
-
-			if offset < 0 {
-				return fmt.Errorf("invalid --offset %d: must be non-negative", offset)
-			}
-
 			// A blank --enclave would silently drop the filter and list
 			// everything, the opposite of what the flag asked for.
 			if cmd.Flags().Changed("enclave") && strings.TrimSpace(enclave) == "" {
@@ -98,8 +90,8 @@ Example:
 
 	outputformat.AddFlag(cmd, &outputFormat)
 
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of workloads to return")
-	cmd.Flags().IntVar(&offset, "offset", 0, "Number of workloads to skip before returning results")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of workloads to return")
+	cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Number of workloads to skip before returning results")
 	cmd.Flags().StringSliceVar(&statuses, "status", nil,
 		"Filter by status (repeatable, also accepts comma-separated values; e.g. running, errored)")
 	cmd.Flags().StringVar(&enclave, "enclave", "",

--- a/cmd/workload/list/cmd_test.go
+++ b/cmd/workload/list/cmd_test.go
@@ -37,7 +37,7 @@ func TestCmd_InvalidLimit(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid --limit")
+	assert.Contains(t, err.Error(), "must be a positive integer")
 }
 
 func TestCmd_InvalidStatus(t *testing.T) {
@@ -67,7 +67,7 @@ func TestCmd_InvalidOffset(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must be non-negative")
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
 }
 
 func TestCmd_BlankEnclave(t *testing.T) {

--- a/cmd/workload/logs/cmd.go
+++ b/cmd/workload/logs/cmd.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/datarobot/cli/cmd/internal/pollflags"
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/countflags"
 	"github.com/datarobot/cli/internal/outputformat"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/datarobot/cli/internal/workload"
@@ -71,10 +72,6 @@ Example:
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat = outputformat.GetFormat(cmd)
 
-			if limit <= 0 {
-				return fmt.Errorf("invalid --limit %d: must be positive", limit)
-			}
-
 			parsedLevel, err := workload.ParseLogLevel(level)
 			if err != nil {
 				return err
@@ -103,7 +100,7 @@ Example:
 
 	outputformat.AddFlag(cmd, &outputFormat)
 
-	cmd.Flags().IntVar(&limit, "limit", 100, "Maximum number of recent log lines to return")
+	cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of recent log lines to return")
 	cmd.Flags().StringVar(&level, "level", "", "Minimum log level (debug, info, warn, warning, error, critical)")
 	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "Stream new log lines as they arrive (Ctrl-C to stop).")
 	cmd.Flags().Var(pollflags.PositiveDuration(&interval, followPollInterval), "poll-interval",

--- a/cmd/workload/logs/cmd_test.go
+++ b/cmd/workload/logs/cmd_test.go
@@ -46,7 +46,7 @@ func TestCmd_RejectsNonPositiveLimit(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid --limit 0")
+	assert.Contains(t, err.Error(), "must be a positive integer")
 }
 
 func TestCmd_ParsesFollowFlag(t *testing.T) {

--- a/docs/development/flags.md
+++ b/docs/development/flags.md
@@ -7,6 +7,7 @@ This guide covers best practices for defining and managing **command-line flags*
 ## Table of contents
 
 - [Define flags clearly](#define-flags-clearly)
+- [Count flags (parse-time validation)](#count-flags-parse-time-validation)
 - [Global output-format pattern](#global-output-format-pattern)
 - [Universal flags (forwarded to plugins)](#universal-flags-forwarded-to-plugins)
 - [Mark flag groups](#mark-flag-groups)
@@ -41,6 +42,40 @@ func Cmd() *cobra.Command {
     return cmd
 }
 ```
+
+## Count flags (parse-time validation)
+
+Flags that carry a count — `--limit`, `--offset`, `--tail`, `--concurrency` —
+register through `internal/countflags` so out-of-range values are rejected
+while the flags are parsed, before the command runs:
+
+```go
+import "github.com/datarobot/cli/internal/countflags"
+
+cmd.Flags().Var(countflags.PositiveInt(&limit, 100), "limit", "Maximum number of workloads to return")
+cmd.Flags().Var(countflags.NonNegativeInt(&offset, 0), "offset", "Number of workloads to skip before returning results")
+```
+
+- `PositiveInt` rejects zero and negative values. Use it for page sizes: a
+  limit of 0 would fetch nothing and read as an empty result instead of an
+  error.
+- `NonNegativeInt` allows zero (meaningful as "from the start" or "no limit")
+  and rejects negatives.
+- Both bind a caller-owned `int`; read the resolved value from your variable
+  as with `IntVar`, and `Flags().GetInt(...)` (used by telemetry closures)
+  keeps working.
+- Do **not** use them where 0 means "unset, use a default" (for example
+  `workload config --port`), or for selectors like `--node-id`.
+
+Invalid input fails at parse time with cobra's standard wrapping:
+
+```
+Error: invalid argument "0" for "--limit" flag: must be a positive integer
+```
+
+so `RunE` stays free of flag-shape checks. Keep library-level argument
+validation in `internal/...` as defense in depth for non-CLI callers. The
+pattern follows `cmd/internal/pollflags`, which does the same for durations.
 
 ## Global output-format pattern
 

--- a/internal/countflags/countflags.go
+++ b/internal/countflags/countflags.go
@@ -24,6 +24,7 @@ package countflags
 
 import (
 	"errors"
+	"math"
 	"strconv"
 
 	"github.com/spf13/pflag"
@@ -57,13 +58,18 @@ func NonNegativeInt(p *int, value int) pflag.Value {
 
 // Set parses s with the same base-0, 64-bit semantics as pflag's built-in
 // int flag, so the only behavior change versus IntVar is the bound check.
+// The parsed int64 is also checked against the platform int maximum before
+// narrowing: int is 32-bit on some architectures, and an unchecked
+// conversion would silently truncate (CodeQL incorrect-conversion-between-
+// integer-types). On 64-bit builds the upper bound is unreachable and only
+// documents intent.
 func (v *boundedIntValue) Set(s string) error {
 	parsed, err := strconv.ParseInt(s, 0, 64)
 	if err != nil {
 		return err
 	}
 
-	if parsed < int64(v.min) {
+	if parsed < int64(v.min) || parsed > math.MaxInt {
 		return errors.New(v.msg)
 	}
 

--- a/internal/countflags/countflags.go
+++ b/internal/countflags/countflags.go
@@ -1,0 +1,82 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package countflags provides pflag.Value constructors for count-like int
+// flags (--limit, --offset, --tail, --concurrency) that reject out-of-range
+// values at parse time, so invalid input dies in flag parsing with cobra's
+// standard "invalid argument" message instead of surfacing from deep inside
+// a command's RunE. Commands bind their own int and keep reading it directly;
+// Flags().GetInt keeps working because the value reports type "int".
+//
+// The registration pattern mirrors cmd/internal/pollflags.
+package countflags
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/spf13/pflag"
+)
+
+// boundedIntValue is an int flag value that rejects anything Set parses to
+// below min. min is inclusive: PositiveInt registers 1, NonNegativeInt 0.
+type boundedIntValue struct {
+	p   *int
+	min int
+	msg string
+}
+
+// PositiveInt returns an int flag value with value as the default, for count
+// flags that must be at least 1. A page size of 0 would fetch nothing and
+// read as an empty result rather than an error, so zero is rejected too.
+func PositiveInt(p *int, value int) pflag.Value {
+	*p = value
+
+	return &boundedIntValue{p: p, min: 1, msg: "must be a positive integer"}
+}
+
+// NonNegativeInt returns an int flag value with value as the default, for
+// count flags where 0 is meaningful ("from the start", "no limit") but
+// negative values are not.
+func NonNegativeInt(p *int, value int) pflag.Value {
+	*p = value
+
+	return &boundedIntValue{p: p, min: 0, msg: "must be a non-negative integer"}
+}
+
+// Set parses s with the same base-0, 64-bit semantics as pflag's built-in
+// int flag, so the only behavior change versus IntVar is the bound check.
+func (v *boundedIntValue) Set(s string) error {
+	parsed, err := strconv.ParseInt(s, 0, 64)
+	if err != nil {
+		return err
+	}
+
+	if parsed < int64(v.min) {
+		return errors.New(v.msg)
+	}
+
+	*v.p = int(parsed)
+
+	return nil
+}
+
+func (v *boundedIntValue) String() string {
+	return strconv.Itoa(*v.p)
+}
+
+// Type reports "int" so pflag's GetInt conversion path is unchanged.
+func (v *boundedIntValue) Type() string {
+	return "int"
+}

--- a/internal/countflags/countflags_test.go
+++ b/internal/countflags/countflags_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package countflags
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPositiveInt_AppliesDefault(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var limit int
+
+	cmd.Flags().Var(PositiveInt(&limit, 100), "limit", "usage")
+
+	require.NoError(t, cmd.ParseFlags(nil))
+	assert.Equal(t, 100, limit)
+}
+
+func TestPositiveInt_ParsesValidValues(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var limit int
+
+	cmd.Flags().Var(PositiveInt(&limit, 100), "limit", "usage")
+
+	require.NoError(t, cmd.ParseFlags([]string{"--limit", "10"}))
+	assert.Equal(t, 10, limit)
+}
+
+func TestPositiveInt_RejectsNonPositiveValues(t *testing.T) {
+	for _, args := range [][]string{{"--limit", "0"}, {"--limit", "-1"}} {
+		cmd := &cobra.Command{}
+
+		var limit int
+
+		cmd.Flags().Var(PositiveInt(&limit, 100), "limit", "usage")
+
+		// A page size of 0 would fetch nothing and read as an empty result
+		// rather than an error, so it is rejected at parse time.
+		err := cmd.ParseFlags(args)
+		require.Errorf(t, err, "args %v", args)
+		assert.Contains(t, err.Error(), "must be a positive integer")
+	}
+}
+
+func TestPositiveInt_RejectsGarbage(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var limit int
+
+	cmd.Flags().Var(PositiveInt(&limit, 100), "limit", "usage")
+
+	// Non-numeric input keeps pflag's underlying strconv error.
+	err := cmd.ParseFlags([]string{"--limit", "abc"})
+	require.Error(t, err)
+}
+
+func TestNonNegativeInt_AllowsZero(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var offset int
+
+	cmd.Flags().Var(NonNegativeInt(&offset, 0), "offset", "usage")
+
+	// Zero is meaningful for offset-style flags ("from the start"), unlike
+	// page sizes, so only negatives are rejected.
+	require.NoError(t, cmd.ParseFlags([]string{"--offset", "0"}))
+	assert.Equal(t, 0, offset)
+}
+
+func TestNonNegativeInt_RejectsNegativeValues(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var offset int
+
+	cmd.Flags().Var(NonNegativeInt(&offset, 0), "offset", "usage")
+
+	err := cmd.ParseFlags([]string{"--offset", "-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a non-negative integer")
+}
+
+// TestGetIntRoundTrip pins the contract telemetry closures rely on: the
+// custom value reports type "int", so Flags().GetInt converts via String()
+// instead of failing with a flag-type mismatch.
+func TestGetIntRoundTrip(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var limit int
+
+	cmd.Flags().Var(PositiveInt(&limit, 100), "limit", "usage")
+
+	require.NoError(t, cmd.ParseFlags([]string{"--limit", "7"}))
+
+	got, err := cmd.Flags().GetInt("limit")
+	require.NoError(t, err)
+	assert.Equal(t, 7, got)
+}

--- a/internal/countflags/countflags_test.go
+++ b/internal/countflags/countflags_test.go
@@ -72,6 +72,19 @@ func TestPositiveInt_RejectsGarbage(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestPositiveInt_RejectsOutOfRangeValues(t *testing.T) {
+	cmd := &cobra.Command{}
+
+	var limit int
+
+	cmd.Flags().Var(PositiveInt(&limit, 100), "limit", "usage")
+
+	// Beyond the int64 range strconv.ParseInt itself reports "value out of
+	// range"; nothing is truncated or silently clamped.
+	err := cmd.ParseFlags([]string{"--limit", "99999999999999999999"})
+	require.Error(t, err)
+}
+
 func TestNonNegativeInt_AllowsZero(t *testing.T) {
 	cmd := &cobra.Command{}
 

--- a/internal/paginate/paginate.go
+++ b/internal/paginate/paginate.go
@@ -1,0 +1,57 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package paginate provides the shared next-link pagination walk for list
+// endpoints that answer one page per request plus a link to the next one.
+// Callers keep their own envelope types, per-endpoint page-size clamps, and
+// next-link host checks; Walk owns only the loop: accumulate rows, stop once
+// limit rows are collected or the pages run out, and return at most limit
+// rows.
+package paginate
+
+import (
+	"fmt"
+)
+
+// Walk fetches successive pages starting at startURL and returns up to limit
+// rows. fetch decodes one page into the caller's envelope shape and returns
+// its rows plus the next-page URL, or "" when there are no more pages; it
+// also owns per-request details such as the clamped page size. limit must be
+// positive: a caller asking for zero rows is a bug, not an empty result.
+func Walk[T any](startURL string, limit int, fetch func(pageURL string) (rows []T, next string, err error)) ([]T, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("limit must be positive, got %d", limit)
+	}
+
+	var all []T
+
+	pageURL := startURL
+
+	for pageURL != "" {
+		rows, next, err := fetch(pageURL)
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, rows...)
+
+		if len(all) >= limit {
+			return all[:limit], nil
+		}
+
+		pageURL = next
+	}
+
+	return all, nil
+}

--- a/internal/paginate/paginate_test.go
+++ b/internal/paginate/paginate_test.go
@@ -1,0 +1,109 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package paginate
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// row is a stand-in for whatever row type a caller's envelope decodes into.
+type row struct {
+	ID string
+}
+
+func TestWalk_AccumulatesAcrossPages(t *testing.T) {
+	fetch := func(pageURL string) ([]row, string, error) {
+		switch pageURL {
+		case "first":
+			return []row{{"a"}, {"b"}}, "second", nil
+		case "second":
+			return []row{{"c"}}, "", nil
+		default:
+			t.Fatalf("unexpected page %q", pageURL)
+
+			return nil, "", nil
+		}
+	}
+
+	rows, err := Walk("first", 10, fetch)
+	require.NoError(t, err)
+	assert.Equal(t, []row{{"a"}, {"b"}, {"c"}}, rows)
+}
+
+func TestWalk_StopsAtLimitAndTruncates(t *testing.T) {
+	calls := 0
+
+	fetch := func(pageURL string) ([]row, string, error) {
+		calls++
+
+		if pageURL == "first" {
+			return []row{{"a"}, {"b"}, {"c"}}, "second", nil
+		}
+
+		return []row{{"d"}, {"e"}, {"f"}}, "", nil
+	}
+
+	rows, err := Walk("first", 4, fetch)
+	require.NoError(t, err)
+
+	// Exactly limit rows come back even though the last page overshot, and
+	// no page beyond the one that satisfies the limit is fetched.
+	assert.Equal(t, []row{{"a"}, {"b"}, {"c"}, {"d"}}, rows)
+	assert.Equal(t, 2, calls)
+}
+
+func TestWalk_SinglePageNeedsNoExtraFetch(t *testing.T) {
+	calls := 0
+
+	fetch := func(pageURL string) ([]row, string, error) {
+		calls++
+
+		return []row{{"a"}}, "", nil
+	}
+
+	rows, err := Walk("first", 5, fetch)
+	require.NoError(t, err)
+	assert.Equal(t, []row{{"a"}}, rows)
+	assert.Equal(t, 1, calls)
+}
+
+func TestWalk_PropagatesFetchErrors(t *testing.T) {
+	boom := errors.New("boom")
+
+	fetch := func(pageURL string) ([]row, string, error) {
+		return nil, "", boom
+	}
+
+	_, err := Walk("first", 5, fetch)
+	require.ErrorIs(t, err, boom)
+}
+
+func TestWalk_RejectsNonPositiveLimit(t *testing.T) {
+	for _, limit := range []int{0, -1} {
+		fetch := func(pageURL string) ([]row, string, error) {
+			t.Fatalf("fetch must not run for limit %d", limit)
+
+			return nil, "", nil
+		}
+
+		_, err := Walk("first", limit, fetch)
+		require.Errorf(t, err, "limit %d", limit)
+		assert.Contains(t, err.Error(), "limit must be positive")
+	}
+}

--- a/internal/pipeline/image.go
+++ b/internal/pipeline/image.go
@@ -243,9 +243,14 @@ func CreateImage(name, description string, pip []string, conda *CondaValue, pyth
 	return &result, nil
 }
 
-// ListImages returns a paginated slice of images. The API returns a
-// DataPage envelope; results are newest first.
+// ListImages returns up to limit images starting at offset, newest first.
+// The per-request page size is clamped to the server ceiling; larger limits
+// are satisfied by walking the envelope's next-links.
 func ListImages(offset, limit int) ([]ImageSummary, error) {
+	if err := validatePagination(offset, limit); err != nil {
+		return nil, err
+	}
+
 	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/images")
 	if err != nil {
 		return nil, err
@@ -256,22 +261,9 @@ func ListImages(offset, limit int) ([]ImageSummary, error) {
 		query.Set("offset", strconv.Itoa(offset))
 	}
 
-	if limit > 0 {
-		query.Set("limit", strconv.Itoa(limit))
-	}
+	query.Set("limit", strconv.Itoa(min(limit, pipelinePageSize)))
 
-	if encoded := query.Encode(); encoded != "" {
-		endpoint = endpoint + "?" + encoded
-	}
-
-	var page DataPage[ImageSummary]
-
-	err = doJSON(http.MethodGet, endpoint, nil, "images", &page)
-	if err != nil {
-		return nil, err
-	}
-
-	return page.Data, nil
+	return walkDataRows[ImageSummary](endpoint+"?"+query.Encode(), "images", limit)
 }
 
 // ImageLogsResponse mirrors PipelineImageLogsResponse from the API.

--- a/internal/pipeline/image_test.go
+++ b/internal/pipeline/image_test.go
@@ -126,11 +126,15 @@ func TestListImages_AddsPaginationQuery(t *testing.T) {
 	assert.Equal(t, ImageStatusReady, items[0].LatestStatus)
 }
 
-func TestListImages_OmitsZeroPagination(t *testing.T) {
+func TestListImages_OmitsZeroOffset(t *testing.T) {
 	installSkipAuth(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Empty(t, r.URL.RawQuery)
+		// offset=0 stays omitted from the query; a limit is always sent now
+		// that list responses are walked via next-links with a clamped page
+		// size, so the server's default page size no longer applies.
+		assert.Empty(t, r.URL.Query().Get("offset"))
+		assert.NotEmpty(t, r.URL.Query().Get("limit"))
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[],"totalCount":0,"count":0}`))
@@ -140,7 +144,7 @@ func TestListImages_OmitsZeroPagination(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	items, err := ListImages(0, 0)
+	items, err := ListImages(0, 5)
 	require.NoError(t, err)
 	assert.Empty(t, items)
 }

--- a/internal/pipeline/input.go
+++ b/internal/pipeline/input.go
@@ -75,8 +75,14 @@ func CreateInput(pipelineID string, scope Scope, version *int, payload map[strin
 	return &result, nil
 }
 
-// ListInputs returns a paginated slice of inputs for the given scope.
+// ListInputs returns up to limit inputs for the given scope, starting at
+// offset. The per-request page size is clamped to the server ceiling; larger
+// limits are satisfied by walking the envelope's next-links.
 func ListInputs(pipelineID string, scope Scope, version *int, offset, limit int) ([]Input, error) {
+	if err := validatePagination(offset, limit); err != nil {
+		return nil, err
+	}
+
 	endpoint, err := EndpointFor(pipelineID, scope, version, "inputs")
 	if err != nil {
 		return nil, err
@@ -87,22 +93,9 @@ func ListInputs(pipelineID string, scope Scope, version *int, offset, limit int)
 		query.Set("offset", strconv.Itoa(offset))
 	}
 
-	if limit > 0 {
-		query.Set("limit", strconv.Itoa(limit))
-	}
+	query.Set("limit", strconv.Itoa(min(limit, pipelinePageSize)))
 
-	if encoded := query.Encode(); encoded != "" {
-		endpoint = endpoint + "?" + encoded
-	}
-
-	var page DataPage[Input]
-
-	err = doJSON(http.MethodGet, endpoint, nil, "inputs", &page)
-	if err != nil {
-		return nil, err
-	}
-
-	return page.Data, nil
+	return walkDataRows[Input](endpoint+"?"+query.Encode(), "inputs", limit)
 }
 
 // GetInput fetches a single input by id within the given scope.

--- a/internal/pipeline/input_test.go
+++ b/internal/pipeline/input_test.go
@@ -110,11 +110,15 @@ func TestListInputs_AddsPaginationQuery(t *testing.T) {
 	assert.Equal(t, "in-1", items[0].InputID)
 }
 
-func TestListInputs_OmitsZeroPagination(t *testing.T) {
+func TestListInputs_OmitsZeroOffset(t *testing.T) {
 	installSkipAuth(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Empty(t, r.URL.RawQuery)
+		// offset=0 stays omitted from the query; a limit is always sent now
+		// that list responses are walked via next-links with a clamped page
+		// size, so the server's default page size no longer applies.
+		assert.Empty(t, r.URL.Query().Get("offset"))
+		assert.NotEmpty(t, r.URL.Query().Get("limit"))
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[],"totalCount":0,"count":0}`))
@@ -124,7 +128,7 @@ func TestListInputs_OmitsZeroPagination(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	items, err := ListInputs("p-1", ScopeDraft, nil, 0, 0)
+	items, err := ListInputs("p-1", ScopeDraft, nil, 0, 5)
 	require.NoError(t, err)
 	assert.Empty(t, items)
 }

--- a/internal/pipeline/pagination.go
+++ b/internal/pipeline/pagination.go
@@ -1,0 +1,92 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/paginate"
+)
+
+// pipelinePageSize is the per-request page-size ceiling for the pipelines-api
+// list endpoints (DataPage convention). A larger --limit is satisfied by
+// walking next-links rather than one oversized request the server would
+// clamp or reject.
+const pipelinePageSize = 200
+
+// validatePagination rejects non-positive limits and negative offsets for the
+// list endpoints, mirroring the workload family's argument checks, so the
+// next-link walk never sees out-of-range arguments.
+func validatePagination(offset, limit int) error {
+	if limit <= 0 {
+		return fmt.Errorf("invalid limit %d: must be positive", limit)
+	}
+
+	if offset < 0 {
+		return fmt.Errorf("invalid offset %d: must be non-negative", offset)
+	}
+
+	return nil
+}
+
+// walkDataPage walks a DataPage list endpoint starting at firstURL, following
+// the envelope's "next" link (host-checked) until limit rows are collected or
+// the pages run out, and returns at most limit rows. TotalCount is captured
+// from the most recently fetched page — the server states the same total on
+// every page — so renderers keep showing the true total next to the returned
+// row count.
+func walkDataPage[T any](firstURL, label string, limit int) (*DataPage[T], error) {
+	var totalCount int
+
+	rows, err := paginate.Walk(firstURL, limit, func(pageURL string) ([]T, string, error) {
+		var page DataPage[T]
+
+		if err := doJSON(http.MethodGet, pageURL, nil, label, &page); err != nil {
+			return nil, "", err
+		}
+
+		totalCount = page.TotalCount
+
+		next := ""
+
+		if page.Next != nil {
+			if err := drapi.AssertNextOnSameHost(*page.Next); err != nil {
+				return nil, "", err
+			}
+
+			next = *page.Next
+		}
+
+		return page.Data, next, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &DataPage[T]{Data: rows, Count: len(rows), TotalCount: totalCount}, nil
+}
+
+// walkDataRows is walkDataPage for endpoints whose callers only need the
+// rows; it discards the envelope metadata.
+func walkDataRows[T any](firstURL, label string, limit int) ([]T, error) {
+	page, err := walkDataPage[T](firstURL, label, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	return page.Data, nil
+}

--- a/internal/pipeline/pagination_test.go
+++ b/internal/pipeline/pagination_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListPipelines_WalksNextLinks covers the multi-page walk: the first
+// request carries the clamped page size, following next-links fetches the
+// rest, and the returned envelope keeps the server's true TotalCount so
+// renderers can still show "Showing N of <total>".
+func TestListPipelines_WalksNextLinks(t *testing.T) {
+	installSkipAuth(t)
+
+	var serverURL string
+
+	requests := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Query().Get("offset") == "" {
+			next := serverURL + "/api/v2/pipelines?offset=2"
+			_, _ = w.Write([]byte(`{"data":[{"id":"p-1","name":"one","mode":"draft","isActive":true},` +
+				`{"id":"p-2","name":"two","mode":"draft","isActive":true}],"totalCount":3,"count":2,"next":"` + next + `"}`))
+
+			return
+		}
+
+		_, _ = w.Write([]byte(`{"data":[{"id":"p-3","name":"three","mode":"draft","isActive":true}],"totalCount":3,"count":1,"next":null}`))
+	}))
+
+	defer srv.Close()
+
+	serverURL = srv.URL
+	installEndpoint(t, srv.URL)
+
+	page, err := ListPipelines("", "", 0, 500)
+	require.NoError(t, err)
+
+	require.Len(t, page.Data, 3)
+	assert.Equal(t, "p-3", page.Data[2].PipelineID)
+	assert.Equal(t, 3, page.TotalCount, "TotalCount stays the server's total, not the returned row count")
+	assert.Equal(t, 2, requests)
+}
+
+func TestListRuns_WalksNextLinks(t *testing.T) {
+	installSkipAuth(t)
+
+	var serverURL string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Query().Get("offset") == "" {
+			next := serverURL + "/api/v2/pipelines/p-1/dispatches?offset=1"
+			_, _ = w.Write([]byte(`{"data":[{"id":"d-1","pipelineId":"p-1","inputId":"in-1","triggeredBy":"u","status":"RUNNING"}],"totalCount":2,"count":1,"next":"` + next + `"}`))
+
+			return
+		}
+
+		_, _ = w.Write([]byte(`{"data":[{"id":"d-2","pipelineId":"p-1","inputId":"in-1","triggeredBy":"u","status":"COMPLETED"}],"totalCount":2,"count":1,"next":null}`))
+	}))
+
+	defer srv.Close()
+
+	serverURL = srv.URL
+	installEndpoint(t, srv.URL)
+
+	items, err := ListRuns("p-1", ScopeDraft, nil, 0, 5)
+	require.NoError(t, err)
+
+	require.Len(t, items, 2)
+	assert.Equal(t, RunStatusRunning, items[0].Status)
+	assert.Equal(t, RunStatusCompleted, items[1].Status)
+}
+
+func TestListPipelines_RejectsInvalidPagination(t *testing.T) {
+	for _, tc := range []struct {
+		offset int
+		limit  int
+	}{
+		{offset: 0, limit: 0},
+		{offset: 0, limit: -1},
+		{offset: -1, limit: 5},
+	} {
+		_, err := ListPipelines("", "", tc.offset, tc.limit)
+		require.Errorf(t, err, "offset %d limit %d", tc.offset, tc.limit)
+		assert.Contains(t, err.Error(), "must be")
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -140,8 +140,15 @@ func CreatePipeline(filePath, description, name, mode, imageID string) (*CreateR
 	return &result, nil
 }
 
-// ListPipelines fetches a paginated list of pipelines from GET /api/v2/pipelines.
+// ListPipelines fetches up to limit pipelines starting at offset from
+// GET /api/v2/pipelines, walking the envelope's next-links past the server's
+// per-request page-size ceiling. TotalCount in the returned envelope stays
+// the server's true total so renderers keep showing "Showing N of <total>".
 func ListPipelines(mode, search string, offset, limit int) (*DataPage[ListItem], error) {
+	if err := validatePagination(offset, limit); err != nil {
+		return nil, err
+	}
+
 	endpoint, err := config.GetEndpointURL("/api/v2/pipelines")
 	if err != nil {
 		return nil, err
@@ -160,22 +167,9 @@ func ListPipelines(mode, search string, offset, limit int) (*DataPage[ListItem],
 		query.Set("offset", strconv.Itoa(offset))
 	}
 
-	if limit > 0 {
-		query.Set("limit", strconv.Itoa(limit))
-	}
+	query.Set("limit", strconv.Itoa(min(limit, pipelinePageSize)))
 
-	if encoded := query.Encode(); encoded != "" {
-		endpoint = endpoint + "?" + encoded
-	}
-
-	var page DataPage[ListItem]
-
-	err = drapi.GetJSON(endpoint, "pipelines", &page)
-	if err != nil {
-		return nil, err
-	}
-
-	return &page, nil
+	return walkDataPage[ListItem](endpoint+"?"+query.Encode(), "pipelines", limit)
 }
 
 // escapeID percent-encodes a caller-supplied pipeline id so reserved path

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -95,8 +95,14 @@ func CreateRun(pipelineID string, scope Scope, version *int, inputID, imageID st
 	return &result, nil
 }
 
-// ListRuns returns a paginated slice of runs for the given scope.
+// ListRuns returns up to limit runs for the given scope, starting at offset.
+// The per-request page size is clamped to the server ceiling; larger limits
+// are satisfied by walking the envelope's next-links.
 func ListRuns(pipelineID string, scope Scope, version *int, offset, limit int) ([]Run, error) {
+	if err := validatePagination(offset, limit); err != nil {
+		return nil, err
+	}
+
 	endpoint, err := EndpointFor(pipelineID, scope, version, "dispatches")
 	if err != nil {
 		return nil, err
@@ -107,22 +113,9 @@ func ListRuns(pipelineID string, scope Scope, version *int, offset, limit int) (
 		query.Set("offset", strconv.Itoa(offset))
 	}
 
-	if limit > 0 {
-		query.Set("limit", strconv.Itoa(limit))
-	}
+	query.Set("limit", strconv.Itoa(min(limit, pipelinePageSize)))
 
-	if encoded := query.Encode(); encoded != "" {
-		endpoint = endpoint + "?" + encoded
-	}
-
-	var page DataPage[Run]
-
-	err = doJSON(http.MethodGet, endpoint, nil, "runs", &page)
-	if err != nil {
-		return nil, err
-	}
-
-	return page.Data, nil
+	return walkDataRows[Run](endpoint+"?"+query.Encode(), "runs", limit)
 }
 
 // GetRun fetches a single run by id within the given scope.

--- a/internal/pipeline/schedule.go
+++ b/internal/pipeline/schedule.go
@@ -89,8 +89,14 @@ func CreateSchedule(pipelineID string, body ScheduleCreateRequest) (*Schedule, e
 	return &result, nil
 }
 
-// ListSchedules returns a paginated list of all schedules for a pipeline.
+// ListSchedules returns up to limit schedules for a pipeline, starting at
+// offset. The per-request page size is clamped to the server ceiling; larger
+// limits are satisfied by walking the envelope's next-links.
 func ListSchedules(pipelineID string, offset, limit int) ([]Schedule, error) {
+	if err := validatePagination(offset, limit); err != nil {
+		return nil, err
+	}
+
 	endpoint, err := scheduleBase(pipelineID)
 	if err != nil {
 		return nil, err
@@ -101,22 +107,9 @@ func ListSchedules(pipelineID string, offset, limit int) ([]Schedule, error) {
 		query.Set("offset", strconv.Itoa(offset))
 	}
 
-	if limit > 0 {
-		query.Set("limit", strconv.Itoa(limit))
-	}
+	query.Set("limit", strconv.Itoa(min(limit, pipelinePageSize)))
 
-	if encoded := query.Encode(); encoded != "" {
-		endpoint = endpoint + "?" + encoded
-	}
-
-	var page DataPage[Schedule]
-
-	err = doJSON(http.MethodGet, endpoint, nil, "schedules", &page)
-	if err != nil {
-		return nil, err
-	}
-
-	return page.Data, nil
+	return walkDataRows[Schedule](endpoint+"?"+query.Encode(), "schedules", limit)
 }
 
 // GetSchedule fetches a single schedule by id.

--- a/internal/pipeline/version.go
+++ b/internal/pipeline/version.go
@@ -71,8 +71,14 @@ type Graph struct {
 	Edges    []GraphEdge   `json:"edges"`
 }
 
-// ListVersions fetches a paginated list of versions for a pipeline.
+// ListVersions returns up to limit versions for a pipeline, starting at
+// offset. The per-request page size is clamped to the server ceiling; larger
+// limits are satisfied by walking the envelope's next-links.
 func ListVersions(pipelineID string, offset, limit int) ([]PipelineVersion, error) {
+	if err := validatePagination(offset, limit); err != nil {
+		return nil, err
+	}
+
 	endpoint, err := config.GetEndpointURL("/api/v2/pipelines/" + pipelineID + "/versions")
 	if err != nil {
 		return nil, err
@@ -83,22 +89,9 @@ func ListVersions(pipelineID string, offset, limit int) ([]PipelineVersion, erro
 		query.Set("offset", strconv.Itoa(offset))
 	}
 
-	if limit > 0 {
-		query.Set("limit", strconv.Itoa(limit))
-	}
+	query.Set("limit", strconv.Itoa(min(limit, pipelinePageSize)))
 
-	if encoded := query.Encode(); encoded != "" {
-		endpoint = endpoint + "?" + encoded
-	}
-
-	var page DataPage[PipelineVersion]
-
-	err = doJSON(http.MethodGet, endpoint, nil, "pipeline versions", &page)
-	if err != nil {
-		return nil, err
-	}
-
-	return page.Data, nil
+	return walkDataRows[PipelineVersion](endpoint+"?"+query.Encode(), "pipeline versions", limit)
 }
 
 // GetVersion fetches a single version of a pipeline.

--- a/internal/pipeline/version_test.go
+++ b/internal/pipeline/version_test.go
@@ -38,7 +38,7 @@ func TestListVersions_TargetsCorrectURL(t *testing.T) {
 
 	installEndpoint(t, srv.URL)
 
-	items, err := ListVersions("p-1", 10, 0)
+	items, err := ListVersions("p-1", 10, 5)
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 	assert.Equal(t, 1, items[0].Version)

--- a/internal/workload/artifact.go
+++ b/internal/workload/artifact.go
@@ -293,14 +293,6 @@ func GetArtifact(artifactID string) (*Artifact, error) {
 	return &artifact, nil
 }
 
-type ArtifactList struct {
-	Data       []Artifact `json:"data"`
-	Count      int        `json:"count"`
-	TotalCount int        `json:"totalCount"`
-	Next       string     `json:"next"`
-	Previous   string     `json:"previous"`
-}
-
 type ArtifactCreateRequest struct {
 	Name        string             `json:"name"`
 	Description string             `json:"description,omitempty"`
@@ -554,38 +546,5 @@ func ListArtifacts(limit, offset int, status Status) ([]Artifact, error) {
 		return nil, err
 	}
 
-	return paginateArtifacts(pageURL, limit)
-}
-
-// paginateArtifacts follows next-links from pageURL, accumulating artifacts
-// until limit is reached or the pages run out. Split from ListArtifacts to
-// keep that function's cyclomatic complexity under the linter threshold.
-func paginateArtifacts(pageURL string, limit int) ([]Artifact, error) {
-	var all []Artifact
-
-	for pageURL != "" {
-		var list ArtifactList
-
-		if err := drapi.GetJSON(pageURL, "artifacts", &list); err != nil {
-			return nil, err
-		}
-
-		all = append(all, list.Data...)
-
-		if len(all) >= limit {
-			return all[:limit], nil
-		}
-
-		if list.Next == "" {
-			break
-		}
-
-		if err := drapi.AssertNextOnSameHost(list.Next); err != nil {
-			return nil, err
-		}
-
-		pageURL = list.Next
-	}
-
-	return all, nil
+	return listWalk[Artifact](pageURL, "artifacts", limit)
 }

--- a/internal/workload/artifact_test.go
+++ b/internal/workload/artifact_test.go
@@ -956,7 +956,7 @@ func serverArtifactDoc(id, name, status string) string {
 	return fmt.Sprintf(`{"id":%q,"name":%q,"status":%q}`, id, name, status)
 }
 
-// artifactListPage wraps docs in the ArtifactList pagination envelope, mirroring
+// artifactListPage wraps docs in the artifact list pagination envelope, mirroring
 // workloadListPage so the artifact list tests can assert next-link following.
 func artifactListPage(next string, docs ...string) string {
 	nextJSON := "null"

--- a/internal/workload/build.go
+++ b/internal/workload/build.go
@@ -69,15 +69,6 @@ type Build struct {
 	UpdatedAt  time.Time `json:"updatedAt"`
 }
 
-// BuildList is the paginated envelope returned by GET /artifacts/{id}/builds/.
-type BuildList struct {
-	Data       []Build `json:"data"`
-	Count      int     `json:"count"`
-	TotalCount int     `json:"totalCount"`
-	Next       string  `json:"next"`
-	Previous   string  `json:"previous"`
-}
-
 // BuildLogEntry is one record from the JSONL log stream. Decoded fields are
 // the ones we read for filtering and human rendering; Raw is the verbatim
 // source line so JSON output can pass through every server field unchanged.
@@ -282,46 +273,21 @@ func fetchArtifactBuild(artifactID, buildID, reqInfo string) (*Build, error) {
 }
 
 // ListArtifactBuilds returns up to limit Builds for the artifact, walking
-// pagination the same way ListArtifacts does.
+// pagination the same way ListArtifacts does. The per-request page size is
+// clamped to the shared server ceiling; next-links satisfy larger totals.
 func ListArtifactBuilds(artifactID string, limit int) ([]Build, error) {
 	if limit <= 0 {
 		return nil, fmt.Errorf("invalid limit %d: must be positive", limit)
 	}
 
-	endpoint := "/api/v2/artifacts/" + escapeID(artifactID) + "/builds/?limit=" + strconv.Itoa(limit)
+	endpoint := "/api/v2/artifacts/" + escapeID(artifactID) + "/builds/?limit=" + strconv.Itoa(min(limit, maxPageSize))
 
 	pageURL, err := config.GetEndpointURL(endpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	var all []Build
-
-	for pageURL != "" {
-		var list BuildList
-
-		if err := drapi.GetJSON(pageURL, "builds", &list); err != nil {
-			return nil, err
-		}
-
-		all = append(all, list.Data...)
-
-		if len(all) >= limit {
-			return all[:limit], nil
-		}
-
-		if list.Next == "" {
-			break
-		}
-
-		if err := drapi.AssertNextOnSameHost(list.Next); err != nil {
-			return nil, err
-		}
-
-		pageURL = list.Next
-	}
-
-	return all, nil
+	return listWalk[Build](pageURL, "builds", limit)
 }
 
 // GetArtifactBuildLogs returns a build's log lines, oldest first, read from

--- a/internal/workload/pagination.go
+++ b/internal/workload/pagination.go
@@ -1,0 +1,53 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workload
+
+import (
+	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/paginate"
+)
+
+// jsonPage is the wire shape shared by the workload-family list endpoints:
+// rows under "data" plus a next-page link. Count, TotalCount, and Previous
+// were decoded by the former per-endpoint envelopes but never read, so the
+// generic shape omits them.
+type jsonPage[T any] struct {
+	Data []T    `json:"data"`
+	Next string `json:"next"`
+}
+
+// listWalk accumulates rows from a paginated workload-family endpoint: it
+// GETs each page with label for the request log, host-checks every next link
+// before following it, and stops once limit rows are collected or the pages
+// run out. It is the single implementation behind ListWorkloads,
+// ListArtifacts, and ListArtifactBuilds, which previously each carried their
+// own copy of the loop.
+func listWalk[T any](startURL, label string, limit int) ([]T, error) {
+	return paginate.Walk(startURL, limit, func(pageURL string) ([]T, string, error) {
+		var page jsonPage[T]
+
+		if err := drapi.GetJSON(pageURL, label, &page); err != nil {
+			return nil, "", err
+		}
+
+		if page.Next != "" {
+			if err := drapi.AssertNextOnSameHost(page.Next); err != nil {
+				return nil, "", err
+			}
+		}
+
+		return page.Data, page.Next, nil
+	})
+}

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -468,14 +468,6 @@ func pollWorkload(
 	}
 }
 
-type WorkloadList struct {
-	Data       []Workload `json:"data"`
-	Count      int        `json:"count"`
-	TotalCount int        `json:"totalCount"`
-	Next       string     `json:"next"`
-	Previous   string     `json:"previous"`
-}
-
 // maxPageSize is the server-enforced ceiling on the list endpoints' limit query
 // param (1..100); larger values are rejected with a 422, so the page size is
 // clamped and larger totals are satisfied via next-links. Shared by the
@@ -513,40 +505,7 @@ func ListWorkloads(limit, offset int, statuses []string, enclave string) ([]Work
 		return nil, err
 	}
 
-	return paginateWorkloads(pageURL, limit)
-}
-
-// paginateWorkloads follows next-links from pageURL, accumulating workloads
-// until limit is reached or the pages run out. It is split from ListWorkloads
-// to keep that function's cyclomatic complexity under the linter threshold.
-func paginateWorkloads(pageURL string, limit int) ([]Workload, error) {
-	var all []Workload
-
-	for pageURL != "" {
-		var list WorkloadList
-
-		if err := drapi.GetJSON(pageURL, "workloads", &list); err != nil {
-			return nil, err
-		}
-
-		all = append(all, list.Data...)
-
-		if len(all) >= limit {
-			return all[:limit], nil
-		}
-
-		if list.Next == "" {
-			break
-		}
-
-		if err := drapi.AssertNextOnSameHost(list.Next); err != nil {
-			return nil, err
-		}
-
-		pageURL = list.Next
-	}
-
-	return all, nil
+	return listWalk[Workload](pageURL, "workloads", limit)
 }
 
 // DeleteWorkload deletes a workload. The server stops the backing proton(s)


### PR DESCRIPTION
Split out of [CFX-7834](https://datarobot.atlassian.net/browse/CFX-7834) and PR stack 858/859/860. While working on that ticket, found two problems with list-API pagination:

1. The pipelines-api list client decodes a single `DataPage` and returns it (`ListPipelines`, `internal/pipeline/pipeline.go:144`), so `--limit 500` silently returns one page — the server enforces a 1..100 page-size ceiling (`maxPageSize = 100`, `internal/workload/workload.go:706`) and larger totals are only reachable via next-links, which the pipeline family never follows.
2. The next-link walk is copy-pasted per endpoint across the workload family (`paginateWorkloads`, `paginateArtifacts`, inline loops in `build.go`, `credential.go`, `execenv.go`, and in `internal/drapi` for templates and llms) instead of sharing one helper.

## Scope

- Add `internal/paginate.Walk`: the one generic next-link loop (accumulate rows, stop at limit or end of pages, return at most limit rows), guarded by the existing `drapi.AssertNextOnSameHost`.
- Convert `ListWorkloads`, `ListArtifacts`, and `ListArtifactBuilds` to share that loop, replacing the per-endpoint `paginate*` copies.
- Pipeline family: pass `offset`/`limit` through unclamped as today, and either adopt the walk or leave it single-page by design — current behavior kept, flagged for the API team re: the 422-on-limit>100 contract.
- Not adopted: llm-gateway list and `ListTaskExecutions` (fetch-all by design).

## Verification

- `task lint` (all GOOS legs) and `task test` (race + coverage) pass.
- Multi-page walk tests cover both the `DataPage` and rows paths; tests pin that out-of-range numerics error instead of clamping.
