### PR TITLE
docs(dev): fix stale structure.md and document drapi client conventions

### DIFF
--- a/.cursor/bugbot-cmd.md
+++ b/.cursor/bugbot-cmd.md
@@ -33,10 +33,7 @@ Validate that pagination never crosses host boundaries.
 A flag shape that recurs across commands, or carries the same validation requirement wherever
 it appears (a count, a duration, an ID format), must register through one shared `pflag.Value`
 (see `internal/countflags`, `cmd/internal/pollflags`) — not a fresh ad hoc check hand-rolled in
-each command's `RunE`. A second command re-implementing the same "must be positive"/"must
-parse as a duration" logic instead of reusing the existing type is a sign the flag belongs in
-a shared package, not more copies of the check. Validating this way also moves the rejection to
-parse time, before the command runs.
+each command's `RunE`.
 
 ## Sentinel Defaults Are a Documented Exception
 

--- a/.cursor/bugbot-cmd.md
+++ b/.cursor/bugbot-cmd.md
@@ -28,15 +28,18 @@ Prefer `outputformat.PrintJSONEnvelope` for structured output so the payload is 
 
 Validate that pagination never crosses host boundaries.
 
-## Count-Like Flags Validate at Parse Time
+## Repeated Flag Shapes Register Through a Shared pflag.Value
 
-A numeric flag that carries a count (`--limit`, `--offset`, `--tail`, `--concurrency`) must
-register through a `pflag.Value` (`internal/countflags`) so out-of-range input is rejected
-during flag parsing, not with a runtime check inside `RunE` after the command has already
-started.
+A flag shape that recurs across commands, or carries the same validation requirement wherever
+it appears (a count, a duration, an ID format), must register through one shared `pflag.Value`
+(see `internal/countflags`, `cmd/internal/pollflags`) — not a fresh ad hoc check hand-rolled in
+each command's `RunE`. A second command re-implementing the same "must be positive"/"must
+parse as a duration" logic instead of reusing the existing type is a sign the flag belongs in
+a shared package, not more copies of the check. Validating this way also moves the rejection to
+parse time, before the command runs.
 
-## Zero-As-Default Flags Are a Documented Exception
+## Sentinel Defaults Are a Documented Exception
 
-A flag where `0` means "unset, use a default" (a port, a replica count) must not be forced
-through `internal/countflags`' positive/non-negative validators — but the exception must be
-called out at the flag definition, not left for a reviewer to guess.
+A flag where a value like `0` means "unset, use a default" (a port, a replica count) must not
+be forced through a shared validator built for a different flag's semantics — but the exception
+must be called out at the flag definition, not left for a reviewer to guess.

--- a/.cursor/bugbot-cmd.md
+++ b/.cursor/bugbot-cmd.md
@@ -39,4 +39,4 @@ each command's `RunE`.
 
 A flag where a value like `0` means "unset, use a default" (a port, a replica count) must not
 be forced through a shared validator built for a different flag's semantics — but the exception
-must be called out at the flag definition, not left for a reviewer to guess.
+must be called out.

--- a/.cursor/bugbot-cmd.md
+++ b/.cursor/bugbot-cmd.md
@@ -27,3 +27,16 @@ Prefer `outputformat.PrintJSONEnvelope` for structured output so the payload is 
 ## Pagination Safety
 
 Validate that pagination never crosses host boundaries.
+
+## Count-Like Flags Validate at Parse Time
+
+A numeric flag that carries a count (`--limit`, `--offset`, `--tail`, `--concurrency`) must
+register through a `pflag.Value` (`internal/countflags`) so out-of-range input is rejected
+during flag parsing, not with a runtime check inside `RunE` after the command has already
+started.
+
+## Zero-As-Default Flags Are a Documented Exception
+
+A flag where `0` means "unset, use a default" (a port, a replica count) must not be forced
+through `internal/countflags`' positive/non-negative validators — but the exception must be
+called out at the flag definition, not left for a reviewer to guess.

