### PR TITLE
[RAPTOR-19741] fix(workload): authenticate public endpoint checks

### DIFF
--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -167,3 +167,7 @@ at `0644` by an older CLI would otherwise stay world-readable forever.
 - `config.SkipAuthKey`&mdash;the viper key for `--skip-auth`. Use the constant at every
   bind and read site: viper does not treat `-` and `_` as equivalent for lookups, and
   reading `"skip_auth"` silently ignored the bound flag.
+
+When attaching credentials to an absolute URL returned by a server response,
+first check it with `drapi.URLMatchesConfiguredBase()`. URLs built locally with
+`config.GetEndpointURL()` already stay on the configured DataRobot host.

--- a/internal/drapi/helpers.go
+++ b/internal/drapi/helpers.go
@@ -15,6 +15,7 @@
 package drapi
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,6 +39,37 @@ func EndpointURL(path string, query url.Values) (string, error) {
 	}
 
 	return full + "?" + query.Encode(), nil
+}
+
+// URLMatchesConfiguredBase reports whether rawURL has the same scheme and host
+// as the configured DataRobot API base. Use it before attaching DataRobot
+// credentials to an absolute URL supplied by a server response, where a hostile
+// or buggy redirect/cursor could otherwise move the request to another origin.
+func URLMatchesConfiguredBase(rawURL string) (bool, error) {
+	target, err := url.Parse(rawURL)
+	if err != nil {
+		return false, fmt.Errorf("parse URL: %w", err)
+	}
+
+	if target.Scheme == "" || target.Host == "" {
+		return false, errors.New("parse URL: missing scheme or host")
+	}
+
+	baseURL := config.GetBaseURL()
+	if baseURL == "" {
+		return false, errors.New("configured API base URL is empty")
+	}
+
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return false, fmt.Errorf("parse API base URL: %w", err)
+	}
+
+	if base.Scheme == "" || base.Host == "" {
+		return false, errors.New("configured API base URL is missing scheme or host")
+	}
+
+	return target.Scheme == base.Scheme && target.Host == base.Host, nil
 }
 
 // ErrFromResp wraps a non-2xx *http.Response into a *HTTPError, capturing

