### PR TITLE
[CFX-7986] auth: honor skip-auth in `dr auth check`

### DIFF
--- a/cmd/auth/check/cmd.go
+++ b/cmd/auth/check/cmd.go
@@ -26,6 +26,7 @@ import (
 	"github.com/datarobot/cli/internal/auth"
 	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
 	"github.com/datarobot/cli/internal/envbuilder"
 	"github.com/datarobot/cli/internal/repo"
 	"github.com/datarobot/cli/tui"
@@ -212,6 +213,13 @@ func checkDotenvCredentials(repoRoot string) bool {
 }
 
 func RunE(_ *cobra.Command, _ []string) error {
+	// skip-auth disables auth (DR Lite / CI / offline); honor it here like login and EnsureAuthenticated do.
+	if viperx.GetBool(config.SkipAuthKey) {
+		fmt.Fprintln(os.Stdout, tui.BaseTextStyle.Render("✅ Authentication checks skipped (DATAROBOT_CLI_SKIP_AUTH)."))
+
+		return nil
+	}
+
 	// Check .env credentials if in a repo
 	// If not, check the CLI credentials only
 	repoRoot, err := repo.FindRepoRoot()

--- a/cmd/auth/check/cmd_test.go
+++ b/cmd/auth/check/cmd_test.go
@@ -22,6 +22,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/config/viperx"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,4 +74,32 @@ func TestVerifyDotenvToken_StatusErrorKeepsMessage(t *testing.T) {
 
 	require.False(t, valid)
 	assert.Contains(t, string(out), "DATAROBOT_API_TOKEN in '.env' is invalid or expired")
+}
+
+// skip-auth must short-circuit RunE with no error and no credential check, so a
+// no-auth stack (DR Lite) passes the `task dev` auth-check gate.
+func TestRunE_SkipAuthShortCircuits(t *testing.T) {
+	viperx.Set(config.SkipAuthKey, true)
+	t.Cleanup(func() { viperx.Set(config.SkipAuthKey, false) })
+	t.Setenv("DATAROBOT_API_TOKEN", "")
+	t.Setenv("DATAROBOT_ENDPOINT", "")
+
+	orig := os.Stdout
+	t.Cleanup(func() { os.Stdout = orig })
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = w
+
+	runErr := RunE(&cobra.Command{}, nil)
+
+	os.Stdout = orig
+	require.NoError(t, w.Close())
+
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	require.NoError(t, runErr)
+	assert.Contains(t, string(out), "Authentication checks skipped")
 }

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -185,6 +185,10 @@ Check DATAROBOT_ENDPOINT, and the instance's status if it persists.
 $ dr auth check
 ❌ DATAROBOT_ENDPOINT environment variable is invalid: unsupported URL scheme "ftp", use https://
 Set it to a valid DataRobot URL and try again.
+
+# Authentication intentionally disabled (--skip-auth or DATAROBOT_CLI_SKIP_AUTH=true)
+$ DATAROBOT_CLI_SKIP_AUTH=true dr auth check
+✅ Authentication checks skipped (DATAROBOT_CLI_SKIP_AUTH).
 ```
 
 > [!TIP]

--- a/docs/development/authentication.md
+++ b/docs/development/authentication.md
@@ -95,8 +95,9 @@ DATAROBOT_CLI_SKIP_AUTH=true dr templates setup
 When `--skip-auth` is enabled, it expect the following behavior:
 
 1. **Bypass all authentication checks**: The `EnsureAuthenticated()` function returns `true` immediately without validating credentials.
-2. **Emit a warning**: Logs a warning message: `Authentication checks are disabled via --skip-auth flag. This may cause API calls to fail`.
-3. **May cause API failures**: Commands that make API calls will likely fail if no valid credentials are present.
+2. **`dr auth check` reports skipped**: It short-circuits before any credential check and prints that authentication was skipped, so gates that run `dr auth check` (for example the generated agent app's `task dev`) pass on a no-auth stack.
+3. **Emit a warning**: Logs a warning message: `Authentication checks are disabled via --skip-auth flag. This may cause API calls to fail`.
+4. **May cause API failures**: Commands that make API calls will likely fail if no valid credentials are present.
 
 #### When to use skip-auth
 


### PR DESCRIPTION
## what

`dr auth check` demanded valid DataRobot credentials regardless of `DATAROBOT_CLI_SKIP_AUTH` / `--skip-auth`. `dr auth login`, `EnsureAuthenticated`, and `resolveToken` all short-circuit on skip-auth; `check` was the one leg that didn't.

## why it matters

On a no-auth stack (DR Lite, offline, CI) skip-auth is the whole point. The generated agent app's `task dev` runs `dr auth check` as a dependency before the dev server starts, so `check` exiting 1 aborts `task dev` even when the app's LLM config is correct and there is no DataRobot auth to validate.

## fix

Short-circuit `check`'s `RunE` on `SkipAuthKey`, the same guard `login` uses. It reports that authentication was skipped and returns success. Behavior with skip-auth off is unchanged.

## testing

- new unit test: `RunE` returns nil and reports skipped when skip-auth is set with no creds present.
- existing `cmd/auth/check` tests green.
- verified live: on a lite setup with `DATAROBOT_CLI_SKIP_AUTH=true`, `dr auth check` now passes and the generated agent app's `task dev` reaches the dev server against an external LLM.

docs: added the skipped-output example to the auth command reference and the skip-auth behavior list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI behavior change that only affects runs with skip-auth explicitly enabled; normal credential validation is unchanged.
> 
> **Overview**
> **`dr auth check` now respects `DATAROBOT_CLI_SKIP_AUTH` / `--skip-auth`**, matching `dr auth login` and `EnsureAuthenticated`. When skip-auth is on, `RunE` exits successfully immediately and prints that authentication checks were skipped, without validating `.env`, env vars, or CLI config.
> 
> This unblocks no-auth workflows (DR Lite, offline, CI) where generated apps run `dr auth check` before `task dev`—previously the gate could fail even when DataRobot credentials were intentionally absent.
> 
> Adds **`TestRunE_SkipAuthShortCircuits`** and documents the skipped output in the auth command reference and skip-auth behavior list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94d72c84ecf96a1b4f6eb87438fccab9e64b2deb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->