### PR TITLE
fix: correct dr self completion help examples

### DIFF
--- a/cmd/self/completion/cmd.go
+++ b/cmd/self/completion/cmd.go
@@ -39,12 +39,12 @@ You can also use the 'install' subcommand to install completions interactively.`
 
 Bash:
 
-  $ source <(` + version.CliName + ` completion bash)
+  $ source <(` + version.CliName + ` self completion bash)
 
   # To load completions for each session, execute once:
 
   # Linux:
-  $ ` + version.CliName + ` completion bash > /etc/bash_completion.d/` + version.CliName + `
+  $ ` + version.CliName + ` self completion bash > /etc/bash_completion.d/` + version.CliName + `
 
 Zsh:
 
@@ -53,21 +53,21 @@ Zsh:
   $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
   # Linux or MacOS:
-  $ ` + version.CliName + ` completion zsh > ${ZDOTDIR:-$HOME}/.zsh/completions/_dr` + version.CliName + `
+  $ ` + version.CliName + ` self completion zsh > ${ZDOTDIR:-$HOME}/.zsh/completions/_` + version.CliName + `
 
 Fish:
 
-  $ ` + version.CliName + ` completion fish | source
+  $ ` + version.CliName + ` self completion fish | source
 
   # To load completions for each session, execute once:
-  $ ` + version.CliName + ` completion fish > ~/.config/fish/completions/` + version.CliName + `.fish
+  $ ` + version.CliName + ` self completion fish > ~/.config/fish/completions/` + version.CliName + `.fish
 
 PowerShell:
 
-  PS> ` + version.CliName + ` completion powershell | Out-String | Invoke-Expression
+  PS> ` + version.CliName + ` self completion powershell | Out-String | Invoke-Expression
 
   # To load completions for every new session, run:
-  PS> ` + version.CliName + ` completion powershell > ` + version.CliName + `.ps1
+  PS> ` + version.CliName + ` self completion powershell > ` + version.CliName + `.ps1
   # and source it from your PowerShell profile.
 `,
 		DisableFlagsInUseLine: true,


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

The `dr self completion --help` output showed incorrect usage examples: it printed
`dr completion bash` instead of the real `dr self completion bash`, since the
command's `Example` text was written before completion was nested under `self`
and never updated. The zsh example was also broken: it concatenated `_dr` +
`CliName` ("dr"), producing the invalid filename `_drdr` instead of `_dr`.

## CHANGES

- Fixed `cmd/self/completion/cmd.go` help `Example` text to use `dr self completion <shell>` for bash/zsh/fish/powershell.
- Fixed the zsh completion filename example from `_dr` + CliName (`_drdr`) to `_` + CliName (`_dr`).

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1788970038.112789 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help text only; no runtime behavior, auth, or data handling changes.
> 
> **Overview**
> Updates **`dr self completion --help`** examples so they match the real command path: all shell snippets now use **`self completion`** instead of the outdated top-level **`completion`**.
> 
> Also fixes the **zsh** install path example so the completion file is **`_` + CliName** (e.g. `_dr`) instead of the broken **`_dr` + CliName** concatenation that produced `_drdr`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3426f9b3b2d34d34732bf34e0bfcdd4d790f788e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->