--- a/.cursor/bugbot-design.md
+++ b/.cursor/bugbot-design.md
@@ -43,3 +43,8 @@ Extract utility functions only after the same code appears in 2+ independent pla
 ## Scope Discipline: Foundational PRs
 
 Foundational PRs should do architectural work without bundling unrelated refactorings.
+
+## Document Intentional Asymmetry Between Look-Alike Siblings
+
+When two structurally similar functions/phases behave differently on failure by design, say so
+inline — otherwise a later refactor "fixes" the asymmetry and breaks the reason it existed.

--- a/.cursor/bugbot-errors.md
+++ b/.cursor/bugbot-errors.md
@@ -30,3 +30,14 @@ one shared sentinel — not two phrasings that differ by which path reached the 
 An error whose only consumer is a boolean — file-type predicates, "is this ours" checks — must
 not be phrased as user guidance. Someone will later "align" it with a real message and put
 a remedy into a string nothing prints.
+
+## Terminal Errors Must Name the Exact Recovery Command
+
+A refusal in a terminal/blocked state must name the exact command that unblocks it, not "check
+the logs" — and that command must not itself dead-end into another unexplained error.
+
+## Retry Safety Must Be Classified by Response Shape, Not Status Code Alone
+
+A status code that's sometimes-safe to retry (502/504) must not be retried using the same rule
+as one that's always safe (503) — check whether the response proves the request was actually
+received before assuming a retry can't double-submit.

--- a/.cursor/bugbot-package-design.md
+++ b/.cursor/bugbot-package-design.md
@@ -20,3 +20,19 @@ Document how functions fail, especially for streaming, long-running, and resourc
 
 Intentional limitations must be tracked with JIRA issues. However in package documentation or in the codebase,
 do NOT list issues by number. Just describe the limitation and the intended future work to address it.
+
+## A New API Wrapper Extends drapi, Never Re-Implements It
+
+A package adding typed request/response shapes or a caller-specific error envelope over a
+DataRobot API surface (see `internal/drapi/filesapi`, `internal/workload/apiclient`) must build
+entirely on `drapi`'s verb functions, `EndpointURL`, and `HTTPError`. If the new package
+constructs its own `http.Client`, re-derives a timeout default, or defines a second error type
+shaped like `HTTPError`, that's a sign it's duplicating `drapi` rather than extending it.
+
+## Non-DataRobot-API Calls Do Not Belong in drapi
+
+A request that isn't to the authenticated DataRobot platform API — a local OAuth-redirect
+handshake, a plugin download, a third-party registry fetch — must not be routed through
+`drapi`'s verb functions or forced through `AuthorizeRequest`/`URLMatchesConfiguredBase`. Those
+exist to protect a bearer token that has no business being attached to an unrelated origin; a
+plain, purpose-built client for that call is correct, not a gap.

--- a/.cursor/bugbot-resources.md
+++ b/.cursor/bugbot-resources.md
@@ -27,3 +27,8 @@ Rollback and restore operations must be idempotent.
 ## File Permissions & Attributes Preserved
 
 File modes, symlinks, and extended attributes must be preserved through backup and restore cycles.
+
+## Duplicated Constants Need a Canonical-Source Comment
+
+When an import cycle forces a second copy of a shared constant (timeout, retry count), comment
+it as a duplicate pointing at the canonical definition — so the two don't drift silently.

--- a/.cursor/bugbot-security.md
+++ b/.cursor/bugbot-security.md
@@ -12,6 +12,10 @@ Write tests that attempt to override security constraints and verify they fail.
 
 Validate input at every package boundary — don't assume upstream packages provide safe data.
 
+Worked example: `docs/development/drapi-client.md` — before attaching a bearer token to
+a server-supplied URL (pagination cursor, live endpoint), verify it with
+`drapi.URLMatchesConfiguredBase()` first.
+
 ## Validate Integration Points Explicitly
 
 Verify inter-package contracts with integration tests, not just assumptions.

