### PR TITLE
[CFX-7608] Reject a non-http/https URL in dr auth set-url

### DIFF
--- a/cmd/auth/seturl/cmd.go
+++ b/cmd/auth/seturl/cmd.go
@@ -16,15 +16,19 @@ package seturl
 
 import (
 	"github.com/datarobot/cli/internal/auth"
+	"github.com/datarobot/cli/internal/cli"
 	"github.com/datarobot/cli/internal/config"
+	"github.com/datarobot/cli/internal/log"
 	"github.com/datarobot/cli/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
 func Cmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "set-url [url]",
-		Short: "🌐 Configure your DataRobot environment URL.",
+		Use:           "set-url [url]",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		Short:         "🌐 Configure your DataRobot environment URL.",
 		Long: `Configure your DataRobot environment URL with an interactive selection.
 
 This command helps you choose the correct DataRobot environment:
@@ -34,28 +38,33 @@ This command helps you choose the correct DataRobot environment:
   • Custom/On-Premise: Your organization's DataRobot URL
 
 💡 If you're unsure, check the URL you use to log in to DataRobot in your browser.`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var url string
 			if len(args) > 0 {
 				url = args[0]
 			}
 
+			// An explicit arg that won't validate is the user's to fix; report it
+			// rather than silently dropping into the interactive picker.
 			if url != "" {
-				err := config.SetURLToConfig(url)
-				if err == nil {
-					_ = auth.WriteConfigFileSilent()
-					_ = auth.EnsureAuthenticatedE(cmd, args)
+				if err := config.SetURLToConfig(url); err != nil {
+					log.Error(err.Error())
 
-					return
+					return cli.ErrSilent
 				}
+
+				_ = auth.WriteConfigFileSilent()
+				_ = auth.EnsureAuthenticatedE(cmd, args)
+
+				return nil
 			}
 
-			urlChanged := auth.SetURLAction()
-
-			if urlChanged {
+			if auth.SetURLAction() {
 				_ = auth.WriteConfigFileSilent()
 				_ = auth.EnsureAuthenticatedE(cmd, args)
 			}
+
+			return nil
 		},
 	}
 

--- a/cmd/auth/seturl/cmd_test.go
+++ b/cmd/auth/seturl/cmd_test.go
@@ -1,0 +1,32 @@
+// Copyright 2026 DataRobot, Inc. and its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package seturl
+
+import (
+	"testing"
+
+	"github.com/datarobot/cli/internal/cli"
+	"github.com/stretchr/testify/require"
+)
+
+// An explicit arg with an unsupported scheme errors out instead of falling
+// through to the interactive picker.
+func TestSetURLRejectsNonHTTPSchemeArg(t *testing.T) {
+	cmd := Cmd()
+
+	err := cmd.RunE(cmd, []string{"ftp://app.datarobot.com"})
+
+	require.ErrorIs(t, err, cli.ErrSilent)
+}

--- a/docs/commands/auth.md
+++ b/docs/commands/auth.md
@@ -295,6 +295,10 @@ dr auth set-url [url]
 
 - `url` (optional) - DataRobot instance URL. For example: `https://app.datarobot.com`
 
+A bare host like `app.datarobot.com` is accepted and defaults to `https`. A URL whose
+scheme is not `http` or `https` is rejected: `dr auth set-url ftp://host` prints
+`unsupported URL scheme "ftp", use https://` and exits non-zero.
+
 **Interactive mode:**
 
 If you run `dr auth set-url` without providing a URL, the CLI shows a picker. Move with

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -125,12 +125,7 @@ func ValidateEndpoint(endpoint string) error {
 		return err
 	}
 
-	// Checked here, not in SchemeHostOnly, which set-url and export share.
-	if scheme, _, _ := strings.Cut(baseURL, "://"); scheme != "http" && scheme != "https" {
-		return fmt.Errorf("unsupported URL scheme %q, use https://", scheme)
-	}
-
-	return nil
+	return config.RequireHTTPScheme(baseURL)
 }
 
 // ReportEnvCredentialsError writes a classified explanation of why an

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -60,11 +60,21 @@ func SchemeHostOnly(longURL string) (string, error) {
 	return parsedURL.String(), nil
 }
 
