### PR TITLE
docs: correct -o shorthand claim in self version docs

### DIFF
--- a/docs/commands/self.md
+++ b/docs/commands/self.md
@@ -147,7 +147,7 @@ dr self version
 
 **Options:**
 
-- `-o, --output-format`&mdash;output format (`text` or `json`, default: `text`)
+- `--output-format`&mdash;output format (`text` or `json`, default: `text`). `-o` is accepted as a deprecated alias (it maps to the legacy `--format` flag, not `--output-format`).
 - `-s, --short`&mdash;print just the version number (text format only)
 
 **Examples:**


### PR DESCRIPTION
## What
Fixes a small inaccuracy in the `dr self version` options list in `docs/commands/self.md`.

## Why
The doc claimed `-o, --output-format`, but `--output-format` has no `-o` shorthand. It is registered via `outputformat.AddFlag`/`AddPersistentFlag` (`cmd.Flags().Var(dest, "output-format", ...)`) with no shorthand. On `dr self version`, `-o` is the shorthand of the deprecated hidden `--format` flag (`cmd/self/version/cmd.go`), kept for backward compatibility with smoke test scripts — it is not an alias of `--output-format`.

## Change
The options entry now reads:

```markdown
- `--output-format` — output format (`text` or `json`, default: `text`). `-o` is accepted as a deprecated alias (it maps to the legacy `--format` flag, not `--output-format`).
```

## Verification
- `markdownlint-cli2 docs/commands/self.md`: the changed line introduces no new warnings (remaining MD060 warnings on line 107 are pre-existing).
- `dr self version -o json` was verified to work and route through the deprecated `--format` flag, confirming the doc wording.

Docs-only change; no code paths affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Updates the **`dr self version`** options in `docs/commands/self.md` so they match how flags are actually registered.
> 
> The doc no longer lists `-o` as shorthand for `--output-format`. It documents **`--output-format`** alone and notes that **`-o`** still works only as a deprecated alias of the legacy **`--format`** flag (not of `--output-format`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc7de55ba661befacd0022b42570e68c7235ef2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->