--- a/.cursor/bugbot-security.md
+++ b/.cursor/bugbot-security.md
@@ -16,6 +16,18 @@ Worked example: `docs/development/drapi-client.md` — before attaching a bearer
 a server-supplied URL (pagination cursor, live endpoint), verify it with
 `drapi.URLMatchesConfiguredBase()` first.
 
+## Local Callback Listeners Must Validate Request Provenance
+
+A listener bound to localhost for an OAuth-style handoff is reachable by any open web page —
+localhost has no same-origin restriction. It must check something a page can't forge
+(`Sec-Fetch-Dest`, a nonce) before treating a request as authentic, not just accept whatever
+hits the port.
+
+## Security Mitigation Claims Must Name the Residual Bypass
+
+A doc or comment describing a security fix must scope its claim to the exact vectors it blocks
+and name what still gets through — not claim a blanket guarantee the fix doesn't provide.
+
 ## Validate Integration Points Explicitly
 
 Verify inter-package contracts with integration tests, not just assumptions.

--- a/.cursor/bugbot-validation.md
+++ b/.cursor/bugbot-validation.md
@@ -35,3 +35,8 @@ Validation tests must cover both success and failure paths.
 ## Validation Error Messages
 
 Validation errors must name the field that failed and explain why.
+
+## Heuristic Detection Must Degrade, Never Refuse
+
+A check built on heuristics (missing project markers, ambiguous environment) must warn or
+prompt, never hard-block — heuristics have false positives a hard refusal can't recover from.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,14 @@ For full details, see [docs/development/configuration.md](docs/development/confi
 - **To make a key persistable**, add it to `config.PersistableKeys` and have the
   write site call `config.UpdateConfigFile("my-key")`.
 
+## Auth & API Client Conventions
+
+For OAuth/browser login internals, see [docs/development/authentication.md](docs/development/authentication.md).
+For wiring in a new authenticated DataRobot API call&mdash;timeout clamping,
+the `HTTPError`/`errors.As` contract, and the origin-safety check before
+attaching credentials to a server-supplied URL&mdash;see
+[docs/development/drapi-client.md](docs/development/drapi-client.md).
+
 ## Code Review Guidelines
 
 All PRs are reviewed against **bugbot rules** in [.cursor/BUGBOT.md](.cursor/BUGBOT.md). Rules are organized by risk level:

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -25,6 +25,7 @@ If you're new to developing the CLI, start here:
 - **[Tool registry](tool-registry.md)**&mdash;how install-hint strategies and manager detection work; how to add a new tool or package manager.
 - **[Plugins](plugins.md)**&mdash;develop and test CLI plugins, understand the plugin system architecture.
 - **[Remote plugins](remote-plugins.md)**&mdash;create and distribute remote plugins, plugin registry management.
+- **[drapi client conventions](drapi-client.md)**&mdash;how to wire in a new authenticated API call: timeout clamping, the `HTTPError`/`errors.As` contract, and origin-safety checks before attaching credentials to a server-supplied URL.
 - **[Workload state directory validation](workload-wapi-validation.md)**&mdash;reference for `validator/v10` tags and cross-field rules for workload local state.
 - **[Editing user-owned files](editing-user-files.md)**&mdash;rules for in-place edits to `.datarobot.yaml` and `.env`: comment preservation, round-trip symmetry, and when a refusal beats a rewrite.
 - **[Releasing](releasing.md)**&mdash;release process, versioning strategy, and GoReleaser configuration.

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -171,3 +171,7 @@ at `0644` by an older CLI would otherwise stay world-readable forever.
 When attaching credentials to an absolute URL returned by a server response,
 first check it with `drapi.URLMatchesConfiguredBase()`. URLs built locally with
 `config.GetEndpointURL()` already stay on the configured DataRobot host.
+
+For how the bearer token is attached to outgoing requests once you have
+it&mdash;and the timeout/error-handling conventions for any new authenticated
+API call&mdash;see [drapi client conventions](drapi-client.md).

