### PR TITLE
CFX-7958: fix(install): wrong completion command

### DIFF
--- a/cmd/self/completion/install/cmd.go
+++ b/cmd/self/completion/install/cmd.go
@@ -103,11 +103,7 @@ By default, this command runs in preview mode. Use '--yes' to install directly.`
 	return cmd
 }
 
-// runInstall takes the invoked *cobra.Command (not just its root) so that
-// user-facing hints can derive the exact "dr self completion install" path
-// from cmd.CommandPath() instead of a hardcoded string. A hardcoded literal
-// silently drifts from the real command path if this command is ever
-// renamed or reparented — see CFX-7958.
+// runInstall keeps user-facing hints tied to the invoked command path.
 func runInstall(cmd *cobra.Command, specifiedShell string, force, yes, dryRun bool) error {
 	shell, err := internalShell.ResolveShell(specifiedShell)
 	if err != nil {

--- a/cmd/self/completion/install/cmd.go
+++ b/cmd/self/completion/install/cmd.go
@@ -60,20 +60,20 @@ This command will:
 
 By default, this command runs in preview mode. Use '--yes' to install directly.`,
 		Example: `  # Preview what would be installed (default behavior):
-  ` + version.CliName + ` completion install
+  ` + version.CliName + ` self completion install
 
   # Install completions for your current shell:
-  ` + version.CliName + ` completion install --yes
+  ` + version.CliName + ` self completion install --yes
 
   # Install completions for a specific shell:
-  ` + version.CliName + ` completion install bash --yes
-  ` + version.CliName + ` completion install zsh --yes
+  ` + version.CliName + ` self completion install bash --yes
+  ` + version.CliName + ` self completion install zsh --yes
 
   # Preview installation for a specific shell:
-  ` + version.CliName + ` completion install bash
+  ` + version.CliName + ` self completion install bash
 
   # Force reinstall, even if completions are already installed:
-  ` + version.CliName + ` completion install --force --yes`,
+  ` + version.CliName + ` self completion install --force --yes`,
 		Args:      cobra.MaximumNArgs(1),
 		ValidArgs: internalShell.SupportedShells(),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -92,7 +92,7 @@ By default, this command runs in preview mode. Use '--yes' to install directly.`
 				effectiveDryRun = true
 			}
 
-			return runInstall(cmd.Root(), shell, force, yes, effectiveDryRun)
+			return runInstall(cmd, shell, force, yes, effectiveDryRun)
 		},
 	}
 