+// unsupportedSchemeError is an ErrInvalidURL, so the interactive picker re-asks
+// on a bad scheme instead of aborting, while keeping its specific message.
+type unsupportedSchemeError struct{ scheme string }
+
+func (e *unsupportedSchemeError) Error() string {
+	return fmt.Sprintf("unsupported URL scheme %q, use https://", e.scheme)
+}
+
+func (e *unsupportedSchemeError) Unwrap() error { return ErrInvalidURL }
+
 // RequireHTTPScheme rejects a normalized base URL whose scheme is not http or
 // https. SchemeHostOnly stays scheme-agnostic (export and GetBaseURL share it).
 func RequireHTTPScheme(baseURL string) error {
 	if scheme, _, _ := strings.Cut(baseURL, "://"); scheme != "http" && scheme != "https" {
-		return fmt.Errorf("unsupported URL scheme %q, use https://", scheme)
+		return &unsupportedSchemeError{scheme}
 	}
 
 	return nil

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -171,6 +171,13 @@ func SaveURLToConfig(newURL string) error {
 		return err
 	}
 
+	// Empty is the reset case below; a non-empty host has to be http/https.
+	if newURL != "" {
+		if err = RequireHTTPScheme(newURL); err != nil {
+			return err
+		}
+	}
+
 	if err = CreateConfigFileDirIfNotExists(); err != nil {
 		return err
 	}

--- a/internal/config/api.go
+++ b/internal/config/api.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -57,6 +58,16 @@ func SchemeHostOnly(longURL string) (string, error) {
 	parsedURL.Path, parsedURL.RawQuery, parsedURL.Fragment = "", "", ""
 
 	return parsedURL.String(), nil
+}
+
+// RequireHTTPScheme rejects a normalized base URL whose scheme is not http or
+// https. SchemeHostOnly stays scheme-agnostic (export and GetBaseURL share it).
+func RequireHTTPScheme(baseURL string) error {
+	if scheme, _, _ := strings.Cut(baseURL, "://"); scheme != "http" && scheme != "https" {
+		return fmt.Errorf("unsupported URL scheme %q, use https://", scheme)
+	}
+
+	return nil
 }
 
 func GetBaseURL() string {
@@ -184,6 +195,10 @@ func SaveURLToConfig(newURL string) error {
 func SetURLToConfig(newURL string) error {
 	newURL, err := SchemeHostOnly(urlFromShortcut(newURL))
 	if err != nil {
+		return err
+	}
+
+	if err := RequireHTTPScheme(newURL); err != nil {
 		return err
 	}
 

--- a/internal/config/api_test.go
+++ b/internal/config/api_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -296,9 +297,10 @@ func TestRequireHTTPScheme(t *testing.T) {
 			err := RequireHTTPScheme(tc.baseURL)
 
 			if tc.wantErr == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
-				assert.ErrorContains(t, err, tc.wantErr)
+				require.ErrorContains(t, err, tc.wantErr)
+				require.ErrorIs(t, err, ErrInvalidURL, "picker re-asks on ErrInvalidURL")
 			}
 		})
 	}

--- a/internal/config/api_test.go
+++ b/internal/config/api_test.go
@@ -95,6 +95,21 @@ func (suite *APITestSuite) TestSetURLToConfig() {
 			input:       "not a url",
 			expectError: true,
 		},
+		{
+			name:        "http scheme is accepted",
+			input:       "http://localhost:8080",
+			expectedURL: "http://localhost:8080/api/v2",
+		},
+		{
+			name:        "ftp scheme is rejected",
+			input:       "ftp://app.datarobot.com",
+			expectError: true,
+		},
+		{
+			name:        "file scheme is rejected",
+			input:       "file://host/etc/passwd",
+			expectError: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -249,5 +264,33 @@ func TestRedactSecretFields_CoversTheOtherNames(t *testing.T) {
 	for _, field := range []string{"password", "secret", "privateKey", "clientSecret", "refreshToken", "token"} {
 		out := RedactSecretFields(`{"` + field + `":"hunter2"}`)
 		assert.NotContains(t, out, "hunter2", "field %q", field)
+	}
+}
+
+// RequireHTTPScheme expects an already-normalized base URL (SchemeHostOnly runs
+// first), so a scheme-less string is rejected, not defaulted.
+func TestRequireHTTPScheme(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		wantErr string
+	}{
+		{"https accepted", "https://app.datarobot.com", ""},
+		{"http accepted", "http://localhost:8080", ""},
+		{"ftp rejected", "ftp://app.datarobot.com", `unsupported URL scheme "ftp"`},
+		{"file rejected", "file://host", `unsupported URL scheme "file"`},
+		{"scheme-less rejected", "app.datarobot.com", "unsupported URL scheme"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := RequireHTTPScheme(tc.baseURL)
+
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/internal/config/api_test.go
+++ b/internal/config/api_test.go
@@ -136,6 +136,15 @@ func (suite *APITestSuite) TestSetURLToConfigDoesNotWriteFile() {
 	suite.NoFileExists(configFile, "SetURLToConfig must not write the config file to disk")
 }
 
+// SaveURLToConfig is the template-setup write path; it must reject a bad scheme
+// too, or the custom-host picker persists an endpoint the CLI cannot use.
+func (suite *APITestSuite) TestSaveURLToConfigRejectsNonHTTPScheme() {
+	err := SaveURLToConfig("ftp://app.datarobot.com")
+
+	suite.Require().Error(err)
+	suite.Empty(viper.GetString(DataRobotURL), "a rejected scheme must not be persisted")
+}
+
 func (suite *APITestSuite) TestCommandPathToTrace() {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
PR 3 of 3: #776 was PR 1, #911 is PR 2

## Summary

`dr auth set-url` accepted any URL scheme and wrote it straight into `drconfig.yaml`, so `dr auth set-url ftp://host` stored a dead endpoint that only failed later at read time with a vaguer error. It now rejects a non-http/https URL at write time and exits non-zero. A bare host like `app.datarobot.com` is still accepted and defaults to `https`.

## Notes for review

The http/https rule is one helper, `config.RequireHTTPScheme`, applied at both write paths that persist the endpoint: `SetURLToConfig` (set-url arg, the interactive picker, stdin, and `dr auth login <url>`) and `SaveURLToConfig` (the template-setup custom-host picker). `SchemeHostOnly` stays scheme-agnostic because `export` and `GetBaseURL` share it, so the rule sits on top rather than inside it.

## Output

```
$ dr auth set-url ftp://app.datarobot.com
ERROR unsupported URL scheme "ftp", use https://
$ echo $?
1
```

## Technical Changes

- internal/config/api.go: add `RequireHTTPScheme`. `SetURLToConfig` and `SaveURLToConfig` both call it after `SchemeHostOnly`.
- internal/auth/auth.go: `ValidateEndpoint` delegates its inline scheme check to the same helper. message byte-identical, no duplication.
- cmd/auth/seturl/cmd.go: a bad arg prints the reason and exits non-zero instead of silently opening the picker. `Run` becomes `RunE` with `SilenceErrors`/`SilenceUsage`.
- docs/commands/auth.md: note the rejection under `set-url`.
- tests: `RequireHTTPScheme` table, both writers' scheme rows, `set-url` arg exits non-zero.

### Breakdown

- code: +43 / -17
- tests: +84 / -0
- docs: +4 / -0

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1789087745.796929 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized URL validation on auth/config write paths with tests; no change to token handling or API auth flow beyond earlier rejection of bad endpoints.
> 
> **Overview**
> **`dr auth set-url`** now rejects endpoints whose scheme is not `http` or `https` at configuration time, with a clear error and non-zero exit, instead of saving unusable values (e.g. `ftp://`) into `drconfig.yaml` or falling back to the interactive picker when the user passed an explicit bad URL.
> 
> Validation is centralized in **`config.RequireHTTPScheme`**, applied after normalization in **`SetURLToConfig`** and **`SaveURLToConfig`** (set-url, login, template setup). **`ValidateEndpoint`** uses the same helper. Bad schemes in the interactive picker still re-prompt because the error wraps **`ErrInvalidURL`**. Bare hosts still default to `https` via **`SchemeHostOnly`**.
> 
> Docs under **`set-url`** describe the rejection behavior; tests cover the helper, both write paths, and the set-url command argument path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e4738b8b1d03ad73a36b4ff382c663880411db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->