### PR TITLE
Add dr dependency install to recipe template's install task

### DIFF
--- a/cmd/task/run/testdata/recipe/.Taskfile.template
+++ b/cmd/task/run/testdata/recipe/.Taskfile.template
@@ -68,6 +68,7 @@ tasks:
   install:
     desc: "🛠️ Install all dependencies"
     cmds:
+      - dr dependency install
       - |
         if [ -n "$VIRTUAL_ENV" ]; then
           echo "Installing datarobot_early_access[core] into active virtualenv: $VIRTUAL_ENV"


### PR DESCRIPTION
# RATIONALE
<!-- Pull Request Guidelines: https://goo.gl/cnhT21 -->

recipe-datarobot-agent-application consolidated all tool installation
behind `dr dependency install`, driven by `.datarobot/cli/versions.yaml`,
and removed the old ad-hoc install paths from its Taskfiles
(datarobot/recipe-datarobot-agent-application#872, and the follow-up
"Remove old installation path" commit that added `dr dependency install`
to `task install`). Carson asked in Slack to keep this CLI's default
recipe template in sync so every new recipe gets the same up-to-date
dependency install step out of the box.

## CHANGES

- Add `dr dependency install` as the first step of the `install` task in
  `cmd/task/run/testdata/recipe/.Taskfile.template`, the default template
  used to generate a recipe's root `Taskfile.yml`.

## TESTING

- `go test ./cmd/task/run/...`
- `task lint`

## RELATED

- https://datarobot.slack.com/archives/C9GU094LB/p1788886730695639?thread_ts=1788792494.257249&cid=C9GU094LB
- datarobot/recipe-datarobot-agent-application#872

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AENc35crjzvpEE3cbywuE

<!-- rr:slack:start -->
<!-- rr:slack:C09RKMC7MA4:1789135512.960239 -->
<!-- rr:slack:end -->
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line addition to a testdata template used for recipe scaffolding; no runtime or security-sensitive logic changes in this repo.
> 
> **Overview**
> **Aligns the default recipe `Taskfile` template with consolidated CLI dependency installation.**
> 
> New recipes generated from `cmd/task/run/testdata/recipe/.Taskfile.template` now run **`dr dependency install`** as the **first** step in the `install` task, before the existing `uv` / `datarobot_early_access[core]` install block and `dr task run install`. This mirrors the agent-application recipe pattern driven by `.datarobot/cli/versions.yaml` so greenfield projects get tool installs from the same path out of the box.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a86599056d056a78c9f2fbde7441c270740bb82. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->