### PR TITLE
[CFX-7847] fix(deps): bump golang.org/x/crypto to v0.55.0 (CVE-2026-56854)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/yuin/goldmark v1.8.2 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
-	golang.org/x/crypto v0.53.0 // indirect
+	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
-	golang.org/x/net v0.56.0 // indirect
+	golang.org/x/net v0.57.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -183,12 +183,12 @@ github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJ
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
-golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
-golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
+golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
+golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
-golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
-golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
+golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
# RATIONALE

`golang.org/x/crypto v0.53.0` is flagged by **CVE-2026-56854** (GO-2026-6303), fixed upstream in
**v0.55.0**. It reaches this module transitively via `golang.org/x/net` and
`github.com/go-playground/validator/v10`.

This is filed against DataRobot's notebook images rather than against this repo, because the scan
target is the `dr` release binary baked into them at `home/notebooks/.local/bin/dr/dr`:

| Jira | Image |
|---|---|
| [CFX-7847](https://datarobot.atlassian.net/browse/CFX-7847) | `datarobotdev/env-notebook-python313-notebook` |
| [CFX-7848](https://datarobot.atlassian.net/browse/CFX-7848) | `datarobotdev/notebooks-kernel-python` |
| [CFX-7849](https://datarobot.atlassian.net/browse/CFX-7849) | `datarobotdev/notebooks-kernel-r` |

Those images pin a `CLI_VERSION` and `wget` the release tarball, so they cannot be fixed downstream —
the bump has to land here and ship in a release first. **Every published release through `v0.4.3`
(2026-09-01) still embeds `golang.org/x/crypto v0.53.0`**, verified with `go version -m` on the
downloaded `dr_<tag>_Linux_x86_64.tar.gz` binaries:

```
v0.2.85  dep  golang.org/x/crypto  v0.53.0     <- pinned by datarobot-user-models python313_notebook
v0.4.0   dep  golang.org/x/crypto  v0.53.0     <- pinned by nbx-kernels (all 5 kernel builds)
v0.4.1   dep  golang.org/x/crypto  v0.53.0
v0.4.2   dep  golang.org/x/crypto  v0.53.0
v0.4.3   dep  golang.org/x/crypto  v0.53.0
```

## Severity note — not exploitable in `dr`

CVE-2026-56854 is in **`golang.org/x/crypto/ssh`**: an SSH *server* that sets a `source-address`
critical option from a `Password` / `KeyboardInteractive` / `NoClientAuth` / `GSSAPI` auth callback
does not enforce it. Vulnerable symbols are `ssh.NewServerConn` and `connection.serverAuthenticate`.

`dr` is not an SSH server, and `golang.org/x/crypto/ssh` is **not linked into the binary at all**.
`go tool nm` on the shipped `v0.4.0` `dr` finds zero `crypto/ssh` symbols; the only `x/crypto`
packages present are the TLS-support ones:

```
$ go tool nm dr | grep -o 'golang\.org/x/crypto/[a-z0-9/]*' | sort -u
golang.org/x/crypto/chacha20
golang.org/x/crypto/chacha20poly1305
golang.org/x/crypto/cryptobyte
golang.org/x/crypto/cryptobyte/asn1
golang.org/x/crypto/internal/poly1305
golang.org/x/crypto/sha3
```

So the CRITICAL rating on the Jira tickets is a module-level (not symbol-level) scanner artifact.
The bump is still worth taking — it is two lines and it clears three release-blocker tickets — but
there is no live exposure and no need to rush a hotfix release.

## CHANGES

- `go.mod` / `go.sum`: `golang.org/x/crypto` `v0.53.0` -> `v0.55.0` (indirect).
- `go.mod` / `go.sum`: `golang.org/x/net` `v0.56.0` -> `v0.57.0`, pulled in as a requirement of
  `x/crypto v0.55.0`. No other module moved.

Verified locally: `go mod tidy` is clean and `go build .` succeeds on `go1.26.7`; the resulting
binary reports

```
dep  golang.org/x/crypto  v0.55.0
dep  golang.org/x/net     v0.57.0
```

## NOTES

**Merging this does not by itself clear CFX-7847/7848/7849.** The remaining chain, for whoever picks
these up:

1. Merge this PR.
2. Cut a `datarobot-oss/cli` release (>= `v0.4.4`) containing it.
3. Re-pin `CLI_VERSION` in `datarobot/nbx-kernels` — 5 lines in `.harness/post_merge/pipeline.yaml`,
   plus `.harness/test_publish_pipelines/Build_Test_Default_Python_Kernel.yaml`,
   `.harness/test_publish_pipelines/Publish_Test_R_Kernel.yaml` and `Makefile:18`. The repo's own
   `.claude/skills/bump-kernel-cli-version` skill covers this and asks for separate Python-family and
   R PRs. Clears CFX-7848 and CFX-7849.
4. Re-pin `ARG CLI_VERSION` (currently `v0.2.85`) in `datarobot/datarobot-user-models`
   `public_dropin_notebook_environments/python313_notebook/Dockerfile`, plus the usual
   `env_info.json` `environmentVersionId` bump to force the rebuild. Clears CFX-7847.
5. Rebuild and republish all three images; verify from the published digest.

Opened by an automated CVE triage run by @dsakagi (dallin@datarobot.com) (DataRobot Access team) — this is not a
repo we own, so please treat it as a drive-by dependency bump and route it however the maintainers
prefer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only indirect dependency upgrades with no application logic changes; runtime exposure to the SSH-server CVE is not expected for this CLI per existing analysis.
> 
> **Overview**
> Bumps **indirect** Go module versions in `go.mod` / `go.sum` to address **CVE-2026-56854** (GO-2026-6303): `golang.org/x/crypto` **v0.53.0 → v0.55.0**, and `golang.org/x/net` **v0.56.0 → v0.57.0** as required by the newer crypto release. There are no source or build-script changes beyond the lockfiles.
> 
> This is aimed at clearing security scans on notebook images that ship the `dr` CLI binary; a new CLI release is still needed downstream to pick up the updated dependency graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f38b59a189d9d6ea47414244ee674778116f1a41. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->