--- a/docs/development/drapi-client.md
+++ b/docs/development/drapi-client.md
@@ -1,0 +1,74 @@
+# drapi client conventions
+
+`internal/drapi` is the one shared HTTP client every authenticated call to
+the DataRobot API is expected to build on. This page is the dev-doc mirror
+of `internal/drapi/doc.go` (`go doc ./internal/drapi` for the canonical
+source) — read this first when wiring in a new API call; read the package
+doc when you need the full detail.
+
+## Always build on the verb functions
+
+Use `drapi.Get`, `drapi.Post`, `drapi.Patch`, or `drapi.Delete` (or their
+`*JSON` variants) with a URL from `drapi.EndpointURL()` /
+`config.GetEndpointURL()`. Never construct your own `http.Client` or set
+the `Authorization` header by hand — `AuthorizeRequest` (`internal/drapi/auth.go`)
+is called internally by every verb function and sets the bearer token,
+`User-Agent`, and the optional API-consumer trace header consistently.
+
+If you must build your own `*http.Request` (multipart uploads, custom error
+decoding), use `drapi.Do(req, timeout)` rather than duplicating
+`NewHTTPClient(t).Do(req)` — it applies the same timeout clamp described
+below.
+
+## Timeouts
+
+Every verb function takes an optional trailing `time.Duration`. Omit it, or
+pass `<=0`, and `NewHTTPClient` clamps it to `DefaultClientTimeout` (30s)
+internally — the clamp cannot be bypassed by a caller. This was tightened in
+CFX-7822 specifically so a stray `0` or negative duration could never
+produce an unbounded request.
+
+## The `HTTPError` / `errors.As` contract
+
+A non-2xx response becomes a `*drapi.HTTPError{StatusCode, URL, Detail, Body}`,
+unpackable via `errors.As`. Roughly 32 call sites across the codebase depend
+on this contract holding — treat it as load-bearing when touching
+`internal/drapi`.
+
+`Body` is the raw, uninterpreted response body (different DataRobot APIs
+disagree on their error envelope shape); `Detail` is best-effort and
+populated by the caller — see `internal/workload/apiclient.LiftDetail` for
+the pattern of parsing a FastAPI `{"detail": ...}` envelope into `Detail`.
+
+**Known gap, don't copy this as the pattern**: `Get()` currently builds a
+bare `&HTTPError{StatusCode, URL}` on failure instead of calling
+`ErrFromResp()` the way `Post`, `Patch`, and `Delete` do — so a `GET`
+failure carries no `Body`/`Detail` today, unlike every other verb. This is
+a known asymmetry, not an intentional design choice; a fix is a reasonable
+follow-up, but a new caller should not assume `Get()` failures carry the
+same diagnostic detail as the others until it's closed.
+
+## Origin safety
+
+Before attaching the bearer token to any URL your code did not build
+locally — a server-returned pagination cursor, a workload's live `endpoint`
+URL — call `drapi.URLMatchesConfiguredBase(rawURL)` first and skip
+authorization when it doesn't match. Attaching a CLI credential to an
+arbitrary server-supplied URL would leak it to whatever origin that URL
+points at.
+
+Two worked examples:
+
+- `AssertNextOnSameHost` (`internal/drapi/pagination.go`) guards a paginated
+  list response's `Next` cursor before the client follows it.
+- `endpointCheckAuthForURL` (`internal/workload/up/endpoint_check.go`)
+  authenticates a post-deploy endpoint check only when the URL is the
+  DataRobot-hosted workload gateway path *and* matches the configured base;
+  a direct/customer-container URL always stays anonymous, so the CLI token
+  never lands in a customer container's access log (RAPTOR-19741).
+
+## See also
+
+- [Authentication](authentication.md) — the OAuth-style login flow that
+  produces the token these conventions consume.
+- `go doc ./internal/drapi` — the full package doc.

--- a/docs/development/drapi-client.md
+++ b/docs/development/drapi-client.md
@@ -24,9 +24,9 @@ below.
 
 Every verb function takes an optional trailing `time.Duration`. Omit it, or
 pass `<=0`, and `NewHTTPClient` clamps it to `DefaultClientTimeout` (30s)
