### PR TITLE
[RAPTOR-19524] Track executable bit for files

### DIFF
--- a/cmd/artifact/code/checkout/checkout.go
+++ b/cmd/artifact/code/checkout/checkout.go
@@ -298,7 +298,7 @@ func downloadAll(c filesapi.Client, catalogID, versionID, checkoutDir string, fi
 	}
 
 	for _, path := range paths {
-		if err := downloadOne(c, catalogID, versionID, checkoutDir, path); err != nil {
+		if err := downloadOne(c, catalogID, versionID, checkoutDir, path, files[path].Mode); err != nil {
 			return err
 		}
 	}
@@ -307,7 +307,7 @@ func downloadAll(c filesapi.Client, catalogID, versionID, checkoutDir string, fi
 }
 
 // Server-side hashes are not re-verified: TLS covers transit corruption and the snapshot is read-only.
-func downloadOne(c filesapi.Client, catalogID, versionID, checkoutDir, path string) error {
+func downloadOne(c filesapi.Client, catalogID, versionID, checkoutDir, path string, mode uint32) error {
 	dst := filepath.Join(checkoutDir, filepath.FromSlash(path))
 
 	if err := os.MkdirAll(filepath.Dir(dst), checkoutDirPerm); err != nil {
@@ -328,6 +328,10 @@ func downloadOne(c filesapi.Client, catalogID, versionID, checkoutDir, path stri
 		_ = os.Remove(dst)
 
 		return fmt.Errorf("download %s: %w", path, err)
+	}
+
+	if err := fileops.ApplyMode(dst, mode); err != nil {
+		return fmt.Errorf("set mode on %s: %w", path, err)
 	}
 
 	return nil

--- a/cmd/artifact/code/checkout/cmd_test.go
+++ b/cmd/artifact/code/checkout/cmd_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	gosync "sync"
 	"testing"
 
@@ -43,6 +44,7 @@ type fakeClient struct {
 
 	versions []filesapi.CatalogVersion
 	content  map[string][]byte
+	modes    map[string]uint32
 
 	allFilesErr error
 	downloadErr error
@@ -69,7 +71,7 @@ func (f *fakeClient) AllFiles(_, _ string) (map[string]filesapi.FileMeta, error)
 
 	for path, data := range f.content {
 		sum := sha256.Sum256(data)
-		out[path] = filesapi.FileMeta{Hash: hex.EncodeToString(sum[:]), Size: int64(len(data))}
+		out[path] = filesapi.FileMeta{Hash: hex.EncodeToString(sum[:]), Size: int64(len(data)), Mode: f.modes[path]}
 	}
 
 	return out, nil
@@ -204,6 +206,41 @@ func TestCheckout_ReportsStateMigration(t *testing.T) {
 	assert.Contains(t, buf.String(), wapi.LegacyDirName)
 	assert.Contains(t, buf.String(), path.Join(wapi.RootDirName, wapi.StateDirName))
 	assert.NoDirExists(t, legacy, "and the move actually happened")
+}
+
+func TestCheckout_RestoresMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not meaningful on Windows")
+	}
+
+	dir := initLinkedDir(t, "cat-1")
+
+	fc := &fakeClient{
+		versions: []filesapi.CatalogVersion{{ID: verA}},
+		content: map[string][]byte{
+			"entrypoint.sh": []byte("#!/bin/sh\n"),
+			"README.md":     []byte("hi"),
+		},
+		modes: map[string]uint32{
+			"entrypoint.sh": 0o755,
+			// README.md deliberately absent -- mode unknown, default stands.
+		},
+	}
+
+	deps := fakeDeps(draftArtifact("art-abc-123"), fc)
+
+	cmd, _ := newTestCmd(t, dir, deps, []string{verA})
+	require.NoError(t, cmd.Execute())
+
+	checkoutDir := wapi.CheckoutDir(dir, verA)
+
+	entrypointInfo, err := os.Stat(filepath.Join(checkoutDir, "entrypoint.sh"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), entrypointInfo.Mode().Perm())
+
+	readmeInfo, err := os.Stat(filepath.Join(checkoutDir, "README.md"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), readmeInfo.Mode().Perm(), "unknown mode leaves the os.Create default untouched")
 }
 
 func TestCheckout_NoCatalog(t *testing.T) {

--- a/cmd/artifact/code/checkout/cmd_test.go
+++ b/cmd/artifact/code/checkout/cmd_test.go
@@ -103,9 +103,12 @@ func (f *fakeClient) callCounts() (all, dl int) {
 }
 
 // Panicking stubs for the rest of filesapi.Client.
-func (*fakeClient) CreateCatalog() (*filesapi.CatalogResp, error)                { panic("unused") }
-func (*fakeClient) CreateStage(string) (*filesapi.StageResp, error)              { panic("unused") }
-func (*fakeClient) UploadToStage(string, string, string, int64, io.Reader) error { panic("unused") }
+func (*fakeClient) CreateCatalog() (*filesapi.CatalogResp, error)   { panic("unused") }
+func (*fakeClient) CreateStage(string) (*filesapi.StageResp, error) { panic("unused") }
+func (*fakeClient) UploadToStage(string, string, string, int64, uint32, io.Reader) error {
+	panic("unused")
+}
+
 func (*fakeClient) ApplyStage(string, string, string) (*filesapi.ApplyStageResp, error) {
 	panic("unused")
 }

--- a/cmd/artifact/code/versions/cmd_test.go
+++ b/cmd/artifact/code/versions/cmd_test.go
@@ -56,7 +56,7 @@ func (*fakeClient) CreateStage(string) (*filesapi.StageResp, error) {
 	panic("unused")
 }
 
-func (*fakeClient) UploadToStage(string, string, string, int64, io.Reader) error {
+func (*fakeClient) UploadToStage(string, string, string, int64, uint32, io.Reader) error {
 	panic("unused")
 }
 

--- a/internal/drapi/filesapi/allfiles.go
+++ b/internal/drapi/filesapi/allfiles.go
@@ -44,7 +44,7 @@ func (c *httpClient) AllFiles(catalogID, versionID string) (map[string]FileMeta,
 				return nil, fmt.Errorf("remote manifest entry %q: %w", item.FileName, err)
 			}
 
-			out[key] = FileMeta{Hash: item.FileChecksum, Size: item.FileSize}
+			out[key] = FileMeta{Hash: item.FileChecksum, Size: item.FileSize, Mode: item.FileMode}
 		}
 
 		if page.Next == "" {

--- a/internal/drapi/filesapi/client.go
+++ b/internal/drapi/filesapi/client.go
@@ -21,7 +21,7 @@ import (
 type Client interface {
 	CreateCatalog() (*CatalogResp, error)
 	CreateStage(catalogID string) (*StageResp, error)
-	UploadToStage(catalogID, stageID, name string, size int64, body io.Reader) error
+	UploadToStage(catalogID, stageID, name string, size int64, mode uint32, body io.Reader) error
 	ApplyStage(catalogID, stageID, overwrite string) (*ApplyStageResp, error)
 	UploadFromZipNew(name string, size int64, body io.Reader) (*FromFileResp, error)
 	UploadFromZipExisting(catalogID, name, overwrite string, size int64, body io.Reader) (*FromFileResp, error)

--- a/internal/drapi/filesapi/client_test.go
+++ b/internal/drapi/filesapi/client_test.go
@@ -118,6 +118,7 @@ func TestUploadToStage_Multipart(t *testing.T) {
 		assert.Equal(t, "/api/v2/files/cid-1/stages/st-1/upload/", r.URL.Path)
 		assert.Equal(t, http.MethodPost, r.Method)
 		assert.Contains(t, r.Header.Get("Content-Type"), "multipart/form-data")
+		assert.Equal(t, "0755", r.URL.Query().Get("mode"))
 
 		mr, err := r.MultipartReader()
 		if !assert.NoError(t, err) {
@@ -146,7 +147,24 @@ func TestUploadToStage_Multipart(t *testing.T) {
 
 	c := New()
 	body := strings.NewReader("print('hi')\n")
-	err := c.UploadToStage("cid-1", "st-1", "agent.py", int64(body.Len()), body)
+	err := c.UploadToStage("cid-1", "st-1", "agent.py", int64(body.Len()), 0o755, body)
+	require.NoError(t, err)
+}
+
+// A zero mode means "unknown" (see FileEntry.Mode) and must omit the query
+// param entirely, not send mode=0 -- a server that doesn't understand the
+// param yet must see exactly what it saw before mode existed.
+func TestUploadToStage_ZeroModeOmitsQueryParam(t *testing.T) {
+	startServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.URL.RawQuery)
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"catalogId":"cid-1","stageId":"st-1"}`))
+	}))
+
+	c := New()
+	body := strings.NewReader("print('hi')\n")
+	err := c.UploadToStage("cid-1", "st-1", "agent.py", int64(body.Len()), 0, body)
 	require.NoError(t, err)
 }
 
@@ -176,7 +194,7 @@ func TestUploadToStage_AdvertisesContentLength(t *testing.T) {
 
 	c := New()
 	body := strings.NewReader(payload)
-	require.NoError(t, c.UploadToStage("cid-1", "st-1", "test.txt", int64(body.Len()), body))
+	require.NoError(t, c.UploadToStage("cid-1", "st-1", "test.txt", int64(body.Len()), 0, body))
 
 	assert.Greater(t, gotContentLength, int64(len(payload)),
 		"Content-Length should include multipart envelope, not just payload")

--- a/internal/drapi/filesapi/stage.go
+++ b/internal/drapi/filesapi/stage.go
@@ -53,14 +53,24 @@ func (c *httpClient) CreateStage(catalogID string) (*StageResp, error) {
 	return &resp, nil
 }
 
-func (c *httpClient) UploadToStage(catalogID, stageID, name string, size int64, body io.Reader) error {
+func (c *httpClient) UploadToStage(catalogID, stageID, name string, size int64, mode uint32, body io.Reader) error {
 	requestURL, err := drapi.EndpointURL(
 		"/files/"+url.PathEscape(catalogID)+"/stages/"+url.PathEscape(stageID)+"/upload/", nil)
 	if err != nil {
 		return fmt.Errorf("build upload url: %w", err)
 	}
 
-	req, err := newStreamingMultipartRequest(requestURL, nil, name, size, body)
+	// mode == 0 means "unknown" (see FileEntry.Mode) -- omit the param
+	// entirely rather than sending mode=0, so a server that doesn't
+	// understand it yet sees no param at all, exactly as before this field
+	// existed.
+	var query url.Values
+
+	if mode != 0 {
+		query = url.Values{"mode": []string{fmt.Sprintf("0%o", mode)}}
+	}
+
+	req, err := newStreamingMultipartRequest(requestURL, query, name, size, body)
 	if err != nil {
 		return err
 	}

--- a/internal/drapi/filesapi/types.go
+++ b/internal/drapi/filesapi/types.go
@@ -14,11 +14,13 @@
 
 package filesapi
 
-// FileMeta is the per-file entry in a manifest: SHA-256 hex + byte size.
-// Shape matches wapi.FileMeta so manifests compare without conversion.
+// FileMeta is the per-file entry in a manifest: SHA-256 hex + byte size +
+// Unix permission bits. Shape matches wapi.FileMeta so manifests compare
+// without conversion.
 type FileMeta struct {
 	Hash string
 	Size int64
+	Mode uint32
 }
 
 // Overwrite modes for the stage and zip endpoints. The sync engine uses
@@ -109,6 +111,10 @@ type AllFilesItem struct {
 	FileType     string `json:"fileType,omitempty"`
 	FileSize     int64  `json:"fileSize"`
 	FileChecksum string `json:"fileChecksum"`
+	// FileMode carries Unix permission bits (0-0777). Absent/zero on any
+	// response from a server that doesn't populate it yet -- treated
+	// uniformly as "mode unknown" by every consumer.
+	FileMode uint32 `json:"fileMode,omitempty"`
 }
 
 type DeleteFilesReq struct {

--- a/internal/workload/fileops/hash.go
+++ b/internal/workload/fileops/hash.go
@@ -30,23 +30,23 @@ const (
 
 var ErrFileTooLarge = errors.New("file exceeds MaxFileSizeBytes")
 
-func HashFile(path string) (string, int64, error) {
+func HashFile(path string) (string, int64, os.FileMode, error) {
 	return hashFile(path, MaxFileSizeBytes)
 }
 
-func hashFile(path string, maxBytes int64) (string, int64, error) {
+func hashFile(path string, maxBytes int64) (string, int64, os.FileMode, error) {
 	info, err := os.Stat(path)
 	if err != nil {
-		return "", 0, fmt.Errorf("stat %s: %w", path, err)
+		return "", 0, 0, fmt.Errorf("stat %s: %w", path, err)
 	}
 
 	if info.Size() > maxBytes {
-		return "", info.Size(), fmt.Errorf("%w: %s (%d bytes)", ErrFileTooLarge, path, info.Size())
+		return "", info.Size(), 0, fmt.Errorf("%w: %s (%d bytes)", ErrFileTooLarge, path, info.Size())
 	}
 
 	f, err := os.Open(path)
 	if err != nil {
-		return "", info.Size(), fmt.Errorf("open %s: %w", path, err)
+		return "", info.Size(), 0, fmt.Errorf("open %s: %w", path, err)
 	}
 
 	defer func() { _ = f.Close() }()
@@ -55,10 +55,10 @@ func hashFile(path string, maxBytes int64) (string, int64, error) {
 	buf := make([]byte, HashChunkSizeBytes)
 
 	if _, err := io.CopyBuffer(h, f, buf); err != nil {
-		return "", info.Size(), fmt.Errorf("hash %s: %w", path, err)
+		return "", info.Size(), 0, fmt.Errorf("hash %s: %w", path, err)
 	}
 
-	return hex.EncodeToString(h.Sum(nil)), info.Size(), nil
+	return hex.EncodeToString(h.Sum(nil)), info.Size(), info.Mode().Perm(), nil
 }
 
 func HashReader(r io.Reader) (string, int64, error) {

--- a/internal/workload/fileops/hash_test.go
+++ b/internal/workload/fileops/hash_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestHashFile(t *testing.T) {
 
 		want := sha256.Sum256(body)
 
-		gotHash, gotSize, err := HashFile(path)
+		gotHash, gotSize, _, err := HashFile(path)
 		require.NoError(t, err)
 		assert.Equal(t, hex.EncodeToString(want[:]), gotHash)
 		assert.Equal(t, int64(len(body)), gotSize)
@@ -46,7 +47,7 @@ func TestHashFile(t *testing.T) {
 		path := filepath.Join(dir, "empty.txt")
 		require.NoError(t, os.WriteFile(path, nil, 0o644))
 
-		gotHash, gotSize, err := HashFile(path)
+		gotHash, gotSize, _, err := HashFile(path)
 		require.NoError(t, err)
 		// Known SHA-256 of empty input.
 		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", gotHash)
@@ -54,7 +55,7 @@ func TestHashFile(t *testing.T) {
 	})
 
 	t.Run("Missing", func(t *testing.T) {
-		_, _, err := HashFile(filepath.Join(dir, "nope.txt"))
+		_, _, _, err := HashFile(filepath.Join(dir, "nope.txt"))
 		require.Error(t, err)
 	})
 
@@ -70,10 +71,24 @@ func TestHashFile(t *testing.T) {
 
 		want := sha256.Sum256(body)
 
-		gotHash, gotSize, err := HashFile(path)
+		gotHash, gotSize, _, err := HashFile(path)
 		require.NoError(t, err)
 		assert.Equal(t, hex.EncodeToString(want[:]), gotHash)
 		assert.Equal(t, int64(len(body)), gotSize)
+	})
+
+	t.Run("CapturesMode", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Unix permission bits are not meaningful on Windows")
+		}
+
+		path := filepath.Join(dir, "exe.sh")
+		require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"), 0o644))
+		require.NoError(t, os.Chmod(path, 0o755))
+
+		_, _, gotMode, err := HashFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o755), gotMode.Perm())
 	})
 }
 
@@ -86,7 +101,7 @@ func TestHashFile_ExceedsMaxSize(t *testing.T) {
 		path := filepath.Join(dir, "x.bin")
 		require.NoError(t, os.WriteFile(path, []byte("0123456789"), 0o644))
 
-		_, _, err := hashFile(path, 4)
+		_, _, _, err := hashFile(path, 4)
 		require.ErrorIs(t, err, ErrFileTooLarge)
 		assert.Contains(t, err.Error(), "x.bin")
 	})

--- a/internal/workload/fileops/mode.go
+++ b/internal/workload/fileops/mode.go
@@ -1,0 +1,38 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileops
+
+import "os"
+
+// ApplyMode chmods path to the low 9 permission bits of mode. mode == 0
+// means "no mode information available" (a manifest/response predating mode
+// tracking, or a server that hasn't shipped a mode field yet) and is a
+// deliberate no-op: chmod-ing to literal 0 would strip all permissions,
+// which is strictly worse than leaving the file at its just-written
+// default mode.
+//
+// On Windows this is a safe no-op beyond the read-only attribute: NTFS has
+// no owner/group/execute concept, so os.Chmod there only honors the 0200
+// (owner-write) bit -- the executable bit this feature exists for is
+// silently ignored, never errored, consistent with how Windows determines
+// executability by extension/interpreter rather than a permission bit.
+func ApplyMode(path string, mode uint32) error {
+	perm := os.FileMode(mode).Perm()
+	if perm == 0 {
+		return nil
+	}
+
+	return os.Chmod(path, perm)
+}

--- a/internal/workload/fileops/mode_test.go
+++ b/internal/workload/fileops/mode_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileops
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not meaningful on Windows")
+	}
+
+	t.Run("chmods for a non-zero mode", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "f")
+		require.NoError(t, os.WriteFile(path, []byte("x"), 0o644))
+
+		require.NoError(t, ApplyMode(path, 0o755))
+
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+	})
+
+	t.Run("no-ops for a zero mode", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "f")
+		require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
+
+		require.NoError(t, ApplyMode(path, 0))
+
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	})
+}

--- a/internal/workload/sync/diff.go
+++ b/internal/workload/sync/diff.go
@@ -20,6 +20,7 @@ import "github.com/datarobot/cli/internal/drapi/filesapi"
 type FileEntry struct {
 	Hash string
 	Size int64
+	Mode uint32
 }
 
 type (
@@ -53,6 +54,8 @@ func Diff(base, local, remote BaseManifest) *SyncPlan {
 			RemoteSize:     r.Size,
 			LocalHash:      l.Hash,
 			RemoteHash:     r.Hash,
+			LocalMode:      l.Mode,
+			RemoteMode:     r.Mode,
 		})
 	}
 
@@ -75,7 +78,7 @@ func pathUnion(maps ...BaseManifest) map[string]struct{} {
 func FromFilesAPI(remote map[string]filesapi.FileMeta) RemoteManifest {
 	out := make(RemoteManifest, len(remote))
 	for k, v := range remote {
-		out[k] = FileEntry{Hash: v.Hash, Size: v.Size}
+		out[k] = FileEntry{Hash: v.Hash, Size: v.Size, Mode: v.Mode}
 	}
 
 	return out

--- a/internal/workload/sync/diff_test.go
+++ b/internal/workload/sync/diff_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/datarobot/cli/internal/drapi/filesapi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func entry(hash string, size int64) FileEntry { return FileEntry{Hash: hash, Size: size} }
@@ -114,12 +115,25 @@ func TestDiff_BytesAccounting(t *testing.T) {
 func TestFromFilesAPI_RoundTrip(t *testing.T) {
 	in := map[string]filesapi.FileMeta{
 		"a.py": {Hash: "aaa", Size: 10},
-		"b.py": {Hash: "bbb", Size: 20},
+		"b.py": {Hash: "bbb", Size: 20, Mode: 0o755},
 	}
 
 	got := FromFilesAPI(in)
 
 	assert.Len(t, got, 2)
 	assert.Equal(t, FileEntry{Hash: "aaa", Size: 10}, got["a.py"])
-	assert.Equal(t, FileEntry{Hash: "bbb", Size: 20}, got["b.py"])
+	assert.Equal(t, FileEntry{Hash: "bbb", Size: 20, Mode: 0o755}, got["b.py"])
+}
+
+func TestDiff_ModePropagation(t *testing.T) {
+	base := BaseManifest{"a.py": {Hash: "aaa", Size: 10, Mode: 0o644}}
+	local := BaseManifest{"a.py": {Hash: "aaa-local", Size: 11, Mode: 0o755}}
+	remote := BaseManifest{"a.py": {Hash: "aaa-remote", Size: 12, Mode: 0o644}}
+
+	plan := Diff(base, local, remote)
+
+	require.Len(t, plan.Conflicts, 1)
+
+	assert.Equal(t, uint32(0o755), plan.Conflicts[0].LocalMode)
+	assert.Equal(t, uint32(0o644), plan.Conflicts[0].RemoteMode)
 }

--- a/internal/workload/sync/download.go
+++ b/internal/workload/sync/download.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"io"
 	"os"
 	"path/filepath"
@@ -123,6 +124,13 @@ func downloadOne(e *Engine, catalogID, versionID string, fa FileAction) error {
 		return fmt.Errorf("close %s: %w", fa.Path, closeErr)
 	}
 
+	return verifyDownload(dst, fa, n, h)
+}
+
+// verifyDownload checks size/hash against what the plan expects, then
+// restores the remote mode. dst is removed if verification fails; a mode
+// restore failure is not, since the content itself is already correct.
+func verifyDownload(dst string, fa FileAction, n int64, h hash.Hash) error {
 	if fa.RemoteSize > 0 && n != fa.RemoteSize {
 		_ = os.Remove(dst)
 		return fmt.Errorf("download size mismatch on %s: expected %d, got %d", fa.Path, fa.RemoteSize, n)
@@ -134,6 +142,10 @@ func downloadOne(e *Engine, catalogID, versionID string, fa FileAction) error {
 			_ = os.Remove(dst)
 			return fmt.Errorf("checksum mismatch on %s: expected %s, got %s", fa.Path, fa.RemoteHash, got)
 		}
+	}
+
+	if err := fileops.ApplyMode(dst, fa.RemoteMode); err != nil {
+		return fmt.Errorf("set mode on %s: %w", fa.Path, err)
 	}
 
 	return nil

--- a/internal/workload/sync/download_test.go
+++ b/internal/workload/sync/download_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// downloadingFilesClient serves fixed content for DownloadFile; everything
+// else is inherited (and panics if hit) from fakeFilesClient.
+type downloadingFilesClient struct {
+	fakeFilesClient
+
+	body []byte
+}
+
+func (f *downloadingFilesClient) DownloadFile(_, _, _ string, w io.Writer) (string, int64, error) {
+	n, err := w.Write(f.body)
+	return "", int64(n), err
+}
+
+func TestDownloadOne_RestoresRemoteMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not meaningful on Windows")
+	}
+
+	dir := t.TempDir()
+	body := []byte("#!/bin/sh\n")
+
+	e := &Engine{
+		projectDir: dir,
+		files:      &downloadingFilesClient{body: body},
+	}
+
+	fa := FileAction{Path: "entrypoint.sh", RemoteMode: 0o755}
+
+	require.NoError(t, downloadOne(e, "cid", "vid", fa))
+
+	info, err := os.Stat(filepath.Join(dir, "entrypoint.sh"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}
+
+func TestDownloadOne_UnknownModeLeavesDefault(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not meaningful on Windows")
+	}
+
+	dir := t.TempDir()
+
+	e := &Engine{
+		projectDir: dir,
+		files:      &downloadingFilesClient{body: []byte("hi")},
+	}
+
+	fa := FileAction{Path: "README.md"}
+
+	require.NoError(t, downloadOne(e, "cid", "vid", fa))
+
+	info, err := os.Stat(filepath.Join(dir, "README.md"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), info.Mode().Perm(), "mode 0 leaves the os.Create default untouched")
+}

--- a/internal/workload/sync/engine_test.go
+++ b/internal/workload/sync/engine_test.go
@@ -64,6 +64,7 @@ type fakeFilesClient struct {
 	versionID     string
 	stageID       string
 	uploadedFiles map[string][]byte
+	uploadedModes map[string]uint32
 	deletedPaths  []string
 	mu            stdsync.Mutex
 }
@@ -84,7 +85,7 @@ func (f *fakeFilesClient) CreateStage(_ string) (*filesapi.StageResp, error) {
 	return &filesapi.StageResp{CatalogID: f.catalogID, StageID: f.stageID}, nil
 }
 
-func (f *fakeFilesClient) UploadToStage(_, _, name string, _ int64, body io.Reader) error {
+func (f *fakeFilesClient) UploadToStage(_, _, name string, _ int64, mode uint32, body io.Reader) error {
 	data, err := io.ReadAll(body)
 	if err != nil {
 		return err
@@ -98,6 +99,12 @@ func (f *fakeFilesClient) UploadToStage(_, _, name string, _ int64, body io.Read
 	}
 
 	f.uploadedFiles[name] = data
+
+	if f.uploadedModes == nil {
+		f.uploadedModes = map[string]uint32{}
+	}
+
+	f.uploadedModes[name] = mode
 
 	return nil
 }

--- a/internal/workload/sync/engine_test.go
+++ b/internal/workload/sync/engine_test.go
@@ -496,5 +496,7 @@ func hashLocal(t *testing.T, dir, rel string) (string, int64, error) {
 
 	abs := filepath.Join(dir, filepath.FromSlash(rel))
 
-	return fileops.HashFile(abs)
+	hash, size, _, err := fileops.HashFile(abs)
+
+	return hash, size, err
 }

--- a/internal/workload/sync/phase1_gather.go
+++ b/internal/workload/sync/phase1_gather.go
@@ -85,7 +85,7 @@ func phase1Gather(e *Engine) error {
 func baseFromManifest(m wapi.Manifest) BaseManifest {
 	out := make(BaseManifest, len(m.Files))
 	for k, v := range m.Files {
-		out[k] = FileEntry{Hash: v.Hash, Size: v.Size}
+		out[k] = FileEntry{Hash: v.Hash, Size: v.Size, Mode: v.Mode}
 	}
 
 	return out

--- a/internal/workload/sync/phase2_manifests.go
+++ b/internal/workload/sync/phase2_manifests.go
@@ -99,12 +99,12 @@ func hashEntries(entries []fileops.Entry) (LocalManifest, error) {
 	out := make(LocalManifest, len(entries))
 
 	for _, ent := range entries {
-		hash, size, err := fileops.HashFile(ent.AbsPath)
+		hash, size, mode, err := fileops.HashFile(ent.AbsPath)
 		if err != nil {
 			return nil, fmt.Errorf("hash %s: %w", ent.RelPath, err)
 		}
 
-		out[ent.RelPath] = FileEntry{Hash: hash, Size: size}
+		out[ent.RelPath] = FileEntry{Hash: hash, Size: size, Mode: uint32(mode)}
 	}
 
 	return out, nil

--- a/internal/workload/sync/phase2_manifests.go
+++ b/internal/workload/sync/phase2_manifests.go
@@ -55,12 +55,14 @@ func phase2Manifests(e *Engine) error {
 		return fmt.Errorf("walk project directory: %w", err)
 	}
 
-	local, err := hashEntries(entries)
+	local, executables, err := hashEntries(entries)
 	if err != nil {
 		return err
 	}
 
 	e.local = local
+
+	warnIfExecutablesFound(executables)
 
 	if cs := caseCollisionsFromManifest(local); len(cs) > 0 {
 		return fmt.Errorf("%s", fileops.FormatCaseCollisions(cs))
@@ -94,20 +96,56 @@ func phase2Manifests(e *Engine) error {
 
 // hashEntries hashes each entry sequentially. Concurrency would help
 // only marginally for typical projects since Phase 5 network is the
-// real bottleneck.
-func hashEntries(entries []fileops.Entry) (LocalManifest, error) {
+// real bottleneck. The returned relpaths are the entries with the
+// executable bit set locally, for warnIfExecutablesFound.
+func hashEntries(entries []fileops.Entry) (LocalManifest, []string, error) {
 	out := make(LocalManifest, len(entries))
+
+	var executables []string
 
 	for _, ent := range entries {
 		hash, size, mode, err := fileops.HashFile(ent.AbsPath)
 		if err != nil {
-			return nil, fmt.Errorf("hash %s: %w", ent.RelPath, err)
+			return nil, nil, fmt.Errorf("hash %s: %w", ent.RelPath, err)
+		}
+
+		if mode&0o111 != 0 {
+			executables = append(executables, ent.RelPath)
 		}
 
 		out[ent.RelPath] = FileEntry{Hash: hash, Size: size, Mode: uint32(mode)}
 	}
 
-	return out, nil
+	return out, executables, nil
+}
+
+// warnIfExecutablesFound tells the user their locally-executable files are
+// now captured and forwarded through the sync, but the server side of this
+// round trip (WAPI/IBS) doesn't apply or return mode yet -- so the bit may
+// still not survive into the built image until that ships. This is worth
+// hearing before a build fails at container startup with a "permission
+// denied" that doesn't obviously point back at sync.
+func warnIfExecutablesFound(executables []string) {
+	if msg := executableWarningMessage(executables); msg != "" {
+		log.Warn(msg)
+	}
+}
+
+// executableWarningMessage builds warnIfExecutablesFound's message, or ""
+// when there's nothing to warn about. Split out as a pure function so the
+// wording can be asserted on directly, without capturing log output.
+func executableWarningMessage(executables []string) string {
+	if len(executables) == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"%d file(s) have the executable bit set locally (e.g. %s). "+
+			"File permissions are now captured and forwarded by the sync, but the "+
+			"server does not yet apply or return them, so the executable bit may "+
+			"still be lost in the built image. If a Dockerfile COPYs one of these "+
+			"directly, add `COPY --chmod=755 <path> ...` as a safety net for now.",
+		len(executables), executables[0])
 }
 
 func caseCollisionsFromManifest(m LocalManifest) []fileops.CaseCollision {

--- a/internal/workload/sync/phase2_manifests_test.go
+++ b/internal/workload/sync/phase2_manifests_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/datarobot/cli/internal/workload/fileops"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashEntries_ReportsExecutables(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not meaningful on Windows")
+	}
+
+	dir := t.TempDir()
+
+	scriptPath := filepath.Join(dir, "entrypoint.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o755))
+
+	readmePath := filepath.Join(dir, "README.md")
+	require.NoError(t, os.WriteFile(readmePath, []byte("hi"), 0o644))
+
+	entries := []fileops.Entry{
+		{AbsPath: scriptPath, RelPath: "entrypoint.sh"},
+		{AbsPath: readmePath, RelPath: "README.md"},
+	}
+
+	manifest, executables, err := hashEntries(entries)
+	require.NoError(t, err)
+
+	assert.Len(t, manifest, 2)
+	assert.Equal(t, []string{"entrypoint.sh"}, executables)
+}
+
+func TestHashEntries_NoExecutablesReportsNone(t *testing.T) {
+	dir := t.TempDir()
+
+	readmePath := filepath.Join(dir, "README.md")
+	require.NoError(t, os.WriteFile(readmePath, []byte("hi"), 0o644))
+
+	entries := []fileops.Entry{{AbsPath: readmePath, RelPath: "README.md"}}
+
+	_, executables, err := hashEntries(entries)
+	require.NoError(t, err)
+	assert.Empty(t, executables)
+}
+
+func TestExecutableWarningMessage(t *testing.T) {
+	t.Run("empty when nothing found", func(t *testing.T) {
+		assert.Empty(t, executableWarningMessage(nil))
+	})
+
+	t.Run("names the count and an example path", func(t *testing.T) {
+		msg := executableWarningMessage([]string{"entrypoint.sh", "bin/tool"})
+		assert.Contains(t, msg, "2 file(s)")
+		assert.Contains(t, msg, "entrypoint.sh")
+	})
+}

--- a/internal/workload/sync/phase6_state.go
+++ b/internal/workload/sync/phase6_state.go
@@ -78,11 +78,11 @@ func buildNewBaseManifest(e *Engine, syncedVersionID string, syncedAt time.Time)
 	files := make(map[string]wapi.FileMeta, len(e.remote))
 
 	for path, fe := range e.remote {
-		files[path] = wapi.FileMeta{Hash: fe.Hash, Size: fe.Size}
+		files[path] = wapi.FileMeta{Hash: fe.Hash, Size: fe.Size, Mode: fe.Mode}
 	}
 
 	for _, fa := range e.plan.Uploads {
-		files[fa.Path] = wapi.FileMeta{Hash: fa.LocalHash, Size: fa.LocalSize}
+		files[fa.Path] = wapi.FileMeta{Hash: fa.LocalHash, Size: fa.LocalSize, Mode: fa.LocalMode}
 	}
 
 	for _, fa := range e.plan.Deletes {
@@ -94,7 +94,7 @@ func buildNewBaseManifest(e *Engine, syncedVersionID string, syncedAt time.Time)
 			continue
 		}
 
-		files[fa.Path] = wapi.FileMeta{Hash: fa.RemoteHash, Size: fa.RemoteSize}
+		files[fa.Path] = wapi.FileMeta{Hash: fa.RemoteHash, Size: fa.RemoteSize, Mode: fa.RemoteMode}
 	}
 
 	syncedAtCopy := syncedAt

--- a/internal/workload/sync/plan.go
+++ b/internal/workload/sync/plan.go
@@ -25,6 +25,8 @@ type FileAction struct {
 	RemoteSize     int64
 	LocalHash      string
 	RemoteHash     string
+	LocalMode      uint32
+	RemoteMode     uint32
 }
 
 // SyncPlan is the blueprint Phase 5 executes and the structure the display

--- a/internal/workload/sync/rollback.go
+++ b/internal/workload/sync/rollback.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/datarobot/cli/internal/workload/fileops"
 	"github.com/datarobot/cli/internal/workload/wapi"
 )
 
@@ -92,6 +93,10 @@ func (r *Rollback) Backup(relPath string) error {
 
 	if err := out.Close(); err != nil {
 		return fmt.Errorf("close backup file: %w", err)
+	}
+
+	if err := fileops.ApplyMode(dst, uint32(info.Mode().Perm())); err != nil {
+		return fmt.Errorf("set mode on backup %s: %w", dst, err)
 	}
 
 	return nil
@@ -182,32 +187,50 @@ func restoreFromDir(rollDir, projectDir string) error {
 			return fmt.Errorf("relativize rollback %s: %w", p, err)
 		}
 
-		dst := filepath.Join(projectDir, rel)
-
-		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-			return fmt.Errorf("mkdir restore parent: %w", err)
-		}
-
-		in, err := os.Open(p) //nolint:gosec // low TOCTOU risk for backup restore
-		if err != nil {
-			return fmt.Errorf("open backup %s: %w", p, err)
-		}
-
-		out, err := os.Create(dst)
-		if err != nil {
-			_ = in.Close()
-			return fmt.Errorf("create restored file %s: %w", dst, err)
-		}
-
-		_, copyErr := io.Copy(out, in)
-
-		_ = in.Close()
-		_ = out.Close()
-
-		if copyErr != nil {
-			return fmt.Errorf("restore copy %s: %w", dst, copyErr)
-		}
-
-		return nil
+		return restoreOneEntry(p, filepath.Join(projectDir, rel))
 	})
+}
+
+// restoreOneEntry copies one backed-up file back to dst and restores its
+// mode. A stat failure on the source is exceptionally unlikely (it was just
+// opened and copied successfully) and this is a best-effort restore path:
+// failing the whole rollback over one missed chmod would lose every other
+// file it already restored, a worse outcome than one file keeping a stale
+// mode -- so a stat failure is silently skipped rather than propagated.
+func restoreOneEntry(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("mkdir restore parent: %w", err)
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open backup %s: %w", src, err)
+	}
+
+	srcInfo, statErr := in.Stat()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		_ = in.Close()
+		return fmt.Errorf("create restored file %s: %w", dst, err)
+	}
+
+	_, copyErr := io.Copy(out, in)
+
+	_ = in.Close()
+	_ = out.Close()
+
+	if copyErr != nil {
+		return fmt.Errorf("restore copy %s: %w", dst, copyErr)
+	}
+
+	if statErr != nil {
+		return nil
+	}
+
+	if err := fileops.ApplyMode(dst, uint32(srcInfo.Mode().Perm())); err != nil {
+		return fmt.Errorf("set mode on restored %s: %w", dst, err)
+	}
+
+	return nil
 }

--- a/internal/workload/sync/rollback_test.go
+++ b/internal/workload/sync/rollback_test.go
@@ -17,6 +17,7 @@ package sync
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/datarobot/cli/internal/workload/wapi"
@@ -70,6 +71,32 @@ func TestRollback_BackupAndRestore(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(dir, "newly-created.txt"))
 	assert.ErrorIs(t, err, os.ErrNotExist, "tracked-created file should be removed")
+}
+
+func TestRollback_BackupAndRestore_PreservesMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not meaningful on Windows")
+	}
+
+	dir := setupProject(t)
+	writeProjectFile(t, dir, "entrypoint.sh", "#!/bin/sh\n")
+
+	scriptPath := filepath.Join(dir, "entrypoint.sh")
+	require.NoError(t, os.Chmod(scriptPath, 0o755))
+
+	r, err := NewRollback(dir)
+	require.NoError(t, err)
+
+	require.NoError(t, r.Backup("entrypoint.sh"))
+
+	// Simulate Phase 5 overwriting the file with a different mode.
+	require.NoError(t, os.WriteFile(scriptPath, []byte("BROKEN"), 0o644))
+
+	require.NoError(t, r.Restore())
+
+	info, err := os.Stat(scriptPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
 }
 
 func TestRollback_MissingFileNoop(t *testing.T) {

--- a/internal/workload/sync/upload_stage.go
+++ b/internal/workload/sync/upload_stage.go
@@ -133,7 +133,7 @@ func uploadOneToStage(e *Engine, catalogID, stageID string, fa FileAction) error
 
 	defer func() { _ = f.Close() }()
 
-	if err := e.files.UploadToStage(catalogID, stageID, fa.Path, fa.LocalSize, f); err != nil {
+	if err := e.files.UploadToStage(catalogID, stageID, fa.Path, fa.LocalSize, fa.LocalMode, f); err != nil {
 		return fmt.Errorf("upload %s: %w", fa.Path, err)
 	}
 

--- a/internal/workload/sync/upload_stage_test.go
+++ b/internal/workload/sync/upload_stage_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploadOneToStage_ForwardsLocalMode(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "entrypoint.sh"), []byte("#!/bin/sh\n"), 0o755))
+
+	fake := &fakeFilesClient{}
+	e := &Engine{projectDir: dir, files: fake}
+
+	fa := FileAction{Path: "entrypoint.sh", LocalSize: 10, LocalMode: 0o755}
+
+	require.NoError(t, uploadOneToStage(e, "cid-1", "st-1", fa))
+
+	assert.Equal(t, uint32(0o755), fake.uploadedModes["entrypoint.sh"])
+}

--- a/internal/workload/sync/upload_zip.go
+++ b/internal/workload/sync/upload_zip.go
@@ -84,7 +84,7 @@ func buildZip(projectDir string, files []FileAction) (string, error) {
 	for _, fa := range files {
 		abs := filepath.Join(projectDir, filepath.FromSlash(fa.Path))
 
-		if err := addToZip(zw, abs, fa.Path); err != nil {
+		if err := addToZip(zw, abs, fa.Path, os.FileMode(fa.LocalMode)); err != nil {
 			_ = os.Remove(tmp.Name())
 			return "", err
 		}
@@ -98,7 +98,11 @@ func buildZip(projectDir string, files []FileAction) (string, error) {
 	return tmp.Name(), nil
 }
 
-func addToZip(zw *zip.Writer, src, archivePath string) error {
+// addToZip writes one file into the archive with its Unix permission bits
+// preserved as the zip's standard Info-ZIP external-attributes encoding
+// (mode.Perm() is already masked to the low 9 bits by the caller -- see
+// FileEntry/FileAction.Mode -- so no further masking is needed here).
+func addToZip(zw *zip.Writer, src, archivePath string, mode os.FileMode) error {
 	in, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("open %s for zip: %w", src, err)
@@ -107,6 +111,7 @@ func addToZip(zw *zip.Writer, src, archivePath string) error {
 	defer func() { _ = in.Close() }()
 
 	hdr := &zip.FileHeader{Name: archivePath, Method: zip.Deflate}
+	hdr.SetMode(mode.Perm())
 
 	w, err := zw.CreateHeader(hdr)
 	if err != nil {

--- a/internal/workload/sync/upload_zip_test.go
+++ b/internal/workload/sync/upload_zip_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildZip_PreservesMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission bits are not meaningful on Windows")
+	}
+
+	dir := t.TempDir()
+
+	scriptPath := filepath.Join(dir, "entrypoint.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\n"), 0o644))
+	require.NoError(t, os.Chmod(scriptPath, 0o755))
+
+	readmePath := filepath.Join(dir, "README.md")
+	require.NoError(t, os.WriteFile(readmePath, []byte("hi"), 0o644))
+
+	files := []FileAction{
+		{Path: "entrypoint.sh", LocalMode: 0o755},
+		{Path: "README.md", LocalMode: 0o644},
+	}
+
+	zipPath, err := buildZip(dir, files)
+	require.NoError(t, err)
+
+	defer func() { _ = os.Remove(zipPath) }()
+
+	r, err := zip.OpenReader(zipPath)
+	require.NoError(t, err)
+
+	defer func() { _ = r.Close() }()
+
+	modes := make(map[string]os.FileMode, len(r.File))
+	for _, f := range r.File {
+		modes[f.Name] = f.Mode().Perm()
+	}
+
+	assert.Equal(t, os.FileMode(0o755), modes["entrypoint.sh"])
+	assert.Equal(t, os.FileMode(0o644), modes["README.md"])
+}

--- a/internal/workload/wapi/manifest.go
+++ b/internal/workload/wapi/manifest.go
@@ -25,10 +25,15 @@ import (
 )
 
 // FileMeta is the per-file entry in the BASE manifest. Hash is SHA-256 hex
-// (64 chars) as produced by the sync engine.
+// (64 chars) as produced by the sync engine. Mode is the Unix permission
+// bits (0-0777); zero means "unknown" -- manifests written before mode
+// tracking existed, or a remote that hasn't reported one yet. lte=511
+// bounds it to 0777 octal (9 permission bits), rejecting a corrupted value
+// outside that range instead of treating it as real permission bits.
 type FileMeta struct {
 	Hash string `json:"hash" validate:"required,dr_sha256hex"`
 	Size int64  `json:"size" validate:"gte=0"`
+	Mode uint32 `json:"mode,omitempty" validate:"lte=511"`
 }
 
 // Manifest is the parsed representation of the project's manifest.json — the BASE

--- a/internal/workload/wapi/manifest_test.go
+++ b/internal/workload/wapi/manifest_test.go
@@ -58,6 +58,37 @@ func TestManifest_SaveLoadRoundTrip(t *testing.T) {
 	assert.Equal(t, original.Files, got.Files)
 }
 
+func TestManifest_ModeRoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	initWapiDir(t, tmp)
+
+	original := Manifest{
+		Version: ManifestVersion,
+		Files: map[string]FileMeta{
+			"bin/entrypoint.sh": {Hash: testHash('1'), Size: 42, Mode: 0o755},
+		},
+	}
+
+	require.NoError(t, SaveManifest(tmp, original))
+
+	got, err := LoadManifest(tmp)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0o755), got.Files["bin/entrypoint.sh"].Mode)
+}
+
+func TestManifest_ModeAbsentDefaultsToZero(t *testing.T) {
+	tmp := t.TempDir()
+	initWapiDir(t, tmp)
+
+	path := filepath.Join(Dir(tmp), manifestFile)
+	body := `{"version":1,"files":{"a.py":{"hash":"` + testHash('a') + `","size":1}}}`
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+
+	got, err := LoadManifest(tmp)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0), got.Files["a.py"].Mode, "manifest predating mode tracking must still parse")
+}
+
 func TestManifest_EmptyFilesMap(t *testing.T) {
 	tmp := t.TempDir()
 	initWapiDir(t, tmp)
@@ -165,6 +196,10 @@ func TestManifest_LoadInvalid(t *testing.T) {
 		{
 			name: "negative size",
 			json: `{"version":1,"files":{"a.py":{"hash":"` + validHash + `","size":-1}}}`,
+		},
+		{
+			name: "mode out of range",
+			json: `{"version":1,"files":{"a.py":{"hash":"` + validHash + `","size":1,"mode":512}}}`,
 		},
 		{
 			name: "syncedAt without syncedVersionId",

--- a/internal/workload/wapi/validate.go
+++ b/internal/workload/wapi/validate.go
@@ -150,6 +150,7 @@ var jsonFieldNames = map[string]string{
 	"SyncedVersionID":     "syncedVersionId",
 	"Hash":                "hash",
 	"Size":                "size",
+	"Mode":                "mode",
 }
 
 func jsonFieldName(fe validator.FieldError) string {


### PR DESCRIPTION
# NOTES

This PR is CLI-only. The mode is captured, forwarded, and restored wherever this repo can do so,
but nothing here can make the server (Files API / workload-api / IBS) actually apply or return it
-- that's tracked separately; see the handoff spec below for what still needs to happen elsewhere.

> [!WARNING]
> `RAPTOR-19524-other-services-agent-brief.md` (commit `2d18245`) is a planning document for the
> Files API / workload-api / IBS follow-up work, not part of this repo's shipped code. **Squash it
> into the branch history or drop it before merge** -- it's included here only so reviewers and
> whoever picks up the cross-service work have it; it should not land on `main`.

# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

<!--
For expedient and efficient review, please explain *why* you are
making this change. It is not always obvious from the code and
the review may happen while you are asleep / otherwise not able to respond quickly.
-->


[RAPTOR-19524](https://datarobot.atlassian.net/browse/RAPTOR-19524) (Critical): `dr workload up`
and `dr artifact code sync` upload the project directory as the server-side image build context,
but the sync pipeline never tracked Unix file mode. An executable synced as `0755` always lands
server-side (and round-trips back via `dr artifact code checkout`) as `0644`. A Dockerfile that
`COPY`s the file without an explicit `--chmod=755` then produces a container that dies at startup
with `exec: "/path": permission denied` -- a failure that names the runtime, not the sync, so it's
expensive to diagnose. Confirmed reproducible locally: Docker preserves whatever mode the build
context handed it, so the bit is already gone by the time the server has the file.

Root cause: the manifest (`wapi.FileMeta`) only ever tracked `hash`/`size`; the file walk/hash
step already `os.Stat`s every file (for size) but threw away `info.Mode()`; neither upload
transport carried mode (the zip path has a natural carrier -- `zip.FileHeader.SetMode`/`Mode()` --
but never called it; the per-file multipart path had no carrier at all); and both download paths
hardcoded `os.Create` with no mode restoration.

**Scope of this PR:** everything fixable within this CLI repo, end to end and backward-compatible.
Whether the mode actually survives in the built image also depends on server-side (Files API /
workload-api / IBS) support that doesn't exist yet -- this repo can't implement or verify that
half, so a sync-time warning stays in place as an interim mitigation until the server side ships
(see the companion agent instructions below).

# CHANGES

- **Capture + plumb mode through the diff engine and local manifest** (`9ab15d9`): `fileops.HashFile`
  now also returns the already-stat'd `os.FileMode`; threaded as a new `Mode uint32` field through
  `wapi.FileMeta` (the local `.datarobot/workload/manifest.json`), `sync.FileEntry`/`FileAction`,
  and `filesapi.FileMeta`/`AllFilesItem` (server-unpopulated for now, decodes as the "mode unknown"
  zero sentinel). No visible behavior change on its own -- pure plumbing.
- **Zip uploads carry mode** (`df5c0a4`): the `ZipUploader` path had a natural carrier -- zip
  external attributes -- but never used it. `addToZip` now calls `zip.FileHeader.SetMode()`.
- **Stage uploads carry mode** (`ea2a400`): the per-file multipart `StageUploader` path had no
  carrier at all. Adds a `mode` param to `filesapi.Client.UploadToStage`, sent as an optional
  `?mode=0755`-style query param -- omitted entirely (not `mode=0`) when unknown, so an old CLI or
  a server that doesn't understand the param yet sees exactly what it saw before this existed.
- **Rollback preserves mode** (`761126e`, includes the download-side restore): both download paths
  (`dr artifact code checkout` and the sync engine's own pull-remote-only-files step) hardcoded
  `os.Create` with no mode restoration -- fixed via a new shared `fileops.ApplyMode` helper (a
  no-op when mode is unknown). Same bug also existed in `Rollback.Backup`/`restoreFromDir` (pure
  local-to-local copies, same class of bug, zero server dependency) -- fixed with the same helper.
- **Sync-time warning** (`dee1f7b`): since the full round trip can't be verified end-to-end yet,
  warns once per sync (naming an example file) when locally-executable files are uploaded, so the
  failure is diagnosable at sync time instead of surfacing later as an opaque container start
  failure. Mirrors the existing shadow-ignore-file/lockfile warning shapes in the same phase.

Mode is represented as `uint32` holding `os.FileMode.Perm()` (0-511 / `0000`-`0777`) everywhere.
Zero is the sentinel for "unknown" (pre-feature manifest, or a server response without the field
yet) -- unambiguous, since a file that was successfully opened and hashed can never legitimately
have `Perm() == 0`.

On Windows, `fileops.ApplyMode` is a safe no-op beyond the read-only attribute: NTFS has no
owner/group/execute concept, so `os.Chmod` there only honors the 0200 (owner-write) bit.



## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->