@@ -103,7 +103,12 @@ By default, this command runs in preview mode. Use '--yes' to install directly.`
 	return cmd
 }
 
-func runInstall(rootCmd *cobra.Command, specifiedShell string, force, yes, dryRun bool) error {
+// runInstall takes the invoked *cobra.Command (not just its root) so that
+// user-facing hints can derive the exact "dr self completion install" path
+// from cmd.CommandPath() instead of a hardcoded string. A hardcoded literal
+// silently drifts from the real command path if this command is ever
+// renamed or reparented — see CFX-7958.
+func runInstall(cmd *cobra.Command, specifiedShell string, force, yes, dryRun bool) error {
 	shell, err := internalShell.ResolveShell(specifiedShell)
 	if err != nil {
 		return fmt.Errorf("resolve shell: %w", err)
@@ -120,11 +125,11 @@ func runInstall(rootCmd *cobra.Command, specifiedShell string, force, yes, dryRu
 		return nil
 	}
 
-	return installForShell(rootCmd, shell, shellType, force, yes, dryRun)
+	return installForShell(cmd, shell, shellType, force, yes, dryRun)
 }
 
-func installForShell(rootCmd *cobra.Command, shell string, shellType internalShell.Shell, force, yes, dryRun bool) error {
-	installPath, installFunc, err := getInstallFunc(rootCmd, shellType, force)
+func installForShell(cmd *cobra.Command, shell string, shellType internalShell.Shell, force, yes, dryRun bool) error {
+	installPath, installFunc, err := getInstallFunc(cmd.Root(), shellType, force)
 	if err != nil {
 		return err
 	}
@@ -132,7 +137,7 @@ func installForShell(rootCmd *cobra.Command, shell string, shellType internalShe
 	// Check if already installed
 	alreadyInstalled := fsutil.FileExists(installPath)
 	if !force && alreadyInstalled {
-		showAlreadyInstalled(installPath)
+		showAlreadyInstalled(cmd, installPath)
 		return nil
 	}
 
@@ -141,7 +146,7 @@ func installForShell(rootCmd *cobra.Command, shell string, shellType internalShe
 
 	// Dry-run mode
 	if dryRun {
-		showDryRunMessage(shell)
+		showDryRunMessage(cmd, shell)
 		return nil
 	}
 
@@ -160,7 +165,7 @@ func installForShell(rootCmd *cobra.Command, shell string, shellType internalShe
 	fmt.Println()
 
 	// Install
-	if err := installFunc(rootCmd); err != nil {
+	if err := installFunc(cmd.Root()); err != nil {
 		return fmt.Errorf("Failed to install completions: %w", err)
 	}
 
@@ -173,10 +178,10 @@ func installForShell(rootCmd *cobra.Command, shell string, shellType internalShe
 	return nil
 }
 
-func showAlreadyInstalled(installPath string) {
+func showAlreadyInstalled(cmd *cobra.Command, installPath string) {
 	fmt.Printf("%s Completion already installed at: %s.\n", successStyle.Render("✓"), installPath)
 	fmt.Println()
-	fmt.Println(infoStyle.Render("To reinstall, use: " + version.CliName + " completion install --force --yes"))
+	fmt.Println(infoStyle.Render("To reinstall, use: " + cmd.CommandPath() + " --force --yes"))
 }
 
 func showInstallationPlan(shell, installPath string, alreadyInstalled bool) {
@@ -193,11 +198,11 @@ func showInstallationPlan(shell, installPath string, alreadyInstalled bool) {
 	fmt.Println()
 }
 
-func showDryRunMessage(shell string) {
+func showDryRunMessage(cmd *cobra.Command, shell string) {
 	fmt.Println(infoStyle.Render("🔍 Dry-run mode (no changes will be made)"))
 	fmt.Println()
 	fmt.Println("To proceed with installation, run:")
-	fmt.Println(infoStyle.Render("  " + version.CliName + " completion install " + shell + " --yes"))
+	fmt.Println(infoStyle.Render("  " + cmd.CommandPath() + " " + shell + " --yes"))
 }
 
 func promptForConfirmation() (bool, error) {

--- a/cmd/self/completion/install/cmd_test.go
+++ b/cmd/self/completion/install/cmd_test.go
@@ -16,6 +16,7 @@ package install
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,8 +24,56 @@ import (
 
 	"github.com/datarobot/cli/internal/fsutil"
 	internalShell "github.com/datarobot/cli/internal/shell"
+	"github.com/datarobot/cli/internal/version"
 	"github.com/spf13/cobra"
 )
+
+// wireCommandPath attaches cmd to a synthetic "dr self completion" parent
+// chain matching the real registration (see cmd/self/cmd.go and
+// cmd/self/completion/cmd.go), so cmd.CommandPath() resolves exactly as it
+// does at runtime. This package can't import cmd/self/completion directly —
+// that package imports this one, so doing so would create an import cycle.
+func wireCommandPath(cmd *cobra.Command) {
+	root := &cobra.Command{Use: version.CliName}
+	selfCmd := &cobra.Command{Use: "self"}
+	completionCmd := &cobra.Command{Use: "completion"}
+
+	completionCmd.AddCommand(cmd)
+	selfCmd.AddCommand(completionCmd)
+	root.AddCommand(selfCmd)
+}
+
+// captureStdout redirects os.Stdout for the duration of fn and returns
+// everything written to it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+
+	t.Cleanup(func() { os.Stdout = orig })
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+
+	os.Stdout = w
+
+	fn()
+
+	os.Stdout = orig
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe: %v", err)
+	}
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+
+	return string(out)
+}
 
 func TestDetectShell(t *testing.T) {
 	// DetectShell() now prioritizes parent process detection over $SHELL.
@@ -258,6 +307,44 @@ func TestInstallCmd(t *testing.T) {
 
 	if cmd.Flags().Lookup("dry-run") == nil {
 		t.Error("dry-run flag not found")
+	}
+}
+
+// TestShowAlreadyInstalled guards against CFX-7958: the printed reinstall
+// hint must derive its command path from cmd.CommandPath() so it can never
+// drift from the real "dr self completion install" invocation.
+func TestShowAlreadyInstalled(t *testing.T) {
+	cmd := Cmd()
+	wireCommandPath(cmd)
+
+	out := captureStdout(t, func() {
+		showAlreadyInstalled(cmd, "/fake/path/_dr")
+	})
+
+	if !strings.Contains(out, "/fake/path/_dr") {
+		t.Errorf("output %q does not mention the install path", out)
+	}
+
+	wantHint := version.CliName + " self completion install --force --yes"
+	if !strings.Contains(out, wantHint) {
+		t.Errorf("output %q does not contain expected reinstall hint %q", out, wantHint)
+	}
+}
+
+// TestShowDryRunMessage guards against CFX-7958: the printed dry-run hint
+// must derive its command path from cmd.CommandPath() so it can never
+// drift from the real "dr self completion install" invocation.
+func TestShowDryRunMessage(t *testing.T) {
+	cmd := Cmd()
+	wireCommandPath(cmd)
+
+	out := captureStdout(t, func() {
+		showDryRunMessage(cmd, "zsh")
+	})
+
+	wantHint := version.CliName + " self completion install zsh --yes"
+	if !strings.Contains(out, wantHint) {
+		t.Errorf("output %q does not contain expected dry-run hint %q", out, wantHint)
 	}
 }
 

--- a/cmd/self/completion/install/cmd_test.go
+++ b/cmd/self/completion/install/cmd_test.go
@@ -16,7 +16,6 @@ package install
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,56 +23,10 @@ import (
 
 	"github.com/datarobot/cli/internal/fsutil"
 	internalShell "github.com/datarobot/cli/internal/shell"
+	"github.com/datarobot/cli/internal/testutil"
 	"github.com/datarobot/cli/internal/version"
 	"github.com/spf13/cobra"
 )
-
-// wireCommandPath attaches cmd to a synthetic "dr self completion" parent
-// chain matching the real registration (see cmd/self/cmd.go and
-// cmd/self/completion/cmd.go), so cmd.CommandPath() resolves exactly as it
-// does at runtime. This package can't import cmd/self/completion directly —
-// that package imports this one, so doing so would create an import cycle.
-func wireCommandPath(cmd *cobra.Command) {
-	root := &cobra.Command{Use: version.CliName}
-	selfCmd := &cobra.Command{Use: "self"}
-	completionCmd := &cobra.Command{Use: "completion"}
-
-	completionCmd.AddCommand(cmd)
-	selfCmd.AddCommand(completionCmd)
-	root.AddCommand(selfCmd)
-}
-
-// captureStdout redirects os.Stdout for the duration of fn and returns
-// everything written to it.
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-
-	orig := os.Stdout
-
-	t.Cleanup(func() { os.Stdout = orig })
-
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create pipe: %v", err)
-	}
-
-	os.Stdout = w
-
-	fn()
-
-	os.Stdout = orig
-
-	if err := w.Close(); err != nil {
-		t.Fatalf("close pipe: %v", err)
-	}
-
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("read pipe: %v", err)
-	}
-
-	return string(out)
-}
 
 func TestDetectShell(t *testing.T) {
 	// DetectShell() now prioritizes parent process detection over $SHELL.
@@ -310,14 +263,12 @@ func TestInstallCmd(t *testing.T) {
 	}
 }
 
-// TestShowAlreadyInstalled guards against CFX-7958: the printed reinstall
-// hint must derive its command path from cmd.CommandPath() so it can never
-// drift from the real "dr self completion install" invocation.
+// TestShowAlreadyInstalled guards against CFX-7958 command path drift.
 func TestShowAlreadyInstalled(t *testing.T) {
 	cmd := Cmd()
-	wireCommandPath(cmd)
+	testutil.WireCompletionCommandPath(cmd)
 
-	out := captureStdout(t, func() {
+	out := testutil.CaptureStdout(t, func() {
 		showAlreadyInstalled(cmd, "/fake/path/_dr")
 	})
 
@@ -331,14 +282,12 @@ func TestShowAlreadyInstalled(t *testing.T) {
 	}
 }
 
-// TestShowDryRunMessage guards against CFX-7958: the printed dry-run hint
-// must derive its command path from cmd.CommandPath() so it can never
-// drift from the real "dr self completion install" invocation.
+// TestShowDryRunMessage guards against CFX-7958 command path drift.
 func TestShowDryRunMessage(t *testing.T) {
 	cmd := Cmd()
-	wireCommandPath(cmd)
+	testutil.WireCompletionCommandPath(cmd)
 
-	out := captureStdout(t, func() {
+	out := testutil.CaptureStdout(t, func() {
 		showDryRunMessage(cmd, "zsh")
 	})
 
@@ -592,16 +541,7 @@ func TestInstallPowerShell(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// On Windows, os.UserHomeDir() reads USERPROFILE, not HOME.
-	// Set both so the test isolates the profile path on all platforms.
-	origHome := os.Getenv("HOME")
-	origUserProfile := os.Getenv("USERPROFILE")
-
-	os.Setenv("HOME", tmpDir)
-	os.Setenv("USERPROFILE", tmpDir)
-
-	defer os.Setenv("HOME", origHome)
-	defer os.Setenv("USERPROFILE", origUserProfile)
+	testutil.SetTestHomeDir(t, tmpDir)
 
 	profilePath, installFn := installPowerShell(rootCmd, false)
 

--- a/cmd/self/completion/uninstall/cmd.go
+++ b/cmd/self/completion/uninstall/cmd.go
@@ -89,10 +89,7 @@ By default, runs in preview mode. Use '--yes' to uninstall directly.`,
 	return cmd
 }
 