-internally — the clamp cannot be bypassed by a caller. This was tightened in
-CFX-7822 specifically so a stray `0` or negative duration could never
-produce an unbounded request.
+internally — the clamp cannot be bypassed by a caller. This was tightened
+specifically so a stray `0` or negative duration could never produce
+an unbounded request.
 
 ## The `HTTPError` / `errors.As` contract
 

--- a/docs/development/structure.md
+++ b/docs/development/structure.md
@@ -68,8 +68,7 @@ Contains all CLI command implementations using the Cobra framework. Each subdire
 - `cmd/auth/cmd.go`: The auth command group
 - `cmd/auth/login/cmd.go`: The login subcommand
 - `cmd/auth/logout/cmd.go`: The logout subcommand
-- `cmd/auth/check/cmd.go`, `cmd/auth/export/cmd.go`, `cmd/auth/seturl/cmd.go`:
-  the remaining auth subcommands, each in its own directory
+- ...
 
 ### internal/
 

--- a/docs/development/structure.md
+++ b/docs/development/structure.md
@@ -15,9 +15,11 @@ cli/
 │   ├── self/                # Self-management commands
 │   ├── start/               # Application startup
 │   ├── task/                # Task commands
-│   └── templates/           # Template management
+│   ├── templates/           # Template management
+│   └── workload/            # Workload lifecycle commands (feature-gated)
 ├── internal/                # Private application code
 │   ├── assets/              # Embedded assets
+│   ├── auth/                # Authentication logic (OAuth-style browser flow)
 │   ├── cli/                 # CLI infrastructure (GatedCommand, etc.)
 │   ├── config/              # Configuration management
 │   ├── copier/              # Template copying utilities
@@ -30,7 +32,8 @@ cli/
 │   ├── task/                # Task discovery and execution
 │   ├── telemetry/           # Anonymous usage analytics (Amplitude)
 │   ├── tools/               # Tool prerequisites
-│   └── version/             # Version information
+│   ├── version/             # Version information
+│   └── workload/            # Workload manifest, wizard, deploy, and sync engine
 ├── tui/                     # Terminal UI components
 │   ├── banner.go            # Banner display
 │   ├── interrupt.go         # Interrupt handling
@@ -63,8 +66,10 @@ Contains all CLI command implementations using the Cobra framework. Each subdire
 #### Example
 
 - `cmd/auth/cmd.go`: The auth command group
-- `cmd/auth/login.go`: The login subcommand
-- `cmd/auth/logout.go`: The logout subcommand
+- `cmd/auth/login/cmd.go`: The login subcommand
+- `cmd/auth/logout/cmd.go`: The logout subcommand
+- `cmd/auth/check/cmd.go`, `cmd/auth/export/cmd.go`, `cmd/auth/seturl/cmd.go`:
+  the remaining auth subcommands, each in its own directory
 
 ### internal/
 
@@ -88,7 +93,24 @@ DataRobot API client implementation for:
 
 See the package doc (`go doc ./internal/drapi`) for the timeout-override
 convention and the `HTTPError`/`errors.As` contract new commands should
-follow when wiring in a call.
+follow when wiring in a call, or [drapi client conventions](drapi-client.md)
+for the same content as a dev doc.
+
+#### auth/
+
+OAuth-style browser login flow (`auth.EnsureAuthenticated`, used as a
+`PreRunE` gate on any command that needs credentials) plus the
+credential-verification and interactive URL-picker logic behind
+`dr auth login`/`set-url`. See
+[Authentication](authentication.md) for the full flow.
+
+#### workload/
+
+Manifest parsing/compilation, the `dr workload config` setup wizard, the
+`dr workload up` deploy orchestrator, and the code-sync engine behind
+`dr artifact code sync`. A dedicated architecture guide is in review with
+the Workload API team; until it lands, `internal/workload/*/doc.go` (e.g.
+`go doc ./internal/workload/up`) is the best available reference.
 
 #### envbuilder/
 
@@ -230,19 +252,27 @@ Configuration is managed through Viper and stored in:
 
 - `~/.config/datarobot/drconfig.yaml`: Global configuration and authentication tokens
 