--- a/internal/drapi/helpers_test.go
+++ b/internal/drapi/helpers_test.go
@@ -64,6 +64,60 @@ func TestEndpointURL_PropagatesConfigError(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+func TestURLMatchesConfiguredBase(t *testing.T) {
+	seedBaseURL(t, "https://example.test/api/v2")
+
+	for _, tc := range []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "same scheme and host", url: "https://example.test/api/v2/files/?limit=1", want: true},
+		{name: "same origin different API path", url: "https://example.test/api/v1/legacy/", want: true},
+		{name: "different host", url: "https://other.example.test/api/v2/files/", want: false},
+		{name: "different scheme", url: "http://example.test/api/v2/files/", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := URLMatchesConfiguredBase(tc.url)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestURLMatchesConfiguredBase_RejectsAmbiguousTargets(t *testing.T) {
+	seedBaseURL(t, "https://example.test")
+
+	for _, rawURL := range []string{"None/api/v2/files/", "://bad"} {
+		t.Run(rawURL, func(t *testing.T) {
+			got, err := URLMatchesConfiguredBase(rawURL)
+
+			require.Error(t, err)
+			assert.False(t, got)
+		})
+	}
+}
+
+func TestURLMatchesConfiguredBase_RequiresConfiguredBase(t *testing.T) {
+	seedBaseURL(t, "")
+
+	got, err := URLMatchesConfiguredBase("https://example.test/api/v2/files/")
+
+	require.Error(t, err)
+	assert.False(t, got)
+}
+
+func TestAssertNextOnSameHost(t *testing.T) {
+	seedBaseURL(t, "https://example.test/api/v2")
+
+	require.NoError(t, AssertNextOnSameHost("https://example.test/api/v2/files/?offset=100"))
+
+	err := AssertNextOnSameHost("https://other.example.test/api/v2/files/?offset=100")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match API base host")
+}
+
 // ErrFromResp interprets nothing: drapi serves APIs that disagree on their
 // error envelope, so even a well-formed FastAPI detail document stays a raw
 // body= dump here. Reading meaning into it is a caller's job (see

--- a/internal/drapi/helpers_test.go
+++ b/internal/drapi/helpers_test.go
@@ -115,7 +115,7 @@ func TestAssertNextOnSameHost(t *testing.T) {
 
 	err := AssertNextOnSameHost("https://other.example.test/api/v2/files/?offset=100")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not match API base host")
+	assert.Contains(t, err.Error(), `Next URL host "other.example.test" does not match API base "https://example.test"`)
 }
 
 // ErrFromResp interprets nothing: drapi serves APIs that disagree on their

--- a/internal/drapi/pagination.go
+++ b/internal/drapi/pagination.go
@@ -38,12 +38,7 @@ func AssertNextOnSameHost(rawNextURL string) error {
 	}
 
 	if !matches {
-		base, err := url.Parse(config.GetBaseURL())
-		if err != nil {
-			return fmt.Errorf("pagination: parse API base URL: %w", err)
-		}
-
-		return fmt.Errorf("pagination: Next URL host %q does not match API base host %q", next.Host, base.Host)
+		return fmt.Errorf("pagination: Next URL host %q does not match API base %q", next.Host, config.GetBaseURL())
 	}
 
 	return nil

--- a/internal/drapi/pagination.go
+++ b/internal/drapi/pagination.go
@@ -32,12 +32,17 @@ func AssertNextOnSameHost(rawNextURL string) error {
 		return fmt.Errorf("pagination: parse Next URL: %w", err)
 	}
 
-	base, err := url.Parse(config.GetBaseURL())
+	matches, err := URLMatchesConfiguredBase(rawNextURL)
 	if err != nil {
-		return fmt.Errorf("pagination: parse API base URL: %w", err)
+		return fmt.Errorf("pagination: %w", err)
 	}
 
-	if next.Scheme != base.Scheme || next.Host != base.Host {
+	if !matches {
+		base, err := url.Parse(config.GetBaseURL())
+		if err != nil {
+			return fmt.Errorf("pagination: parse API base URL: %w", err)
+		}
+
 		return fmt.Errorf("pagination: Next URL host %q does not match API base host %q", next.Host, base.Host)
 	}
 

--- a/internal/workload/logs_test.go
+++ b/internal/workload/logs_test.go
@@ -255,7 +255,7 @@ func TestGetWorkloadLogs_RejectsOffHostNext(t *testing.T) {
 
 	_, err := GetWorkloadLogs("wl-1", 10, "")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not match API base host")
+	assert.Contains(t, err.Error(), "does not match API base")
 }
 
 func TestGetWorkloadLogs_RejectsMalformedNext(t *testing.T) {

--- a/internal/workload/up/endpoint_check.go
+++ b/internal/workload/up/endpoint_check.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/drapi"
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/tui"
 )
 
@@ -171,6 +172,14 @@ func endpointCheckAuthForURL(rawURL string) (endpointCheckAuthMode, error) {
 
 	matches, err := drapi.URLMatchesConfiguredBase(rawURL)
 	if err != nil || !matches {
+		// Public workload paths only receive credentials when they are on the
+		// configured DataRobot origin. Log the anonymous fallback so debug users
+		// can distinguish a gateway 401 from an intentional token-withheld check.
+		log.Debug("endpoint check: withholding token because endpoint URL does not match configured base",
+			"endpoint", rawURL,
+			"configured_base", config.GetBaseURL(),
+			"error", err)
+
 		return endpointCheckAnonymous, nil
 	}
 

--- a/internal/workload/up/endpoint_check.go
+++ b/internal/workload/up/endpoint_check.go
@@ -17,9 +17,12 @@ package up
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/tui"
 )
@@ -29,11 +32,19 @@ import (
 // is for one that is still booting, which the report then says.
 const endpointCheckTimeout = 10 * time.Second
 
+type endpointCheckAuthMode string
+
+const (
+	endpointCheckAnonymous     endpointCheckAuthMode = "anonymous"
+	endpointCheckAuthenticated endpointCheckAuthMode = "authenticated"
+	workloadEndpointPathPrefix                       = config.DRAPIURLSuffix + "/endpoints/workloads/"
+)
+
 // checkEndpointFn performs the GET, swapped by tests. The request is
-// anonymous on purpose: the user's API token has no business in a container's
-// access log, and a 401 or 403 proves something is serving as well as a 200
-// does.
-var checkEndpointFn = func(url string) (int, error) {
+// anonymous for direct workload URLs and authenticated for the DataRobot public
+// gateway URL. The gateway consumes the token before proxying, while a direct
+// URL would carry the token into the user's container access logs.
+var checkEndpointFn = func(rawURL string) (int, error) {
 	client := drapi.NewHTTPClient(endpointCheckTimeout)
 
 	// The endpoint's own answer, never a hop beyond it: a gateway that 302s
@@ -44,7 +55,23 @@ var checkEndpointFn = func(url string) (int, error) {
 		return http.ErrUseLastResponse
 	}
 
-	resp, err := client.Get(url)
+	authMode, err := endpointCheckAuthForURL(rawURL)
+	if err != nil {
+		return 0, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	if authMode == endpointCheckAuthenticated {
+		if err = drapi.AuthorizeRequest(req); err != nil {
+			return 0, err
+		}
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return 0, err
 	}
@@ -70,6 +97,15 @@ var checkEndpointFn = func(url string) (int, error) {
 // is fine.
 func verifyEndpoint(result Result, unconfirmed string, report *reporter) {
 	if result.Endpoint == "" {
+		return
+	}
+
+	authMode, endpointErr := endpointCheckAuthForURL(result.Endpoint)
+	if endpointErr != nil {
+		report.say("  %s\n", tui.WarnStyle.Render("⚠ Skipping endpoint check: "+endpointErr.Error()))
+		report.say("    %s\n", tui.HintStyle.Render(
+			"The workload API returned an endpoint URL the CLI cannot GET."))
+
 		return
 	}
 
@@ -101,7 +137,7 @@ func verifyEndpoint(result Result, unconfirmed string, report *reporter) {
 	}
 
 	report.say("  %s\n", tui.HintStyle.Render(
-		"Endpoint check: an anonymous GET answered HTTP "+httpStatusLabel(status)+"."))
+		"Endpoint check: an "+string(authMode)+" GET answered HTTP "+httpStatusLabel(status)+"."))
 
 	// Said only when the wait could not confirm the handover, and carrying the
 	// reason, because they are not the same problem: an install without the
@@ -114,6 +150,31 @@ func verifyEndpoint(result Result, unconfirmed string, report *reporter) {
 			"The deploy could not tell whether the previous version has stopped answering, because "+
 				unconfirmed+". The line above may describe it."))
 	}
+}
+
+// endpointCheckAuthForURL keeps the credential-safety decision next to the
+// workload endpoint policy: only DataRobot public workload ingress URLs receive
+// the CLI token, because direct service URLs can be owned by user containers.
+func endpointCheckAuthForURL(rawURL string) (endpointCheckAuthMode, error) {
+	endpointURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse endpoint URL %q: %w", rawURL, err)
+	}
+
+	if endpointURL.Scheme == "" || endpointURL.Host == "" {
+		return "", fmt.Errorf("endpoint URL %q is not absolute", rawURL)
+	}
+
+	if !strings.HasPrefix(endpointURL.EscapedPath(), workloadEndpointPathPrefix) {
+		return endpointCheckAnonymous, nil
+	}
+
+	matches, err := drapi.URLMatchesConfiguredBase(rawURL)
+	if err != nil || !matches {
+		return endpointCheckAnonymous, nil
+	}
+
+	return endpointCheckAuthenticated, nil
 }
 
 // httpStatusLabel renders "404 Not Found" rather than a bare number, because

--- a/internal/workload/up/endpoint_check_test.go
+++ b/internal/workload/up/endpoint_check_test.go
@@ -19,12 +19,16 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/datarobot/cli/internal/config"
 	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/drapi"
+	drlog "github.com/datarobot/cli/internal/log"
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -166,6 +170,25 @@ func TestCheckEndpoint_SendsCredentialsToConfiguredWorkloadGateway(t *testing.T)
 	assert.Equal(t, "Bearer endpoint-test-token", gotAuth)
 }
 
+// A gateway-shaped URL on the wrong origin stays anonymous for credential
+// safety, but the fallback must leave a debug breadcrumb so a same-looking 401
+// can be diagnosed as a token intentionally withheld by the CLI.
+func TestEndpointCheckAuthForURL_LogsWhenGatewayOriginDoesNotMatchConfig(t *testing.T) {
+	installEndpointCheckAuth(t, "https://configured.example.test", "endpoint-test-token")
+
+	logDir := startEndpointCheckDebugLog(t)
+
+	mode, err := endpointCheckAuthForURL("https://returned.example.test/api/v2/endpoints/workloads/wl-1")
+	require.NoError(t, err)
+	assert.Equal(t, endpointCheckAnonymous, mode)
+
+	content, err := os.ReadFile(filepath.Join(logDir, ".dr-tui-debug.log"))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "withholding token")
+	assert.Contains(t, string(content), "returned.example.test")
+	assert.Contains(t, string(content), "configured.example.test")
+}
+
 // A redirect is reported as the 3xx it is, never followed: a gateway that
 // 302s an anonymous GET to a login page would otherwise have the check
 // report the login page's 200 for a container serving nothing — the one
@@ -249,4 +272,22 @@ func installEndpointCheckAuth(t *testing.T, baseURL, token string) {
 		viperx.Set(config.DataRobotAPIKey, prevToken)
 		drapi.SetToken(prevCachedToken)
 	})
