### PR TITLE
[RAPTOR-19348] fix(artifact): don't prompt in code sync --dry-run and emit one JSON document

### DIFF
--- a/cmd/artifact/code/codesync/cmd.go
+++ b/cmd/artifact/code/codesync/cmd.go
@@ -313,6 +313,13 @@ func finishJSON(engine engineRunner, plan *sync.SyncPlan, out io.Writer, flags r
 		return display.RenderSyncJSON(out, plan, nil, locked)
 	}
 
+	// The document is written only after Execute succeeds, so a failed sync
+	// leaves stdout empty and reports the error on stderr with a non-zero exit.
+	// This differs from the old two-document output, which emitted the plan
+	// before Execute and so left a plan on stdout even when the sync failed:
+	// with a single document, stdout carries a result only when there is one,
+	// and a consumer keys off the exit status rather than parsing a document
+	// that describes what was attempted rather than what happened.
 	result, err := engine.Execute(plan)
 	if err != nil {
 		return err

--- a/cmd/artifact/code/codesync/cmd.go
+++ b/cmd/artifact/code/codesync/cmd.go
@@ -67,6 +67,10 @@ func (r realEngine) Fetcher() display.ContentFetcher { return r.Engine.Fetcher()
 type Deps struct {
 	NewEngine func(dir string, opts sync.Options) (engineRunner, error)
 	ReadLine  func() (string, error)
+	// AskDir prompts for the project directory when neither --dir nor a
+	// non-interactive mode supplies one. A seam so tests can assert the
+	// preview modes never reach it.
+	AskDir func(label, defaultVal string) (string, error)
 }
 
 // runFlags is the parsed view of the boolean flags that gate
@@ -76,6 +80,14 @@ type runFlags struct {
 	DryRun bool
 	Diff   bool
 	Yes    bool
+}
+
+// Preview reports whether this run only shows a plan and writes nothing, on
+// either the local or the remote side. Such a run must never block on a
+// prompt: an operation that by definition changes nothing has no confirmation
+// to ask for (RAPTOR-19348).
+func (f runFlags) Preview() bool {
+	return f.DryRun || f.Diff
 }
 
 func defaultDeps() Deps {
@@ -89,6 +101,7 @@ func defaultDeps() Deps {
 			return realEngine{e}, nil
 		},
 		ReadLine: reader.ReadString,
+		AskDir:   dirprompt.AskWithDefault,
 	}
 }
 
@@ -118,8 +131,9 @@ versioned step.
 
 Use --dry-run to preview the plan without writing anything; --diff to
 also print per-file unified diffs. Both modes exit before any remote
-write. --yes auto-confirms the post-plan prompt and skips any
-interactive directory prompt.
+write and never prompt, so they are safe to run unattended. --yes
+auto-confirms the post-plan prompt and skips any interactive directory
+prompt.
 
 Run 'dr artifact code init <artifact-id>' first to link a project
 directory to an artifact.
@@ -165,7 +179,14 @@ func runSync(cmd *cobra.Command, outputFormat outputformat.OutputFormat, deps De
 
 	dirFlag, _ := cmd.Flags().GetString("dir")
 
-	dir, err := dirprompt.ResolveDir(dirFlag, flags.Yes, dirprompt.AskWithDefault)
+	ask := deps.AskDir
+	if ask == nil {
+		ask = dirprompt.AskWithDefault
+	}
+
+	// A preview writes nothing, so it resolves the directory without asking:
+	// --dry-run used to block on this prompt before ever reaching the plan.
+	dir, err := dirprompt.ResolveDir(dirFlag, flags.Yes || flags.Preview(), ask)
 	if err != nil {
 		return err
 	}
@@ -275,24 +296,21 @@ func shouldPromptConflicts(plan *sync.SyncPlan, yes bool) bool {
 	return !yes && plan.HasConflicts()
 }
 
-// finishJSON is the --output-format=json analogue of finishSync. The
-// plan is always emitted; if neither --dry-run nor --diff is set and
-// the plan does not require explicit confirmation, an Execute runs
-// and the Result is emitted as a second JSON document. Conflicts
-// without --yes are treated like the human-path quit branch: the
-// plan is emitted and no Execute is run, so callers can inspect the
-// plan and re-invoke with --yes if they want to proceed.
+// finishJSON is the --output-format=json analogue of finishSync. It emits
+// exactly one JSON document: the plan at the top level and, when a
+// version-writing Execute runs, its result under a "result" key. Emitting the
+// plan and the result as two concatenated documents broke every consumer's
+// json.loads (RAPTOR-19348).
+//
+// An Execute runs only when neither preview mode is set, the plan is non-empty,
+// and it does not require explicit confirmation. Conflicts without --yes are
+// treated like the human-path quit branch: the plan is emitted and no Execute
+// is run, so callers can inspect it and re-invoke with --yes to proceed.
 func finishJSON(engine engineRunner, plan *sync.SyncPlan, out io.Writer, flags runFlags) error {
-	if err := display.RenderPlanJSON(out, plan, engine.LockedNotice() != ""); err != nil {
-		return err
-	}
+	locked := engine.LockedNotice() != ""
 
-	if flags.DryRun || flags.Diff || plan.IsEmpty() {
-		return nil
-	}
-
-	if shouldPromptConflicts(plan, flags.Yes) {
-		return nil
+	if flags.Preview() || plan.IsEmpty() || shouldPromptConflicts(plan, flags.Yes) {
+		return display.RenderSyncJSON(out, plan, nil, locked)
 	}
 
 	result, err := engine.Execute(plan)
@@ -300,5 +318,5 @@ func finishJSON(engine engineRunner, plan *sync.SyncPlan, out io.Writer, flags r
 		return err
 	}
 
-	return display.RenderResultJSON(out, result)
+	return display.RenderSyncJSON(out, plan, result, locked)
 }

--- a/cmd/artifact/code/codesync/cmd_test.go
+++ b/cmd/artifact/code/codesync/cmd_test.go
@@ -148,6 +148,65 @@ func TestCmd_NotLinked(t *testing.T) {
 	assert.Contains(t, err.Error(), "not linked")
 }
 
+// TestRunE_DryRun_DoesNotPromptForDirectory: --dry-run writes nothing, so it
+// resolves the directory without the prompt that used to block it forever
+// before the plan (RAPTOR-19348). No --dir and no --yes: the old code prompted.
+func TestRunE_DryRun_DoesNotPromptForDirectory(t *testing.T) {
+	asked := false
+
+	deps := fakeEngineDeps(&fakeEngine{plan: &sync.SyncPlan{}})
+	deps.AskDir = func(_, defaultVal string) (string, error) {
+		asked = true
+
+		return defaultVal, nil
+	}
+
+	// The resolved "." is not a linked project, so the run ends in a "not
+	// linked" error; the point of the test is that it got there without asking.
+	_, _, _, _ = runWithDeps(t, deps, map[string]string{"dry-run": "true"})
+
+	assert.False(t, asked, "--dry-run must not prompt for the project directory")
+}
+
+// TestRunE_Diff_DoesNotPromptForDirectory: --diff is the same no-write preview
+// and must not block on the directory prompt either.
+func TestRunE_Diff_DoesNotPromptForDirectory(t *testing.T) {
+	asked := false
+
+	deps := fakeEngineDeps(&fakeEngine{plan: &sync.SyncPlan{}})
+	deps.AskDir = func(_, defaultVal string) (string, error) {
+		asked = true
+
+		return defaultVal, nil
+	}
+
+	_, _, _, _ = runWithDeps(t, deps, map[string]string{"diff": "true"})
+
+	assert.False(t, asked, "--diff must not prompt for the project directory")
+}
+
+// TestRunE_Interactive_PromptsForDirectory is the control for the two preview
+// tests above: a normal run with neither --dir nor --yes does reach the
+// directory prompt, so those tests prove the preview modes skip it rather than
+// the seam being dead.
+func TestRunE_Interactive_PromptsForDirectory(t *testing.T) {
+	dir := t.TempDir()
+	linkProject(t, dir)
+
+	asked := false
+
+	deps := fakeEngineDeps(&fakeEngine{plan: &sync.SyncPlan{}})
+	deps.AskDir = func(_, _ string) (string, error) {
+		asked = true
+
+		return dir, nil
+	}
+
+	_, _, _, err := runWithDeps(t, deps, map[string]string{})
+	require.NoError(t, err)
+	assert.True(t, asked, "an interactive run with no --dir must prompt for the directory")
+}
+
 // TestCmd_DryRunDiffMutuallyExclusive confirms cobra's
 // MarkFlagsMutuallyExclusive wiring is in place.
 func TestCmd_DryRunDiffMutuallyExclusive(t *testing.T) {
@@ -266,10 +325,10 @@ func TestRunE_IgnoreFileNotice_GoesToStderrAndLeavesStdoutParseable(t *testing.T
 	}
 }
 
-// assertOnlyJSON drains r as a stream of JSON documents and fails if anything
-// else is in there. The command emits the plan and then the result, so the
-// count is not fixed, but "parses to EOF" is the property the repo's
-// JSON-purity rule actually states.
+// assertOnlyJSON drains r and requires it to be exactly one JSON document. The
+// command emits a single object — the plan, with the result nested under
+// "result" when one ran — so a consumer's json.loads sees one document and no
+// longer needs a splitter (RAPTOR-19348).
 func assertOnlyJSON(t *testing.T, r io.Reader) {
 	t.Helper()
 
@@ -290,11 +349,12 @@ func assertOnlyJSON(t *testing.T, r io.Reader) {
 		docs++
 	}
 
-	assert.Positive(t, docs, "expected at least one JSON document on stdout")
+	assert.Equal(t, 1, docs, "stdout must be exactly one JSON document")
 }
 
-// TestRunE_JSONOutput emits the plan plus result as two JSON
-// documents on the non-conflict, non-dry-run path.
+// TestRunE_JSONOutput emits exactly one JSON document on the non-conflict,
+// non-dry-run path: the plan at the top level with the executed result nested
+// under "result", parseable in a single Unmarshal (RAPTOR-19348).
 func TestRunE_JSONOutput(t *testing.T) {
 	dir := t.TempDir()
 	linkProject(t, dir)
@@ -309,9 +369,22 @@ func TestRunE_JSONOutput(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, fe.executed, "non-dry-run JSON path must Execute")
 
-	out := stdout.String()
-	assert.Contains(t, out, `"a.py"`)
-	assert.Contains(t, out, `"v2"`)
+	assertOnlyJSON(t, bytes.NewReader(stdout.Bytes()))
+
+	var doc struct {
+		Uploads []struct {
+			Path string `json:"path"`
+		} `json:"uploads"`
+		Result *struct {
+			NewVersion string `json:"newVersion"`
+		} `json:"result"`
+	}
+
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &doc), "stdout must be one JSON object")
+	require.Len(t, doc.Uploads, 1)
+	assert.Equal(t, "a.py", doc.Uploads[0].Path)
+	require.NotNil(t, doc.Result, "an executed run carries its result under \"result\"")
+	assert.Equal(t, "v2", doc.Result.NewVersion)
 }
 
 // Exit is 0 and the upload list reads as a sync that will work, so this flag

--- a/cmd/artifact/code/codesync/cmd_test.go
+++ b/cmd/artifact/code/codesync/cmd_test.go
@@ -387,6 +387,27 @@ func TestRunE_JSONOutput(t *testing.T) {
 	assert.Equal(t, "v2", doc.Result.NewVersion)
 }
 
+// A sync that fails during Execute leaves stdout empty and surfaces the error,
+// rather than the old behavior of leaving a plan document on stdout. stdout
+// carries a document only when there is a result to report; a consumer keys off
+// the exit status (RAPTOR-19348).
+func TestRunE_JSONOutput_ExecuteError_LeavesStdoutEmpty(t *testing.T) {
+	dir := t.TempDir()
+	linkProject(t, dir)
+
+	fe := &fakeEngine{
+		plan:       &sync.SyncPlan{Uploads: []sync.FileAction{{Path: "a.py"}}},
+		executeErr: errors.New("upload failed mid-sync"),
+	}
+
+	flags := map[string]string{"dir": dir, "yes": "true", "output-format": "json"}
+
+	_, stdout, _, err := runWithDeps(t, fakeEngineDeps(fe), flags)
+	require.Error(t, err)
+	assert.True(t, fe.executed, "the error must come from Execute, not an earlier gate")
+	assert.Empty(t, stdout.String(), "a failed JSON sync writes no document to stdout")
+}
+
 // Exit is 0 and the upload list reads as a sync that will work, so this flag
 // is the only thing in the document that says the plan can never be applied.
 // The stderr notice does not reach a script.

--- a/internal/workload/sync/display/json.go
+++ b/internal/workload/sync/display/json.go
@@ -58,16 +58,27 @@ type PlanStatsJSON struct {
 	OldVersionShort string `json:"oldVersionShort,omitempty"`
 }
 
-// RenderPlanJSON writes plan as pretty-printed JSON to w.
-func RenderPlanJSON(w io.Writer, plan *sync.SyncPlan, locked bool) error {
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
+// SyncJSON is the single document `dr artifact code sync --output-format json`
+// emits. The plan's fields sit at the top level (its shape unchanged), and the
+// result of a version-writing run is nested under "result" when one ran.
+//
+// One document per invocation: emitting the plan and the result as two
+// concatenated top-level objects made stdout unparseable by a plain json.loads
+// and forced every consumer to write a splitter (RAPTOR-19348).
+type SyncJSON struct {
+	PlanJSON
 
+	Result *ResultJSON `json:"result,omitempty"`
+}
+
+// planJSON builds the plan view. A nil plan carries only the locked flag, which
+// is all a preview of an unreadable plan can report.
+func planJSON(plan *sync.SyncPlan, locked bool) PlanJSON {
 	if plan == nil {
-		return enc.Encode(PlanJSON{Locked: locked})
+		return PlanJSON{Locked: locked}
 	}
 
-	out := PlanJSON{
+	return PlanJSON{
 		Locked:    locked,
 		Uploads:   actionsJSON(plan.Uploads),
 		Downloads: actionsJSON(plan.Downloads),
@@ -83,9 +94,23 @@ func RenderPlanJSON(w io.Writer, plan *sync.SyncPlan, locked bool) error {
 			OldVersionShort: plan.OldVersionShort,
 		},
 	}
+}
+
+// RenderSyncJSON writes the one-document sync view to w: the plan, plus the
+// result under "result" when result is non-nil.
+func RenderSyncJSON(w io.Writer, plan *sync.SyncPlan, result *sync.Result, locked bool) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	out := SyncJSON{PlanJSON: planJSON(plan, locked)}
+
+	if result != nil {
+		r := resultJSON(result)
+		out.Result = &r
+	}
 
 	if err := enc.Encode(out); err != nil {
-		return fmt.Errorf("encode plan json: %w", err)
+		return fmt.Errorf("encode sync json: %w", err)
 	}
 
 	return nil
@@ -102,16 +127,9 @@ type ResultJSON struct {
 	DurationMS      int64    `json:"durationMs"`
 }
 
-// RenderResultJSON writes result as pretty-printed JSON to w.
-func RenderResultJSON(w io.Writer, r *sync.Result) error {
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-
-	if r == nil {
-		return enc.Encode(ResultJSON{})
-	}
-
-	out := ResultJSON{
+// resultJSON builds the result view of a completed sync.
+func resultJSON(r *sync.Result) ResultJSON {
+	return ResultJSON{
 		OldVersion:      r.OldVersion,
 		NewVersion:      r.NewVersion,
 		UploadedCount:   r.UploadedCount,
@@ -121,12 +139,6 @@ func RenderResultJSON(w io.Writer, r *sync.Result) error {
 		ConflictCopies:  r.ConflictCopies,
 		DurationMS:      r.Duration.Milliseconds(),
 	}
-
-	if err := enc.Encode(out); err != nil {
-		return fmt.Errorf("encode result json: %w", err)
-	}
-
-	return nil
 }
 
 func actionsJSON(in []sync.FileAction) []FileActionJSON {

--- a/internal/workload/sync/display/json.go
+++ b/internal/workload/sync/display/json.go
@@ -65,6 +65,12 @@ type PlanStatsJSON struct {
 // One document per invocation: emitting the plan and the result as two
 // concatenated top-level objects made stdout unparseable by a plain json.loads
 // and forced every consumer to write a splitter (RAPTOR-19348).
+//
+// The plan sits at the top level (result nested), which is the opposite of
+// `dr workload up` (scalars at the top level, plan under "plan"). The shapes
+// differ deliberately: this command's documented output is the plan's own
+// uploads[]/downloads[]/conflicts[] keys, so they have to stay at the root that
+// existing consumers read.
 type SyncJSON struct {
 	PlanJSON
 

--- a/internal/workload/sync/display/json_test.go
+++ b/internal/workload/sync/display/json_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package display
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/datarobot/cli/internal/workload/sync"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countDocuments reports how many top-level JSON documents b contains. The
+// whole point of RAPTOR-19348 is that this is always 1.
+func countDocuments(t *testing.T, b []byte) int {
+	t.Helper()
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+
+	n := 0
+
+	for {
+		var doc json.RawMessage
+
+		err := dec.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		require.NoError(t, err)
+
+		n++
+	}
+
+	return n
+}
+
+// An executed sync renders one document: the plan at the top level with the
+// result nested under "result".
+func TestRenderSyncJSON_OneDocumentWithNestedResult(t *testing.T) {
+	plan := &sync.SyncPlan{
+		Uploads:         []sync.FileAction{{Path: "a.py"}},
+		OldVersionShort: "abcd1234",
+	}
+	result := &sync.Result{NewVersion: "v2", UploadedCount: 1, Duration: 3 * time.Second}
+
+	var buf bytes.Buffer
+
+	require.NoError(t, RenderSyncJSON(&buf, plan, result, false))
+
+	assert.Equal(t, 1, countDocuments(t, buf.Bytes()), "must be exactly one JSON document")
+
+	var doc struct {
+		Uploads []FileActionJSON `json:"uploads"`
+		Locked  bool             `json:"locked"`
+		Result  *ResultJSON      `json:"result"`
+	}
+
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc), "the whole stream is one object")
+	require.Len(t, doc.Uploads, 1)
+	assert.Equal(t, "a.py", doc.Uploads[0].Path)
+	require.NotNil(t, doc.Result)
+	assert.Equal(t, "v2", doc.Result.NewVersion)
+}
+
+// A preview (no execute) renders the same single document with no "result"
+// key, so a plan-only run stays parseable in one Unmarshal too.
+func TestRenderSyncJSON_OmitsResultWhenNil(t *testing.T) {
+	plan := &sync.SyncPlan{Downloads: []sync.FileAction{{Path: "b.py"}}}
+
+	var buf bytes.Buffer
+
+	require.NoError(t, RenderSyncJSON(&buf, plan, nil, true))
+
+	assert.Equal(t, 1, countDocuments(t, buf.Bytes()))
+	assert.NotContains(t, buf.String(), `"result"`, "a plan-only run carries no result key")
+
+	var doc struct {
+		Downloads []FileActionJSON `json:"downloads"`
+		Locked    bool             `json:"locked"`
+	}
+
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+	require.Len(t, doc.Downloads, 1)
+	assert.True(t, doc.Locked, "the locked flag rides the top level, as before")
+}


### PR DESCRIPTION
# RATIONALE

Two of the three defects reported in [RAPTOR-19348](https://datarobot.atlassian.net/browse/RAPTOR-19348) against `dr artifact code sync` — the two quick, self-contained ones. The third (bidirectional remote-wins overwrite / no push-only mode — the data-loss headline) is an engine change with open product decisions and is being handled separately.

## CHANGES

### D2 — `--dry-run` no longer hangs on a prompt

`runSync` resolved the project directory with `dirprompt.ResolveDir(dirFlag, flags.Yes, …)`, which prompts whenever `--dir` is absent and `--yes` is not set — it never looked at the preview flags. So `dr artifact code sync --dry-run` (no `--dir`/`--yes`) **blocked on `Project directory [.]:` before it ever built the plan**, for an operation that by definition writes nothing. The reporter hit a 2-minute timeout and had to discover `--dry-run --yes`.

- A preview (`--dry-run` or `--diff`) now resolves the directory **non-interactively** (`runFlags.Preview()`), defaulting to `.` without asking.
- The post-plan confirmation was already skipped for previews, so this closes the last prompt on that path.
- The directory prompt is injected via `Deps.AskDir` so a test can assert the preview modes never reach it, with an interactive control proving the seam still fires on a normal run.

### D3 — `--output-format json` emits one document

`finishJSON` wrote the plan and then the result as **two concatenated top-level JSON documents**, so `json.loads` failed and every consumer needed a custom splitter.

- `finishJSON` now emits **exactly one document** via `display.RenderSyncJSON`: the plan at the top level (**shape unchanged** — `uploads[]`, `downloads[]`, `deletes[]`, `conflicts[]`, `stats`, `locked`) with the executed result nested under a new `"result"` key, present only when an `Execute` actually ran.
- `RenderPlanJSON`/`RenderResultJSON` are folded into `planJSON`/`resultJSON` builders behind it.

The top-level plan shape is preserved, so the reporter's documented workaround (reading `conflicts[]`/`downloads[]` at the root) keeps working — it just no longer needs a splitter.

## OUT OF SCOPE

- **D1** (data loss: bidirectional, remote-wins, no `--push-only`) — tracked separately; it is an engine change (the plan's `Downloads`/`REMOTE_DELETED`/`Conflicts` all write the working tree, and `Downloads` do so with no prompt and no `.LOCAL` backup) with flag/opt-in decisions still open.

## TESTING

- Preview modes don't prompt for the directory (`--dry-run`, `--diff`), with an interactive control that they otherwise do.
- JSON output is one `Unmarshal`-able document with the result nested under `"result"`; `assertOnlyJSON` now requires **exactly one** document; display-level `RenderSyncJSON` shape tests.
- `task lint` clean on all GOOS; `go test -race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CLI UX and JSON stdout contract changes in `artifact code sync`; sync execution and auth paths are unchanged, with added tests.
> 
> **Overview**
> Fixes **RAPTOR-19348** for `dr artifact code sync`: preview runs no longer block on input, and JSON mode stdout is a single parseable object.
> 
> **`--dry-run` / `--diff`** are treated as **preview** (`runFlags.Preview()`): directory resolution uses the same non-interactive path as `--yes`, so unattended previews default the project dir without `Project directory [.]:`. `Deps.AskDir` is injectable for tests; help text notes previews never prompt.
> 
> **`--output-format json`** now writes **one** document via `display.RenderSyncJSON` instead of concatenating plan + result. Top-level plan fields are unchanged; when `Execute` runs, outcome lives under **`result`**. Plan-only paths omit `result`.
> 
> Tests cover no directory prompt in preview modes, interactive control, exactly-one-JSON assertions, and `RenderSyncJSON` shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bb85b84548f68cfc67b0e20d0c5acd00d923680. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->