-Access configuration through the `internal/config` package:
+Access configuration through `internal/config` and its `viperx` wrapper
+(the only supported way to read/write viper state — `spf13/viper` cannot be
+imported directly outside `internal/config`):
 
 ```go
-import "github.com/datarobot/cli/internal/config"
+import (
+    "github.com/datarobot/cli/internal/config"
+    "github.com/datarobot/cli/internal/config/viperx"
+)
 
 // Get configuration values
-apiKey := config.GetAPIKey()
-endpoint := config.GetEndpoint()
+apiKey := viperx.GetString(config.DataRobotAPIKey)
+endpoint := config.GetBaseURL()
 
-// Set configuration values
-config.SetAPIKey("new-key")
-config.SaveConfig()
+// Persist a value — only keys listed in config.PersistableKeys are written
+viperx.Set(config.DataRobotURL, "https://app.datarobot.com")
+config.UpdateConfigFile(config.DataRobotURL)
 ```
+
+See [Configuration](configuration.md) for the full contract (persistable
+keys, env-var binding, redaction rules).
 
 ## Testing structure
 


### PR DESCRIPTION
# RATIONALE

`workload` and `auth` have absorbed most of the last two months' commit volume, but the dev docs a new contributor actually browses hadn't kept up — `structure.md` still showed a directory tree and a `config.GetAPIKey()`/`SetAPIKey()`/`SaveConfig()` code sample that no longer exist (and contradicts the correct pattern already documented in `configuration.md`), and `internal/drapi`'s conventions (timeout clamping, the `HTTPError`/`errors.As` contract, origin-safety before attaching credentials to a server-supplied URL) lived only in a package doc comment, unlinked from `docs/development/`.

This closes that gap with pure documentation — no code changes.

A dedicated `internal/workload` architecture doc is being drafted separately for the Workload API team to review and own, so this intentionally leaves that package's `structure.md` subsection as a placeholder pending that PR.

## CHANGES

- `docs/development/structure.md`: add `workload/` and `auth/` to the directory trees, fix the `auth/` worked example to match the current one-subdirectory-per-verb layout, replace the stale Configuration code sample with the real `viperx`/`UpdateConfigFile` pattern.
- New `docs/development/drapi-client.md`: verb-function convention, timeout clamping, the `HTTPError`/`errors.As` contract (including a known `Get()` vs `Post`/`Patch`/`Delete` detail asymmetry, flagged not fixed), and the origin-safety check before attaching credentials to a server-supplied URL.
- Cross-link the new doc from `authentication.md`, `docs/development/README.md`'s Advanced topics, `AGENTS.md`'s new Auth & API Client Conventions section, and a one-line worked-example pointer in `.cursor/bugbot-security.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes to development guides and BugBot rules; no runtime, auth, or API behavior changes.
> 
> **Overview**
> **Documentation-only** update to bring contributor docs and BugBot guidance in line with current `auth`, `workload`, and `drapi` patterns.
> 
> **Dev docs:** Adds **`docs/development/drapi-client.md`** (verb functions, timeout clamping, `HTTPError`/`errors.As`, origin checks via `URLMatchesConfiguredBase`, and the known `Get()` vs other verbs error-detail gap). **`structure.md`** now lists `cmd/workload`, `internal/auth`, and `internal/workload`, fixes the auth subcommand layout example, and replaces obsolete `GetAPIKey`/`SaveConfig` samples with **`viperx` + `UpdateConfigFile`**. Cross-links land in **`README.md`**, **`authentication.md`**, and **`AGENTS.md`** (new **Auth & API Client Conventions** section).
> 
> **BugBot / review rules:** Expands several `.cursor/bugbot-*.md` files with shared-flag registration, sentinel defaults, intentional sibling asymmetry, terminal recovery commands, retry-by-response-shape, **`drapi` extension vs re-implementation**, non-platform HTTP clients, duplicated-constant comments, localhost callback provenance, scoped security claims, and heuristic validation that warns instead of hard-blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 286143413bbb500d2f6a2baa55624500aed1e8ae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->