+}
+
+func startEndpointCheckDebugLog(t *testing.T) string {
+	t.Helper()
+
+	prevDebug := viperx.GetBool("debug")
+	logDir := t.TempDir()
+
+	testutil.SetTestHomeDir(t, logDir)
+	viperx.Set("debug", true)
+	drlog.Start()
+
+	t.Cleanup(func() {
+		drlog.Stop()
+		viperx.Set("debug", prevDebug)
+	})
+
+	return logDir
 }

--- a/internal/workload/up/endpoint_check_test.go
+++ b/internal/workload/up/endpoint_check_test.go
@@ -22,6 +22,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/datarobot/cli/internal/drapi"
 	"github.com/datarobot/cli/internal/workload"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +45,28 @@ func TestVerifyEndpoint_StatesTheStatusInWords(t *testing.T) {
 
 	assert.Contains(t, out.String(), "404 Not Found")
 	assert.Contains(t, out.String(), "anonymous GET")
+}
+
+// Gateway-routed workload URLs are DataRobot API URLs: the gateway consumes the
+// token before proxying, so the status can describe the workload instead of the
+// gateway's unauthenticated 401.
+func TestVerifyEndpoint_StatesAuthenticatedGatewayChecks(t *testing.T) {
+	installEndpointCheckAuth(t, "https://app.example.test", "endpoint-test-token")
+	force(t, &checkEndpointFn, func(url string) (int, error) {
+		assert.Equal(t, "https://app.example.test/api/v2/endpoints/workloads/wl-1?protonId=p-1", url)
+
+		return http.StatusOK, nil
+	})
+
+	var out bytes.Buffer
+
+	verifyEndpoint(Result{
+		Endpoint:   "https://app.example.test/api/v2/endpoints/workloads/wl-1?protonId=p-1",
+		WorkloadID: "wl-1",
+	}, "", newReporter(&out, false))
+
+	assert.Contains(t, out.String(), "authenticated GET")
+	assert.Contains(t, out.String(), "200 OK")
 }
 
 // An endpoint that does not answer is the case this check exists for: with no
