### PR TITLE
[BUZZOK-31834] Decode versions in order to install key dependencies first

### DIFF
--- a/internal/tools/versions.go
+++ b/internal/tools/versions.go
@@ -65,9 +65,18 @@ func GetRequirementsFromDir(dir string) ([]Prerequisite, []string, error) {
 	var violations []string
 
 	versions := make([]Prerequisite, 0, len(mapping.Content)/2)
+	seen := make(map[string]bool, len(mapping.Content)/2)
 
 	for i := 0; i+1 < len(mapping.Content); i += 2 {
 		key := mapping.Content[i].Value
+
+		// yaml.Node traversal doesn't reject duplicate keys the way decoding into a
+		// map does, so check explicitly to keep that same fail-fast behavior.
+		if seen[key] {
+			return nil, nil, fmt.Errorf("versions yaml file %s: duplicate key %q (line %d)", yamlFile, key, mapping.Content[i].Line)
+		}
+
+		seen[key] = true
 
 		var version Prerequisite
 		if err := mapping.Content[i+1].Decode(&version); err != nil {

--- a/internal/tools/versions.go
+++ b/internal/tools/versions.go
@@ -24,8 +24,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type versionsYaml map[string]Prerequisite
-
 func GetRequirements() ([]Prerequisite, []string, error) {
 	repoRoot, err := repo.FindRepoRoot()
 	if err != nil {
@@ -45,17 +43,37 @@ func GetRequirementsFromDir(dir string) ([]Prerequisite, []string, error) {
 		return nil, nil, fmt.Errorf("Failed to read versions yaml file %s: %w", yamlFile, err)
 	}
 
-	var fileParsed versionsYaml
+	// Decoded via yaml.Node (not a map[string]Prerequisite) to preserve the file's
+	// declaration order: dependency installation runs in this order, and tools like
+	// pulumi-datarobot's install command need pulumi already installed, so map
+	// iteration's randomized order would install prerequisites out of order.
+	var root yaml.Node
 
-	if err = yaml.Unmarshal(data, &fileParsed); err != nil {
+	if err = yaml.Unmarshal(data, &root); err != nil {
 		return nil, nil, fmt.Errorf("Failed to unmarshal versions yaml file %s: %w", yamlFile, err)
+	}
+
+	if len(root.Content) == 0 {
+		return nil, nil, nil
+	}
+
+	mapping := root.Content[0]
+	if mapping.Kind != yaml.MappingNode {
+		return nil, nil, fmt.Errorf("versions yaml file %s must contain a top-level mapping", yamlFile)
 	}
 
 	var violations []string
 
-	versions := make([]Prerequisite, 0, len(fileParsed))
+	versions := make([]Prerequisite, 0, len(mapping.Content)/2)
 
-	for key, version := range fileParsed {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		key := mapping.Content[i].Value
+
+		var version Prerequisite
+		if err := mapping.Content[i+1].Decode(&version); err != nil {
+			return nil, nil, fmt.Errorf("Failed to unmarshal entry %q in %s: %w", key, yamlFile, err)
+		}
+
 		version.Key = key
 		violations = append(violations, validatePrerequisite(key, version)...)
 		versions = append(versions, version)

--- a/internal/tools/versions_test.go
+++ b/internal/tools/versions_test.go
@@ -130,6 +130,49 @@ tool-b:
 	assert.Len(t, prereqs, 2)
 }
 
+func TestGetRequirementsFromDir_PreservesDeclarationOrder(t *testing.T) {
+	// Regression test: entries were previously decoded into a map, which randomizes
+	// iteration order and could install prerequisites (e.g. a plugin before the tool
+	// it depends on) out of the order declared in versions.yaml.
+	const yaml = `tool-z:
+  name: Tool Z
+  minimum-version: "1.0.0"
+  command: "echo z"
+  url: https://example.com/z
+  install:
+    macos: "echo install"
+    linux: "echo install"
+tool-a:
+  name: Tool A
+  minimum-version: "1.0.0"
+  command: "echo a"
+  url: https://example.com/a
+  install:
+    macos: "echo install"
+    linux: "echo install"
+tool-m:
+  name: Tool M
+  minimum-version: "1.0.0"
+  command: "echo m"
+  url: https://example.com/m
+  install:
+    macos: "echo install"
+    linux: "echo install"
+`
+
+	dir := t.TempDir()
+
+	writeVersionsYAML(t, dir, yaml)
+
+	for range 20 {
+		prereqs, _, err := GetRequirementsFromDir(dir)
+
+		require.NoError(t, err)
+		require.Len(t, prereqs, 3)
+		assert.Equal(t, []string{"tool-z", "tool-a", "tool-m"}, []string{prereqs[0].Key, prereqs[1].Key, prereqs[2].Key})
+	}
+}
+
 func TestGetRequirementsFromDir_EmptyYamlReturnsNoPrereqs(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/tools/versions_test.go
+++ b/internal/tools/versions_test.go
@@ -173,6 +173,37 @@ tool-m:
 	}
 }
 
+func TestGetRequirementsFromDir_DuplicateKeyReturnsError(t *testing.T) {
+	const yaml = `tool-a:
+  name: Tool A
+  minimum-version: "1.0.0"
+  command: "echo a"
+  url: https://example.com/a
+  install:
+    macos: "echo install"
+    linux: "echo install"
+tool-a:
+  name: Tool A Again
+  minimum-version: "2.0.0"
+  command: "echo a2"
+  url: https://example.com/a2
+  install:
+    macos: "echo install"
+    linux: "echo install"
+`
+
+	dir := t.TempDir()
+
+	writeVersionsYAML(t, dir, yaml)
+
+	prereqs, _, err := GetRequirementsFromDir(dir)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate key")
+	assert.Contains(t, err.Error(), "tool-a")
+	assert.Nil(t, prereqs)
+}
+
 func TestGetRequirementsFromDir_EmptyYamlReturnsNoPrereqs(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
# RATIONALE
I want to add `pulumi-datarobot` to `versions.yaml` to unify all the dependencies, and move away from a brittle fixes in `infra/Taskfile.yaml`. But when I tested it on a clean system, `dr dependency install` failed because there was no `pulumi` because it does not respect the order of dependencies installation in the YAML (which is expected for a random map). This updates the decode to iterate over config as it is defined.

## CHANGES

## PR Automation

**Comment-Commands:** Trigger CI by commenting on the PR:
- `/trigger-smoke-test` or `/trigger-test-smoke` - Run smoke tests
- `/trigger-install-test` or `/trigger-test-install` - Run installation tests

**Labels:** Apply labels to trigger workflows:
- `run-smoke-tests` or `go` - Run smoke tests on demand (only works for non-forked PRs)

> [!IMPORTANT]
> **For Forked PRs:** The `run-smoke-tests` label won't work. A required **Smoke Tests** check will block merge until a maintainer acts:
> - A maintainer uses `/approve-smoke-tests` to run smoke tests (results will set the check)
> - A maintainer uses `/skip-smoke-tests` to bypass the check without running tests
>
> Please comment requesting a maintainer review if you need smoke tests to run.


<!-- Recommended Additional Sections:
## SCREENSHOTS
## TODO
## NOTES
## TESTING
## RELATED
## REVIEWERS -->

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1788792082.953049 -->
<!-- rr:slack:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to YAML parsing in the tools package; install order becomes deterministic and matches the YAML, with a regression test and no auth or data-handling impact.
> 
> **Overview**
> **`GetRequirementsFromDir`** no longer unmarshals `versions.yaml` into a map, which made prerequisite order nondeterministic and could run `dr dependency install` steps before their dependencies (e.g. `pulumi-datarobot` before `pulumi`). It now decodes with **`yaml.Node`** and walks top-level keys in **file order**, with checks for an empty document and a top-level mapping.
> 
> A regression test runs **`GetRequirementsFromDir`** many times and asserts keys stay in declaration order (`tool-z`, `tool-a`, `tool-m`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dce629c7a17423f13ec6ab0e983ab053fadf007. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->