-// runUninstall takes the invoked *cobra.Command so the dry-run hint can
-// derive the exact "dr self completion uninstall" path from
-// cmd.CommandPath() instead of a hardcoded string — see CFX-7958, where a
-// hardcoded literal silently drifted from the real command path.
+// runUninstall keeps user-facing hints tied to the invoked command path.
 func runUninstall(cmd *cobra.Command, specifiedShell string, yes, dryRun bool) error {
 	shell, err := resolveShellForUninstall(specifiedShell)
 	if err != nil {

--- a/cmd/self/completion/uninstall/cmd.go
+++ b/cmd/self/completion/uninstall/cmd.go
@@ -53,14 +53,14 @@ This command will:
 
 By default, runs in preview mode. Use '--yes' to uninstall directly.`,
 		Example: `  # Preview what would be removed (default behavior)
-  ` + version.CliName + ` completion uninstall
+  ` + version.CliName + ` self completion uninstall
 
   # Uninstall completions for your current shell
-  ` + version.CliName + ` completion uninstall --yes
+  ` + version.CliName + ` self completion uninstall --yes
 
   # Uninstall completions for a specific shell
-  ` + version.CliName + ` completion uninstall bash --yes
-  ` + version.CliName + ` completion uninstall zsh --yes`,
+  ` + version.CliName + ` self completion uninstall bash --yes
+  ` + version.CliName + ` self completion uninstall zsh --yes`,
 		Args:      cobra.MaximumNArgs(1),
 		ValidArgs: internalShell.SupportedShells(),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -79,7 +79,7 @@ By default, runs in preview mode. Use '--yes' to uninstall directly.`,
 				effectiveDryRun = true
 			}
 
-			return runUninstall(shell, yes, effectiveDryRun)
+			return runUninstall(cmd, shell, yes, effectiveDryRun)
 		},
 	}
 
@@ -89,7 +89,11 @@ By default, runs in preview mode. Use '--yes' to uninstall directly.`,
 	return cmd
 }
 
-func runUninstall(specifiedShell string, yes, dryRun bool) error {
+// runUninstall takes the invoked *cobra.Command so the dry-run hint can
+// derive the exact "dr self completion uninstall" path from
+// cmd.CommandPath() instead of a hardcoded string — see CFX-7958, where a
+// hardcoded literal silently drifted from the real command path.
+func runUninstall(cmd *cobra.Command, specifiedShell string, yes, dryRun bool) error {
 	shell, err := resolveShellForUninstall(specifiedShell)
 	if err != nil {
 		return err
@@ -108,7 +112,7 @@ func runUninstall(specifiedShell string, yes, dryRun bool) error {
 
 	// Dry-run mode
 	if dryRun {
-		showUninstallDryRunMessage(shell)
+		showUninstallDryRunMessage(cmd, shell)
 		return nil
 	}
 
@@ -172,11 +176,11 @@ func showUninstallationPlan(shell string, existingPaths []string) {
 	fmt.Println()
 }
 
-func showUninstallDryRunMessage(shell string) {
+func showUninstallDryRunMessage(cmd *cobra.Command, shell string) {
 	fmt.Println(infoStyle.Render("🔍 Dry-run mode (no changes will be made)"))
 	fmt.Println()
 	fmt.Println("To proceed with uninstallation, run:")
-	fmt.Println(infoStyle.Render("  " + version.CliName + " completion uninstall " + shell + " --yes"))
+	fmt.Println(infoStyle.Render("  " + cmd.CommandPath() + " " + shell + " --yes"))
 }
 
 func performUninstall(shell internalShell.Shell) error {

--- a/cmd/self/completion/uninstall/cmd_test.go
+++ b/cmd/self/completion/uninstall/cmd_test.go
@@ -15,7 +15,6 @@
 package uninstall
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -26,55 +25,7 @@ import (
 	internalShell "github.com/datarobot/cli/internal/shell"
 	"github.com/datarobot/cli/internal/testutil"
 	"github.com/datarobot/cli/internal/version"
-	"github.com/spf13/cobra"
 )
-
-// wireCommandPath attaches cmd to a synthetic "dr self completion" parent
-// chain matching the real registration (see cmd/self/cmd.go and
-// cmd/self/completion/cmd.go), so cmd.CommandPath() resolves exactly as it
-// does at runtime. This package can't import cmd/self/completion directly —
-// that package imports this one, so doing so would create an import cycle.
-func wireCommandPath(cmd *cobra.Command) {
-	root := &cobra.Command{Use: version.CliName}
-	selfCmd := &cobra.Command{Use: "self"}
-	completionCmd := &cobra.Command{Use: "completion"}
-
-	completionCmd.AddCommand(cmd)
-	selfCmd.AddCommand(completionCmd)
-	root.AddCommand(selfCmd)
-}
-
-// captureStdout redirects os.Stdout for the duration of fn and returns
-// everything written to it.
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-
-	orig := os.Stdout
-
-	t.Cleanup(func() { os.Stdout = orig })
-
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create pipe: %v", err)
-	}
-
-	os.Stdout = w
-
-	fn()
-
-	os.Stdout = orig
-
-	if err := w.Close(); err != nil {
-		t.Fatalf("close pipe: %v", err)
-	}
-
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("read pipe: %v", err)
-	}
-
-	return string(out)
-}
 
 func TestFindExistingCompletions(t *testing.T) {
 	// Create temporary directory structure
@@ -181,14 +132,12 @@ func TestUninstallCmd(t *testing.T) {
 	}
 }
 
-// TestShowUninstallDryRunMessage guards against CFX-7958: the printed
-// dry-run hint must derive its command path from cmd.CommandPath() so it
-// can never drift from the real "dr self completion uninstall" invocation.
+// TestShowUninstallDryRunMessage guards against CFX-7958 command path drift.
 func TestShowUninstallDryRunMessage(t *testing.T) {
 	cmd := Cmd()
-	wireCommandPath(cmd)
+	testutil.WireCompletionCommandPath(cmd)
 
-	out := captureStdout(t, func() {
+	out := testutil.CaptureStdout(t, func() {
 		showUninstallDryRunMessage(cmd, "zsh")
 	})
 

--- a/cmd/self/completion/uninstall/cmd_test.go
+++ b/cmd/self/completion/uninstall/cmd_test.go
@@ -15,6 +15,7 @@
 package uninstall
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -24,7 +25,56 @@ import (
 	"github.com/datarobot/cli/internal/fsutil"
 	internalShell "github.com/datarobot/cli/internal/shell"
 	"github.com/datarobot/cli/internal/testutil"
+	"github.com/datarobot/cli/internal/version"
+	"github.com/spf13/cobra"
 )
+
+// wireCommandPath attaches cmd to a synthetic "dr self completion" parent
+// chain matching the real registration (see cmd/self/cmd.go and
+// cmd/self/completion/cmd.go), so cmd.CommandPath() resolves exactly as it
+// does at runtime. This package can't import cmd/self/completion directly —
+// that package imports this one, so doing so would create an import cycle.
+func wireCommandPath(cmd *cobra.Command) {
+	root := &cobra.Command{Use: version.CliName}
+	selfCmd := &cobra.Command{Use: "self"}
+	completionCmd := &cobra.Command{Use: "completion"}
+
+	completionCmd.AddCommand(cmd)
+	selfCmd.AddCommand(completionCmd)
+	root.AddCommand(selfCmd)
+}
+
+// captureStdout redirects os.Stdout for the duration of fn and returns
+// everything written to it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+
+	t.Cleanup(func() { os.Stdout = orig })
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+
+	os.Stdout = w
+
+	fn()
+
+	os.Stdout = orig
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe: %v", err)
+	}
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+
+	return string(out)
+}
 
 func TestFindExistingCompletions(t *testing.T) {
 	// Create temporary directory structure
@@ -128,6 +178,23 @@ func TestUninstallCmd(t *testing.T) {
 
 	if cmd.Flags().Lookup("dry-run") == nil {
 		t.Error("dry-run flag not found")
+	}
+}
+
+// TestShowUninstallDryRunMessage guards against CFX-7958: the printed
+// dry-run hint must derive its command path from cmd.CommandPath() so it
+// can never drift from the real "dr self completion uninstall" invocation.
+func TestShowUninstallDryRunMessage(t *testing.T) {
+	cmd := Cmd()
+	wireCommandPath(cmd)
+
+	out := captureStdout(t, func() {
+		showUninstallDryRunMessage(cmd, "zsh")
+	})
+
+	wantHint := version.CliName + " self completion uninstall zsh --yes"
+	if !strings.Contains(out, wantHint) {
+		t.Errorf("output %q does not contain expected dry-run hint %q", out, wantHint)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/yuin/goldmark v1.8.2 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
-	golang.org/x/crypto v0.53.0 // indirect
+	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
-	golang.org/x/net v0.56.0 // indirect
+	golang.org/x/net v0.57.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -183,12 +183,12 @@ github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJ
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
-golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
-golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
+golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
+golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
-golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
-golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
+golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/testutil/command.go
+++ b/internal/testutil/command.go
@@ -1,0 +1,66 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/datarobot/cli/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// CaptureStdout redirects os.Stdout while fn runs and returns the captured text.
+func CaptureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+
+	t.Cleanup(func() { os.Stdout = orig })
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+
+	os.Stdout = w
+
+	fn()
+
+	os.Stdout = orig
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe: %v", err)
+	}
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+
+	return string(out)
+}
+
+// WireCompletionCommandPath attaches a command to the real completion parent path.
+func WireCompletionCommandPath(cmd *cobra.Command) {
+	root := &cobra.Command{Use: version.CliName}
+	selfCmd := &cobra.Command{Use: "self"}
+	completionCmd := &cobra.Command{Use: "completion"}
+
+	completionCmd.AddCommand(cmd)
+	selfCmd.AddCommand(completionCmd)
+	root.AddCommand(selfCmd)
+}


### PR DESCRIPTION
```
╰─ ❯ dr self update -f                                                                      👾 v0.4.2 👾 staging.dr
    ____        __        ____        __          __
   / __ \____ _/ /_____ _/ __ \____  / /_  ____  / /_
  / / / / __ `/ __/ __ `/ /_/ / __ \/ __ \/ __ \/ __/
 / /_/ / /_/ / /_/ /_/ / _, _/ /_/ / /_/ / /_/ / /_
/_____/\__,_/\__/\__,_/_/ |_|\____/_.___/\____/\__/

==> Installing DataRobot CLI

  → Detected platform: Darwin arm64
  → Fetching latest version...
   Version: v0.4.3
  → Current installation: v0.4.2
  → Target version: v0.4.3
==> Update available: v0.4.2 → v0.4.3
  → Upgrading to: v0.4.3

==> Downloading and installing...
  → Downloading from GitHub...
   https://github.com/datarobot-oss/cli/releases/download/v0.4.3/dr_v0.4.3_Darwin_arm64.tar.gz
######################################################################## 100.0%
  → Extracting binary...
  → Installing binary to /Users/aj.alon/.local/bin/dr...
  → Creating 'datarobot' alias...

==> Installation complete!
  → Verifying installation...
   ✓ DataRobot CLI version: v0.4.3
  → Installation directory is in PATH
  → To install completions, run: dr self completion install --yes

==> Get started by running: dr --help


╭ notebooks on  aj/notebooks-and-workload-api is 📦 v0.1.0 via 🪖  via 🐍 v3.14.6 (notebooks)  u/na took 7s217ms as aj.alon@datarobot.com (AJ Alon) .☸ k3d-nbx in
╰─ ❯ dr self completion install --yes                                                       👾 v0.4.3 👾 staging.dr
→ Detected shell: zsh

✓ Completion already installed at: /Users/aj.alon/.zsh/completions/_dr.

To reinstall, use: dr completion install --force --yes
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI messaging and help examples only; no changes to install/uninstall behavior or security-sensitive paths.
> 
> **Overview**
> Fixes **CFX-7958**, where reinstall and dry-run messages suggested `dr completion install` (and similar) even though the real command is **`dr self completion install`**.
> 
> **Install** and **uninstall** now pass the invoked `*cobra.Command` into the hint helpers so copy uses **`cmd.CommandPath()`** instead of a hardcoded `CliName + " completion …"` string. Completion generation still uses **`cmd.Root()`** where needed. Help **examples** are updated to show the `self completion` path.
> 
> Tests add a synthetic parent chain (`wireCommandPath`), stdout capture, and assertions that printed hints match `dr self completion install|uninstall …`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f19d5b0a4b533b61bcd3e2bebf02cb9265ca4bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->