@@ -78,10 +103,32 @@ func TestVerifyEndpoint_SkipsWithoutAnEndpoint(t *testing.T) {
 	assert.Empty(t, out.String())
 }
 
-// The real GET is anonymous. The user's API token has no business in a
-// container's access log, and a 401 proves something is serving as well as a
-// 200 does.
-func TestCheckEndpoint_SendsNoCredentials(t *testing.T) {
+// A malformed endpoint is not evidence that the workload failed to answer: the
+// CLI never made a network request, so the report says the check was skipped.
+func TestVerifyEndpoint_SkipsMalformedEndpoint(t *testing.T) {
+	force(t, &checkEndpointFn, func(string) (int, error) {
+		t.Fatal("nothing may be fetched when the endpoint is not an absolute URL")
+
+		return 0, nil
+	})
+
+	var out bytes.Buffer
+
+	verifyEndpoint(Result{
+		Endpoint:   "None/api/v2/endpoints/workloads/wl-1?protonId=p-1",
+		WorkloadID: "wl-1",
+	}, "", newReporter(&out, false))
+
+	text := out.String()
+	assert.Contains(t, text, "Skipping endpoint check")
+	assert.Contains(t, text, "not absolute")
+	assert.NotContains(t, text, "did not answer")
+}
+
+// A direct workload URL stays anonymous. The user's API token has no business
+// in a container's access log, and a 401 proves something is serving as well as
+// a 200 does when the request actually reaches the container.
+func TestCheckEndpoint_SendsNoCredentialsToDirectEndpoint(t *testing.T) {
 	var gotAuth string
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -96,6 +143,27 @@ func TestCheckEndpoint_SendsNoCredentials(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusTeapot, status)
 	assert.Empty(t, gotAuth, "the GET carries no credentials")
+}
+
+// The public workload endpoint is an API gateway URL. The CLI token is safe to
+// attach there because the gateway consumes it before proxying to the container.
+func TestCheckEndpoint_SendsCredentialsToConfiguredWorkloadGateway(t *testing.T) {
+	var gotAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	defer srv.Close()
+
+	installEndpointCheckAuth(t, srv.URL, "endpoint-test-token")
+
+	status, err := checkEndpointFn(srv.URL + "/api/v2/endpoints/workloads/wl-1?protonId=p-1")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusTeapot, status)
+	assert.Equal(t, "Bearer endpoint-test-token", gotAuth)
 }
 
 // A redirect is reported as the 3xx it is, never followed: a gateway that
