### PR TITLE
Add opencode plugin v0.1.7

### DIFF
--- a/docs/plugins/index.json
+++ b/docs/plugins/index.json
@@ -252,6 +252,12 @@
       "description": "AI agent design, coding, and deployment assistant",
       "versions": [
         {
+          "version": "0.1.7",
+          "url": "opencode/opencode-0.1.7.tar.xz",
+          "sha256": "b141529706f1f23d90d1532716acf5ff539c45779bdb33c7d467fb4461da2a2a",
+          "releaseDate": "2026-09-09"
+        },
+        {
           "version": "0.1.6",
           "url": "opencode/opencode-0.1.6.tar.xz",
           "sha256": "4a6f84068ed850e57278e6a2f6f81ab7c733cacc10392dd37d21562f65432256",


### PR DESCRIPTION
## Summary

Adds the opencode plugin v0.1.7 to the CLI plugin index.

- Plugin: opencode
- Version: 0.1.7
- Release: https://github.com/datarobot/opencode-cli-plugin/releases/tag/v0.1.7
- SHA256: b141529706f1f23d90d1532716acf5ff539c45779bdb33c7d467fb4461da2a2a

## Test Plan

- [ ] dr plugin install opencode installs successfully
- [ ] dr opencode --help shows usage

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1788975852.534149 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Catalog-only JSON update with no application logic changes; incorrect metadata would only affect plugin install verification.
> 
> **Overview**
> Registers **opencode v0.1.7** in `docs/plugins/index.json` as the newest entry in the plugin’s `versions` list (tarball URL, SHA256, release date 2026-09-09).
> 
> This lets the CLI registry resolve and install **0.1.7** via `dr plugin install opencode` instead of defaulting to **0.1.6**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a01e28dadaf30a8a1cfccfa814fa9aaedcf44b81. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->