@@ -160,4 +228,25 @@ func TestRun_ReportsTheEndpointAnswer(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, stderr, "Endpoint check")
 	assert.Contains(t, stderr, "200 OK")
+}
+
+func installEndpointCheckAuth(t *testing.T, baseURL, token string) {
+	t.Helper()
+
+	prevBase := viperx.GetString(config.DataRobotURL)
+	prevSkip := viperx.GetBool(config.SkipAuthKey)
+	prevToken := viperx.GetString(config.DataRobotAPIKey)
+	prevCachedToken := drapi.GetToken()
+
+	viperx.Set(config.DataRobotURL, baseURL)
+	viperx.Set(config.SkipAuthKey, true)
+	viperx.Set(config.DataRobotAPIKey, token)
+	drapi.SetToken("")
+
+	t.Cleanup(func() {
+		viperx.Set(config.DataRobotURL, prevBase)
+		viperx.Set(config.SkipAuthKey, prevSkip)
+		viperx.Set(config.DataRobotAPIKey, prevToken)
+		drapi.SetToken(prevCachedToken)
+	})
 }

--- a/internal/workload/up/run_test.go
+++ b/internal/workload/up/run_test.go
@@ -432,7 +432,7 @@ func TestRun_WizardRedirectIsFollowed(t *testing.T) {
 			return wizard.Result{Path: manifest.Path(app)}, nil
 		},
 		create: func(any) (*workload.Workload, error) { return running("wl-new"), nil },
-		wait: func(string, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
+		wait: func(string, workload.Serving, time.Duration, time.Duration, func(*workload.Workload)) (*workload.Workload, error) {
 			return running("wl-new"), nil
 		},
 		writeID: func(path, _ string) error {


### PR DESCRIPTION
# RATIONALE

The post-deploy workload endpoint check currently performs an anonymous GET against the workload endpoint. For public DataRobot gateway workload endpoints, the gateway authenticates before proxying to the workload, so the check receives 401 and never validates container reachability. (This is true for both the legacy and the new api-gateway.)

Direct/container endpoint checks remain anonymous so the CLI never sends a user token to a user-controlled workload container.

## CHANGES

- Add a shared `drapi.URLMatchesConfiguredBase()` helper for safe same-configured-host checks.
- Reuse the helper from pagination's Next-link host guard.
- Authenticate post-deploy endpoint checks only for configured DataRobot public workload routes.
- Keep direct/non-DataRobot endpoint checks anonymous.
- Skip malformed endpoint URLs instead of reporting them as workload connectivity failures.
- Add tests for authenticated gateway checks, anonymous direct checks, malformed endpoints, and the shared URL helper.
- Document the credential-safety rule for server-returned absolute URLs.

## TESTING

- `go test -count=1 -race ./internal/drapi ./internal/workload/up`
- `go test -count=1 -race ./internal/drapi ./internal/workload ./internal/workload/up`
- `task test`
- `task lint`

### Before

```sh
$ export DATAROBOT_CLI_FEATURE_WORKLOAD=true

$ dr self version --short
v0.4.1

$ dr workload up --yes --dir tmp/raptor-19741-stable

  + workload   raptor-19741-stable will be created, with its first artifact
  ✓ Creating workload (1.1s)
  ✓ Waiting for the workload to run (17.2s)
  ✓ Checking the endpoint (100ms)
  Endpoint check: an anonymous GET answered HTTP 401 Unauthorized.

  ✓ Workload endpoint: https://staging.datarobot.com/api/v2/endpoints/workloads/6a922ed8884efda7a81fdde4/

  ⚠ This workload is running a draft artifact.
    Draft workloads are stopped after 8 hours, whether or not they are in use.
    Run 'dr workload up --lock' to version the artifact and make it permanent.

Next:
  dr workload up --lock  Lock the artifact to make it permanent
  dr workload logs 6a922ed8884efda7a81fdde4  View the container logs
  dr workload status 6a922ed8884efda7a81fdde4  Check the workload status

$ echo 0
0

$ dr workload stop 6a922ed8884efda7a81fdde4
stopping
Check progress with: dr workload status 6a922ed8884efda7a81fdde4

$ dr workload status 6a922ed8884efda7a81fdde4
stopped
```

### After

```sh
$ export DATAROBOT_CLI_FEATURE_WORKLOAD=true

$ ./dist/dr self version --short
v0.4.0-2-gbc966cbd772c630

$ ./dist/dr workload up --yes --dir tmp/raptor-19741-repro
  + workload   raptor-19741-repro will be created, with its first artifact
  ✓ Creating workload (1.4s)
  ✓ Waiting for the workload to run (17.3s)
  ✓ Checking the endpoint (300ms)
  Endpoint check: an authenticated GET answered HTTP 200 OK.

  ✓ Workload endpoint: https://staging.datarobot.com/api/v2/endpoints/workloads/6a922a5a8a63278410ee018c/

  ⚠ This workload is running a draft artifact.
    Draft workloads are stopped after 8 hours, whether or not they are in use.
    Run 'dr workload up --lock' to version the artifact and make it permanent.

Next:
  dr workload up --lock  Lock the artifact to make it permanent
  dr workload logs 6a922a5a8a63278410ee018c  View the container logs
  dr workload status 6a922a5a8a63278410ee018c  Check the workload status

$ ./dist/dr workload stop 6a922a5a8a63278410ee018c
stopping
Check progress with: dr workload status 6a922a5a8a63278410ee018c

$ ./dist/dr workload status 6a922a5a8a63278410ee018c
stopped
```

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1787963212.702239 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when deploy-time GETs attach bearer tokens, but only for configured-host gateway paths; direct endpoints remain anonymous. Shared URL validation affects pagination Next-link guarding.
> 
> **Overview**
> Post-deploy workload endpoint checks no longer always use anonymous GETs. **Public DataRobot gateway URLs** under `/api/v2/endpoints/workloads/` on the configured host are checked with the CLI bearer token so the gateway can proxy and the reported HTTP status reflects the workload instead of an unauthenticated **401**.
> 
> **Direct or non-gateway endpoints stay anonymous** so user API tokens are not sent to container URLs that may appear in access logs. Malformed non-absolute endpoint URLs **skip** the check with a warning rather than looking like a connectivity failure.
> 
> Adds shared **`drapi.URLMatchesConfiguredBase()`** for same-origin checks before attaching credentials to server-supplied absolute URLs; pagination’s **`AssertNextOnSameHost`** now delegates to it. Auth docs note this pattern for credential safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc966cbd772c630ee184c6bb767f294bcf92af52. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->